### PR TITLE
重命名 Android 包名和 Flatpak 标识

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -280,7 +280,7 @@ preBuild.dependsOn createWindowsJunctionLinks
 createWindowsJunctionLinks.dependsOn makeLocalization
 
 android {
-    namespace "com.cleverraven.cataclysmdda"
+    namespace "com.lyhglytx.cataclysmcb"
     compileSdkVersion override_compileSdkVersion
     ndkVersion override_ndkVersion
 
@@ -298,7 +298,7 @@ android {
         versionCode Integer.valueOf(override_versionCode)
         versionName new File("$version_header_path").text.split('\"')[1]
         if (buildAsApplication) {
-            applicationId "com.cleverraven.cataclysmdda"
+            applicationId "com.lyhglytx.cataclysmcb"
         }
         resValue "string", "app_name", "Cataclysm DDA"
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -62,7 +62,7 @@
         <!-- Expose app's private data directory for backup without root -->
         <provider
             android:name=".CDDADocumentsProvider"
-            android:authorities="com.cleverraven.cataclysmdda.documents"
+            android:authorities="com.lyhglytx.cataclysmcb.documents"
             android:exported="true"
             android:grantUriPermissions="true"
             android:permission="android.permission.MANAGE_DOCUMENTS">

--- a/android/app/src/main/java/com/lyhglytx/cataclysmcb/CDDADocumentsProvider.java
+++ b/android/app/src/main/java/com/lyhglytx/cataclysmcb/CDDADocumentsProvider.java
@@ -1,4 +1,4 @@
-package com.cleverraven.cataclysmdda;
+package com.lyhglytx.cataclysmcb;
 
 import android.annotation.TargetApi;
 import android.content.Context;

--- a/android/app/src/main/java/com/lyhglytx/cataclysmcb/CataclysmDDA.java
+++ b/android/app/src/main/java/com/lyhglytx/cataclysmcb/CataclysmDDA.java
@@ -1,4 +1,4 @@
-package com.cleverraven.cataclysmdda;
+package com.lyhglytx.cataclysmcb;
 
 import org.libsdl.app.SDLActivity;
 

--- a/android/app/src/main/java/com/lyhglytx/cataclysmcb/CataclysmDDA_Helpers.java
+++ b/android/app/src/main/java/com/lyhglytx/cataclysmcb/CataclysmDDA_Helpers.java
@@ -1,4 +1,4 @@
-package com.cleverraven.cataclysmdda;
+package com.lyhglytx.cataclysmcb;
 
 import java.util.HashSet;
 import java.util.List;

--- a/android/app/src/main/java/com/lyhglytx/cataclysmcb/NativeUI.java
+++ b/android/app/src/main/java/com/lyhglytx/cataclysmcb/NativeUI.java
@@ -1,4 +1,4 @@
-package com.cleverraven.cataclysmdda;
+package com.lyhglytx.cataclysmcb;
 
 import java.util.concurrent.Semaphore;
 

--- a/android/app/src/main/java/com/lyhglytx/cataclysmcb/SplashScreen.java
+++ b/android/app/src/main/java/com/lyhglytx/cataclysmcb/SplashScreen.java
@@ -1,4 +1,4 @@
-package com.cleverraven.cataclysmdda;
+package com.lyhglytx.cataclysmcb;
 
 import java.io.BufferedReader;
 import java.io.File;

--- a/org.cataclysmdda.CataclysmDDA.json
+++ b/org.cataclysmdda.CataclysmDDA.json
@@ -1,5 +1,5 @@
 {
-  "id": "org.cataclysmdda.CataclysmDDA",
+  "id": "org.lyhglytx.cataclysmcb",
   "default-branch": "experimental",
   "runtime": "org.freedesktop.Platform",
   "runtime-version": "22.08",

--- a/org.cataclysmdda.CataclysmDDA.yml
+++ b/org.cataclysmdda.CataclysmDDA.yml
@@ -1,4 +1,4 @@
-id: "org.cataclysmdda.CataclysmDDA"
+id: "org.lyhglytx.cataclysmcb"
 runtime: "org.freedesktop.Platform"
 runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
@@ -21,13 +21,13 @@ modules:
       - make -j $FLATPAK_BUILDER_N_JOBS $MAKE_ARGS
       - make $MAKE_ARGS localization
       - make $MAKE_ARGS install
-      - install -Dm644 data/xdg/org.cataclysmdda.CataclysmDDA.svg /app/share/icons/hicolor/scalable/apps/org.cataclysmdda.CataclysmDDA.svg
-      - install -Dm755 data/xdg/org.cataclysmdda.CataclysmDDA.desktop /app/share/applications/org.cataclysmdda.CataclysmDDA.desktop
-      - install -Dm644 org.cataclysmdda.CataclysmDDA.appdata.xml /app/share/metainfo/org.cataclysmdda.CataclysmDDA.appdata.xml
+      - install -Dm644 data/xdg/org.lyhglytx.cataclysmcb.svg /app/share/icons/hicolor/scalable/apps/org.lyhglytx.cataclysmcb.svg
+      - install -Dm755 data/xdg/org.lyhglytx.cataclysmcb.desktop /app/share/applications/org.lyhglytx.cataclysmcb.desktop
+      - install -Dm644 org.lyhglytx.cataclysmcb.appdata.xml /app/share/metainfo/org.lyhglytx.cataclysmcb.appdata.xml
     sources:
       - type: git
         url: https://github.com/CleverRaven/Cataclysm-DDA.git
         commit: "3a1e04656d51c79af87b5505b1b3c37867378cce"
       - type: file
-        url: https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/dedfc2e5310b505a9728098d1b59777cb8b1e861/data/xdg/org.cataclysmdda.CataclysmDDA.appdata.xml
+        url: https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/dedfc2e5310b505a9728098d1b59777cb8b1e861/data/xdg/org.lyhglytx.cataclysmcb.appdata.xml
         sha256: ca7bf1a3a0598729440aaae73111ffa3992121fa19f0e36d988eee22055db29e


### PR DESCRIPTION
## 改动内容

将 Android 包名和 Flatpak 标识从上游 CDDA 项目改为本项目专属标识。

### 改了什么

| 原标识 | 新标识 |
|--------|--------|
| `com.cleverraven.cataclysmdda` | **`com.lyhglytx.cataclysmcb`** |
| `org.cataclysmdda.CataclysmDDA` | **`org.lyhglytx.cataclysmcb`** |

### 修改文件（9 个）

| 文件 | 改动 |
|------|------|
| `android/app/build.gradle` | `namespace` + `applicationId` |
| `android/app/src/main/AndroidManifest.xml` | provider `authorities` |
| `CDDADocumentsProvider.java` | `package` 声明 |
| `CataclysmDDA.java` | `package` 声明 |
| `CataclysmDDA_Helpers.java` | `package` 声明 |
| `NativeUI.java` | `package` 声明 |
| `SplashScreen.java` | `package` 声明 |
| `org.cataclysmdda.CataclysmDDA.json` | Flatpak `id` |
| `org.cataclysmdda.CataclysmDDA.yml` | Flatpak `id` + 安装路径 |

### 未改的文件
- `settings.gradle` — 不含包名
- `gradle.properties` — 不含包名
- `release.yml` / `release-android-bundle.yaml` — 不含包名直接引用
- `src/` 下所有 C++ 代码 — 不受 Android 包名影响