### PR TITLE
撤销: 移除精神病态者(PSYCHOPATH)的 NPC 社交惩罚（#86578）

### DIFF
--- a/data/json/npcs/common_chat/TALK_COMMON_OTHER.json
+++ b/data/json/npcs/common_chat/TALK_COMMON_OTHER.json
@@ -106,7 +106,7 @@
         "trial": {
           "type": "PERSUADE",
           "difficulty": 20,
-          "mod": [ [ "FEAR", 8 ], [ "VALUE", 2 ], [ "TRUST", 2 ], [ "BRAVERY", -2 ], [ "u_has_trait: PSYCHOPATH", -40 ] ]
+          "mod": [ [ "FEAR", 8 ], [ "VALUE", 2 ], [ "TRUST", 2 ], [ "BRAVERY", -2 ] ]
         },
         "success": {
           "topic": "TALK_AGREE_FOLLOW",
@@ -133,7 +133,6 @@
             [ "BRAVERY", 2 ],
             [ "ANGER", -6 ],
             [ "VALUE", 2 ],
-            [ "u_has_trait: PSYCHOPATH", -40 ]
           ]
         },
         "success": {
@@ -155,7 +154,7 @@
         "trial": {
           "type": "PERSUADE",
           "difficulty": 0,
-          "mod": [ [ "TRUST", 3 ], [ "VALUE", 3 ], [ "ANGER", -3 ], [ "u_has_flag: PSYCHOPATH", -40 ] ]
+          "mod": [ [ "TRUST", 3 ], [ "VALUE", 3 ], [ "ANGER", -3 ] ]
         },
         "success": {
           "topic": "TALK_AGREE_FOLLOW",
@@ -176,7 +175,7 @@
         "trial": {
           "type": "INTIMIDATE",
           "difficulty": 20,
-          "mod": [ [ "FEAR", 8 ], [ "VALUE", 2 ], [ "TRUST", 2 ], [ "BRAVERY", -2 ], [ "u_has_flag: PSYCHOPATH", -30 ] ]
+          "mod": [ [ "FEAR", 8 ], [ "VALUE", 2 ], [ "TRUST", 2 ], [ "BRAVERY", -2 ] ]
         },
         "success": {
           "topic": "TALK_AGREE_FOLLOW",
@@ -464,7 +463,7 @@
         "trial": {
           "type": "PERSUADE",
           "difficulty": 10,
-          "mod": [ [ "TRUST", 1 ], [ "VALUE", 3 ], [ "ALTRUISM", 2 ], [ "u_has_flag: PSYCHOPATH", -10 ] ]
+          "mod": [ [ "TRUST", 1 ], [ "VALUE", 3 ], [ "ALTRUISM", 2 ] ]
         },
         "success": {
           "topic": "TALK_GIVE_EQUIPMENT",
@@ -481,7 +480,7 @@
         "trial": {
           "type": "PERSUADE",
           "difficulty": 12,
-          "mod": [ [ "TRUST", 1 ], [ "VALUE", 2 ], [ "ALTRUISM", 1 ], [ "MISSIONS", 1 ], [ "u_has_flag: PSYCHOPATH", -10 ] ]
+          "mod": [ [ "TRUST", 1 ], [ "VALUE", 2 ], [ "ALTRUISM", 1 ], [ "MISSIONS", 1 ] ]
         },
         "success": { "topic": "TALK_GIVE_EQUIPMENT", "effect": "give_equipment" },
         "failure": { "topic": "TALK_DENY_EQUIPMENT", "opinion": { "value": -1, "anger": 2 } }
@@ -493,7 +492,7 @@
         "trial": {
           "type": "LIE",
           "difficulty": 0,
-          "mod": [ [ "TRUST", 2 ], [ "VALUE", 5 ], [ "ALTRUISM", 3 ], [ "u_has_flag: PSYCHOPATH", -10 ] ]
+          "mod": [ [ "TRUST", 2 ], [ "VALUE", 5 ], [ "ALTRUISM", 3 ] ]
         },
         "success": {
           "topic": "TALK_GIVE_EQUIPMENT",
@@ -562,7 +561,7 @@
         "trial": {
           "type": "INTIMIDATE",
           "difficulty": 30,
-          "mod": [ [ "FEAR", 8 ], [ "VALUE", 2 ], [ "TRUST", 2 ], [ "BRAVERY", -2 ], [ "u_has_trait: PSYCHOPATH", -25 ] ]
+          "mod": [ [ "FEAR", 8 ], [ "VALUE", 2 ], [ "TRUST", 2 ], [ "BRAVERY", -2 ] ]
         },
         "success": { "topic": "TALK_KEEPING_ITEM", "effect": { "u_faction_rep": -2 } },
         "failure": { "topic": "TALK_DONE", "effect": [ "hostile", { "u_faction_rep": -75 } ] }
@@ -573,7 +572,7 @@
         "trial": {
           "type": "PERSUADE",
           "difficulty": 20,
-          "mod": [ [ "TRUST", 3 ], [ "VALUE", 3 ], [ "ANGER", -3 ], [ "u_has_flag: PSYCHOPATH", -25 ] ]
+          "mod": [ [ "TRUST", 3 ], [ "VALUE", 3 ], [ "ANGER", -3 ] ]
         },
         "success": { "topic": "TALK_ALLOW_KEEP_ITEM", "effect": { "u_faction_rep": -1 } },
         "failure": { "topic": "TALK_DISALLOW_KEEP_ITEM", "opinion": { "trust": -3, "anger": 2 }, "effect": { "u_faction_rep": -15 } }
@@ -581,7 +580,7 @@
       {
         "text": "What, this?  It's not the same one, you are mistaken.",
         "condition": "u_has_stolen_item",
-        "trial": { "type": "LIE", "difficulty": 25, "mod": [ [ "TRUST", 3 ], [ "u_has_flag: PSYCHOPATH", -25 ] ] },
+        "trial": { "type": "LIE", "difficulty": 25, "mod": [ [ "TRUST", 3 ] ] },
         "success": { "topic": "TALK_DONE", "effect": "remove_stolen_status" },
         "failure": { "topic": "TALK_DISALLOW_KEEP_ITEM", "opinion": { "trust": -3, "value": -1, "anger": 2 } }
       },

--- a/data/json/npcs/common_chat/TALK_FRIEND_CONVERSATION.json
+++ b/data/json/npcs/common_chat/TALK_FRIEND_CONVERSATION.json
@@ -126,24 +126,7 @@
         "text": "<chitchat_player_responses>",
         "topic": "TALK_DONE",
         "switch": true,
-        "condition": { "not": { "u_has_flag": "PSYCHOPATH" } },
         "effect": [ "morale_chat_activity", { "npc_add_effect": "asked_to_socialize", "duration": 7000 } ]
-      },
-      {
-        "text": "<chitchat_player_responses>",
-        "topic": "TALK_DONE",
-        "switch": true,
-        "condition": { "u_has_flag": "PSYCHOPATH" },
-        "effect": [
-          {
-            "u_add_morale": "morale_chat_uncaring",
-            "bonus": -10,
-            "max_bonus": -20,
-            "duration": "120 minutes",
-            "decay_start": "60 minutes"
-          },
-          { "npc_add_effect": "asked_to_socialize", "duration": 7000 }
-        ]
       }
     ]
   }


### PR DESCRIPTION
## 撤销内容
撤销上游 PR #86578 `没有人愿意和精神病患者合作` 中的对话惩罚。

### 车轮碾压概率代码（参考 #83004）
核心逻辑在 `src/vehicle_move.cpp:1311-1395`：
- `wheel_damage_chance_vs_item()` — 损坏概率 = min( (物品硬度/车轮硬度)^2, 1.0 )
- `apply_tire_punctures()` — 充气轮胎：刺穿→瘪胎
- `apply_generic_wheel_fault()` — 木质车轮：90%裂轮毂→10%断轴
- 只有带 `RESIST_RUNOVER_DAMAGE` 标记的车轮有双倍有效硬度

```
损坏概率 = min((item_hardness / wheel_hardness)^2, 1.0)
如果 RESIST_RUNOVER_DAMAGE: wheel_hardness *= 2
触发条件: chance > 0 且 >= 随机0~1数字
```

### 本次修改
| 文件 | 改动 |
|------|------|
| `TALK_COMMON_OTHER.json` | 移除所有 PSYCHOPATH 的 -10~-40 社交修正（说服/恐吓/说谎） |
| `TALK_FRIEND_CONVERSATION.json` | 移除精神病态者专属负面对话分支，统一为普通社交回应 |

### 效果
精神变态特质不再在 NPC 招募对话中被处处针对，可以正常社交。