### PR TITLE
撤销 PSYCHOPATH 社交惩罚 + 大幅降低车轮碾压损坏概率

### DIFF
--- a/data/json/npcs/common_chat/TALK_COMMON_OTHER.json
+++ b/data/json/npcs/common_chat/TALK_COMMON_OTHER.json
@@ -106,7 +106,7 @@
         "trial": {
           "type": "PERSUADE",
           "difficulty": 20,
-          "mod": [ [ "FEAR", 8 ], [ "VALUE", 2 ], [ "TRUST", 2 ], [ "BRAVERY", -2 ], [ "u_has_trait: PSYCHOPATH", -40 ] ]
+          "mod": [ [ "FEAR", 8 ], [ "VALUE", 2 ], [ "TRUST", 2 ], [ "BRAVERY", -2 ] ]
         },
         "success": {
           "topic": "TALK_AGREE_FOLLOW",
@@ -133,7 +133,6 @@
             [ "BRAVERY", 2 ],
             [ "ANGER", -6 ],
             [ "VALUE", 2 ],
-            [ "u_has_trait: PSYCHOPATH", -40 ]
           ]
         },
         "success": {
@@ -155,7 +154,7 @@
         "trial": {
           "type": "PERSUADE",
           "difficulty": 0,
-          "mod": [ [ "TRUST", 3 ], [ "VALUE", 3 ], [ "ANGER", -3 ], [ "u_has_flag: PSYCHOPATH", -40 ] ]
+          "mod": [ [ "TRUST", 3 ], [ "VALUE", 3 ], [ "ANGER", -3 ] ]
         },
         "success": {
           "topic": "TALK_AGREE_FOLLOW",
@@ -176,7 +175,7 @@
         "trial": {
           "type": "INTIMIDATE",
           "difficulty": 20,
-          "mod": [ [ "FEAR", 8 ], [ "VALUE", 2 ], [ "TRUST", 2 ], [ "BRAVERY", -2 ], [ "u_has_flag: PSYCHOPATH", -30 ] ]
+          "mod": [ [ "FEAR", 8 ], [ "VALUE", 2 ], [ "TRUST", 2 ], [ "BRAVERY", -2 ] ]
         },
         "success": {
           "topic": "TALK_AGREE_FOLLOW",
@@ -464,7 +463,7 @@
         "trial": {
           "type": "PERSUADE",
           "difficulty": 10,
-          "mod": [ [ "TRUST", 1 ], [ "VALUE", 3 ], [ "ALTRUISM", 2 ], [ "u_has_flag: PSYCHOPATH", -10 ] ]
+          "mod": [ [ "TRUST", 1 ], [ "VALUE", 3 ], [ "ALTRUISM", 2 ] ]
         },
         "success": {
           "topic": "TALK_GIVE_EQUIPMENT",
@@ -481,7 +480,7 @@
         "trial": {
           "type": "PERSUADE",
           "difficulty": 12,
-          "mod": [ [ "TRUST", 1 ], [ "VALUE", 2 ], [ "ALTRUISM", 1 ], [ "MISSIONS", 1 ], [ "u_has_flag: PSYCHOPATH", -10 ] ]
+          "mod": [ [ "TRUST", 1 ], [ "VALUE", 2 ], [ "ALTRUISM", 1 ], [ "MISSIONS", 1 ] ]
         },
         "success": { "topic": "TALK_GIVE_EQUIPMENT", "effect": "give_equipment" },
         "failure": { "topic": "TALK_DENY_EQUIPMENT", "opinion": { "value": -1, "anger": 2 } }
@@ -493,7 +492,7 @@
         "trial": {
           "type": "LIE",
           "difficulty": 0,
-          "mod": [ [ "TRUST", 2 ], [ "VALUE", 5 ], [ "ALTRUISM", 3 ], [ "u_has_flag: PSYCHOPATH", -10 ] ]
+          "mod": [ [ "TRUST", 2 ], [ "VALUE", 5 ], [ "ALTRUISM", 3 ] ]
         },
         "success": {
           "topic": "TALK_GIVE_EQUIPMENT",
@@ -562,7 +561,7 @@
         "trial": {
           "type": "INTIMIDATE",
           "difficulty": 30,
-          "mod": [ [ "FEAR", 8 ], [ "VALUE", 2 ], [ "TRUST", 2 ], [ "BRAVERY", -2 ], [ "u_has_trait: PSYCHOPATH", -25 ] ]
+          "mod": [ [ "FEAR", 8 ], [ "VALUE", 2 ], [ "TRUST", 2 ], [ "BRAVERY", -2 ] ]
         },
         "success": { "topic": "TALK_KEEPING_ITEM", "effect": { "u_faction_rep": -2 } },
         "failure": { "topic": "TALK_DONE", "effect": [ "hostile", { "u_faction_rep": -75 } ] }
@@ -573,7 +572,7 @@
         "trial": {
           "type": "PERSUADE",
           "difficulty": 20,
-          "mod": [ [ "TRUST", 3 ], [ "VALUE", 3 ], [ "ANGER", -3 ], [ "u_has_flag: PSYCHOPATH", -25 ] ]
+          "mod": [ [ "TRUST", 3 ], [ "VALUE", 3 ], [ "ANGER", -3 ] ]
         },
         "success": { "topic": "TALK_ALLOW_KEEP_ITEM", "effect": { "u_faction_rep": -1 } },
         "failure": { "topic": "TALK_DISALLOW_KEEP_ITEM", "opinion": { "trust": -3, "anger": 2 }, "effect": { "u_faction_rep": -15 } }
@@ -581,7 +580,7 @@
       {
         "text": "What, this?  It's not the same one, you are mistaken.",
         "condition": "u_has_stolen_item",
-        "trial": { "type": "LIE", "difficulty": 25, "mod": [ [ "TRUST", 3 ], [ "u_has_flag: PSYCHOPATH", -25 ] ] },
+        "trial": { "type": "LIE", "difficulty": 25, "mod": [ [ "TRUST", 3 ] ] },
         "success": { "topic": "TALK_DONE", "effect": "remove_stolen_status" },
         "failure": { "topic": "TALK_DISALLOW_KEEP_ITEM", "opinion": { "trust": -3, "value": -1, "anger": 2 } }
       },

--- a/data/json/npcs/common_chat/TALK_FRIEND_CONVERSATION.json
+++ b/data/json/npcs/common_chat/TALK_FRIEND_CONVERSATION.json
@@ -126,24 +126,7 @@
         "text": "<chitchat_player_responses>",
         "topic": "TALK_DONE",
         "switch": true,
-        "condition": { "not": { "u_has_flag": "PSYCHOPATH" } },
         "effect": [ "morale_chat_activity", { "npc_add_effect": "asked_to_socialize", "duration": 7000 } ]
-      },
-      {
-        "text": "<chitchat_player_responses>",
-        "topic": "TALK_DONE",
-        "switch": true,
-        "condition": { "u_has_flag": "PSYCHOPATH" },
-        "effect": [
-          {
-            "u_add_morale": "morale_chat_uncaring",
-            "bonus": -10,
-            "max_bonus": -20,
-            "duration": "120 minutes",
-            "decay_start": "60 minutes"
-          },
-          { "npc_add_effect": "asked_to_socialize", "duration": 7000 }
-        ]
       }
     ]
   }

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1318,8 +1318,14 @@ double vehicle::wheel_damage_chance_vs_item( const item &it, const vehicle_part 
     }
     // Items attempting to do damage use the best/hardest possible value, the pointy bits.
     const double item_hardness = item_hardness_calc( it ).second;
+    // CCB: 大幅降低车轮碾压损坏概率，碾压碎片基本不伤轮胎
+    // 原公式 pow(hardness_ratio, 2.0) → 木材 (30/80)² = 14%，几棵树就废
+    // 新公式 pow(hardness_ratio, 6.0) + 上限 0.2，因为大部分碎片不应损坏轮胎：
+    //   - 木材/家具 (30/80)⁶ ≈ 0.2% — 基本无害
+    //   - 中等硬度 (50/80)⁶ ≈ 5.9% — 偶尔有威胁
+    //   - 钢制碎块 (80/80)⁶ = 100% → 封顶 20% — 即使最硬物品损坏概率也很低
     // It is exponentially more difficult for soft items to damage wheels, even if you're hitting a lot of them.
-    const double chance_to_damage = std::min( std::pow( item_hardness / wheel_hardness, 2.0 ), 1.0 );
+    const double chance_to_damage = std::min( std::pow( item_hardness / wheel_hardness, 6.0 ), 0.2 );
     add_msg_debug( debugmode::DF_VEHICLE_MOVE,
                    "Vehicle %s running over item %s."
                    "\n Chance to damage: %f%%."


### PR DESCRIPTION
## 改动内容

两个改动合并提交：

### 1. 撤销 PR #86578：移除精神病态者的 NPC 社交惩罚

| 文件 | 改动 |
|------|------|
| `TALK_COMMON_OTHER.json` | 移除说服/恐吓/说谎对话中所有 `u_has_flag/trait: PSYCHOPATH -10~-40` 惩罚 |
| `TALK_FRIEND_CONVERSATION.json` | 移除精神病态者专属负面对话分支，统一为普通社交回应 |

### 2. 大幅降低车轮碾压损坏概率（#83004）

| 改动 | 详情 |
|------|------|
| 文件 | `src/vehicle_move.cpp` |
| 原公式 | `pow(item_hardness / wheel_hardness, 2.0)` |
| 新公式 | `pow(item_hardness / wheel_hardness, 6.0)`，上限 **0.2** |

#### 效果对比

| 物件 | 硬度 | 车轮硬度 | 原概率 | 新概率 |
|------|------|---------|--------|--------|
| 木材/家具 | ~30 | ~80 | `(30/80)² = 14%` | `(30/80)⁶ ≈ 0.2%` |
| 中等碎块 | ~50 | ~80 | `(50/80)² ≈ 39%` | `(50/80)⁶ ≈ 5.9%` |
| 最硬钢块 | ~80 | ~80 | `100%` | `封顶 20%` |

碾压碎片基本不伤轮胎，只有尖锐硬物才可能扎破，即使最硬物品最多20%概率。碾压扫地不会频繁坏车。

//CCB: 精神变态不该被针对 + 载具碾压不应频繁损坏车轮