### PR TITLE
恢复世界生成城市滑块 #85382

### DIFF
--- a/data/core/world_option_sliders.json
+++ b/data/core/world_option_sliders.json
@@ -1,6 +1,33 @@
 [
   {
     "type": "option_slider",
+    "id": "world_cities",
+    "context": "WORLDGEN",
+    "name": "Cities",
+    "default": 0,
+    "levels": [
+      {
+        "level": 0,
+        "name": "Suburbia",
+        "description": "Cities use default size and distances, with small to large cities separated by large rural areas.",
+        "options": [ { "option": "CITY_SIZE", "type": "int", "val": 8 }, { "option": "CITY_SPACING", "type": "int", "val": 4 } ]
+      },
+      {
+        "level": 1,
+        "name": "Cityscape",
+        "description": "Cities are 50% larger and 25% closer to each other.",
+        "options": [ { "option": "CITY_SIZE", "type": "int", "val": 12 }, { "option": "CITY_SPACING", "type": "int", "val": 3 } ]
+      },
+      {
+        "level": 2,
+        "name": "Megacity",
+        "description": "Cities are nearly continuous, with minimal distance between them.",
+        "options": [ { "option": "CITY_SIZE", "type": "int", "val": 16 }, { "option": "CITY_SPACING", "type": "int", "val": 1 } ]
+      }
+    ]
+  },
+  {
+    "type": "option_slider",
     "id": "world_difficulty",
     "context": "WORLDGEN",
     "name": "Difficulty",


### PR DESCRIPTION
## 改动

撤销 PR #85382 (Megacity mod) 中删除的 `world_cities` 世界滑块。

### 原 PR 做了什么
在 `data/core/world_option_sliders.json` 中删除了城市规模滑块（27行），意味着新建世界时无法再快速调整城市大小和间距。

### 本次恢复
重新添加 `world_cities` 滑块，包含三个档位：

| 档位 | 名称 | CITY_SIZE | CITY_SPACING |
|------|------|-----------|--------------|
| 0 | Suburbia（郊区） | 8 | 4 |
| 1 | Cityscape（城市景观） | 12 | 3 |
| 2 | Megacity（超级城市） | 16 | 1 |

### 不影响
- Megacity 模组保持不变
- `src/overmap_city.cpp` 中 MEGACITY 选项的城市放置逻辑不变
- 只在滑块层面恢复用户界面选择

//CCB: 还原被移除的城市规模选项