### PR TITLE
修复 SplashScreen.java 包名引用遗漏

### DIFF
--- a/android/app/src/main/java/com/lyhglytx/cataclysmcb/SplashScreen.java
+++ b/android/app/src/main/java/com/lyhglytx/cataclysmcb/SplashScreen.java
@@ -28,7 +28,7 @@ import android.os.*;
 import android.preference.PreferenceManager;
 import android.util.Log;
 
-import com.cleverraven.cataclysmdda.CataclysmDDA_Helpers;
+import com.lyhglytx.cataclysmcb.CataclysmDDA_Helpers;
 
 public class SplashScreen extends Activity {
     private static final String TAG = "Splash";


### PR DESCRIPTION
## 问题
PR #10 (重命名 Android 包名) 遗漏了 SplashScreen.java 中的一行 import 语句，导致 Android 构建失败。

## 错误日志
```
import com.cleverraven.cataclysmdda.CataclysmDDA_Helpers;
// error: package com.cleverraven.cataclysmdda does not exist
```

## 修复
- `import com.cleverraven.cataclysmdda.CataclysmDDA_Helpers;`
+ `import com.lyhglytx.cataclysmcb.CataclysmDDA_Helpers;`

## 影响
修复后 Android APK 构建恢复正常。