### PR TITLE
模板中项目名由 CDDA 改为 CCB

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        请注意，CDDA 是一个开源项目，任何人都可以参与贡献。建议你看看能否自己实现这个想法。CDDA 有很大一部分是用 JSON 编写的，它本质上就是任何人都能编辑的纯文本代码。
+        请注意，CCB 是一个开源项目，任何人都可以参与贡献。建议你看看能否自己实现这个想法。CCB 有很大一部分是用 JSON 编写的，它本质上就是任何人都能编辑的纯文本代码。
 
   - type: markdown
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -50,7 +50,7 @@ https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/blob/master/data/changelog
 <!-- 在此添加关于这个特性或 bug 修复的其他背景信息（例如原型图、概念验证或截图）。 -->
 
 
-<!--README: Cataclysm: Dark Days Ahead 以 Creative Commons Attribution ShareAlike 3.0 许可证发布。
+<!--README: Cataclysm: Cleanwater Bomb (CCB) 以 Creative Commons Attribution ShareAlike 3.0 许可证发布。
 游戏的代码与内容可自由用于任何目的的使用、修改和再分发。
 通过为本项目做贡献，你即同意该许可证的条款，并同意你所做的任何贡献也将受同一许可证覆盖。
 详见 http://creativecommons.org/licenses/by-sa/3.0/ 。 -->


### PR DESCRIPTION
#### 概述 (Summary)
None

#### 改动目的 (Purpose of change)
PR #20 合并较快，这条改动当时没赶上，单独补一个 PR。把 issue / PR 模板里残留的上游项目名（CDDA / Cataclysm: Dark Days Ahead）改为本项目 CCB。

#### 解决方案描述 (Describe the solution)
- `ISSUE_TEMPLATE/feature_request.yaml`：将「CDDA 是一个开源项目…CDDA 有很大一部分是用 JSON 编写的」两处 CDDA 改为 CCB。
- `pull_request_template.md`：末尾 README 注释「Cataclysm: Dark Days Ahead 以 CC BY-SA 3.0 许可证发布」改为「Cataclysm: Cleanwater Bomb (CCB)」。许可证条款保持不变（CCB 作为衍生作品沿用同一 CC BY-SA 3.0 许可）。

#### 测试 (Testing)
feature_request.yaml 用 PyYAML 校验解析正常；PR 模板注释结构完整。

#### 补充说明 (Additional context)
仅文案改动，不影响游戏代码与构建。