### PR TITLE
PR模板: 明确要求使用英文关闭关键词以自动关闭 issue

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,9 +29,17 @@ https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/blob/master/data/changelog
 
 <!-- 用几句话描述你做这次改动的原因。
 如果它与某个已有 issue 相关，可以用「#」加 GitHub issue 编号来关联，例如 #1234。
-当你的 PR 能完全解决某个 issue 时，请使用 [GitHub 的关闭关键字](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
-（如 Fixes #1234 / 修复 #1234），以便 PR 合并后自动关闭该 issue。
+
+【重要】当你的 PR 能完全解决某个 issue 时，必须使用 [GitHub 的英文关闭关键字](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
+才能在 PR 合并后自动关闭该 issue，例如：Fixes #1234。
+只能用以下英文关键词（后面紧跟「#编号」）：
+  close / closes / closed
+  fix / fixes / fixed
+  resolve / resolves / resolved
+注意：中文「修复 #1234」不会触发自动关闭，GitHub 只识别上述英文关键词。
+
 如果没有相关 issue，请在这里说明你要解决的问题、特性或其他关注点。如果这是一个 bug 修复，请附上复现原始 bug 的步骤，以便你的修复可以被验证。 -->
+
 
 #### 解决方案描述 (Describe the solution)
 


### PR DESCRIPTION
#### 概述 (Summary)
None

#### 改动目的 (Purpose of change)
原 PR 模板把中文「修复 #1234」与英文 `Fixes #1234` 并列写成等效写法，误导贡献者使用中文关键词。但 GitHub 只识别英文关闭关键词，中文「修复」不会触发自动关闭，导致 PR 合并后关联 issue 仍处于 OPEN（例如 #17：PR #19 已合并修复，但因写的是「修复 #17」而未自动关闭）。

#### 解决方案描述 (Describe the solution)
修改 `.github/pull_request_template.md` 的「改动目的」说明：
- 去掉误导性的「修复 #1234」等效写法。
- 明确【必须】使用英文关闭关键词才能自动关闭 issue，并列出可用词：close/closes/closed、fix/fixes/fixed、resolve/resolves/resolved。
- 显式提示中文「修复 #1234」不会触发自动关闭。

#### 测试 (Testing)
纯文档/模板改动，无需编译。已在 GitHub 网页预览确认渲染正常。本 PR 自身即用规范写法示范。

#### 补充说明 (Additional context)
关联的 #17 已手动关闭并备注 Fixed by #19。