### PR TITLE
性能优化:光照与体温热点的循环不变量外提与短路重排

### DIFF
--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -479,11 +479,14 @@ void Character::update_bodytemp()
         scaled_sleepiness;
 
     // Sunlight
-    const float scaled_sun_irradiance = incident_sun_irradiance( get_weather().weather_id,
+    const float scaled_sun_irradiance = incident_sun_irradiance( weather_man.weather_id,
                                         calendar::turn ) / max_sun_irradiance();
-    const units::temperature_delta sunlight_warmth = !g->is_sheltered( pos_bub() ) ? 3_C_delta *
+    // Reuse the cached `sheltered` computed above instead of recomputing
+    // is_sheltered() (which queries veh_at + is_outside) for the same position.
+    const units::temperature_delta sunlight_warmth = !sheltered ? 3_C_delta *
         scaled_sun_irradiance :
         0_C_delta;
+
     const int best_fire = get_best_fire( pos_bub() );
 
     const units::temperature_delta lying_warmth = use_floor_warmth ? floor_warmth(
@@ -520,6 +523,11 @@ void Character::update_bodytemp()
     // We might not use this at all, so leave it empty
     // If we do need to use it, we'll initialize it (once) there
     std::map<bodypart_id, int> fire_armor_per_bp;
+    // Local humidity depends only on loop-invariant inputs (weather humidity,
+    // weather type and shelter), so compute it once instead of per body part.
+    const int local_humidity = get_local_humidity( weather.humidity, weather_man.weather_id,
+                               sheltered );
+
     // Current temperature and converging temperature calculations
     for( const bodypart_id &bp : get_all_body_parts() ) {
 
@@ -542,10 +550,10 @@ void Character::update_bodytemp()
 
         bp_windpower = static_cast<int>( static_cast<float>( bp_windpower ) *
                                          ( 1 - wind_res_per_bp[bp] / 100.0 ) );
-        // Calculate windchill
+        // Calculate windchill (local_humidity precomputed above; loop-invariant)
         units::temperature_delta windchill = get_local_windchill( player_local_temp,
-                                             get_local_humidity( weather.humidity, get_weather().weather_id, sheltered ),
-                                             bp_windpower );
+                                             local_humidity, bp_windpower );
+
 
         static const auto is_lower = []( const bodypart_id & bp ) {
             return bp->has_flag( json_flag_LIMB_LOWER );

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -895,11 +895,12 @@ map::apparent_light_info map::apparent_light_helper( const level_cache &map_cach
     };
 
     // possibly reduce view if aiming (also blocks light)
-    if( get_avatar().recoil < MAX_RECOIL ) {
-        if( get_avatar().cant_see( p ) ) {
+    if( u.recoil < MAX_RECOIL ) {
+        if( u.cant_see( p ) ) {
             return { true, true, 0.0 };
         }
     }
+
 
     const bool p_opaque = is_opaque( p.xy() );
     float apparent_light;
@@ -925,19 +926,28 @@ map::apparent_light_info map::apparent_light_helper( const level_cache &map_cach
         };
 
         four_quadrants seen_from( 0 );
+        // Hoist loop-invariant player position and vision range out of the
+        // 8-neighbour loop (player does not move within a single helper call).
+        const point_bub_ms u_xy = u.pos_bub().xy();
+        const int u_range = u.unimpaired_range();
         for( const offset_and_quadrants &oq : adjacent_offsets ) {
             const point_bub_ms neighbour = p.xy() + oq.offset;
 
             if( !lightmap_boundaries.contains( neighbour ) ) {
                 continue;
             }
-            if( is_opaque( neighbour ) ) {
+            // Cheapest rejection first: a neighbour that is neither directly
+            // seen nor camera-covered contributes nothing, so skip it before
+            // the more expensive is_opaque (two cache reads) and rl_dist.
+            const float n_camera = map_cache.camera_cache[neighbour.x()][neighbour.y()];
+            const float n_seen = map_cache.seen_cache[neighbour.x()][neighbour.y()];
+            if( n_seen == 0 && n_camera == 0 ) {
                 continue;
             }
-            if( ( rl_dist( u.pos_bub().xy(), neighbour ) > u.unimpaired_range() &&
-                  map_cache.camera_cache[neighbour.x()][neighbour.y()] == 0 ) ||
-                ( map_cache.seen_cache[neighbour.x()][neighbour.y()] == 0 &&
-                  map_cache.camera_cache[neighbour.x()][neighbour.y()] == 0 ) ) {
+            if( n_camera == 0 && rl_dist( u_xy, neighbour ) > u_range ) {
+                continue;
+            }
+            if( is_opaque( neighbour ) ) {
                 continue;
             }
             // This is a non-opaque visible neighbour, so count visibility from the relevant
@@ -945,6 +955,7 @@ map::apparent_light_info map::apparent_light_helper( const level_cache &map_cach
             seen_from[oq.quadrants[0]] = vis;
             seen_from[oq.quadrants[1]] = vis;
         }
+
         apparent_light = ( seen_from * map_cache.lm[p.x()][p.y()] ).max();
     } else {
         // This is the simple case, for a non-opaque tile light from all


### PR DESCRIPTION
## 概述

针对性能采样数据中确认的两个 CPU 热点做**逻辑等价**优化,不改变任何游戏逻辑与平衡数值,纯属性能优化。

## 改动详情

### `src/lightmap.cpp` — `map::apparent_light_helper`(采样 inclusive 占比约 40%,头号逻辑热点)
- 8 邻居循环内调整短路判断顺序:先做最廉价的 `seen`/`camera` 布尔判断,再触碰更昂贵的 `is_opaque`(两次 cache 读)与 `rl_dist`,减少不必要的内存访问。
- 将循环不变量(玩家位置 `u_xy`、视野范围 `u_range`)提到循环外,避免每个邻居重复调用 `pos_bub()` 与 `unimpaired_range()`。
- 复用已有的局部引用 `u` 替代重复的 `get_avatar()`。

### `src/character_body.cpp` — `Character::update_bodytemp`(采样约 8%)
- 消除对同一位置的重复 `g->is_sheltered()` 调用(其内部走 `veh_at` + `is_outside`,非廉价 getter),复用上方已缓存的 `sheltered`。
- 将 `get_local_humidity()` 从「每个身体部位调用一次」提升为循环外计算一次:三个入参均为循环不变量,结果恒定;顺带消除每次隐含的 `get_weather()` 调用。

## 测试

- `-Werror` 下干净编译。
- 可见回归套件 `[temperature]` + `[vision]` 全过:**27144 断言 / 38 用例 / 0 失败**。
- 两个 `[.bodytemp]` 隐藏测试的失败经基线对照(还原原版重编后**同样失败**)确认为**预存问题**,与本次改动无关。

## 受影响功能

无功能/平衡改动,均为等价的循环不变量外提与短路重排。