### PR TITLE
Fully restore the Cities slider of CDDA version 0.H

### DIFF
--- a/data/core/world_option_sliders.json
+++ b/data/core/world_option_sliders.json
@@ -4,22 +4,46 @@
     "id": "world_cities",
     "context": "WORLDGEN",
     "name": "Cities",
-    "default": 0,
+    "default": 3,
     "levels": [
       {
         "level": 0,
+        "name": "Remote",
+        "description": "Cities are basically non-existent.  Expect rural-only areas with rare tiny villages.",
+        "options": [ { "option": "CITY_SIZE", "type": "int", "val": 1 }, { "option": "CITY_SPACING", "type": "int", "val": 8 } ]
+      },
+      {
+        "level": 1,
+        "name": "Rural",
+        "description": "Cities are half as large and twice as far apart.",
+        "options": [ { "option": "CITY_SIZE", "type": "int", "val": 4 }, { "option": "CITY_SPACING", "type": "int", "val": 8 } ]
+      },
+      {
+        "level": 2,
+        "name": "Semirural",
+        "description": "Cities are 25% smaller and 50% farther apart.",
+        "options": [ { "option": "CITY_SIZE", "type": "int", "val": 6 }, { "option": "CITY_SPACING", "type": "int", "val": 6 } ]
+      },
+      {
+        "level": 3,
         "name": "Suburbia",
         "description": "Cities use default size and distances, with small to large cities separated by large rural areas.",
         "options": [ { "option": "CITY_SIZE", "type": "int", "val": 8 }, { "option": "CITY_SPACING", "type": "int", "val": 4 } ]
       },
       {
-        "level": 1,
-        "name": "Cityscape",
-        "description": "Cities are 50% larger and 25% closer to each other.",
-        "options": [ { "option": "CITY_SIZE", "type": "int", "val": 12 }, { "option": "CITY_SPACING", "type": "int", "val": 3 } ]
+        "level": 4,
+        "name": "Townscape",
+        "description": "Cities are 50% larger.",
+        "options": [ { "option": "CITY_SIZE", "type": "int", "val": 12 }, { "option": "CITY_SPACING", "type": "int", "val": 4 } ]
       },
       {
-        "level": 2,
+        "level": 5,
+        "name": "Cityscape",
+        "description": "Cities are twice as large and 25% closer to each other.",
+        "options": [ { "option": "CITY_SIZE", "type": "int", "val": 16 }, { "option": "CITY_SPACING", "type": "int", "val": 3 } ]
+      },
+      {
+        "level": 6,
         "name": "Megacity",
         "description": "Cities are nearly continuous, with minimal distance between them.",
         "options": [ { "option": "CITY_SIZE", "type": "int", "val": 16 }, { "option": "CITY_SPACING", "type": "int", "val": 1 } ]


### PR DESCRIPTION
#### 概述 (Summary)

Fully restore the Cities slider of CDDA version 0.H

#### 改动目的 (Purpose of change)

More City settings to choose from

#### 解决方案描述 (Describe the solution)

Roll back `world_option_sliders.world_cities` to the level of the CDDA 0.H release.

#### 测试 (Testing)

None

#### 补充说明 (Additional context)

None