### PR TITLE
修复复制世界设置后 Tab 键无法切换面板

### DIFF
--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -1004,12 +1004,17 @@ int worldfactory::show_worldgen_tab_modselection( const catacurses::window &win,
     ctxt.register_action( "RIGHT", to_translation( "Switch to other list" ) );
     ctxt.register_action( "HELP_KEYBINDINGS" );
     ctxt.register_action( "QUIT" );
-    ctxt.register_action( "NEXT_CATEGORY_TAB" );
-    ctxt.register_action( "PREV_CATEGORY_TAB" );
+    // Register NEXT_TAB/PREV_TAB before NEXT_CATEGORY_TAB/PREV_CATEGORY_TAB so that, when
+    // the tabbed worldgen view is shown (e.g. after copying a world's settings), the Tab key
+    // switches between the World Mods / World Options panels instead of being consumed by the
+    // mod category switching (which shares the Tab binding). Category switching remains on </>.
     if( with_tabs ) {
         ctxt.register_action( "NEXT_TAB" );
         ctxt.register_action( "PREV_TAB" );
     }
+    ctxt.register_action( "NEXT_CATEGORY_TAB" );
+    ctxt.register_action( "PREV_CATEGORY_TAB" );
+
     ctxt.register_action( "CONFIRM", to_translation( "Activate / deactivate mod" ) );
     ctxt.register_action( "MOVE_MOD_UP" );
     ctxt.register_action( "MOVE_MOD_DOWN" );


### PR DESCRIPTION
Fixes #25

## 概述
创建世界后复制该世界配置，进入带标签页的 worldgen 视图时，按 Tab 无法在 `World Mods` / `World Options` 面板间切换。

## 原因
`worldfactory::show_worldgen_tab_modselection` 中，`NEXT_TAB`/`PREV_TAB`（Tab 键）与 `NEXT_CATEGORY_TAB`/`PREV_CATEGORY_TAB` 共用 Tab 绑定。原先类别切换动作先于面板切换动作注册，导致 `input_context` 优先匹配到类别切换，Tab 被其消费，面板无法切换。

## 改动
调整 action 注册顺序：当 `with_tabs` 为真时，先注册 `NEXT_TAB`/`PREV_TAB`，再注册类别切换动作。这样 Tab 用于面板切换，类别切换仍保留在 `<` / `>` 上。仅改动注册顺序，无功能性副作用。

## 测试
- 本地全量构建通过（修正了构建不一致问题，二进制版本与 HEAD 一致）。
- 手动复现：复制世界配置 → 进入 worldgen → Tab 可在 World Mods / World Options 间正常切换，不再崩溃。