### PR TITLE
修复体温在阈值附近抖动时消息刷屏的问题

### DIFF
--- a/src/character.h
+++ b/src/character.h
@@ -4140,6 +4140,14 @@ class Character : public Creature, public visitable
         /** warnings from a faction about bad behavior */
         mutable std::map<faction_id, std::pair<int, time_point>> warning_record;
         /**
+         * Throttling for body temperature change messages ("You feel your X getting warm.", etc).
+         * Key is the body part; value is the temperature tier last announced for that part and the
+         * time of that announcement. Used by update_bodytemp() to suppress message spam when a
+         * body part's temperature hovers around a threshold. Runtime only, not serialized.
+         */
+        std::map<bodypart_id, std::pair<int, time_point>> temp_message_record;
+
+        /**
          * Traits / mutations of the character. Key is the mutation id (it's also a valid
          * key into @ref mutation_data), the value describes the status of the mutation.
          * If there is not entry for a mutation, the character does not have it. If the map

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -761,32 +761,86 @@ void Character::update_bodytemp()
 
         update_frostbite( bp, bp_windpower, warmth_per_bp );
 
-        // Warn the player if condition worsens
-        if( temp_before > BODYTEMP_FREEZING && temp_after < BODYTEMP_FREEZING ) {
-            //~ %s is bodypart
-            add_msg_if_player( m_warning, _( "You feel your %s beginning to go numb from the cold!" ),
-                               body_part_name( bp ) );
-        } else if( temp_before > BODYTEMP_VERY_COLD && temp_after < BODYTEMP_VERY_COLD ) {
-            //~ %s is bodypart
-            add_msg_if_player( m_warning, _( "You feel your %s getting very cold." ),
-                               body_part_name( bp ) );
-        } else if( temp_before > BODYTEMP_COLD && temp_after < BODYTEMP_COLD ) {
-            //~ %s is bodypart
-            add_msg_if_player( m_warning, _( "You feel your %s getting chilly." ),
-                               body_part_name( bp ) );
-        } else if( temp_before < BODYTEMP_SCORCHING && temp_after > BODYTEMP_SCORCHING ) {
-            //~ %s is bodypart
-            add_msg_if_player( m_bad, _( "You feel your %s getting red hot from the heat!" ),
-                               body_part_name( bp ) );
-        } else if( temp_before < BODYTEMP_VERY_HOT && temp_after > BODYTEMP_VERY_HOT ) {
-            //~ %s is bodypart
-            add_msg_if_player( m_warning, _( "You feel your %s getting very hot." ),
-                               body_part_name( bp ) );
-        } else if( temp_before < BODYTEMP_HOT && temp_after > BODYTEMP_HOT ) {
-            //~ %s is bodypart
-            add_msg_if_player( m_warning, _( "You feel your %s getting warm." ),
-                               body_part_name( bp ) );
+        // Warn the player if condition worsens.
+        // To avoid flooding the log when a body part's temperature hovers around a
+        // threshold, these messages are throttled: a message is shown if the body part
+        // reaches a dangerous tier (freezing / red hot), if it reaches a different tier
+        // than the one last announced for that part (a large or new change), or if enough
+        // time has passed since the last message for that part. See temp_message_record.
+        const auto temp_tier = []( const units::temperature & t ) -> int {
+            if( t < BODYTEMP_FREEZING )
+            {
+                return -3;
+            } else if( t < BODYTEMP_VERY_COLD )
+            {
+                return -2;
+            } else if( t < BODYTEMP_COLD )
+            {
+                return -1;
+            } else if( t > BODYTEMP_SCORCHING )
+            {
+                return 3;
+            } else if( t > BODYTEMP_VERY_HOT )
+            {
+                return 2;
+            } else if( t > BODYTEMP_HOT )
+            {
+                return 1;
+            }
+            return 0;
+        };
+
+        const int tier_before = temp_tier( temp_before );
+        const int tier_after = temp_tier( temp_after );
+        // Only warn when crossing a threshold in the worsening direction (further from comfort).
+        const bool worsening = ( tier_after > 0 && tier_after > tier_before ) ||
+                               ( tier_after < 0 && tier_after < tier_before );
+        if( worsening ) {
+            constexpr time_duration temp_message_cooldown = 5_minutes;
+            const auto rec = temp_message_record.find( bp );
+            const bool is_danger = tier_after <= -3 || tier_after >= 3;
+            const bool new_tier = rec == temp_message_record.end() || rec->second.first != tier_after;
+            const bool cooled_down = rec == temp_message_record.end() ||
+                                     calendar::turn - rec->second.second >= temp_message_cooldown;
+            if( is_danger || new_tier || cooled_down ) {
+                switch( tier_after ) {
+                    case -3:
+                        //~ %s is bodypart
+                        add_msg_if_player( m_warning, _( "You feel your %s beginning to go numb from the cold!" ),
+                                           body_part_name( bp ) );
+                        break;
+                    case -2:
+                        //~ %s is bodypart
+                        add_msg_if_player( m_warning, _( "You feel your %s getting very cold." ),
+                                           body_part_name( bp ) );
+                        break;
+                    case -1:
+                        //~ %s is bodypart
+                        add_msg_if_player( m_warning, _( "You feel your %s getting chilly." ),
+                                           body_part_name( bp ) );
+                        break;
+                    case 3:
+                        //~ %s is bodypart
+                        add_msg_if_player( m_bad, _( "You feel your %s getting red hot from the heat!" ),
+                                           body_part_name( bp ) );
+                        break;
+                    case 2:
+                        //~ %s is bodypart
+                        add_msg_if_player( m_warning, _( "You feel your %s getting very hot." ),
+                                           body_part_name( bp ) );
+                        break;
+                    case 1:
+                        //~ %s is bodypart
+                        add_msg_if_player( m_warning, _( "You feel your %s getting warm." ),
+                                           body_part_name( bp ) );
+                        break;
+                    default:
+                        break;
+                }
+                temp_message_record[bp] = std::make_pair( tier_after, calendar::turn );
+            }
         }
+
 
         // Note: Numbers are based off of BODYTEMP at the top of weather.h
         // If torso is BODYTEMP_COLD which is 34C, the early stages of hypothermia begin


### PR DESCRIPTION
## 概述

修复体温变化提示在温度于某个阈值附近反复抖动时疯狂刷屏的问题。

## 问题

`Character::update_bodytemp()` 在每个 tick 都会用 `temp_before` / `temp_after` 与各档阈值（COLD / VERY_COLD / FREEZING / HOT / VERY_HOT / SCORCHING）逐一对比，只要"穿过"阈值就 `add_msg`。当某个部位的温度恰好停在阈值附近来回抖动时，几乎每个 tick 都会输出一条"你感觉到你的 XX 变冷/变热"，把消息日志彻底淹没。

## 改动

将温度离散成"档位"，仅在**向更难受方向越档**时才考虑提示，并满足以下**任一**条件才真正输出消息：

1. **大幅变化**：跳到与上次给该部位提示不同的档位（新档位）。
2. **危险值**：红热（`BODYTEMP_SCORCHING`）/ 冻僵（`BODYTEMP_FREEZING`）等危险档**永远提示**，不会被节流静音。
3. **冷却时间**：非危险档的同档位重复提示，按**每个部位 5 分钟**冷却，冷却期内不再重复。

新增运行时缓存 `Character::temp_message_record`（`std::map<bodypart_id, std::pair<int, time_point>>`），记录每个部位上次提示的档位与时间。

- 纯运行时数据，**不写入存档**，无存档兼容性影响。
- 所有消息文案与翻译标记（`//~ %s is bodypart`）保持不变。

冷却时长由 `temp_message_cooldown`（当前 `5_minutes`）控制，后续如需调整可直接改该常量。

## 测试

- 单独编译 `obj/tiles/character_body.o` 通过（`-Werror` 全开，零警告零错误）。

## 涉及文件

- `src/character.h`：新增运行时缓存字段 `temp_message_record`。
- `src/character_body.cpp`：用分档 + 节流逻辑替换原有的阈值 if/else 判断。