### PR TITLE
更新今日消息与贡献者页面

### DIFF
--- a/data/credits/en.credits
+++ b/data/credits/en.credits
@@ -1,9 +1,16 @@
 # Lines longer than 78 characters will be wrapped automatically
 # The following line is for reference
 ##############################################################################
-(<color_cyan>0.I</color>):</color>
-<color_white>Original author:</color>    <color_white>Project Manager:</color>
-<color_yellow>Whales</color> (<color_dark_gray>retired</color>)    <color_yellow>KevinGranade</color>
+(<color_cyan>0.Aa</color>):</color>
+<color_white>Original author:</color>    <color_white>Original Project Manager:</color>    <color_white>Project Manager:</color>
+<color_yellow>Whales</color> (<color_dark_gray>retired</color>)    <color_yellow>KevinGranade</color>                 <color_yellow>g1ytx</color>
+
+<color_white>Founders:</color>
+<color_yellow>滑稽摸鱼Na--喵</color> (<color_cyan>lapp2333xhj</color>)
+<color_yellow>g1ytx</color> (<color_cyan>LYHGLYTX</color>)
+<color_yellow>滴哒</color> (<color_cyan>EliadOArias</color>)
+<color_yellow>幽月琉璃</color> (<color_cyan>LunaGlaze</color>)
+<color_yellow>byiyuebai</color> (<color_cyan>byjbaiyue</color>)
 
 <color_white>Special thanks to:</color>
 <color_yellow>Standing-Storm</color> - Creator and maintainer of the enormous 'Mind over Matter' mod and numerous contributions to other mods (fair folk and espers and wizards, oh my!)
@@ -30,11 +37,12 @@
 <color_yellow>gettingusedto</color> - MSX+ heavyweight and all around nice guy. We've gotten used to (heh) seeing them around!
 
 <color_white>For a full list of contributors please see:</color>
+<color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
 <color_cyan>https://github.com/CleverRaven/Cataclysm-DDA/contributors</color>
 <color_cyan>https://github.com/I-am-Erk/CDDA-Tilesets/graphs/contributors</color>
 <color_cyan>https://github.com/pixel-32/CDDA-tileset/graphs/contributors</color>
 
-<color_light_cyan>Cataclysm</color>: <color_light_blue>Dark Days Ahead</color> is released under <color_white>CC-BY-SA 3.0</color>:
+<color_light_cyan>Cataclysm</color>: <color_light_blue>Cleanwater Bomb</color> is released under <color_white>CC-BY-SA 3.0</color>:
 <color_cyan>https://creativecommons.org/licenses/by-sa/3.0/</color>
 
 

--- a/data/credits/zh_CN.credits
+++ b/data/credits/zh_CN.credits
@@ -1,11 +1,18 @@
 # 超过78个字符的段落将自动换行
 # 下面这行这么长
 ##############################################################################
-(<color_cyan>0.I</color>):</color>
-<color_white>原作者：</color>           <color_white>项目主管：</color>
-<color_yellow>Whales</color>（<color_dark_gray>不再参与</color>） <color_yellow>KevinGranade</color>
+(<color_cyan>0.Aa</color>):</color>
+<color_white>原作者：</color>           <color_white>原项目主管：           </color><color_white>项目主管：</color>
+<color_yellow>Whales</color>（<color_dark_gray>不再参与</color>） <color_yellow>KevinGranade</color>   <color_yellow>g1ytx</color>
 
-<color_white>特别感谢：</color>
+<color_white>项目创始人：</color>
+<color_yellow>滑稽摸鱼Na--喵</color>（<color_cyan>lapp2333xhj</color>）
+<color_yellow>g1ytx</color>（<color_cyan>LYHGLYTX</color>）
+<color_yellow>滴哒</color>（<color_cyan>EliadOArias</color>）
+<color_yellow>幽月琉璃</color>（<color_cyan>LunaGlaze</color>）
+<color_yellow>byiyuebai</color>（<color_cyan>byjbaiyue</color>）
+
+<color_white>原项目特别感谢：</color>
 <color_yellow>Standing-Storm</color> - 大型Mod 'Mind over Matter' 的创建者和维护者以及其他几个Mod的有力贡献者（平民、超能力者和巫师，哦我的天！）
 <color_yellow>Maleclypse</color> - Xedra Evolved的维护者和整合者，在这个发布周期整合了超过2000（是千！）个整合内容。
 <color_yellow>GuardianDll</color> - 整合，非特定json和c++改动，记录与引用所有人都需要的文件。  “我不记得我发布过这么多PR呀，什么鬼？” - GuardianDll
@@ -30,11 +37,12 @@
 <color_yellow>gettingusedto</color> - MSX + 大量代码，到处都是好人。我们已经习惯了 (嘿嘿) 看到他们在周围！
 
 <color_white>完整贡献者列表请见：</color>
+<color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
 <color_cyan>https://github.com/CleverRaven/Cataclysm-DDA/contributors</color>
 <color_cyan>https://github.com/I-am-Erk/CDDA-Tilesets/graphs/contributors</color>
 <color_cyan>https://github.com/pixel-32/CDDA-tileset/graphs/contributors</color>
 
-《<color_light_cyan>大灾变</color>：<color_light_blue>劫后余生</color>》按 <color_white>CC-BY-SA 3.0</color> 授权协议发布：
+《<color_light_cyan>大灾变</color>：<color_light_blue>净化协议</color>》按 <color_white>CC-BY-SA 3.0</color> 授权协议发布：
 <color_cyan>https://creativecommons.org/licenses/by-sa/3.0/</color>
 
 

--- a/data/motd/ar.motd
+++ b/data/motd/ar.motd
@@ -3,18 +3,16 @@
 ##############################################################################
 <color_white>زورونا:</color>
 
-<color_light_gray>* الصفحة الرئيسية:</color>  <color_cyan> https://cataclysmdda.org</color>
+<color_light_gray>* الصفحة الرئيسية:</color>  <color_cyan> https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>البلاغ عن الأخطاء وإرسال الاقتراحات ومتابعة التطوير على:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CleverRaven/Cataclysm-DDA/issues</color>
-<color_light_gray>* البريد الاكتروني: </color> <color_light_cyan>kevin.granade@gmail.com</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* البريد الاكتروني: </color> <color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>انضم إلى المناقشة في المنتديات والدردشات على:</color>
 
-<color_light_gray>* Discourse:                 </color><color_cyan>https://discourse.cataclysmdda.org/</color>
-<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/jFEc7Yp</color>
-<color_light_gray>* IRC:                       </color><color_cyan>#CataclysmDDA at libera.chat</color>
+<color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
 
 <color_light_gray>تتوفر روابط مفيدة أخرى على صفحتنا الرئيسية.</color>
 

--- a/data/motd/cs.motd
+++ b/data/motd/cs.motd
@@ -3,18 +3,16 @@
 ##############################################################################
 <color_white>Navštivte nás na:</color>
 
-<color_light_gray>*Domovská stránka:</color>    <color_cyan>https://cataclysmdda.org</color>
+<color_light_gray>*Domovská stránka:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Hlaste případné chyby, sdělte své návrhy a sledujte vývoj hry na stránkách:</color>
 
-<color_light_gray>* Github:</color><color_light_cyan>https://github.com/CleverRaven/Cataclysm-DDA/issues</color>
-<color_light_gray>* e-mail:</color><color_light_cyan>kevin.granade@gmail.com</color>
+<color_light_gray>* Github:</color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* e-mail:</color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Připojte se k diskuzi na fórech a chatech:</color>
 
-<color_light_gray>* Discourse:                 </color> <color_cyan>https://discourse.cataclysmdda.org/</color>
-<color_light_gray>* Discord: </color><color_cyan>https://discord.gg/jFEc7Yp</color>
-<color_light_gray>* IRC:                       </color><color_cyan>#CataclysmDDA at libera.chat</color>
+<color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
 
 <color_light_gray>Další užitečné odkazy jsou dostupné na Domovské stránke</color>
 

--- a/data/motd/de.motd
+++ b/data/motd/de.motd
@@ -3,18 +3,16 @@
 ##############################################################################
 <color_white>Besuche uns:</color>
 
-<color_light_gray>* Homepage:</color>    <color_cyan>https://cataclysmdda.org</color>
+<color_light_gray>* Homepage:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Melde Fehler, mache Vorschläge und folgen der Entwicklung unter:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CleverRaven/Cataclysm-DDA/issues</color>
-<color_light_gray>* E-Mail: </color><color_light_cyan>kevin.granade@gmail.com</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* E-Mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Nimm an den Diskussionen in Foren und Chats teil:</color>
 
-<color_light_gray>* Discourse:                 </color><color_cyan>https://discourse.cataclysmdda.org/</color>
-<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/jFEc7Yp</color>
-<color_light_gray>* IRC:                       </color><color_cyan>#CataclysmDDA at libera.chat4</color>
+<color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
 
 <color_light_gray>Weitere nützliche Links findest Du auch auf unserer Homepage.</color>
 

--- a/data/motd/el.motd
+++ b/data/motd/el.motd
@@ -3,18 +3,16 @@
 ##############################################################################
 <color_white>Επισκεφθείτε μας:</color>
 
-<color_light_gray>*Αρχική σελίδα:</color>    <color_cyan>https://cataclysmdda.org</color>
+<color_light_gray>*Αρχική σελίδα:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>* Αναφέρετε σφάλματα, προτάσεις και ακολουθήστε την ανάπτυξη στο:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CleverRaven/Cataclysm-DDA/issues</color>
-<color_light_gray>* e-mail: </color><color_light_cyan>kevin.granade@gmail.com</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Λάβετε μέρος στη συζήτηση στα φόρουμ και στα chats:</color>
 
-<color_light_gray>*Συζήτηση:                  </color><color_cyan>https://discourse.cataclysmdda.org/</color>
-<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/jFEc7Yp</color>
-<color_light_gray>* IRC:                       </color><color_cyan>#CataclysmDDA στο libera.chat</color>
+<color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
 
 <color_light_gray>Άλλοι χρήσιμοι σύνδεσμοι είναι επίσης διαθέσιμοι στην αρχική μας σελίδα.</color>
 

--- a/data/motd/en.motd
+++ b/data/motd/en.motd
@@ -3,18 +3,16 @@
 ##############################################################################
 <color_white>Visit us:</color>
 
-<color_light_gray>* Homepage:</color>    <color_cyan>https://cataclysmdda.org</color>
+<color_light_gray>* Homepage:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Report bugs, suggestion and follow the development at:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CleverRaven/Cataclysm-DDA/issues</color>
-<color_light_gray>* e-mail: </color><color_light_cyan>kevin.granade@gmail.com</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Join the discussion on forums and chats:</color>
 
-<color_light_gray>* Discourse:                 </color><color_cyan>https://discourse.cataclysmdda.org/</color>
-<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/jFEc7Yp</color>
-<color_light_gray>* IRC:                       </color><color_cyan>#CataclysmDDA at libera.chat</color>
+<color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
 
 <color_light_gray>Other useful links are also available at our Homepage.</color>
 

--- a/data/motd/es_AR.motd
+++ b/data/motd/es_AR.motd
@@ -3,18 +3,16 @@
 ##############################################################################
 <color_white>Visitanos:</color>
 
-<color_light_gray>* Página web:</color>    <color_cyan>https://cataclysmdda.org</color>
+<color_light_gray>* Página web:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Comentar bugs, sugerencias y ver el desarrollo del juego:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CleverRaven/Cataclysm-DDA/issues</color>
-<color_light_gray>* e-mail: </color><color_light_cyan>kevin.granade@gmail.com</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Vení a discutir en los foros y chats:</color>
 
-<color_light_gray>* Discourse:                 </color><color_cyan>https://discourse.cataclysmdda.org/</color>
-<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/jFEc7Yp</color>
-<color_light_gray>* IRC:                       </color><color_cyan>#CataclysmDDA en libera.chat</color>
+<color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
 
 <color_light_gray>En nuestra página web también hay otros links interesantes.</color>
 

--- a/data/motd/es_ES.motd
+++ b/data/motd/es_ES.motd
@@ -3,18 +3,16 @@
 ##############################################################################
 <color_white>Visitanos:</color>
 
-<color_light_gray>* Pagina principal:</color>    <color_cyan>https://cataclysmdda.org</color>
+<color_light_gray>* Pagina principal:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Informar de errores, sugerencias y seguir el desarrollo en: </color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CleverRaven/Cataclysm-DDA/issues</color>
-<color_light_gray>* e-mail: </color><color_light_cyan>kevin.granade@gmail.com</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Comunícate y habla en los foros y chats: </color>
 
-<color_light_gray>* Discourse:                 </color><color_cyan>https://discourse.cataclysmdda.org/</color>
-<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/jFEc7Yp</color>
-<color_light_gray>* IRC:                       </color><color_cyan>#CataclysmDDA en libera.chat</color>
+<color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
 
 <color_light_gray>Otros enlaces de utilidad están disponibles en nuestra Página principal. </color>
 

--- a/data/motd/fil_PH.motd
+++ b/data/motd/fil_PH.motd
@@ -3,18 +3,16 @@
 ##############################################################################
 <color_white>Bisitahin kami:</color>
 
-<color_light_gray>* Ang aming homepage:</color>    <color_cyan>https://cataclysmdda.org</color>
+<color_light_gray>* Ang aming homepage:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Mag-report ng bugs, suwestiyon at I-follow ang development sa:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CleverRaven/Cataclysm-DDA/issues</color>
-<color_light_gray>* e-mail: </color><color_light_cyan>kevin.granade@gmail.com</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Sundin ang aming diskusyon sa aming forums at chats:</color>
 
-<color_light_gray>* Discourse:                 </color><color_cyan>https://discourse.cataclysmdda.org/</color>
-<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/jFEc7Yp</color>
-<color_light_gray>* IRC:                       </color><color_cyan>#CataclysmDDA at libera.chat</color>
+<color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
 
 <color_light_gray>Mga iba pang links ay makikita rin sa aming homepage.</color>
 

--- a/data/motd/fr.motd
+++ b/data/motd/fr.motd
@@ -3,18 +3,16 @@
 ##############################################################################
 <color_white>Rendez-nous visite:</color>
 
-<color_light_gray>*Accueil:</color>    <color_cyan>https://cataclysmdda.org</color>
+<color_light_gray>*Accueil:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white> Signalez des bugs, faites des suggestions et suivez le développement du jeu sur : </color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CleverRaven/Cataclysm-DDA/issues</color>
-<color_light_gray>* e-mail: </color><color_light_cyan>kevin.granade@gmail.com</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Rejoignez la discussion sur les forums et chats:</color>
 
-<color_light_gray>* Discourse:                 </color><color_cyan>https://discourse.cataclysmdda.org/</color>
-<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/jFEc7Yp</color>
-<color_light_gray>* IRC:                       </color><color_cyan>#CataclysmDDA sur libera.chat</color>
+<color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
 
 <color_light_gray>D'autres liens utiles se trouvent sur notre page d'accueil.</color>
 

--- a/data/motd/ga_IE.motd
+++ b/data/motd/ga_IE.motd
@@ -3,18 +3,16 @@
 ##############################################################################
 <color_white>Tar ar cuairt chugainn:</color>
 
-<color_light_gray>* Leathanach baile:</color>    <color_cyan>https://cataclysmdda.org</color>
+<color_light_gray>* Leathanach baile:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Tuairiscigh fabhtanna, cuir moltaí isteach, agus lean forbairt ag:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CleverRaven/Cataclysm-DDA/issues</color>
-<color_light_gray>* R-phoist:</color><color_light_cyan>kevin.granade@gmail.com</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* R-phoist:</color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Bí sa chomhrá ar fóraim agus comhráite grúpaí:</color>
 
-<color_light_gray>* Discourse:                 </color><color_cyan>https://discourse.cataclysmdda.org/</color>
-<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/jFEc7Yp</color>
-<color_light_gray>* IRC:                       </color><color_cyan>#CataclysmDDA at libera.chat</color>
+<color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
 
 <color_light_gray>Tá naisc úsáideacha eile ar fáil ar ár leathanach baile.</color>
 

--- a/data/motd/hu.motd
+++ b/data/motd/hu.motd
@@ -3,18 +3,16 @@
 ##############################################################################
 <color_white>Rólunk:</color>
 
-<color_light_gray>* Honlap:</color>    <color_cyan>https://cataclysmdda.org</color>
+<color_light_gray>* Honlap:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Programhibák bejelentése, új ötletek és folyamatos fejlesztés:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CleverRaven/Cataclysm-DDA/issues</color>
-<color_light_gray>* e-mail: </color><color_light_cyan>kevin.granade@gmail.com</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Angol nyelvű fórumozás és chat:</color>
 
-<color_light_gray>* Discourse:                 </color><color_cyan>https://discourse.cataclysmdda.org/</color>
-<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/jFEc7Yp</color>
-<color_light_gray>* IRC:                       </color><color_cyan>#CataclysmDDA at libera.chat</color>
+<color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
 
 <color_light_gray>További hasznos hivatkozásokért lásd a honlapot.</color>
 

--- a/data/motd/id.motd
+++ b/data/motd/id.motd
@@ -3,18 +3,16 @@
 ##############################################################################
 <color_white>Kunjungi kami:</color>
 
-<color_light_gray>* Halaman depan:</color>    <color_cyan>https://cataclysmdda.org</color>
+<color_light_gray>* Halaman depan:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Laporkan bug, saran dan ikuti pengembangannya di:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CleverRaven/Cataclysm-DDA/issues</color>
-<color_light_gray>* e-mail: </color><color_light_cyan>kevin.granade@gmail.com</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Ikuti diskusi di forum dan chat:</color>
 
-<color_light_gray>* Discourse:                 </color><color_cyan>https://discourse.cataclysmdda.org/</color>
-<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/jFEc7Yp</color>
-<color_light_gray>* IRC:                       </color><color_cyan>#CataclysmDDA at libera.chat</color>
+<color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
 
 <color_light_gray>Link berguna lainnya juga tersedia di Halaman Depan kami.</color>
 

--- a/data/motd/it_IT.motd
+++ b/data/motd/it_IT.motd
@@ -3,18 +3,16 @@
 ##############################################################################
 <color_white>Visitaci:</color>
 
-<color_light_gray>* Homepage:</color>  <color_cyan>https://cataclysmdda.org</color>
+<color_light_gray>* Homepage:</color>  <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Segnala bug, suggerimenti e segui lo sviluppo su:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CleverRaven/Cataclysm-DDA/issues</color>
-<color_light_gray>* e-mail: </color><color_light_cyan>kevin.granade@gmail.com</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Unisciti alla discussione nei forum e nelle chat:</color>
 
-<color_light_gray>* Discourse:                 </color><color_cyan>https://discourse.cataclysmdda.org/</color>
-<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/jFEc7Yp</color>
-<color_light_gray>* IRC:                       </color><color_cyan>#CataclysmDDA su libera.chat</color>
+<color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
 
 <color_light_gray>Altri link utili sono disponibili sulla nostra Homepage.</color>
 

--- a/data/motd/ja.motd
+++ b/data/motd/ja.motd
@@ -3,18 +3,16 @@
 ##############################################################################
 <color_white>関連リンク:</color>
 
-<color_light_gray>* 公式サイト:</color>    <color_cyan>https://cataclysmdda.org</color>
+<color_light_gray>* 公式サイト:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>バグ報告、提案、開発状況の確認:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CleverRaven/Cataclysm-DDA/issues</color>
-<color_light_gray>* e-mail: </color><color_light_cyan>kevin.granade@gmail.com</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>議論やチャットへの参加:</color>
 
-<color_light_gray>* Discourse:                 </color><color_cyan>https://discourse.cataclysmdda.org/</color>
-<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/jFEc7Yp</color>
-<color_light_gray>* IRC:                       </color><color_cyan>libera.chat チャンネル名#CataclysmDDA</color>
+<color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
 
 <color_light_gray>その他の便利なリンクは公式サイトでご覧いただけます。</color>
 

--- a/data/motd/ko.motd
+++ b/data/motd/ko.motd
@@ -3,18 +3,16 @@
 ##############################################################################
 <color_white>방문하기:</color>
 
-<color_light_gray>* 홈페이지:</color>    <color_cyan>https://cataclysmdda.org</color>
+<color_light_gray>* 홈페이지:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>버그 보고, 기능 제안, 개발현황 확인:</color>
 
-<color_light_gray>* 깃허브: </color><color_light_cyan>https://github.com/CleverRaven/Cataclysm-DDA/issues</color>
-<color_light_gray>* 이메일: </color><color_light_cyan>kevin.granade@gmail.com</color>
+<color_light_gray>* 깃허브: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* 이메일: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>포럼과 챗에서 토론하기:</color>
 
-<color_light_gray>* 디스코스:                 </color><color_cyan>https://discourse.cataclysmdda.org/</color>
-<color_light_gray>* 디스코드:                   </color><color_cyan>https://discord.gg/jFEc7Yp</color>
-<color_light_gray>* IRC:                       </color><color_cyan>libera.chat 채널이름 #CataclysmDDA</color>
+<color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
 
 <color_light_gray>다른 유용한 링크들도 홈페이지에서 이용할 수 있습니다.</color>
 

--- a/data/motd/nb.motd
+++ b/data/motd/nb.motd
@@ -3,18 +3,16 @@
 ##############################################################################
 <color_white>Besøk oss:</color>
 
-<color_light_gray>*Hjemmeside:</color> <color_cyan>https://cataclysmdda.org</color>
+<color_light_gray>*Hjemmeside:</color> <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Rapporter feil, forslag og følg utviklingen ved:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CleverRaven/Cataclysm-DDA/issues</color>
-<color_light_gray>* e-mail: </color><color_light_cyan>kevin.granade@gmail.com</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Delta i diskusjonene på forum og chatter:</color>
 
-<color_light_gray>* Discourse:                 </color><color_cyan>https://discourse.cataclysmdda.org/</color>
-<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/jFEc7Yp</color>
-<color_light_gray>* IRC:                       </color><color_cyan>#CataclysmDDA at libera.chat</color>
+<color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
 
 <color_light_gray>Andre nyttige lenker er også tilgjengelige på hjemmesiden vår.</color>
 

--- a/data/motd/pl.motd
+++ b/data/motd/pl.motd
@@ -3,18 +3,16 @@
 ##############################################################################
 <color_white>Odwiedź nas:</color>
 
-<color_light_gray>* Strona domowa:</color>    <color_cyan>https://cataclysmdda.org</color>
+<color_light_gray>* Strona domowa:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Zgłaszaj błędy, sugestie i śledź rozwój gry na:</color>
 
-<color_light_gray>* GitHub: </color><color_light_cyan>https://github.com/CleverRaven/Cataclysm-DDA/issues</color>
-<color_light_gray>* e-mail: </color><color_light_cyan>kevin.granade@gmail.com</color>
+<color_light_gray>* GitHub: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Dołącz do dyskusji na forach i czatach:</color>
 
-<color_light_gray>* Discourse:                 </color><color_cyan>https://discourse.cataclysmdda.org/</color>
-<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/jFEc7Yp</color>
-<color_light_gray>* IRC:                       </color><color_cyan>#CataclysmDDA na libera.chat</color>
+<color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
 
 <color_light_gray>Inne użyteczne odnośniki są dostępne również na naszej stronie głównej.</color>
 

--- a/data/motd/pt_BR.motd
+++ b/data/motd/pt_BR.motd
@@ -3,18 +3,16 @@
 ##############################################################################
 <color_white>Nos visite:</color>
 
-<color_light_gray>* Homepage:</color>    <color_cyan>https://cataclysmdda.org</color>
+<color_light_gray>* Homepage:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Reporte bugs, sugestões e siga o desenvolvimento em: </color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CleverRaven/Cataclysm-DDA/issues</color>
-<color_light_gray>* e-mail: </color><color_light_cyan>kevin.granade@gmail.com</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Entre na discussão em fóruns e chats:</color>
 
-<color_light_gray>* Discourse:                 </color><color_cyan>https://discourse.cataclysmdda.org/</color>
-<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/jFEc7Yp</color>
-<color_light_gray>* IRC:                       </color><color_cyan>#CataclysmDDA no libera.chat</color>
+<color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
 
 <color_light_gray>Outros links úteis também estão disponíveis na nossa Homepage.</color>
 

--- a/data/motd/ru.motd
+++ b/data/motd/ru.motd
@@ -3,18 +3,16 @@
 ##############################################################################
 <color_white>Посетите нас:</color>
 
-<color_light_gray>* Официальный сайт:</color>    <color_cyan>https://cataclysmdda.org</color>
+<color_light_gray>* Официальный сайт:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Сообщайте о багах, выдвигайте предложения и следите за разработкой:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CleverRaven/Cataclysm-DDA/issues</color>
-<color_light_gray>* e-mail: </color><color_light_cyan>kevin.granade@gmail.com</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Присоединяйтесь к обсуждению на форумах и в чатах:</color>
 
-<color_light_gray>* Discourse:                 </color><color_cyan>https://discourse.cataclysmdda.org/</color>
-<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/jFEc7Yp</color>
-<color_light_gray>* IRC:                       </color><color_cyan>#CataclysmDDA at libera.chat</color>
+<color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
 
 <color_light_gray>Другие полезные ссылки можно найти на нашем сайте.</color>
 

--- a/data/motd/tr.motd
+++ b/data/motd/tr.motd
@@ -3,18 +3,16 @@
 ##############################################################################
 <color_white>Bizi ziyaret edin:</color>
 
-<color_light_gray>* Ana Sayfa:</color>    <color_cyan>https://cataclysmdda.org</color>
+<color_light_gray>* Ana Sayfa:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Hataları rapor etmek, öneride bulunmak ve gelişmeleri takip etmek için:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CleverRaven/Cataclysm-DDA/issues</color>
-<color_light_gray>* e-posta: </color><color_light_cyan>kevin.granade@gmail.com</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* e-posta: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Forumlara ve sohbetlere katılmak için:</color>
 
-<color_light_gray>* Discourse:                 </color><color_cyan>https://discourse.cataclysmdda.org/</color>
-<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/jFEc7Yp</color>
-<color_light_gray>* IRC:                       </color><color_cyan>libera.chat içinde #CataclysmDDA</color>
+<color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
 
 <color_light_gray>Diğer kullanışlı linkler ana sayfamızdan bulunabilir.</color>
 

--- a/data/motd/uk_UA.motd
+++ b/data/motd/uk_UA.motd
@@ -3,18 +3,16 @@
 ##############################################################################
 <color_white>Відвідати нас:</color>
 
-<color_light_gray>* Домашня сторінка гри:</color>      <color_cyan>https://cataclysmdda.org</color>
+<color_light_gray>* Домашня сторінка гри:</color>      <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Повідомте про помилки, пропозиції та стежте за розробками на:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CleverRaven/Cataclysm-DDA/issues</color>
-<color_light_gray>* е-мейл: </color><color_light_cyan>kevin.granade@gmail.com</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* е-мейл: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Приєднуйтесь до розмов на форумах і чатах:</color>
 
-<color_light_gray>* Discourse:               </color> <color_cyan>https://discourse.cataclysmdda.org/</color>
-<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/jFEc7Yp</color>
-<color_light_gray>* IRC:                       </color><color_cyan>#CataclysmDDA at libera.chat</color>
+<color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
 
 <color_light_gray>Інші корисні посилання також доступні на нашій домашній сторінці.</color>
 

--- a/data/motd/zh_CN.motd
+++ b/data/motd/zh_CN.motd
@@ -3,18 +3,16 @@
 ##############################################################################
 <color_white>访问官网：</color>
 
-<color_light_gray>* 主页：</color><color_cyan>https://cataclysmdda.org</color>
+<color_light_gray>* 主页：</color><color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>报告BUG，提交建议及跟进开发进度：</color>
 
-<color_light_gray>* Github：</color><color_light_cyan>https://github.com/CleverRaven/Cataclysm-DDA/issues</color>
-<color_light_gray>* E-mail：</color><color_light_cyan>kevin.granade@gmail.com</color>
+<color_light_gray>* Github：</color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* E-mail：</color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>加入论坛及讨论组：</color>
 
-<color_light_gray>* 论坛            ：</color><color_cyan>https://discourse.cataclysmdda.org/</color>
-<color_light_gray>* 讨论组          ：</color><color_cyan>https://discord.gg/jFEc7Yp</color>
-<color_light_gray>* IRC             ：</color><color_cyan>#CataclysmDDA at libera.chat</color>
+<color_light_gray>* QQ群            ：</color><color_cyan>552610319</color>
 
 <color_light_gray>官网主页上还提供了其他有用的链接。</color>
 

--- a/data/motd/zh_TW.motd
+++ b/data/motd/zh_TW.motd
@@ -3,18 +3,16 @@
 ##############################################################################
 <color_white>造訪我們</color>
 
-<color_light_gray>* 官網：</color>    <color_cyan>https://cataclysmdda.org</color>
+<color_light_gray>* 官網：</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>回報bug，提供建議與關注開發進度：</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CleverRaven/Cataclysm-DDA/issues</color>
-<color_light_gray>* e-mail: </color><color_light_cyan>kevin.granade@gmail.com</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>在論壇或聊天室討論：</color>
 
-<color_light_gray>* Discourse:                 </color><color_cyan>https://discourse.cataclysmdda.org/</color>
-<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/jFEc7Yp</color>
-<color_light_gray>* IRC:                       </color><color_cyan>#CataclysmDDA at irc.libera.chat</color>
+<color_light_gray>* QQ群            ：</color><color_cyan>552610319</color>
 
 <color_light_gray>我們的官網上還有其他有用的連結</color>
 


### PR DESCRIPTION
## 改动内容

### 今日消息（MOTD）
- 主页链接、Github issues 链接改为本项目仓库地址
- 联系邮箱改为 lyhxit@gmail.com
- 将原 Discourse / Discord / IRC 三行合并为一行 QQ 群（552610319）
- 以上改动覆盖全部 23 个语言文件（非中文用 `QQ Group:`，中文用 `QQ群：`）

### 贡献者（Credits，zh_CN 与 en 兜底）
- 保留原作者 Whales、原项目主管 KevinGranade
- 新增项目主管：g1ytx
- 新增「项目创始人」段：滑稽摸鱼Na--喵 (lapp2333xhj)、g1ytx (LYHGLYTX)、滴哒 (EliadOArias)、幽月琉璃 (LunaGlaze)、byiyuebai (byjbaiyue)
- 当前版本块：版本号改为 0.Aa；副标题改为「净化协议 / Cleanwater Bomb」；完整贡献者列表加入本项目仓库链接

## 备注
仅修改当前版本块的副标题与版本号，0.H 及更早历史发布块保留原始记录。所有颜色标签均成对闭合。