### PR TITLE
Performance "优化燃烧时 item::burn 的 UNBREAKABLE 检查，减少火灾场景卡顿"

### DIFF
--- a/src/flag.h
+++ b/src/flag.h
@@ -42,6 +42,7 @@ enum class hot_flag_bit : uint64_t {
     GIBBED             = 1ULL << 20,
     SKINNED            = 1ULL << 21,
     QUARTERED          = 1ULL << 22,
+    UNBREAKABLE        = 1ULL << 23,
 };
 
 // Returns the hot bit for f, or 0 if f is not in the hot set.

--- a/src/flag_hot_bits.cpp
+++ b/src/flag_hot_bits.cpp
@@ -77,5 +77,8 @@ uint64_t hot_bit_for( const flag_id &f ) noexcept
     if( f == flag_QUARTERED ) {
         return static_cast<uint64_t>( hot_flag_bit::QUARTERED );
     }
+    if( f == flag_UNBREAKABLE ) {
+        return static_cast<uint64_t>( hot_flag_bit::UNBREAKABLE );
+    }
     return 0;
 }

--- a/src/item_degrade.cpp
+++ b/src/item_degrade.cpp
@@ -1173,7 +1173,8 @@ float item::simulate_burn( fire_data &frd ) const
 
 bool item::burn( fire_data &frd )
 {
-    if( has_flag( flag_UNBREAKABLE ) ) {
+    constexpr uint64_t unbreakable_bit = static_cast<uint64_t>( hot_flag_bit::UNBREAKABLE );
+    if( combined_hot_flags() & unbreakable_bit ) {
         return false;
     }
     float burn_added = simulate_burn( frd );

--- a/tests/hot_flag_bits_test.cpp
+++ b/tests/hot_flag_bits_test.cpp
@@ -19,6 +19,7 @@ static constexpr uint64_t bit_fit = static_cast<uint64_t>( hot_flag_bit::FIT );
 static constexpr uint64_t bit_dirty = static_cast<uint64_t>( hot_flag_bit::DIRTY );
 static constexpr uint64_t bit_varsize = static_cast<uint64_t>( hot_flag_bit::VARSIZE );
 static constexpr uint64_t bit_diamond = static_cast<uint64_t>( hot_flag_bit::DIAMOND );
+static constexpr uint64_t bit_unbreakable = static_cast<uint64_t>( hot_flag_bit::UNBREAKABLE );
 
 TEST_CASE( "hot_flag_bits_set_unset_toggle_own_bits", "[item][flag]" )
 {
@@ -140,4 +141,25 @@ TEST_CASE( "hot_flag_bits_combined_view_agrees_with_public_has_flag", "[item][fl
     CHECK( it.has_flag( flag_DIAMOND ) == ( ( it.combined_hot_flags() & bit_diamond ) != 0 ) );
     CHECK( it.has_flag( flag_VARSIZE ) == ( ( it.combined_hot_flags() & bit_varsize ) != 0 ) );
     CHECK( it.has_flag( flag_DIRTY ) == ( ( it.combined_hot_flags() & bit_dirty ) != 0 ) );
+}
+
+// item::burn() short-circuits on flag_UNBREAKABLE via the hot-bit mask instead
+// of has_flag(); these guard that the fast path stays equivalent to has_flag().
+TEST_CASE( "hot_flag_bits_unbreakable_toggles_own_bit_and_matches_has_flag", "[item][flag]" )
+{
+    item it( itype_helmet_army );
+    REQUIRE( ( it.own_hot_flags() & bit_unbreakable ) == 0 );
+    REQUIRE( it.has_flag( flag_UNBREAKABLE ) ==
+             ( ( it.combined_hot_flags() & bit_unbreakable ) != 0 ) );
+
+    it.set_flag( flag_UNBREAKABLE );
+    CHECK( ( it.own_hot_flags() & bit_unbreakable ) == bit_unbreakable );
+    CHECK( it.has_flag( flag_UNBREAKABLE ) );
+    CHECK( it.has_flag( flag_UNBREAKABLE ) ==
+           ( ( it.combined_hot_flags() & bit_unbreakable ) != 0 ) );
+
+    it.unset_flag( flag_UNBREAKABLE );
+    CHECK( ( it.own_hot_flags() & bit_unbreakable ) == 0 );
+    CHECK( it.has_flag( flag_UNBREAKABLE ) ==
+           ( ( it.combined_hot_flags() & bit_unbreakable ) != 0 ) );
 }


### PR DESCRIPTION
#### 概述 (Summary)

Performance "优化燃烧时 item::burn 的 UNBREAKABLE 检查，减少火灾场景卡顿"

#### 改动目的 (Purpose of change)

**中文：**
火灾场景下 `item::burn()` 会对火场内每个物品逐回合反复调用。性能分析（sleepy profiler）显示，其耗时的约 80% 集中在函数开头的 `has_flag( flag_UNBREAKABLE )` 一行上：

| 调用 / Call | 占比 / Share |
|------|------|
| `item::has_flag` | 54.56% |
| `item::has_own_flag`（由上面的 has_flag 内部调用 / called from has_flag） | 25.26% |
| `item::simulate_burn`（真正的燃烧计算 / actual burn math） | 10.60% |
| `item_contents::heat_up` | 8.97% |

根因：`has_flag()` 每次调用都要做一次 `is_valid()` 校验，再依次查三个 `flat_set`（type / inherited / own）。而 `UNBREAKABLE` 是罕见 flag，绝大多数物品都没有，于是每次都把整条查找链走到底（这正是 `has_own_flag` 单独占 25% 的原因）。在火灾这种高频热路径上累积起来非常可观。

**English:**
During fires, `item::burn()` is called every turn for every item in the fire. Profiling (sleepy profiler) shows ~80% of its time is spent on the very first line, `has_flag( flag_UNBREAKABLE )`. Each `has_flag()` call runs an `is_valid()` check and then three `flat_set` lookups (type / inherited / own). Since `UNBREAKABLE` is a rare flag absent on almost every item, the full lookup chain runs to the end every time (which is why `has_own_flag` alone accounts for 25%). On a hot path like fire propagation this adds up significantly.

#### 解决方案描述 (Describe the solution)

**中文：**
代码库已有一套 O(1) 的 `hot_flag_bit` 位掩码机制（参见 `item::is_broken()` 的用法）。本 PR 将 `UNBREAKABLE` 纳入该机制：

- `flag.h`：`hot_flag_bit` 枚举新增 `UNBREAKABLE = 1ULL << 23`（64 位中目前用到第 24 位）。
- `flag_hot_bits.cpp`：`hot_bit_for()` 新增对应映射分支。
- `item_degrade.cpp`：`item::burn()` 开头的检查改为 `combined_hot_flags() & unbreakable_bit` 的一次按位与。

热路径上的检查从「`is_valid()` + 3 次 `flat_set` 查找」降为一次整型按位与，`has_own_flag` 那 25% 也随之消失。正确性方面，`combined_hot_flags()` 由 `type->hot_flag_bits`、`hot_flags_own`、`hot_flags_inherited` 三部分 OR 而成，三者分别在 `finalize_post`（所有类型 flag 装载完之后）、`set_flag`/`unset_flag`/`unset_flags`、`update_inherited_flags` 中通过 `hot_bit_for()` 累积维护。因此新增的 UNBREAKABLE 位无论来自物品类型、运行时设置还是从内容物继承，都能被正确反映，与原 `has_flag` 语义严格等价。该写法与既有的 `is_broken()` 完全同构。

**English:**
The codebase already has an O(1) `hot_flag_bit` bitmask mechanism (see `item::is_broken()`). This PR brings `UNBREAKABLE` into it:

- `flag.h`: add `UNBREAKABLE = 1ULL << 23` to the `hot_flag_bit` enum (24th of 64 bits in use).
- `flag_hot_bits.cpp`: add the corresponding mapping branch in `hot_bit_for()`.
- `item_degrade.cpp`: the check at the top of `item::burn()` becomes a single bitwise-and, `combined_hot_flags() & unbreakable_bit`.

The hot-path check drops from "`is_valid()` + 3 `flat_set` lookups" to one integer AND, and the 25% from `has_own_flag` disappears with it. For correctness, `combined_hot_flags()` is the OR of `type->hot_flag_bits`, `hot_flags_own`, and `hot_flags_inherited`, each maintained via `hot_bit_for()` in `finalize_post` (after all type flags are loaded), `set_flag`/`unset_flag`/`unset_flags`, and `update_inherited_flags` respectively. So the new UNBREAKABLE bit is reflected correctly whether the flag comes from the item type, runtime setting, or inheritance from contents — strictly equivalent to the original `has_flag`. The pattern is identical to the existing `is_broken()`.

#### 你考虑过的替代方案 (Describe alternatives you've considered)

**中文：**
- **把 fast-path 直接做进 `has_flag()` 本身**：能惠及所有调用点，但会让每次 `has_flag` 都先过一遍 `hot_bit_for()` 的分支链；对于不在热点集合里的常见 flag 反而是净增开销，有回归其它调用点的风险。故只改燃烧这一处已被 profiler 证实的热点，最小化影响面。
- **维持现状**：火灾时持续卡顿，不可取。

**English:**
- **Putting the fast path inside `has_flag()` itself**: would benefit every call site, but would force every `has_flag` call through the `hot_bit_for()` branch chain first — a net cost for the common non-hot flags and a regression risk elsewhere. So I limited the change to the one profiler-confirmed hotspot to minimize the blast radius.
- **Doing nothing**: leaves the persistent fire-time stutter, not acceptable.

#### 测试 (Testing)

**中文：**
- 在 `tests/hot_flag_bits_test.cpp` 新增用例 `hot_flag_bits_unbreakable_toggles_own_bit_and_matches_has_flag`，断言 `set_flag`/`unset_flag` 正确切换 own 位，并锁定 `has_flag( flag_UNBREAKABLE )` 与 `combined_hot_flags() & bit_unbreakable` 在各状态下严格一致——即本次改动依赖的等价不变量。
- 既有的 `hot_flag_bits_*` 测试（type 位、继承、convert、存档读写等）继续覆盖三类掩码来源的同步，未受影响。
- 行为为纯等价替换，预期不改变任何游戏内可观察行为，仅降低燃烧热路径开销。

**English:**
- Added `hot_flag_bits_unbreakable_toggles_own_bit_and_matches_has_flag` in `tests/hot_flag_bits_test.cpp`, asserting `set_flag`/`unset_flag` toggle the own bit correctly and pinning `has_flag( flag_UNBREAKABLE )` equal to `combined_hot_flags() & bit_unbreakable` across states — the equivalence invariant this change relies on.
- The existing `hot_flag_bits_*` tests (type bits, inheritance, convert, save/load) still cover synchronization of all three mask sources and are unaffected.
- This is a pure equivalent replacement; no observable in-game behavior should change, only the hot-path cost is reduced.

#### 补充说明 (Additional context)

改动共 4 文件（+28/-1），与现有 `hot_flag_bit` 基础设施同构，风险低。
4 files changed (+28/-1), isomorphic to the existing `hot_flag_bit` infrastructure, low risk.
