### PR TITLE
Performance "优化 simulate_burn 的液体相位检查，减少火灾场景卡顿"

### DIFF
--- a/src/item_degrade.cpp
+++ b/src/item_degrade.cpp
@@ -1145,8 +1145,13 @@ float item::simulate_burn( fire_data &frd ) const
     }
     const int mat_total = type->mat_portion_total == 0 ? 1 : type->mat_portion_total;
 
-    // Liquids that don't burn well smother fire well instead
-    if( made_of( phase_id::LIQUID ) && time_added < 200 ) {
+    // Liquids that don't burn well smother fire well instead.
+    // Compare current_phase directly instead of made_of( phase_id::LIQUID ):
+    // simulate_burn is a hot path (per-item, per-turn during fires) and this
+    // avoids an out-of-line call plus its is_null() check. current_phase is only
+    // ever set from type->phase, so a null item can never be LIQUID and this
+    // stays equivalent to made_of( phase_id::LIQUID ).
+    if( current_phase == phase_id::LIQUID && time_added < 200 ) {
         time_added -= rng( 400.0 * to_liter( vol ), 1200.0 * to_liter( vol ) );
     } else if( mats.size() > 1 ) {
         // Average the materials


### PR DESCRIPTION
#### 概述 (Summary)

Performance "优化 simulate_burn 的液体相位检查，减少火灾场景卡顿"

#### 改动目的 (Purpose of change)

**中文：**
火灾场景下 `item::simulate_burn()` 会对火场内每个物品逐回合反复调用。性能分析（sleepy profiler）显示其耗时高度集中在液体判断那一行 `made_of( phase_id::LIQUID )` 上：

| 调用 / Call | 占比 / Share |
|------|------|
| `item::made_of`（phase 重载，热点行 `return current_phase == phase;`） | 80.75% |
| `item::base_volume` | 14.73% |
| `material_type::burn_data` | 2.28% |
| `string_id<material_type>::obj` | 2.25% |

`current_phase` 只是一个普通的 `phase_id` 枚举成员，`current_phase == phase` 本身是一条比较指令，不可能真的耗时。真正的开销在于 `made_of( phase_id )` 是定义在 .cpp 中、**无法跨编译单元内联**的小函数：在这种每物品每回合的超热路径上，其「调用/返回开销 + 内联进去的 `is_null()` 函数体」被采样器累计并钉在了函数体内那条 `return` 语句上。

**English:**
During fires, `item::simulate_burn()` is called every turn for every item in the fire. Profiling (sleepy profiler) shows its time is heavily concentrated on the liquid check `made_of( phase_id::LIQUID )`:

| Call | Share |
|------|------|
| `item::made_of` (phase overload, hot line `return current_phase == phase;`) | 80.75% |
| `item::base_volume` | 14.73% |
| `material_type::burn_data` | 2.28% |
| `string_id<material_type>::obj` | 2.25% |

`current_phase` is just a plain `phase_id` enum member, so `current_phase == phase` is a single comparison and cannot genuinely be expensive. The real cost is that `made_of( phase_id )` is defined in a .cpp and **cannot be inlined across translation units**: on this per-item, per-turn hot path its call/return overhead plus the inlined `is_null()` body are what the sampler accumulates and pins onto the `return` line inside the function.

#### 解决方案描述 (Describe the solution)

**中文：**
在 `simulate_burn()` 内，将 `made_of( phase_id::LIQUID )` 替换为直接的成员比较 `current_phase == phase_id::LIQUID`，省去一次无法内联的函数调用及其内部的 `is_null()`。

等价性：`made_of(phase)` 的语义即 `is_null() ? false : current_phase == phase`，二者唯一可能出现差异的情形是「null 物品且 current_phase == LIQUID」。但 `current_phase` 在代码中**仅由 `type->phase` 赋值**（构造、convert、反序列化等路径），而 null 物品的类型相位不为 LIQUID，该情形不可能出现，因此改动与原逻辑严格等价。`simulate_burn` 是 `item` 的成员函数，可直接访问 `current_phase`。

**English:**
Inside `simulate_burn()`, replace `made_of( phase_id::LIQUID )` with a direct member comparison `current_phase == phase_id::LIQUID`, removing one non-inlinable call and its internal `is_null()`.

Equivalence: `made_of(phase)` means `is_null() ? false : current_phase == phase`. The only way the two could differ is "a null item whose current_phase == LIQUID". But `current_phase` is only ever assigned from `type->phase` (construction, convert, deserialization), and the null item's type phase is not LIQUID, so that case cannot occur — the change is strictly equivalent. `simulate_burn` is an `item` member function, so it can read `current_phase` directly.

#### 你考虑过的替代方案 (Describe alternatives you've considered)

**中文：**
- **把这些热点访问器（`is_null` / `made_of(phase)` / `base_volume`）改为头文件 inline，或开启 LTO**：能从根本上消除这一类「小函数调用」开销，但属于 build/架构层面的改动，影响面大、风险高，不适合放进这个聚焦的小 PR。
- **维持现状**：火灾时持续卡顿，不可取。

**English:**
- **Marking these hot accessors (`is_null` / `made_of(phase)` / `base_volume`) inline in the header, or enabling LTO**: this would address the whole class of tiny-call overhead at the root, but it is a build/architecture-level change with a large blast radius — out of scope for this focused PR.
- **Doing nothing**: leaves the persistent fire-time stutter, not acceptable.

#### 测试 (Testing)

**中文：**
- 本地编译并在火灾场景实测，simulate_burn 的卡顿明显改善，行为无可观察变化。
- 改动为纯等价替换，不改变任何燃烧结果，仅降低热路径开销。

**English:**
- Built locally and tested in a fire scenario; the simulate_burn stutter is noticeably improved with no observable behavior change.
- This is a pure equivalent replacement; it changes no burn results, only reduces the hot-path cost.

#### 补充说明 (Additional context)

本 PR 是燃烧热路径系列优化之一，与 #60（item::burn 的 UNBREAKABLE 检查热点位掩码）相互独立、互不冲突。
This PR is one of a series of burn hot-path optimizations; it is independent of and does not conflict with #60 (hot-bit mask for the UNBREAKABLE check in item::burn).