### PR TITLE
修复 item_rot() EOC math 函数的编译错误（#62 后续）

### DIFF
--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -1403,9 +1403,10 @@ double item_rot_eval(const_dialogue const &d, char scope, std::vector<diag_value
             double turns = to_turns<double>(rotting);
             return _time_in_unit(turns, unit_val.str(d));
         }
-        else if (format == "relative")
+        else
         {
-            return obj.get_relative_rot()
+            // format already validated to be "raw" or "relative" above
+            return obj.get_relative_rot();
         }
     }
     else
@@ -1414,7 +1415,7 @@ double item_rot_eval(const_dialogue const &d, char scope, std::vector<diag_value
     }
 }
 
-void item_rot_ass(double val, dialogue& d, char scope, std::vector << diag_value > const&/*params*/, diag_kwargs const& kwargs)
+void item_rot_ass(double val, dialogue& d, char scope, std::vector<diag_value> const &/*params*/, diag_kwargs const& kwargs)
 {
     item_location* it = d.actor(is_beta(scope))->get_item();
     if (it == nullptr) {


### PR DESCRIPTION
#### 概述 (Summary)

None

#### 改动目的 (Purpose of change)

#62 合并的 `item_rot()` EOC math 函数存在笔误，导致 `math_parser_diag.cpp` 无法编译，进而中断整个构建（并在 `dialogue_funcs` map 初始化、`item_pocket::is_type` 链接等处产生连锁的假错误）。本 PR 作为 #62 的后续修复，让其恢复正常编译。

#### 解决方案描述 (Describe the solution)

修复 `math_parser_diag.cpp` 中 `item_rot_eval` / `item_rot_ass` 的三处错误：

- `item_rot_ass` 的签名里 `std::vector << diag_value >` 多打了一个 `<`，被编译器当作缺少模板参数的 `std::vector`，一路连锁误解析直到 `dialogue_funcs` 映射的初始化列表。改回 `std::vector<diag_value>`。
- `item_rot_eval` 中 `return obj.get_relative_rot()` 缺少分号，已补上。
- `item_rot_eval` 存在不返回值的控制流路径；因为上方已校验 `format` 只能是 `"raw"` 或 `"relative"`，把 `"relative"` 分支改为单纯的 `else`，保证每条路径都有返回值。

#### 你考虑过的替代方案 (Describe alternatives you've considered)

无，均为单纯的编译错误修复。

#### 测试 (Testing)

`src/math_parser_diag.cpp` 现已通过单文件语法检查（g++ 15.2，`-std=c++17 -fsyntax-only`）。等待 CI 完整编译进一步验证。