### PR TITLE
Implement the deficiency effect of `vitamin.calcium`.

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -4319,6 +4319,52 @@
   },
   {
     "type": "effect_type",
+    "id": "hypocalcemia",
+    "name": [ "Hypocalcemia", "Weak bones", "Brittle bones" ],
+    "desc": [ "A lack of calcium in your diet will make your bones progressively weaker." ],
+    "apply_message": "Your bones are becoming more brittle.",
+    "remove_message": "Your bones regain their usual strength.",
+    "decay_messages": [
+      [ "Your calcium deficiency is nearly resolved.", "good" ],
+      [ "Your bones become stronger as your calcium deficiency improves.", "good" ]
+    ],
+    "max_intensity": 3,
+    "rating": "bad",
+    "base_mods": {
+      "str_mod": [ -1 ],
+      "speed_mod": [ -5 ],
+      "h_mod_min": [ -1 ],
+      "h_mod_min_val": [ 0 ],
+      "h_mod_chance": [ 900 ]
+    },
+    "scaling_mods": {
+      "str_mod": [ -1 ],
+      "dex_mod": [ -0.5 ],
+      "speed_mod": [ -10 ],
+      "h_mod_min_val": [ -50 ],
+      "h_mod_chance": [ -200 ]
+    },
+    "enchantments": [
+      {
+        "condition": "ALWAYS",
+        "incoming_damage_mod": [
+          {
+            "type": "bash",
+            "multiply": { "math": [ "min( (u_effect_intensity('hypocalcemia') * 0.1 ), 0.3)" ] }
+          }
+        ],
+        "values": [
+          {
+            "value": "CARRY_WEIGHT",
+            "multiply": { "math": [ "max( (-0.08 * u_effect_intensity('hypocalcemia') ), -0.24)" ] }
+          }
+        ]
+      }
+    ],
+    "blood_analysis_description": "Hypocalcemia"
+  },
+  {
+    "type": "effect_type",
     "id": "anemia",
     "name": [ "Early Iron Deficiency", "Iron Deficiency", "Acute Iron Deficiency" ],
     "desc": [

--- a/data/json/vitamin.json
+++ b/data/json/vitamin.json
@@ -4,6 +4,7 @@
     "type": "vitamin",
     "vit_type": "vitamin",
     "name": { "str": "Calcium" },
+    "deficiency": "hypocalcemia",
     "min": -48000,
     "max": 0,
     "//": [
@@ -11,7 +12,8 @@
       "1000mg for 19-50yr olds from https://ods.od.nih.gov/factsheets/calcium-HealthProfessional/#h2"
     ],
     "weight_per_unit": "10 mg 420 μg",
-    "rate": "15 m"
+    "rate": "15 m",
+    "disease": [ [ -19200, -22400 ], [ -22401, -25600 ], [ -25601, -48000 ] ]
   },
   {
     "id": "iron",


### PR DESCRIPTION
#### 概述 (Summary)

Add `hypocalcemia` and set specific effects to implement a deficiency penalty for `vitamin.calcium`.

#### 改动目的 (Purpose of change)

Calcium, Iron, and Vitamin C are currently the three main key nutritional components (vitamins) in Cataclysm for maintaining a healthy balance. However, the symptoms of Calcium deficiency do not seem to be effectively addressed. With the other two being correctly addressed, Calcium, listed alongside them, appears somewhat awkward.

The current plan is to trigger the deficiency penalty only after a very long period without any replenishment, serving as a long-term management goal. This approach is less likely to cause frustration in the early stages of the game, without making Calcium feel like a vestigial placeholder.

#### 解决方案描述 (Describe the solution)

Drawing from another fork CBN's implementation and academic literature, `effect_type.hypocalcemia` and its specific effects were defined.

| **Attribute**                | **Intensity 1** (Early) | **Intensity 2** (Moderate) | **Intensity 3** (Severe) |
| ---------------------------- | ---------------------- | ---------------------- | --------------------- |
| **Name**                     | Hypocalcemia           | Weak bones             | Brittle bones         |
| **Strength**                 | −1                     | −2                     | −3                    |
| **Dexterity**                | −0                     | −0(0.5)                | −1                    |
| **Speed**                    | −5                     | −15                    | −25                   |
| **Bash Damage Taken**        | +10%                   | +20%                   | +30%                  |
| **Carry Weight Capacity**    | -8%                    | -16%                   | -24%                  |
| **Health Mod Deterioration** | Very slow (0.11%/turn) | Slow (0.14%/turn)      | Moderate (0.20%/turn) |
| **Health Modifier Floor**    | 0                      | −50                    | −100                  |

The current design requires 200 days (2.2 seasons under default settings) without any `vitamin.calcium` supplementation to achieve the desired effect. Given that calcium tablets are not extremely difficult to obtain and are relatively easy to obtain through bone meal supplements in the game, players should be able to easily manage their vitamin levels.

#### 你考虑过的替代方案 (Describe alternatives you've considered)

 - Maintain missing state
 - Introduce a placeholder
 - Remove this vitamin

#### 测试 (Testing)

After opening the game and changing the calcium value to -20000, -25000, and -48000, the effects at each level are displayed correctly.

#### 补充说明 (Additional context)

Please refer to the following additional fork data or references:

**CBN Effect Reference:** https://github.com/cataclysmbn/Cataclysm-BN/blob/main/data/json/effects.json  
**CBN Vitamin Reference:** https://github.com/cataclysmbn/Cataclysm-BN/blob/main/data/json/vitamin.json  
**Osteomalacia Pathophysiology:** https://www.ncbi.nlm.nih.gov/books/NBK551616/  
**Hypocalcemia Clinical Manifestations:** https://www.ncbi.nlm.nih.gov/books/NBK279022/

Effects have been simplified and/or mitigated for balance within the game system.