### PR TITLE
Fix stackable charge item handling / 修复可堆叠 charges 物品处理

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2869,8 +2869,15 @@ void spellcasting_activity_actor::finish( player_activity &act, Character &who )
             if( spell_item_casting ) {
                 item *it = spell_item_casting.get_item();
                 if( it != nullptr && it->has_flag( flag_SINGLE_USE ) ) {
-                    who.i_rem( it );
-                    spell_item_casting = item_location::nowhere;
+                    // A stackable (count_by_charges) single-use item spends a
+                    // single unit per cast; removing the whole item object would
+                    // destroy the entire stack. Mirrors the firstaid fix.
+                    if( it->count_by_charges() && it->charges > 1 ) {
+                        it->charges -= 1;
+                    } else {
+                        who.i_rem( it );
+                        spell_item_casting = item_location::nowhere;
+                    }
                 } else if( it && !it->has_flag( flag_USE_PLAYER_ENERGY ) ) {
                     it->consume_tool_uses( 1, get_map(), who.pos_bub(), &who );
                 }
@@ -10398,7 +10405,14 @@ void firstaid_activity_actor::finish( player_activity &act, Character &who )
                            *used_tool, healed );
     std::list<item>used;
     if( used_tool->has_flag( flag_SINGLE_USE ) ) {
-        it.remove_item();
+        // A stackable (count_by_charges) single-use item, e.g. a cotton sheet,
+        // consumes a single unit from the stack per use. Removing the whole
+        // item_location here would destroy the entire stack instead of one.
+        if( used_tool->count_by_charges() && used_tool->charges > 1 ) {
+            used_tool->charges -= 1;
+        } else {
+            it.remove_item();
+        }
     } else if( used_tool->is_medication() ) {
         if( !it->count_by_charges() ||
             it->use_charges( it->typeId(), charges_consumed, used, it.pos_bub( here ) ) ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4494,7 +4494,14 @@ bool Character::invoke_item( item *used, const std::string &method, const tripoi
     actually_used->activation_consume( charges_used.value(), pt, this );
 
     if( actually_used->has_flag( flag_SINGLE_USE ) || actually_used->is_bionic() ) {
-        i_rem( actually_used );
+        // For a stackable (count_by_charges) single-use item, only one unit of
+        // the stack is spent per activation. Removing the whole item object
+        // would destroy the entire stack rather than the single item used.
+        if( actually_used->count_by_charges() && actually_used->charges > 1 ) {
+            actually_used->charges -= 1;
+        } else {
+            i_rem( actually_used );
+        }
         return true;
     }
 
@@ -4534,6 +4541,13 @@ bool Character::consume_charges( item &used, int qty )
     }
 
     if( used.is_tool() && !used.needs_charges_to_use() ) {
+        // A stackable (count_by_charges) tool consumes `qty` units from the
+        // stack per use; removing the whole item object here would destroy the
+        // entire stack instead. Mirror the comestible branch above.
+        if( used.count_by_charges() && used.charges > qty ) {
+            used.charges -= qty;
+            return false;
+        }
         if( has_item( used ) ) {
             i_rem( &used );
         } else {

--- a/src/item_degrade.cpp
+++ b/src/item_degrade.cpp
@@ -218,8 +218,8 @@ bool item::activation_success() const
 
 float item::damage_adjusted_melee_weapon_damage( float value, const damage_type_id &dt ) const
 {
-    if( type->count_by_charges() ) {
-    return value; // count by charges items don't have partial damage
+    if( max_damage() == 0 ) {
+    return value; // items without a damage range don't have partial damage
 }
 
 for( fault_id fault : faults ) {
@@ -238,16 +238,16 @@ for( fault_id fault : faults ) {
 
 float item::damage_adjusted_gun_damage( float value ) const
 {
-    if( type->count_by_charges() ) {
-    return value; // count by charges items don't have partial damage
+    if( max_damage() == 0 ) {
+    return value; // items without a damage range don't have partial damage
 }
 return value - 2 * std::max( 0, damage_level() - 1 );
 }
 
 float item::damage_adjusted_armor_resist( float value, const damage_type_id &dmg_type ) const
 {
-    if( type->count_by_charges() ) {
-    return value; // count by charges items don't have partial damage
+    if( max_damage() == 0 ) {
+    return value; // items without a damage range don't have partial damage
 }
 
 for( fault_id fault : faults ) {
@@ -859,7 +859,11 @@ bool item::mod_damage( int qty, const Character *holder )
     if( has_flag( flag_UNBREAKABLE ) ) {
         return false;
     }
-    if( count_by_charges() ) {
+    if( max_damage() == 0 ) {
+        // Items with no damage range (ammo, liquid/gas comestibles) lose units
+        // when damaged instead of accumulating damage. Stackable resources have
+        // a real damage range and fall through to the normal damage path below,
+        // so the whole stack shares a single damage value.
         charges -= std::min( type->stack_size * qty / itype::damage_scale, charges );
         return charges == 0; // return destroy = true if no charges
     } else {

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2350,6 +2350,16 @@ void Item_factory::check_definitions() const
             }
         }
 
+        // A stackable (count_by_charges) item is a single object representing the
+        // whole stack, so a container pocket would share one set of contents
+        // across every unit and duplicate them when the stack is split. Disallow
+        // the combination rather than supporting per-unit pocket contents.
+        if( type->is_stackable() && is_container( type ) ) {
+            msg += "is stackable and has a CONTAINER pocket; this duplicates pocket "
+                   "contents when the stack is split.  Remove the pocket or the "
+                   "\"stackable\" property.\n";
+        }
+
         if( !type->picture_id.is_empty() && !type->picture_id.is_valid() ) {
             msg +=  "item has unknown ascii_picture.";
         }

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -159,7 +159,9 @@ int itype::damage_level( int damage ) const
     if( damage == 0 ) {
         return 0;
     }
-    if( count_by_charges() ) {
+    // Items with no damage range (ammo, liquid/gas comestibles) have no
+    // meaningful damage level; also guards the division below.
+    if( damage_max() == 0 ) {
         return 5;
     }
     return std::clamp( 1 + 4 * damage / damage_max(), 0, 5 );

--- a/src/itype.h
+++ b/src/itype.h
@@ -1648,7 +1648,11 @@ struct itype {
 
 
         int damage_max() const {
-            return count_by_charges() ? 0 : damage_max_;
+            // count_by_charges items (ammo, liquid/gas comestibles) have no
+            // individual damage state. Stackable resources are the exception:
+            // they are count_by_charges for stacking purposes but still carry a
+            // real damage range (so they work as vehicle part bases, etc.).
+            return ( count_by_charges() && !stackable_ ) ? 0 : damage_max_;
         }
         /** Number of degradation increments before the item is destroyed */
         int degrade_increments() const {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -3805,19 +3805,31 @@ std::optional<int> iuse::rpgdie( Character *you, item *die, const tripoint_bub_m
     if( you->cant_do_mounted() ) {
         return std::nullopt;
     }
-    int num_sides = die->get_var( "die_num_sides", 0 );
+    // A stack of dice (count_by_charges) is a single item object; setting the
+    // side count on `die` directly would lock every die in the stack to the
+    // same value. Split the one die being rolled off an as-yet-undetermined
+    // stack so only it gets determined, leaving the rest free to roll later.
+    item split_die;
+    item *rolled = die;
+    if( die->get_var( "die_num_sides", 0 ) == 0 && die->count_by_charges() && die->charges > 1 ) {
+        split_die = die->split( 1 );
+        rolled = &split_die;
+    }
+    int num_sides = rolled->get_var( "die_num_sides", 0 );
     if( num_sides == 0 ) {
         const std::vector<int> sides_options = { 4, 6, 8, 10, 12, 20, 50 };
-        const int sides = sides_options[ rng( 0, sides_options.size() - 1 ) ];
-        num_sides = sides;
-        die->set_var( "die_num_sides", sides );
+        num_sides = sides_options[ rng( 0, sides_options.size() - 1 ) ];
+        rolled->set_var( "die_num_sides", num_sides );
     }
     const int roll = rng( 1, num_sides );
     //~ %1$d: roll number, %2$d: side number of a die, %3$s: die item name
     you->add_msg_if_player( pgettext( "dice", "You roll a %1$d on your %2$d sided %3$s" ), roll,
-                            num_sides, die->tname() );
+                            num_sides, rolled->tname() );
     if( roll == num_sides ) {
         add_msg( m_good, _( "Critical!" ) );
+    }
+    if( rolled == &split_die ) {
+        you->i_add_or_drop( split_die );
     }
     return roll;
 }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -3943,9 +3943,23 @@ int heal_actor::finish_using( Character &healer, Character &patient, item &it,
         // If the item is a tool, `make` it the new form
         // Otherwise it probably was consumed, so create a new one
         if( it.is_tool() ) {
-            it.convert( used_up_item_id, &healer );
-            for( const auto &flag : used_up_item_flags ) {
-                it.set_flag( flag );
+            if( it.count_by_charges() && it.charges > 1 ) {
+                // For a stackable (count_by_charges) tool, only the single unit
+                // that was used up takes the new (e.g. FILTHY) form. Converting
+                // and flagging `it` in place would contaminate the entire stack.
+                item used_up( it );
+                used_up.charges = 1;
+                used_up.convert( used_up_item_id, &healer );
+                for( const auto &flag : used_up_item_flags ) {
+                    used_up.set_flag( flag );
+                }
+                it.charges -= 1;
+                healer.i_add_or_drop( used_up );
+            } else {
+                it.convert( used_up_item_id, &healer );
+                for( const auto &flag : used_up_item_flags ) {
+                    it.set_flag( flag );
+                }
             }
         } else {
             item used_up( used_up_item_id, it.birthday() );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5733,7 +5733,9 @@ std::pair<item *, tripoint_bub_ms> map::_add_item_or_charges( const tripoint_bub
         return true;
     };
 
-    // Get how many copies of the item can fit in a tile
+    // Get how many copies of the item can fit in a tile. Only used for items
+    // that are not count_by_charges; charge-counted stacks are split by charges
+    // in a dedicated branch further down.
     auto how_many_copies_fit = [&]( const tripoint_bub_ms & e ) {
         return std::min( { copies_remaining,
                            obj.volume() == 0_ml ? INT_MAX : free_volume( e ) / obj.volume(),
@@ -5742,15 +5744,6 @@ std::pair<item *, tripoint_bub_ms> map::_add_item_or_charges( const tripoint_bub
 
     // Performs the actual insertion of the object onto the map
     auto place_item = [&]( const tripoint_bub_ms & tile, int &copies ) -> item& {
-        if( obj.count_by_charges() )
-        {
-            for( item &e : i_at( tile ) ) {
-                if( e.merge_charges( obj ) ) {
-                    return e;
-                }
-            }
-        }
-
         support_dirty( tile );
         return add_item( tile, obj, copies );
     };
@@ -5767,6 +5760,136 @@ std::pair<item *, tripoint_bub_ms> map::_add_item_or_charges( const tripoint_bub
     // If intended drop tile destroys the item then we don't attempt to overflow
     if( !valid_tile( pos ) ) {
         return { &null_item_reference(), tripoint_bub_ms::invalid };
+    }
+
+    // count_by_charges items are a single divisible stack. Treating the whole
+    // stack as one indivisible "copy" makes a stack larger than a tile's volume
+    // vanish, and dumping it all onto one tile overfills the tile past its limit.
+    // Instead split it across the target tile and, if needed, adjacent tiles by
+    // each tile's free volume, so a huge stack spreads into several normal
+    // stacks. Only when no reachable tile can hold the remainder do we overfill,
+    // as a last resort, so items are never silently destroyed.
+    if( obj.count_by_charges() ) {
+        // For charge-counted items, copies collapse into a single stack's charge
+        // count (N identical stacks on a tile would merge into one anyway).
+        const std::int64_t total_charges = static_cast<std::int64_t>( obj.charges ) *
+                                            std::max( copies_remaining, 1 );
+        obj.charges = static_cast<int>( std::min<std::int64_t>( total_charges, INT_MAX ) );
+
+        std::optional<std::pair<item *, tripoint_bub_ms>> charge_first_added;
+
+        auto drop_action_applies = []( const item & it ) {
+            return it.made_of( phase_id::LIQUID ) || !it.has_flag( flag_DROP_ACTION_ONLY_IF_LIQUID );
+        };
+
+        // Whether placing item it on tile e needs no new item slot (there is
+        // already a stack to merge into) or there is still room for a new stack.
+        auto room_for_stack = [&]( const tripoint_bub_ms & e, const item & stack_item ) {
+            for( item &it : i_at( e ) ) {
+                if( it.stacks_with( stack_item ) ) {
+                    return true;
+                }
+            }
+            return static_cast<int>( i_at( e ).size() ) < MAX_ITEM_IN_SQUARE;
+        };
+
+        // Place up to qty charges of obj on tile e, merging into an existing
+        // identical stack when possible. Runs drop actions on the per-tile slice
+        // so quantity-scaled effects and item mutations match what is inserted.
+        // Decrements obj.charges by the amount handled and records the first
+        // stack we touched.
+        auto place_charges = [&]( const tripoint_bub_ms & e, int qty ) {
+            if( qty < 1 ) {
+                return false;
+            }
+            item slice = obj;
+            slice.charges = qty;
+            if( drop_action_applies( slice ) && slice.on_drop( e, *this ) ) {
+                obj.charges -= qty;
+                return true;
+            }
+            if( !room_for_stack( e, slice ) ) {
+                return false;
+            }
+            item *placed = nullptr;
+            for( item &it : i_at( e ) ) {
+                if( it.merge_charges( slice ) ) {
+                    placed = &it;
+                    break;
+                }
+            }
+            if( placed == nullptr ) {
+                support_dirty( e );
+                int one = 1;
+                placed = &add_item( e, slice, one );
+            }
+            if( placed != nullptr && !placed->is_null() ) {
+                obj.charges -= qty;
+                if( !charge_first_added ) {
+                    charge_first_added = std::make_pair( placed, e );
+                }
+            }
+            return false;
+        };
+
+        // How many charges of obj fit in tile e's current free volume.
+        auto charges_that_fit = [&]( const tripoint_bub_ms & e ) {
+            const units::volume avail = std::max( free_volume( e ), 0_ml );
+            return std::min( obj.charges, obj.charges_per_volume( avail, true ) );
+        };
+
+        auto tile_accepts_items = [&]( const tripoint_bub_ms & e ) {
+            return !has_flag( ter_furn_flag::TFLAG_NOITEM, e ) ||
+                   ( has_flag( ter_furn_flag::TFLAG_LIQUIDCONT, e ) && obj.made_of( phase_id::LIQUID ) );
+        };
+
+        // Target tile first.
+        if( tile_accepts_items( pos ) ) {
+            if( room_for_stack( pos, obj ) ) {
+                if( place_charges( pos, charges_that_fit( pos ) ) ) {
+                    return { &null_item_reference(), tripoint_bub_ms::invalid };
+                }
+            }
+        }
+
+        // Spill the remainder across nearby tiles, each up to its free volume.
+        if( overflow && obj.charges > 0 ) {
+            const int max_dist = 2;
+            std::vector<tripoint_bub_ms> tiles = closest_points_first( pos, 1, max_dist );
+            const int max_path_length = 4 * max_dist;
+            const pathfinding_settings setting( {}, max_dist, max_path_length, 0, false, false, true, false,
+                                                false, false );
+            for( const tripoint_bub_ms &e : tiles ) {
+                if( obj.charges <= 0 ) {
+                    break;
+                }
+                if( !inbounds( e ) || !valid_tile( e ) ) {
+                    continue;
+                }
+                if( has_flag( ter_furn_flag::TFLAG_NOITEM, e ) ||
+                    has_flag( ter_furn_flag::TFLAG_SEALED, e ) ) {
+                    continue;
+                }
+                // must be a path to the target tile
+                if( route( pos, pathfinding_target::point( e ), setting ).empty() ) {
+                    continue;
+                }
+                if( room_for_stack( e, obj ) ) {
+                    if( place_charges( e, charges_that_fit( e ) ) ) {
+                        return charge_first_added ? charge_first_added.value() :
+                               std::make_pair( &null_item_reference(), tripoint_bub_ms::invalid );
+                    }
+                }
+            }
+        }
+
+        // If no reachable tile can hold the rest by volume, the leftover charges
+        // are intentionally dropped: every placed stack stays within its tile's
+        // volume limit (no overfilling), so the stack is effectively reduced to
+        // what the available tiles can legitimately hold.
+        copies_remaining = obj.charges > 0 ? std::max( copies_remaining, 1 ) : 0;
+        return charge_first_added ? charge_first_added.value() :
+               std::make_pair( &null_item_reference(), tripoint_bub_ms::invalid );
     }
 
     std::optional<std::pair<item *, tripoint_bub_ms>> first_added;

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -205,13 +205,16 @@ double vehicle_part::floating_leak_threshold() const
 
 double vehicle_part::damage_percent() const
 {
-    return static_cast<double>( damage() ) / max_damage();
+    const int dmg_max = max_damage();
+    return dmg_max > 0 ? static_cast<double>( damage() ) / dmg_max : 0.0;
 }
 
 /** parts are considered broken at zero health */
 bool vehicle_part::is_broken() const
 {
-    return base.damage() >= base.max_damage();
+    // A base item with no damage range (max_damage()==0) has no notion of being
+    // broken via damage; without this guard it would read as broken at 0 damage.
+    return base.max_damage() > 0 && base.damage() >= base.max_damage();
 }
 
 bool vehicle_part::is_cleaner_on() const


### PR DESCRIPTION
#### 概述 (Summary)
Bugfixes "修复按 charges 堆叠物品在消耗、损坏和掉落时的整堆误处理问题 / Fix whole-stack mishandling for charge-counted stackable items during use, damage, and dropping"

#### 改动目的 (Purpose of change)

中文：
部分 `count_by_charges()` 的可堆叠物品会用一个 `item` 对象表示整堆数量。此前若这些物品同时具有一次性使用、医疗用后产物、随机骰子变量、车辆部件基底或地图掉落溢出等行为，代码容易把整堆当作一个单体处理，导致一次使用删除整堆、整堆共享单个用后状态、大堆掉落时超体积或丢失，以及数量缩放的 `drop_action` 按错误数量触发。

English:
Some stackable `count_by_charges()` items represent the whole stack as a single `item` object. Several paths treated that object as one indivisible item, which could delete an entire stack on one use, apply used-up state to the whole stack, force random per-unit state to the whole stack, mishandle vehicle-part damage, or split large map drops while running quantity-scaled `drop_action`s against the wrong amount.

#### 解决方案描述 (Describe the solution)

中文：
- 一次性使用和无充能工具消耗现在只扣除实际使用的 charges，而不是移除整个堆叠对象。
- 医疗工具产生用后物品时，会拆出一个单位转换为用后状态，保留剩余干净堆叠。
- RPG 骰子在未确定面数且数量大于 1 时先拆出一个骰子，避免整堆共享同一个随机面数。
- `damage_max()` 现在允许 `stackable` 资源保留真实损坏范围，同时让无损坏范围物品继续按丢失 charges 处理损坏。
- 地图掉落按每格可用体积拆分 charge-counted 堆叠；每个 per-tile slice 先执行 `on_drop`，再把同一个 slice 合并或插入，保证 `DIRTY` 等状态和 `scale_qty` drop action 使用正确数量。
- 增加 JSON 校验，禁止 stackable item 带 container pocket，避免拆堆时复制 pocket 内容。

English:
- Single-use and no-charge tool consumption now subtract only the consumed charges instead of removing the whole stack object.
- Medical used-up tool results split off one unit before conversion, preserving the remaining clean stack.
- Undetermined RPG dice split one die before assigning a random side count, so the whole stack does not share one random result.
- `damage_max()` now lets `stackable` resources keep a real damage range while zero-damage-range items still lose charges when damaged.
- Map drops split charge-counted stacks by available tile volume; each per-tile slice runs `on_drop` before that same slice is merged or inserted, so mutations such as `DIRTY` and quantity-scaled drop actions use the correct amount.
- JSON validation now rejects stackable items with container pockets to avoid duplicating pocket contents when stacks are split.

#### 你考虑过的替代方案 (Describe alternatives you've considered)

中文：
考虑过继续把所有 `count_by_charges()` 物品视为无单体损坏状态，但这会让需要作为车辆部件基底的 stackable 资源无法正常表达损坏。也考虑过允许 stackable container pocket 并在拆堆时做 per-unit contents 迁移，但这会明显扩大改动面；当前选择是显式禁止这种数据组合。

English:
I considered keeping all `count_by_charges()` items damage-less, but that prevents stackable resources used as vehicle part bases from carrying meaningful damage. I also considered supporting stackable container pockets by migrating per-unit contents when splitting, but that would broaden the change substantially; this PR instead rejects that data combination explicitly.

#### 测试 (Testing)

中文：
- 已完成代码审阅，重点检查了 `map::_add_item_or_charges` 的 charge splitting、`on_drop` mutation 和 `scale_qty` drop action 数量路径。
- 未完成本地构建验证；之前启动的增量构建被中断。

English:
- Reviewed the changed code paths, especially `map::_add_item_or_charges` charge splitting, `on_drop` mutation, and quantity-scaled drop action handling.
- Local build verification was not completed; the earlier incremental build command was interrupted.

#### 补充说明 (Additional context)

中文：
这个 PR 聚焦于可堆叠 charge-counted item 的一致性处理，尤其是“一个 item 对象代表整堆”与“每次操作只影响一个或部分单位”之间的边界。

English:
This PR focuses on consistent handling for stackable charge-counted items, especially the boundary between “one item object represents the whole stack” and “one action affects only one unit or a subset of charges.”
