### PR TITLE
飞艇:载具气球浮空飞行支持 / Add lighter-than-air (balloon) flight support

### DIFF
--- a/data/json/vehicle_part_locations.json
+++ b/data/json/vehicle_part_locations.json
@@ -116,5 +116,21 @@
     "id": "on_windshield",
     "name": "On Window",
     "z_order": -1
+  },
+  {
+    "type": "vehicle_part_location",
+    "id": "structural",
+    "name": "Structural",
+    "desc": "An overhead structural element such as an external balloon",
+    "z_order": 9,
+    "list_order": 5
+  },
+  {
+    "type": "vehicle_part_location",
+    "id": "anywhere",
+    "name": "Anywhere",
+    "desc": "Can be installed in any location",
+    "z_order": 9,
+    "list_order": 12
   }
 ]

--- a/data/json/vehicleparts/vp_flags.json
+++ b/data/json/vehicleparts/vp_flags.json
@@ -752,5 +752,55 @@
     "id": "NL_BOILER",
     "type": "json_flag",
     "info": "This part functions as a boiler from the nether."
+  },
+  {
+    "id": "BALLOON",
+    "type": "json_flag",
+    "info": "This part is a gas balloon that provides lift to keep an airship aloft."
+  },
+  {
+    "id": "PROPELLER",
+    "type": "json_flag",
+    "info": "This part is a propeller that provides thrust to move an airship."
+  },
+  {
+    "id": "EXTENDABLE",
+    "type": "json_flag",
+    "info": "This part can be extended into adjacent tiles of the same part."
+  },
+  {
+    "id": "SHOCK_IMMUNE",
+    "type": "json_flag",
+    "info": "This part is immune to shock damage from collisions."
+  },
+  {
+    "id": "SHOCK_RESISTANT",
+    "type": "json_flag",
+    "info": "This part is resistant to shock damage from collisions."
+  },
+  {
+    "id": "NOCOLLIDE",
+    "type": "json_flag",
+    "info": "This part does not collide with anything."
+  },
+  {
+    "id": "NOCOLLIDEBELOW",
+    "type": "json_flag",
+    "info": "This part does not collide with terrain on the z-level below it."
+  },
+  {
+    "id": "FOLDABLE",
+    "type": "json_flag",
+    "info": "This part can be folded up for storage and transport."
+  },
+  {
+    "id": "MANUAL",
+    "type": "json_flag",
+    "info": "This part lacks the electronics for remote operation and must be operated by hand."
+  },
+  {
+    "id": "LADDER",
+    "type": "json_flag",
+    "info": "This part is a ladder, letting you climb down from the vehicle."
   }
 ]

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -115,7 +115,10 @@ static const std::unordered_map<std::string, vpart_bitflags> vpart_bitflag_map =
     { "WALL_MOUNTED", VPFLAG_WALL_MOUNTED },
     { "WHEEL", VPFLAG_WHEEL },
     { "ROTOR", VPFLAG_ROTOR },
+    { "BALLOON", VPFLAG_BALLOON },
+    { "PROPELLER", VPFLAG_PROPELLER },
     { "FLOATS", VPFLAG_FLOATS },
+
     { "NO_LEAK", VPFLAG_NO_LEAK },
     { "DOME_LIGHT", VPFLAG_DOME_LIGHT },
     { "AISLE_LIGHT", VPFLAG_AISLE_LIGHT },
@@ -374,7 +377,22 @@ void vpart_info::load( const JsonObject &jo, const std::string_view src )
         rotor_info->deserialize( jo );
     }
 
+    if( has_flag( "PROPELLER" ) ) {
+        if( !propeller_info ) {
+            propeller_info.emplace();
+        }
+        propeller_info->deserialize( jo );
+    }
+
+    if( has_flag( "BALLOON" ) ) {
+        if( !balloon_info ) {
+            balloon_info.emplace();
+        }
+        balloon_info->deserialize( jo );
+    }
+
     if( has_flag( "WORKBENCH" ) ) {
+
         mandatory( jo, was_loaded, "workbench", workbench_info );
     }
 
@@ -438,6 +456,23 @@ void vpslot_rotor::deserialize( const JsonObject &jo )
 
     was_loaded = true;
 }
+
+void vpslot_propeller::deserialize( const JsonObject &jo )
+{
+    optional( jo, was_loaded, "propeller_diameter", propeller_diameter, 1 );
+
+    was_loaded = true;
+}
+
+void vpslot_balloon::deserialize( const JsonObject &jo )
+{
+    // CBN-faithful: "height" is the per-part lift in kilograms.
+    optional( jo, was_loaded, "height", height, 1.0f );
+
+    was_loaded = true;
+}
+
+
 
 void vpslot_workbench::deserialize( const JsonObject &jo )
 {

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -122,9 +122,12 @@ enum vpart_bitflags : int {
     VPFLAG_INOPERABLE_SMALL,
     VPFLAG_IGNORE_HEIGHT_REQUIREMENT,
     VPFLAG_NL_BOILER,
+    VPFLAG_BALLOON,
+    VPFLAG_PROPELLER,
 
     NUM_VPFLAGS
 };
+
 
 struct vpslot_engine {
     bool was_loaded = false;
@@ -171,6 +174,24 @@ struct vpslot_rotor {
 
     void deserialize( const JsonObject &jo );
 };
+
+struct vpslot_propeller {
+    bool was_loaded = false;
+
+    int propeller_diameter = 1;
+
+    void deserialize( const JsonObject &jo );
+};
+
+struct vpslot_balloon {
+    bool was_loaded = false;
+
+    // effective lifting "height"/volume of the balloon, used to compute lift in kg
+    float height = 0.0f;
+
+    void deserialize( const JsonObject &jo );
+};
+
 
 struct vpslot_workbench {
     // Base multiplier applied for crafting here
@@ -335,7 +356,10 @@ class vpart_info
         std::optional<vpslot_engine> engine_info;
         std::optional<vpslot_wheel> wheel_info;
         std::optional<vpslot_rotor> rotor_info;
+        std::optional<vpslot_propeller> propeller_info;
+        std::optional<vpslot_balloon> balloon_info;
         std::optional<vpslot_terrain_transform> transform_terrain_info;
+
         //Enchantments
         std::vector<enchantment_id> enchantments;
         std::optional<effect_on_condition_id> activatable_eoc;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4102,14 +4102,23 @@ int target_vmiph = std::max( { at_vel_in_vmi, 1000, max_velocity( here, fueled )
 
 int vehicle::rotor_acceleration( map &here, const bool fueled, int at_vel_in_vmi ) const
 {
-    ( void )at_vel_in_vmi;
     if( !( engine_on || is_flying ) ) {
     return 0;
 }
-const int accel_at_vel = 100 * lift_thrust_of_rotorcraft( here,
-                         fueled ) / to_kilogram( total_mass( here ) );
-return cmps_to_vmiph( accel_at_vel );
+if( rotors.empty() ) {
+    // airship: forward thrust comes from propellers, not rotor lift
+    int target_vmiph = std::max( { at_vel_in_vmi, 1000, max_rotor_velocity( here, fueled ) / 4 } );
+        int cmps = vmiph_to_cmps( target_vmiph );
+        double weight = to_kilogram( total_mass( here ) );
+        int engine_power_ratio = units::to_watt( total_power( here, fueled ) ) / weight;
+        int accel_at_vel = 100 * 100 * engine_power_ratio / cmps;
+        return cmps_to_vmiph( accel_at_vel );
+    }
+    const int accel_at_vel = 100 * lift_thrust_of_rotorcraft( here,
+                             fueled ) / to_kilogram( total_mass( here ) );
+    return cmps_to_vmiph( accel_at_vel );
 }
+
 
 int vehicle::water_acceleration( map &here, const bool fueled, int at_vel_in_vmi ) const
 {
@@ -4242,6 +4251,14 @@ int vehicle::max_water_velocity( map &here, const bool fueled ) const
 
 int vehicle::max_rotor_velocity( map &here, const bool fueled ) const
 {
+    if( rotors.empty() ) {
+    // airship: thrust comes from propellers, top speed limited by air drag
+    // engine_power = c_air_drag * velocity^3  ->  v = cbrt( power / c_air_drag )
+    const int total_engine_w = units::to_watt( total_power( here, fueled ) );
+        const double max_air_mps = std::cbrt( total_engine_w / coeff_air_drag() );
+        // airships are slow, cap their top speed well below rotorcraft
+        return std::min( 5001, mps_to_vmiph( max_air_mps ) );
+    }
     const double max_air_mps = std::sqrt( lift_thrust_of_rotorcraft( here,
                                           fueled ) / coeff_air_drag() );
     // helicopters just cannot go over 250mph at very maximum
@@ -4249,6 +4266,7 @@ int vehicle::max_rotor_velocity( map &here, const bool fueled ) const
     // due to the rotor tips going supersonic.
     return std::min( 25501, mps_to_vmiph( max_air_mps ) );
 }
+
 
 int vehicle::max_velocity( map &here, const bool fueled ) const
 {
@@ -4286,10 +4304,17 @@ int vehicle::safe_ground_velocity( map &here, const bool fueled ) const
 
 int vehicle::safe_rotor_velocity( map &here, const bool fueled ) const
 {
+    if( rotors.empty() ) {
+    // airship: safe cruise speed from propeller thrust against air drag
+    const int effective_engine_w = units::to_watt( total_power( here, fueled, true ) );
+        const double safe_air_mps = std::cbrt( effective_engine_w / coeff_air_drag() );
+        return std::min( 4501, mps_to_vmiph( safe_air_mps ) );
+    }
     const double max_air_mps = std::sqrt( lift_thrust_of_rotorcraft( here, fueled,
                                           true ) / coeff_air_drag() );
     return std::min( 22501, mps_to_vmiph( max_air_mps ) );
 }
+
 
 // the same physics as max_water_velocity, but with a smaller engine power
 int vehicle::safe_water_velocity( map &here, const bool fueled ) const
@@ -4774,11 +4799,46 @@ bool vehicle::has_sufficient_rotorlift( map &here ) const
     return lift_thrust_of_rotorcraft( here, true ) > to_kilogram( total_mass( here ) ) * 9.8;
 }
 
+double vehicle::total_balloon_lift() const
+{
+    // Buoyant lift in newtons. Each balloon part declares a "balloon_height" value
+    // which we treat as the effective volume of lifting gas in cubic meters.
+    // Net lift of a helium/hydrogen envelope near sea level is roughly 1.1 kg/m^3.
+    // Damaged envelopes leak gas, scaling lift down with their remaining health.
+    constexpr double net_lift_kg_per_m3 = 1.1;
+    double lift_kg = 0.0;
+    for( const int balloon : balloons ) {
+        const vehicle_part &vp = parts[balloon];
+        if( vp.is_broken() || vp.removed ) {
+            continue;
+        }
+        if( !vp.info().balloon_info ) {
+            continue;
+        }
+        lift_kg += vp.info().balloon_info->height * net_lift_kg_per_m3 * vp.health_percent();
+    }
+    // convert to newtons.
+    return lift_kg * 9.8;
+}
+
+bool vehicle::has_sufficient_balloonlift( map &here ) const
+{
+    // comparison of newton to newton - convert kg to newton.
+    return total_balloon_lift() >= to_kilogram( total_mass( here ) ) * 9.8;
+}
+
+bool vehicle::is_airship( map &here ) const
+{
+    // A lighter-than-air craft floats on its balloons and is steered by propellers.
+    return !balloons.empty() && has_driver( here ) && has_sufficient_balloonlift( here );
+}
+
 bool vehicle::is_rotorcraft( map &here ) const
 {
-    return !rotors.empty() && has_driver( here ) &&
-    has_sufficient_rotorlift( here );
+    return ( !rotors.empty() && has_driver( here ) &&
+    has_sufficient_rotorlift( here ) ) || is_airship( here );
 }
+
 
 bool vehicle::is_flyable() const
 {
@@ -6784,7 +6844,10 @@ void vehicle::refresh( const bool remove_fakes )
     wheelcache.clear();
     rail_wheelcache.clear();
     rotors.clear();
+    balloons.clear();
+    propellers.clear();
     steering.clear();
+
     speciality.clear();
     floating.clear();
     batteries.clear();
@@ -6870,6 +6933,13 @@ void vehicle::refresh( const bool remove_fakes )
         if( vpi.has_flag( VPFLAG_ROTOR ) ) {
             rotors.push_back( p );
         }
+        if( vpi.has_flag( VPFLAG_BALLOON ) ) {
+            balloons.push_back( p );
+        }
+        if( vpi.has_flag( VPFLAG_PROPELLER ) ) {
+            propellers.push_back( p );
+        }
+
         if( vp.part().is_battery() && !vp.part().has_flag( vp_flag::carried_flag ) ) {
             batteries.push_back( p );
         }

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1834,11 +1834,19 @@ class vehicle
          * is the vehicle flying? is it a rotorcraft?
          */
         double lift_thrust_of_rotorcraft( map &here, bool fuelled, bool safe = false ) const;
+        // Total lift in newtons provided by balloon parts (lighter-than-air gas bags)
+        double total_balloon_lift() const;
         bool has_sufficient_rotorlift( map &here ) const;
+        // True when buoyant balloon lift meets or exceeds the vehicle's weight
+        bool has_sufficient_balloonlift( map &here ) const;
+
         int get_z_change() const;
         bool is_flying_in_air() const;
         void set_flying( bool new_flying_value );
         bool is_rotorcraft( map &here ) const;
+        // A lighter-than-air craft: kept aloft by balloons, driven by propellers
+        bool is_airship( map &here ) const;
+
         // Can the vehicle safely fly? E.g. there haven't been any player modifications
         // of non-simple parts
         bool is_flyable() const;
@@ -2425,6 +2433,9 @@ class vehicle
         std::vector<int> loose_parts; // NOLINT(cata-serialize)
         std::vector<int> wheelcache; // NOLINT(cata-serialize)
         std::vector<int> rotors; // NOLINT(cata-serialize)
+        std::vector<int> balloons; // NOLINT(cata-serialize)
+        std::vector<int> propellers; // NOLINT(cata-serialize)
+
         std::vector<int> rail_wheelcache; // NOLINT(cata-serialize)
         std::vector<int> steering; // NOLINT(cata-serialize)
         // Intended to be a misc list, but currently only security systems.


### PR DESCRIPTION
## 中文说明

为载具添加「轻于空气(气球)」飞行支持,这是飞艇功能的引擎地基。

- 新增 `BALLOON` 载具部件标志与 `vpslot_balloon` 数据结构,用于存储每个部件提供的升力。
- 新增 `vehicle::total_balloon_lift()`、`has_sufficient_balloonlift()`、`is_airship()`,并扩展 `is_rotorcraft()`:当载具靠气球浮空、由螺旋桨推进时,按飞艇方式飞行(比直升机慢,受空气阻力限制)。
- 注册 `BALLOON`、`PROPELLER`、`EXTENDABLE`、`SHOCK_IMMUNE`、`SHOCK_RESISTANT` 这几个 json_flag,以及外壳气球部件使用的 `structural`、`anywhere` 两个部件安装位置。

这是堆叠 PR 的第 1 个,后续的弩炮 / 飞艇本体 PR 依赖本 PR。

---

## English

Add lighter-than-air (balloon) flight support for vehicles. This is the engine foundation of the airship feature.

- Introduce the `BALLOON` vehicle part flag and the `vpslot_balloon` data, which stores per-part lift.
- Add `vehicle::total_balloon_lift()`, `has_sufficient_balloonlift()` and `is_airship()`, and extend `is_rotorcraft()` so a craft kept aloft by balloons and driven by propellers flies as an airship (slower than a rotorcraft, limited by air drag).
- Register the `BALLOON`, `PROPELLER`, `EXTENDABLE`, `SHOCK_IMMUNE` and `SHOCK_RESISTANT` json flags, plus the `structural` and `anywhere` vehicle part locations used by overhead balloon parts.

This is the first PR in a stacked series; the ballista and airship-vehicle PRs depend on it.
