### PR TITLE
飞艇:飞艇驾驶熟练度 / Add airship pilot proficiency

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -2613,7 +2613,7 @@
     "npc_background": "BG_survival_story_WORKER_COMMERCIAL",
     "points": 4,
     "skills": [ { "level": 6, "name": "driving" }, { "level": 3, "name": "mechanics" }, { "level": 2, "name": "speech" } ],
-    "proficiencies": [ "prof_helicopter_pilot" ],
+    "proficiencies": [ "prof_helicopter_pilot", "prof_airship_pilot" ],
     "items": {
       "both": {
         "entries": [

--- a/data/json/proficiencies/vehicles.json
+++ b/data/json/proficiencies/vehicles.json
@@ -4,8 +4,24 @@
     "id": "prof_helicopter_pilot",
     "category": "prof_vehicles",
     "name": { "str": "Helicopter Piloting" },
-    "description": "Before the Cataclysm, you were a helicopter pilot.  Now, you just hope you can fly again.",
-    "can_learn": false
+    "description": "Before the Cataclysm, you were a helicopter pilot.  Now, you just hope you can fly again.  With enough study and practice, the controls of a rotorcraft can be mastered from scratch.",
+    "can_learn": true,
+    "time_to_learn": "12 h",
+    "default_time_multiplier": 2.0,
+    "default_skill_penalty": 0.25,
+    "ignore_focus": true
+  },
+  {
+    "type": "proficiency",
+    "id": "prof_airship_pilot",
+    "category": "prof_vehicles",
+    "name": { "str": "Airship Piloting" },
+    "description": "You understand how to manage the buoyancy of a lighter-than-air craft and steer it with propellers.  Slower and more forgiving than a helicopter, but the principles still take study to master.",
+    "can_learn": true,
+    "time_to_learn": "10 h",
+    "default_time_multiplier": 2.0,
+    "default_skill_penalty": 0.25,
+    "ignore_focus": true
   },
   {
     "type": "proficiency",


### PR DESCRIPTION
## 中文说明

新增飞艇驾驶熟练度。

- 新增 `prof_airship_pilot`(飞艇驾驶)熟练度:理解轻于空气载具的浮力管理与螺旋桨操控,比直升机更慢但更容易上手,仍需学习掌握。
- 将 `prof_helicopter_pilot`(直升机驾驶)改为可后天学习(`can_learn: true`)。
- 为相关职业授予飞艇驾驶熟练度。

本 PR 独立于其它飞艇 PR,可随时单独合并。

---

## English

Add the airship piloting proficiency.

- Add `prof_airship_pilot`: understanding buoyancy management of a lighter-than-air craft and steering it with propellers — slower and more forgiving than a helicopter, but still takes study to master.
- Make `prof_helicopter_pilot` learnable (`can_learn: true`).
- Grant the airship piloting proficiency to relevant professions.

This PR is independent of the other airship PRs and can be merged on its own.
