### PR TITLE
Adjust or remove attribute limits

### DIFF
--- a/data/core/external_options.json
+++ b/data/core/external_options.json
@@ -25,28 +25,28 @@
     "name": "PLAYER_MAX_STR_VALUE",
     "//": "Sets a cap on maximum effective strength for characters.",
     "stype": "int",
-    "value": 20
+    "value": 30
   },
   {
     "type": "EXTERNAL_OPTION",
     "name": "PLAYER_MAX_DEX_VALUE",
     "//": "Sets a cap on maximum effective dexterity for characters.",
     "stype": "int",
-    "value": 20
+    "value": 30
   },
   {
     "type": "EXTERNAL_OPTION",
     "name": "PLAYER_MAX_PER_VALUE",
     "//": "Sets a cap on maximum effective perception for characters.",
     "stype": "int",
-    "value": 20
+    "value": 30
   },
   {
     "type": "EXTERNAL_OPTION",
     "name": "PLAYER_MAX_INT_VALUE",
     "//": "Sets a cap on maximum effective intelligence for characters.",
     "stype": "int",
-    "value": 20
+    "value": 30
   },
   {
     "type": "EXTERNAL_OPTION",

--- a/data/mods/PLAYER_MAX_ATTR_VALUE/modinfo.json
+++ b/data/mods/PLAYER_MAX_ATTR_VALUE/modinfo.json
@@ -1,0 +1,39 @@
+[
+  {
+    "type": "MOD_INFO",
+    "id": "PLAYER_MAX_ATTR_VALUE",
+    "name": "Remove attribute limits",
+    "authors": [ "LunaGlaze" ],
+    "description": "This mod adjusts the player's attribute cap to `int.max-2`, effectively removing the attribute cap restriction. This mod needs to be placed at the bottom of the sorted list for it to work correctly.",
+    "category": "rebalance",
+    "dependencies": [ "dda" ]
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "PLAYER_MAX_STR_VALUE",
+    "//": "Sets a cap on maximum effective strength for characters.",
+    "stype": "int",
+    "value": 2147483645
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "PLAYER_MAX_DEX_VALUE",
+    "//": "Sets a cap on maximum effective dexterity for characters.",
+    "stype": "int",
+    "value": 2147483645
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "PLAYER_MAX_PER_VALUE",
+    "//": "Sets a cap on maximum effective perception for characters.",
+    "stype": "int",
+    "value": 2147483645
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "PLAYER_MAX_INT_VALUE",
+    "//": "Sets a cap on maximum effective intelligence for characters.",
+    "stype": "int",
+    "value": 2147483645
+  }
+]


### PR DESCRIPTION
#### 概述 (Summary)

Increase the default player attribute cap to 30 and add a mod to remove the cap.

#### 改动目的 (Purpose of change)

According to Cataclysm's lore, 20 is the attribute cap for native humans, not an insurmountable limit for cybernetic cyborgs and mutants.

Based on our surveys and interviews, a significant number of players are dissatisfied with this setting, even though some built-in mods in the game's inventory increase this value. After all, the CBM and mutation systems are already present in the pure version that only loads the core.

#### 解决方案描述 (Describe the solution)

Some mods (such as MOM/XE) raise this cap to 35, while I changed the original cap to 30, a number slightly lower than 35.

Additionally, I created a dedicated mod that sets the attribute cap to `int.max -2` to make it appear as if the limitation has been removed, for players who extremely dislike this setting.

#### 你考虑过的替代方案 (Describe alternatives you've considered)

We considered removing the setting option entirely, but we're putting that on hold for now.

#### 测试 (Testing)

Just some json