### PR TITLE
Rename game title to Cataclysm: Cleanwater Bomb

### DIFF
--- a/src/loading_ui.cpp
+++ b/src/loading_ui.cpp
@@ -204,7 +204,7 @@ static void update_state( const std::string &context, const std::string &step )
 #else
         std::string splash = PATH_INFO::title( get_holiday_from_time() );
         if( get_option<bool>( "ENABLE_ASCII_TITLE" ) ) {
-            splash = read_whole_file( splash ).value_or( _( "Cataclysm: Dark Days Ahead" ) );
+            splash = read_whole_file( splash ).value_or( _( "Cataclysm: Cleanwater Bomb" ) );
         }
         gLUI->splash = string_split( splash, '\n' );
         gLUI->blanks = std::string( TERMX, ' ' );

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -430,7 +430,7 @@ void main_menu::init_windows()
 void main_menu::init_strings()
 {
     // ASCII Art
-    mmenu_title = load_file( PATH_INFO::title( current_holiday ), _( "Cataclysm: Dark Days Ahead" ) );
+    mmenu_title = load_file( PATH_INFO::title( current_holiday ), _( "Cataclysm: Cleanwater Bomb" ) );
     // MOTD
     auto motd = load_file( PATH_INFO::motd(), _( "No message today." ) );
 

--- a/src/path_info.cpp
+++ b/src/path_info.cpp
@@ -484,7 +484,7 @@ std::string PATH_INFO::title( const holiday current_holiday )
     std::string theme_fallback = theme_basepath + "en.title";
 
     if( !get_option<bool>( "ENABLE_ASCII_TITLE" ) ) {
-        return _( "Cataclysm: Dark Days Ahead" );
+        return _( "Cataclysm: Cleanwater Bomb" );
     }
 
     if( x_in_y( get_option<int>( "ALT_TITLE" ), 100 ) ) {

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -214,7 +214,7 @@ static void InitSDL()
     // Requires SDL 2.0.18. String used multiple ways, one of them is the game
     // identifying itself when asking to inhibit screensaver via dbus under
     // Linux.
-    SDL_SetHint( SDL_HINT_APP_NAME, _( "Cataclysm: Dark Days Ahead" ) );
+    SDL_SetHint( SDL_HINT_APP_NAME, _( "Cataclysm: Cleanwater Bomb" ) );
 #endif
 
 #if defined(__linux__) && SDL_MAJOR_VERSION < 3

--- a/src/translations.cpp
+++ b/src/translations.cpp
@@ -104,5 +104,5 @@ void set_language( const std::string &lang )
     // names.
     SNIPPET.reload_names( PATH_INFO::names() );
 
-    set_title( string_format( _( "Cataclysm: Dark Days Ahead - %s" ), getVersionString() ) );
+    set_title( string_format( _( "Cataclysm: Cleanwater Bomb - %s" ), getVersionString() ) );
 }


### PR DESCRIPTION
## Summary
Replace all display strings of "Cataclysm: Dark Days Ahead" with "Cataclysm: Cleanwater Bomb".

Changed in 5 source files:
- src/translations.cpp — window title bar (with version)
- src/sdltiles.cpp — SDL app name (SDL_HINT_APP_NAME)
- src/main_menu.cpp — main menu ASCII title fallback
- src/loading_ui.cpp — loading splash fallback
- src/path_info.cpp — title file resolution fallback

## Tested
Incremental build with TILES=1 SOUND=1 RELEASE=1; recompiled and relinked the 5 affected files with no errors or warnings.

## Notes
These are `_()`-wrapped translatable strings; translated locales (.mo) would need matching updates. English/untranslated locales show the new title directly.