### PR TITLE
将 Transifex 翻译配置指回上游 CDDA

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,21 +1,21 @@
 [main]
 host = https://www.transifex.com
 
-[o:lyhglytx:p:cataclysm-cleanwater-bomb:r:master-game]
+[o:cataclysm-dda-translators:p:cataclysm-dda:r:master-cataclysm-dda]
 file_filter  = lang/po/<lang>.po
 source_file  = lang/po/cataclysm-dda.pot
 source_lang  = en
 type         = PO
 minimum_perc = 0
 
-[o:lyhglytx:p:cataclysm-cleanwater-bomb:r:credits-master]
+[o:cataclysm-dda-translators:p:cataclysm-dda:r:credits-master]
 file_filter  = data/credits/<lang>.credits
 source_file  = data/credits/en.credits
 source_lang  = en
 type         = TXT
 minimum_perc = 20
 
-[o:lyhglytx:p:cataclysm-cleanwater-bomb:r:motd-master]
+[o:cataclysm-dda-translators:p:cataclysm-dda:r:motd-master]
 file_filter  = data/motd/<lang>.motd
 source_file  = data/motd/en.motd
 source_lang  = en


### PR DESCRIPTION
## 背景
此前 PR 把 `.tx/config` 的资源坐标改成了本仓库的 Transifex 项目 `o:lyhglytx:p:cataclysm-cleanwater-bomb`,但我们自己的 Transifex 项目尚未申请下来,导致构建时 `tx pull` 无法拉取到翻译文件。

## 改动
将 `.tx/config` 中三个资源段改回上游 CDDA 的 Transifex 项目坐标:
- `master-game` → `o:cataclysm-dda-translators:p:cataclysm-dda:r:master-cataclysm-dda`
- credits / motd 段同样改回 `o:cataclysm-dda-translators:p:cataclysm-dda`

这样构建流程(build-translations 中的 `tx pull`)可以从上游 CDDA 项目正常拉取翻译,等本项目 Transifex 申请下来后再切回。

## 影响
仅 `.tx/config`,不影响代码与游戏数据。