### PR TITLE
在游戏内今日消息(MOTD)中加入 Discord 与 Reddit 链接

### DIFF
--- a/data/motd/ar.motd
+++ b/data/motd/ar.motd
@@ -13,6 +13,8 @@
 <color_white>انضم إلى المناقشة في المنتديات والدردشات على:</color>
 
 <color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
+<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/tUG9MFwCqf</color>
+<color_light_gray>* Reddit:                    </color><color_cyan>https://www.reddit.com/r/CataclysmCB/</color>
 
 <color_light_gray>تتوفر روابط مفيدة أخرى على صفحتنا الرئيسية.</color>
 

--- a/data/motd/cs.motd
+++ b/data/motd/cs.motd
@@ -13,6 +13,8 @@
 <color_white>Připojte se k diskuzi na fórech a chatech:</color>
 
 <color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
+<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/tUG9MFwCqf</color>
+<color_light_gray>* Reddit:                    </color><color_cyan>https://www.reddit.com/r/CataclysmCB/</color>
 
 <color_light_gray>Další užitečné odkazy jsou dostupné na Domovské stránke</color>
 

--- a/data/motd/de.motd
+++ b/data/motd/de.motd
@@ -13,6 +13,8 @@
 <color_white>Nimm an den Diskussionen in Foren und Chats teil:</color>
 
 <color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
+<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/tUG9MFwCqf</color>
+<color_light_gray>* Reddit:                    </color><color_cyan>https://www.reddit.com/r/CataclysmCB/</color>
 
 <color_light_gray>Weitere nützliche Links findest Du auch auf unserer Homepage.</color>
 

--- a/data/motd/el.motd
+++ b/data/motd/el.motd
@@ -13,6 +13,8 @@
 <color_white>Λάβετε μέρος στη συζήτηση στα φόρουμ και στα chats:</color>
 
 <color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
+<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/tUG9MFwCqf</color>
+<color_light_gray>* Reddit:                    </color><color_cyan>https://www.reddit.com/r/CataclysmCB/</color>
 
 <color_light_gray>Άλλοι χρήσιμοι σύνδεσμοι είναι επίσης διαθέσιμοι στην αρχική μας σελίδα.</color>
 

--- a/data/motd/en.motd
+++ b/data/motd/en.motd
@@ -13,6 +13,8 @@
 <color_white>Join the discussion on forums and chats:</color>
 
 <color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
+<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/tUG9MFwCqf</color>
+<color_light_gray>* Reddit:                    </color><color_cyan>https://www.reddit.com/r/CataclysmCB/</color>
 
 <color_light_gray>Other useful links are also available at our Homepage.</color>
 

--- a/data/motd/es_AR.motd
+++ b/data/motd/es_AR.motd
@@ -13,6 +13,8 @@
 <color_white>Vení a discutir en los foros y chats:</color>
 
 <color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
+<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/tUG9MFwCqf</color>
+<color_light_gray>* Reddit:                    </color><color_cyan>https://www.reddit.com/r/CataclysmCB/</color>
 
 <color_light_gray>En nuestra página web también hay otros links interesantes.</color>
 

--- a/data/motd/es_ES.motd
+++ b/data/motd/es_ES.motd
@@ -13,6 +13,8 @@
 <color_white>Comunícate y habla en los foros y chats: </color>
 
 <color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
+<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/tUG9MFwCqf</color>
+<color_light_gray>* Reddit:                    </color><color_cyan>https://www.reddit.com/r/CataclysmCB/</color>
 
 <color_light_gray>Otros enlaces de utilidad están disponibles en nuestra Página principal. </color>
 

--- a/data/motd/fil_PH.motd
+++ b/data/motd/fil_PH.motd
@@ -13,6 +13,8 @@
 <color_white>Sundin ang aming diskusyon sa aming forums at chats:</color>
 
 <color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
+<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/tUG9MFwCqf</color>
+<color_light_gray>* Reddit:                    </color><color_cyan>https://www.reddit.com/r/CataclysmCB/</color>
 
 <color_light_gray>Mga iba pang links ay makikita rin sa aming homepage.</color>
 

--- a/data/motd/fr.motd
+++ b/data/motd/fr.motd
@@ -13,6 +13,8 @@
 <color_white>Rejoignez la discussion sur les forums et chats:</color>
 
 <color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
+<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/tUG9MFwCqf</color>
+<color_light_gray>* Reddit:                    </color><color_cyan>https://www.reddit.com/r/CataclysmCB/</color>
 
 <color_light_gray>D'autres liens utiles se trouvent sur notre page d'accueil.</color>
 

--- a/data/motd/ga_IE.motd
+++ b/data/motd/ga_IE.motd
@@ -13,6 +13,8 @@
 <color_white>Bí sa chomhrá ar fóraim agus comhráite grúpaí:</color>
 
 <color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
+<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/tUG9MFwCqf</color>
+<color_light_gray>* Reddit:                    </color><color_cyan>https://www.reddit.com/r/CataclysmCB/</color>
 
 <color_light_gray>Tá naisc úsáideacha eile ar fáil ar ár leathanach baile.</color>
 

--- a/data/motd/hu.motd
+++ b/data/motd/hu.motd
@@ -13,6 +13,8 @@
 <color_white>Angol nyelvű fórumozás és chat:</color>
 
 <color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
+<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/tUG9MFwCqf</color>
+<color_light_gray>* Reddit:                    </color><color_cyan>https://www.reddit.com/r/CataclysmCB/</color>
 
 <color_light_gray>További hasznos hivatkozásokért lásd a honlapot.</color>
 

--- a/data/motd/id.motd
+++ b/data/motd/id.motd
@@ -13,6 +13,8 @@
 <color_white>Ikuti diskusi di forum dan chat:</color>
 
 <color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
+<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/tUG9MFwCqf</color>
+<color_light_gray>* Reddit:                    </color><color_cyan>https://www.reddit.com/r/CataclysmCB/</color>
 
 <color_light_gray>Link berguna lainnya juga tersedia di Halaman Depan kami.</color>
 

--- a/data/motd/it_IT.motd
+++ b/data/motd/it_IT.motd
@@ -13,6 +13,8 @@
 <color_white>Unisciti alla discussione nei forum e nelle chat:</color>
 
 <color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
+<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/tUG9MFwCqf</color>
+<color_light_gray>* Reddit:                    </color><color_cyan>https://www.reddit.com/r/CataclysmCB/</color>
 
 <color_light_gray>Altri link utili sono disponibili sulla nostra Homepage.</color>
 

--- a/data/motd/ja.motd
+++ b/data/motd/ja.motd
@@ -13,6 +13,8 @@
 <color_white>議論やチャットへの参加:</color>
 
 <color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
+<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/tUG9MFwCqf</color>
+<color_light_gray>* Reddit:                    </color><color_cyan>https://www.reddit.com/r/CataclysmCB/</color>
 
 <color_light_gray>その他の便利なリンクは公式サイトでご覧いただけます。</color>
 

--- a/data/motd/ko.motd
+++ b/data/motd/ko.motd
@@ -13,6 +13,8 @@
 <color_white>포럼과 챗에서 토론하기:</color>
 
 <color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
+<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/tUG9MFwCqf</color>
+<color_light_gray>* Reddit:                    </color><color_cyan>https://www.reddit.com/r/CataclysmCB/</color>
 
 <color_light_gray>다른 유용한 링크들도 홈페이지에서 이용할 수 있습니다.</color>
 

--- a/data/motd/nb.motd
+++ b/data/motd/nb.motd
@@ -13,6 +13,8 @@
 <color_white>Delta i diskusjonene på forum og chatter:</color>
 
 <color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
+<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/tUG9MFwCqf</color>
+<color_light_gray>* Reddit:                    </color><color_cyan>https://www.reddit.com/r/CataclysmCB/</color>
 
 <color_light_gray>Andre nyttige lenker er også tilgjengelige på hjemmesiden vår.</color>
 

--- a/data/motd/pl.motd
+++ b/data/motd/pl.motd
@@ -13,6 +13,8 @@
 <color_white>Dołącz do dyskusji na forach i czatach:</color>
 
 <color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
+<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/tUG9MFwCqf</color>
+<color_light_gray>* Reddit:                    </color><color_cyan>https://www.reddit.com/r/CataclysmCB/</color>
 
 <color_light_gray>Inne użyteczne odnośniki są dostępne również na naszej stronie głównej.</color>
 

--- a/data/motd/pt_BR.motd
+++ b/data/motd/pt_BR.motd
@@ -13,6 +13,8 @@
 <color_white>Entre na discussão em fóruns e chats:</color>
 
 <color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
+<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/tUG9MFwCqf</color>
+<color_light_gray>* Reddit:                    </color><color_cyan>https://www.reddit.com/r/CataclysmCB/</color>
 
 <color_light_gray>Outros links úteis também estão disponíveis na nossa Homepage.</color>
 

--- a/data/motd/ru.motd
+++ b/data/motd/ru.motd
@@ -13,6 +13,8 @@
 <color_white>Присоединяйтесь к обсуждению на форумах и в чатах:</color>
 
 <color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
+<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/tUG9MFwCqf</color>
+<color_light_gray>* Reddit:                    </color><color_cyan>https://www.reddit.com/r/CataclysmCB/</color>
 
 <color_light_gray>Другие полезные ссылки можно найти на нашем сайте.</color>
 

--- a/data/motd/tr.motd
+++ b/data/motd/tr.motd
@@ -13,6 +13,8 @@
 <color_white>Forumlara ve sohbetlere katılmak için:</color>
 
 <color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
+<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/tUG9MFwCqf</color>
+<color_light_gray>* Reddit:                    </color><color_cyan>https://www.reddit.com/r/CataclysmCB/</color>
 
 <color_light_gray>Diğer kullanışlı linkler ana sayfamızdan bulunabilir.</color>
 

--- a/data/motd/uk_UA.motd
+++ b/data/motd/uk_UA.motd
@@ -13,6 +13,8 @@
 <color_white>Приєднуйтесь до розмов на форумах і чатах:</color>
 
 <color_light_gray>* QQ Group:                  </color><color_cyan>552610319</color>
+<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/tUG9MFwCqf</color>
+<color_light_gray>* Reddit:                    </color><color_cyan>https://www.reddit.com/r/CataclysmCB/</color>
 
 <color_light_gray>Інші корисні посилання також доступні на нашій домашній сторінці.</color>
 

--- a/data/motd/zh_CN.motd
+++ b/data/motd/zh_CN.motd
@@ -13,6 +13,8 @@
 <color_white>加入论坛及讨论组：</color>
 
 <color_light_gray>* QQ群            ：</color><color_cyan>552610319</color>
+<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/tUG9MFwCqf</color>
+<color_light_gray>* Reddit:                    </color><color_cyan>https://www.reddit.com/r/CataclysmCB/</color>
 
 <color_light_gray>官网主页上还提供了其他有用的链接。</color>
 

--- a/data/motd/zh_TW.motd
+++ b/data/motd/zh_TW.motd
@@ -13,6 +13,8 @@
 <color_white>在論壇或聊天室討論：</color>
 
 <color_light_gray>* QQ群            ：</color><color_cyan>552610319</color>
+<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/tUG9MFwCqf</color>
+<color_light_gray>* Reddit:                    </color><color_cyan>https://www.reddit.com/r/CataclysmCB/</color>
 
 <color_light_gray>我們的官網上還有其他有用的連結</color>
 


### PR DESCRIPTION
## 改动
在全部 23 个 MOTD 语言文件的社区/讨论区(QQ 群下方)新增官方 Discord 与 Reddit 链接:
- Discord: https://discord.gg/tUG9MFwCqf
- Reddit: https://www.reddit.com/r/CataclysmCB/

格式与现有 QQ 群条目对齐(`color` 标签 + 缩进)。

## 说明
- README 中英文社区区此前已包含这两个链接,内容一致,无需改动。
- 仅改 `data/motd/*.motd`,不影响代码与游戏逻辑。