### PR TITLE
Fix stackable container pocket split handling / 修复可堆叠容器口袋分割处理

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -7706,6 +7706,29 @@ static bool is_bulk_load( const item_location &lhs, const item_location &rhs )
     return false;
 }
 
+static bool is_empty_stackable_container_stack( const item_location &loc )
+{
+    return loc && loc->count_by_charges() && loc->charges > 1 &&
+           loc->is_container() && loc->container_type_pockets_empty();
+}
+
+static bool is_empty_stackable_container( const item_location &loc )
+{
+    return loc && loc->count_by_charges() && loc->charges > 0 &&
+           loc->is_container() && loc->container_type_pockets_empty();
+}
+
+static item_location single_container_from_stack( item_location &loc )
+{
+    if( is_empty_stackable_container_stack( loc ) ) {
+        item_location split = loc.split_stack( 1 );
+        if( split ) {
+            return split;
+        }
+    }
+    return loc;
+}
+
 void insert_item_activity_actor::start( player_activity &act, Character &who )
 {
     if( items.empty() ) {
@@ -7758,7 +7781,57 @@ static ret_val<void> try_insert( item_location &holster, drop_location &holstere
             return ret;
         }
 
+        holster = single_container_from_stack( holster );
+        if( !holster ) {
+            return ret_val<void>::make_failure( _( "item can't be stored there" ) );
+        }
         return holster->put_in( it, pocket_type::CONTAINER, /*unseal_pockets=*/true, carrier );
+    }
+
+    if( is_empty_stackable_container( holster ) ) {
+        item_location stack = holster;
+        item_location first_filled = item_location::nowhere;
+        int total_added = 0;
+        ret_val<void> last_ret = ret_val<void>::make_failure( _( "item can't be stored there" ) );
+        while( is_empty_stackable_container( stack ) &&
+               holstered_item.second > total_added ) {
+            last_ret = stack->can_contain_partial_directly( it );
+            if( !last_ret.success() ) {
+                break;
+            }
+            ret_val<int> max_parent_charges = stack.max_charges_by_parent_recursive( it );
+            if( !max_parent_charges.success() ) {
+                last_ret = ret_val<void>::make_failure( max_parent_charges.str() );
+                break;
+            }
+            const int charges_to_insert = std::min( holstered_item.second - total_added,
+                                                    max_parent_charges.value() );
+            if( charges_to_insert <= 0 ) {
+                break;
+            }
+            item_location target = single_container_from_stack( stack );
+            if( !target ) {
+                break;
+            }
+            const int added = target->fill_with( it, charges_to_insert, /*unseal_pockets=*/true,
+                                                /*allow_sealed=*/true, /*ignore_settings*/true, /*into_bottom*/true,
+                                                /*allow_nested*/allow_fill_charge_item_nested, carrier );
+            if( added <= 0 ) {
+                last_ret = ret_val<void>::make_failure( _( "item can't be stored there" ) );
+                break;
+            }
+            if( !first_filled ) {
+                first_filled = target;
+            }
+            total_added += added;
+            last_ret = ret_val<void>::make_success();
+        }
+        if( total_added > 0 ) {
+            *charges_added = total_added;
+            holster = first_filled;
+            return ret_val<void>::make_success();
+        }
+        return last_ret;
     }
 
     ret = holster->can_contain_partial_directly( it );

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -7744,7 +7744,8 @@ void insert_item_activity_actor::start( player_activity &act, Character &who )
 }
 
 static ret_val<void> try_insert( item_location &holster, drop_location &holstered_item,
-                                 int *charges_added, Character *carrier, bool allow_fill_charge_item_nested )
+                                 int *charges_added, item_location *filled_container,
+                                 Character *carrier, bool allow_fill_charge_item_nested )
 {
     item &it = *holstered_item.first;
     ret_val<void> ret = ret_val<void>::make_failure( _( "item can't be stored there" ) );
@@ -7781,11 +7782,15 @@ static ret_val<void> try_insert( item_location &holster, drop_location &holstere
             return ret;
         }
 
-        holster = single_container_from_stack( holster );
-        if( !holster ) {
+        item_location target = single_container_from_stack( holster );
+        if( !target ) {
             return ret_val<void>::make_failure( _( "item can't be stored there" ) );
         }
-        return holster->put_in( it, pocket_type::CONTAINER, /*unseal_pockets=*/true, carrier );
+        ret = target->put_in( it, pocket_type::CONTAINER, /*unseal_pockets=*/true, carrier );
+        if( ret.success() && filled_container != nullptr ) {
+            *filled_container = target;
+        }
+        return ret;
     }
 
     if( is_empty_stackable_container( holster ) ) {
@@ -7828,7 +7833,9 @@ static ret_val<void> try_insert( item_location &holster, drop_location &holstere
         }
         if( total_added > 0 ) {
             *charges_added = total_added;
-            holster = first_filled;
+            if( filled_container != nullptr ) {
+                *filled_container = first_filled;
+            }
             return ret_val<void>::make_success();
         }
         return last_ret;
@@ -7863,6 +7870,9 @@ static ret_val<void> try_insert( item_location &holster, drop_location &holstere
     if( *charges_added <= 0 ) {
         return ret_val<void>::make_failure( _( "item can't be stored there" ) );
     }
+    if( filled_container != nullptr ) {
+        *filled_container = holster;
+    }
 
     return ret;
 }
@@ -7882,21 +7892,22 @@ void insert_item_activity_actor::finish( player_activity &act, Character &who )
             bulk_load = is_bulk_load( holstered_item.first, itr->first );
         }
         ret_val<void> ret = ret_val<void>::make_failure( _( "item can't be stored there" ) );
+        item_location filled_container = item_location::nowhere;
 
         if( !it.count_by_charges() ) {
-            ret = try_insert( holster, holstered_item, nullptr, carrier, false );
+            ret = try_insert( holster, holstered_item, nullptr, &filled_container, carrier, false );
 
             if( ret.success() ) {
                 //~ %1$s: item to put in the container, %2$s: container to put item in
                 who.add_msg_if_player( string_format( _( "You put your %1$s into the %2$s." ),
-                                                      holstered_item.first->display_name(), holster->type->nname( 1 ) ) );
-                handler.add_unsealed( holster );
+                                                      holstered_item.first->display_name(), filled_container->type->nname( 1 ) ) );
+                handler.add_unsealed( filled_container );
                 handler.unseal_pocket_containing( holstered_item.first );
                 holstered_item.first.remove_item();
             }
         } else {
             int charges_added = 0;
-            ret = try_insert( holster, holstered_item, &charges_added, carrier,
+            ret = try_insert( holster, holstered_item, &charges_added, &filled_container, carrier,
                               allow_fill_count_by_charge_item_nested );
 
             if( ret.success() ) {
@@ -7904,8 +7915,8 @@ void insert_item_activity_actor::finish( player_activity &act, Character &who )
                 copy.charges = charges_added;
                 //~ %1$s: item to put in the container, %2$s: container to put item in
                 who.add_msg_if_player( string_format( _( "You put your %1$s into the %2$s." ),
-                                                      copy.display_name(), holster->type->nname( 1 ) ) );
-                handler.add_unsealed( holster );
+                                                      copy.display_name(), filled_container->type->nname( 1 ) ) );
+                handler.add_unsealed( filled_container );
                 handler.unseal_pocket_containing( holstered_item.first );
                 it.charges -= charges_added;
                 if( it.charges == 0 ) {

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -7,6 +7,7 @@
 #include <iterator>
 #include <memory>
 #include <numeric>
+#include <optional>
 #include <ostream>
 
 #include "avatar_action.h"
@@ -2289,13 +2290,80 @@ for( const item &it : worn ) {
     }
 }
 
-void outfit::pickup_stash( const item &newit, int &remaining_charges, bool ignore_pkt_settings )
+static bool is_empty_stackable_container_stack( const item_location &loc )
+{
+    return loc && loc->count_by_charges() && loc->charges > 1 &&
+           loc->is_container() && loc->container_type_pockets_empty();
+}
+
+static bool is_empty_stackable_container( const item_location &loc )
+{
+    return loc && loc->count_by_charges() && loc->charges > 0 &&
+           loc->is_container() && loc->container_type_pockets_empty();
+}
+
+static item_location single_container_from_stack( item_location &loc )
+{
+    if( is_empty_stackable_container_stack( loc ) ) {
+        item_location split = loc.split_stack( 1 );
+        if( split ) {
+            return split;
+        }
+    }
+    return loc;
+}
+
+static int fill_empty_stackable_containers( item_location loc, const item &newit,
+        const int amount, Character &guy, const bool unseal_pockets, const bool allow_sealed,
+        const bool ignore_settings, const bool into_bottom, const bool allow_nested )
+{
+    int total_added = 0;
+    while( is_empty_stackable_container( loc ) && amount > total_added ) {
+        item contained_copy( newit );
+        if( contained_copy.count_by_charges() ) {
+            contained_copy.charges = 1;
+        }
+        ret_val<void> can_contain = loc->can_contain( contained_copy, false, false,
+                                    ignore_settings, false, item_location(), 10000000_ml, allow_nested );
+        if( !can_contain.success() ) {
+            break;
+        }
+        ret_val<int> max_parent_charges = loc.max_charges_by_parent_recursive( newit );
+        if( !max_parent_charges.success() ) {
+            break;
+        }
+        const int charges_to_insert = std::min( amount - total_added,
+                                                max_parent_charges.value() );
+        if( charges_to_insert <= 0 ) {
+            break;
+        }
+        item_location target = single_container_from_stack( loc );
+        if( !target ) {
+            break;
+        }
+        const int added = target->fill_with( newit, charges_to_insert, unseal_pockets,
+                                            allow_sealed, ignore_settings, into_bottom, allow_nested, &guy );
+        if( added <= 0 ) {
+            break;
+        }
+        total_added += added;
+    }
+    return total_added;
+}
+
+void outfit::pickup_stash( Character &guy, const item &newit, int &remaining_charges,
+                           bool ignore_pkt_settings )
 {
     for( item &i : worn ) {
         if( remaining_charges == 0 ) {
             break;
         }
-        if( i.can_contain_partial( newit ).success() ) {
+        item_location loc( guy, &i );
+        if( is_empty_stackable_container( loc ) ) {
+            const int used_charges = fill_empty_stackable_containers( loc, newit, remaining_charges,
+                                     guy, false, false, ignore_pkt_settings, false, true );
+            remaining_charges -= used_charges;
+        } else if( i.can_contain_partial( newit ).success() ) {
             const int used_charges =
                 i.fill_with( newit, remaining_charges, false, false, ignore_pkt_settings );
             remaining_charges -= used_charges;
@@ -2304,17 +2372,12 @@ void outfit::pickup_stash( const item &newit, int &remaining_charges, bool ignor
 }
 
 static std::vector<pocket_data_with_parent> get_child_pocket_with_parent(
-    const item_pocket *pocket, const item_location &parent, item_location it, const int nested_level,
+    const item_pocket *pocket, item_location it, const int nested_level,
     const std::function<bool( const item_pocket * )> &filter = return_true<const item_pocket *> )
 {
     std::vector<pocket_data_with_parent> ret;
     if( pocket != nullptr ) {
-        pocket_data_with_parent pocket_data = { pocket, item_location::nowhere, nested_level };
-        const item_location new_parent = item_location( it );
-
-        if( parent != item_location::nowhere ) {
-            pocket_data.parent = item_location( parent, it.get_item() );
-        }
+        pocket_data_with_parent pocket_data = { pocket, item_location( it ), nested_level };
         if( filter( pocket_data.pocket_ptr ) ) {
             ret.emplace_back( pocket_data );
         }
@@ -2323,8 +2386,7 @@ static std::vector<pocket_data_with_parent> get_child_pocket_with_parent(
             const item_location poc_loc = item_location( it, const_cast<item *>( contained ) );
             for( const item_pocket *pocket_nest : contained->get_container_pockets() ) {
                 std::vector<pocket_data_with_parent> child =
-                    get_child_pocket_with_parent( pocket_nest, new_parent,
-                                                  poc_loc, nested_level + 1, filter );
+                    get_child_pocket_with_parent( pocket_nest, poc_loc, nested_level + 1, filter );
                 ret.insert( ret.end(), child.begin(), child.end() );
             }
         }
@@ -2417,7 +2479,7 @@ std::vector<pocket_data_with_parent> Character::get_all_pocket_with_parent(
     for( item_location &loc : locs ) {
         for( const item_pocket *pocket : loc->get_container_pockets() ) {
             std::vector<pocket_data_with_parent> child =
-                get_child_pocket_with_parent( pocket, item_location::nowhere, loc, 0, filter );
+                get_child_pocket_with_parent( pocket, loc, 0, filter );
             ret.insert( ret.end(), child.begin(), child.end() );
         }
     }
@@ -2425,6 +2487,46 @@ std::vector<pocket_data_with_parent> Character::get_all_pocket_with_parent(
         std::sort( ret.begin(), ret.end(), sort_pockets_func );
     }
     return ret;
+}
+
+static std::optional<size_t> container_pocket_index( const item_location &loc,
+        const item_pocket *pocket )
+{
+    if( !loc || pocket == nullptr ) {
+        return std::nullopt;
+    }
+    const std::vector<const item_pocket *> pockets = loc->get_container_pockets();
+    for( size_t index = 0; index < pockets.size(); index++ ) {
+        if( pockets[index] == pocket ) {
+            return index;
+        }
+    }
+    return std::nullopt;
+}
+
+static item_pocket *pocket_for_fill_target( const pocket_data_with_parent &pocket_data,
+        item_location &parent )
+{
+    item_pocket *pocket = const_cast<item_pocket *>( pocket_data.pocket_ptr );
+    parent = pocket_data.parent;
+    if( !is_empty_stackable_container_stack( parent ) ) {
+        return pocket;
+    }
+
+    std::optional<size_t> pocket_index = container_pocket_index( parent, pocket );
+    if( !pocket_index ) {
+        return nullptr;
+    }
+    item_location split = parent.split_stack( 1 );
+    if( !split ) {
+        return nullptr;
+    }
+    std::vector<item_pocket *> split_pockets = split->get_container_pockets();
+    if( *pocket_index >= split_pockets.size() ) {
+        return nullptr;
+    }
+    parent = split;
+    return split_pockets[*pocket_index];
 }
 
 void outfit::add_stash( Character &guy, const item &newit, int &remaining_charges,
@@ -2436,14 +2538,20 @@ void outfit::add_stash( Character &guy, const item &newit, int &remaining_charge
         // Crawl First : wielded item
         item_location carried_item = guy.get_wielded_item();
         if( carried_item && !carried_item->has_pocket_type( pocket_type::MAGAZINE ) &&
-            carried_item->can_contain_partial( newit ).success() ) {
-            int used_charges = carried_item->fill_with( newit, remaining_charges, /*unseal_pockets=*/false,
-                               /*allow_sealed=*/false, /*ignore_settings=*/false, /*into_bottom*/false, /*allow_nested*/true,
-                               &guy );
+            is_empty_stackable_container( carried_item ) ) {
+            int used_charges = fill_empty_stackable_containers( carried_item, newit, remaining_charges,
+                               guy, /*unseal_pockets=*/false, /*allow_sealed=*/false, /*ignore_settings=*/false,
+                               /*into_bottom*/false, /*allow_nested*/true );
+            remaining_charges -= used_charges;
+        } else if( carried_item && !carried_item->has_pocket_type( pocket_type::MAGAZINE ) &&
+                   carried_item->can_contain_partial( newit ).success() ) {
+            int used_charges = carried_item->fill_with( newit, remaining_charges,
+                               /*unseal_pockets=*/false, /*allow_sealed=*/false, /*ignore_settings=*/false,
+                               /*into_bottom*/false, /*allow_nested*/true, &guy );
             remaining_charges -= used_charges;
         }
         // Crawl Next : worn items
-        pickup_stash( newit, remaining_charges, ignore_pkt_settings );
+        pickup_stash( guy, newit, remaining_charges, ignore_pkt_settings );
     } else {
         //item copy for test can contain
         item temp_it = item( newit );
@@ -2463,28 +2571,41 @@ void outfit::add_stash( Character &guy, const item &newit, int &remaining_charge
         const int amount = remaining_charges;
         int num_contained = 0;
         for( const pocket_data_with_parent &pocket_data_ptr : pockets_with_parent ) {
-            if( amount <= num_contained || remaining_charges <= 0 ) {
-                break;
-            }
-            int filled_count = 0;
-            item_pocket *pocke = const_cast<item_pocket *>( pocket_data_ptr.pocket_ptr );
-            if( pocke == nullptr ) {
-                continue;
-            }
-            int max_contain_value = pocke->remaining_capacity_for_item( newit );
-            const item_location parent_data = pocket_data_ptr.parent;
+            while( amount > num_contained && remaining_charges > 0 ) {
+                item_location parent_data;
+                int filled_count = 0;
+                item_pocket *pocke = const_cast<item_pocket *>( pocket_data_ptr.pocket_ptr );
+                parent_data = pocket_data_ptr.parent;
+                if( pocke == nullptr ) {
+                    break;
+                }
+                int max_contain_value = pocke->remaining_capacity_for_item( newit );
 
-            if( parent_data.has_parent() ) {
-                if( parent_data.parents_can_contain_recursive( &temp_it ).success() ) {
-                    max_contain_value = parent_data.max_charges_by_parent_recursive( temp_it ).value();
-                } else {
-                    max_contain_value = 0;
+                if( parent_data && parent_data.has_parent() ) {
+                    if( parent_data.parents_can_contain_recursive( &temp_it ).success() ) {
+                        max_contain_value = parent_data.max_charges_by_parent_recursive( temp_it ).value();
+                    } else {
+                        max_contain_value = 0;
+                    }
+                }
+                const int charges = std::min( max_contain_value, remaining_charges ) ;
+                if( charges <= 0 ) {
+                    break;
+                }
+                pocke = pocket_for_fill_target( pocket_data_ptr, parent_data );
+                if( pocke == nullptr ) {
+                    break;
+                }
+                filled_count = pocke->fill_with( newit, guy, charges, false, false );
+                if( filled_count <= 0 ) {
+                    break;
+                }
+                num_contained += filled_count;
+                remaining_charges -= filled_count;
+                if( !is_empty_stackable_container( pocket_data_ptr.parent ) ) {
+                    break;
                 }
             }
-            const int charges = std::min( max_contain_value, remaining_charges ) ;
-            filled_count = pocke->fill_with( newit, guy, charges, false, false );
-            num_contained += filled_count;
-            remaining_charges -= filled_count;
         }
     }
 }

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -108,6 +108,18 @@ units::mass get_selected_stack_weight( const item *i, const std::map<const item 
     return 0_gram;
 }
 
+static bool is_stackable_container_with_contents( const item &it )
+{
+    return it.count_by_charges() && it.charges > 1 &&
+           it.is_container() && !it.container_type_pockets_empty();
+}
+
+static bool is_wearable_empty_stackable_container_stack( const item_location &loc )
+{
+    return loc && loc->count_by_charges() && loc->charges > 1 &&
+           loc->is_container() && loc->container_type_pockets_empty();
+}
+
 ret_val<void> Character::can_wear( const item &it, bool with_equip_change ) const
 {
 
@@ -135,6 +147,9 @@ ret_val<void> Character::can_wear( const item &it, bool with_equip_change ) cons
     }
     if( !it.is_armor() ) {
     return ret_val<void>::make_failure( _( "Putting on a %s would be tricky." ), it.tname() );
+    }
+    if( is_stackable_container_with_contents( it ) ) {
+        return ret_val<void>::make_failure( _( "Can't wear a stackable container with contents." ) );
     }
 
     if( has_trait( trait_WOOLALLERGY ) && ( it.made_of( material_wool ) ||
@@ -285,14 +300,12 @@ Character::wear( int pos, bool interactive )
 std::optional<std::list<item>::iterator>
 Character::wear( item_location item_wear, bool interactive )
 {
-    item &to_wear = *item_wear;
-
     // Need to account for case where we're trying to wear something that belongs to someone else
-    if( !avatar_action::check_stealing( *this, to_wear ) ) {
+    if( !avatar_action::check_stealing( *this, *item_wear ) ) {
         return std::nullopt;
     }
 
-    if( is_worn( to_wear ) ) {
+    if( is_worn( *item_wear ) ) {
         if( interactive ) {
             add_msg_player_or_npc( m_info,
                                    _( "You are already wearing that." ),
@@ -301,7 +314,7 @@ Character::wear( item_location item_wear, bool interactive )
         }
         return std::nullopt;
     }
-    if( to_wear.is_null() ) {
+    if( item_wear->is_null() ) {
         if( interactive ) {
             add_msg_player_or_npc( m_info,
                                    _( "You don't have that item." ),
@@ -309,8 +322,16 @@ Character::wear( item_location item_wear, bool interactive )
         }
         return std::nullopt;
     }
+    if( is_wearable_empty_stackable_container_stack( item_wear ) ) {
+        item_location split = item_wear.split_stack( 1 );
+        if( !split ) {
+            return std::nullopt;
+        }
+        item_wear = split;
+    }
 
     bool was_weapon;
+    item &to_wear = *item_wear;
     item to_wear_copy( to_wear );
     if( &to_wear == &weapon ) {
         weapon = item();
@@ -2060,6 +2081,9 @@ void outfit::best_pocket( Character &guy, const item &it, const item *avoid,
         if( &worn_it == &it || &worn_it == avoid ) {
             continue;
         }
+        if( is_stackable_container_with_contents( worn_it ) ) {
+            continue;
+        }
         item_location loc( guy, &worn_it );
         std::pair<item_location, item_pocket *> internal_pocket =
             worn_it.best_pocket( it, loc, avoid, false, ignore_settings );
@@ -2358,6 +2382,9 @@ void outfit::pickup_stash( Character &guy, const item &newit, int &remaining_cha
         if( remaining_charges == 0 ) {
             break;
         }
+        if( is_stackable_container_with_contents( i ) ) {
+            continue;
+        }
         item_location loc( guy, &i );
         if( is_empty_stackable_container( loc ) ) {
             const int used_charges = fill_empty_stackable_containers( loc, newit, remaining_charges,
@@ -2477,6 +2504,9 @@ std::vector<pocket_data_with_parent> Character::get_all_pocket_with_parent(
     }
 
     for( item_location &loc : locs ) {
+        if( is_stackable_container_with_contents( *loc ) ) {
+            continue;
+        }
         for( const item_pocket *pocket : loc->get_container_pockets() ) {
             std::vector<pocket_data_with_parent> child =
                 get_child_pocket_with_parent( pocket, loc, 0, filter );
@@ -2538,6 +2568,9 @@ void outfit::add_stash( Character &guy, const item &newit, int &remaining_charge
         // Crawl First : wielded item
         item_location carried_item = guy.get_wielded_item();
         if( carried_item && !carried_item->has_pocket_type( pocket_type::MAGAZINE ) &&
+            is_stackable_container_with_contents( *carried_item ) ) {
+            // Stackable container stacks with contents should not collect contents while wielded.
+        } else if( carried_item && !carried_item->has_pocket_type( pocket_type::MAGAZINE ) &&
             is_empty_stackable_container( carried_item ) ) {
             int used_charges = fill_empty_stackable_containers( carried_item, newit, remaining_charges,
                                guy, /*unseal_pockets=*/false, /*allow_sealed=*/false, /*ignore_settings=*/false,

--- a/src/character_attire.h
+++ b/src/character_attire.h
@@ -224,7 +224,8 @@ class outfit
         // called after reading in savegame json to update the whole outfit
         void on_item_wear( Character &guy );
         // used in the pickup code in the STASH section
-        void pickup_stash( const item &newit, int &remaining_charges, bool ignore_pkt_settings = false );
+        void pickup_stash( Character &guy, const item &newit, int &remaining_charges,
+                           bool ignore_pkt_settings = false );
         void add_stash( Character &guy, const item &newit, int &remaining_charges,
                         bool ignore_pkt_settings = false );
         // used for npc generation

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -3064,17 +3064,138 @@ bool Character::wield_contents( item &container, item *internal_item, bool penal
     return true;
 }
 
+static bool is_empty_stackable_container_stack( const item_location &loc )
+{
+    return loc && loc->count_by_charges() && loc->charges > 1 &&
+           loc->is_container() && loc->container_type_pockets_empty();
+}
+
+static bool is_empty_stackable_container( const item_location &loc )
+{
+    return loc && loc->count_by_charges() && loc->charges > 0 &&
+           loc->is_container() && loc->container_type_pockets_empty();
+}
+
+static item_location single_container_from_stack( item_location &loc )
+{
+    if( is_empty_stackable_container_stack( loc ) ) {
+        item_location split = loc.split_stack( 1 );
+        if( split ) {
+            return split;
+        }
+    }
+    return loc;
+}
+
 void Character::store( item &container, item &put, bool penalties, int base_cost,
                        pocket_type pk_type, bool check_best_pkt )
 {
-    mod_moves( -item_store_cost( put, container, penalties, base_cost ) );
+    const bool stackable_empty_container = container.count_by_charges() && container.charges > 1 &&
+                                           container.is_container() &&
+                                           container.container_type_pockets_empty();
+    item_location container_loc;
+    if( stackable_empty_container ) {
+        container_loc = item_location( *this, &container );
+    }
+    if( stackable_empty_container && pk_type == pocket_type::CONTAINER && put.count_by_charges() ) {
+        const bool use_best_pocket = check_best_pkt && container.get_container_pockets().size() > 1;
+        int total_stored = 0;
+        while( is_empty_stackable_container( container_loc ) && total_stored < put.charges ) {
+            item contained_copy( put );
+            contained_copy.charges = 1;
+            ret_val<void> can_store = container_loc->can_contain( contained_copy, false, false,
+                                      use_best_pocket, false, item_location(), 10000000_ml, use_best_pocket );
+            if( !can_store.success() ) {
+                break;
+            }
+            ret_val<int> max_parent_charges = container_loc.max_charges_by_parent_recursive( put );
+            if( !max_parent_charges.success() ) {
+                break;
+            }
+            const int charges_to_store = std::min( put.charges - total_stored,
+                                                   max_parent_charges.value() );
+            if( charges_to_store <= 0 ) {
+                break;
+            }
+            item_location target = single_container_from_stack( container_loc );
+            if( !target ) {
+                break;
+            }
+            const bool split_from_stack = target != container_loc;
+            const int stored = target->fill_with( put, charges_to_store, false, false, use_best_pocket,
+                                                  false, use_best_pocket, this );
+            if( stored <= 0 ) {
+                if( split_from_stack ) {
+                    container_loc->charges += target->charges;
+                    target.remove_item();
+                }
+                break;
+            }
+            total_stored += stored;
+        }
+        if( total_stored <= 0 ) {
+            return;
+        }
+        mod_moves( -item_store_cost( put, container, penalties, base_cost ) );
+        if( total_stored >= put.charges ) {
+            i_rem( &put );
+        } else {
+            put.charges -= total_stored;
+        }
+        calc_encumbrance();
+        return;
+    }
+
+    item *target_container = &container;
+    item_location split;
+    if( stackable_empty_container ) {
+        if( pk_type == pocket_type::CONTAINER ) {
+            const bool use_partial_check = check_best_pkt &&
+                                           container.get_container_pockets().size() > 1 &&
+                                           put.count_by_charges();
+            ret_val<void> can_store = use_partial_check ? container.can_contain_partial( put ) :
+                                      container.can_contain_directly( put );
+            if( !can_store.success() ) {
+                return;
+            }
+        }
+        split = container_loc.split_stack( 1 );
+        if( !split ) {
+            return;
+        }
+        target_container = split.get_item();
+    }
+    const auto rollback_split = [&container, &split]() {
+        if( split ) {
+            container.charges += split->charges;
+            split.remove_item();
+        }
+    };
+
     if( check_best_pkt && pk_type == pocket_type::CONTAINER &&
-        container.get_container_pockets().size() > 1 ) {
+        target_container->get_container_pockets().size() > 1 && put.count_by_charges() ) {
         // Bypass pocket settings (assuming the item is manually stored)
-        int charges = put.count_by_charges() ? put.charges : 1;
-        container.fill_with( i_rem( &put ), charges, false, false, true, false, true, this );
+        const int charges = put.charges;
+        const int charges_stored = target_container->fill_with( put, charges, false, false, true, false,
+                                  true, this );
+        if( charges_stored <= 0 ) {
+            rollback_split();
+            return;
+        }
+        mod_moves( -item_store_cost( put, container, penalties, base_cost ) );
+        if( charges_stored >= put.charges ) {
+            i_rem( &put );
+        } else {
+            put.charges -= charges_stored;
+        }
     } else {
-        container.put_in( i_rem( &put ), pk_type, false, this );
+        ret_val<void> stored = target_container->put_in( put, pk_type, false, this, true );
+        if( !stored.success() ) {
+            rollback_split();
+            return;
+        }
+        mod_moves( -item_store_cost( put, container, penalties, base_cost ) );
+        i_rem( &put );
     }
     calc_encumbrance();
 }
@@ -3091,9 +3212,13 @@ void Character::store( item_pocket *pocket, item &put, bool penalties, int base_
     if( !!pkt_best && pocket->better_pocket( *pkt_best, put, true ) ) {
         pocket = pkt_best;
     }
+    ret_val<item *> result = pocket->insert_item( put );
+    if( !result.success() ) {
+        return;
+    }
     mod_moves( -std::max( item_store_cost( put, null_item_reference(), penalties, base_cost ),
                           pocket->obtain_cost( put ) ) );
-    ret_val<item *> result = pocket->insert_item( i_rem( &put ) );
+    i_rem( &put );
     result.value()->on_pickup( *this );
     calc_encumbrance();
 }

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -283,7 +283,9 @@ std::pair<item_location, item_pocket *> Character::best_pocket( const item &it, 
 {
     item_location weapon_loc( *this, &weapon );
     std::pair<item_location, item_pocket *> ret = std::make_pair( item_location(), nullptr );
-    if( &weapon != &it && &weapon != avoid ) {
+    if( &weapon != &it && &weapon != avoid &&
+        !( weapon.count_by_charges() && weapon.charges > 1 &&
+           weapon.is_container() && !weapon.container_type_pockets_empty() ) ) {
         ret = weapon.best_pocket( it, weapon_loc, avoid, false, ignore_settings );
     }
     worn.best_pocket( *this, it, avoid, ret, ignore_settings );
@@ -322,6 +324,9 @@ item_location Character::try_add( item it, const item *avoid, const item *origin
         // this will set ret to either it, or to stack where it was placed
         item *newit = nullptr;
         pocket.second->add( it, &newit );
+        if( newit == nullptr ) {
+            return ret;
+        }
         if( !keep_invlet && ( !it.count_by_charges() || it.charges == newit->charges ) ) {
             inv->update_invlet( *newit, true, original_inventory_item );
         }

--- a/src/flexbuffer_json-inl.h
+++ b/src/flexbuffer_json-inl.h
@@ -512,18 +512,36 @@ bool JsonValue::read( cata::colony<T> &v, bool throw_on_error ) const
                 if( rle_element[ 0 ].read( element, throw_on_error ) &&
                     rle_element[ 1 ].read( run_l, throw_on_error )
                   ) { // all is good
+                    const auto insert_loaded_item = [&v]( T &&loaded ) {
+                        if( stackable_container_contents_need_split( loaded ) ) {
+                            T empty_stack;
+                            split_stackable_container_contents_from_stack( loaded, empty_stack );
+                            v.insert( std::move( loaded ) );
+                            v.insert( std::move( empty_stack ) );
+                        } else {
+                            v.insert( std::move( loaded ) );
+                        }
+                    };
                     // first insert (run_l-1) elements
                     for( int i = 0; i < run_l - 1; i++ ) {
-                        v.insert( element );
+                        T copy = element;
+                        insert_loaded_item( std::move( copy ) );
                     }
                     // micro-optimization, move last element
-                    v.insert( std::move( element ) );
+                    insert_loaded_item( std::move( element ) );
                 } else { // array is malformed, skipping it entirely
                     error_or_false( throw_on_error, "Expected end of array" );
                 }
             } else {
                 if( jv.read( element, throw_on_error ) ) {
-                    v.insert( std::move( element ) );
+                    if( stackable_container_contents_need_split( element ) ) {
+                        T empty_stack;
+                        split_stackable_container_contents_from_stack( element, empty_stack );
+                        v.insert( std::move( element ) );
+                        v.insert( std::move( empty_stack ) );
+                    } else {
+                        v.insert( std::move( element ) );
+                    }
                 }
             }
         }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -856,6 +856,10 @@ bool _stacks_components( item const &lhs, item const &rhs, bool check_components
 stacking_info item::stacks_with( const item &rhs, bool check_components, bool combine_liquid,
                                  bool check_cat, int depth, int maxdepth, bool precise ) const
 {
+    if( count_by_charges() && ( !container_type_pockets_empty() || !rhs.container_type_pockets_empty() ) ) {
+        return {};
+    }
+
     // Type mismatch cannot stack without a CATEGORY check.
     if( type != rhs.type && !check_cat ) {
         return {};

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -499,6 +499,10 @@ item item::split( int qty )
     if( !count_by_charges() || qty <= 0 || qty >= charges ) {
         return item();
     }
+    if( is_container() && !container_type_pockets_empty() ) {
+        debugmsg( "tried to split stackable container with contents: %s", tname() );
+        return item();
+    }
     item res = *this;
     res.charges = qty;
     charges -= qty;

--- a/src/item.h
+++ b/src/item.h
@@ -3506,6 +3506,8 @@ class item : public visitable
 
 
     public:
+        friend bool split_stackable_container_contents_from_stack( item &it, item &empty_stack );
+
         static const int INFINITE_CHARGES;
 
         const itype *type;

--- a/src/item.h
+++ b/src/item.h
@@ -58,6 +58,8 @@ class enchantment;
 class gun_type_type;
 class gunmod_location;
 class item;
+bool stackable_container_contents_need_split( const item &it );
+bool split_stackable_container_contents_from_stack( item &it, item &empty_stack );
 class iteminfo_query;
 class map;
 class monster;

--- a/src/item_container.cpp
+++ b/src/item_container.cpp
@@ -184,9 +184,43 @@ int item::insert_cost( const item &it ) const
     return contents.insert_cost( it );
 }
 
+static bool is_stackable_container_stack( const item &it )
+{
+    return it.count_by_charges() && it.charges > 1 && it.is_container();
+}
+
+bool stackable_container_contents_need_split( const item &it )
+{
+    return is_stackable_container_stack( it ) && !it.container_type_pockets_empty();
+}
+
+bool split_stackable_container_contents_from_stack( item &it, item &empty_stack )
+{
+    if( !stackable_container_contents_need_split( it ) ) {
+        return false;
+    }
+
+    const int old_charges = it.charges;
+    empty_stack = it;
+    it.charges = 1;
+    empty_stack.charges = old_charges - 1;
+    empty_stack.get_contents().clear_pockets_if( []( const item_pocket &pocket ) {
+        return pocket.is_type( pocket_type::CONTAINER );
+    } );
+    it.update_inherited_flags();
+    empty_stack.update_inherited_flags();
+    DebugLog( D_INFO, D_MAIN ) << string_format(
+        "Loaded stackable container %s with contents and %d charges; split off %d empty container(s).",
+        it.tname(), old_charges, old_charges - 1 );
+    return true;
+}
+
 ret_val<void> item::put_in( const item &payload, pocket_type pk_type,
                             const bool unseal_pockets, Character *carrier, const bool quiet )
 {
+    if( is_stackable_container_stack( *this ) ) {
+        return ret_val<void>::make_failure( _( "can't put contents into a stackable container stack" ) );
+    }
     ret_val<item *> result = contents.insert_item( payload, pk_type, false, unseal_pockets );
     if( !result.success() ) {
         if( !quiet ) {
@@ -722,6 +756,9 @@ int item::fill_with( const item &contained, const int amount,
                      Character *carrier )
 {
     if( amount <= 0 ) {
+        return 0;
+    }
+    if( is_stackable_container_stack( *this ) ) {
         return 0;
     }
 

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2350,16 +2350,6 @@ void Item_factory::check_definitions() const
             }
         }
 
-        // A stackable (count_by_charges) item is a single object representing the
-        // whole stack, so a container pocket would share one set of contents
-        // across every unit and duplicate them when the stack is split. Disallow
-        // the combination rather than supporting per-unit pocket contents.
-        if( type->is_stackable() && is_container( type ) ) {
-            msg += "is stackable and has a CONTAINER pocket; this duplicates pocket "
-                   "contents when the stack is split.  Remove the pocket or the "
-                   "\"stackable\" property.\n";
-        }
-
         if( !type->picture_id.is_empty() && !type->picture_id.is_valid() ) {
             msg +=  "item has unknown ascii_picture.";
         }

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -134,6 +134,7 @@ class item_location::impl
         };
         virtual std::string describe( const Character * ) const = 0;
         virtual item_location obtain( Character &, int ) = 0;
+        virtual item_location split_stack( int ) = 0;
         virtual units::volume volume_capacity() const = 0;
         virtual units::mass weight_capacity() const = 0;
         virtual bool check_parent_capacity_recursive() const = 0;
@@ -214,6 +215,11 @@ class item_location::impl::nowhere : public item_location::impl
         }
 
         item_location obtain( Character &, int ) override {
+            debugmsg( "invalid use of nowhere item_location" );
+            return item_location();
+        }
+
+        item_location split_stack( int ) override {
             debugmsg( "invalid use of nowhere item_location" );
             return item_location();
         }
@@ -335,6 +341,20 @@ class item_location::impl::item_on_map : public item_location::impl
                 remove_item();
                 return get_local_location( ch, inv );
             }
+        }
+
+        item_location split_stack( const int qty ) override {
+            on_contents_changed();
+            item obj = target()->split( qty );
+            if( obj.is_null() ) {
+                return item_location();
+            }
+            item &split = get_map().add_item( cur.pos_bub(), std::move( obj ) );
+            if( split.is_null() ) {
+                target()->charges += qty;
+                return item_location();
+            }
+            return item_location( cur, &split );
         }
 
         int obtain_cost( const Character &ch, int qty ) const override {
@@ -506,6 +526,19 @@ class item_location::impl::item_on_person : public item_location::impl
             }
         }
 
+        item_location split_stack( const int qty ) override {
+            if( !ensure_who_unpacked() ) {
+                return item_location();
+            }
+            on_contents_changed();
+            item obj = target()->split( qty );
+            if( obj.is_null() ) {
+                return item_location();
+            }
+            item &split = who->inv->add_item( std::move( obj ), false, false, false );
+            return item_location( *who, &split );
+        }
+
         int obtain_cost( const Character &ch, int qty ) const override {
             if( !target() || !ensure_who_unpacked() ) {
             return 0;
@@ -663,6 +696,19 @@ class item_location::impl::item_on_vehicle : public item_location::impl
                 remove_item();
                 return inv;
             }
+        }
+
+        item_location split_stack( const int qty ) override {
+            on_contents_changed();
+            item obj = target()->split( qty );
+            if( obj.is_null() ) {
+                return item_location();
+            }
+            vehicle_part &vp = cur.veh.part( cur.part );
+            obj.preserve_location( cur.veh.pos_abs() );
+            auto split = vp.items.insert( obj );
+            cur.veh.invalidate_mass();
+            return item_location( cur, &( *split ) );
         }
 
         int obtain_cost( const Character &ch, int qty ) const override {
@@ -862,6 +908,25 @@ for( const item *it : container->all_items_container_top() ) {
                 remove_item();
                 return inv;
             }
+        }
+
+        item_location split_stack( const int qty ) override {
+            on_contents_changed();
+            item obj = target()->split( qty );
+            if( obj.is_null() ) {
+                return item_location();
+            }
+            item_pocket *pocket = parent_pocket();
+            if( pocket == nullptr ) {
+                target()->charges += qty;
+                return item_location();
+            }
+            ret_val<item *> result = pocket->insert_item( obj, false, false );
+            if( !result.success() ) {
+                target()->charges += qty;
+                return item_location();
+            }
+            return item_location( container, result.value() );
         }
 
         int obtain_cost( const Character &ch, int qty ) const override {
@@ -1256,6 +1321,15 @@ item_location item_location::obtain( Character &ch, int qty )
         return item_location();
     }
     return ptr->obtain( ch, qty );
+}
+
+item_location item_location::split_stack( const int qty )
+{
+    if( !ptr->valid() ) {
+        debugmsg( "item location does not point to valid item" );
+        return item_location();
+    }
+    return ptr->split_stack( qty );
 }
 
 int item_location::obtain_cost( const Character &ch, int qty ) const

--- a/src/item_location.h
+++ b/src/item_location.h
@@ -89,6 +89,9 @@ class item_location
          *  @return item_location for the item */
         item_location obtain( Character &ch, int qty = -1 );
 
+        /** Split charges from this stack into a separate item in the same location. */
+        item_location split_stack( int qty = 1 );
+
         /** Calculate (but do not deduct) number of moves required to obtain an item
          *  @see item_location::obtain */
         int obtain_cost( const Character &ch, int qty = -1 ) const;

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -2169,8 +2169,21 @@ const pocket_data *item_pocket::get_pocket_data() const
     return data;
 }
 
+static bool is_invalid_stackable_container_payload( const item &it )
+{
+    return it.count_by_charges() && it.charges > 1 &&
+           it.is_container() && !it.container_type_pockets_empty();
+}
+
 void item_pocket::add( const item &it, item **ret )
 {
+    if( is_invalid_stackable_container_payload( it ) ) {
+        debugmsg( "tried to add stackable container stack with contents to a pocket: %s", it.tname() );
+        if( ret != nullptr ) {
+            *ret = nullptr;
+        }
+        return;
+    }
     contents.push_back( it );
     if( ret == nullptr ) {
         restack();
@@ -2185,6 +2198,10 @@ void item_pocket::add( const item &it, item **ret )
 
 void item_pocket::add( const item &it, const int copies, std::vector<item *> &added )
 {
+    if( is_invalid_stackable_container_payload( it ) ) {
+        debugmsg( "tried to add stackable container stack with contents to a pocket: %s", it.tname() );
+        return;
+    }
     for( auto iter = contents.insert( contents.end(), copies, it ); iter != contents.end(); iter++ ) {
         added.push_back( &*iter );
     }
@@ -2260,6 +2277,10 @@ std::list<item> &item_pocket::edit_contents()
 ret_val<item *> item_pocket::insert_item( const item &it,
         const bool into_bottom, bool restack_charges, bool ignore_contents )
 {
+    if( is_invalid_stackable_container_payload( it ) ) {
+        return ret_val<item *>::make_failure( nullptr,
+                                              _( "can't put a stackable container stack with contents in a pocket" ) );
+    }
     ret_val<item_pocket::contain_code> containable = can_contain( it, ignore_contents );
 
     if( !containable.success() ) {

--- a/src/json.h
+++ b/src/json.h
@@ -42,6 +42,8 @@ class TextJsonIn;
 class TextJsonObject;
 class TextJsonValue;
 class item;
+bool stackable_container_contents_need_split( const item &it );
+bool split_stackable_container_contents_from_stack( item &it, item &empty_stack );
 
 // Traits class to distinguish sequences which are string like from others
 template< class, class = void >
@@ -606,12 +608,23 @@ class TextJsonIn
                             read( run_l, throw_on_error ) &&
                             end_array()
                           ) { // all is good
+                            const auto insert_loaded_item = [&v]( T &&loaded ) {
+                                if( stackable_container_contents_need_split( loaded ) ) {
+                                    T empty_stack;
+                                    split_stackable_container_contents_from_stack( loaded, empty_stack );
+                                    v.insert( std::move( loaded ) );
+                                    v.insert( std::move( empty_stack ) );
+                                } else {
+                                    v.insert( std::move( loaded ) );
+                                }
+                            };
                             // first insert (run_l-1) elements
                             for( int i = 0; i < run_l - 1; i++ ) {
-                                v.insert( element );
+                                T copy = element;
+                                insert_loaded_item( std::move( copy ) );
                             }
                             // micro-optimization, move last element
-                            v.insert( std::move( element ) );
+                            insert_loaded_item( std::move( element ) );
                         } else { // array is malformed, skipping it entirely
                             error_or_false( throw_on_error, "Expected end of array" );
                             seek( prev_pos );
@@ -619,7 +632,14 @@ class TextJsonIn
                         }
                     } else {
                         if( read( element, throw_on_error ) ) {
-                            v.insert( std::move( element ) );
+                            if( stackable_container_contents_need_split( element ) ) {
+                                T empty_stack;
+                                split_stackable_container_contents_from_stack( element, empty_stack );
+                                v.insert( std::move( element ) );
+                                v.insert( std::move( empty_stack ) );
+                            } else {
+                                v.insert( std::move( element ) );
+                            }
                         } else {
                             skip_value();
                         }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -258,6 +258,49 @@ static tripoint_bub_ms read_legacy_creature_pos( const JsonObject &data )
     return pos;
 }
 
+static void split_loaded_stackable_container_contents( std::list<item> &items )
+{
+    if( std::none_of( items.begin(), items.end(), stackable_container_contents_need_split ) ) {
+        return;
+    }
+
+    std::list<item> corrected;
+    for( item &it : items ) {
+        if( stackable_container_contents_need_split( it ) ) {
+            item empty_stack;
+            split_stackable_container_contents_from_stack( it, empty_stack );
+            corrected.emplace_back( std::move( it ) );
+            corrected.emplace_back( std::move( empty_stack ) );
+        } else {
+            corrected.emplace_back( std::move( it ) );
+        }
+    }
+    items = std::move( corrected );
+}
+
+static void split_loaded_stackable_container_contents( std::vector<item> &items )
+{
+    const size_t split_count = static_cast<size_t>( std::count_if(
+                                   items.begin(), items.end(), stackable_container_contents_need_split ) );
+    if( split_count == 0 ) {
+        return;
+    }
+
+    std::vector<item> corrected;
+    corrected.reserve( items.size() + split_count );
+    for( item &it : items ) {
+        if( stackable_container_contents_need_split( it ) ) {
+            item empty_stack;
+            split_stackable_container_contents_from_stack( it, empty_stack );
+            corrected.emplace_back( std::move( it ) );
+            corrected.emplace_back( std::move( empty_stack ) );
+        } else {
+            corrected.emplace_back( std::move( it ) );
+        }
+    }
+    items = std::move( corrected );
+}
+
 void item_contents::serialize( JsonOut &json ) const
 {
     if( !contents.empty() || !get_ablative_pockets().empty() || !additional_pockets.empty() ) {
@@ -295,6 +338,7 @@ void item_pocket::deserialize( const JsonObject &data )
 {
     data.allow_omitted_members();
     data.read( "contents", contents );
+    split_loaded_stackable_container_contents( contents );
     int saved_type_int;
     data.read( "pocket_type", saved_type_int );
     _saved_type = static_cast<pocket_type>( saved_type_int );
@@ -912,6 +956,7 @@ void Character::load( const JsonObject &data )
     if( data.has_array( "worn" ) ) {
         std::list<item> items;
         data.read( "worn", items );
+        split_loaded_stackable_container_contents( items );
         worn = outfit( items );
     } else {
         data.read( "worn", worn );
@@ -2469,6 +2514,7 @@ void inventory::json_load_items( const JsonArray &ja )
         tmp.deserialize( jo );
         batch.emplace_back( std::move( tmp ) );
     }
+    split_loaded_stackable_container_contents( batch );
     add_items_bulk( std::move( batch ), true, false );
 }
 
@@ -3737,6 +3783,8 @@ void vehicle_part::deserialize( const JsonObject &data )
     data.read( "items", items );
     data.read( "tools", tools );
     data.read( "salvageable", salvageable );
+    split_loaded_stackable_container_contents( tools );
+    split_loaded_stackable_container_contents( salvageable );
     data.read( "target_first_x", target.first.x() );
     data.read( "target_first_y", target.first.y() );
     data.read( "target_first_z", target.first.z() );


### PR DESCRIPTION
﻿#### 概述 (Summary)
Bugfixes "Fix stackable container pocket split handling / 修复可堆叠容器口袋分割处理"

#### 改动目的 (Purpose of change)
EN: Fix the stackable-container edge cases where items with contents could still behave like a stack, causing partial insertions, invalid wear/pickup interactions, and incorrect load-time correction.
ZH: 修复有内容的可堆叠容器仍按堆叠处理的边界问题，避免出现只插入一个、穿戴/拾取异常以及读取时纠错不完整的问题。

#### 解决方案描述 (Describe the solution)
EN: Split loaded stackable containers with contents into one filled container plus the remaining empty containers, block invalid contents insertion into multi-charge container stacks, and keep stackable empty containers available for split-fill flows.
ZH: 将读取到的“有内容的可堆叠容器”拆成 1 个有内容单容器加剩余空容器，禁止向多 charge 容器堆叠写入内容，同时保留空的可堆叠容器用于 split-fill 流程。

#### 你考虑过的替代方案 (Describe alternatives you've considered)
EN: I considered forcing all invalid stacks to collapse to a single item, but that would silently drop the extra empty containers and lose data.
ZH: 曾考虑把所有非法堆叠直接压成单件，但那会静默丢失多余的空容器数量，属于数据损失。

#### 测试 (Testing)
EN: Not compiled or run. Static review only, per request.
ZH: 按要求未编译、未运行测试，仅做静态检查。

#### 补充说明 (Additional context)
EN: This branch also includes the earlier stackable-container insert handling changes required to make the split behavior work end to end.
ZH: 这个分支还包含先前的可堆叠容器插入处理改动，确保分割行为可以端到端生效。
