### PR TITLE
尝试修复material_type.extend.resist未按照预期工作（pr#27 后续）

### DIFF
--- a/src/material.cpp
+++ b/src/material.cpp
@@ -93,11 +93,11 @@ void material_type::load( const JsonObject &jsobj, std::string_view )
             _res_was_loaded.emplace_back( jmemb.name() );
         }
     }
-    else if( was_loaded ) {
+    if( was_loaded ) {
         // A temporary solution, manually add `extend` support.
         // Handwritten data instead of going through generic_factory, but this processing is really crude.
         // The `delete` option may cause more bugs and is not currently being considered for handling.
-        if( jsobj.has_object( "extend" ) && jsobj.has_string("copy-from") ) {
+        if( jsobj.has_object( "extend" ) ) {
             JsonObject ext = jsobj.get_object( "extend" );
             ext.allow_omitted_members();
             if( ext.has_object("resist") ) {


### PR DESCRIPTION
# 中文说明

pr #27 中，似乎`material_type.extend.resist`没有按照预期进行工作，未能成功支持扩展数据进行修改。

略微调整了可疑的逻辑，期望这能够使其正常工作。

# 英文说明

In pr #27, it seems that `material_type.extend.resist` is not working as expected and fails to support modifications to extended data.

I've slightly tweaked the questionable logic, hoping this will make it work correctly.