### PR TITLE
飞艇驾驶熟练度系统

### DIFF
--- a/data/json/vehicleparts/airship.json
+++ b/data/json/vehicleparts/airship.json
@@ -23,6 +23,7 @@
     },
     "durability": 60,
     "damage_modifier": 80,
+    "control_requirements": { "air": { "proficiencies": [ "prof_airship_pilot" ] } },
     "//": "Todo: should explode if damaged or destroyed by bullets, fire, or electric damage.",
     "breaks_into": [ { "item": "plastic_chunk", "count": [ 10, 20 ] } ],
     "flags": [ "BALLOON", "SHOCK_IMMUNE" ],
@@ -46,6 +47,7 @@
     "broken_color": "light_gray",
     "variants": [ { "symbols": "X", "symbols_broken": "O" } ],
     "flags": [ "PROPELLER", "PROTRUSION", "SHOCK_RESISTANT" ],
+    "control_requirements": { "air": { "proficiencies": [ "prof_airship_pilot" ] } },
     "description": "A set of aerofoil propeller rotors, when spun at high speed, they generate thrust via horizontal momentum."
   },
   {

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2353,6 +2353,10 @@ bool read_activity_actor::player_read( avatar &you )
             }
         }
 
+        for( const book_proficiency_bonus &bonus : islotbook->proficiencies ) {
+            learner->practice_proficiency( bonus.id, islotbook->time * bonus.time_factor * penalty );
+        }
+
         if( learner_left && learner->getID().get_value() == learner_id ) {
             learner_left = false;
         }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4830,13 +4830,18 @@ bool vehicle::has_sufficient_balloonlift( map &here ) const
 bool vehicle::is_airship( map &here ) const
 {
     // A lighter-than-air craft floats on its balloons and is steered by propellers.
-    return !balloons.empty() && has_driver( here ) && has_sufficient_balloonlift( here );
+    // Buoyancy keeps it aloft whether or not a pilot is aboard, so - matching CBN -
+    // we do not require a driver here. Without a pilot it simply hovers in place
+    // instead of crashing (see issue #74).
+    return !balloons.empty() && has_sufficient_balloonlift( here );
 }
 
 bool vehicle::is_rotorcraft( map &here ) const
 {
-    return ( !rotors.empty() && has_driver( here ) &&
-    has_sufficient_rotorlift( here ) ) || is_airship( here );
+    // Like CBN, flightworthiness depends only on having enough lift, not on a
+    // pilot being seated. An unmanned craft with sufficient lift hovers rather
+    // than dropping out of the sky.
+    return ( !rotors.empty() && has_sufficient_rotorlift( here ) ) || is_airship( here );
 }
 
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4915,9 +4915,9 @@ bool vehicle::is_in_water( bool deep_water ) const
 
 bool vehicle::can_control_in_air( const Character &pc ) const
 {
-for( const int index : control_req_parts ) {
+    for( const int index : control_req_parts ) {
     for( const proficiency_id prof : parts[index].info().control_air.proficiencies ) {
-            if( !pc.has_proficiency( prof ) ) {
+            if( pc.get_proficiency_practice( prof ) <= 0.0f ) {
                 return false;
             }
         }
@@ -5414,6 +5414,15 @@ void vehicle::consume_fuel( map &here, int load, bool idling )
     // if engine is under load, player is actively piloting a vehicle, so train appropriate vehicle proficiency
     if( load > 0 ) {
         practice_pilot_proficiencies( *driver, in_deep_water );
+        if( is_flying_in_air() ) {
+            for( const int index : control_req_parts ) {
+                for( const proficiency_id prof : parts[index].info().control_air.proficiencies ) {
+                    if( !driver->has_proficiency( prof ) ) {
+                        driver->practice_proficiency( prof, 1_seconds );
+                    }
+                }
+            }
+        }
     }
 
     if( load > 0 && fuel_left( here, fuel_type_muscle ) > 0 &&


### PR DESCRIPTION
- can_control_in_air() 改为部分熟练度门禁：proficiency 练习值 > 0% 即放行
- 飞行时每秒给 air proficiency 练习值
- 读书时根据书的 proficiencies 字段涨 proficiency 练习值
- 气球和螺旋桨加 control_requirements：飞艇升空需 prof_airship_pilot