### PR TITLE
Living Paradox can make rotten food fresh again.

### DIFF
--- a/data/mods/Xedra_Evolved/eocs/chronomancer_eocs.json
+++ b/data/mods/Xedra_Evolved/eocs/chronomancer_eocs.json
@@ -183,7 +183,13 @@
           {
             "id": "EOC_XEDRA_CHRONOMANCER_REVERSE_ENTROPY_INV_SCANNER_DURABILITY",
             "effect": [
-              { "math": [ "n_hp('ALL') += xedra_chron_spell_calc( u_spell_level('xedra_chronomancer_reverse_entropy'), 0.1, 1 )" ] }
+              { "math": [ "n_hp('ALL') += xedra_chron_spell_calc( u_spell_level('xedra_chronomancer_reverse_entropy'), 0.1, 1 )" ] },
+              {
+                "if": { "math": [ "n_item_rot() >= 0" ] },
+                "then": [
+                  { "math": [ " n_item_rot('format':'raw','unit':'minute') -= min( n_item_rot('format':'raw','unit':'minute'), xedra_chron_spell_calc( u_spell_level('xedra_chronomancer_reverse_entropy'), 0.1, 1 ) )" ] }
+                ]
+              }
             ]
           }
         ]
@@ -274,6 +280,12 @@
             "effect": [
               {
                 "math": [ "n_hp('ALL') += xedra_chron_spell_calc( u_spell_level('xedra_chronomancer_rewrite_equipment_causality'), 10, 0 )" ]
+              },
+              {
+                "if": { "math": [ "n_item_rot() >= 0" ] },
+                "then": [
+                  { "math": [ " n_item_rot('format':'raw','unit':'minute') -= min( n_item_rot('format':'raw','unit':'minute'), xedra_chron_spell_calc( u_spell_level('xedra_chronomancer_rewrite_equipment_causality'), 10, 0 ) )" ] }
+                ]
               }
             ]
           }


### PR DESCRIPTION
#### (Summary)

[Xedra Evolved] Add an effect to the spells `Rewrite Equipment Causality` and `Reverse Entropy` that reduces the decay progress of rotten items.

#### (Purpose of change)

Look!

`Reverse Entropy`'s lore:
```
Reverse the entropy on your equipment, repairing any damage it has taken or energy it has spent over time.
```
`Rewrite Equipment Causality`'s lore:
```
Sink into a mediative trance where you steadily rewrite the causality of your carried items, efficiently repairing any faults they may have.
```

What powerful descriptions! Reducing entropy, reversing the second law of physics, rewriting causality. But Living Paradox's two spells can't even make food fresher, which, according to Lore, should be within their jurisdiction!

#### (Describe the solution)

pr #64 exposed the rot val to the EOC, which resolved the issue of spells being unable to manipulate the item decay process.

A new effect has been added to `EOC_XEDRA_CHRONOMANCER_REVERSE_ENTROPY_INV_SCANNER_DURABILITY` and `EOC_XEDRA_CHRONOMANCER_REWRITE_EQUIPMENT_CAUSALITY_ONGOING_REPAIR_SCANNER`, which reduces the item's rot progress if the condition `{ "math": [ "n_item_rot() >= 0" ] }` passes. This value is set in minutes, consistent with the item durability regeneration of the corresponding spell.

#### (Describe alternatives you've considered)

Living Paradox is too strong. Weaken this profession. (?)

#### (Testing)

Modified the JSON, launched the game, learned the spells via the debug menu, and spawned a portion of rotten fried rice.

Activated both spells respectively, and noticed that the item quickly turned from rotten to old, and eventually became completely fresh as time progressed.