### PR TITLE
There may be a distinction between high and low functions, but it's not simply a matter of "Nobody wants to cooperate with psychopaths".

### DIFF
--- a/data/json/npcs/common_chat/TALK_COMMON_OTHER.json
+++ b/data/json/npcs/common_chat/TALK_COMMON_OTHER.json
@@ -103,7 +103,7 @@
         "switch": true,
         "default": true,
         "text": "I can keep you safe.",
-        "trial": { "type": "PERSUADE", "difficulty": 20, "mod": [ [ "FEAR", 8 ], [ "VALUE", 2 ], [ "TRUST", 2 ], [ "BRAVERY", -2 ] ] },
+        "trial": { "type": "PERSUADE", "difficulty": 20, "mod": [ [ "FEAR", 8 ], [ "VALUE", 2 ], [ "TRUST", 2 ], [ "BRAVERY", -2 ], [ "LOWFUNC_PSYCHOPATH", -10 ], [ "HIGHFUNC_PSYCHOPATH", 2 ] ] },
         "success": {
           "topic": "TALK_AGREE_FOLLOW",
           "effect": [
@@ -123,7 +123,7 @@
         "trial": {
           "type": "PERSUADE",
           "difficulty": 0,
-          "mod": [ [ "ALTRUISM", 6 ], [ "POS_FEAR", -6 ], [ "BRAVERY", 2 ], [ "ANGER", -6 ], [ "VALUE", 2 ] ]
+          "mod": [ [ "ALTRUISM", 6 ], [ "POS_FEAR", -6 ], [ "BRAVERY", 2 ], [ "ANGER", -6 ], [ "VALUE", 2 ], [ "LOWFUNC_PSYCHOPATH", -10 ], [ "HIGHFUNC_PSYCHOPATH", 2 ] ]
         },
         "success": {
           "topic": "TALK_AGREE_FOLLOW",
@@ -141,7 +141,7 @@
         "switch": true,
         "default": true,
         "text": "We're friends, aren't we?",
-        "trial": { "type": "PERSUADE", "difficulty": 0, "mod": [ [ "TRUST", 3 ], [ "VALUE", 3 ], [ "ANGER", -3 ] ] },
+        "trial": { "type": "PERSUADE", "difficulty": 0, "mod": [ [ "TRUST", 3 ], [ "VALUE", 3 ], [ "ANGER", -3 ], [ "LOWFUNC_PSYCHOPATH", -10 ], [ "HIGHFUNC_PSYCHOPATH", 2 ] ] },
         "success": {
           "topic": "TALK_AGREE_FOLLOW",
           "effect": [
@@ -158,7 +158,7 @@
         "switch": true,
         "default": true,
         "text": "I'll kill you if you don't.",
-        "trial": { "type": "INTIMIDATE", "difficulty": 20, "mod": [ [ "FEAR", 8 ], [ "VALUE", 2 ], [ "TRUST", 2 ], [ "BRAVERY", -2 ] ] },
+        "trial": { "type": "INTIMIDATE", "difficulty": 20, "mod": [ [ "FEAR", 8 ], [ "VALUE", 2 ], [ "TRUST", 2 ], [ "BRAVERY", -2 ], [ "LOWFUNC_PSYCHOPATH", 5 ], [ "HIGHFUNC_PSYCHOPATH", 2 ] ] },
         "success": {
           "topic": "TALK_AGREE_FOLLOW",
           "effect": [
@@ -442,7 +442,7 @@
         "text": "Because I'm your friend!",
         "switch": true,
         "default": true,
-        "trial": { "type": "PERSUADE", "difficulty": 10, "mod": [ [ "TRUST", 1 ], [ "VALUE", 3 ], [ "ALTRUISM", 2 ] ] },
+        "trial": { "type": "PERSUADE", "difficulty": 10, "mod": [ [ "TRUST", 1 ], [ "VALUE", 3 ], [ "ALTRUISM", 2 ], [ "LOWFUNC_PSYCHOPATH", -2 ], [ "HIGHFUNC_PSYCHOPATH", 1 ] ] },
         "success": {
           "topic": "TALK_GIVE_EQUIPMENT",
           "effect": { "give_equipment": { "allowance": [ [ "TRUST", 1 ], [ "VALUE", 3 ], [ "ALTRUISM", 2 ], [ "TOTAL", 300 ] ] } },
@@ -458,7 +458,7 @@
         "trial": {
           "type": "PERSUADE",
           "difficulty": 12,
-          "mod": [ [ "TRUST", 1 ], [ "VALUE", 2 ], [ "ALTRUISM", 1 ], [ "MISSIONS", 1 ] ]
+          "mod": [ [ "TRUST", 1 ], [ "VALUE", 2 ], [ "ALTRUISM", 1 ], [ "MISSIONS", 1 ], [ "LOWFUNC_PSYCHOPATH", -2 ], [ "HIGHFUNC_PSYCHOPATH", 1 ] ]
         },
         "success": { "topic": "TALK_GIVE_EQUIPMENT", "effect": "give_equipment" },
         "failure": { "topic": "TALK_DENY_EQUIPMENT", "opinion": { "value": -1, "anger": 2 } }
@@ -467,7 +467,7 @@
         "text": "I'll give it back!",
         "switch": true,
         "default": true,
-        "trial": { "type": "LIE", "difficulty": 0, "mod": [ [ "TRUST", 2 ], [ "VALUE", 5 ], [ "ALTRUISM", 3 ] ] },
+        "trial": { "type": "LIE", "difficulty": 0, "mod": [ [ "TRUST", 2 ], [ "VALUE", 5 ], [ "ALTRUISM", 3 ], [ "LOWFUNC_PSYCHOPATH", -2 ], [ "HIGHFUNC_PSYCHOPATH", 1 ] ] },
         "success": {
           "topic": "TALK_GIVE_EQUIPMENT",
           "effect": { "give_equipment": { "allowance": [ [ "TRUST", 1 ], [ "VALUE", 3 ], [ "ALTRUISM", 2 ], [ "TOTAL", 300 ] ] } },
@@ -532,21 +532,21 @@
       {
         "text": "No, I'm keeping it.  Try and take it off me, I dare you.",
         "condition": "u_has_stolen_item",
-        "trial": { "type": "INTIMIDATE", "difficulty": 30, "mod": [ [ "FEAR", 8 ], [ "VALUE", 2 ], [ "TRUST", 2 ], [ "BRAVERY", -2 ] ] },
+        "trial": { "type": "INTIMIDATE", "difficulty": 30, "mod": [ [ "FEAR", 8 ], [ "VALUE", 2 ], [ "TRUST", 2 ], [ "BRAVERY", -2 ], [ "LOWFUNC_PSYCHOPATH", 5 ], [ "HIGHFUNC_PSYCHOPATH", 1 ] ] },
         "success": { "topic": "TALK_KEEPING_ITEM", "effect": { "u_faction_rep": -2 } },
         "failure": { "topic": "TALK_DONE", "effect": [ "hostile", { "u_faction_rep": -75 } ] }
       },
       {
         "text": "Look, I really need this.  Please let me have it.",
         "condition": "u_has_stolen_item",
-        "trial": { "type": "PERSUADE", "difficulty": 20, "mod": [ [ "TRUST", 3 ], [ "VALUE", 3 ], [ "ANGER", -3 ] ] },
+        "trial": { "type": "PERSUADE", "difficulty": 20, "mod": [ [ "TRUST", 3 ], [ "VALUE", 3 ], [ "ANGER", -3 ], [ "LOWFUNC_PSYCHOPATH", -5 ], [ "HIGHFUNC_PSYCHOPATH", 1 ] ] },
         "success": { "topic": "TALK_ALLOW_KEEP_ITEM", "effect": { "u_faction_rep": -1 } },
         "failure": { "topic": "TALK_DISALLOW_KEEP_ITEM", "opinion": { "trust": -3, "anger": 2 }, "effect": { "u_faction_rep": -15 } }
       },
       {
         "text": "What, this?  It's not the same one, you are mistaken.",
         "condition": "u_has_stolen_item",
-        "trial": { "type": "LIE", "difficulty": 25, "mod": [ [ "TRUST", 3 ] ] },
+        "trial": { "type": "LIE", "difficulty": 25, "mod": [ [ "TRUST", 3 ], [ "LOWFUNC_PSYCHOPATH", -5 ], [ "HIGHFUNC_PSYCHOPATH", 1 ] ] },
         "success": { "topic": "TALK_DONE", "effect": "remove_stolen_status" },
         "failure": { "topic": "TALK_DISALLOW_KEEP_ITEM", "opinion": { "trust": -3, "value": -1, "anger": 2 } }
       },

--- a/doc/JSON/NPCs.md
+++ b/doc/JSON/NPCs.md
@@ -792,6 +792,11 @@ u_has_trait checks if the player character has the specified trait.
 npc_has_trait checks if the NPC has the specified trait.
 Modifier is 1 if they have the trait, 0 otherwise.
 
+### `LOWFUNC_PSYCHOPATH` / `HIGHFUNC_PSYCHOPATH`
+LOWFUNC_PSYCHOPATH and HIGHFUNC_PSYCHOPATH check if the player has the `PSYCHOPATH` JSON flag and their current Intelligence attribute.
+LOWFUNC_PSYCHOPATH is applied when the `PSYCHOPATH` flag exists and the Intelligence is below 8(inclusive).
+HIGHFUNC_PSYCHOPATH is applied when the `PSYCHOPATH` flag exists and the Intelligence is above 16(inclusive).
+
 ### `TOTAL`
 The special `"TOTAL"` modifier sums all previous modifiers and then multiplies the result by its value and is used when setting the owed value.
 

--- a/src/talker_avatar.cpp
+++ b/src/talker_avatar.cpp
@@ -4,9 +4,11 @@
 
 #include "avatar.h"
 #include "calendar.h"
+#include "character.h"
 #include "coordinates.h"
 #include "debug.h"
 #include "enums.h"
+#include "flag.h"
 #include "game.h"
 #include "messages.h"
 #include "monster.h"
@@ -26,6 +28,8 @@ static const itype_id itype_foodperson_mask( "foodperson_mask" );
 static const itype_id itype_foodperson_mask_on( "foodperson_mask_on" );
 
 static const trait_id trait_PROF_FOODP( "PROF_FOODP" );
+
+static const json_character_flag json_flag_PSYCHOPATH( "PSYCHOPATH" );
 
 std::vector<std::string> talker_avatar_const::get_topics( bool ) const
 {
@@ -50,7 +54,14 @@ int talker_avatar_const::parse_mod( const std::string &attribute, const int fact
         const std::string after = "u_has_trait: ";
         trait_id checked_trait = trait_id( attribute.substr( after.size() ) );
         modifier = me_chr->has_trait( checked_trait ) ? 1 : 0;
+    } else if ( attribute == "LOWFUNC_PSYCHOPATH" )
+    {
+        modifier = me_chr-> has_flag( json_flag_PSYCHOPATH ) && get_int() <= 8 ? 1 : 0;
+    } else if ( attribute == "HIGHFUNC_PSYCHOPATH" )
+    {
+        modifier = me_chr-> has_flag( json_flag_PSYCHOPATH ) && get_int() >= 16 ? 1 : 0;
     }
+    
     modifier *= factor;
     return modifier;
 }


### PR DESCRIPTION
#### 概述 (Summary)

[balance] Adds a social penalty to the `UNCARING` trait when intelligence is at or below average, but provides a small reward as compensation when intelligence is exceptionally high.

#### 改动目的 (Purpose of change)

Some of the points in [PR#86578](https://github.com/CleverRaven/Cataclysm-DDA/pull/86578) are not entirely without merit, but it is likely that it is blinded by a radical and extreme hatred of a certain trait.

In fact, I've observed that `UNCARING` (internal ID `PSYCHOPATH`) has long been portrayed in games as a character whose behavior closely resembles a culmination of stereotypes about ASPD and mental illness in the conventional sense. Furthermore, the character portrayal seems to be closer to ASPD. Such characters do indeed exhibit numerous social issues, particularly due to a potential lack of empathy. However, they are not entirely incapable of learning and mimicking normal human behavior, even though doing so can be highly "energy-consuming." The original PR applies a massive -40 penalty across the board—a penalty so severe that it can hardly be offset by social skills—which seems somewhat inappropriate. Even when considering common public perceptions rather than deep medical mechanisms, individuals with psychopathic traits like ASPD are recognized in these contexts as having high-functioning and low-functioning distinctions.

#### 解决方案描述 (Describe the solution)

After reviewing some medical literature, I decided to refactor its data balancing.

Two new `trial.mod` check flags, `LOWFUNC_PSYCHOPATH` and `HIGHFUNC_PSYCHOPATH`, have been added to compositely check whether the character has the `json_flag_PSYCHOPATH` and to evaluate their intelligence stat. The current design sets the threshold at less than or equal to 8 for "low-functioning" and greater than or equal to 16 for "high-functioning".

Meanwhile, the penalty from the original PR has been modified to apply only under the low-functioning branch, with the values reduced to 20%–25% of the original amount. A minor bonus (only 1–2 points, unable to compensate for general penalties) has been introduced for the high-functioning branch. Additionally, under the low-functioning branch, the social modifier for intimidation-type interactions has been adjusted with a +5 bonus to offset the -5 `social_modifiers` value.

For now, this only addresses the content modified in #86578.

Under the current design, as long as the PC is above the human average, they can avoid this penalty entirely—unless they completely neglect their intelligence attribute and choose not to install or activate any intelligence-related CBMs. On the other hand, unless players choose a min-maxed high-attribute start in the vanilla game, only those who specifically specialize in intelligence can benefit from this minor bonus. Statistically speaking, even with mods enabled, it is generally only the intelligence-focused builds that push intelligence to 16+. Therefore, this approach should maintain proper balance and prevent any numerical breakdown without breaking player experience.

#### 你考虑过的替代方案 (Describe alternatives you've considered)

Keep deleted

#### 补充说明 (Additional context)

All relevant references:
 - https://pmc.ncbi.nlm.nih.gov/articles/PMC3042879/
 - https://pmc.ncbi.nlm.nih.gov/articles/PMC2538613/
 - https://pmc.ncbi.nlm.nih.gov/articles/PMC11782123/
 - https://pmc.ncbi.nlm.nih.gov/articles/PMC9067243/

Considering the game's presentation, it's difficult to fully replicate real-world medical research. Furthermore, current game mechanics cannot establish a highly definitive relationship with real-world psychopathology and can only serve as a reference.

Effects have been simplified and/or mitigated for balance within the game system.