### PR TITLE
性能: 减少移动时渲染卡顿 / perf: reduce movement-time render stutter

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -633,7 +633,17 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
     if( here.draw_points_cache_dirty ) {
         here.draw_points_cache_dirty = false;
         // overlay_strings and color_blocks are generated with draw_points and thus are cleared together
-        here.draw_points_cache.clear();
+        // Soft clear: keep the z/row tree nodes and each row's vector capacity so
+        // the per-move rebuild reuses last frame's buffers instead of freeing and
+        // reallocating every step. Freeing here was the dominant movement-time cost
+        // (profiled: std::map _Erase_tree + vector reserve/realloc churn). All access
+        // is via operator[], so leftover empty rows are indistinguishable from absent.
+        for( std::pair<const int, std::map<int, std::vector<tile_render_info>>> &z_entry :
+             here.draw_points_cache ) {
+            for( std::pair<const int, std::vector<tile_render_info>> &row_entry : z_entry.second ) {
+                row_entry.second.clear(); // clear() keeps capacity
+            }
+        }
         here.overlay_strings_cache.clear();
         here.color_blocks_cache = {};
 

--- a/src/pixel_minimap.cpp
+++ b/src/pixel_minimap.cpp
@@ -261,13 +261,29 @@ void pixel_minimap::clear_unused_cache()
 //draws individual updates to the submap cache texture
 void pixel_minimap::flush_cache_updates()
 {
+    // Batch render-target switches: scoped_render_target restores the prior target
+    // on each destruction, so binding it per chunk inside the loop costs ~2N target
+    // switches (screen->chunk->screen per chunk). Each switch forces a driver sync
+    // (profiled: ZwDelayExecution / D3D11_RunCommandQueue stalls in flush). Bind each
+    // chunk directly and restore the prior target once after the loop -> N+1 switches.
+    bool target_changed = false;
+    SDL_Texture *prior_target = nullptr;
+
     for( auto &mcp : cache ) {
         if( mcp.second.update_list.empty() ) {
             continue;
         }
 
-        scoped_render_target chunk_scope( renderer, mcp.second.chunk_tex.get() );
-        if( !chunk_scope.is_valid() ) {
+        if( !target_changed ) {
+            prior_target = SDL_GetRenderTarget( renderer.get() );
+            target_changed = true;
+        }
+
+#if SDL_MAJOR_VERSION >= 3
+        if( !SDL_SetRenderTarget( renderer.get(), mcp.second.chunk_tex.get() ) ) {
+#else
+        if( SDL_SetRenderTarget( renderer.get(), mcp.second.chunk_tex.get() ) != 0 ) {
+#endif
             continue;
         }
 
@@ -302,6 +318,10 @@ void pixel_minimap::flush_cache_updates()
         }
 
         mcp.second.update_list.clear();
+    }
+
+    if( target_changed ) {
+        SDL_SetRenderTarget( renderer.get(), prior_target );
     }
 }
 


### PR DESCRIPTION
# 性能:减少移动时的渲染卡顿 / perf: reduce movement-time render stutter

## 概述 / Summary

**中文**
用 Very Sleepy CS 对自编译的 `cataclysm-tiles.exe` 做采样剖析,定位"移动时一顿一顿"的主线程开销,做了两处针对性优化。两者都**不改变渲染输出**,只改变内部的内存/渲染目标管理方式。

**EN**
Profiled the local `cataclysm-tiles.exe` build with Very Sleepy CS to find the main-thread cost behind the move-time stutter, and made two targeted optimizations. Both are **render-output-identical** — they only change internal memory / render-target management.

---

## 改动 / Changes

### 1. `draw_points_cache` 改用保留容量的 soft-clear(主要收益 / the real win)

**中文**
每移动一步,视口原点变化使 `draw_points_cache`(`std::map<int z, std::map<int row, std::vector<tile_render_info>>>`)失效,旧代码 `clear()` 会**销毁整棵嵌套 map 并释放所有叶子 vector**,下一帧重建再重新分配。剖析显示这是移动帧的主要开销(`_Erase_tree` + `vector::reserve` realloc + `NtFreeVirtualMemory`)。
改为遍历清空叶子 vector 但**保留容量与树节点**,重建复用上一帧缓冲。所有访问均经 `operator[]`,残留空行与缺失键等价,行为不变。

**EN**
Every step invalidates `draw_points_cache`; the old `clear()` destroyed the whole nested map and freed every leaf vector, then the rebuild re-allocated them. Profiling showed this (map `_Erase_tree` + `vector::reserve` realloc + `NtFreeVirtualMemory`) was the dominant move-frame cost. Now we clear the leaf vectors but **keep their capacity and the tree nodes**, so the rebuild reuses last frame's buffers. All access is via `operator[]`, so leftover empty rows are indistinguishable from absent keys — behavior is unchanged.

`src/cata_tiles.cpp` — `cata_tiles::draw()`

### 2. `pixel_minimap::flush_cache_updates` 批处理渲染目标切换 / batch render-target switches

**中文**
`flush_cache_updates` 原本在逐 chunk 循环内创建 `scoped_render_target`,其析构会把渲染目标恢复成 screen,于是 N 个脏 chunk 产生 `screen→chunk→screen…` ≈ **2N 次渲染目标切换**,每次切换触发一次 GPU 驱动同步停顿。改为逐 chunk 直接 `SDL_SetRenderTarget`、循环结束统一恢复一次 → **N+1 次**。沿用 `cata_shader.cpp` 中既有的保存-恢复写法。

**EN**
`flush_cache_updates` created a `scoped_render_target` inside the per-chunk loop; its destructor restored the screen target each time, so N dirty chunks cost `screen→chunk→screen…` ≈ **2N render-target switches**, each a GPU driver sync. Now each chunk is bound directly with `SDL_SetRenderTarget` and the prior target is restored **once** after the loop → **N+1 switches**, mirroring the save/restore pattern already used in `cata_shader.cpp`.

`src/pixel_minimap.cpp` — `pixel_minimap::flush_cache_updates()`

---

## 实测 / Measured (Very Sleepy, before → after)

**改动 1 / Change 1** — `capture4`(改前)→ `capture5`(改后),移动负载更重仍下降 / heavier movement yet lower:

| item (inclusive weight) | before | after |
|---|---:|---:|
| `std::map<…tile_render_info…>::_Erase_tree` | 6.15 | **0** |
| `vector<tile_render_info>::reserve` | 2.36 | **0** |
| `NtFreeVirtualMemory` | 1.88 | **0** |
| `emplace_back<tile_render_info>` | 5.00 | **1.29** |
| `tile_render_info::common::common` | 4.98 | **1.20** |

体感:移动卡顿明显改善 / Subjectively, the move stutter is noticeably improved.

**改动 2 / Change 2** — `capture5` → `capture6`,flush 内的渲染目标切换驱动开销下降 / the switch-driven driver work in flush dropped:

| item under `flush_cache_updates` | before | after |
|---|---:|---:|
| `D3D11_RunCommandQueue` | 0.37 | **0.17** |
| `D3DKMTOpenResource` | 0.34 | **0.18** |

**坦白说明 / Honest note:** 渲染目标切换开销本来只占 `flush` 的 ~14%,其余是"等 GPU"的固有开销,所以改动 2 对小地图总成本的影响较小;它是个**正确、零副作用**的清理。/ The switch overhead was only ~14% of `flush` (the rest is fundamental GPU-wait), so Change 2's impact on total minimap cost is modest — it is a **correct, zero-downside** cleanup.

> 跨抓取的时长/操作量不同,绝对值不可直接比;以上以"内部成分"为准。/ Captures differ in length/workload, so absolute values aren't directly comparable — the figures above are internal-composition signals.

---

## 风险与测试 / Risk & testing

- **中文**:两处都只改内部管理方式,像素输出应一致。已在本地 Windows / D3D11(AMD)build 编译并运行(capture5、capture6 即改后实测)。建议回归:地图绘制、多 z 层、视野/记忆瓦片、小地图地形/光照/敌人光标闪烁/缩放与滚动、跨 submap、z 切换、debug overlay。
- **EN**: Both are internal-only; pixel output should be identical. Built and run on a local Windows / D3D11 (AMD) build (capture5/capture6 are the post-change runs). Suggested regression: map draw, multi-z, vision/memorized tiles, minimap terrain/lighting/critter beacons/scale+scroll, submap crossing, z-changes, debug overlays.

## 后续(不在本 PR)/ Follow-ups (not in this PR)

- **中文**:剖析显示移动后剩余开销主要是 GPU 贴图(`draw_sprite_at`/`draw_terrain` 的 `RenderCopyEx`)与移动时光照/视野重算(`update_visibility_cache`/`build_map_cache`/`cast_zlight`),属较大工程;小地图若要进一步降本需改 `SDL_UpdateTexture` 流式上传(等距投影需另行处理)。
- **EN**: Remaining post-move cost is mostly GPU blits (`RenderCopyEx` in `draw_sprite_at`/`draw_terrain`) and move-time lighting/vision recompute — larger efforts. Further minimap savings would need an `SDL_UpdateTexture` streaming rewrite (isometric projection needs care).

🤖 Generated with [Claude Code](https://claude.com/claude-code)