### PR TITLE
加快捣碎丧尸速度：将时间除数1000改为100，最低时间30秒改为10秒

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11404,10 +11404,10 @@ pulp_data game::calculate_pulpability( const Character &you, const mtype &corpse
     float corpse_volume = units::to_liter( corpse_mtype.volume );
     // in seconds
     int time_to_pulp = std::max( 1.0, ( std::pow( corpse_volume,
-                                        pow_factor ) * 1000 ) / pd.nominal_pulp_power );
+                                        pow_factor ) * 100 ) / pd.nominal_pulp_power );
     // in seconds also
     // 30 seconds for human body volume of 62.5L, scale from this
-    int min_time_to_pulp = std::max( 1.0, 30 * corpse_volume / 62.5 );
+    int min_time_to_pulp = std::max( 1.0, 10 * corpse_volume / 62.5 );
 
     // you have a hard time pulling armor to reach important parts of this monster
     if( corpse_mtype.has_flag( mon_flag_PULP_PRYING ) ) {
@@ -11419,7 +11419,7 @@ pulp_data game::calculate_pulpability( const Character &you, const mtype &corpse
     }
 
     // Adjust pulp_power to match the time taken.
-    pd.pulp_power = ( std::pow( corpse_volume, pow_factor ) * 1000 ) / time_to_pulp;
+    pd.pulp_power = ( std::pow( corpse_volume, pow_factor ) * 100 ) / time_to_pulp;
 
     // +25% to pulp time if char knows no weakpoints of monster
     // -25% if knows all of them
@@ -11441,7 +11441,7 @@ pulp_data game::calculate_pulpability( const Character &you, const mtype &corpse
     if( time_to_pulp < min_time_to_pulp ) {
         pd.time_to_pulp = min_time_to_pulp;
         // Reducing the power to match the time in order to get the same amount of splatter.
-        pd.pulp_power = pd.time_to_pulp / ( std::pow( corpse_volume, pow_factor ) * 1000 );
+        pd.pulp_power = pd.time_to_pulp / ( std::pow( corpse_volume, pow_factor ) * 100 );
     } else {
         pd.time_to_pulp = time_to_pulp;
     }


### PR DESCRIPTION
PR #78948 修复了捣碎速度过快的问题，PR #79483 彻底重写了捣碎系统，自此捣碎丧尸的速度变得过慢。一只普通丧尸徒手需要约5.2分钟，10只将近1小时，严重影响游戏体验。

修改内容 (`src/game.cpp`)：
- `calculate_pulpability()` 中时间除数 `1000` -> `100`（3处）
- 最小时间底线 `30`秒 -> `10`秒（1处）

| 场景                         | 修改前      | 修改后 |
|------------------------------|:-----------:|:------:|
| 徒手/普通钝器 (10力)          | ~312秒 (5.2分) | ~31秒 |
| 消防斧 (bash 20+cut 20)      | ~124秒 (2.1分) | ~10秒 |
| PULP_PRYING 装甲丧尸 + 无撬棍 | ~530秒 (8.8分) | ~53秒 |
| PULP_PRYING 装甲丧尸 + 有撬棍 | ~390秒 (6.5分) | ~39秒 |