### PR TITLE
性能: critter 图层避免逐瓦片 creature_at 扫描 / Avoid per-tile creature_at scan in critter layers

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -914,6 +914,20 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
     overlay_strings = here.overlay_strings_cache;
     color_blocks = here.color_blocks_cache;
 
+    // Precompute creature positions once per draw so the critter layers can skip
+    // the per-tile creature_at hash lookup (there are usually a handful of creatures
+    // versus thousands of visible tiles). Consumed by draw_critter_at (early-out on
+    // empty tiles) and draw_critter_above (skip the upward flying-shadow scan when
+    // nothing is above). Matches creature_at's sources: monsters (incl.
+    // hallucinations), npcs, and the avatar.
+    m_creature_positions.clear();
+    m_creature_columns.clear();
+    for( Creature &cr : g->all_creatures() ) {
+        const tripoint_bub_ms cpos = cr.pos_bub();
+        m_creature_positions.insert( cpos );
+        m_creature_columns.insert( cpos.xy() );
+    }
+
     // List all layers for a single z-level
     const std::array<decltype( &cata_tiles::draw_furniture ), 11> drawing_layers = {{
             &cata_tiles::draw_terrain, &cata_tiles::draw_furniture, &cata_tiles::draw_graffiti, &cata_tiles::draw_trap, &cata_tiles::draw_part_con,
@@ -3550,6 +3564,12 @@ bool cata_tiles::draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &h
         return false;
     }
 
+    // Fast path: with no creature on this tile (and no debug monster override
+    // active), there is nothing to draw here — skip the creature_at hash lookup.
+    if( monster_override.empty() && m_creature_positions.find( p ) == m_creature_positions.end() ) {
+        return false;
+    }
+
     bool result;
     bool is_player;
     bool sees_player;
@@ -3719,6 +3739,14 @@ bool cata_tiles::draw_critter_above( const tripoint_bub_ms &p, lit_level ll, int
                                      const std::array<bool, 5> &invisible )
 {
     if( invisible[0] ) {
+        return false;
+    }
+
+    // No creature anywhere in this (x,y) column — nothing can cast a shadow down
+    // onto this tile, so skip the upward creature_at scan entirely. This is the
+    // common case (creatures are sparse); only columns that actually contain a
+    // creature pay for the scan.
+    if( m_creature_columns.find( p.xy() ) == m_creature_columns.end() ) {
         return false;
     }
 

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -862,6 +862,16 @@ class cata_tiles
         sprite_screen_bounds *m_cur_bounds = nullptr;
         small_literal_vector<tint_sprite_record, 4> *m_cur_tint_sprites = nullptr;
 
+        // Per-draw caches rebuilt once per draw() from g->all_creatures(). Let the
+        // critter layers skip the per-tile creature_at hash lookup for the ~all
+        // tiles that hold no creature:
+        //   m_creature_positions - exact tiles, for draw_critter_at's early-out.
+        //   m_creature_columns   - (x,y) columns containing any creature, for
+        //     draw_critter_above: a creature only casts a downward shadow within
+        //     its own column, so columns with no creature skip the upward z-scan.
+        std::unordered_set<tripoint_bub_ms> m_creature_positions;
+        std::unordered_set<point_bub_ms> m_creature_columns;
+
         // Scratch render target for the ortho silhouette mask tint path. Sized
         // to fit the largest batched sprite region; reused across tiles/frames.
         SDL_Texture_Ptr tint_mask_tex;


### PR DESCRIPTION
## 概要 / Summary

**中文**

移动时,`cata_tiles::draw` 对每个可见瓦片(每帧约 2000 个)都会调用 `draw_critter_at` / `draw_critter_above`,二者内部各调用一次 `creature_at`——一次按瓦片的哈希查找;`draw_critter_above` 还会沿 z 轴向上扫描以绘制飞行生物的投影。在 Very Sleepy 抓取(持续移动)中,这是渲染准备阶段一处明确的逐瓦片热点。

本 PR 在每次 draw 开始时,从 `g->all_creatures()` 一次性预计算两个集合:

- `m_creature_positions`(精确 `tripoint_bub_ms` 集合)——生物只可能在这些瓦片上;
- `m_creature_columns`(`point_bub_ms` 列集合)——生物只会向其自身所在列的上方投影。

critter 两个图层据此早退:没有生物的瓦片在 `draw_critter_at` 直接返回;没有生物的列在 `draw_critter_above` 跳过向上扫描。集合的来源与 `creature_at` 完全一致,**渲染输出不变**,只是把 O(瓦片) 的每帧扫描换成 O(生物) 的预计算 + O(1) 查表。

**English**

While moving, `cata_tiles::draw` calls `draw_critter_at` / `draw_critter_above` for every visible tile (~2000/frame). Each calls `creature_at` — a per-tile hash lookup — and `draw_critter_above` additionally scans upward along z to render flying-creature shadows. Very Sleepy captures (sustained movement) show this as a clear per-tile hotspot in draw preparation.

This PR precomputes, once per draw, two sets from `g->all_creatures()`:

- `m_creature_positions` (exact `tripoint_bub_ms`) — creatures can only be on these tiles;
- `m_creature_columns` (`point_bub_ms`) — a creature only shadows down/up its own column.

The two critter layers early-out accordingly: tiles with no creature return immediately in `draw_critter_at`; columns with no creature skip the upward scan in `draw_critter_above`. The set source is identical to `creature_at`, so **rendering output is unchanged** — it just replaces an O(tiles) per-frame scan with an O(creatures) precompute + O(1) lookups.

## 实测 / Measurements

Very Sleepy CS,持续移动,改前(capture5)→ 改后(capture9),按抓取时长归一化:

| symbol | before | after | Δ |
|---|---|---|---|
| `draw_critter_above` | 3.35 | 0.17 | **−92%** |
| `creature_at<Creature>` | 3.16 | 0.26 | **−88%** |
| `draw_critter_at` | 0.94 | 0.22 | **−64%** |
| `npc_coloring` hash self | 1.99 | 0.17 | **−87%** |
| `cata_tiles::draw` (whole) | 48.2 | 29.2 | −10% beyond duration |

未改动的对照函数(`draw_terrain` / `draw_field_or_item`)仅在噪声范围内浮动,确认收益真实、非抓取差异。

Untargeted control functions (`draw_terrain` / `draw_field_or_item`) moved only within noise, confirming the gain is real and not a capture artifact.

## 改动 / Changes

- `src/cata_tiles.cpp`: 每次 draw 构建两个集合;`draw_critter_at` / `draw_critter_above` 早退。
- `src/cata_tiles.h`: 新增 `m_creature_positions` / `m_creature_columns` 成员。

+38 行,纯内部逻辑,无行为变化 / +38 lines, internal-only, no behavior change.