### PR TITLE
修复 parse_mod 中 get_int() 缺少 me_chr-> 前缀导致无法编译的问题 (指向 #99)

### DIFF
--- a/src/talker_avatar.cpp
+++ b/src/talker_avatar.cpp
@@ -56,10 +56,10 @@ int talker_avatar_const::parse_mod( const std::string &attribute, const int fact
         modifier = me_chr->has_trait( checked_trait ) ? 1 : 0;
     } else if ( attribute == "LOWFUNC_PSYCHOPATH" )
     {
-        modifier = me_chr-> has_flag( json_flag_PSYCHOPATH ) && get_int() <= 8 ? 1 : 0;
+        modifier = me_chr->has_flag( json_flag_PSYCHOPATH ) && me_chr->get_int() <= 8 ? 1 : 0;
     } else if ( attribute == "HIGHFUNC_PSYCHOPATH" )
     {
-        modifier = me_chr-> has_flag( json_flag_PSYCHOPATH ) && get_int() >= 16 ? 1 : 0;
+        modifier = me_chr->has_flag( json_flag_PSYCHOPATH ) && me_chr->get_int() >= 16 ? 1 : 0;
     }
     
     modifier *= factor;


### PR DESCRIPTION
修复两处编译问题：
-  应为 （talker_avatar_const 没有 get_int 方法）
-  多余空格修复

目标分支: LunaGlaze 的 #99 PR 分支