### PR TITLE
恢复屠宰速度至 PR #83376 之前的旧值

### DIFF
--- a/src/butchery.cpp
+++ b/src/butchery.cpp
@@ -394,23 +394,23 @@ int butcher_time_to_cut( Character &you, const item &corpse_item, const butcher_
     switch( corpse.size ) {
         // Time (roughly) in turns to cut up the corpse
         case creature_size::tiny:
-            time_to_cut = 900;
+            time_to_cut = 150;
             break;
         case creature_size::small:
-            time_to_cut = 1800;
+            time_to_cut = 300;
             break;
         case creature_size::medium:
-            time_to_cut = 2700;
+            time_to_cut = 450;
             break;
         case creature_size::large:
-            time_to_cut = 3600;
+            time_to_cut = 600;
             break;
         case creature_size::huge:
-            time_to_cut = 10800;
+            time_to_cut = 1800;
             break;
         default:
             debugmsg( "ERROR: Invalid creature_size on %s", corpse.nname() );
-            time_to_cut = 2700; // default to medium
+            time_to_cut = 450; // default to medium
             break;
     }
 


### PR DESCRIPTION
PR #83376 将所有体型的基础屠宰时间乘以6倍，使正常大小的丧尸完整屠宰从约1.2小时变为7.3小时，浩克更是高达29.2小时，一条小鱼也要近2小时，严重影响游戏体验。

修改内容 (`src/butchery.cpp`)：
`butcher_time_to_cut()` 中6个基础值恢复至旧值：

| 体型 | 新(×6) | 旧(恢复) |
|------|:------:|:--------:|
| tiny | 900 | 150 |
| small | 1800 | 300 |
| medium | 2700 | 450 |
| large | 3600 | 600 |
| huge | 10800 | 1800 |

效果 (战术小刀 BUTCHER 19, 无熟练度, 完整屠宰 FULL)：

| 目标 | 新时间 | 旧时间 |
|------|--------|--------|
| 丧尸小孩 (small) | 4.9小时 | 49分钟 |
| 普通丧尸 (medium) | 7.3小时 | 1.2小时 |
| 丧尸浩克 (huge) | 29.2小时 | 4.9小时 |
| 小鱼 (tiny) | 2.4小时 | 24分钟 |
| 鳟鱼 (small) | 4.9小时 | 49分钟 |