### PR TITLE
CI: 添加 CBN 不死人贴图 (MSX++UnDeadPeopleEdition) 拉取支持

### DIFF
--- a/.github/workflows/compose-tilesets.yml
+++ b/.github/workflows/compose-tilesets.yml
@@ -115,6 +115,12 @@ jobs:
             compose_args: --use-all
             tileset_repo: pixel-32/CDDA-tileset
             tileset_src_checkout: ""
+          - name: MSX++UndeadPeopleEdition
+            tileset_repo: LYHGLYTX/CCB-UndeadPeople-Tileset
+            tileset_ref: v1.0
+            tileset_dir: gfx/MSX++UnDeadPeopleEdition
+            precomposed: true
+            tileset_src_checkout: ""
 
     name: Compose tileset
     runs-on: ubuntu-latest
@@ -134,6 +140,7 @@ jobs:
       - run: pip install pyvips
 
       - name: Clone tileset repo
+        if: matrix.precomposed != true
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{ matrix.tileset_repo }}
@@ -143,7 +150,18 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Clone precomposed tileset repo
+        if: matrix.precomposed == true
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: ${{ matrix.tileset_repo }}
+          ref: ${{ matrix.tileset_ref || 'master' }}
+          path: precomposed-tileset
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Build ${{ matrix.name }}
+        if: matrix.precomposed != true
         run: |
           export SOURCE="${{github.workspace}}/build-tilesets/${{ matrix.tileset_dir }}"
           export DEST="${{github.workspace}}/gfx/${{ matrix.name }}"
@@ -152,6 +170,14 @@ jobs:
           mv -v "$SOURCE/tileset.txt" "$DEST/"
           [ -f "$SOURCE/fallback.png"  ] && mv -v "$SOURCE/fallback.png" "$DEST/" || echo "No fallback.png for ${{ matrix.name }}"
           [ -f "$SOURCE/layering.json" ] && mv -v "$SOURCE/layering.json" "$DEST/" || echo "No layering.json for ${{ matrix.name }}"
+
+      - name: Copy precomposed ${{ matrix.name }}
+        if: matrix.precomposed == true
+        run: |
+          export SOURCE="${{github.workspace}}/precomposed-tileset/${{ matrix.tileset_dir }}"
+          export DEST="${{github.workspace}}/gfx/${{ matrix.name }}"
+          mkdir -p "$DEST"
+          cp -r "$SOURCE"/* "$DEST/"
 
       - name: Store artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4


### PR DESCRIPTION
## 概述

从独立仓库 [LYHGLYTX/CCB-UndeadPeople-Tileset](https://github.com/LYHGLYTX/CCB-UndeadPeople-Tileset) (v1.0) 拉取预组合的不死人贴图，与 I-am-Erk 的 MShockXotto+ 并行提供。

## 修改内容

### compose-tilesets.yml
- 新增  字段支持：预组合贴图跳过 compose.py，直接复制
- 新增矩阵条目：MSX++UndeadPeopleEdition

### data/json/external_tileset/
- 内置 CBN 的外部精灵表（头发、皮肤、眼睛、地形等覆盖）
- 只针对不死人贴图生效 ()

## CI 构建后效果

`gfx/` 下两个贴图并存：
| 贴图 | 来源 | 状态 |
|------|------|------|
| MShockXotto+ | I-am-Erk/CDDA-Tilesets (上游重建) | 可能不全 |
| MSX++UndeadPeopleEdition | CBN 完整版 (预组合) | 精灵较全 |

## 署名

- MShock777: MShockXotto+ 原版作者
- SomeDeadGuy: DeadPeople 贴图包维护者
- CBN 团队: MSX++UnDeadPeople 贴图包的后续维护
- I-am-Erk: CDDA-Tilesets 仓库维护者

协议: CC-BY-SA 3.0