### PR TITLE
修复: talker_avatar parse_mod 中 get_int 缺少接收者 / Fix missing receiver for get_int in talker_avatar

### DIFF
--- a/src/talker_avatar.cpp
+++ b/src/talker_avatar.cpp
@@ -56,10 +56,10 @@ int talker_avatar_const::parse_mod( const std::string &attribute, const int fact
         modifier = me_chr->has_trait( checked_trait ) ? 1 : 0;
     } else if ( attribute == "LOWFUNC_PSYCHOPATH" )
     {
-        modifier = me_chr-> has_flag( json_flag_PSYCHOPATH ) && get_int() <= 8 ? 1 : 0;
+        modifier = me_chr-> has_flag( json_flag_PSYCHOPATH ) && me_chr->get_int() <= 8 ? 1 : 0;
     } else if ( attribute == "HIGHFUNC_PSYCHOPATH" )
     {
-        modifier = me_chr-> has_flag( json_flag_PSYCHOPATH ) && get_int() >= 16 ? 1 : 0;
+        modifier = me_chr-> has_flag( json_flag_PSYCHOPATH ) && me_chr->get_int() >= 16 ? 1 : 0;
     }
     
     modifier *= factor;


### PR DESCRIPTION
## 中文

`talker_avatar_const::parse_mod` 的 PSYCHOPATH 社交惩罚分支裸调了 `get_int()`,导致编译失败(`get_int: 找不到标识符`)。`talker_avatar_const` 并非 `Character` 子类,`get_int()` 是 `Character` 的成员函数;同一函数其余调用都经由 `me_chr->`,此处遗漏了接收者。补回 `me_chr->`。

由 PR #99(UNCARING 社交惩罚)引入,仅在全量重编时暴露。

## English

The PSYCHOPATH social-penalty branches in `talker_avatar_const::parse_mod` called `get_int()` with no receiver, breaking the build (`get_int: identifier not found`). `talker_avatar_const` is not a `Character` subclass — `get_int()` is a `Character` member, and every other call in the function goes through `me_chr->`. Restored the `me_chr->` receiver.

Introduced by PR #99 (UNCARING social penalties); only surfaces on a full rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)