### PR TITLE
CI: 修复 external_tileset 复制步骤遗漏

### DIFF
--- a/.github/workflows/compose-tilesets.yml
+++ b/.github/workflows/compose-tilesets.yml
@@ -179,6 +179,16 @@ jobs:
           mkdir -p "$DEST"
           cp -r "$SOURCE"/* "$DEST/"
 
+      - name: Copy external_tileset (precomposed only)
+        if: matrix.precomposed == true
+        run: |
+          export EXT_SRC="${{github.workspace}}/precomposed-tileset/external_tileset"
+          export EXT_DEST="${{github.workspace}}/data/json/external_tileset"
+          if [ -d "$EXT_SRC" ]; then
+            mkdir -p "$EXT_DEST"
+            cp -r "$EXT_SRC"/* "$EXT_DEST/"
+          fi
+
       - name: Store artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:


### PR DESCRIPTION
PR #107 遗漏了 external_tileset 复制步骤，导致 CI 构建的发布包缺少不死人贴图的外部精灵表。

加回 precomposed 贴图专用的 external_tileset 复制步骤。