### PR TITLE
载具界面: 移植 CBN 的贴图化载具布局展示

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -98,6 +98,10 @@ static const trait_id trait_INATTENTIVE( "INATTENTIVE" );
 
 static const trap_str_id tr_unfinished_construction( "tr_unfinished_construction" );
 
+// Iterating a vehicle's "structure" parts yields one part per occupied square, so the vehicle
+// preview draws exactly one sprite per tile (the same basis the ASCII display_veh() uses).
+static const vpart_location_id vpart_location_structure( "structure" );
+
 static const std::string ITEM_HIGHLIGHT( "highlight_item" );
 static const std::string ZOMBIE_REVIVAL_INDICATOR( "zombie_revival_indicator" );
 
@@ -3553,6 +3557,87 @@ bool cata_tiles::draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height
         }
     }
     return false;
+}
+
+bool cata_tiles::draw_vehicle_preview( const catacurses::window &w_disp, const vehicle &veh,
+                                       const point_rel_ms &cursor_vp_mount, int &cpart )
+{
+    // Reuses the normal map sprite path (draw_from_id_string, exactly as draw_vpart does) to
+    // render the vehicle into an arbitrary curses window, without modifying the core renderer.
+    // The trick: temporarily repoint the draw origin (o/op) and scale at the target window, draw
+    // each part at a synthetic tile coordinate relative to the cursor, then restore on exit.
+
+    // Isometric tilesets use a different projection that this simple rectangular grid does
+    // not handle; signal the caller to fall back to the ASCII display.
+    if( is_isometric() ) {
+        return false;
+    }
+
+    // This temporarily rescales the shared tile context. cata_tiles::draw() does not reset
+    // the scale every frame, so we must restore it before returning or the map would stay
+    // at the preview scale.
+    const int saved_zoom = g->get_zoom();
+    // Fixed preview scale (16 == native tile size). Lower it to fit more of large vehicles.
+    constexpr int preview_scale = 16;
+    set_draw_scale( preview_scale );
+
+    // Target window rectangle, in screen pixels.
+    const window_dimensions dim = get_window_dimensions( w_disp );
+    const point win_px_beg = dim.window_pos_pixel;
+    const point win_px_size = dim.window_size_pixel;
+    const point center_px = win_px_beg + win_px_size / 2;
+
+    // Repurpose the draw origin so a synthetic tile coordinate maps straight to a screen
+    // pixel: player_to_screen( pos ) == op + ( pos - o ) * { tile_width, tile_height } in the
+    // non-isometric case. With o == (0,0) and op == window centre, synthetic tile (0,0)
+    // lands at the centre, where the cursor part is drawn.
+    o = point::zero;
+    op = center_px;
+
+    // Clip to the panel so an oversized vehicle does not bleed into neighbouring windows.
+    const SDL_Rect clip{ win_px_beg.x, win_px_beg.y, win_px_size.x, win_px_size.y };
+    RenderSetClipRect( renderer, &clip );
+
+    int center_part = -1;
+    // One sprite per structural square, mirroring the ASCII display_veh().
+    for( const int part_idx : veh.all_parts_at_location( vpart_location_structure ) ) {
+        const vehicle_part &vp = veh.part( part_idx );
+        const vpart_display vd = veh.get_display_of_tile( vp.mount, false, false );
+        if( vd.id.is_null() ) {
+            continue;
+        }
+        // Same fixed, heading-independent layout transform the ASCII view uses.
+        const point_rel_ms q = ( vp.mount + cursor_vp_mount ).rotate( 3 );
+        const tripoint_bub_ms screen_tile( tripoint( q.x(), q.y(), 0 ) );
+        const int subtile = vd.is_open ? open_ : vd.is_broken ? broken : 0;
+        // Canonical (un-rotated) orientation, the tile analogue of the ASCII path's
+        // rotate=false symbols. If the whole vehicle looks rotated by a multiple of 90
+        // degrees, change this to 1, 2 or 3.
+        const int rotation = 0;
+        int height_3d = 0;
+        draw_from_id_string( "vp_" + vd.id.str(), TILE_CATEGORY::VEHICLE_PART, empty_string,
+                             screen_tile, subtile, rotation, lit_level::LIT, false, height_3d, 0,
+                             vd.variant.id );
+        if( vd.has_cargo ) {
+            // Cargo space holding items: overlay the item-highlight, as the map path does.
+            draw_item_highlight( screen_tile, height_3d );
+        }
+        if( q == point_rel_ms::zero ) {
+            center_part = part_idx;   // the part under the cursor, drawn at the window centre
+        }
+    }
+    cpart = center_part;
+
+    // Mark the selected cell with the "cursor" sprite (the yellow selection box, the same
+    // sprite the look-around cursor uses). The cursor part is at the synthetic origin, i.e.
+    // the window centre. Drawn after the parts so it sits on top, and still inside the clip.
+    draw_from_id_string( "cursor", tripoint_bub_ms( tripoint( 0, 0, 0 ) ), 0, 0, lit_level::LIT,
+                         false );
+
+    // Restore the clip rectangle and the map draw scale.
+    RenderSetClipRect( renderer, nullptr );
+    set_draw_scale( saved_zoom );
+    return true;
 }
 
 bool cata_tiles::draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &height_3d,

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -56,8 +56,14 @@ class memorized_tile;
 class monster;
 class nc_color;
 class pixel_minimap;
+class vehicle;
 struct sprite_screen_bounds;
 struct tint_sprite_record;
+
+namespace catacurses
+{
+class window;
+} // namespace catacurses
 enum class direction : unsigned int;
 enum class lit_level : uint8_t;
 enum class visibility_type : int;
@@ -661,6 +667,17 @@ class cata_tiles
         bool draw_item_highlight( const tripoint_bub_ms &pos, int &height_3d );
 
     public:
+        /**
+         * Draw a vehicle's layout into @p w_disp using graphical tiles, centered on the
+         * structural part under @p cursor_vp_mount. Used by veh_interact as a graphical
+         * alternative to the ASCII display_veh(). @p cpart is set to the structural part
+         * index under the cursor (matching the ASCII path's contract).
+         * Returns false without drawing for isometric tilesets, so the caller can fall
+         * back to the ASCII display.
+         */
+        bool draw_vehicle_preview( const catacurses::window &w_disp, const vehicle &veh,
+                                   const point_rel_ms &cursor_vp_mount, int &cpart );
+
         // Animation layers
         void init_explosion( const tripoint_bub_ms &p, int radius );
         void draw_explosion_frame();

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2479,6 +2479,11 @@ void options_manager::add_options_graphics()
              true, COPT_CURSES_HIDE
            );
 
+        add( "VEHICLE_EDIT_TILES", page_id, to_translation( "Graphical vehicle display" ),
+             to_translation( "If true, the vehicle interaction screen displays the vehicle layout using graphical tiles instead of ASCII symbols." ),
+             true, COPT_CURSES_HIDE
+           );
+
         add( "SWAP_ZOOM", page_id, to_translation( "Zoom Threshold" ),
              to_translation( "Choose when you should swap tileset (lower is more zoomed out)." ),
              1, 4, 2, COPT_CURSES_HIDE
@@ -2489,6 +2494,7 @@ void options_manager::add_options_graphics()
         get_option( "DISTANT_TILES" ).setPrerequisite( "USE_DISTANT_TILES" );
         get_option( "SWAP_ZOOM" ).setPrerequisite( "USE_DISTANT_TILES" );
         get_option( "CREATURE_OVERLAY_ICONS" ).setPrerequisite( "USE_TILES" );
+        get_option( "VEHICLE_EDIT_TILES" ).setPrerequisite( "USE_TILES" );
 
         add( "USE_OVERMAP_TILES", page_id, to_translation( "Use tiles to display overmap" ),
              to_translation( "If true, replaces some TTF-rendered text with tiles for overmap display." ),

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -72,6 +72,15 @@
 #include "vpart_position.h"
 #include "vpart_range.h"
 
+#if defined(TILES)
+// Only for the graphical vehicle-layout branch in display_veh(): use_tiles (cached_options),
+// get_option (options), and tilecontext / cata_tiles::draw_vehicle_preview (sdltiles / cata_tiles).
+#include "cached_options.h"
+#include "cata_tiles.h"
+#include "options.h"
+#include "sdltiles.h"
+#endif
+
 static const ammotype ammo_battery( "battery" );
 
 static const faction_id faction_no_faction( "no_faction" );
@@ -2299,6 +2308,17 @@ void veh_interact::display_grid()
  */
 void veh_interact::display_veh( map &here )
 {
+#if defined(TILES)
+    // Graphical layout (option-gated, active tileset only). Falls through to ASCII below
+    // when disabled, when no tileset is loaded, or for isometric tilesets.
+    if( use_tiles && get_option<bool>( "VEHICLE_EDIT_TILES" ) ) {
+        werase( w_disp );
+        wnoutrefresh( w_disp );
+        if( tilecontext->draw_vehicle_preview( w_disp, *veh, cursor_vp_mount, cpart ) ) {
+            return;
+        }
+    }
+#endif
     werase( w_disp );
     const point h_size = point( getmaxx( w_disp ), getmaxy( w_disp ) ) / 2;
 


### PR DESCRIPTION
<!-- 使用说明：在下面每个「#### 标题」下填写与你的 PR 相关的信息。
请保留这些标题。像这样的注释可以安全删除。

如果你是在 GitHub 网页界面发起这个 PR，可以用「preview（预览）」按钮查看 PR 对他人显示的样子。

PR 提交准则：
- 让你的改动只聚焦于一个具体的问题或变更，外加为实现它所必需的最小相关改动。
- 一个经验法则：大多数 PR 的改动应少于 500 行。
- 你可以另开 PR 来拆分一次较大的预期改动；如果不确定怎么拆，尽管问。我们很乐意与你协作，并建议合并你 PR 的最佳方式。
-->

#### 概述 (Summary)
Feature "Add Tile-Based Vehicle Layout Preview to veh_interactwith Minimal Intrusion"

<!-- 这一节应当只有一行，请编辑上面那一行。
1. 把「分类」替换为下列具体分类之一：Features、Content、Interface、Mods、Balance、Bugfixes、Performance、Infrastructure、Build、I18N。
2. 把引号内的文字替换为对你改动的简要描述。
如果你不希望生成更新日志条目，把整行替换为单独一个词「None」（不带引号）。
示例：
1. None
2. Bugfixes "修复长矛无法锁定不同楼层敌人的问题"
3. Interface "在制作界面显示制作失败几率"
分类含义详见：
https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/blob/master/doc/CHANGELOG_GUIDELINES.md
合并后，你的概述会被加入项目更新日志：
https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/blob/master/data/changelog.txt -->

#### 改动目的 (Purpose of change)

<!-- 用几句话描述你做这次改动的原因。
如果它与某个已有 issue 相关，可以用「#」加 GitHub issue 编号来关联，例如 #1234。

【重要】当你的 PR 能完全解决某个 issue 时，必须使用 [GitHub 的英文关闭关键字](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
才能在 PR 合并后自动关闭该 issue，例如：Fixes #1234。
只能用以下英文关键词（后面紧跟「#编号」）：
  close / closes / closed
  fix / fixes / fixed
  resolve / resolves / resolved
注意：中文「修复 #1234」不会触发自动关闭，GitHub 只识别上述英文关键词。

如果没有相关 issue，请在这里说明你要解决的问题、特性或其他关注点。如果这是一个 bug 修复，请附上复现原始 bug 的步骤，以便你的修复可以被验证。 -->


#### 解决方案描述 (Describe the solution)

1、New Option:​ Added VEHICLE_EDIT_TILES(under the Graphics tab, enabled by default, requires USE_TILES). On = Tiles, Off = ASCII.
2、Rendering Logic:​ Implemented cata_tiles::draw_vehicle_preview. This reuses existing map tile paths (draw_from_id_string) and temporarily adjusts the drawing origin (o/op) and scaling to render component sprites into the w_disppanel. Cargo bays containing items are overlaid with item-highlight, and selected tiles are marked with the "cursor" sprite (yellow border).
3、Fallback Mechanism:​ Added a tile rendering branch at the top of veh_interact::display_veh. The system automatically falls back to the original ASCII display if the option is disabled, no tileset is loaded, or an isometric tileset is detected.
4、Non-Breaking Change:​ This is a purely additive modification; it does not touch existing rendering logic or build scripts.

<!-- 这个特性是如何工作的，或者这个 bug 是怎么被修复的？方案越易于理解，就越快能被合并。 -->

#### 你考虑过的替代方案 (Describe alternatives you've considered)

<!-- 说明你为解决同一问题考虑过的其他方案、不同思路或可能性。 -->

#### 测试 (Testing)

<!-- 描述你采取了哪些步骤来测试这个 PR 是否修复了 bug 或添加了特性，以及你做了哪些测试以确保没有引入回归问题。也请为审阅者和维护者提供测试建议。参见 TESTING_YOUR_CHANGES.md -->

#### 补充说明 (Additional context)

Attribution

The graphical tile-based vehicle layout display introduced in this PR was inspired by the vehicle_preview module in the open-source project [Cataclysm: Bright Nights](https://github.com/cataclysmbnteam/Cataclysm-BN). Due to significant API divergence between the two projects, no code was directly transplanted; the feature was re-implemented independently on top of this project's existing rendering pipeline.

Cataclysm: Bright Nights is released under the CC BY-SA 3.0 license.


<!--README: Cataclysm: Cleanwater Bomb (CCB) 以 Creative Commons Attribution ShareAlike 3.0 许可证发布。
游戏的代码与内容可自由用于任何目的的使用、修改和再分发。
通过为本项目做贡献，你即同意该许可证的条款，并同意你所做的任何贡献也将受同一许可证覆盖。
详见 http://creativecommons.org/licenses/by-sa/3.0/ 。 -->