### PR TITLE
High temperatures should not accelerate food rot.

### DIFF
--- a/src/item_degrade.cpp
+++ b/src/item_degrade.cpp
@@ -555,12 +555,15 @@ int item::spoilage_sort_order() const
  * Rate of rot doubles every 16 F (~8.8888 C) increase in temperature
  * Rate of rot halves every 16 F decrease in temperature
  * Rot maxes out at 105 F
- * Rot stops below 32 F (0C) and above 145 F (63 C)
+ * Above 105°F, rate of rot halve every 8°F (~4.4444°C) increase in temperature
+ * Above 145°F (63°C), the rate of rot decreases to ~636 rot/hour
+ * Rot stops below 32 F (0C)
  */
 float item::calc_hourly_rotpoints_at_temp( const units::temperature &temp ) const
 {
     const units::temperature dropoff = units::from_fahrenheit( 38 ); // F, ~3 C
     const float max_rot_temp = 105; // F, ~41 C, Maximum rotting rate is at this temperature
+    const float safe_temp = 145; // F, ~63 C, threshold above which rot is severely slowed
 
     // Cryogenic rot is much simpler, rot simply idicates how many turns the item might survive outside of cryogenic storage, so they rot as if temperature was 65F.
     if( has_flag( flag_CRYOGENIC_ROT ) && temp > units::from_fahrenheit( -320 ) ) {
@@ -574,11 +577,15 @@ float item::calc_hourly_rotpoints_at_temp( const units::temperature &temp ) cons
                     temperatures::freezing ) );
     } else if( temp < units::from_fahrenheit( max_rot_temp ) ) {
         // Exponential progress from 38 F (3 C) to 105 F (41 C)
+        // Max rot from 105 F (41 C) is approximately 20364.67 rot/hour
         return 3600.f * std::exp2( ( units::to_fahrenheit( temp ) - 65.f ) / 16.f );
     } else {
-        // Constant rot from 105 F (41 C) upwards
-        // This is approximately 20364.67 rot/hour
-        return 3600.f * std::exp2( ( max_rot_temp - 65.f ) / 16.f );
+        // Exponential decay from 105 F to 145 F
+        // Rate halves every 8 F (~4.44 C) above 105 F, min approach 636 rot/hour
+        // Constant very slowly rot from 145 F (63 C) upwards.
+        const float capped_temp = std::min( units::to_fahrenheit( temp ), safe_temp );
+        return 3600.f * std::exp2( ( max_rot_temp - 65.f ) / 16.f
+                               - ( capped_temp - max_rot_temp ) / 8.f );
     }
 }
 

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -112,13 +112,13 @@ TEST_CASE( "Hourly_rotpoints", "[rot]" )
     // No rot below 32F/0C
     CHECK( normal_item.calc_hourly_rotpoints_at_temp( units::from_celsius( 0 ) ) == 0 );
 
-    // Max rot above 145F/63C
+    // Rot is severely slowed above 145F/63C
     CHECK( normal_item.calc_hourly_rotpoints_at_temp( units::from_celsius( 63 ) ) == Approx(
-               20364.67 ) );
+               636.396 ) );
 
-    // Make sure no off by one error at the border
+    // Rot is slowed near 145F/63C
     CHECK( normal_item.calc_hourly_rotpoints_at_temp( units::from_celsius( 62 ) ) == Approx(
-               20364.67 ) );
+               718.469 ) );
 
     // 3200 point/h at 65F/18C
     CHECK( normal_item.calc_hourly_rotpoints_at_temp( units::from_fahrenheit( 65 ) ) == Approx(
@@ -136,7 +136,25 @@ TEST_CASE( "Hourly_rotpoints", "[rot]" )
     CHECK( normal_item.calc_hourly_rotpoints_at_temp( units::from_fahrenheit( 35 ) ) == Approx(
                1117.672 / 2 ) );
 
-    // Maximum rot at above 105 F
-    CHECK( normal_item.calc_hourly_rotpoints_at_temp( units::from_fahrenheit( 107 ) ) == Approx(
+    // Maximum rot at 105 F
+    CHECK( normal_item.calc_hourly_rotpoints_at_temp( units::from_fahrenheit( 105 ) ) == Approx(
                20364.67 ) );
+
+    // Rot decays above 105 F
+    CHECK( normal_item.calc_hourly_rotpoints_at_temp( units::from_fahrenheit( 107 ) ) == Approx(
+               17124.58 ) );
+
+    // Rot halves every 8 F above 105 F
+    CHECK( normal_item.calc_hourly_rotpoints_at_temp( units::from_fahrenheit( 105 + 8 ) ) == Approx(
+               20364.67 / 2 ) );
+    CHECK( normal_item.calc_hourly_rotpoints_at_temp( units::from_fahrenheit( 105 + 16 ) ) == Approx(
+               20364.67 / 4 ) );
+    CHECK( normal_item.calc_hourly_rotpoints_at_temp( units::from_fahrenheit( 105 + 24 ) ) == Approx(
+               20364.67 / 8 ) );
+    CHECK( normal_item.calc_hourly_rotpoints_at_temp( units::from_fahrenheit( 105 + 32 ) ) == Approx(
+               20364.67 / 16 ) );
+
+    // Rot is constant above 145 F
+    CHECK( normal_item.calc_hourly_rotpoints_at_temp( units::from_fahrenheit( 212 ) ) == Approx(
+               636.396 ) );
 }


### PR DESCRIPTION
#### (Summary)

[balance] Fix `calc_hourly_rotpoints_at_temp` to implement high-temperature bacterial inhibition for reduced rotting speed.

#### (Purpose of change)

When gathering player feedback within the community, a player pointed out that high temperatures currently accelerate food spoilage instead of preventing it, and provided a link to [PR74058](https://github.com/CleverRaven/Cataclysm-DDA/pull/74058), hoping CCB developers would revert it.

After reviewing the changes in that PR and the related [issue](https://github.com/CleverRaven/Cataclysm-DDA/issues/86781), I believe simply reverting the change is not a wise choice. I completely agree with RenechCDDA's perspective in the discussion that allowing high temperatures to keep food indefinitely fresh and edible would be absurd. However, the unmodified parts of the system, along with conflicts between the code comments and implementation, do present genuine issues. Specifically, RenechCDDA left the large explanatory comment at the beginning of the function untouched, which still states `Rot stops below 32 F (0C) and above 145 F (63 C)`. Leaving `and above 145 F (63 C)` in the comments will very likely cause confusion for future developers. Furthermore, because the rotting system is intuitively tied to microbial growth, using it as a direct proxy to simulate physical degradation (thermal damage) at a 1:1 ratio feels unauthentic.

According to relevant literature and food safety standards, the range of 38°F–105°F (3°C–41°C) is indeed the "Danger Zone" where bacterial growth accelerates. The `calc_hourly_rotpoints_at_temp` function models this with an exponential increase in spoilage speed, which is highly reasonable. However, the original function used to cap the rot speed at its maximum above 105°F before abruptly clipping to 0 at 145°F. The modified version removed this high-temperature cutoff entirely, causing it to perpetually return the maximum value. Neither approach fully aligns with the scientific consensus on food safety. Beyond 105°F / 41°C, bacterial reproduction theoretically becomes inhibited, meaning the spoilage rate should gradually decrease. In USDA food safety guidelines, 145°F is the recommended safe internal temperature for cooking; a pot of boiling soup rotting at maximum speed while actively boiling defies basic real-world intuition.

That being said, as RenechCDDA noted: `Although food does not "rot" once you've killed all the microbes, it eventually ceases being food. Rotting is an acceptable mechanic to represent this.` Given that we currently lack a fully-fledged and distinct thermal degradation system, allowing high temperatures to halt all decay processes completely would be unrealistic and unbalanced. The mechanic simply needs a more scientifically grounded adjustment—slowing down the "rot" speed without stopping it entirely—at least until a proper thermal degradation system is implemented.

Of course, the counterargument brought up in [issue86781](https://github.com/CleverRaven/Cataclysm-DDA/issues/86781) regarding "perpetual stew" is historically valid. Even today, many traditional culinary techniques preserve this practice, and to my knowledge, certain cultural heritage broths have been kept simmering for over a century. Dismissing system adjustments with a simple "Perpetual stew isn't perpetual. If you've ever cooked you'll be well aware what happens when you leave food on to simmer for too long" seems somewhat dismissive. However, a crucial detail to consider is that a perpetual stew is not a static batch of food simmered forever; it is a "Stew of Theseus"—the cook constantly ladles out the old and replenishes it with new ingredients. Since our system does not yet support this mechanic, the existence of perpetual stews cannot serve as a valid argument for reverting to the early-version behavior where high temperatures completely stop decay.


#### (Describe the solution)

Modified the `calc_hourly_rotpoints_at_temp` function in `item_degrade.cpp` and the validation function in `rot_test.cpp`, currently achieving the following effects:
 - Keeps the original function completely unchanged when the temperature is below 105 F (41 C)
 - When the temperature is above 105 F (41 C), changes returning the maximum value to an exponential decrease
 - Currently set to rate halves every 8 F (~4.44 C) above 105 F
 - When the temperature is higher than `safe_temp` (i.e., 145 F/63 C), clamps the function calculation, so any temperature higher than this is calculated as 145F
 - No new if else branches were added or old ones modified; when the thermal degradation system is implemented, the threshold temperature can be easily added to the first branch to make it return 0
 - The current minimum high-temperature rot rate is 636 rot/hour, close to 1/5 of that under 65F, thereby achieving preservation rather than perpetual freshness

#### (Describe alternatives you've considered)

Directly copying the penalty system where certain foods become mushy and tasteless after freezing and thawing to act as a substitute for a thermal degradation system, but I think this might be somewhat inappropriate.