### PR TITLE
fix(ci): 修复贴图 CI 分支名缺失 + release 工作流格式

### DIFF
--- a/.github/workflows/compose-tilesets.yml
+++ b/.github/workflows/compose-tilesets.yml
@@ -119,6 +119,7 @@ jobs:
             tileset_repo: LYHGLYTX/CCB-UndeadPeople-Tileset
             tileset_dir: .
             compose_args: --use-all
+            tileset_ref: main
 
     name: Compose tileset
     runs-on: ubuntu-latest
@@ -142,7 +143,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{ matrix.tileset_repo }}
-          ref: master
+          ref: ${{ matrix.tileset_ref || 'master' }}
           path: build-tilesets
           sparse-checkout: ${{matrix.tileset_src_checkout}}
           fetch-depth: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,34 +30,25 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     outputs:
-      timestamp: ${{ steps.get-timestamp.outputs.time }}
+      timestamp: ${{ steps.meta.outputs.time }}
     steps:
-      - name: Get build timestamp
-        id: get-timestamp
+      - name: Generate release metadata
+        id: meta
         run: |
-          echo "time=$(TZ=Asia/Shanghai /bin/date "+%Y-%m-%d-%H%M")" >> $GITHUB_OUTPUT
-      - name: Generate environmental variables
-        id: generate_env_vars
-        run: |
-          echo "tag_name=ccb-experimental-${STEPS_GET_TIMESTAMP_OUTPUTS_TIME}" >> $GITHUB_OUTPUT
-          echo "release_name=Cataclysm-Cleanwater-Bomb experimental build ${STEPS_GET_TIMESTAMP_OUTPUTS_TIME}" >> $GITHUB_OUTPUT
-        env:
-          STEPS_GET_TIMESTAMP_OUTPUTS_TIME: ${{ steps.get-timestamp.outputs.time }}
+          time=$(TZ=Asia/Shanghai /bin/date "+%Y-%m-%d-%H%M")
+          echo "time=$time" >> $GITHUB_OUTPUT
+          echo "tag_name=ccb-experimental-${time}" >> $GITHUB_OUTPUT
+          echo "release_name=Cataclysm-Cleanwater-Bomb experimental build ${time}" >> $GITHUB_OUTPUT
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
       - name: Generate Release Notes
-        id: generate-release-notes
         run: |
           npm install @actions/github@8
-          node build-scripts/generate-release-notes.js '${{ secrets.GITHUB_TOKEN }}' "${STEPS_GENERATE_ENV_VARS_OUTPUTS_TAG_NAME}" "$(git log -1 --format='%H')" > notes.txt
-        env:
-          STEPS_GENERATE_ENV_VARS_OUTPUTS_TAG_NAME: ${{ steps.generate_env_vars.outputs.tag_name }}
-      - run: |
-          gh release create ${STEPS_GENERATE_ENV_VARS_OUTPUTS_TAG_NAME} --notes-file notes.txt --prerelease --title "${STEPS_GENERATE_ENV_VARS_OUTPUTS_RELEASE_NAME}" --target "$(git log -1 --format='%H')"
-        env:
-          STEPS_GENERATE_ENV_VARS_OUTPUTS_TAG_NAME: ${{ steps.generate_env_vars.outputs.tag_name }}
-          STEPS_GENERATE_ENV_VARS_OUTPUTS_RELEASE_NAME: ${{ steps.generate_env_vars.outputs.release_name }}
+          node build-scripts/generate-release-notes.js '${{ secrets.GITHUB_TOKEN }}' '${{ steps.meta.outputs.tag_name }}' "$(git log -1 --format='%H')" > notes.txt
+      - name: Create GitHub Release
+        run: |
+          gh release create '${{ steps.meta.outputs.tag_name }}' --notes-file notes.txt --prerelease --title '${{ steps.meta.outputs.release_name }}' --target "$(git log -1 --format='%H')"
 
   compose-tilesets:
     uses: ./.github/workflows/compose-tilesets.yml


### PR DESCRIPTION
## 修复内容

### 1. compose-tilesets.yml: 分支名不匹配导致 MSX++UnDeadPeople 贴图无法 compose

**问题**：非预组合 checkout 硬编码 `ref: master`，但 `LYHGLYTX/CCB-UndeadPeople-Tileset` 贴图仓库的默认分支是 `main`，导致 checkout 失败。

**修复**：
- 将 `ref: master` 改为 `ref: ${{ matrix.tileset_ref || 'master' }}`
- 为 MSX++UnDeadPeopleEdition 矩阵条目添加 `tileset_ref: main`

### 2. release.yml: 移除 STEPS_* 中转 env var，规范 Actions 格式

**问题**：步骤间输出传递使用了 `STEPS_GET_TIMESTAMP_OUTPUTS_TIME`、`STEPS_GENERATE_ENV_VARS_OUTPUTS_TAG_NAME` 等非标准 env var 命名，Actions 页面显示混乱。

**修复**：
- 合并 `Get build timestamp` + `Generate environmental variables` 为单一 `meta` 步骤
- 后续步骤直接使用 `${{ steps.meta.outputs.tag_name }}` 等标准引用
- 步骤命名更清晰：Generate release metadata → Generate Release Notes → Create GitHub Release

### 3. sync_ids.yml（贴图仓库）: PNG 精灵名与 JSON 不匹配

**问题**：`max_fg` 计数器在 JSON 写入和 PNG 生成两个循环间跨 category 共享，导致透明占位 PNG 文件名与 JSON 中 `fg` 字段不一致，compose.py 找不到对应文件。

**修复**：PNG 生成改为从已写入的 JSON 文件重新读取 `id→fg` 映射来生成匹配的 PNG。
（已在贴图仓库推送: `f902929`）