### PR TITLE
feat(ci): MSX++UnDead 贴图改为拉取最新 Release

### DIFF
--- a/.github/workflows/compose-tilesets.yml
+++ b/.github/workflows/compose-tilesets.yml
@@ -118,8 +118,8 @@ jobs:
           - name: MSX++UndeadPeopleEdition
             tileset_repo: LYHGLYTX/CCB-UndeadPeople-Tileset
             tileset_dir: .
-            compose_args: --use-all
-            tileset_ref: main
+            precomposed: true
+            release_download: true
 
     name: Compose tileset
     runs-on: ubuntu-latest
@@ -149,8 +149,20 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Download ${{ matrix.name }} from latest release
+        if: matrix.release_download == true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG=$(gh release list -R ${{ matrix.tileset_repo }} --limit 1 --json tagName -q '.[0].tagName')
+          echo "Downloading release $TAG from ${{ matrix.tileset_repo }}"
+          gh release download "$TAG" -R ${{ matrix.tileset_repo }} -p 'MSX++*.zip' -O tileset.zip
+          unzip -q tileset.zip
+          mkdir -p precomposed-tileset
+          cp -r MSX++UnDeadPeopleEdition/* precomposed-tileset/
+
       - name: Clone precomposed tileset repo
-        if: matrix.precomposed == true
+        if: matrix.precomposed == true && matrix.release_download != true
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{ matrix.tileset_repo }}


### PR DESCRIPTION
## 变更

### CCB compose-tilesets.yml
MSX++UnDeadPeopleEdition 从 compose-from-source 改为 **拉取贴图仓库时间上最新的 GitHub Release**：

```yaml
TAG=$(gh release list -R LYHGLYTX/CCB-UndeadPeople-Tileset --limit 1 --json tagName -q '.[0].tagName')
gh release download $TAG -p 'MSX++*.zip'
```

- `gh release list --limit 1` 按发布时间排序取最新（非 GitHub "Latest" 标记）
- 下载预组合的 zip 直接解压，不再依赖 compose.py
- 更快更可靠，每次 push 自动拉取最新贴图

### 贴图仓库 compose.yml
- 移除 `--prerelease` 标记，auto release 不再被标记为预发布

## 相关
本次 release #100 的 MSX++ 贴图 compose 失败 (精灵名含 `/` 导致)，本 PR 改为直接从 release 拉取预组合包，彻底规避 compose 兼容性问题。