### PR TITLE
The contribution of improved limb score to aiming speed.

### DIFF
--- a/data/json/character_modifiers.json
+++ b/data/json/character_modifiers.json
@@ -18,7 +18,7 @@
     "id": "aim_speed_mod",
     "description": "Gun aim speed modifier <color_dark_gray>(Manipulation, Grip, Lift)</color> ",
     "mod_type": "x",
-    "value": { "limb_score": [ [ "grip", 0.2 ], [ "manip", 0.2 ], [ "lift", 0.6 ] ], "limb_score_op": "+", "min": 0.1, "max": 1.0 }
+    "value": { "limb_score": [ [ "grip", 0.4 ], [ "manip", 0.4 ], [ "lift", 0.9 ] ], "limb_score_op": "+", "min": 0.1, "max": 1.8 }
   },
   {
     "type": "character_mod",


### PR DESCRIPTION
# 中文说明

有关[issue#43](https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues/43)的微调。

征集到社区大量有关认为枪械不够符合玩家对现实世界中的枪械“又快又强”的印象的反馈，目前确信枪械系统有待重构或增强。

目前初步查阅有关文献和教学影片后，确认到“拿稳枪械”确实是使用枪械的一个重要门槛，且至少在“新手期”表现显著。具有较强力量且“手很稳”的人物也被描述为较有天赋。

从这些方面来看，目前游戏对人物肢体能力（即limb_score数据）对枪械使用的影响数据确实存在保守倾向，有适当提升的必要性。我们被推荐了一个玩家自制的枪械瞄准系统提升mod，但其中夸张的数值几乎将所有枪械有关的强度数据都翻了三倍以上。作为仓库官方是数据平衡，显然不应该给出如此慷慨的数值走向另一个极端，这将破坏游戏的平衡性，大幅度缩短游戏的寿命。

经过取舍，目前决定做出以下调整：
 - 操纵与抓握能力的贡献水平翻倍，由原先的0.2变为0.4
 - 举重能力的贡献水平提升50%，由原先的0.6变为0.9
 - aim_speed_mod的limb_score的整体可贡献水平最低值保持不变，最高值提升80%变为1.8
 - 只调整角色aim_speed_mod的上限与limb_score的贡献，暂不增强其他有关枪械系统的数据
 - 目前的数据属于初步调整实验，需要收集更多玩家使用反馈来确定是否有必要进行进一步调整或缩减增强幅度

# English

Fine-tuning regarding [issue#43](https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues/43).

We have gathered a large amount of community feedback stating that firearms do not sufficiently align with the player impression of real-world firearms being "fast and powerful." It is currently confirmed that the firearms system requires refactoring or buffing.

After a preliminary review of relevant literature and instructional videos, it has been confirmed that "holding the firearm steadily" is indeed a major threshold for using firearms, and its effects are distinct at least during the "novice stage." Characters with higher strength who are "steady-handed" are also described as being more talented.

From these perspectives, the game's current data regarding the impact of character limb capabilities (i.e., limb_score data) on firearm usage does show a conservative tendency, making a moderate increase necessary. We were recommended a player-made firearm aiming system buff mod, but its exaggerated values multiplied almost all firearm strength-related data by more than three times. As the official repository's data balancing, we obviously should not provide such generous values to go to the other extreme, which would break the game balance and drastically shorten the game's lifespan.

After making trade-offs, it has been decided to make the following adjustments:
 - The contribution levels of Manipulation and Grip have been doubled, from the original 0.2 to 0.4
 - The contribution level of Lift has been increased by 50%, from the original 0.6 to 0.9
 - The minimum total contributable level of limb_score for aim_speed_mod remains unchanged, while the maximum value is increased by 80% to become 1.8
 - Only adjusted the upper limit of the character's aim_speed_mod and the contribution of limb_score, without buffing other firearm system-related data for now
 - The current data belongs to a preliminary adjustment experiment, and more player feedback needs to be collected to determine whether further adjustments or a reduction in the buff magnitude are necessary