### PR TITLE
Vehicle coloring: random vehicle part color palette system

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -5,6 +5,11 @@
     "info": "This is not intended to be visible during normal gameplay.  <bad>Please file a bug report</bad> unless you are seeing this in the debug menu."
   },
   {
+    "id": "NO_PAINT",
+    "type": "json_flag",
+    "info": "This vehicle part keeps its own sprite colors and is never tinted by a vehicle color palette."
+  },
+  {
     "id": "SWIM_UNDER",
     "type": "json_flag",
     "info": "Terrain with this flag is treated as having water beneath a covering (e.g. ice); entities may be considered under water for swimming and related mechanics."

--- a/data/json/named_colors.json
+++ b/data/json/named_colors.json
@@ -1,0 +1,1089 @@
+[
+  {
+    "//": "Custom",
+    "type": "named_color",
+    "name": "Cataclysm Red",
+    "value": "#622625"
+  },
+  {
+    "type": "named_color",
+    "name": "Cataclysm Green",
+    "value": "#3f4535"
+  },
+  {
+    "//": "RAL Classic",
+    "type": "named_color",
+    "name": "Green beige",
+    "value": "#CDBA88"
+  },
+  {
+    "type": "named_color",
+    "name": "Beige",
+    "value": "#D0B084"
+  },
+  {
+    "type": "named_color",
+    "name": "Sand yellow",
+    "value": "#D2AA6D"
+  },
+  {
+    "type": "named_color",
+    "name": "Signal yellow",
+    "value": "#F9A800"
+  },
+  {
+    "type": "named_color",
+    "name": "Golden yellow",
+    "value": "#E49E00"
+  },
+  {
+    "type": "named_color",
+    "name": "Honey yellow",
+    "value": "#CB8E00"
+  },
+  {
+    "type": "named_color",
+    "name": "Maize yellow",
+    "value": "#E29000"
+  },
+  {
+    "type": "named_color",
+    "name": "Daffodil yellow",
+    "value": "#E88C00"
+  },
+  {
+    "type": "named_color",
+    "name": "Brown beige",
+    "value": "#AF804F"
+  },
+  {
+    "type": "named_color",
+    "name": "Lemon yellow",
+    "value": "#DDAF27"
+  },
+  {
+    "type": "named_color",
+    "name": "Oyster white",
+    "value": "#E3D9C6"
+  },
+  {
+    "type": "named_color",
+    "name": "Ivory",
+    "value": "#DDC49A"
+  },
+  {
+    "type": "named_color",
+    "name": "Light ivory",
+    "value": "#E6D2B5"
+  },
+  {
+    "type": "named_color",
+    "name": "Sulfur yellow",
+    "value": "#F1DD38"
+  },
+  {
+    "type": "named_color",
+    "name": "Saffron yellow",
+    "value": "#F6A950"
+  },
+  {
+    "type": "named_color",
+    "name": "Zinc yellow",
+    "value": "#FACA30"
+  },
+  {
+    "type": "named_color",
+    "name": "Grey beige",
+    "value": "#A48F7A"
+  },
+  {
+    "type": "named_color",
+    "name": "Olive yellow",
+    "value": "#A08F65"
+  },
+  {
+    "type": "named_color",
+    "name": "Colza yellow",
+    "value": "#F6B600"
+  },
+  {
+    "type": "named_color",
+    "name": "Traffic yellow",
+    "value": "#F7B500"
+  },
+  {
+    "type": "named_color",
+    "name": "Ochre yellow",
+    "value": "#BA8F4C"
+  },
+  {
+    "type": "named_color",
+    "name": "Luminous yellow",
+    "value": "#FFFF00"
+  },
+  {
+    "type": "named_color",
+    "name": "Curry",
+    "value": "#A77F0E"
+  },
+  {
+    "type": "named_color",
+    "name": "Melon yellow",
+    "value": "#FF9B00"
+  },
+  {
+    "type": "named_color",
+    "name": "Broom yellow",
+    "value": "#E2A300"
+  },
+  {
+    "type": "named_color",
+    "name": "Dahlia yellow",
+    "value": "#F99A1C"
+  },
+  {
+    "type": "named_color",
+    "name": "Pastel yellow",
+    "value": "#EB9C52"
+  },
+  {
+    "type": "named_color",
+    "name": "Pearl beige",
+    "value": "#908370"
+  },
+  {
+    "type": "named_color",
+    "name": "Pearl gold",
+    "value": "#80643F"
+  },
+  {
+    "type": "named_color",
+    "name": "Sun yellow",
+    "value": "#F09200"
+  },
+  {
+    "type": "named_color",
+    "name": "Yellow orange",
+    "value": "#DD7907"
+  },
+  {
+    "type": "named_color",
+    "name": "Red orange",
+    "value": "#BE4E20"
+  },
+  {
+    "type": "named_color",
+    "name": "Vermilion",
+    "value": "#C63927"
+  },
+  {
+    "type": "named_color",
+    "name": "Pastel orange",
+    "value": "#FA842B"
+  },
+  {
+    "type": "named_color",
+    "name": "Pure orange",
+    "value": "#E75B12"
+  },
+  {
+    "type": "named_color",
+    "name": "Luminous orange",
+    "value": "#FF2300"
+  },
+  {
+    "type": "named_color",
+    "name": "Luminous bright orange",
+    "value": "#FFA421"
+  },
+  {
+    "type": "named_color",
+    "name": "Bright red orange",
+    "value": "#F3752C"
+  },
+  {
+    "type": "named_color",
+    "name": "Traffic orange",
+    "value": "#E15501"
+  },
+  {
+    "type": "named_color",
+    "name": "Signal orange",
+    "value": "#D4652F"
+  },
+  {
+    "type": "named_color",
+    "name": "Deep orange",
+    "value": "#EC7C25"
+  },
+  {
+    "type": "named_color",
+    "name": "Salmon orange",
+    "value": "#DB6A50"
+  },
+  {
+    "type": "named_color",
+    "name": "Pearl orange",
+    "value": "#954527"
+  },
+  {
+    "type": "named_color",
+    "name": "RAL orange",
+    "value": "#FA4402"
+  },
+  {
+    "type": "named_color",
+    "name": "Flame red",
+    "value": "#AB2524"
+  },
+  {
+    "type": "named_color",
+    "name": "Signal red",
+    "value": "#A02128"
+  },
+  {
+    "type": "named_color",
+    "name": "Carmine red",
+    "value": "#A1232B"
+  },
+  {
+    "type": "named_color",
+    "name": "Ruby red",
+    "value": "#8D1D2C"
+  },
+  {
+    "type": "named_color",
+    "name": "Purple red",
+    "value": "#701F29"
+  },
+  {
+    "type": "named_color",
+    "name": "Wine red",
+    "value": "#5E2028"
+  },
+  {
+    "type": "named_color",
+    "name": "Black red",
+    "value": "#402225"
+  },
+  {
+    "type": "named_color",
+    "name": "Oxide red",
+    "value": "#703731"
+  },
+  {
+    "type": "named_color",
+    "name": "Brown red",
+    "value": "#7E292C"
+  },
+  {
+    "type": "named_color",
+    "name": "Beige red",
+    "value": "#CB8D73"
+  },
+  {
+    "type": "named_color",
+    "name": "Tomato red",
+    "value": "#9C322E"
+  },
+  {
+    "type": "named_color",
+    "name": "Antique pink",
+    "value": "#D47479"
+  },
+  {
+    "type": "named_color",
+    "name": "Light pink",
+    "value": "#E1A6AD"
+  },
+  {
+    "type": "named_color",
+    "name": "Coral red",
+    "value": "#AC4034"
+  },
+  {
+    "type": "named_color",
+    "name": "Rose",
+    "value": "#D3545F"
+  },
+  {
+    "type": "named_color",
+    "name": "Strawberry red",
+    "value": "#D14152"
+  },
+  {
+    "type": "named_color",
+    "name": "Traffic red",
+    "value": "#C1121C"
+  },
+  {
+    "type": "named_color",
+    "name": "Salmon pink",
+    "value": "#D56D56"
+  },
+  {
+    "type": "named_color",
+    "name": "Luminous red",
+    "value": "#F70000"
+  },
+  {
+    "type": "named_color",
+    "name": "Luminous bright red",
+    "value": "#FF0000"
+  },
+  {
+    "type": "named_color",
+    "name": "Raspberry red",
+    "value": "#B42041"
+  },
+  {
+    "type": "named_color",
+    "name": "Pure red",
+    "value": "#E72512"
+  },
+  {
+    "type": "named_color",
+    "name": "Orient red",
+    "value": "#AC323B"
+  },
+  {
+    "type": "named_color",
+    "name": "Pearl ruby red",
+    "value": "#711521"
+  },
+  {
+    "type": "named_color",
+    "name": "Pearl pink",
+    "value": "#B24C43"
+  },
+  {
+    "type": "named_color",
+    "name": "Red lilac",
+    "value": "#8A5A83"
+  },
+  {
+    "type": "named_color",
+    "name": "Red violet",
+    "value": "#933D50"
+  },
+  {
+    "type": "named_color",
+    "name": "Heather violet",
+    "value": "#D15B8F"
+  },
+  {
+    "type": "named_color",
+    "name": "Claret violet",
+    "value": "#691639"
+  },
+  {
+    "type": "named_color",
+    "name": "Blue lilac",
+    "value": "#83639D"
+  },
+  {
+    "type": "named_color",
+    "name": "Traffic purple",
+    "value": "#992572"
+  },
+  {
+    "type": "named_color",
+    "name": "Purple violet",
+    "value": "#4A203B"
+  },
+  {
+    "type": "named_color",
+    "name": "Signal violet",
+    "value": "#904684"
+  },
+  {
+    "type": "named_color",
+    "name": "Pastel violet",
+    "value": "#A38995"
+  },
+  {
+    "type": "named_color",
+    "name": "Telemagenta",
+    "value": "#C63678"
+  },
+  {
+    "type": "named_color",
+    "name": "Pearl violet",
+    "value": "#8773A1"
+  },
+  {
+    "type": "named_color",
+    "name": "Pearl blackberry",
+    "value": "#6B6880"
+  },
+  {
+    "type": "named_color",
+    "name": "Violet blue",
+    "value": "#384C70"
+  },
+  {
+    "type": "named_color",
+    "name": "Green blue",
+    "value": "#1F4764"
+  },
+  {
+    "type": "named_color",
+    "name": "Ultramarine blue",
+    "value": "#2B2C7C"
+  },
+  {
+    "type": "named_color",
+    "name": "Sapphire blue",
+    "value": "#2A3756"
+  },
+  {
+    "type": "named_color",
+    "name": "Black blue",
+    "value": "#1D1F2A"
+  },
+  {
+    "type": "named_color",
+    "name": "Signal blue",
+    "value": "#154889"
+  },
+  {
+    "type": "named_color",
+    "name": "Brilliant blue",
+    "value": "#41678D"
+  },
+  {
+    "type": "named_color",
+    "name": "Grey blue",
+    "value": "#313C48"
+  },
+  {
+    "type": "named_color",
+    "name": "Azure blue",
+    "value": "#2E5978"
+  },
+  {
+    "type": "named_color",
+    "name": "Gentian blue",
+    "value": "#13447C"
+  },
+  {
+    "type": "named_color",
+    "name": "Steel blue",
+    "value": "#232C3F"
+  },
+  {
+    "type": "named_color",
+    "name": "Light blue",
+    "value": "#3481B8"
+  },
+  {
+    "type": "named_color",
+    "name": "Cobalt blue",
+    "value": "#232D53"
+  },
+  {
+    "type": "named_color",
+    "name": "Pigeon blue",
+    "value": "#6C7C98"
+  },
+  {
+    "type": "named_color",
+    "name": "Sky blue",
+    "value": "#2874B2"
+  },
+  {
+    "type": "named_color",
+    "name": "Traffic blue",
+    "value": "#0E518D"
+  },
+  {
+    "type": "named_color",
+    "name": "Turquoise blue",
+    "value": "#21888F"
+  },
+  {
+    "type": "named_color",
+    "name": "Capri blue",
+    "value": "#1A5784"
+  },
+  {
+    "type": "named_color",
+    "name": "Ocean blue",
+    "value": "#0B4151"
+  },
+  {
+    "type": "named_color",
+    "name": "Water blue",
+    "value": "#07737A"
+  },
+  {
+    "type": "named_color",
+    "name": "Night blue",
+    "value": "#2F2A5A"
+  },
+  {
+    "type": "named_color",
+    "name": "Distant blue",
+    "value": "#4D668E"
+  },
+  {
+    "type": "named_color",
+    "name": "Pastel blue",
+    "value": "#6A93B0"
+  },
+  {
+    "type": "named_color",
+    "name": "Pearl Gentian blue",
+    "value": "#296478"
+  },
+  {
+    "type": "named_color",
+    "name": "Pearl night blue",
+    "value": "#102C54"
+  },
+  {
+    "type": "named_color",
+    "name": "Patina green",
+    "value": "#327662"
+  },
+  {
+    "type": "named_color",
+    "name": "Emerald green",
+    "value": "#28713E"
+  },
+  {
+    "type": "named_color",
+    "name": "Leaf green",
+    "value": "#276235"
+  },
+  {
+    "type": "named_color",
+    "name": "Olive green",
+    "value": "#4B573E"
+  },
+  {
+    "type": "named_color",
+    "name": "Blue green",
+    "value": "#0E4243"
+  },
+  {
+    "type": "named_color",
+    "name": "Moss green",
+    "value": "#0F4336"
+  },
+  {
+    "type": "named_color",
+    "name": "Grey olive",
+    "value": "#40433B"
+  },
+  {
+    "type": "named_color",
+    "name": "Bottle green",
+    "value": "#283424"
+  },
+  {
+    "type": "named_color",
+    "name": "Brown green",
+    "value": "#35382E"
+  },
+  {
+    "type": "named_color",
+    "name": "Fir green",
+    "value": "#26392F"
+  },
+  {
+    "type": "named_color",
+    "name": "Grass green",
+    "value": "#3E753B"
+  },
+  {
+    "type": "named_color",
+    "name": "Reseda green",
+    "value": "#68825B"
+  },
+  {
+    "type": "named_color",
+    "name": "Black green",
+    "value": "#31403D"
+  },
+  {
+    "type": "named_color",
+    "name": "Reed green",
+    "value": "#797C5A"
+  },
+  {
+    "type": "named_color",
+    "name": "Yellow olive",
+    "value": "#444337"
+  },
+  {
+    "type": "named_color",
+    "name": "Black olive",
+    "value": "#3D403A"
+  },
+  {
+    "type": "named_color",
+    "name": "Turquoise green",
+    "value": "#026A52"
+  },
+  {
+    "type": "named_color",
+    "name": "May green",
+    "value": "#468641"
+  },
+  {
+    "type": "named_color",
+    "name": "Yellow green",
+    "value": "#48A43F"
+  },
+  {
+    "type": "named_color",
+    "name": "Pastel green",
+    "value": "#B7D9B1"
+  },
+  {
+    "type": "named_color",
+    "name": "Chrome green",
+    "value": "#354733"
+  },
+  {
+    "type": "named_color",
+    "name": "Pale green",
+    "value": "#86A47C"
+  },
+  {
+    "type": "named_color",
+    "name": "Olive-drab/brown olive",
+    "value": "#3E3C32"
+  },
+  {
+    "type": "named_color",
+    "name": "Traffic green",
+    "value": "#008754"
+  },
+  {
+    "type": "named_color",
+    "name": "Fern green",
+    "value": "#53753C"
+  },
+  {
+    "type": "named_color",
+    "name": "Opal green",
+    "value": "#005D52"
+  },
+  {
+    "type": "named_color",
+    "name": "Light green",
+    "value": "#81C0BB"
+  },
+  {
+    "type": "named_color",
+    "name": "Pine green",
+    "value": "#2D5546"
+  },
+  {
+    "type": "named_color",
+    "name": "Mint green",
+    "value": "#007243"
+  },
+  {
+    "type": "named_color",
+    "name": "Signal green",
+    "value": "#0F8558"
+  },
+  {
+    "type": "named_color",
+    "name": "Mint turquoise",
+    "value": "#478A84"
+  },
+  {
+    "type": "named_color",
+    "name": "Pastel turquoise",
+    "value": "#7FB0B2"
+  },
+  {
+    "type": "named_color",
+    "name": "Pearl green",
+    "value": "#1B542C"
+  },
+  {
+    "type": "named_color",
+    "name": "Pearl opal green",
+    "value": "#005D4C"
+  },
+  {
+    "type": "named_color",
+    "name": "Pure green",
+    "value": "#25E712"
+  },
+  {
+    "type": "named_color",
+    "name": "Luminous green",
+    "value": "#00F700"
+  },
+  {
+    "type": "named_color",
+    "name": "Squirrel grey",
+    "value": "#7E8B92"
+  },
+  {
+    "type": "named_color",
+    "name": "Silver grey",
+    "value": "#8F999F"
+  },
+  {
+    "type": "named_color",
+    "name": "Olive grey",
+    "value": "#817F68"
+  },
+  {
+    "type": "named_color",
+    "name": "Moss grey",
+    "value": "#7A7B6D"
+  },
+  {
+    "type": "named_color",
+    "name": "Signal grey",
+    "value": "#9EA0A1"
+  },
+  {
+    "type": "named_color",
+    "name": "Mouse grey",
+    "value": "#6B716F"
+  },
+  {
+    "type": "named_color",
+    "name": "Beige grey",
+    "value": "#756F61"
+  },
+  {
+    "type": "named_color",
+    "name": "Khaki grey",
+    "value": "#746643"
+  },
+  {
+    "type": "named_color",
+    "name": "Green grey",
+    "value": "#5B6259"
+  },
+  {
+    "type": "named_color",
+    "name": "Tarpaulin grey",
+    "value": "#575D57"
+  },
+  {
+    "type": "named_color",
+    "name": "Iron grey",
+    "value": "#555D61"
+  },
+  {
+    "type": "named_color",
+    "name": "Basalt grey",
+    "value": "#596163"
+  },
+  {
+    "type": "named_color",
+    "name": "Brown grey",
+    "value": "#555548"
+  },
+  {
+    "type": "named_color",
+    "name": "Slate grey",
+    "value": "#51565C"
+  },
+  {
+    "type": "named_color",
+    "name": "Anthracite grey",
+    "value": "#373F43"
+  },
+  {
+    "type": "named_color",
+    "name": "Black grey",
+    "value": "#2E3234"
+  },
+  {
+    "type": "named_color",
+    "name": "Umbra grey",
+    "value": "#4B4D46"
+  },
+  {
+    "type": "named_color",
+    "name": "Concrete grey",
+    "value": "#818479"
+  },
+  {
+    "type": "named_color",
+    "name": "Graphite grey",
+    "value": "#474A50"
+  },
+  {
+    "type": "named_color",
+    "name": "Granite grey",
+    "value": "#374447"
+  },
+  {
+    "type": "named_color",
+    "name": "Stone grey",
+    "value": "#939388"
+  },
+  {
+    "type": "named_color",
+    "name": "Blue grey",
+    "value": "#5D6970"
+  },
+  {
+    "type": "named_color",
+    "name": "Pebble grey",
+    "value": "#B9B9A8"
+  },
+  {
+    "type": "named_color",
+    "name": "Cement grey",
+    "value": "#818979"
+  },
+  {
+    "type": "named_color",
+    "name": "Yellow grey",
+    "value": "#939176"
+  },
+  {
+    "type": "named_color",
+    "name": "Light grey",
+    "value": "#CBD0CC"
+  },
+  {
+    "type": "named_color",
+    "name": "Platinum grey",
+    "value": "#9A9697"
+  },
+  {
+    "type": "named_color",
+    "name": "Dusty grey",
+    "value": "#7C7F7E"
+  },
+  {
+    "type": "named_color",
+    "name": "Agate grey",
+    "value": "#B4B8B0"
+  },
+  {
+    "type": "named_color",
+    "name": "Quartz grey",
+    "value": "#6B695F"
+  },
+  {
+    "type": "named_color",
+    "name": "Window grey",
+    "value": "#9DA3A6"
+  },
+  {
+    "type": "named_color",
+    "name": "Traffic grey A",
+    "value": "#8F9695"
+  },
+  {
+    "type": "named_color",
+    "name": "Traffic grey B",
+    "value": "#4E5451"
+  },
+  {
+    "type": "named_color",
+    "name": "Silk grey",
+    "value": "#BDBDB2"
+  },
+  {
+    "type": "named_color",
+    "name": "Telegrey 1",
+    "value": "#91969A"
+  },
+  {
+    "type": "named_color",
+    "name": "Telegrey 2",
+    "value": "#82898E"
+  },
+  {
+    "type": "named_color",
+    "name": "Telegrey 4",
+    "value": "#CFD0CF"
+  },
+  {
+    "type": "named_color",
+    "name": "Pearl mouse grey",
+    "value": "#888175"
+  },
+  {
+    "type": "named_color",
+    "name": "Green brown",
+    "value": "#887142"
+  },
+  {
+    "type": "named_color",
+    "name": "Ochre brown",
+    "value": "#9C6B30"
+  },
+  {
+    "type": "named_color",
+    "name": "Signal brown",
+    "value": "#7B5141"
+  },
+  {
+    "type": "named_color",
+    "name": "Clay brown",
+    "value": "#80542F"
+  },
+  {
+    "type": "named_color",
+    "name": "Copper brown",
+    "value": "#8F4E35"
+  },
+  {
+    "type": "named_color",
+    "name": "Fawn brown",
+    "value": "#6F4A2F"
+  },
+  {
+    "type": "named_color",
+    "name": "Olive brown",
+    "value": "#6F4F28"
+  },
+  {
+    "type": "named_color",
+    "name": "Nut brown",
+    "value": "#5A3A29"
+  },
+  {
+    "type": "named_color",
+    "name": "Red brown",
+    "value": "#673831"
+  },
+  {
+    "type": "named_color",
+    "name": "Sepia brown",
+    "value": "#49392D"
+  },
+  {
+    "type": "named_color",
+    "name": "Chestnut brown",
+    "value": "#633A34"
+  },
+  {
+    "type": "named_color",
+    "name": "Mahogany brown",
+    "value": "#4C2F26"
+  },
+  {
+    "type": "named_color",
+    "name": "Chocolate brown",
+    "value": "#44322D"
+  },
+  {
+    "type": "named_color",
+    "name": "Grey brown",
+    "value": "#3F3A3A"
+  },
+  {
+    "type": "named_color",
+    "name": "Black brown",
+    "value": "#211F20"
+  },
+  {
+    "type": "named_color",
+    "name": "Orange brown",
+    "value": "#A65E2F"
+  },
+  {
+    "type": "named_color",
+    "name": "Beige brown",
+    "value": "#79553C"
+  },
+  {
+    "type": "named_color",
+    "name": "Pale brown",
+    "value": "#755C49"
+  },
+  {
+    "type": "named_color",
+    "name": "Terra brown",
+    "value": "#4E3B2B"
+  },
+  {
+    "type": "named_color",
+    "name": "Pearl copper",
+    "value": "#773C27"
+  },
+  {
+    "type": "named_color",
+    "name": "Cream",
+    "value": "#EFEBDC"
+  },
+  {
+    "type": "named_color",
+    "name": "Grey white",
+    "value": "#DDDED4"
+  },
+  {
+    "type": "named_color",
+    "name": "Signal white",
+    "value": "#F4F8F4"
+  },
+  {
+    "type": "named_color",
+    "name": "Signal black",
+    "value": "#2E3032"
+  },
+  {
+    "type": "named_color",
+    "name": "Jet black",
+    "value": "#0A0A0D"
+  },
+  {
+    "type": "named_color",
+    "name": "White aluminium",
+    "value": "#A5A8A6"
+  },
+  {
+    "type": "named_color",
+    "name": "Grey aluminium",
+    "value": "#8F8F8C"
+  },
+  {
+    "type": "named_color",
+    "name": "Pure white",
+    "value": "#F7F9EF"
+  },
+  {
+    "type": "named_color",
+    "name": "Graphite black",
+    "value": "#1C1C1C"
+  },
+  {
+    "type": "named_color",
+    "name": "Clean room white",
+    "value": "#FFFDE6"
+  },
+  {
+    "type": "named_color",
+    "name": "Traffic white",
+    "value": "#F7FBF5"
+  },
+  {
+    "type": "named_color",
+    "name": "Traffic black",
+    "value": "#2A2D2F"
+  },
+  {
+    "type": "named_color",
+    "name": "Papyrus white",
+    "value": "#CFD3CD"
+  },
+  {
+    "type": "named_color",
+    "name": "Pearl light grey",
+    "value": "#858583"
+  },
+  {
+    "type": "named_color",
+    "name": "Pearl dark grey",
+    "value": "#7E8182"
+  }
+]

--- a/data/json/vehicle_palette.json
+++ b/data/json/vehicle_palette.json
@@ -1,0 +1,357 @@
+[
+  {
+    "type": "vehicle_color_palette",
+    "id": "car_standard",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk_flat", "hatch" ],
+        "colors": [
+          { "color": "Jet black", "weight": 10 },
+          { "color": "Cataclysm Red", "weight": 10 },
+          { "color": "Cataclysm Green", "weight": 10 },
+          { "color": "Signal brown", "weight": 10 },
+          { "color": "Sapphire blue", "weight": 10 },
+          { "color": "Purple violet", "weight": 10 },
+          { "color": "Azure blue", "weight": 10 },
+          { "color": "Silver grey", "weight": 10 },
+          { "color": "Black grey", "weight": 10 },
+          { "color": "Bright red orange", "weight": 10 },
+          { "color": "Grass green", "weight": 10 },
+          { "color": "Golden yellow", "weight": 10 },
+          { "color": "Light blue", "weight": 10 },
+          { "color": "Telemagenta", "weight": 10 },
+          { "color": "Pastel blue", "weight": 10 },
+          { "color": "Traffic white", "weight": 10 }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "cargo_standard",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "inflate", "trunk_flat", "hatch" ],
+        "colors": [
+          { "color": "White aluminium", "weight": 8 },
+          { "color": "Silver grey", "weight": 8 },
+          { "color": "Grey aluminium", "weight": 8 },
+          { "color": "Black brown", "weight": 8 },
+          { "color": "Beige", "weight": 8 }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "visibility_standard",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "inflate", "trunk_flat", "hatch" ],
+        "colors": [
+          { "color": "Capri Blue", "weight": 12 },
+          { "color": "Cataclysm Red", "weight": 20 },
+          { "color": "Orange brown", "weight": 4 },
+          { "color": "Yellow orange", "weight": 2 },
+          { "color": "Green grey", "weight": 4 },
+          { "color": "Yellow orange", "weight": 4 },
+          { "color": "Telemagenta", "weight": 4 },
+          { "color": "Traffic Purple", "weight": 4 }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "military_standard",
+    "//": "Actual US Military vehicle colors, See: Federal Standard FED-STD-595B, As close as the limited selection gets",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk_flat", "hatch" ],
+        "colors": [
+          { "color": "Pine Green", "weight": 20, "//": "CARC Green 383 (Federal Standard 34094)" },
+          { "color": "Brown grey", "weight": 10, "//": "CARC Brown 383ish (Federal Standard 30051)" },
+          { "color": "Black grey", "weight": 10, "//": "CARC Black (Federal Standard 37030)" },
+          { "color": "Olive Grey", "weight": 5, "//": "CARC Sand (Federal Standard 33303)" },
+          { "color": "Sand Yellow", "weight": 5, "//": "CARC Tan 686 (Federal Standard 33446)" },
+          { "color": "Traffic Purple", "weight": 1, "//": "Sneaky military craft :)" }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "military_fighter",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "wing", "propeller", "windshield", "door", "roof", "trunk_flat", "trunk_carbon_flat", "hatch" ],
+        "colors": [
+          { "color": "Telegrey 1", "weight": 20, "//": "Federal Standard 36176" },
+          { "color": "Pastel turquoise", "weight": 10 },
+          { "color": "Black grey", "weight": 10, "//": "CARC Black (Federal Standard 37030)" },
+          { "color": "Brilliant blue", "weight": 10 },
+          { "color": "Capri blue", "weight": 5 },
+          { "color": "Traffic Purple", "weight": 1, "//": "Sneaky military craft :)" }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "military_heli",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "wing", "rotor", "windshield", "door", "roof", "trunk_flat", "hatch" ],
+        "colors": [
+          { "color": "Cataclysm Green", "weight": 20 },
+          { "color": "Black grey", "weight": 10, "//": "CARC Black (Federal Standard 37030)" },
+          { "color": "Pastel turquoise", "weight": 5 },
+          { "color": "White aluminium", "weight": 5 },
+          { "color": "Traffic Purple", "weight": 1, "//": "Sneaky military craft :)" }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "military_boat",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk_flat", "hatch" ],
+        "colors": [
+          { "color": "Cataclysm Green", "weight": 20 },
+          { "color": "Grey aluminium", "weight": 10 },
+          { "color": "Black grey", "weight": 10 },
+          { "color": "Yellow Olive", "weight": 5 },
+          { "color": "Traffic Purple", "weight": 1, "//": "Sneaky military craft :)" }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "police_standard",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk_flat", "hatch" ],
+        "colors": [
+          { "color": "Black grey", "weight": 10 },
+          { "color": "Silver grey", "weight": 10 },
+          { "color": "Steel Blue", "weight": 5 },
+          { "color": "Pastel blue", "weight": 2, "//": "old pre-90s style police lightblue" }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "swat_standard",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk_flat", "hatch" ],
+        "colors": [ { "color": "Black grey", "weight": 10 }, { "color": "Steel Blue", "weight": 5 } ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "construction_standard",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk_flat", "hatch" ],
+        "colors": [ { "color": "Traffic Yellow", "weight": 10 }, { "color": "Yellow Orange", "weight": 5 } ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "farm_standard",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk_flat", "hatch" ],
+        "colors": [
+          { "color": "Flame Red", "weight": 10 },
+          { "color": "Pearl Green", "weight": 10 },
+          { "color": "Traffic Blue", "weight": 2 },
+          { "color": "Traffic Orange", "weight": 2 },
+          { "color": "Lemon Yellow", "weight": 2 }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "firetruck_standard",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk_flat", "hatch" ],
+        "colors": [
+          { "color": "Flame Red", "weight": 20 },
+          { "color": "White aluminium", "weight": 5 },
+          { "color": "Broom Yellow", "weight": 5, "//": "this is actually a yellow" },
+          { "color": "Yellow Green", "weight": 1, "//": "airport firetruck color" }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "ems_standard",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk_flat", "hatch" ],
+        "colors": [
+          { "color": "White aluminium", "weight": 20 },
+          { "color": "Flame Red", "weight": 10 },
+          { "color": "Traffic Yellow", "weight": 1 }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "bus_standard",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk_flat", "hatch" ],
+        "colors": [ { "color": "Traffic Yellow", "weight": 1 } ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "wienermobile_standard",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk_flat", "hatch" ],
+        "colors": [ { "color": "Yellow Orange", "weight": 1 } ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "limo_standard",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk_flat", "hatch" ],
+        "colors": [
+          { "color": "Black grey", "weight": 10 },
+          { "color": "White aluminium", "weight": 10 },
+          { "color": "Traffic Purple", "weight": 1 }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "sneaky_standard",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk_flat", "hatch" ],
+        "colors": [
+          { "color": "Grey aluminium", "weight": 10 },
+          { "color": "Black grey", "weight": 10 },
+          { "color": "Traffic Purple", "weight": 5, "//": "Sneaky military craft :)" }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "aircraft_standard",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "wing", "rotor", "propeller", "windshield", "door", "roof", "trunk_flat", "hatch" ],
+        "colors": [
+          { "color": "Pigeon Blue", "weight": 10 },
+          { "color": "Black grey", "weight": 5 },
+          { "color": "Red Orange", "weight": 5 },
+          { "color": "Pure Orange", "weight": 5 },
+          { "color": "Traffic Yellow", "weight": 5 },
+          { "color": "Pearl Green", "weight": 5 },
+          { "color": "Light Blue", "weight": 5 },
+          { "color": "Ultramarine Blue", "weight": 1 }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "aircraft_commercial",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "wing", "rotor", "propeller", "windshield", "door", "roof", "trunk_flat", "hatch" ],
+        "colors": [
+          { "color": "White aluminium", "weight": 15 },
+          { "color": "Gentian blue", "weight": 10 },
+          { "color": "Red Orange", "weight": 10 },
+          { "color": "Lemon Yellow", "weight": 5 },
+          { "color": "Turquoise Green", "weight": 5 },
+          { "color": "Ultramarine Blue", "weight": 1 }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "wooden_standard",
+    "palette": [
+      {
+        "fuzzy_ids": [
+          "woodboard",
+          "woodhalfboard",
+          "boat_board",
+          "raft_board",
+          "wing_wood",
+          "propeller_wood",
+          "windshield",
+          "wood box",
+          "travois",
+          "seat_wood",
+          "wooden_aisle",
+          "door_wood",
+          "roof_wood"
+        ],
+        "colors": [
+          { "color": "Green beige", "weight": 5 },
+          { "color": "Beige", "weight": 5 },
+          { "color": "Brown beige", "weight": 5 },
+          { "color": "Broom yellow", "weight": 5 },
+          { "color": "Brown red", "weight": 5 },
+          { "color": "Beige red", "weight": 5 },
+          { "color": "Olive grey", "weight": 5 },
+          { "color": "Beige grey", "weight": 5 },
+          { "color": "Khaki grey", "weight": 5 },
+          { "color": "Green brown", "weight": 5 },
+          { "color": "Ochre brown", "weight": 5 },
+          { "color": "Clay brown", "weight": 5 },
+          { "color": "Olive brown", "weight": 5 },
+          { "color": "Nut brown", "weight": 5 },
+          { "color": "Sepia brown", "weight": 5 },
+          { "color": "Chestnut brown", "weight": 5 },
+          { "color": "Mahogany brown", "weight": 5 },
+          { "color": "Chocolate brown", "weight": 5 },
+          { "color": "Beige brown", "weight": 5 }
+        ]
+      },
+      {
+        "fuzzy_ids": [ "clothboard", "cloth_halfboard", "roof_cloth", "cargo_bag" ],
+        "colors": [
+          { "color": "Oyster white", "weight": 5 },
+          { "color": "Ivory", "weight": 5 },
+          { "color": "Light ivory", "weight": 5 },
+          { "color": "Grey beige", "weight": 5 },
+          { "color": "Grey blue", "weight": 5 },
+          { "color": "Silver grey", "weight": 5 },
+          { "color": "Beige grey", "weight": 5 },
+          { "color": "Black grey", "weight": 5 },
+          { "color": "Light grey", "weight": 5 },
+          { "color": "Cream", "weight": 5 },
+          { "color": "Grey white", "weight": 5 },
+          { "color": "Papyrus white", "weight": 5 },
+          { "color": "Flame red", "weight": 5, "//": "Red Baron" }
+        ]
+      }
+    ]
+  }
+]

--- a/data/json/vehicles/boats.json
+++ b/data/json/vehicles/boats.json
@@ -2,6 +2,7 @@
   {
     "type": "vehicle",
     "id": "canoe",
+    "color_palette": "wooden_standard",
     "name": "canoe",
     "blueprint": [ [ "<OO>" ] ],
     "parts": [
@@ -14,6 +15,7 @@
   {
     "type": "vehicle",
     "id": "DUKW",
+    "color_palette": "car_standard",
     "name": "Amphibious Truck",
     "parts": [
       { "x": 0, "y": 0, "parts": [ "frame#cross", "seat", "seatbelt", "controls", "dashboard", "roof", "metal_boat_hull" ] },
@@ -88,6 +90,7 @@
   {
     "type": "vehicle",
     "id": "kayak",
+    "color_palette": "wooden_standard",
     "name": "kayak",
     "blueprint": [ [ "<O>" ] ],
     "parts": [
@@ -99,6 +102,7 @@
   {
     "type": "vehicle",
     "id": "kayak_racing",
+    "color_palette": "wooden_standard",
     "name": "racing kayak",
     "blueprint": [ [ "<O>" ] ],
     "parts": [
@@ -150,6 +154,7 @@
   {
     "type": "vehicle",
     "id": "raft",
+    "color_palette": "wooden_standard",
     "name": "raft",
     "blueprint": [
       [ "OO" ],
@@ -211,6 +216,7 @@
   {
     "type": "vehicle",
     "id": "wood_rowboat_double",
+    "color_palette": "wooden_standard",
     "name": "wooden rowboat",
     "blueprint": [
       [ " /\\" ],
@@ -246,6 +252,7 @@
   },
   {
     "id": "cabin_cruiser_wood",
+    "color_palette": "wooden_standard",
     "type": "vehicle",
     "name": "Wooden Cabin Cruiser",
     "parts": [

--- a/data/json/vehicles/cars.json
+++ b/data/json/vehicles/cars.json
@@ -1,6 +1,7 @@
 [
   {
     "abstract": "4x4_car_abstract",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "4x4 Car",
     "blueprint": [
@@ -63,6 +64,7 @@
   },
   {
     "id": "4x4_car",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "4x4_car_abstract",
     "parts": [
@@ -72,6 +74,7 @@
   },
   {
     "id": "4x4_car_diesel",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "4x4_car_abstract",
     "parts": [
@@ -81,6 +84,7 @@
   },
   {
     "id": "beetle",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Beetle",
     "blueprint": [
@@ -124,6 +128,7 @@
   },
   {
     "abstract": "car_abstract_no_items_1_missing_wheel",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Station Wagon",
     "blueprint": [
@@ -168,6 +173,7 @@
   },
   {
     "abstract": "car_abstract",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_abstract_no_items_1_missing_wheel",
     "parts": [ { "x": -2, "y": -1, "parts": [ "wheel" ] } ],
@@ -181,6 +187,7 @@
   },
   {
     "id": "car",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_abstract",
     "parts": [
@@ -190,6 +197,7 @@
   },
   {
     "id": "car_mayhem_tire_change",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_abstract_no_items_1_missing_wheel",
     "parts": [
@@ -205,6 +213,7 @@
   },
   {
     "id": "car_diesel",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_abstract",
     "parts": [
@@ -214,6 +223,7 @@
   },
   {
     "id": "car_rack",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car",
     "name": "Station Wagon with Bike Rack",
@@ -226,6 +236,7 @@
   },
   {
     "id": "car_luxury",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Luxury Station Wagon",
     "blueprint": [
@@ -286,6 +297,7 @@
   },
   {
     "id": "car_anmlcmpt",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "//": "animal compartment version",
     "name": "Station Wagon",
@@ -340,6 +352,7 @@
   },
   {
     "id": "car_chassis",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Car Chassis",
     "blueprint": [
@@ -380,6 +393,7 @@
   },
   {
     "id": "car_hybrid_rack",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_hybrid",
     "name": "Hybrid Car with Bike Rack",
@@ -392,6 +406,7 @@
   },
   {
     "id": "car_hybrid",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Hybrid Car",
     "blueprint": [
@@ -457,6 +472,7 @@
   },
   {
     "id": "car_mini",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "City Car",
     "blueprint": [
@@ -501,6 +517,7 @@
   },
   {
     "abstract": "car_micro_abstract",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Microcar",
     "blueprint": [
@@ -540,6 +557,7 @@
   },
   {
     "id": "car_micro",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_micro_abstract",
     "parts": [
@@ -550,6 +568,7 @@
   },
   {
     "id": "car_micro_hybrid",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_micro_abstract",
     "name": "Hybrid Microcar",
@@ -564,6 +583,7 @@
   },
   {
     "id": "car_micro_electric",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_micro_abstract",
     "name": "Electric Microcar",
@@ -575,6 +595,7 @@
   },
   {
     "abstract": "scompact_abstract",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Supercompact Car",
     "blueprint": [
@@ -610,6 +631,7 @@
   },
   {
     "id": "scompact",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "scompact_abstract",
     "parts": [
@@ -620,6 +642,7 @@
   },
   {
     "id": "scompact_hybrid",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "scompact_abstract",
     "name": "Hybrid Supercompact Car",
@@ -634,6 +657,7 @@
   },
   {
     "id": "scompact_electric",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "scompact_abstract",
     "name": "Electric Supercompact Car",
@@ -645,6 +669,7 @@
   },
   {
     "abstract": "scompact_tandem_abstract",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Supercompact Tandem Car",
     "blueprint": [
@@ -679,6 +704,7 @@
   },
   {
     "id": "scompact_tandem_stow",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "scompact_tandem_abstract",
     "parts": [
@@ -694,6 +720,7 @@
   },
   {
     "id": "scompact_tandem_hboard",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "scompact_tandem_abstract",
     "parts": [
@@ -709,6 +736,7 @@
   },
   {
     "id": "scompact_tandem_electric_stow",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "scompact_tandem_abstract",
     "name": "Electric Supercompact Tandem Car",
@@ -725,6 +753,7 @@
   },
   {
     "id": "scompact_tandem_electric_hboard",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "scompact_tandem_abstract",
     "name": "Electric Supercompact Tandem Car",
@@ -741,6 +770,7 @@
   },
   {
     "id": "scompact_tandem_2wheel_stow",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "scompact_tandem_abstract",
     "name": "Tandem Cabin Motorcycle",
@@ -757,6 +787,7 @@
   },
   {
     "id": "scompact_tandem_2wheel_hboard",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "scompact_tandem_abstract",
     "name": "Tandem Cabin Motorcycle",
@@ -773,6 +804,7 @@
   },
   {
     "id": "scompact_tandem_electric_2wheel_stow",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "scompact_tandem_abstract",
     "name": "Electric Tandem Cabin Motorcycle",
@@ -789,6 +821,7 @@
   },
   {
     "id": "scompact_tandem_electric_2wheel_hboard",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "scompact_tandem_abstract",
     "name": "Electric Tandem Cabin Motorcycle",
@@ -805,6 +838,7 @@
   },
   {
     "id": "scompact_tandem_3wheel_stow",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "scompact_tandem_abstract",
     "name": "Tandem Three-Wheeled Supercompact Car",
@@ -819,6 +853,7 @@
   },
   {
     "id": "scompact_tandem_3wheel_hboard",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "scompact_tandem_abstract",
     "name": "Tandem Three-Wheeled Supercompact Car",
@@ -833,6 +868,7 @@
   },
   {
     "id": "scompact_tandem_electric_3wheel_stow",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "scompact_tandem_abstract",
     "name": "Electric Tandem Three-Wheeled Supercompact Car",
@@ -848,6 +884,7 @@
   },
   {
     "id": "scompact_tandem_electric_3wheel_hboard",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "scompact_tandem_abstract",
     "name": "Electric Tandem Three-Wheeled Supercompact Car",
@@ -863,6 +900,7 @@
   },
   {
     "abstract": "car_hatch_abstract",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Hatchback",
     "blueprint": [
@@ -914,6 +952,7 @@
   },
   {
     "id": "car_hatch",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_hatch_abstract",
     "name": "Hatchback",
@@ -925,6 +964,7 @@
   },
   {
     "id": "car_hatch_diesel",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_hatch_abstract",
     "name": "Hatchback",
@@ -936,6 +976,7 @@
   },
   {
     "id": "car_hatch_rack",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_hatch",
     "name": "Hatchback with Bike Rack",
@@ -948,6 +989,7 @@
   },
   {
     "id": "car_sports",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Sports Car",
     "blueprint": [
@@ -1005,6 +1047,7 @@
   },
   {
     "abstract": "car_shootingbrake_abstract",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Shooting Brake",
     "blueprint": [
@@ -1060,6 +1103,7 @@
   },
   {
     "id": "car_shootingbrake_v8",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_shootingbrake_abstract",
     "parts": [
@@ -1070,6 +1114,7 @@
   },
   {
     "id": "car_shootingbrake_v12",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_shootingbrake_abstract",
     "name": "Premium Shooting Brake",
@@ -1081,6 +1126,7 @@
   },
   {
     "id": "car_shootingbrake_electric",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_shootingbrake_abstract",
     "name": "Electric Shooting Brake",
@@ -1095,6 +1141,7 @@
   },
   {
     "abstract": "car_shootingbrake_long_abstract",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Shooting Brake",
     "blueprint": [
@@ -1156,6 +1203,7 @@
   },
   {
     "id": "car_shootingbrake_long_v8",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_shootingbrake_long_abstract",
     "parts": [
@@ -1166,6 +1214,7 @@
   },
   {
     "id": "car_shootingbrake_long_v12",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_shootingbrake_long_abstract",
     "name": "Premium Shooting Brake",
@@ -1177,6 +1226,7 @@
   },
   {
     "id": "car_shootingbrake_long_electric",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_shootingbrake_long_abstract",
     "name": "Electric Shooting Brake",
@@ -1191,6 +1241,7 @@
   },
   {
     "abstract": "car_sedan_abstract",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Sedan",
     "blueprint": [
@@ -1240,6 +1291,7 @@
   },
   {
     "id": "car_sedan",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_sedan_abstract",
     "parts": [
@@ -1257,6 +1309,7 @@
   },
   {
     "id": "car_sedan_diesel_i4",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_sedan_abstract",
     "parts": [
@@ -1271,6 +1324,7 @@
   },
   {
     "id": "car_sedan_diesel_v6",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_sedan_abstract",
     "parts": [
@@ -1285,6 +1339,7 @@
   },
   {
     "id": "car_sedan_v8",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_sedan_abstract",
     "name": "V8 Sports Sedan",
@@ -1306,6 +1361,7 @@
   },
   {
     "id": "car_sedan_sports_v12",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_sedan_abstract",
     "name": "V12 Sports Sedan",
@@ -1327,6 +1383,7 @@
   },
   {
     "id": "car_sedan_sports_v6",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_sedan_abstract",
     "name": "V6 Sports Sedan",
@@ -1348,6 +1405,7 @@
   },
   {
     "id": "car_sedan_luxury_v6",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_sedan_abstract",
     "name": "Luxury Sedan",
@@ -1364,6 +1422,7 @@
   },
   {
     "id": "car_sedan_electric",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_sedan_abstract",
     "name": "Electric Sedan",
@@ -1383,6 +1442,7 @@
   },
   {
     "id": "car_sedan_luxury_electric",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_sedan_abstract",
     "name": "Luxury Electric Sedan",
@@ -1402,6 +1462,7 @@
   },
   {
     "id": "car_sedan_sports_electric",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_sedan_abstract",
     "name": "Electric Sports Sedan",
@@ -1426,6 +1487,7 @@
   },
   {
     "abstract": "car_town_abstract",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Town Car",
     "blueprint": [
@@ -1486,6 +1548,7 @@
   },
   {
     "id": "car_town",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_town_abstract",
     "parts": [
@@ -1501,6 +1564,7 @@
   },
   {
     "id": "car_town_diesel",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_town_abstract",
     "parts": [
@@ -1516,6 +1580,7 @@
   },
   {
     "id": "car_town_budget",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_town_abstract",
     "name": "Budget Town Car",
@@ -1531,6 +1596,7 @@
   },
   {
     "id": "car_town_budget_superior",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_town_abstract",
     "name": "Budget Town Car",
@@ -1546,6 +1612,7 @@
   },
   {
     "id": "car_town_diesel_budget",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_town_abstract",
     "parts": [
@@ -1560,6 +1627,7 @@
   },
   {
     "abstract": "car_coupe_abstract",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Coupe",
     "blueprint": [
@@ -1608,6 +1676,7 @@
   },
   {
     "id": "car_coupe",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_coupe_abstract",
     "parts": [
@@ -1623,6 +1692,7 @@
   },
   {
     "id": "car_coupe_diesel_i4",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_coupe_abstract",
     "parts": [
@@ -1638,6 +1708,7 @@
   },
   {
     "id": "car_coupe_diesel_v6",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_coupe_abstract",
     "parts": [
@@ -1653,6 +1724,7 @@
   },
   {
     "id": "car_coupe_muscle",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_coupe_abstract",
     "name": "Muscle Car",
@@ -1669,6 +1741,7 @@
   },
   {
     "id": "car_coupe_sports_v12",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_coupe_abstract",
     "name": "V12 Sports Coupe",
@@ -1685,6 +1758,7 @@
   },
   {
     "id": "car_coupe_sports_v6",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_coupe_abstract",
     "name": "V6 Sports Coupe",
@@ -1701,6 +1775,7 @@
   },
   {
     "id": "car_coupe_luxury_v6",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_coupe_abstract",
     "name": "Luxury Coupe",
@@ -1714,6 +1789,7 @@
   },
   {
     "id": "car_coupe_electric",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_coupe_abstract",
     "name": "Electric Coupe",
@@ -1730,6 +1806,7 @@
   },
   {
     "id": "car_coupe_luxury_electric",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_coupe_abstract",
     "name": "Luxury Electric Coupe",
@@ -1746,6 +1823,7 @@
   },
   {
     "id": "car_coupe_sports_electric",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_coupe_abstract",
     "name": "Electric Sports Coupe",
@@ -1765,6 +1843,7 @@
   },
   {
     "abstract": "car_super_abstract",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Supercar",
     "blueprint": [
@@ -1816,6 +1895,7 @@
   },
   {
     "id": "car_super_v12",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_super_abstract",
     "name": "V12 Super Car",
@@ -1830,6 +1910,7 @@
   },
   {
     "id": "car_super_electric",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_super_abstract",
     "name": "Electric Super Car",
@@ -1847,6 +1928,7 @@
   },
   {
     "id": "car_super_electric_alt",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "car_super_abstract",
     "name": "Electric Super Car",
@@ -1865,6 +1947,7 @@
   },
   {
     "id": "car_sports_electric",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Electric Sports Car",
     "blueprint": [
@@ -1913,6 +1996,7 @@
   },
   {
     "id": "car_racing_electric",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Electric Racing Car",
     "blueprint": [
@@ -1961,6 +2045,7 @@
   },
   {
     "id": "electric_car",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Electric Car",
     "blueprint": [
@@ -2012,6 +2097,7 @@
   },
   {
     "id": "rara_x",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Solar Car",
     "blueprint": [
@@ -2060,6 +2146,7 @@
   },
   {
     "id": "suv",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "SUV",
     "blueprint": [
@@ -2131,6 +2218,7 @@
   },
   {
     "id": "suv_electric",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Electric SUV",
     "blueprint": [
@@ -2201,6 +2289,7 @@
   },
   {
     "id": "suv_electric_rack",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "copy-from": "suv_electric",
     "name": "Electric SUV with Bike Rack",
@@ -2213,6 +2302,7 @@
   },
   {
     "id": "surv_car",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Survivor Car",
     "parts": [

--- a/data/json/vehicles/custom_vehicles.json
+++ b/data/json/vehicles/custom_vehicles.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "hearse",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Hearse",
     "blueprint": [
@@ -74,6 +75,7 @@
   {
     "type": "vehicle",
     "id": "pickup_technical",
+    "color_palette": "military_standard",
     "name": "Technical",
     "blueprint": [
       [ "o--+-ox" ],
@@ -152,6 +154,7 @@
   },
   {
     "id": "truck_trailer_explosives",
+    "color_palette": "military_standard",
     "//": "This is for use in part 2 of Luke Isherwoods' truck explosive mission.",
     "type": "vehicle",
     "name": "Truck Trailer",

--- a/data/json/vehicles/emergency.json
+++ b/data/json/vehicles/emergency.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "ambulance",
+    "color_palette": "ems_standard",
     "type": "vehicle",
     "name": "Ambulance",
     "blueprint": [
@@ -79,6 +80,7 @@
   },
   {
     "id": "car_fbi",
+    "color_palette": "swat_standard",
     "type": "vehicle",
     "name": "FBI, Emergency",
     "blueprint": [
@@ -140,6 +142,7 @@
   },
   {
     "id": "fire_engine",
+    "color_palette": "firetruck_standard",
     "type": "vehicle",
     "name": "Fire Engine",
     "blueprint": [
@@ -270,6 +273,7 @@
   },
   {
     "id": "fire_truck",
+    "color_palette": "firetruck_standard",
     "type": "vehicle",
     "name": "Fire Truck",
     "blueprint": [
@@ -403,6 +407,7 @@
   },
   {
     "id": "policecar",
+    "color_palette": "police_standard",
     "type": "vehicle",
     "name": "Police Car",
     "blueprint": [
@@ -466,6 +471,7 @@
   },
   {
     "id": "policecar_k9",
+    "color_palette": "police_standard",
     "type": "vehicle",
     "name": "Police K9 Unit",
     "blueprint": [
@@ -528,6 +534,7 @@
   },
   {
     "id": "policesuv",
+    "color_palette": "police_standard",
     "type": "vehicle",
     "name": "Police SUV",
     "blueprint": [
@@ -597,6 +604,7 @@
   },
   {
     "id": "policesuv_k9",
+    "color_palette": "police_standard",
     "type": "vehicle",
     "name": "Police K9 Unit",
     "blueprint": [
@@ -668,6 +676,7 @@
   },
   {
     "id": "police_k9tpt",
+    "color_palette": "police_standard",
     "type": "vehicle",
     "name": "Police K9 Transport",
     "blueprint": [
@@ -739,6 +748,7 @@
   },
   {
     "id": "truck_swat",
+    "color_palette": "swat_standard",
     "type": "vehicle",
     "name": "SWAT Truck",
     "blueprint": [

--- a/data/json/vehicles/factional.json
+++ b/data/json/vehicles/factional.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "FM_early_pickup",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Caravaner's Pickup Truck",
     "//": "Basically a pickup truck, but spawns some different items in the bed.  Later versions could have a mounted gun, a ram, and some armour.",
@@ -72,6 +73,7 @@
   },
   {
     "id": "traveler_van_motorhome",
+    "color_palette": "car_standard",
     "//": "Just a normal mini RV with a few different items included.  Later versions could inlcude things like makeshift armor, a trailer, or a ram.",
     "type": "vehicle",
     "name": "Mini RV",

--- a/data/json/vehicles/farm.json
+++ b/data/json/vehicles/farm.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "oldtractor",
+    "color_palette": "farm_standard",
     "type": "vehicle",
     "name": "Primitive Tractor",
     "blueprint": [
@@ -31,6 +32,7 @@
   },
   {
     "id": "autotractor",
+    "color_palette": "farm_standard",
     "type": "vehicle",
     "name": "Automatic Tractor",
     "blueprint": [
@@ -68,6 +70,7 @@
   },
   {
     "id": "tractor_plow",
+    "color_palette": "farm_standard",
     "type": "vehicle",
     "name": "Plow Tractor",
     "blueprint": [
@@ -103,6 +106,7 @@
   },
   {
     "id": "tractor_reaper",
+    "color_palette": "farm_standard",
     "type": "vehicle",
     "name": "Reaper Tractor",
     "blueprint": [
@@ -138,6 +142,7 @@
   },
   {
     "id": "tractor_seed",
+    "color_palette": "farm_standard",
     "type": "vehicle",
     "name": "Planter Tractor",
     "blueprint": [
@@ -176,6 +181,7 @@
   },
   {
     "id": "uncovered_wagon",
+    "color_palette": "wooden_standard",
     "type": "vehicle",
     "name": "Wagon",
     "blueprint": [
@@ -204,6 +210,7 @@
   },
   {
     "id": "covered_wagon",
+    "color_palette": "wooden_standard",
     "type": "vehicle",
     "name": "Covered Wagon",
     "blueprint": [
@@ -267,6 +274,7 @@
   },
   {
     "id": "stagecoach",
+    "color_palette": "wooden_standard",
     "type": "vehicle",
     "name": "Stagecoach",
     "blueprint": [
@@ -329,6 +337,7 @@
   },
   {
     "id": "gig_carriage",
+    "color_palette": "wooden_standard",
     "type": "vehicle",
     "name": "Gig Carriage",
     "blueprint": [
@@ -346,6 +355,7 @@
   },
   {
     "id": "horse_trailer",
+    "color_palette": "wooden_standard",
     "type": "vehicle",
     "name": "Horse Trailer",
     "blueprint": [

--- a/data/json/vehicles/helicopters.json
+++ b/data/json/vehicles/helicopters.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "2seater2",
+    "color_palette": "aircraft_standard",
     "type": "vehicle",
     "name": "2-seater helicopter A",
     "parts": [
@@ -48,6 +49,7 @@
   },
   {
     "id": "2seater2_scenario",
+    "color_palette": "aircraft_standard",
     "type": "vehicle",
     "name": "2-seater helicopter A",
     "parts": [
@@ -97,6 +99,7 @@
   },
   {
     "id": "SmallFlier1",
+    "color_palette": "aircraft_standard",
     "type": "vehicle",
     "name": "Small helicopter",
     "parts": [
@@ -131,6 +134,7 @@
   },
   {
     "id": "SmallFlier2",
+    "color_palette": "aircraft_standard",
     "type": "vehicle",
     "name": "Small helicopter",
     "parts": [
@@ -167,6 +171,7 @@
   },
   {
     "id": "SmallFlier3",
+    "color_palette": "aircraft_standard",
     "type": "vehicle",
     "name": "Small helicopter",
     "parts": [
@@ -205,6 +210,7 @@
   },
   {
     "id": "Medevac1",
+    "color_palette": "ems_standard",
     "type": "vehicle",
     "name": "Medevac helicopter 1",
     "parts": [
@@ -270,6 +276,7 @@
   },
   {
     "id": "Medevac2",
+    "color_palette": "ems_standard",
     "type": "vehicle",
     "name": "Medevac helicopter 2",
     "parts": [
@@ -335,6 +342,7 @@
   },
   {
     "id": "2seater2_Wreck",
+    "color_palette": "aircraft_standard",
     "type": "vehicle",
     "name": "2-seater helicopter 2",
     "parts": [
@@ -373,6 +381,7 @@
   },
   {
     "id": "Smallflier1_Wreck",
+    "color_palette": "aircraft_standard",
     "type": "vehicle",
     "name": "Small helicopter",
     "parts": [
@@ -399,6 +408,7 @@
   },
   {
     "id": "SmallFlier2_Wreck",
+    "color_palette": "aircraft_standard",
     "type": "vehicle",
     "name": "SmallFlier2 Wreck",
     "parts": [
@@ -429,6 +439,7 @@
   },
   {
     "id": "SmallFlier3_Wreck",
+    "color_palette": "aircraft_standard",
     "type": "vehicle",
     "name": "Small helicopter",
     "parts": [
@@ -465,6 +476,7 @@
   },
   {
     "id": "Medevac1_Wreck",
+    "color_palette": "ems_standard",
     "type": "vehicle",
     "name": "Medevac helicopter w1",
     "parts": [
@@ -519,6 +531,7 @@
   },
   {
     "id": "Medevac2_Wreck",
+    "color_palette": "ems_standard",
     "type": "vehicle",
     "name": "Medevac helicopter w2",
     "parts": [
@@ -584,6 +597,7 @@
   },
   {
     "id": "helicopter_apache_1a",
+    "color_palette": "military_heli",
     "type": "vehicle",
     "name": "AH-64 Apache",
     "blueprint": [
@@ -708,6 +722,7 @@
   },
   {
     "id": "helicopter_apache_1b",
+    "color_palette": "military_heli",
     "type": "vehicle",
     "name": "AH-64 Apache",
     "blueprint": [
@@ -810,6 +825,7 @@
   },
   {
     "id": "helicopter_apache_1c",
+    "color_palette": "military_heli",
     "type": "vehicle",
     "name": "AH-64 Apache",
     "blueprint": [
@@ -906,6 +922,7 @@
   },
   {
     "id": "helicopter_osprey_2a",
+    "color_palette": "military_heli",
     "type": "vehicle",
     "name": "V-22 Osprey",
     "blueprint": [
@@ -1152,6 +1169,7 @@
   },
   {
     "id": "helicopter_osprey_2b",
+    "color_palette": "military_heli",
     "type": "vehicle",
     "name": "V-22 Osprey",
     "blueprint": [
@@ -1377,6 +1395,7 @@
   },
   {
     "id": "helicopter_osprey_2c",
+    "color_palette": "military_heli",
     "type": "vehicle",
     "name": "V-22 Osprey",
     "blueprint": [
@@ -1562,6 +1581,7 @@
   },
   {
     "id": "helicopter_blackhawk_3a",
+    "color_palette": "military_heli",
     "type": "vehicle",
     "name": "UH-60 Blackhawk",
     "blueprint": [
@@ -1692,6 +1712,7 @@
   },
   {
     "id": "helicopter_blackhawk_3b",
+    "color_palette": "military_heli",
     "type": "vehicle",
     "name": "UH-60 Blackhawk",
     "blueprint": [
@@ -1818,6 +1839,7 @@
   },
   {
     "id": "helicopter_blackhawk_3c",
+    "color_palette": "military_heli",
     "type": "vehicle",
     "name": "UH-60 Blackhawk",
     "blueprint": [

--- a/data/json/vehicles/military.json
+++ b/data/json/vehicles/military.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "aapc-gl",
+    "color_palette": "military_standard",
     "type": "vehicle",
     "name": "Mechanized Infantry Carrier",
     "//": "grenade launcher version",
@@ -108,6 +109,7 @@
   },
   {
     "id": "aapc-mg",
+    "color_palette": "military_standard",
     "type": "vehicle",
     "name": "Mechanized Infantry Carrier",
     "parts": [
@@ -210,6 +212,7 @@
   },
   {
     "id": "apc",
+    "color_palette": "military_standard",
     "type": "vehicle",
     "name": "Armored Personnel Carrier",
     "parts": [
@@ -296,6 +299,7 @@
   },
   {
     "id": "apc-gl",
+    "color_palette": "military_standard",
     "type": "vehicle",
     "name": "Armored Personnel Carrier",
     "//": "grenade launcher version",
@@ -387,6 +391,7 @@
   },
   {
     "id": "humvee",
+    "color_palette": "military_standard",
     "type": "vehicle",
     "name": "Humvee",
     "blueprint": [
@@ -473,6 +478,7 @@
   },
   {
     "id": "humvee_gl",
+    "color_palette": "military_standard",
     "type": "vehicle",
     "name": "Humvee",
     "blueprint": [
@@ -558,6 +564,7 @@
   },
   {
     "id": "humvee_tow",
+    "color_palette": "military_standard",
     "type": "vehicle",
     "name": "Humvee",
     "blueprint": [
@@ -646,6 +653,7 @@
   },
   {
     "id": "military_cargo_truck",
+    "color_palette": "military_standard",
     "type": "vehicle",
     "name": "Military Cargo Truck",
     "blueprint": [
@@ -748,6 +756,7 @@
   },
   {
     "id": "military_cargo_truck_b",
+    "color_palette": "military_standard",
     "type": "vehicle",
     "name": "Military Cargo Truck",
     "blueprint": [
@@ -850,6 +859,7 @@
   },
   {
     "id": "cannon_3in",
+    "color_palette": "military_standard",
     "type": "vehicle",
     "name": "cannon",
     "blueprint": [ "HUH" ],
@@ -861,6 +871,7 @@
   },
   {
     "id": "cannon_3in_plugged",
+    "color_palette": "military_standard",
     "type": "vehicle",
     "name": "cannon",
     "blueprint": [ "HUH" ],

--- a/data/json/vehicles/trains.json
+++ b/data/json/vehicles/trains.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "train_car_passenger",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Passenger Car",
     "parts": [
@@ -410,6 +411,7 @@
   },
   {
     "id": "trolley",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Trolley",
     "blueprint": [ "O" ],
@@ -586,6 +588,7 @@
   },
   {
     "id": "train_car_passenger_small",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Small Passenger Car",
     "blueprint": [

--- a/data/json/vehicles/trucks.json
+++ b/data/json/vehicles/trucks.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "flatbed_truck",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Flatbed Truck",
     "blueprint": [
@@ -85,6 +86,7 @@
   },
   {
     "id": "pickup",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Pickup Truck",
     "blueprint": [
@@ -144,6 +146,7 @@
   },
   {
     "id": "extended_pickup",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Extended Bed 4 Seat Pickup Truck",
     "blueprint": [
@@ -212,6 +215,7 @@
   },
   {
     "id": "4seat_pickup",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "4 Seat Pickup Truck",
     "blueprint": [
@@ -276,6 +280,7 @@
   },
   {
     "id": "semi_truck",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Semi Truck",
     "blueprint": [
@@ -363,6 +368,7 @@
   },
   {
     "id": "semi_truck_scenario",
+    "color_palette": "car_standard",
     "//": "semi trailer for the Trucker scenario start, includes spawn for a lab entrance card.",
     "type": "vehicle",
     "name": "Semi Truck",
@@ -450,6 +456,7 @@
   },
   {
     "id": "truck_trailer",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Truck Trailer",
     "blueprint": [
@@ -559,6 +566,7 @@
   },
   {
     "id": "tatra_truck",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Heavy-duty Cargo Truck",
     "blueprint": [
@@ -637,6 +645,7 @@
   },
   {
     "id": "animalctrl",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Animal Control Truck",
     "blueprint": [
@@ -709,6 +718,7 @@
   },
   {
     "id": "underlift_tow_truck",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Underlift Tow Truck",
     "blueprint": [
@@ -793,6 +803,7 @@
   },
   {
     "id": "underlift_tow_truck_lack_wheels",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Underlift Tow Truck",
     "blueprint": [

--- a/data/json/vehicles/utility.json
+++ b/data/json/vehicles/utility.json
@@ -41,6 +41,7 @@
   },
   {
     "id": "excavator",
+    "color_palette": "construction_standard",
     "type": "vehicle",
     "name": "Excavator",
     "blueprint": [
@@ -78,6 +79,7 @@
   },
   {
     "id": "road_roller",
+    "color_palette": "construction_standard",
     "type": "vehicle",
     "name": "Road Roller",
     "blueprint": [
@@ -132,6 +134,7 @@
   {
     "type": "vehicle",
     "id": "forklift",
+    "color_palette": "construction_standard",
     "name": "Electric Forklift",
     "blueprint": [
       [ "|" ],
@@ -170,6 +173,7 @@
   {
     "type": "vehicle",
     "id": "forklift_diesel",
+    "color_palette": "construction_standard",
     "name": "Heavy-Duty Forklift",
     "blueprint": [
       [ "o#o-" ],
@@ -202,6 +206,7 @@
   },
   {
     "id": "trencher",
+    "color_palette": "construction_standard",
     "type": "vehicle",
     "name": "Trencher",
     "blueprint": [

--- a/data/json/vehicles/vans_busses.json
+++ b/data/json/vehicles/vans_busses.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "armored_car",
+    "color_palette": "military_standard",
     "type": "vehicle",
     "name": "Armored Car",
     "blueprint": [
@@ -84,6 +85,7 @@
   },
   {
     "id": "cube_van",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Cube Van",
     "blueprint": [
@@ -174,6 +176,7 @@
   },
   {
     "id": "fridge_van",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Refrigerated Van",
     "blueprint": [
@@ -264,6 +267,7 @@
   },
   {
     "id": "cube_van_cheap",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Low-End Cube Van",
     "blueprint": [
@@ -347,6 +351,7 @@
   },
   {
     "id": "hippie_van",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Hippie Van",
     "blueprint": [
@@ -413,6 +418,7 @@
   },
   {
     "id": "van_full-size",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Full-size Van",
     "blueprint": [
@@ -482,6 +488,7 @@
   },
   {
     "id": "van_full-size_hybrid",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Hybrid Full-size Van",
     "blueprint": [
@@ -556,6 +563,7 @@
   },
   {
     "id": "van_mini",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Minivan",
     "blueprint": [
@@ -629,6 +637,7 @@
   },
   {
     "id": "van_mini_hybrid",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Hybrid Minivan",
     "blueprint": [
@@ -703,6 +712,7 @@
   },
   {
     "id": "van_cargo",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Cargo Van",
     "blueprint": [
@@ -768,6 +778,7 @@
   },
   {
     "id": "van_camper",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Camper Van",
     "blueprint": [
@@ -835,6 +846,7 @@
   },
   {
     "id": "van_motorhome",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Mini RV",
     "blueprint": [
@@ -903,6 +915,7 @@
   },
   {
     "id": "icecream_truck",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Ice Cream Truck",
     "blueprint": [
@@ -998,6 +1011,7 @@
   },
   {
     "id": "food_truck_taco",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Taco Truck",
     "blueprint": [
@@ -1093,6 +1107,7 @@
   },
   {
     "id": "food_truck",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Food Truck",
     "blueprint": [
@@ -1216,6 +1231,7 @@
   {
     "//": "This is a duplicate used for the last delivery starting scenario",
     "id": "food_truck_delivery_mission",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Food Truck",
     "blueprint": [
@@ -1336,6 +1352,7 @@
   },
   {
     "id": "lux_rv",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Luxury RV",
     "parts": [
@@ -1452,6 +1469,7 @@
   },
   {
     "id": "surv_rv",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Survivor RV",
     "parts": [
@@ -1590,6 +1608,7 @@
   },
   {
     "id": "meth_lab",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Mobile Meth Lab",
     "blueprint": [
@@ -1696,6 +1715,7 @@
   },
   {
     "id": "rv",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "RV",
     "blueprint": [
@@ -1799,6 +1819,7 @@
   },
   {
     "id": "limousine",
+    "color_palette": "limo_standard",
     "type": "vehicle",
     "name": "Limousine",
     "blueprint": [
@@ -1887,6 +1908,7 @@
   },
   {
     "id": "schoolbus",
+    "color_palette": "bus_standard",
     "type": "vehicle",
     "name": "Schoolbus",
     "blueprint": [
@@ -1994,6 +2016,7 @@
   },
   {
     "id": "bus_prison",
+    "color_palette": "police_standard",
     "type": "vehicle",
     "name": "Prison Bus",
     "blueprint": [
@@ -2132,6 +2155,7 @@
   },
   {
     "id": "bus",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Bus",
     "blueprint": [
@@ -2263,6 +2287,7 @@
   },
   {
     "id": "bus_rack",
+    "color_palette": "bus_standard",
     "type": "vehicle",
     "copy-from": "bus",
     "name": "Bus with Bike Rack",
@@ -2276,6 +2301,7 @@
   },
   {
     "id": "bus_tour",
+    "color_palette": "car_standard",
     "type": "vehicle",
     "name": "Tour Bus",
     "blueprint": [
@@ -2409,6 +2435,7 @@
   },
   {
     "id": "security_van",
+    "color_palette": "swat_standard",
     "type": "vehicle",
     "name": "Security Van",
     "blueprint": [
@@ -2510,6 +2537,7 @@
   },
   {
     "id": "wienermobile",
+    "color_palette": "wienermobile_standard",
     "type": "vehicle",
     "name": "Wienermobile",
     "blueprint": [
@@ -2601,6 +2629,7 @@
   },
   {
     "id": "prisoner_van_1",
+    "color_palette": "police_standard",
     "type": "vehicle",
     "name": "Prisoner Van",
     "blueprint": [

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -310,6 +310,7 @@ void tileset::clear()
     overexposed_tile_values.clear();
     memory_tile_values.clear();
     silhouette_tile_values.clear();
+    tinted_tile_values.clear();
     atlas_descriptors.clear();
     default_item_highlight_index.reset();
     renderer_instance_generation_at_upload = 0;
@@ -2530,7 +2531,12 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
     }
 
     //draw it!
-    const tile_render_params rp{ ll, nv_color_active };
+    tile_render_params rp{ ll, nv_color_active };
+    // Vehicle parts carry a per-instance paint color via pending_part_tint_
+    // (set by draw_vpart). Only apply it to vehicle part sprites.
+    if( category == TILE_CATEGORY::VEHICLE_PART ) {
+        rp.tint = pending_part_tint_;
+    }
     draw_tile_at( display_tile, screen_pos, loc_rand, rota, rp,
                   retract, height_3d, offset );
 
@@ -2583,8 +2589,12 @@ bool cata_tiles::draw_sprite_at(
     // preset, late session-disable) try_begin returns false and the
     // fallthrough below picks the matching pre-baked variant atlas.
     if( m_variant_pass ) {
+        // A painted vehicle part is recolored on the CPU below, so force NORMAL
+        // (no GPU variant transform); otherwise the shader samples the base atlas
+        // and ignores the tinted texture. NORMAL also clears prior shader state.
         const cata_shader::variant_kind v =
-            compute_variant_kind( rp.ll, rp.use_night_vision_tiles );
+            rp.tint ? cata_shader::variant_kind::NORMAL
+            : compute_variant_kind( rp.ll, rp.use_night_vision_tiles );
         // Call try_begin for every variant including NORMAL. State-cached
         // bind stays put across same-variant runs; NORMAL clears any prior
         // shader state so it doesn't leak onto the next sprite.
@@ -2613,6 +2623,14 @@ bool cata_tiles::draw_sprite_at(
             if( const texture *ptr = tileset_ptr->get_shadow_tile( sprite_index ) ) {
                 sprite_tex = ptr;
             }
+        }
+    }
+
+    // Recolor the chosen (light-adjusted) sprite toward the vehicle part's paint.
+    if( rp.tint ) {
+        if( const texture *tinted = tileset_ptr->get_tinted_tile(
+                                        renderer, sprite_index, *rp.tint, sprite_tex ) ) {
+            sprite_tex = tinted;
         }
     }
 
@@ -3521,11 +3539,15 @@ bool cata_tiles::draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height
             }
             if( !overridden ) {
                 int height_3d_temp = height_3d;
+                // Paint the displayed part with its color while it draws (the tint
+                // is consumed when tile_render_params is built); cleared right after.
+                pending_part_tint_ = get_vpart_tint( veh, ovp->mount_pos() );
                 const bool ret = memorize_only
                                  ? false
                                  : draw_from_id_string( "vp_" + vd.id.str(), TILE_CATEGORY::VEHICLE_PART,
                                                         empty_string, p, subtile, rotation, ll,
                                                         nv_goggles_activated, height_3d_temp, 0, vd.variant.id );
+                pending_part_tint_ = std::nullopt;
                 if( ret && vd.has_cargo ) {
                     draw_item_highlight( p, height_3d_temp );
                 }
@@ -3645,9 +3667,14 @@ bool cata_tiles::draw_vehicle_preview( const catacurses::window &w_disp, const v
         // degrees, change this to 1, 2 or 3.
         const int rotation = 0;
         int height_3d = 0;
+        // Tint with the DISPLAYED part's paint (which may be a board/door on top
+        // of this structure frame), mirroring the main-map path. The frame itself
+        // is never colored by a palette, so checking vp here would always be empty.
+        pending_part_tint_ = get_vpart_tint( veh, vp.mount );
         draw_from_id_string( "vp_" + vd.id.str(), TILE_CATEGORY::VEHICLE_PART, empty_string,
                              screen_tile, subtile, rotation, lit_level::LIT, false, height_3d, 0,
                              vd.variant.id );
+        pending_part_tint_ = std::nullopt;
         if( vd.has_cargo ) {
             // Cargo space holding items: overlay the item-highlight, as the map path does.
             draw_item_highlight( screen_tile, height_3d );

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -26,6 +26,7 @@
 #include "coordinates.h"
 #include "creature.h"
 #include "cuboid_rectangle.h"
+#include "hsv_color.h"
 #include "mapdata.h"
 #include "options.h"
 #include "pimpl.h"
@@ -198,6 +199,8 @@ class texture
 struct tile_render_params {
     lit_level ll;
     bool use_night_vision_tiles = false;
+    // When set, the sprite is recolored toward this color (vehicle part paint).
+    std::optional<RGBColor> tint = std::nullopt;
 };
 
 /**
@@ -262,6 +265,12 @@ class tileset
         std::vector<texture> overexposed_tile_values;
         std::vector<texture> memory_tile_values;
         std::vector<texture> silhouette_tile_values;
+
+        // Lazily-baked HSV-tinted variants of base sprites, keyed by
+        // (sprite_index << 32 | packed RGBA). Filled on demand by
+        // get_tinted_tile (a const memoizing accessor, hence mutable) and cleared
+        // whenever base textures are (re)uploaded.
+        mutable std::unordered_map<uint64_t, texture> tinted_tile_values;
 
         // Descriptors recorded during JSON parsing; replayed by upload_atlases.
         std::vector<atlas_replay_descriptor> atlas_descriptors;
@@ -342,6 +351,18 @@ class tileset
         }
         const texture *get_silhouette_tile( const size_t index ) const {
             return get_if_available( index, silhouette_tile_values );
+        }
+        /**
+         * Returns an HSV-tinted variant of sprite \p index recolored toward
+         * \p color, baking and caching it on first use. \p source is the already
+         * looked-up base/lit texture to recolor (so the tint stacks on the right
+         * light variant); falls back to the plain base tile when null.
+         * Returns nullptr if the sprite can't be tinted.
+         */
+        const texture *get_tinted_tile( const SDL_Renderer_Ptr &renderer, size_t index,
+                                        const RGBColor &color, const texture *source ) const;
+        void clear_tinted_tiles() {
+            tinted_tile_values.clear();
         }
 
         const std::unordered_set<std::string> &get_duplicate_ids() const {
@@ -645,6 +666,10 @@ class cata_tiles
                                  const std::array<bool, 5> &invisible, bool memorize_only );
         bool draw_vpart_roof( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                               const std::array<bool, 5> &invisible, bool memorize_only );
+        // Paint color to tint the vehicle part displayed at \p mount of \p veh,
+        // or nullopt when it is unpainted or the VEHICLE_PART_COLOR option is off.
+        std::optional<RGBColor> get_vpart_tint( const vehicle &veh,
+                                                const point_rel_ms &mount ) const;
         bool draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                               const std::array<bool, 5> &invisible, bool memorize_only );
         bool draw_critter_above( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
@@ -878,6 +903,11 @@ class cata_tiles
         // tinting; null for iso tiles, UI overlays, and non-tinted tiles.
         sprite_screen_bounds *m_cur_bounds = nullptr;
         small_literal_vector<tint_sprite_record, 4> *m_cur_tint_sprites = nullptr;
+
+        // Set by draw_vpart around its draw_from_id_string call so the vehicle
+        // part sprite gets recolored with the part's paint color; nullopt
+        // otherwise. Consumed when building tile_render_params.
+        std::optional<RGBColor> pending_part_tint_ = std::nullopt;
 
         // Per-draw caches rebuilt once per draw() from g->all_creatures(). Let the
         // critter layers skip the per-tile creature_at hash lookup for the ~all

--- a/src/cata_tiles_color.cpp
+++ b/src/cata_tiles_color.cpp
@@ -1,0 +1,121 @@
+#if defined(TILES)
+#include "cata_tiles.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <utility>
+
+#include "hsv_color.h"
+#include "options.h"
+#include "sdl_utils.h"
+#include "sdl_wrappers.h"
+#include "vehicle.h"
+
+// Self-contained rendering helpers for vehicle part coloring, kept out of
+// tileset_loader.cpp / cata_tiles.cpp so those files stay almost untouched:
+//  - tileset::get_tinted_tile bakes (and caches) an HSV-recolored sprite.
+//  - cata_tiles::get_vpart_tint resolves the paint color of a displayed part.
+
+const texture *tileset::get_tinted_tile( const SDL_Renderer_Ptr &renderer, const size_t index,
+        const RGBColor &color, const texture *source ) const
+{
+    if( source == nullptr ) {
+        source = get_tile( index );
+    }
+    if( source == nullptr ) {
+        return nullptr;
+    }
+
+    // Key on the source texture identity (which encodes the sprite AND its light
+    // variant; pointers are stable until the next upload, when this cache is
+    // cleared) mixed with the exact RGBA, so a part tinted in shadow does not
+    // get reused at full light.
+    const uint64_t color_key = ( static_cast<uint64_t>( color.r ) << 24 ) |
+                               ( static_cast<uint64_t>( color.g ) << 16 ) |
+                               ( static_cast<uint64_t>( color.b ) << 8 ) |
+                               static_cast<uint64_t>( color.a );
+    const uint64_t key = reinterpret_cast<uintptr_t>( source ) ^
+                         ( color_key * 0x9E3779B97F4A7C15ULL );
+    const auto cached = tinted_tile_values.find( key );
+    if( cached != tinted_tile_values.end() ) {
+        return &cached->second;
+    }
+
+    const std::pair<int, int> dim = source->dimension();
+    const int w = dim.first;
+    const int h = dim.second;
+    if( w <= 0 || h <= 0 ) {
+        return nullptr;
+    }
+
+    // Render the (already light-adjusted) source sprite to an offscreen target
+    // and read it back so its pixels can be recolored in HSV space.
+    SDL_Texture_Ptr target = CreateTexture( renderer, SDL_PIXELFORMAT_RGBA8888,
+                                            SDL_TEXTUREACCESS_TARGET, w, h );
+    if( !target ) {
+        return nullptr;
+    }
+    SetTextureBlendMode( target, SDL_BLENDMODE_BLEND );
+
+    SDL_Surface_Ptr surf = create_surface_32( w, h );
+    if( !surf ) {
+        return nullptr;
+    }
+    {
+        scoped_render_target swap_target( renderer, target.get() );
+        if( !swap_target.is_valid() ) {
+            return nullptr;
+        }
+        SetRenderDrawColor( renderer, 0, 0, 0, 0 );
+        RenderClear( renderer );
+        const SDL_Rect dst{ 0, 0, w, h };
+        source->render_copy_ex( renderer, &dst, 0.0, nullptr, SDL_FLIP_NONE );
+        const SDL_Rect read_rect{ 0, 0, w, h };
+        if( !RenderReadPixels( renderer, &read_rect, GetSurfacePixelFormat( surf ),
+                               surf->pixels, surf->pitch ) ) {
+            return nullptr;
+        }
+    }
+
+    // Recolor non-transparent pixels. create_surface_32 is tightly packed
+    // (pitch == w*4), matching the linear walk used by apply_color_filter.
+    SDL_Color *pix = static_cast<SDL_Color *>( surf->pixels );
+    for( int y = 0, ey = surf->h; y < ey; ++y ) {
+        for( int x = 0, ex = surf->w; x < ex; ++x, ++pix ) {
+            if( pix->a == 0x00 ) {
+                continue;
+            }
+            *pix = static_cast<SDL_Color>( tint_blend( RGBColor( *pix ), color ) );
+        }
+    }
+
+    std::shared_ptr<SDL_Texture> tex_ptr = CreateTextureFromSurface( renderer, surf );
+    if( !tex_ptr ) {
+        return nullptr;
+    }
+    SetTextureBlendMode( tex_ptr, SDL_BLENDMODE_BLEND );
+    texture baked( tex_ptr, SDL_Rect{ 0, 0, w, h }, source->get_opaque_rect() );
+    const auto inserted = tinted_tile_values.emplace( key, std::move( baked ) );
+    return &inserted.first->second;
+}
+
+std::optional<RGBColor> cata_tiles::get_vpart_tint( const vehicle &veh,
+        const point_rel_ms &mount ) const
+{
+    if( !get_option<bool>( "VEHICLE_PART_COLOR" ) ) {
+        return std::nullopt;
+    }
+    const int part_idx = veh.part_displayed_at( mount, true );
+    if( part_idx < 0 ) {
+        return std::nullopt;
+    }
+    const vehicle_part &vp = veh.part( part_idx );
+    if( !vp.has_custom_color() ) {
+        return std::nullopt;
+    }
+    return vp.get_color().fg;
+}
+
+#endif // TILES

--- a/src/hsv_color.cpp
+++ b/src/hsv_color.cpp
@@ -1,0 +1,399 @@
+#include "hsv_color.h"
+
+// Implementation of the vehicle-coloring color primitives (see hsv_color.h).
+// hsv2rgb/rgb2hsv use a fixed-point integer HSV representation (HSVColor) ported
+// verbatim from CBN so the tint math matches; tint_blend() is the recolor used
+// at render time.
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <cstdint>
+#include <iterator>
+#include <sstream>
+#include <vector>
+
+#include "debug.h"
+#include "rng.h"
+#include "string_formatter.h"
+#include "translations.h"
+
+#if defined(TILES)
+#include "sdl_utils.h"
+#endif
+
+static std::unordered_map<RGBColor, std::string> named_colors = {};
+static std::unordered_map<RGBColor, std::string> similar_name_cache = {};
+
+void RGBColor::load_named_color( const JsonObject &jo, std::string_view )
+{
+    const std::string name = jo.get_string( "name" );
+    if( jo.has_member( "value" ) ) {
+        RGBColor color;
+        color.deserialize( jo.get_member( "value" ) );
+        named_colors.insert_or_assign( color, name );
+    }
+}
+
+void RGBColor::unload_names()
+{
+    named_colors.clear();
+    similar_name_cache.clear();
+}
+
+static bool char_cmp_ignore_case( const char a, const char b )
+{
+    return std::tolower( static_cast<unsigned char>( a ) )
+           == std::tolower( static_cast<unsigned char>( b ) );
+}
+
+std::pair<RGBColor, std::string> RGBColor::random_named( std::string fuzzy_match )
+{
+    if( fuzzy_match.empty() ) {
+        return random_entry( named_colors );
+    }
+
+    std::vector<decltype( named_colors )::value_type> candidates;
+    std::copy_if( named_colors.begin(), named_colors.end(), std::back_inserter( candidates ),
+    [&]( const std::pair<const RGBColor, std::string> & c ) {
+        const std::string::const_iterator it = std::search( c.second.begin(), c.second.end(),
+                fuzzy_match.begin(), fuzzy_match.end(), char_cmp_ignore_case );
+        return it != c.second.end();
+    } );
+    return random_entry( candidates );
+}
+
+std::unordered_map<RGBColor, std::string> RGBColor::get_all_named_colors()
+{
+    return named_colors;
+}
+
+std::string RGBColor::friendly_name() const
+{
+    const std::unordered_map<RGBColor, std::string>::iterator it = named_colors.find( *this );
+    if( it != named_colors.end() ) {
+        return it->second;
+    }
+
+    // https://www.compuphase.com/cmetric.htm
+    const auto distFunc = []( const RGBColor & e1, const RGBColor & e2 ) {
+        const uint32_t r_mean = ( static_cast<uint32_t>( e1.r ) + static_cast<uint32_t>( e2.r ) ) / 2;
+        const uint32_t r = static_cast<uint32_t>( e1.r ) - static_cast<uint32_t>( e2.r );
+        const uint32_t g = static_cast<uint32_t>( e1.g ) - static_cast<uint32_t>( e2.g );
+        const uint32_t b = static_cast<uint32_t>( e1.b ) - static_cast<uint32_t>( e2.b );
+        return std::sqrt( ( ( ( 512 + r_mean ) * r * r ) >> 8 )
+                          + 4 * g * g
+                          + ( ( ( 767 - r_mean ) * b * b ) >> 8 ) );
+    };
+
+    const std::unordered_map<RGBColor, std::string>::iterator nearest = similar_name_cache.find( *this );
+    if( nearest != similar_name_cache.end() ) {
+        return nearest->second;
+    }
+
+    if( named_colors.empty() ) {
+        return _( "Unknown color" );
+    }
+
+    const std::unordered_map<RGBColor, std::string>::iterator min = std::min_element(
+            named_colors.begin(), named_colors.end(),
+    [&]( const std::pair<const RGBColor, std::string> & a,
+         const std::pair<const RGBColor, std::string> & b ) {
+        return distFunc( a.first, *this ) < distFunc( b.first, *this );
+    } );
+    std::string similar_name = string_format( _( "%s (Off-Brand)" ), min->second );
+    similar_name_cache.emplace( *this, similar_name );
+    return similar_name;
+}
+
+auto curses_color_to_RGB( const nc_color &color ) -> RGBColor
+{
+#if defined(TILES)
+    return RGBColor( curses_color_to_SDL( color ) );
+#else
+    ( void )color;
+    return RGBColor{ 255, 255, 255, 255 };
+#endif
+}
+
+static uint8_t median( const uint8_t a, const uint8_t b, const uint8_t c )
+{
+    if( ( a > b ) ^ ( a > c ) ) {
+        return a;
+    }
+    if( ( b < a ) ^ ( b < c ) ) {
+        return b;
+    }
+    return c;
+}
+
+auto hsv2rgb( HSVColor color ) -> RGBColor
+{
+    constexpr int E = ( 1 << 16 ) - 1;
+
+    const uint32_t H = color.H;
+    const uint16_t S = color.S;
+    const uint8_t V = color.V;
+    const uint8_t A = color.A;
+
+    if( S == 0 || V == 0 ) {
+        return RGBColor{V, V, V, A};
+    }
+
+    uint8_t I;
+    if( H < E ) {
+        I = 0;
+    } else if( H < 2 * E ) {
+        I = 1;
+    } else if( H < 3 * E ) {
+        I = 2;
+    } else if( H < 4 * E ) {
+        I = 3;
+    } else if( H < 5 * E ) {
+        I = 4;
+    } else {
+        I = 5;
+    }
+
+    uint32_t F = ( H - static_cast<uint32_t>( E * I ) );
+    if( F == 0 ) {
+        ++F;
+    }
+
+    if( I % 2 != 0 ) {
+        F = ( E - F );
+    }
+
+    const int d = ( ( S * V ) >> 16 ) + 1;
+    const uint8_t m = static_cast<uint8_t>( V - d );
+    const uint8_t c = static_cast<uint8_t>( ( ( F * static_cast<uint32_t>( d ) ) >> 16 ) + m );
+
+    switch( I ) {
+        case 0:
+            return {V, c, m, A};
+        case 1:
+            return {c, V, m, A};
+        case 2:
+            return {m, V, c, A};
+        case 3:
+            return {m, c, V, A};
+        case 4:
+            return {c, m, V, A};
+        case 5:
+            return {V, m, c, A};
+        default:
+            return {0, 0, 0, A};
+    }
+}
+
+auto rgb2hsv( RGBColor color ) -> HSVColor
+{
+    const uint8_t R = color.r;
+    const uint8_t G = color.g;
+    const uint8_t B = color.b;
+    const uint8_t A = color.a;
+    const uint8_t min = std::min( {R, G, B } );
+    const uint8_t max = std::max( {R, G, B } );
+    const uint8_t med = median( R, G, B );
+
+    const uint8_t V = max;
+
+    const int d = max - min;
+    if( d == 0 || max == 0 ) {
+        return HSVColor{0, 0, V, A};
+    }
+
+    const uint16_t S = static_cast<uint16_t>( ( ( d << 16 ) - 1 ) / V );
+
+    int I;
+    if( max == R && min == B ) {
+        I = 0;
+    } else if( max == G && min == B ) {
+        I = 1;
+    } else if( max == G && min == R ) {
+        I = 2;
+    } else if( max == B && min == R ) {
+        I = 3;
+    } else if( max == B && min == G ) {
+        I = 4;
+    } else {
+        I = 5;
+    }
+
+    constexpr int E = ( 1 << 16 ) - 1;
+    int F = ( ( ( med - min ) << 16 ) / d ) + 1;
+    if( I % 2 != 0 ) {
+        F = E - F;
+    }
+
+    const uint32_t H = static_cast<uint32_t>( ( E * I ) + F );
+
+    return HSVColor{H, S, V, A};
+}
+
+RGBColor tint_blend( const RGBColor &base, const RGBColor &tint )
+{
+    HSVColor base_hsv = rgb2hsv( base );
+    const HSVColor dest_hsv = rgb2hsv( tint );
+
+    const auto lerp16 = []( const uint16_t a, const uint16_t b, const uint8_t t ) -> uint16_t {
+        return static_cast<uint16_t>( a + ( ( static_cast<int>( b ) - static_cast<int>( a ) ) * t ) / 255 );
+    };
+    const auto lerp8 = []( const uint8_t a, const uint8_t b, const uint8_t t ) -> uint8_t {
+        return static_cast<uint8_t>( a + ( ( static_cast<int>( b ) - static_cast<int>( a ) ) * t ) / 255 );
+    };
+    // Pegtop-style overlay used by CBN to preserve the source sprite's shading.
+    const auto overlay = []( const uint8_t b, const uint8_t blend ) -> uint8_t {
+        if( b > 127 ) {
+            return static_cast<uint8_t>( std::clamp<int>( 255 - ( std::max( 255 - blend, 1 ) ) *
+                                         ( ( 255 - b ) * 255 / 127 ) / 255, 0, 255 ) );
+        }
+        return static_cast<uint8_t>( std::clamp<int>( blend * ( b * 255 / 127 ) / 255, 0, 255 ) );
+    };
+
+    base_hsv.H = dest_hsv.H;
+    base_hsv.S = lerp16( std::min( base_hsv.S, dest_hsv.S ), dest_hsv.S, 127 );
+    base_hsv.V = lerp8( base_hsv.V, overlay( base_hsv.V, dest_hsv.V ), 127 );
+
+    RGBColor out = hsv2rgb( base_hsv );
+    out.a = base.a;
+    return out;
+}
+
+void RGBColor::serialize( JsonOut &jsout ) const
+{
+    jsout.start_array();
+    jsout.write( r );
+    jsout.write( g );
+    jsout.write( b );
+    if( a != 255 ) {
+        jsout.write( a );
+    }
+    jsout.end_array();
+}
+
+void RGBColor::deserialize( const JsonValue &jv )
+{
+    if( jv.test_string() ) {
+        const std::string str = jv.get_string();
+        const std::optional<RGBColor> col = try_parse( str );
+        if( col.has_value() ) {
+            *this = col.value();
+        } else {
+            debugmsg( "Unknown color value: %s", str );
+        }
+    } else if( jv.test_array() ) {
+        JsonArray arr = jv.get_array();
+        if( arr.size() == 3 ) {
+            r = static_cast<uint8_t>( std::clamp( arr.get_int( 0 ), 0, 255 ) );
+            g = static_cast<uint8_t>( std::clamp( arr.get_int( 1 ), 0, 255 ) );
+            b = static_cast<uint8_t>( std::clamp( arr.get_int( 2 ), 0, 255 ) );
+            a = 255;
+        } else if( arr.size() == 4 ) {
+            r = static_cast<uint8_t>( std::clamp( arr.get_int( 0 ), 0, 255 ) );
+            g = static_cast<uint8_t>( std::clamp( arr.get_int( 1 ), 0, 255 ) );
+            b = static_cast<uint8_t>( std::clamp( arr.get_int( 2 ), 0, 255 ) );
+            a = static_cast<uint8_t>( std::clamp( arr.get_int( 3 ), 0, 255 ) );
+        } else {
+            jv.throw_error( "Invalid color value, expected 3 or 4 element array" );
+        }
+    } else {
+        jv.throw_error( "Invalid color value, expected string or array" );
+    }
+}
+
+static RGBColor rgb_from_hex_string( std::string str )
+{
+    if( !str.empty() && str.front() == '#' ) {
+        str = str.substr( 1 );
+    }
+
+    if( str.empty() || std::any_of( str.begin(), str.end(), []( const char & c ) {
+    return !std::isxdigit( static_cast<unsigned char>( c ) );
+    } ) ) {
+        debugmsg( "Invalid color value: %s", str );
+        return {};
+    }
+
+    uint32_t d = 0;
+    std::istringstream is( str );
+    is >> std::hex >> d;
+    switch( str.size() ) {
+        case 3: {
+            const uint8_t nr = static_cast<uint8_t>( ( d >> 8 ) & 0x0F );
+            const uint8_t ng = static_cast<uint8_t>( ( d >> 4 ) & 0x0F );
+            const uint8_t nb = static_cast<uint8_t>( ( d >> 0 ) & 0x0F );
+            return RGBColor{static_cast<uint8_t>( nr | nr << 4 ),
+                            static_cast<uint8_t>( ng | ng << 4 ),
+                            static_cast<uint8_t>( nb | nb << 4 ),
+                            static_cast<uint8_t>( 255 )};
+        }
+        case 4: {
+            const uint8_t nr = static_cast<uint8_t>( ( d >> 12 ) & 0x0F );
+            const uint8_t ng = static_cast<uint8_t>( ( d >> 8 ) & 0x0F );
+            const uint8_t nb = static_cast<uint8_t>( ( d >> 4 ) & 0x0F );
+            const uint8_t na = static_cast<uint8_t>( ( d >> 0 ) & 0x0F );
+            return RGBColor{
+                static_cast<uint8_t>( nr | nr << 4 ),
+                static_cast<uint8_t>( ng | ng << 4 ),
+                static_cast<uint8_t>( nb | nb << 4 ),
+                static_cast<uint8_t>( na | na << 4 ),
+            };
+        }
+        case 6: {
+            return RGBColor{
+                static_cast<uint8_t>( d >> 16 ), static_cast<uint8_t>( d >> 8 ),
+                static_cast<uint8_t>( d >> 0 ), static_cast<uint8_t>( 255 )};
+        }
+        case 8: {
+            return RGBColor{
+                static_cast<uint8_t>( d >> 24 ),
+                static_cast<uint8_t>( d >> 16 ),
+                static_cast<uint8_t>( d >> 8 ),
+                static_cast<uint8_t>( d >> 0 ),
+            };
+        }
+        default:
+            debugmsg( "Invalid color value: %s", str );
+            return {};
+    }
+}
+
+std::string RGBColor::to_hex() const
+{
+    if( a == 255 ) {
+        return string_format( "#%02x%02x%02x", r, g, b );
+    }
+    return string_format( "#%02x%02x%02x%02x", r, g, b, a );
+}
+
+RGBColor RGBColor::from_hex( const std::string &str )
+{
+    return try_parse( str ).value_or( RGBColor{} );
+}
+
+std::optional<RGBColor> RGBColor::try_parse( const std::string &str )
+{
+    if( !str.empty() && str.front() == '#' ) {
+        return rgb_from_hex_string( str );
+    }
+
+    if( !str.empty() && str.front() == '!' ) {
+        return random_named( str.substr( 1 ) ).first;
+    }
+
+    const color_manager &cm = get_all_colors();
+    const color_id nc_id = cm.name_to_id( str, report_color_error::no );
+    if( nc_id != def_c_unset ) {
+        return curses_color_to_RGB( cm.get( nc_id ) );
+    }
+
+    for( const std::pair<const RGBColor, std::string> & entry : named_colors ) {
+        if( str.size() == entry.second.size() &&
+            std::equal( str.begin(), str.end(), entry.second.begin(), char_cmp_ignore_case ) ) {
+            return entry.first;
+        }
+    }
+
+    return std::nullopt;
+}

--- a/src/hsv_color.h
+++ b/src/hsv_color.h
@@ -1,0 +1,134 @@
+#pragma once
+
+// Color primitives for the vehicle part coloring feature (ported from
+// Cataclysm: Bright Nights). Feature overview:
+//   - named_colors.json + load_named_color() define palette colors by name.
+//   - VehiclePalette (vehicle_palette.h) rolls per-part colors when a vehicle
+//     spawns; the color is stored in the part's base item variables.
+//   - Rendering recolors sprites in HSV space via tint_blend() (used by
+//     cata_tiles_color.cpp::get_tinted_tile).
+// Note: unlike CBN we store the color as a hex string in item variables (see
+// to_hex/from_hex) because this fork's item vars are backed by diag_value, which
+// has no generic serializable-type support.
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+
+#include "color.h"
+#include "hash_utils.h"
+#include "json.h"
+
+#if defined(TILES)
+#include "sdl_wrappers.h"
+#endif
+
+/**
+ * Simple 32-bit RGBA color, used for vehicle part tinting.
+ *
+ * Ported from Cataclysm: Bright Nights. Unlike CBN this fork stores the color
+ * in item variables as a hex string (see @ref to_hex / @ref from_hex) instead
+ * of the data_vars converter, because this fork's item variables are backed by
+ * diag_value which has no generic serializable-type support.
+ */
+struct RGBColor {
+    uint8_t r = 0;
+    uint8_t g = 0;
+    uint8_t b = 0;
+    uint8_t a = 0;
+
+    constexpr RGBColor() = default;
+    constexpr RGBColor( const uint8_t r, const uint8_t g, const uint8_t b, const uint8_t a )
+        : r{r}, g{g}, b{b}, a{a} {}
+#if defined(TILES)
+    explicit constexpr RGBColor( const SDL_Color &c ) : r( c.r ), g( c.g ), b( c.b ), a( c.a ) {}
+    explicit constexpr operator SDL_Color() const {
+        return SDL_Color{ r, g, b, a };
+    }
+#endif
+
+    void serialize( JsonOut & ) const;
+    void deserialize( const JsonValue & );
+
+    /** Encode as "#RRGGBB" (or "#RRGGBBAA" when not fully opaque) for item-var storage. */
+    std::string to_hex() const;
+    /** Decode a string produced by @ref to_hex (also accepts any @ref try_parse form). */
+    static RGBColor from_hex( const std::string &str );
+
+    /**
+     * Parse a color from a string. Accepts:
+     *  - "#RGB" / "#RGBA" / "#RRGGBB" / "#RRGGBBAA" hex
+     *  - "!fuzzy" for a random named color whose name contains "fuzzy"
+     *  - a curses color name (e.g. "red")
+     *  - a named color loaded from named_colors.json (e.g. "Cataclysm Red")
+     */
+    static std::optional<RGBColor> try_parse( const std::string &str );
+    static std::pair<RGBColor, std::string> random_named( std::string fuzzy_match = "" );
+    static std::unordered_map<RGBColor, std::string> get_all_named_colors();
+
+    static void load_named_color( const JsonObject &jo, std::string_view src );
+    static void unload_names();
+
+    std::string friendly_name() const;
+
+    bool operator==( const RGBColor &other ) const {
+        return r == other.r && g == other.g && b == other.b && a == other.a;
+    }
+    bool operator!=( const RGBColor &other ) const {
+        return !( *this == other );
+    }
+};
+
+struct RGBColorPair {
+    RGBColor bg;
+    RGBColor fg;
+};
+
+struct HSVColor {
+    /// Hue: 0 ~ ( ( 1 << 16 ) - 1 ) * 6
+    uint32_t H;
+    /// Saturation: 0 ~ 65535
+    uint16_t S;
+    /// Value: 0 ~ 255
+    uint8_t V;
+    /// Alpha: 0 ~ 255
+    uint8_t A;
+};
+
+auto curses_color_to_RGB( const nc_color &color ) -> RGBColor;
+auto hsv2rgb( HSVColor color ) -> RGBColor;
+auto rgb2hsv( RGBColor color ) -> HSVColor;
+
+/**
+ * Recolor a source pixel toward a tint, in HSV space (CBN's "tint" blend mode,
+ * mask-less variant): take the tint's hue, pull saturation toward the tint, and
+ * keep the source's value/shading (via an overlay). The source alpha is kept.
+ * This is what makes one sprite render in many colors while preserving detail.
+ */
+RGBColor tint_blend( const RGBColor &base, const RGBColor &tint );
+
+template<> struct std::hash<RGBColor> {
+    std::size_t operator()( const RGBColor &color ) const noexcept {
+        std::size_t hash = 0;
+        cata::hash_combine( hash, color.r );
+        cata::hash_combine( hash, color.g );
+        cata::hash_combine( hash, color.b );
+        cata::hash_combine( hash, color.a );
+        return hash;
+    }
+};
+
+template<> struct std::hash<HSVColor> {
+    std::size_t operator()( const HSVColor &color ) const noexcept {
+        std::size_t hash = 0;
+        cata::hash_combine( hash, color.H );
+        cata::hash_combine( hash, color.S );
+        cata::hash_combine( hash, color.V );
+        cata::hash_combine( hash, color.A );
+        return hash;
+    }
+};

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -56,6 +56,7 @@
 #include "global_vars.h"
 #include "harvest.h"
 #include "help.h"
+#include "hsv_color.h"
 #include "input.h"
 #include "item_action.h"
 #include "item_category.h"
@@ -121,6 +122,7 @@
 #include "type_id.h"
 #include "veh_type.h"
 #include "vehicle_group.h"
+#include "vehicle_palette.h"
 #include "vehicle_part_location.h"
 #include "vitamin.h"
 #include "weakpoint.h"
@@ -354,6 +356,9 @@ void DynamicDataLoader::initialize()
     add( "vehicle_group",  &VehicleGroup::load );
     add( "vehicle_placement",  &VehiclePlacement::load );
     add( "vehicle_spawn",  &VehicleSpawn::load );
+    // Vehicle part coloring (see hsv_color.h / vehicle_palette.h).
+    add( "vehicle_color_palette", &VehiclePalette::load );
+    add( "named_color", &RGBColor::load_named_color );
 
     add( "requirement", []( const JsonObject & jo ) {
         requirement_data::load_requirement( jo, string_id<requirement_data>::NULL_ID(), true );
@@ -772,6 +777,8 @@ void DynamicDataLoader::unload_data()
     trap::reset();
     trap_migrations::reset();
     unload_talk_topics();
+    RGBColor::unload_names();
+    VehiclePalette::reset();
     VehicleGroup::reset();
     VehiclePlacement::reset();
     VehicleSpawn::reset();
@@ -978,6 +985,7 @@ void DynamicDataLoader::check_consistency()
             { _( "Vehicle parts" ), &vehicles::parts::check },
             { _( "Vehicle part locations" ), &vpart_location::check_all },
             { _( "Vehicle part migrations" ), &vpart_migration::check },
+            { _( "Vehicle color palettes" ), &VehiclePalette::check },
             { _( "Mapgen definitions" ), &check_mapgen_definitions },
             { _( "Mapgen palettes" ), &mapgen_palette::check_definitions },
             {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2484,6 +2484,11 @@ void options_manager::add_options_graphics()
              true, COPT_CURSES_HIDE
            );
 
+        add( "VEHICLE_PART_COLOR", page_id, to_translation( "Vehicle part colors" ),
+             to_translation( "If true, vehicle parts are drawn tinted with their assigned or painted colors." ),
+             true, COPT_CURSES_HIDE
+           );
+
         add( "SWAP_ZOOM", page_id, to_translation( "Zoom Threshold" ),
              to_translation( "Choose when you should swap tileset (lower is more zoomed out)." ),
              1, 4, 2, COPT_CURSES_HIDE
@@ -2495,6 +2500,7 @@ void options_manager::add_options_graphics()
         get_option( "SWAP_ZOOM" ).setPrerequisite( "USE_DISTANT_TILES" );
         get_option( "CREATURE_OVERLAY_ICONS" ).setPrerequisite( "USE_TILES" );
         get_option( "VEHICLE_EDIT_TILES" ).setPrerequisite( "USE_TILES" );
+        get_option( "VEHICLE_PART_COLOR" ).setPrerequisite( "USE_TILES" );
 
         add( "USE_OVERMAP_TILES", page_id, to_translation( "Use tiles to display overmap" ),
              to_translation( "If true, replaces some TTF-rendered text with tiles for overmap display." ),

--- a/src/tileset_loader.cpp
+++ b/src/tileset_loader.cpp
@@ -1028,6 +1028,9 @@ void tileset_cache::loader::upload_atlases( tileset &ts, const SDL_Renderer_Ptr 
     ts.overexposed_tile_values = std::move( cand_overexposed );
     ts.memory_tile_values = std::move( cand_memory );
     ts.silhouette_tile_values = std::move( cand_silhouette );
+    // Base textures were just (re)uploaded; previously baked tints reference the
+    // stale textures, so drop them and let them rebake on demand.
+    ts.clear_tinted_tiles();
 
     ts.set_upload_generations( renderer_instance_generation, gpu_textures_generation );
 }

--- a/src/type_id.h
+++ b/src/type_id.h
@@ -385,6 +385,9 @@ using vpart_location_id = string_id<vpart_location>;
 struct vehicle_prototype;
 using vproto_id = string_id<vehicle_prototype>;
 
+class VehiclePalette;
+using vpalette_id = string_id<VehiclePalette>;
+
 class weather_generator;
 using weather_generator_id = string_id<weather_generator>;
 

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -45,6 +45,7 @@
 #include "value_ptr.h"
 #include "vehicle.h"
 #include "vehicle_group.h"
+#include "vehicle_palette.h"
 #include "vpart_position.h"
 #include "vpart_range.h"
 #include "wcwidth.h"
@@ -1402,6 +1403,10 @@ void vehicle_prototype::load( const JsonObject &jo, std::string_view )
 
     optional( jo, was_loaded, "items", item_spawns );
     optional( jo, was_loaded, "zones", zone_defs, json_read_reader<zone_def> {} );
+
+    if( jo.has_member( "color_palette" ) ) {
+        color_palette = vpalette_id( jo.get_string( "color_palette" ) );
+    }
 }
 
 void vehicle_prototype::save_vehicle_as_prototype( const vehicle &veh,
@@ -1582,6 +1587,14 @@ void vehicles::finalize_prototypes()
             if( !pt.part.is_valid() ) {
                 debugmsg( "unknown vehicle part %s in %s", pt.part.c_str(), proto.id.str() );
                 continue;
+            }
+
+            // Map each part id to its palette color group, so spawning can color it.
+            if( proto.color_palette.is_valid() && proto.color_match.count( pt.part.str() ) == 0 ) {
+                const int index = proto.color_palette->fuzzy_to_index( pt.part );
+                if( index != -1 ) {
+                    proto.color_match[pt.part.str()] = index;
+                }
             }
 
             const int part_idx = blueprint.install_part( here, pt.pos, pt.part );

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -589,6 +589,11 @@ struct vehicle_prototype {
         std::vector<zone_def> zone_defs;
         std::vector<std::pair<vproto_id, mod_id>> src;
 
+        /** Optional random color palette applied to parts when the vehicle spawns. */
+        vpalette_id color_palette;
+        /** Built during finalization: part-id string -> palette color-group index. */
+        std::map<std::string, int> color_match;
+
         shared_ptr_fast<vehicle> blueprint;
 
         void load( const JsonObject &jo, std::string_view src );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -83,6 +83,7 @@
 #include "units_utility.h"
 #include "value_ptr.h"
 #include "veh_type.h"
+#include "vehicle_palette.h"
 #include "vehicle_part_location.h"
 #include "vehicle_selector.h"
 #include "weather.h"
@@ -256,7 +257,32 @@ vehicle::vehicle( const vproto_id &proto_id )
         // The game language may have changed after the blueprint was created,
         // so translated the prototype name again.
         name = proto.name.translated();
+        // Roll a random color scheme for this instance from the prototype's
+        // palette (each spawned vehicle gets its own colors). Saved vehicles are
+        // restored via deserialize instead, so they are not re-rolled here.
+        apply_color_palette( proto );
         refresh( );
+    }
+}
+
+void vehicle::apply_color_palette( const vehicle_prototype &proto )
+{
+    if( !proto.color_palette.is_valid() || proto.color_match.empty() ) {
+        return;
+    }
+    const std::vector<RGBColor> colors = proto.color_palette->pick_colors();
+    if( colors.empty() ) {
+        return;
+    }
+    for( vehicle_part &vp : parts ) {
+        const auto it = proto.color_match.find( vp.info().id.str() );
+        if( it == proto.color_match.end() ) {
+            continue;
+        }
+        const int idx = it->second;
+        if( idx >= 0 && idx < static_cast<int>( colors.size() ) ) {
+            vp.set_color( colors[idx], colors[idx] );
+        }
     }
 }
 

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -66,6 +66,8 @@ class vpart_variant;
 enum class ter_furn_flag : int;
 enum vpart_bitflags : int;
 struct itype;
+struct RGBColor;
+struct RGBColorPair;
 struct vehicle_part;
 template <typename E> struct enum_traits;
 
@@ -279,6 +281,21 @@ struct vehicle_part {
         std::vector<item> get_salvageable() const;
         // set part base to \p new_base, std::move()-ing it
         void set_base( item &&new_base );
+
+        /**
+         * Vehicle part display color (tinting), ported from CBN.
+         *
+         * The color is stored directly in the base item's variables (as a hex
+         * string), so it is persisted with saves and travels with the part when
+         * it is removed and reinstalled on another vehicle. There is no separate
+         * cached copy to keep in sync.
+         */
+        /** Painted color, or the part type's default color when unpainted (unless \p ignore_default). */
+        RGBColorPair get_color( bool ignore_default = false ) const;
+        /** Assign a paint color, stored on the base item. No-op for NO_PAINT parts. */
+        void set_color( const RGBColor &bg, const RGBColor &fg );
+        /** True if this part has an explicitly assigned (painted or spawned) color. */
+        bool has_custom_color() const;
 
         bool has_flag( const vp_flag flag ) const noexcept {
             const uint32_t flag_as_uint32 = static_cast<uint32_t>( flag );
@@ -992,6 +1009,10 @@ class vehicle
 
     private:
         vehicle &operator=( const vehicle & ) = default;
+
+        // Roll and apply a random color scheme from the prototype's palette to
+        // this freshly-spawned instance's parts (see vehicle_palette).
+        void apply_color_palette( const vehicle_prototype &proto );
 
     public:
         /** Disable or enable refresh() ; used to speed up performance when creating a vehicle */

--- a/src/vehicle_palette.cpp
+++ b/src/vehicle_palette.cpp
@@ -1,0 +1,110 @@
+#include "vehicle_palette.h"
+
+// VehiclePalette loading/lookup (see vehicle_palette.h). Each palette maps fuzzy
+// part-id prefixes to a weighted color group; fuzzy_to_index() finds a part's
+// group and pick_colors() rolls one weighted-random color per group. Colors are
+// referenced by name (resolved through RGBColor::try_parse -> named_colors.json).
+
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "debug.h"
+#include "hsv_color.h"
+#include "json.h"
+#include "type_id.h"
+
+// Only ever accessed from this translation unit (all lookups route through the
+// vpalette_id string_id indirection below), so keep it file-local rather than a
+// header static like CBN does.
+static std::unordered_map<vpalette_id, VehiclePalette> vehicle_color_palettes;
+
+/** @relates string_id */
+template<>
+const VehiclePalette &string_id<VehiclePalette>::obj() const
+{
+    const auto iter = vehicle_color_palettes.find( *this );
+    if( iter == vehicle_color_palettes.end() ) {
+        debugmsg( "invalid vehicle color palette id %s", c_str() );
+        static const VehiclePalette dummy{};
+        return dummy;
+    }
+    return iter->second;
+}
+
+/** @relates string_id */
+template<>
+bool string_id<VehiclePalette>::is_valid() const
+{
+    return vehicle_color_palettes.find( *this ) != vehicle_color_palettes.end();
+}
+
+void VehiclePalette::load( const JsonObject &jo )
+{
+    VehiclePalette &palette = vehicle_color_palettes[vpalette_id( jo.get_string( "id" ) )];
+
+    if( jo.has_bool( "clear" ) && jo.get_bool( "clear" ) ) {
+        palette.fuzzy_color_match.clear();
+        palette.colors.clear();
+    }
+    palette.id = vpalette_id( jo.get_string( "id" ) );
+    for( const JsonObject obj : jo.get_array( "palette" ) ) {
+        for( const std::string &id : obj.get_string_array( "fuzzy_ids" ) ) {
+            palette.fuzzy_color_match[id] = palette.colors.size();
+        }
+        weighted_int_list<std::string> weights;
+        for( const JsonObject col : obj.get_array( "colors" ) ) {
+            weights.add( col.get_string( "color" ), col.get_int( "weight" ) );
+        }
+        palette.colors.push_back( weights );
+    }
+}
+
+void VehiclePalette::check()
+{
+    for( const auto &palette : vehicle_color_palettes ) {
+        for( const auto &colorlist : palette.second.colors ) {
+            for( const auto &entry : colorlist ) {
+                const std::optional<RGBColor> color = RGBColor::try_parse( entry.first );
+                if( !color ) {
+                    debugmsg( "Invalid Color %s in Vehicle Palette %s", entry.first, palette.first.str() );
+                }
+            }
+        }
+    }
+}
+
+int VehiclePalette::fuzzy_to_index( const vpart_id &id ) const
+{
+    for( const auto &[fuzzy, index] : fuzzy_color_match ) {
+        if( id.str() == fuzzy || id.str().find( fuzzy ) != std::string::npos ) {
+            return index;
+        }
+    }
+    return -1;
+}
+
+std::vector<RGBColor> VehiclePalette::pick_colors() const
+{
+    std::vector<RGBColor> result;
+    for( const weighted_int_list<std::string> &colorlist : colors ) {
+        const std::string *colorstr = colorlist.pick();
+        if( !colorstr ) {
+            continue;
+        }
+        const std::optional<RGBColor> color = RGBColor::try_parse( *colorstr );
+        if( color ) {
+            result.push_back( *color );
+        } else {
+            debugmsg( "Invalid Color %s in Vehicle Palette %s", *colorstr, id.str() );
+        }
+    }
+    return result;
+}
+
+void VehiclePalette::reset()
+{
+    vehicle_color_palettes.clear();
+}

--- a/src/vehicle_palette.h
+++ b/src/vehicle_palette.h
@@ -1,0 +1,44 @@
+#pragma once
+
+// Vehicle color palettes (ported from CBN). A vehicle prototype may reference a
+// palette by id via its "color_palette" JSON field; when the vehicle spawns,
+// pick_colors() rolls one color per group and they are applied to the matching
+// parts (see vehicle::apply_color_palette and vehicle_prototype::color_match).
+// Palettes are defined in data/json/vehicle_palette.json.
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "hsv_color.h"
+#include "json.h"
+#include "type_id.h"
+#include "weighted_list.h"
+
+/**
+ * Random vehicle color palette. Ported from Cataclysm: Bright Nights.
+ *
+ * Each palette maps fuzzy part-id prefixes (e.g. "door", "windshield") to a
+ * weighted color group. When a vehicle spawns, one color per group is rolled
+ * (see @ref pick_colors) and applied to the matching parts.
+ */
+class VehiclePalette
+{
+    public:
+        VehiclePalette() = default;
+
+        static void load( const JsonObject &jo );
+        static void check();
+        static void reset();
+
+        /** Returns the color-group index a part id belongs to, or -1 if none matches. */
+        int fuzzy_to_index( const vpart_id &id ) const;
+
+        /** Rolls one weighted-random color per color group. */
+        std::vector<RGBColor> pick_colors() const;
+
+    private:
+        vpalette_id id;
+        std::vector<weighted_int_list<std::string>> colors;
+        std::map<std::string, int> fuzzy_color_match;
+};

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -12,6 +12,7 @@
 #include "fault.h"
 #include "flag.h"
 #include "game.h"
+#include "hsv_color.h"
 #include "item.h"
 #include "itype.h"
 #include "mapdata.h"
@@ -100,6 +101,58 @@ void vehicle_part::set_base( item &&new_base )
     }
     base = std::move( new_base );
     base.set_flag( flag_VEHICLE );
+}
+
+namespace
+{
+// Item-variable keys for vehicle part paint color. Stored on the base item so a
+// painted part keeps its color when removed and reinstalled on another vehicle.
+const std::string TINT_COLOR_VAR_NAME( "tint_color" );
+const std::string TINT_COLOR_BG_VAR_NAME( "tint_color_bg" );
+const std::string TINT_COLOR_FG_VAR_NAME( "tint_color_fg" );
+} // namespace
+
+RGBColorPair vehicle_part::get_color( const bool ignore_default ) const
+{
+    // Color is read straight from the base item variables (the single source of
+    // truth), so it stays correct across save/load and part transfers with no
+    // cache to refresh.
+    if( base.has_var( TINT_COLOR_VAR_NAME ) ) {
+        const RGBColor primary = RGBColor::from_hex( base.get_var( TINT_COLOR_VAR_NAME ) );
+        const RGBColor bg = base.has_var( TINT_COLOR_BG_VAR_NAME )
+                            ? RGBColor::from_hex( base.get_var( TINT_COLOR_BG_VAR_NAME ) )
+                            : primary;
+        const RGBColor fg = base.has_var( TINT_COLOR_FG_VAR_NAME )
+                            ? RGBColor::from_hex( base.get_var( TINT_COLOR_FG_VAR_NAME ) )
+                            : primary;
+        return RGBColorPair{ bg, fg };
+    }
+    if( ignore_default ) {
+        return RGBColorPair{};
+    }
+    const RGBColor def = curses_color_to_RGB( info().color );
+    return RGBColorPair{ def, def };
+}
+
+bool vehicle_part::has_custom_color() const
+{
+    return base.has_var( TINT_COLOR_VAR_NAME );
+}
+
+void vehicle_part::set_color( const RGBColor &bg, const RGBColor &fg )
+{
+    // Parts flagged NO_PAINT (windows, lights, wheels, …) keep their own art.
+    if( info().has_flag( "NO_PAINT" ) ) {
+        return;
+    }
+    base.set_var( TINT_COLOR_VAR_NAME, fg.to_hex() );
+    if( bg != fg ) {
+        base.set_var( TINT_COLOR_BG_VAR_NAME, bg.to_hex() );
+        base.set_var( TINT_COLOR_FG_VAR_NAME, fg.to_hex() );
+    } else {
+        base.remove_var( TINT_COLOR_BG_VAR_NAME );
+        base.remove_var( TINT_COLOR_FG_VAR_NAME );
+    }
 }
 
 std::string vehicle_part::name( bool with_prefix ) const


### PR DESCRIPTION
<!-- 使用说明：在下面每个「#### 标题」下填写与你的 PR 相关的信息。
请保留这些标题。像这样的注释可以安全删除。

如果你是在 GitHub 网页界面发起这个 PR，可以用「preview（预览）」按钮查看 PR 对他人显示的样子。

PR 提交准则：
- 让你的改动只聚焦于一个具体的问题或变更，外加为实现它所必需的最小相关改动。
- 一个经验法则：大多数 PR 的改动应少于 500 行。
- 你可以另开 PR 来拆分一次较大的预期改动；如果不确定怎么拆，尽管问。我们很乐意与你协作，并建议合并你 PR 的最佳方式。
-->

#### 概述 (Summary)
Feature "vehicle coloring: random vehicle part color palette system"

<!-- 这一节应当只有一行，请编辑上面那一行。
1. 把「分类」替换为下列具体分类之一：Features、Content、Interface、Mods、Balance、Bugfixes、Performance、Infrastructure、Build、I18N。
2. 把引号内的文字替换为对你改动的简要描述。
如果你不希望生成更新日志条目，把整行替换为单独一个词「None」（不带引号）。
示例：
1. None
2. Bugfixes "修复长矛无法锁定不同楼层敌人的问题"
3. Interface "在制作界面显示制作失败几率"
分类含义详见：
https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/blob/master/doc/CHANGELOG_GUIDELINES.md
合并后，你的概述会被加入项目更新日志：
https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/blob/master/data/changelog.txt -->

#### 改动目的 (Purpose of change)

<!-- 用几句话描述你做这次改动的原因。
如果它与某个已有 issue 相关，可以用「#」加 GitHub issue 编号来关联，例如 #1234。

【重要】当你的 PR 能完全解决某个 issue 时，必须使用 [GitHub 的英文关闭关键字](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
才能在 PR 合并后自动关闭该 issue，例如：Fixes #1234。
只能用以下英文关键词（后面紧跟「#编号」）：
  close / closes / closed
  fix / fixes / fixed
  resolve / resolves / resolved
注意：中文「修复 #1234」不会触发自动关闭，GitHub 只识别上述英文关键词。

如果没有相关 issue，请在这里说明你要解决的问题、特性或其他关注点。如果这是一个 bug 修复，请附上复现原始 bug 的步骤，以便你的修复可以被验证。 -->


#### 解决方案描述 (Describe the solution)

    - New files: hsv_color.{h,cpp}, vehicle_palette.{h,cpp}, cata_tiles_color.cpp
    - HSV hue-replacement tinting applied at render time (main map + vehicle UI)
    - Colors stored as hex strings in item vars; persist through save/load and
      part transplant without extra serialization
    - Lazy tinted-texture cache keyed by (source texture pointer XOR color key)
    - VEHICLE_PART_COLOR toggle option (Graphics > Tileset options)
    - Named colors (named_colors.json) and 20 palettes (vehicle_palette.json)
      copied from CBN; 203 vehicles assigned palettes (86 direct id matches +
      117 role-based equivalents)
    - NO_PAINT flag defined for parts that should not be recolored

<!-- 这个特性是如何工作的，或者这个 bug 是怎么被修复的？方案越易于理解，就越快能被合并。 -->

#### 你考虑过的替代方案 (Describe alternatives you've considered)

<!-- 说明你为解决同一问题考虑过的其他方案、不同思路或可能性。 -->

#### 测试 (Testing)

<!-- 描述你采取了哪些步骤来测试这个 PR 是否修复了 bug 或添加了特性，以及你做了哪些测试以确保没有引入回归问题。也请为审阅者和维护者提供测试建议。参见 TESTING_YOUR_CHANGES.md -->

#### 补充说明 (Additional context)

This feature is partially derived from [Cataclysm: Bright Nights](https://github.com/cataclysmbnteam/Cataclysm-BN) (src/hsv_color.*, src/vehicle_palette.*, data/json/named_colors.json, data/json/vehicle_palette.json). The HSV hue-replacement tinting math and palette/named-color data are ported from CBN's vehicle coloring system. The rendering integration and data-storage layer have been re-implemented to fit this project's architecture.

<!-- 在此添加关于这个特性或 bug 修复的其他背景信息（例如原型图、概念验证或截图）。 -->


<!--README: Cataclysm: Cleanwater Bomb (CCB) 以 Creative Commons Attribution ShareAlike 3.0 许可证发布。
游戏的代码与内容可自由用于任何目的的使用、修改和再分发。
通过为本项目做贡献，你即同意该许可证的条款，并同意你所做的任何贡献也将受同一许可证覆盖。
详见 http://creativecommons.org/licenses/by-sa/3.0/ 。 -->