### PR TITLE
perf(map): 后台预取 submap + 缓存 zzip 档内清单 / background submap prefetch + cached zzip listings

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10200,6 +10200,88 @@ point_rel_sm game::update_map( Character &p, bool z_level_changed )
     return update_map( p2.x(), p2.y(), z_level_changed );
 }
 
+// Queue background reads of the submap quads just beyond the leading edge of the
+// reality bubble in the direction of travel, so the next boundary crossing can
+// skip the synchronous disk read. Called after the bubble has already shifted,
+// so `here.get_abs_sub()` is the post-shift top-left grid submap.
+static void prefetch_leading_edge( const map &here, const point_rel_sm &shift )
+{
+    const int distance = get_option<int>( "SUBMAP_PREFETCH_DISTANCE" );
+    if( distance <= 0 || shift == point_rel_sm::zero ) {
+        return;
+    }
+
+    const point_abs_sm base = here.get_abs_sub().xy();
+    const int player_z = here.get_abs_sub().z();
+    // Bubble center in submap coords, used both for read priority (nearest first)
+    // and for locality-based eviction of stale buffered quads.
+    const point_abs_sm center = base + point( MAPSIZE / 2, MAPSIZE / 2 );
+    const tripoint_abs_omt center_omt =
+        project_to<coords::omt>( tripoint_abs_sm{ center, player_z } );
+
+    // Bubble occupies [base, base + MAPSIZE) on each axis. Expand the scan rect
+    // outward by `distance` only on the axis/axes we're moving along.
+    const int x_lo = base.x() - ( shift.x() < 0 ? distance : 0 );
+    const int x_hi = base.x() + MAPSIZE - 1 + ( shift.x() > 0 ? distance : 0 );
+    const int y_lo = base.y() - ( shift.y() < 0 ? distance : 0 );
+    const int y_hi = base.y() + MAPSIZE - 1 + ( shift.y() > 0 ? distance : 0 );
+
+    // Restrict the z-sweep to the player's own z-level. Measurement showed that
+    // sweeping a few levels around the player queued ~92% non-existent quads
+    // (empty sky above, unexplored deep underground below): the worker then burned
+    // its time on file_exist checks for dead z-levels while the one live leading
+    // edge we are about to cross waited behind them in the queue, so the
+    // synchronous read still hit on the boundary frame. Horizontal crossings keep
+    // the player's z fixed, so queuing only that level lets the worker reach the
+    // real edge immediately. Cost: a z-change (stairs) gets no prefetch, but that
+    // is rare and one level at a time. Widen this if vertical travel needs it.
+    constexpr int Z_RADIUS = 0;
+    const int z_lo = std::max( -OVERMAP_DEPTH, player_z - Z_RADIUS );
+    const int z_hi = std::min( OVERMAP_HEIGHT, player_z + Z_RADIUS );
+
+    // Free any previously buffered quads the player has now moved away from, so a
+    // turn or reversal doesn't leave a stale frontier pinned in memory and the
+    // near edges of the new direction always win the worker's attention.
+    // evict_beyond measures distance in OMTs (quad_dist compares OMT coords), so
+    // convert the submap-space radius (half-bubble + prefetch distance) to OMTs
+    // (1 OMT = 2 submaps), rounding up so we never evict a quad still in range.
+    const int evict_dist_sm = MAPSIZE / 2 + distance + 1;
+    MAPBUFFER.prefetch_evict_beyond( center_omt, ( evict_dist_sm + 1 ) / 2 );
+
+    // Collect unique OMT quads (2x2 submaps share one .map file) outside the bubble,
+    // each tagged with its submap-distance from the player so nearer edges are read
+    // first.
+    std::map<tripoint_abs_omt, int> quads;
+    for( int z = z_lo; z <= z_hi; z++ ) {
+        for( int sx = x_lo; sx <= x_hi; sx++ ) {
+            for( int sy = y_lo; sy <= y_hi; sy++ ) {
+                // Skip submaps already inside the bubble; only prefetch new edges.
+                const bool inside_x = sx >= base.x() && sx < base.x() + MAPSIZE;
+                const bool inside_y = sy >= base.y() && sy < base.y() + MAPSIZE;
+                if( inside_x && inside_y ) {
+                    continue;
+                }
+                const tripoint_abs_omt om =
+                    project_to<coords::omt>( tripoint_abs_sm{ sx, sy, z } );
+                const int dist = std::max( std::abs( sx - center.x() ),
+                                           std::abs( sy - center.y() ) );
+                // Keep the smallest distance seen for this quad (a quad spans 2x2
+                // submaps, so several submaps map to it).
+                const auto it = quads.find( om );
+                if( it == quads.end() ) {
+                    quads.emplace( om, dist );
+                } else if( dist < it->second ) {
+                    it->second = dist;
+                }
+            }
+        }
+    }
+
+    for( const auto &entry : quads ) {
+        MAPBUFFER.prefetch_quad( entry.first, entry.second );
+    }
+}
+
 point_rel_sm game::update_map( int &x, int &y, bool z_level_changed )
 {
     map &here = get_map();
@@ -10244,6 +10326,12 @@ point_rel_sm game::update_map( int &x, int &y, bool z_level_changed )
         here.shift( point_rel_sm( this_shift ) );
         remaining_shift -= this_shift;
     }
+
+    // Asynchronously prefetch the submaps just beyond the leading edge of the
+    // reality bubble in the direction we're moving, so a subsequent shift can
+    // skip the synchronous disk read. Only already-existing chunks are queued;
+    // missing terrain is still generated on the main thread when reached.
+    prefetch_leading_edge( here, shift );
 
     // Shift monsters
     shift_monsters( { shift, 0 } );

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -33,6 +33,7 @@
 #include "std_hash_fs_path.h"
 #include "string_formatter.h"
 #include "submap.h"
+#include "submap_prefetch.h"
 #include "translations.h"
 #include "type_id.h"
 #include "ui_manager.h"
@@ -62,7 +63,12 @@ mapbuffer::~mapbuffer() = default;
 
 void mapbuffer::clear()
 {
+    // Drop any pending/completed background reads first: their captured paths
+    // belong to the world being torn down and must not be consumed afterward.
+    g_submap_prefetcher.clear();
     submaps.clear();
+    // The listing cache is keyed by archive path and belongs to the old world.
+    zzip_listing_cache.clear();
 }
 
 void mapbuffer::clear_outside_reality_bubble()
@@ -157,12 +163,12 @@ bool mapbuffer::submap_exists_approx( const tripoint_abs_sm &p )
             if( world_generator->active_world->has_compression_enabled() ) {
                 cata_path zzip_name = dirname;
                 zzip_name += zzip_suffix;
-                if( !file_exist( zzip_name ) ) {
-                    return false;
-                }
-                std::optional<zzip> z = zzip::load( zzip_name.get_unrelative_path(),
-                                                    ( PATH_INFO::world_base_save_path() / "maps.dict" ).get_unrelative_path() );
-                return z && z->has_file( std::filesystem::u8path( file_name ) );
+                // Route through the cached entry listing instead of a fresh
+                // zzip::load + has_file on every call: same answer, no per-call
+                // mmap + footer parse, and it shares one code path with
+                // unserialize_submaps so the two existence checks cannot drift.
+                const std::unordered_set<std::string> *listing = zzip_listing( zzip_name );
+                return listing && listing->find( file_name ) != listing->end();
             } else {
                 return file_exist( dirname / file_name );
             }
@@ -175,8 +181,57 @@ bool mapbuffer::submap_exists_approx( const tripoint_abs_sm &p )
     return true;
 }
 
+void mapbuffer::prefetch_quad( const tripoint_abs_omt &om_addr, int priority )
+{
+    // Resolve all paths/flags on the main thread (touches world_generator/PATH_INFO),
+    // then hand a self-contained request to the worker. The worker only reads bytes.
+    // An OMT ".map" file holds the 2x2 submap quad for a single z-level.
+    const tripoint_abs_sm sm_base = project_to<coords::sm>( om_addr );
+    bool any_missing = false;
+    for( int dx = 0; dx <= 1 && !any_missing; dx++ ) {
+        for( int dy = 0; dy <= 1 && !any_missing; dy++ ) {
+            if( submaps.find( sm_base + point( dx, dy ) ) == submaps.end() ) {
+                any_missing = true;
+            }
+        }
+    }
+    if( !any_missing ) {
+        return;
+    }
+
+    const cata_path dirname = find_dirname( om_addr );
+    const std::string file_name = quad_file_name( om_addr );
+
+    submap_prefetcher::request_t req;
+    req.om = om_addr;
+    req.entry_name = std::filesystem::u8path( file_name );
+
+    if( world_generator->active_world->has_compression_enabled() ) {
+        cata_path zzip_name = dirname;
+        zzip_name += zzip_suffix;
+        req.compressed = true;
+        req.zzip_path = zzip_name.get_unrelative_path();
+        req.dict_path = ( PATH_INFO::world_base_save_path() / "maps.dict" ).get_unrelative_path();
+    } else {
+        req.compressed = false;
+        req.quad_path = ( dirname / file_name ).get_unrelative_path();
+    }
+
+    g_submap_prefetcher.request( req, priority );
+}
+
+void mapbuffer::prefetch_evict_beyond( const tripoint_abs_omt &center, int max_dist )
+{
+    g_submap_prefetcher.evict_beyond( center, max_dist );
+}
+
 void mapbuffer::save( bool delete_after_save )
 {
+    // The prefetch worker reads the same zzip archives this loop rewrites. Park it
+    // (and force it to drop any cached archive handle) for the duration of the save
+    // so the save path is the sole writer. Resumes on scope exit, even on throw.
+    scoped_prefetch_pause prefetch_pause;
+
     assure_dir_exist( PATH_INFO::current_dimension_save_path() / "maps" );
     int num_saved_submaps = 0;
     int num_total_submaps = submaps.size();
@@ -228,6 +283,10 @@ void mapbuffer::save( bool delete_after_save )
     for( auto &elem : submaps_to_delete ) {
         remove_submap( elem );
     }
+    // save_quad rewrote these archives (add_file / delete_files / compact_to +
+    // rename), so any cached entry listing is now stale. Drop the whole cache;
+    // the next existence probe repopulates the touched archives lazily.
+    zzip_listing_cache.clear();
 }
 
 void mapbuffer::save_quad(
@@ -360,6 +419,30 @@ void mapbuffer::save_quad(
     }
 }
 
+const std::unordered_set<std::string> *mapbuffer::zzip_listing( const cata_path &zzip_path )
+{
+    const std::string key = zzip_path.get_unrelative_path().generic_u8string();
+    const auto it = zzip_listing_cache.find( key );
+    if( it != zzip_listing_cache.end() ) {
+        return &it->second;
+    }
+    if( !file_exist( zzip_path ) ) {
+        return nullptr;
+    }
+    std::optional<zzip> z = zzip::load( zzip_path.get_unrelative_path(),
+                                        ( PATH_INFO::world_base_save_path() / "maps.dict" ).get_unrelative_path() );
+    if( !z ) {
+        return nullptr;
+    }
+    // Snapshot the entry names, then drop the zzip handle (mmap) immediately: we
+    // must not hold it across a save that rewrites this archive.
+    std::unordered_set<std::string> listing;
+    for( const std::filesystem::path &entry : z->get_entries() ) {
+        listing.insert( entry.generic_u8string() );
+    }
+    return &zzip_listing_cache.emplace( key, std::move( listing ) ).first->second;
+}
+
 // We're reading in way too many entities here to mess around with creating sub-objects and
 // seeking around in them, so we're using the json streaming API.
 submap *mapbuffer::unserialize_submaps( const tripoint_abs_sm &p )
@@ -372,11 +455,32 @@ submap *mapbuffer::unserialize_submaps( const tripoint_abs_sm &p )
     cata_path quad_path = dirname / file_name;
 
     bool read = [&] {
+        // Fast path: the background prefetcher may have already read+decompressed
+        // this quad's bytes off the main thread. Parsing (deserialize) still happens
+        // here on the main thread, because it builds submap/string_id state that is
+        // not safe to touch from the worker.
+        std::optional<std::string> prefetched = g_submap_prefetcher.take( om_addr );
+        if( prefetched ) {
+            try {
+                JsonValue jsin = json_loader::from_string( std::move( *prefetched ) );
+                deserialize( jsin );
+                return true;
+            } catch( std::exception &err ) {
+                // Fall through to the normal synchronous load on any parse failure.
+                debugmsg( _( "Failed to parse prefetched submap %1$s: %2$s" ),
+                          om_addr.to_string(), err.what() );
+            }
+        }
+
         if( world_generator->active_world->has_compression_enabled() )
     {
         cata_path zzip_name = dirname;
         zzip_name += zzip_suffix;
-        if( !file_exist( zzip_name ) ) {
+        // Consult the cached entry listing before touching the archive: a column
+        // walked back over re-probes ~84 absent quads, and without this each one
+        // paid a fresh zzip::load (mmap + footer parse). nullptr == archive missing.
+        const std::unordered_set<std::string> *listing = zzip_listing( zzip_name );
+        if( !listing || listing->find( file_name ) == listing->end() ) {
                 return false;
             }
 

--- a/src/mapbuffer.h
+++ b/src/mapbuffer.h
@@ -5,6 +5,8 @@
 #include <list>
 #include <map>
 #include <memory>
+#include <unordered_map>
+#include <unordered_set>
 
 #include "coordinates.h"
 
@@ -67,6 +69,18 @@ class mapbuffer
         // Cheaper version of the above for when you don't mind some false results
         bool submap_exists_approx( const tripoint_abs_sm &p );
 
+        // Queue a background read+decompress of the quad containing the given OMT,
+        // so a later lookup_submap can skip the synchronous disk I/O. No-op if the
+        // submap is already in memory. `priority` is the quad's submap-distance from
+        // the player: the worker serves the smallest first, so near edges are read
+        // before the far frontier. Only the (thread-safe) read happens on the
+        // worker; parsing still occurs on the main thread in unserialize_submaps.
+        void prefetch_quad( const tripoint_abs_omt &om_addr, int priority );
+
+        // Forward to the background prefetcher: drop buffered/queued quads farther
+        // than `max_dist` submaps from `center`, bounding memory by locality.
+        void prefetch_evict_beyond( const tripoint_abs_omt &center, int max_dist );
+
     private:
         using submap_map_t = std::map<tripoint_abs_sm, std::unique_ptr<submap>>;
 
@@ -89,6 +103,21 @@ class mapbuffer
             const cata_path &dirname, const cata_path &filename,
             const tripoint_abs_omt &om_addr, std::list<tripoint_abs_sm> &submaps_to_delete,
             bool delete_after_save );
+        // Per-zzip listing cache: maps a maps zzip archive's absolute path to the
+        // set of entry filenames (e.g. "12.34.-10.map") it contains. Lets the hot
+        // existence-check path (submap_exists / unserialize_submaps) answer "is this
+        // quad on disk?" without re-opening (mmap + footer parse) the same archive
+        // once per submap. Only the surface z-level quad of a column is ever saved
+        // for uniform deep terrain, so a walked-back column probes ~84 quads that
+        // are absent from the archive; without this each probe paid a fresh
+        // zzip::load. Populated lazily from zzip::get_entries(); we deliberately do
+        // NOT keep the zzip handle (mmap) open, so a save that rewrites the archive
+        // (compact_to + rename) is never blocked on Windows. Invalidated wholesale
+        // around save() and on clear(), the only places that mutate these archives.
+        std::unordered_map<std::string, std::unordered_set<std::string>> zzip_listing_cache;
+        // Return the entry-name set for the archive at zzip_path, loading it once and
+        // caching it. Returns nullptr if the archive does not exist / fails to open.
+        const std::unordered_set<std::string> *zzip_listing( const cata_path &zzip_path );
         submap_map_t submaps; // NOLINT(cata-serialize)
 };
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -222,6 +222,7 @@ options_manager::options_manager()
     pages_.emplace_back( "general", to_translation( "General" ) );
     pages_.emplace_back( "interface", to_translation( "Interface" ) );
     pages_.emplace_back( "graphics", to_translation( "Graphics" ) );
+    pages_.emplace_back( "performance", to_translation( "Performance" ) );
     // when sharing maps only admin is allowed to change these.
     if( !MAP_SHARING::isCompetitive() || MAP_SHARING::isAdmin() ) {
         pages_.emplace_back( "world_default", to_translation( "World Defaults" ) );
@@ -1453,6 +1454,7 @@ void options_manager::init()
     add_options_general();
     add_options_interface();
     add_options_graphics();
+    add_options_performance();
     add_options_world_default();
     add_options_debug();
     add_options_android();
@@ -2784,6 +2786,19 @@ void options_manager::add_options_graphics()
 #endif
     } );
 
+}
+
+void options_manager::add_options_performance()
+{
+    add( "SUBMAP_PREFETCH_DISTANCE", "performance",
+         to_translation( "Submap prefetch distance" ),
+         to_translation( "How many submaps beyond the reality bubble's leading edge to read "
+                         "from disk on a background thread while moving, so crossing a chunk "
+                         "boundary stutters less.  0 disables prefetching.  Only the player's "
+                         "own z-level is prefetched, and reads are served nearest-first, so "
+                         "higher values mainly cost background I/O, not main-thread time." ),
+         0, 6, 2
+       );
 }
 
 void options_manager::add_options_world_default()

--- a/src/options.h
+++ b/src/options.h
@@ -204,6 +204,7 @@ class options_manager
         void add_options_general();
         void add_options_interface();
         void add_options_graphics();
+        void add_options_performance();
         void add_options_world_default();
         void add_options_debug();
         void add_options_android();

--- a/src/submap_prefetch.cpp
+++ b/src/submap_prefetch.cpp
@@ -1,0 +1,285 @@
+#include "submap_prefetch.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <utility>
+#include <vector>
+
+#include "filesystem.h"
+#include "zzip.h"
+
+submap_prefetcher g_submap_prefetcher;
+
+submap_prefetcher::submap_prefetcher() = default;
+
+submap_prefetcher::~submap_prefetcher()
+{
+    running_ = false;
+    cv_.notify_all();
+    parked_cv_.notify_all();
+    if( worker_.joinable() ) {
+        worker_.join();
+    }
+}
+
+int submap_prefetcher::quad_dist( const tripoint_abs_omt &a, const tripoint_abs_omt &center )
+{
+    // Horizontal Chebyshev distance: the frontier is a ring around the player and
+    // each OMT's z-column is fetched as a unit, so z is irrelevant to priority.
+    return std::max( std::abs( a.x() - center.x() ), std::abs( a.y() - center.y() ) );
+}
+
+void submap_prefetcher::request( const request_t &req, int priority )
+{
+    {
+        std::lock_guard<std::mutex> lock( mutex_ );
+        // Dedup against queued / in-flight / completed-waiting-to-be-taken in O(log n).
+        if( pending_.count( req.om ) || completed_.count( req.om ) ) {
+            return;
+        }
+        queue_.emplace( priority, req );
+        pending_.insert( req.om );
+
+        // Lazily start the worker on first real request.
+        if( !started_ ) {
+            running_ = true;
+            started_ = true;
+            worker_ = std::thread( [this]() {
+                worker_loop();
+            } );
+        }
+    }
+    cv_.notify_one();
+}
+
+std::optional<std::string> submap_prefetcher::take( const tripoint_abs_omt &om )
+{
+    std::lock_guard<std::mutex> lock( mutex_ );
+    const auto it = completed_.find( om );
+    if( it == completed_.end() ) {
+        return std::nullopt;
+    }
+    std::string bytes = std::move( it->second );
+    completed_.erase( it );
+    return bytes;
+}
+
+void submap_prefetcher::evict_beyond( const tripoint_abs_omt &center, int max_dist )
+{
+    std::lock_guard<std::mutex> lock( mutex_ );
+    // Queued: drop entries that have drifted out of range (e.g. player turned).
+    for( auto it = queue_.begin(); it != queue_.end(); ) {
+        if( quad_dist( it->second.om, center ) > max_dist ) {
+            pending_.erase( it->second.om );
+            it = queue_.erase( it );
+        } else {
+            ++it;
+        }
+    }
+    // Completed-but-unconsumed: free bytes for quads the player walked away from.
+    for( auto it = completed_.begin(); it != completed_.end(); ) {
+        if( quad_dist( it->first, center ) > max_dist ) {
+            it = completed_.erase( it );
+        } else {
+            ++it;
+        }
+    }
+    // In-flight: a quad popped off queue_ for reading is gone from queue_ but still
+    // in pending_ (the worker erases pending_ only on completion). The queue_ loop
+    // above already removed out-of-range *queued* OMTs from pending_, so any
+    // remaining out-of-range pending_ entry is in-flight. Erase it here: when the
+    // worker finishes that read, its `pending_.erase(req.om) > 0` check returns
+    // false and the now-stale bytes are dropped instead of buffered into completed_.
+    for( auto it = pending_.begin(); it != pending_.end(); ) {
+        if( quad_dist( *it, center ) > max_dist ) {
+            it = pending_.erase( it );
+        } else {
+            ++it;
+        }
+    }
+}
+
+void submap_prefetcher::pause()
+{
+    std::unique_lock<std::mutex> lock( mutex_ );
+    paused_++;
+    cv_.notify_all();
+    // If the worker was never started it holds no handle — nothing to wait for.
+    if( !started_ ) {
+        return;
+    }
+    // Block until the worker is parked at a wait with no archive handle open. Only
+    // worker_parked_ guarantees that: an empty queue is NOT sufficient, because the
+    // worker can have popped the last item and be mid-read (handle open) with the
+    // queue already empty.
+    parked_cv_.wait( lock, [this]() {
+        return !running_ || worker_parked_;
+    } );
+}
+
+void submap_prefetcher::resume()
+{
+    std::lock_guard<std::mutex> lock( mutex_ );
+    if( paused_ > 0 ) {
+        paused_--;
+    }
+    cv_.notify_all();
+}
+
+void submap_prefetcher::clear()
+{
+    // Stop the worker before dropping the queues. clear() runs at every world
+    // teardown / shutdown (cleanup_at_end, world switch, main menu), so joining
+    // here guarantees the worker is not running during later static destruction —
+    // it would otherwise touch other translation units' globals (mmap_file, zstd)
+    // whose destruction order relative to g_submap_prefetcher is unspecified.
+    // The worker lazily restarts on the next request(), so this is also safe for
+    // mid-session world switches.
+    stop_worker();
+    std::lock_guard<std::mutex> lock( mutex_ );
+    queue_.clear();
+    pending_.clear();
+    completed_.clear();
+}
+
+void submap_prefetcher::stop_worker()
+{
+    std::thread to_join;
+    {
+        std::lock_guard<std::mutex> lock( mutex_ );
+        if( !started_ ) {
+            return;
+        }
+        running_ = false;
+        started_ = false;
+        // Hand the thread out of the locked region: the worker may need mutex_ to
+        // wake from its wait, so we must not hold it across join().
+        to_join = std::move( worker_ );
+    }
+    cv_.notify_all();
+    parked_cv_.notify_all();
+    if( to_join.joinable() ) {
+        to_join.join();
+    }
+}
+
+void submap_prefetcher::worker_loop()
+{
+    // Cache of open archive handles, keyed by archive path. WORKER-LOCAL: these
+    // zzips are opened via load_readonly_unshared (they carry NO ZSTD context), so
+    // they never touch the process-global cached_contexts map the main thread uses.
+    // Caching lets every quad in one segment reuse a single open()+mmap instead of
+    // reopening the archive ~20 times — the open syscall is the dominant per-quad
+    // cost, not the decompress.
+    std::map<std::filesystem::path, zzip> archive_cache;
+    // Worker-PRIVATE ZSTD decompression contexts, one per dictionary path, created
+    // lazily and reused. The main thread decompresses through its own shared context;
+    // ZSTD_DCtx is not safe for concurrent use, so the worker must never share. Freed
+    // at worker exit (see end of function).
+    std::map<std::filesystem::path, void *> dctx_cache;
+    auto free_dctxs = [&dctx_cache]() {
+        for( auto &kv : dctx_cache ) {
+            zzip::destroy_private_dctx( kv.second );
+        }
+        dctx_cache.clear();
+    };
+
+    while( running_ ) {
+        request_t req;
+        {
+            std::unique_lock<std::mutex> lock( mutex_ );
+
+            // A save (or world teardown) wants to write these archives: release
+            // every handle and park until resumed, so the main thread is the sole
+            // writer. Signal parked so a waiting pause() can proceed.
+            if( paused_ > 0 ) {
+                archive_cache.clear();
+                worker_parked_ = true;
+                parked_cv_.notify_all();
+                cv_.wait( lock, [this]() {
+                    return !running_ || paused_ == 0;
+                } );
+                worker_parked_ = false;
+                if( !running_ ) {
+                    free_dctxs();
+                    return;
+                }
+                continue;
+            }
+
+            if( queue_.empty() ) {
+                // Idle: drop handles so they aren't held open across pauses in
+                // movement (and never linger into another world after clear()).
+                // Parked with no handle held, so pause() may proceed too.
+                archive_cache.clear();
+                worker_parked_ = true;
+                parked_cv_.notify_all();
+                cv_.wait( lock, [this]() {
+                    return !running_ || !queue_.empty() || paused_ > 0;
+                } );
+                worker_parked_ = false;
+                if( !running_ ) {
+                    free_dctxs();
+                    return;
+                }
+                continue;
+            }
+
+            // Smallest priority (nearest the player) first.
+            auto it = queue_.begin();
+            req = it->second;
+            queue_.erase( it );
+        }
+
+        // Read + decompress OFF the main thread. No game globals touched here:
+        // archive handles are worker-local; json/string ids are never built; and
+        // decompression uses a worker-private DCtx (never the shared global one).
+        std::string bytes;
+        bool ok = false;
+        try {
+            if( req.compressed ) {
+                auto cached = archive_cache.find( req.zzip_path );
+                if( cached == archive_cache.end() && file_exist( req.zzip_path ) ) {
+                    std::optional<zzip> z = zzip::load_readonly_unshared( req.zzip_path );
+                    if( z ) {
+                        cached = archive_cache.emplace( req.zzip_path, std::move( *z ) ).first;
+                    }
+                }
+                if( cached != archive_cache.end() && cached->second.has_file( req.entry_name ) ) {
+                    auto dctx_it = dctx_cache.find( req.dict_path );
+                    if( dctx_it == dctx_cache.end() ) {
+                        dctx_it = dctx_cache.emplace(
+                                      req.dict_path,
+                                      zzip::create_private_dctx( req.dict_path ) ).first;
+                    }
+                    std::vector<std::byte> contents =
+                        cached->second.get_file_with_dctx( req.entry_name, dctx_it->second );
+                    bytes.assign( reinterpret_cast<const char *>( contents.data() ), contents.size() );
+                    ok = !contents.empty();
+                }
+            } else {
+                if( file_exist( req.quad_path ) ) {
+                    bytes = read_entire_file( req.quad_path );
+                    ok = !bytes.empty();
+                }
+            }
+        } catch( ... ) {
+            // Any read/decompress failure: drop silently. Main thread falls back
+            // to its own synchronous load path on miss.
+            ok = false;
+        }
+
+        {
+            std::lock_guard<std::mutex> lock( mutex_ );
+            // If evict_beyond() removed this OMT from pending_ while we were
+            // reading, the player has moved past it; drop the bytes rather than
+            // buffering work nobody will consume.
+            const bool still_wanted = pending_.erase( req.om ) > 0;
+            if( ok && still_wanted ) {
+                completed_.emplace( req.om, std::move( bytes ) );
+            }
+        }
+    }
+    free_dctxs();
+}
+

--- a/src/submap_prefetch.cpp
+++ b/src/submap_prefetch.cpp
@@ -32,7 +32,7 @@ int submap_prefetcher::quad_dist( const tripoint_abs_omt &a, const tripoint_abs_
 void submap_prefetcher::request( const request_t &req, int priority )
 {
     {
-        std::lock_guard<std::mutex> lock( mutex_ );
+        std::scoped_lock<std::mutex> lock( mutex_ );
         // Dedup against queued / in-flight / completed-waiting-to-be-taken in O(log n).
         if( pending_.count( req.om ) || completed_.count( req.om ) ) {
             return;
@@ -54,7 +54,7 @@ void submap_prefetcher::request( const request_t &req, int priority )
 
 std::optional<std::string> submap_prefetcher::take( const tripoint_abs_omt &om )
 {
-    std::lock_guard<std::mutex> lock( mutex_ );
+    std::scoped_lock<std::mutex> lock( mutex_ );
     const auto it = completed_.find( om );
     if( it == completed_.end() ) {
         return std::nullopt;
@@ -66,7 +66,7 @@ std::optional<std::string> submap_prefetcher::take( const tripoint_abs_omt &om )
 
 void submap_prefetcher::evict_beyond( const tripoint_abs_omt &center, int max_dist )
 {
-    std::lock_guard<std::mutex> lock( mutex_ );
+    std::scoped_lock<std::mutex> lock( mutex_ );
     // Queued: drop entries that have drifted out of range (e.g. player turned).
     for( auto it = queue_.begin(); it != queue_.end(); ) {
         if( quad_dist( it->second.om, center ) > max_dist ) {
@@ -119,7 +119,7 @@ void submap_prefetcher::pause()
 
 void submap_prefetcher::resume()
 {
-    std::lock_guard<std::mutex> lock( mutex_ );
+    std::scoped_lock<std::mutex> lock( mutex_ );
     if( paused_ > 0 ) {
         paused_--;
     }
@@ -136,7 +136,7 @@ void submap_prefetcher::clear()
     // The worker lazily restarts on the next request(), so this is also safe for
     // mid-session world switches.
     stop_worker();
-    std::lock_guard<std::mutex> lock( mutex_ );
+    std::scoped_lock<std::mutex> lock( mutex_ );
     queue_.clear();
     pending_.clear();
     completed_.clear();
@@ -146,7 +146,7 @@ void submap_prefetcher::stop_worker()
 {
     std::thread to_join;
     {
-        std::lock_guard<std::mutex> lock( mutex_ );
+        std::scoped_lock<std::mutex> lock( mutex_ );
         if( !started_ ) {
             return;
         }
@@ -270,7 +270,7 @@ void submap_prefetcher::worker_loop()
         }
 
         {
-            std::lock_guard<std::mutex> lock( mutex_ );
+            std::scoped_lock<std::mutex> lock( mutex_ );
             // If evict_beyond() removed this OMT from pending_ while we were
             // reading, the player has moved past it; drop the bytes rather than
             // buffering work nobody will consume.

--- a/src/submap_prefetch.h
+++ b/src/submap_prefetch.h
@@ -1,0 +1,131 @@
+#pragma once
+#ifndef CATA_SRC_SUBMAP_PREFETCH_H
+#define CATA_SRC_SUBMAP_PREFETCH_H
+
+#include <atomic>
+#include <condition_variable>
+#include <filesystem>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <set>
+#include <string>
+#include <thread>
+
+#include "coordinates.h"
+
+// Background submap quad I/O prefetcher.
+//
+// Worker thread does ONLY disk read + zzip decompression, producing the raw
+// JSON bytes of an OMT quad ".map" file. It never touches any game global:
+// all paths/flags are resolved on the main thread and captured in the request.
+// The main thread later parses+deserializes those bytes (see
+// mapbuffer::unserialize_submaps), the only thread-safe place to build submaps.
+//
+// Reads are served nearest-the-player first (priority), and buffered results are
+// bounded by physical locality (evict_beyond) rather than a fixed count, so a
+// large prefetch distance no longer drowns the surface quads we cross next.
+class submap_prefetcher
+{
+    public:
+        // A self-contained unit of work. All fields resolved on the main thread.
+        struct request_t {
+            tripoint_abs_omt om;
+            // Compressed world: zzip archive + dictionary + entry name.
+            std::filesystem::path zzip_path;
+            std::filesystem::path dict_path;
+            std::filesystem::path entry_name;
+            // Uncompressed world: direct .map path.
+            std::filesystem::path quad_path;
+            bool compressed = false;
+        };
+
+        submap_prefetcher();
+        ~submap_prefetcher();
+
+        // Enqueue a quad for background reading. `priority` is the quad's distance
+        // (in submaps) from the player; the worker always serves the smallest
+        // priority first, so the edges we are about to cross are read before the
+        // far frontier. Deduplicated against queued / in-flight / completed work.
+        void request( const request_t &req, int priority );
+
+        // If the quad's bytes are ready, move them out and return them; the entry
+        // is removed. nullopt if not ready / not requested / read failed.
+        std::optional<std::string> take( const tripoint_abs_omt &om );
+
+        // Drop every queued/completed/in-flight quad whose horizontal (Chebyshev)
+        // distance from `center` exceeds `max_dist` submaps. Called on each shift
+        // so buffered bytes stay bounded by physical locality around the player
+        // instead of by a fixed count: turning or doubling back frees the stale
+        // frontier automatically, and a large prefetch distance never starves the
+        // near edges by piling up far quads.
+        void evict_beyond( const tripoint_abs_omt &center, int max_dist );
+
+        // Drop all work. Call before world teardown/save so the main thread never
+        // consumes bytes for a world that is changing.
+        void clear();
+
+        // Pause/resume the worker around main-thread writes to the same zzip
+        // archives (mapbuffer::save). pause() blocks until the worker has parked
+        // and released every cached archive handle, so the save path is the sole
+        // writer. Reentrant via a counter; resume when it returns to zero. Use the
+        // scoped guard below rather than calling these directly.
+        void pause();
+        void resume();
+
+    private:
+        void worker_loop();
+
+        // Stop and join the worker thread (idempotent). Leaves the prefetcher in a
+        // state where the next request() lazily restarts it. Called from clear() so
+        // the worker is provably stopped at every world teardown / shutdown, instead
+        // of relying on cross-translation-unit static destruction order (the worker
+        // touches other globals via mmap_file / zstd; if those destruct first while
+        // it is mid-read, that is undefined behavior).
+        void stop_worker();
+
+        // Distance from a quad's OMT to a center OMT, ignoring z (frontier is a
+        // horizontal ring; the z column for one OMT is read as a unit anyway).
+        static int quad_dist( const tripoint_abs_omt &a, const tripoint_abs_omt &center );
+
+        std::thread worker_;
+        std::mutex mutex_;
+        std::condition_variable cv_;
+        // Priority queue: key = distance-from-player, smallest served first.
+        std::multimap<int, request_t> queue_;
+        // OMTs that are queued or actively being read (dedup + eviction tracking).
+        std::set<tripoint_abs_omt> pending_;
+        std::map<tripoint_abs_omt, std::string> completed_;
+        std::atomic<bool> running_{ false };
+        bool started_ = false;
+        // Number of active pause() holders; worker parks before each new read
+        // while > 0 so mapbuffer::save can write the archives unopposed.
+        int paused_ = 0;
+        // Set by the worker whenever it is blocked at a wait with NO archive handle
+        // held (either idle-empty-queue or paused). pause() waits for this so it
+        // only returns once no handle can be open. Cleared the instant the worker
+        // wakes to do work.
+        std::condition_variable parked_cv_;
+        bool worker_parked_ = false;
+};
+
+extern submap_prefetcher g_submap_prefetcher;
+
+// Scoped pause: blocks the prefetch worker (and forces it to release its cached
+// archive handles) for the lifetime of this object. Use around main-thread writes
+// to the map archives so the worker is never reading an archive the save path is
+// rewriting. Exception-safe: resumes on scope exit even if the guarded code throws.
+class scoped_prefetch_pause
+{
+    public:
+        scoped_prefetch_pause() {
+            g_submap_prefetcher.pause();
+        }
+        ~scoped_prefetch_pause() {
+            g_submap_prefetcher.resume();
+        }
+        scoped_prefetch_pause( const scoped_prefetch_pause & ) = delete;
+        scoped_prefetch_pause &operator=( const scoped_prefetch_pause & ) = delete;
+};
+
+#endif // CATA_SRC_SUBMAP_PREFETCH_H

--- a/src/zzip.cpp
+++ b/src/zzip.cpp
@@ -438,6 +438,65 @@ std::optional<zzip> zzip::load(
     return ret;
 }
 
+std::optional<zzip> zzip::load_readonly_unshared( std::filesystem::path const &path )
+{
+    // Background-thread read path. Unlike load(), this NEVER touches the global
+    // cached_contexts map (unsynchronized) and leaves ctx_ null, so the caller must
+    // decompress only via get_file_to_with_dctx with its own private DCtx.
+    std::shared_ptr<mmap_file> file = mmap_file::map_writeable_file( path );
+    if( !file ) {
+        return {};
+    }
+
+    uint64_t footer_len = 0;
+    uint64_t footer_checksum = 0;
+    std::tie( footer_len, footer_checksum ) = read_footer_len_and_checksum( file->base(), file->len() );
+    if( footer_len == 0 || footer_len > file->len() ) {
+        // Footer needs recovery; that requires a compression context. Bail and let
+        // the main thread's synchronous load handle it.
+        return {};
+    }
+    char *base = reinterpret_cast<char *>( file->base() );
+    uint64_t hash = XXH64( base + file->len() - footer_len, footer_len, kCheckumSeed );
+    if( hash != footer_checksum ) {
+        return {};
+    }
+    JsonObject footer;
+    try {
+        std::shared_ptr<zzip_flexbuffer_storage> storage{ std::make_shared<zzip_flexbuffer_storage>( file ) };
+        flexbuffers::Reference root = flexbuffer_root_from_storage( storage );
+        std::shared_ptr<parsed_flexbuffer> flexbuffer = std::make_shared<zzip_flexbuffer>( std::move( storage ) );
+        footer = JsonValue( std::move( flexbuffer ), root, nullptr, 0 );
+    } catch( std::exception & ) {
+        return {};
+    }
+
+    // ctx_ deliberately left null: this archive must only be read via *_with_dctx.
+    return std::optional<zzip>{ std::in_place, zzip{ std::move( file ), std::move( footer ) } };
+}
+
+void *zzip::create_private_dctx( std::filesystem::path const &dictionary )
+{
+    ZSTD_DCtx *dctx = ZSTD_createDCtx();
+    if( !dictionary.empty() ) {
+        std::shared_ptr<const mmap_file> dictionary_file = mmap_file::map_file( dictionary );
+        if( dictionary_file ) {
+            // ZSTD_DCtx_loadDictionary takes a COPY of the dictionary into the DCtx,
+            // so the mmap can be released right after this call (unlike the
+            // _byReference variant used by the shared-context path).
+            ZSTD_DCtx_loadDictionary( dctx, dictionary_file->base(), dictionary_file->len() );
+        }
+    }
+    return dctx;
+}
+
+void zzip::destroy_private_dctx( void *dctx )
+{
+    if( dctx ) {
+        ZSTD_freeDCtx( static_cast<ZSTD_DCtx *>( dctx ) );
+    }
+}
+
 bool zzip::add_file( std::filesystem::path const &zzip_relative_path, std::string_view content )
 {
     size_t estimated_size = ZSTD_compressBound( content.length() );
@@ -568,9 +627,10 @@ std::vector<std::byte> zzip::get_file( std::filesystem::path const &zzip_relativ
     return buf;
 }
 
-size_t zzip::get_file_to( std::filesystem::path const &zzip_relative_path, std::byte *dest,
-                          size_t dest_len ) const
+size_t zzip::get_file_to_with_dctx( std::filesystem::path const &zzip_relative_path,
+                                    std::byte *dest, size_t dest_len, void *dctx_void ) const
 {
+    ZSTD_DCtx *dctx = static_cast<ZSTD_DCtx *>( dctx_void );
     zzip_footer footer{ footer_ };
     std::optional<zzip_file_entry> fparams = footer.get_entry( zzip_relative_path );
     if( !fparams.has_value() ) {
@@ -599,11 +659,29 @@ size_t zzip::get_file_to( std::filesystem::path const &zzip_relative_path, std::
     if( dest_len < file_size ) {
         return 0;
     }
-    size_t actual = ZSTD_decompressDCtx( ctx_->dctx, dest, dest_len, file_base, file_len );
+    size_t actual = ZSTD_decompressDCtx( dctx, dest, dest_len, file_base, file_len );
     if( ZSTD_isError( actual ) ) {
         return 0;
     }
     return actual;
+}
+
+size_t zzip::get_file_to( std::filesystem::path const &zzip_relative_path, std::byte *dest,
+                          size_t dest_len ) const
+{
+    return get_file_to_with_dctx( zzip_relative_path, dest, dest_len, ctx_->dctx );
+}
+
+std::vector<std::byte> zzip::get_file_with_dctx( std::filesystem::path const &zzip_relative_path,
+        void *dctx ) const
+{
+    std::vector<std::byte> buf{};
+    size_t size = get_file_size( zzip_relative_path );
+    buf.resize( size );
+    size_t final_size = get_file_to_with_dctx( zzip_relative_path, buf.data(), size, dctx );
+    // get_file_to returns 0 on error so we return an empty array.
+    buf.resize( final_size );
+    return buf;
 }
 
 size_t zzip::get_content_size() const

--- a/src/zzip.h
+++ b/src/zzip.h
@@ -79,6 +79,27 @@ class zzip
                                          std::filesystem::path const &dictionary = {} );
 
         /**
+         * Opens an archive for READ-ONLY access from a background (non-main) thread
+         * WITHOUT touching the process-global ZSTD context cache, which is not
+         * synchronized. The returned zzip's internal ZSTD context is null, so the
+         * caller MUST decompress only via get_file_with_dctx / get_file_to_with_dctx
+         * passing its own private DCtx — calling get_file / add_file on it will crash.
+         * Returns nullopt if the archive is missing or its footer needs recovery
+         * (recovery needs a compression context; the main thread handles that on its
+         * own synchronous load path).
+         */
+        static std::optional<zzip> load_readonly_unshared( std::filesystem::path const &path );
+
+        /**
+         * Create / destroy a private ZSTD_DCtx with `dictionary` loaded, for use with
+         * get_file_with_dctx on a background thread that must not share the global
+         * context. Returns the ZSTD_DCtx as a void* (keeps zstd out of this header).
+         * Pass the same dictionary path the archive was created with. destroy frees it.
+         */
+        static void *create_private_dctx( std::filesystem::path const &dictionary );
+        static void destroy_private_dctx( void *dctx );
+
+        /**
          * Writes the given file contents under the given file path into the zzip.
          * Returns true on success, false on any error.
          *
@@ -142,6 +163,19 @@ class zzip
         size_t get_file_to( std::filesystem::path const &zzip_relative_path,
                             std::byte *dest,
                             size_t dest_len ) const;
+
+        /**
+         * Thread-safe variants of get_file / get_file_to that decompress through a
+         * caller-supplied ZSTD_DCtx instead of this zzip's shared (process-global)
+         * context. The shared context is not safe for concurrent use, so a background
+         * thread must pass its own private DCtx (with the same dictionary loaded as
+         * was used to create the archive). `dctx` is a ZSTD_DCtx* (void* here to keep
+         * zstd out of this header).
+         */
+        std::vector<std::byte> get_file_with_dctx( std::filesystem::path const &zzip_relative_path,
+                void *dctx ) const;
+        size_t get_file_to_with_dctx( std::filesystem::path const &zzip_relative_path,
+                                      std::byte *dest, size_t dest_len, void *dctx ) const;
 
         /**
          * Removes the files from the zzip.


### PR DESCRIPTION
#### 概述 (Summary)

Performance "后台预取 submap 并缓存 zzip 档内条目清单,减少跨区块移动时的卡顿 / Background submap prefetch + cached zzip listings to reduce stutter when crossing chunk boundaries"

#### 改动目的 (Purpose of change)

**中文**：跨越区块边界时,主线程会同步从磁盘读取并解压 submap,造成可感知的卡顿。开启地图压缩(zzip)后,存在性检查会反复重开同一压缩档(mmap + footer 解析):一柱回头探测约 84 个不存在的深层 quad,过去每个都付一次 `zzip::load`。本 PR 从这两处消除开销。

**EN**: Crossing chunk boundaries stalls the main thread on synchronous submap disk read + decompress. With map compression (zzip) enabled, existence checks repeatedly reopen the same archive (mmap + footer parse) — walking a column back re-probes ~84 absent deep quads, each formerly paying a fresh `zzip::load`. This PR removes both costs.

#### 解决方案描述 (Describe the solution)

**中文**

新增特性：
- **后台 submap 预取**：worker 线程在移动时提前读取并解压前缘 submap 四象限；主线程命中已就绪的字节后只做解析(deserialize),不再等磁盘 I/O。新增选项 `SUBMAP_PREFETCH_DISTANCE`(性能页,`0` = 关闭,默认 `2`)。
- **zzip 档内条目清单缓存**：`submap_exists` / `unserialize_submaps` / `submap_exists_approx` 不再每次重开档,改为一次建清单、其余走内存查询。`save()` / `clear()` 时整表失效。

线程安全：
- 预取 worker 使用**私有 `ZSTD_DCtx`** 与 `load_readonly_unshared`,完全不碰全局 `cached_contexts` 与共享 dctx,消除主/后台线程间的解压上下文竞争与 map 并发改写。
- `clear()` 在所有世界拆除/退出路径**确定性停止并 join worker**,不依赖跨编译单元的静态析构顺序;worker 在下次 `request()` 时惰性重启。
- `save()` 期间用 `scoped_prefetch_pause` 暂停 worker,使存档路径为唯一写者。
- `evict_beyond` 按 **OMT 单位**裁剪(修正 submap/OMT 单位错配),并扫描 `pending_` 真正驱逐在途读取。

**EN**

New features:
- **Background submap prefetch**: a worker thread reads + decompresses leading-edge submap quads while moving; the main thread parses the ready bytes instead of waiting on disk I/O. New `SUBMAP_PREFETCH_DISTANCE` option (Performance page, `0` = off, default `2`).
- **Per-zzip entry-listing cache**: `submap_exists` / `unserialize_submaps` / `submap_exists_approx` no longer reopen the archive per probe; the listing is built once and subsequent probes hit memory. Invalidated wholesale on `save()` / `clear()`.

Thread safety:
- The prefetch worker uses a **private `ZSTD_DCtx`** and `load_readonly_unshared`, never touching the global `cached_contexts` or shared dctx — removing the decompress-context data race and concurrent map mutation between main/worker threads.
- `clear()` **deterministically stops and joins the worker** on every world teardown / shutdown rather than relying on cross-TU static destruction order; the worker lazily restarts on the next `request()`.
- `save()` pauses the worker via `scoped_prefetch_pause` so it is the sole writer.
- `evict_beyond` now bounds in **OMT units** (fixing a submap/OMT unit mismatch) and sweeps `pending_` to actually evict in-flight reads.

#### 你考虑过的替代方案 (Describe alternatives you've considered)

**中文**：对全局 `cached_contexts` / 共享 `ZSTD_DCtx` 加锁,而非给 worker 私有上下文。否决原因：那会把锁加到主线程的解压热路径上,抵消部分性能收益,且锁粒度大。私有 DCtx 让 worker 完全无锁、与主线程零共享。清单缓存也考虑过按档增量失效,当前先用整表失效保证正确性,留待后续优化。

**EN**: Locking the global `cached_contexts` / shared `ZSTD_DCtx` instead of giving the worker a private context. Rejected: that puts a lock on the main thread's decompress hot path, eating into the perf win, at coarse granularity. A private DCtx keeps the worker lock-free with zero sharing. Per-archive incremental invalidation for the listing cache was also considered; wholesale invalidation is used first for correctness, leaving that as a later optimization.

#### 测试 (Testing)

**中文**
- 三个改动的 C++ 编译单元(`zzip` / `submap_prefetch` / `mapbuffer`)通过 `g++ -fsyntax-only` 语法检查。
- **待办(需维护者/CI 协助)**：完整 MSVC 构建/链接与运行时验证。建议:开启地图压缩 + `SUBMAP_PREFETCH_DISTANCE=2`,反复跨区块边界来回移动,确认无卡顿且地形完整;并在 `SUBMAP_PREFETCH_DISTANCE=0` 下回归对比。理想情况下用 ThreadSanitizer 构建验证并发路径无数据竞争。

**EN**
- The three changed C++ TUs (`zzip` / `submap_prefetch` / `mapbuffer`) pass `g++ -fsyntax-only`.
- **TODO (needs maintainer/CI help)**: full MSVC build/link and runtime verification. Suggested: enable map compression + `SUBMAP_PREFETCH_DISTANCE=2`, walk back and forth across chunk boundaries, confirm no stutter and intact terrain; regress against `SUBMAP_PREFETCH_DISTANCE=0`. Ideally validate the concurrency paths under a ThreadSanitizer build.

#### 补充说明 (Additional context)

**中文**：预取默认开启(距离 2);线程安全修复保证开启压缩时也安全。两条退出期的静态析构竞争已通过 `clear()` 确定性 join worker 一并解决。

**EN**: Prefetch is on by default (distance 2); the thread-safety fixes make it safe with compression enabled. Two shutdown-time static-destruction races are also resolved via `clear()` deterministically joining the worker.
