### PR TITLE
修复搬运列表为空时弹出调试报错

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -876,7 +876,7 @@ static void haul()
 
     if( hauling && !autohaul ) {
         if( haul_qty == 0 ) {
-            debugmsg( "Invalid hauling state: hauling enabled, nothing is being hauled, autohaul is off." );
+            status_header = ( "You are currently hauling nothing.\nAutohaul is disabled." );
         } else {
             status_header = string_format( _( "You are currently hauling %d items.\nAutohaul is disabled." ),
                                            haul_qty );


### PR DESCRIPTION
#### 概要 (Summary)

Bugfixes "修复搬运列表为空时弹出调试报错"

#### 改动目的 (Purpose of change)

当角色处于搬运状态、自动搬运关闭、但当前搬运列表为空时，打开搬运菜单会触发调试报错。

这种情况对玩家来说更像是一个普通状态：当前没有搬运任何物品，而不是需要弹出 debug 信息的内部错误。

#### 解决方案描述 (Describe the solution)

将该状态下的 `debugmsg` 改为搬运菜单里的正常状态提示。

现在菜单会提示玩家当前没有搬运物品，并且自动搬运已关闭。

Closes #57