### PR TITLE
Fix legacy issues brought by the separation of pride items (Follow-up to PR#102)

### DIFF
--- a/data/mods/CrazyCataclysm/crazy_items.json
+++ b/data/mods/CrazyCataclysm/crazy_items.json
@@ -638,22 +638,6 @@
     "description": "A fifty-cent coin, featuring a portrait of famed rapper 50 Cent.  On the back is the date of minting, and the G-Unit symbol."
   },
   {
-    "id": "pride_flag",
-    "copy-from": "pride_flag",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR" ],
-    "extend": {
-      "variants": [
-        {
-          "id": "newbrunswick_pride_flag",
-          "name": { "str": "NB flag" },
-          "description": "A yellow flag with a ship and lion, representing New Brunswick.  You have a feeling this might be the wrong NB flag.",
-          "weight": 5
-        }
-      ]
-    }
-  },
-  {
     "id": "kitchen_gun",
     "type": "ITEM",
     "subtypes": [ "GUN" ],

--- a/data/mods/CrazyCataclysm/mod_interactions/pride_items/crazy_items.json
+++ b/data/mods/CrazyCataclysm/mod_interactions/pride_items/crazy_items.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "pride_flag",
+    "copy-from": "pride_flag",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "extend": {
+      "variants": [
+        {
+          "id": "newbrunswick_pride_flag",
+          "name": { "str": "NB flag" },
+          "description": "A yellow flag with a ship and lion, representing New Brunswick.  You have a feeling this might be the wrong NB flag.",
+          "weight": 5
+        }
+      ]
+    }
+  }
+]

--- a/data/mods/Sky_Island/itemgroups/requirements.json
+++ b/data/mods/Sky_Island/itemgroups/requirements.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "any_flag_landing_upgradekey",
+    "type": "requirement",
+    "//": "For when a recipe calls for a flag.",
+    "components": [
+      [
+        [ "national_flag", 1 ],
+        [ "american_flag", 1 ],
+        [ "state_flag", 1 ]
+      ]
+    ]
+  },
+  {
     "id": "any_badge",
     "type": "requirement",
     "//": "For when a recipe calls for a badge.",

--- a/data/mods/Sky_Island/missions/raid_upgrades/landing.json
+++ b/data/mods/Sky_Island/missions/raid_upgrades/landing.json
@@ -389,7 +389,7 @@
     "reversible": false,
     "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
     "components": [
-      [ [ "pride_flag", 6 ], [ "national_flag", 6 ], [ "american_flag", 6 ], [ "state_flag", 6 ] ],
+      [ [ "any_flag_landing_upgradekey", 6, "LIST"] ],
       [ [ "warptoken", 16 ] ],
       [
         [ "roadmap", 6 ],

--- a/data/mods/Sky_Island/mod_interactions/pride_items/requirements.json
+++ b/data/mods/Sky_Island/mod_interactions/pride_items/requirements.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": "any_flag_landing_upgradekey",
+    "type": "requirement",
+    "//": "For when a recipe calls for a flag.",
+    "extend": { "components": [ [ [ "pride_flag", 1 ] ] ] }
+  }
+]


### PR DESCRIPTION
#### 概述 (Summary)

[fix] Move content in other mods that reference or extend `pride_flag` to the `mod_interactions` directory

#### 改动目的 (Purpose of change)

closes #47

The two mods, Crazy Cataclysm and Sky Island, respectively extended or referenced the `pride_flag` item in recipes. However, according to pr #102 , the corresponding item has been moved to the pride items mod. This directly caused loading the relevant mods to trigger errors.

#### 解决方案描述 (Describe the solution)

Created a new `mod_interactions.pride_items` directory and moved the references to the `pride_flag` item, which cannot be statically ignored, to the corresponding path.

For the recipe reference in Sky Island, a requirement with the id `any_flag_landing_upgradekey` has been temporarily created, implementing the expansion of allowed recipe ingredients through mod_interactions and the extend mechanism of json inheritance.

#### 你考虑过的替代方案 (Describe alternatives you've considered)

None