### PR TITLE
fix(ci): 让 dmgbuild 自动计算 macOS 镜像大小 (对齐上游 #87464)

### DIFF
--- a/build-data/osx/dmgsettings.py
+++ b/build-data/osx/dmgsettings.py
@@ -36,9 +36,6 @@ def icon_from_app(app_path):
 # Volume format (see hdiutil create -help)
 format = defines.get('format', 'UDBZ')
 
-# Volume size (must be large enough for your files)
-size = defines.get('size', '500M')
-
 # Files to include
 files = [application]
 


### PR DESCRIPTION
## 背景

release 工作流的 macOS SDL3 任务在最后打包 `.dmg` 阶段失败,报错 `No space left on device`:

```
ditto: /Volumes/Cataclysm DDA/.../gfx/Altica/giant.png: No space left on device
OSError: [Errno 28] No space left on device: '/Applications' -> '/Volumes/Cataclysm DDA/Applications'
make: *** [dmgdist] Error 1
```

编译本身是通过的,失败仅发生在 `dmgdist` 打包环节。

## 原因

`build-data/osx/dmgsettings.py` 把 DMG 临时卷大小写死成 `500M`。本 fork 将多套 tileset(Altica、UltimateCataclysm 等)打入 `Cataclysm.app`,SDL3 版再叠加 4 个 SDL3 动态库后整体体积超过 500M,`ditto` 往临时卷拷贝时写爆。同一次 run 里 SDL2 版恰好卡在边界内未触发,只有 SDL3 版失败。

## 改动

移除写死的卷大小,改由 dmgbuild 根据实际打包内容自动估算并留余量。以后 tileset 继续增长也不会再撞这个上限,同时少一个需要手动维护的尺寸参数。

本改动对齐上游已合并的 [CleverRaven/Cataclysm-DDA#87464](https://github.com/CleverRaven/Cataclysm-DDA/pull/87464),diff 完全一致。

## 测试

CI 工作流改动,需在 release 流水线重跑 macOS SDL3 任务端到端验证。本地无法运行 GitHub Actions / dmgbuild(macOS 专用)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)