### PR TITLE
fix(ci): 翻译缺失时拒绝打包,避免发布无翻译版本

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,10 +284,22 @@ jobs:
           path: gfx
           merge-multiple: true
       - name: Fetch translations artifact into build
-        continue-on-error: true
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: translations
+      - name: Verify translations are present
+        shell: bash
+        run: |
+          # Guard against silently shipping an untranslated release: the
+          # translations artifact must contain real .po files, not just the
+          # committed placeholder. Catches both a failed Transifex pull
+          # (placeholder-only artifact) and a failed/empty artifact download.
+          count=$(find lang/po -maxdepth 1 -name '*.po' ! -name 'placeholder.po' | wc -l)
+          if [ "$count" -eq 0 ]; then
+            echo "::error::No real translations found in lang/po (placeholder only). Refusing to package an untranslated build."
+            exit 1
+          fi
+          echo "Found $count translation .po file(s)."
       - name: Fetch shader artifacts into build (SDL3)
         if: matrix.sdl3 == 1
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4


### PR DESCRIPTION
## 问题

有时发布的版本游戏内没有翻译,但 release 流水线却显示成功。

## 原因

仓库只提交了占位文件 `lang/po/placeholder.po`,真实翻译由 `build-translations` 任务从 Transifex 现拉,作为 `translations` artifact 传给 `builds` 任务,再由 `make ... LANGUAGES=all` 编入游戏。

链路中有两处 `continue-on-error: true` 会把偶发失败静默吞掉:

- `release.yml` 的 "Fetch translations artifact into build" 步骤(本次移除)
- `build-translations.yml` 的 `tx pull` 步骤(保留)

任意一处触发,`lang/po` 里就只剩 placeholder,编出的游戏没翻译,但包仍会正常打出并标记成功——表现就是「不等翻译直接打包」。

## 改动

- 移除 "Fetch translations artifact into build" 的 `continue-on-error`,artifact 下载失败时直接让任务报错。
- 新增 "Verify translations are present" 步骤:打包前校验 `lang/po` 中除 `placeholder.po` 外至少存在一个真实 `.po`,否则用 `::error::` 响亮失败、拒绝发布无翻译包。该校验同时兜住「Transifex 拉空」与「artifact 下载失败/为空」两种情况。

保留 `build-translations.yml` 中 `tx pull` 的 token 判空逻辑,它用于没有 `TX_TOKEN` 的 fork PR;翻译完整性统一由消费端这道校验兜底。

## 测试

CI 工作流改动,需在 release 流水线重跑验证。本地无法运行 GitHub Actions。

🤖 Generated with [Claude Code](https://claude.com/claude-code)