### PR TITLE
Features "CBN 式方向子弹曳光 / CBN-style directional bullet tracers"

### DIFF
--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -26,6 +26,7 @@
 #include "game.h"
 #include "game_constants.h"
 #include "input.h"
+#include "line.h"
 #include "map.h"
 #include "memory_fast.h"
 #include "monster.h"
@@ -504,13 +505,86 @@ void draw_bullet_curses( map &m, const tripoint_bub_ms &t, const char bullet,
     bullet_animation().progress();
 }
 
+// Direction of travel at trajectory point i (uses the segment leading into i).
+direction get_bullet_dir( const std::vector<tripoint_bub_ms> &trajectory, size_t i )
+{
+    return i == 0 && trajectory.size() > 1 ?
+           direction_from( trajectory[i], trajectory[i + 1] ) :
+           ( i >= 1 && i < trajectory.size() ) ?
+           direction_from( trajectory[i - 1], trajectory[i] ) :
+           direction::NORTH;
+}
+
+std::string bullet_sprite_id( const char bullet )
+{
+    switch( bullet ) {
+        case '*':
+            return "animation_bullet_normal";
+        case '#':
+            return "animation_bullet_flame";
+        case '`':
+            return "animation_bullet_shrapnel";
+        default:
+            return {};
+    }
+}
+
+// Directional tracer sprite for the gun-line: an upward-pointing (0deg) beam
+// streak that the renderer rotates to the travel direction. Mirrors CBN's
+// "animation_bullet_*_0deg" convention. These sprites are flagged rotates:true
+// in the tileset; falls back to the round bullet sprite if absent.
+std::string tracer_sprite_id( const char bullet )
+{
+    switch( bullet ) {
+        case '*':
+            return "animation_bullet_normal_0deg";
+        case '#':
+            return "animation_bullet_flame_0deg";
+        case '`':
+            return "animation_bullet_shrapnel_0deg";
+        default:
+            return bullet_sprite_id( bullet );
+    }
+}
+
+// Map a travel direction to this renderer's rotation index. 0 == sprite's
+// default orientation (north/up). Cardinals reuse the engine's existing
+// rota codes (1=E, 2=S, 3=W); diagonals use the extended codes 5-8 added to
+// draw_sprite_at(). NOTE: cardinals follow THIS engine's handedness
+// (case 1 renders +90 deg), which is mirrored from CBN on E/W; the diagonal
+// angles (45/-45/-135/135) match CBN exactly.
+int get_bullet_rotation( direction dir )
+{
+    switch( dir ) {
+        case direction::NORTH:
+            return 0;
+        case direction::EAST:
+            return 1; // +90
+        case direction::SOUTH:
+            return 2; // 180
+        case direction::WEST:
+            return 3; // -90
+        case direction::NORTHEAST:
+            return 5; // +45
+        case direction::NORTHWEST:
+            return 6; // -45
+        case direction::SOUTHWEST:
+            return 7; // -135
+        case direction::SOUTHEAST:
+            return 8; // +135
+        default:
+            return 0;
+    }
+}
+
 } // namespace
 
 #if defined(TILES)
 /* Bullet Animation -- Maybe change this to animate the ammo itself flying through the air?*/
 // need to have a version where there is no player defined, possibly. That way shrapnel works as intended
 void game::draw_bullet( const tripoint_bub_ms &t, const int /*i*/,
-                        const std::vector<tripoint_bub_ms> &/*trajectory*/, const char bullet )
+                        const std::vector<tripoint_bub_ms> &/*trajectory*/, const char bullet,
+                        const std::string &custom_sprite )
 {
     if( test_mode ) {
         // avoid segfault from null tilecontext in tests
@@ -530,8 +604,11 @@ void game::draw_bullet( const tripoint_bub_ms &t, const int /*i*/,
     static const std::string bullet_flame    {"animation_bullet_flame"};
     static const std::string bullet_shrapnel {"animation_bullet_shrapnel"};
 
+    // An ammo/throw-specific sprite (looked up in projectile_attack) takes
+    // precedence over the generic per-symbol sprite, mirroring CBN.
     const std::string &bullet_type =
-        bullet == '*' ? bullet_normal
+        !custom_sprite.empty() ? custom_sprite
+        : bullet == '*' ? bullet_normal
         : bullet == '#' ? bullet_flame
         : bullet == '`' ? bullet_shrapnel
         : bullet_unknown;
@@ -548,9 +625,95 @@ void game::draw_bullet( const tripoint_bub_ms &t, const int /*i*/,
 #else
 void game::draw_bullet( const tripoint_bub_ms &t, const int i,
                         const std::vector<tripoint_bub_ms> &trajectory,
-                        const char bullet )
+                        const char bullet, const std::string &/*custom_sprite*/ )
 {
     draw_bullet_curses( m, t, bullet, &trajectory[i] );
+}
+#endif
+
+#if defined(TILES)
+// Draw the entire trajectory at once as a line of rotated tracer sprites (CBN-style gun line).
+void game::draw_bullet_line( const std::vector<tripoint_bub_ms> &trajectory, const char bullet,
+                             const std::string &custom_sprite )
+{
+    if( test_mode ) {
+        // avoid segfault from null tilecontext in tests
+        return;
+    }
+    if( trajectory.size() < 2 ) {
+        return;
+    }
+
+    if( !use_tiles ) {
+        // Curses fallback: highlight every visible tile of the trajectory in one frame.
+        avatar &player_character = get_avatar();
+        const tripoint_bub_ms vp = player_character.pos_bub() + player_character.view_offset;
+        map &here = get_map();
+        shared_ptr_fast<draw_callback_t> line_cb = make_shared_fast<draw_callback_t>( [&]() {
+            for( const tripoint_bub_ms &p : trajectory ) {
+                if( is_point_visible( p ) && p.z() == vp.z() ) {
+                    here.drawsq( g->w_terrain, p, drawsq_params().highlight( true ) );
+                }
+            }
+        } );
+        add_draw_callback( line_cb );
+        bullet_animation().progress();
+        return;
+    }
+
+    // Per-ammo/throw sprite (looked up in projectile_attack) wins; otherwise the
+    // directional beam streak (animation_bullet_*_0deg), rotated per-tile to point
+    // along the trajectory. Rotating a directional streak (not the round dot) is
+    // what makes the flight path read as a continuous gun line.
+    const std::string sprite = !custom_sprite.empty() ? custom_sprite : tracer_sprite_id( bullet );
+
+    std::vector<tripoint_bub_ms> points;
+    std::vector<std::string> sprites;
+    std::vector<int> rotations;
+    points.reserve( trajectory.size() );
+    sprites.reserve( trajectory.size() );
+    rotations.reserve( trajectory.size() );
+    for( size_t i = 0; i < trajectory.size(); ++i ) {
+        if( !is_point_visible( trajectory[i] ) ) {
+            continue;
+        }
+        points.push_back( trajectory[i] );
+        sprites.push_back( sprite );
+        // A single bullet sprite, rotated to point along the trajectory. The
+        // renderer rotates it per-tile (incl. diagonals) so the whole flight
+        // path reads as one continuous gun line.
+        rotations.push_back( get_bullet_rotation( get_bullet_dir( trajectory, i ) ) );
+    }
+    if( points.empty() ) {
+        return;
+    }
+
+    shared_ptr_fast<draw_callback_t> line_cb = make_shared_fast<draw_callback_t>( [&]() {
+        tilecontext->init_draw_bullets( points, sprites, rotations );
+    } );
+    add_draw_callback( line_cb );
+    bullet_animation().progress();
+    tilecontext->void_bullet();
+}
+#else
+void game::draw_bullet_line( const std::vector<tripoint_bub_ms> &trajectory, const char bullet,
+                             const std::string &/*custom_sprite*/ )
+{
+    if( trajectory.size() < 2 ) {
+        return;
+    }
+    avatar &player_character = get_avatar();
+    const tripoint_bub_ms vp = player_character.pos_bub() + player_character.view_offset;
+    map &here = get_map();
+    shared_ptr_fast<draw_callback_t> line_cb = make_shared_fast<draw_callback_t>( [&]() {
+        for( const tripoint_bub_ms &p : trajectory ) {
+            if( is_point_visible( p ) && p.z() == vp.z() ) {
+                here.drawsq( g->w_terrain, p, drawsq_params().highlight( true ) );
+            }
+        }
+    } );
+    add_draw_callback( line_cb );
+    bullet_animation().progress();
 }
 #endif
 

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -40,6 +40,10 @@
 #include "type_id.h"
 #include "units.h"
 #include "vpart_position.h"
+#if defined(TILES)
+#include "cata_tiles.h" // for per-ammo bullet sprite lookup
+#include "sdltiles.h"    // for tilecontext
+#endif
 
 static const ammo_effect_str_id ammo_effect_ACT_ON_RANGED_HIT( "ACT_ON_RANGED_HIT" );
 static const ammo_effect_str_id ammo_effect_BOUNCE( "BOUNCE" );
@@ -302,11 +306,49 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
                         proj_effects.count( ammo_effect_JET ) > 0;
     const char bullet = stream ? '#' : '*';
     const bool no_item_damage = proj_effects.count( ammo_effect_NO_ITEM_DAMAGE ) > 0;
-    const bool do_draw_line = proj_effects.count( ammo_effect_DRAW_AS_LINE ) > 0;
+    const bool do_draw_line = proj_effects.count( ammo_effect_DRAW_AS_LINE ) > 0 ||
+                              get_option<bool>( "BULLETS_AS_LASERS" );
     const bool null_source = proj_effects.count( ammo_effect_NULL_SOURCE ) > 0;
     // Determines whether it can penetrate obstacles
     const bool is_bullet = proj_arg.speed >= 200 &&
                            !proj_effects.count( ammo_effect_NO_PENETRATE_OBSTACLES );
+
+    // Look up an ammo/throw-specific flight sprite, mirroring CBN. Falls back to
+    // the generic '*'/'#'/'`' sprite when no per-item art exists. The source
+    // weapon is available via wp_attack.weapon (set by both the gun and throw
+    // paths), so no signature change is needed here.
+    std::string custom_bullet_sprite;
+#if defined(TILES)
+    if( tilecontext ) {
+        const bool is_thrown = wp_attack.is_thrown;
+        const auto set_sprite_from_lookup = [&]( const std::string & candidate,
+        const TILE_CATEGORY cat ) {
+            if( !custom_bullet_sprite.empty() ) {
+                return;
+            }
+            const std::string resolved = tilecontext->find_bullet_sprite_id( candidate, cat );
+            if( !resolved.empty() ) {
+                custom_bullet_sprite = resolved;
+            }
+        };
+
+        const item &drop = proj.get_drop();
+        if( !drop.is_null() ) {
+            const std::string id = drop.typeId().str();
+            set_sprite_from_lookup( "animation_bullet_" + id, TILE_CATEGORY::BULLET );
+            if( is_thrown ) {
+                set_sprite_from_lookup( id, TILE_CATEGORY::ITEM );
+            }
+        }
+
+        if( custom_bullet_sprite.empty() && wp_attack.weapon ) {
+            const itype_id ammo_type = wp_attack.weapon->ammo_current();
+            if( !ammo_type.is_null() ) {
+                set_sprite_from_lookup( "animation_bullet_" + ammo_type.str(), TILE_CATEGORY::BULLET );
+            }
+        }
+    }
+#endif // TILES
 
     // If we were targeting a tile rather than a monster, don't overshoot
     // Unless the target was a wall, then we are aiming high enough to overshoot
@@ -485,7 +527,7 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
                 if( projectile_skip_current_frame >= projectile_skip_calculation ) {
                     // TODO: Refine so overlapping maps are handled.
                     if( here == &reality_bubble() ) {
-                        g->draw_bullet( tp, static_cast<int>( i ), trajectory, bullet );
+                        g->draw_bullet( tp, static_cast<int>( i ), trajectory, bullet, custom_bullet_sprite );
                     }
                     projectile_skip_current_frame = 0;
                     // If we missed recalculate the skip factor so they spread out.
@@ -654,8 +696,8 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
         if( first && do_animation && do_draw_line && traj_len > 2 ) {
             t_copy.erase( t_copy.begin() );
             t_copy.resize( traj_len-- );
-            g->draw_line( tp, t_copy );
-            g->draw_bullet( tp, static_cast<int>( traj_len-- ), t_copy, bullet );
+            // Draw the whole flight path at once as a gun line of rotated tracer sprites.
+            g->draw_bullet_line( t_copy, bullet, custom_bullet_sprite );
         }
 
         if( here->impassable( tp ) ) {

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1836,6 +1836,12 @@ const T &obj = s_id.obj();
 return find_tile_looks_like( obj.looks_like, category, "", looks_like_jumps_limit - 1 );
 }
 
+std::string cata_tiles::find_bullet_sprite_id( const std::string &id, TILE_CATEGORY category )
+{
+    std::optional<tile_lookup_res> res = find_tile_looks_like( id, category, "" );
+    return res ? res->id() : std::string{};
+}
+
 std::optional<tile_lookup_res>
 cata_tiles::find_tile_looks_like( const std::string &id, TILE_CATEGORY category,
                                   const std::string &variant,
@@ -2470,9 +2476,12 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
             }
     }
 
-    // make sure we aren't going to rotate the tile if it shouldn't be rotated
+    // make sure we aren't going to rotate the tile if it shouldn't be rotated.
+    // BULLET is exempt: projectile sprites are intentionally rotated to point
+    // along the trajectory even though the tile itself is flagged rotates:false.
     if( !display_tile.rotates && !( category == TILE_CATEGORY::NONE )
-        && !( category == TILE_CATEGORY::MONSTER ) ) {
+        && !( category == TILE_CATEGORY::MONSTER )
+        && !( category == TILE_CATEGORY::BULLET ) ) {
         rota = 0;
     }
 
@@ -2538,7 +2547,7 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
         rp.tint = pending_part_tint_;
     }
     draw_tile_at( display_tile, screen_pos, loc_rand, rota, rp,
-                  retract, height_3d, offset );
+                  retract, height_3d, offset, /*allow_diagonal_rota:*/ category == TILE_CATEGORY::BULLET );
 
     return true;
 }
@@ -2546,7 +2555,8 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
 bool cata_tiles::draw_sprite_at(
     const tile_type &tile, const weighted_int_list<std::vector<int>> &svlist,
     const point &p, unsigned int loc_rand, bool rota_fg, int rota,
-    const tile_render_params &rp, int retract, int &height_3d, const point &offset )
+    const tile_render_params &rp, int retract, int &height_3d, const point &offset,
+    bool allow_diagonal_rota )
 {
     const std::vector<int> *picked = svlist.pick( loc_rand );
     if( !picked ) {
@@ -2695,7 +2705,10 @@ bool cata_tiles::draw_sprite_at(
         if( rota == -1 ) {
             render_flip = SDL_FLIP_HORIZONTAL;
         } else if( !iso ) {
-            switch( rota % 4 ) {
+            // Non-bullet tiles keep the historical `% 4` fold exactly. Bullets
+            // opt into the extended codes (5-8) for true diagonal rotation.
+            const int r = allow_diagonal_rota ? rota : ( rota % 4 );
+            switch( r ) {
                 case 1:
                     render_angle = 90;
                     break;
@@ -2704,6 +2717,19 @@ bool cata_tiles::draw_sprite_at(
                     break;
                 case 3:
                     render_angle = -90;
+                    break;
+                // Diagonal rotations, only reachable when allow_diagonal_rota.
+                case 5:
+                    render_angle = 45;
+                    break;
+                case 6:
+                    render_angle = -45;
+                    break;
+                case 7:
+                    render_angle = -135;
+                    break;
+                case 8:
+                    render_angle = 135;
                     break;
                 default:
                     break;
@@ -2727,7 +2753,10 @@ bool cata_tiles::draw_sprite_at(
                       renderer, &destination, 0, nullptr,
                       static_cast<CataFlipMode>( SDL_FLIP_HORIZONTAL ) );
         } else {
-            switch( rota % 4 ) {
+            // Non-bullet tiles keep the historical `% 4` fold exactly. Bullets
+            // opt into the extended codes (5-8) for true diagonal rotation.
+            const int r = allow_diagonal_rota ? rota : ( rota % 4 );
+            switch( r ) {
                 default:
                 case 0:
                     // unrotated (and 180, with just two sprites)
@@ -2782,6 +2811,46 @@ bool cata_tiles::draw_sprite_at(
                                                           SDL_FLIP_NONE );
                     }
                     break;
+                case 5:
+                    // 45 degrees (diagonal, bullets only)
+                    if( !iso ) {
+                        ret = sprite_tex->render_copy_ex( renderer, &destination, 45, nullptr,
+                                                          SDL_FLIP_NONE );
+                    } else {
+                        ret = sprite_tex->render_copy_ex( renderer, &destination, 0, nullptr,
+                                                          SDL_FLIP_NONE );
+                    }
+                    break;
+                case 6:
+                    // -45 degrees (diagonal, bullets only)
+                    if( !iso ) {
+                        ret = sprite_tex->render_copy_ex( renderer, &destination, -45, nullptr,
+                                                          SDL_FLIP_NONE );
+                    } else {
+                        ret = sprite_tex->render_copy_ex( renderer, &destination, 0, nullptr,
+                                                          SDL_FLIP_NONE );
+                    }
+                    break;
+                case 7:
+                    // -135 degrees (diagonal, bullets only)
+                    if( !iso ) {
+                        ret = sprite_tex->render_copy_ex( renderer, &destination, -135, nullptr,
+                                                          SDL_FLIP_NONE );
+                    } else {
+                        ret = sprite_tex->render_copy_ex( renderer, &destination, 0, nullptr,
+                                                          SDL_FLIP_NONE );
+                    }
+                    break;
+                case 8:
+                    // 135 degrees (diagonal, bullets only)
+                    if( !iso ) {
+                        ret = sprite_tex->render_copy_ex( renderer, &destination, 135, nullptr,
+                                                          SDL_FLIP_NONE );
+                    } else {
+                        ret = sprite_tex->render_copy_ex( renderer, &destination, 0, nullptr,
+                                                          SDL_FLIP_NONE );
+                    }
+                    break;
             }
         }
     } else {
@@ -2804,13 +2873,13 @@ bool cata_tiles::draw_sprite_at(
 bool cata_tiles::draw_tile_at(
     const tile_type &tile, const point &p, unsigned int loc_rand, int rota,
     const tile_render_params &rp, int retract, int &height_3d,
-    const point &offset )
+    const point &offset, bool allow_diagonal_rota )
 {
     int fake_int = height_3d;
     draw_sprite_at( tile, tile.bg, p, loc_rand, /*fg:*/ false, rota, rp,
-                    retract, fake_int, offset );
+                    retract, fake_int, offset, allow_diagonal_rota );
     draw_sprite_at( tile, tile.fg, p, loc_rand, /*fg:*/ true, rota, rp,
-                    retract, height_3d, offset );
+                    retract, height_3d, offset, allow_diagonal_rota );
     return true;
 }
 
@@ -4217,11 +4286,20 @@ void cata_tiles::init_custom_explosion_layer( const std::map<tripoint_bub_ms, ex
     do_draw_custom_explosion = true;
     custom_explosion_layer = layer;
 }
-void cata_tiles::init_draw_bullet( const tripoint_bub_ms &p, std::string name )
+void cata_tiles::init_draw_bullet( const tripoint_bub_ms &p, std::string name, int rotation )
 {
     do_draw_bullet = true;
-    bul_pos = p;
-    bul_id = std::move( name );
+    bul_pos.push_back( p );
+    bul_id.push_back( std::move( name ) );
+    bul_rotation.push_back( rotation );
+}
+void cata_tiles::init_draw_bullets( const std::vector<tripoint_bub_ms> &ps,
+                                    const std::vector<std::string> &names, const std::vector<int> &rotations )
+{
+    do_draw_bullet = true;
+    bul_pos.insert( bul_pos.end(), ps.begin(), ps.end() );
+    bul_id.insert( bul_id.end(), names.begin(), names.end() );
+    bul_rotation.insert( bul_rotation.end(), rotations.begin(), rotations.end() );
 }
 void cata_tiles::init_draw_hit( const Creature &critter )
 {
@@ -4330,8 +4408,9 @@ void cata_tiles::void_custom_explosion()
 void cata_tiles::void_bullet()
 {
     do_draw_bullet = false;
-    bul_pos = { -1, -1, -1 };
+    bul_pos.clear();
     bul_id.clear();
+    bul_rotation.clear();
 }
 void cata_tiles::void_hit()
 {
@@ -4565,8 +4644,10 @@ void cata_tiles::draw_custom_explosion_frame()
 }
 void cata_tiles::draw_bullet_frame()
 {
-    draw_from_id_string( bul_id, TILE_CATEGORY::BULLET, empty_string, bul_pos, 0, 0,
-                         lit_level::LIT, false );
+    for( size_t i = 0; i < bul_pos.size(); ++i ) {
+        draw_from_id_string( bul_id[i], TILE_CATEGORY::BULLET, empty_string, bul_pos[i], 0,
+                             bul_rotation[i], lit_level::LIT, false );
+    }
 }
 void cata_tiles::draw_hit_frame()
 {

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -520,6 +520,14 @@ class cata_tiles
         /** Minimap functionality */
         void draw_minimap( const point &dest, const tripoint_bub_ms &center, int width, int height );
 
+        /**
+         * Resolve a candidate tile id (following looks_like fallbacks) and return
+         * the id of an existing sprite, or an empty string if none is found.
+         * Public wrapper around find_tile_looks_like for callers outside the
+         * renderer (e.g. per-ammo bullet sprite lookup in ballistics).
+         */
+        std::string find_bullet_sprite_id( const std::string &id, TILE_CATEGORY category );
+
     protected:
         /** How many rows and columns of tiles fit into given dimensions, fully
          ** or partially shown, but disregarding any extra contents outside the
@@ -608,10 +616,11 @@ class cata_tiles
         bool draw_sprite_at(
             const tile_type &tile, const weighted_int_list<std::vector<int>> &svlist,
             const point &, unsigned int loc_rand, bool rota_fg, int rota,
-            const tile_render_params &rp, int retract, int &height_3d, const point &offset );
+            const tile_render_params &rp, int retract, int &height_3d, const point &offset,
+            bool allow_diagonal_rota = false );
         bool draw_tile_at( const tile_type &tile, const point &, unsigned int loc_rand, int rota,
                            const tile_render_params &rp, int retract, int &height_3d,
-                           const point &offset );
+                           const point &offset, bool allow_diagonal_rota = false );
 
         /* Tile Picking */
         void get_tile_values( int t, const std::array<int, 4> &tn, int &subtile, int &rotation,
@@ -712,7 +721,9 @@ class cata_tiles
         void draw_custom_explosion_frame();
         void void_custom_explosion();
 
-        void init_draw_bullet( const tripoint_bub_ms &p, std::string name );
+        void init_draw_bullet( const tripoint_bub_ms &p, std::string name, int rotation = 0 );
+        void init_draw_bullets( const std::vector<tripoint_bub_ms> &ps,
+                                const std::vector<std::string> &names, const std::vector<int> &rotations );
         void draw_bullet_frame();
         void void_bullet();
 
@@ -948,8 +959,9 @@ class cata_tiles
         std::map<tripoint_bub_ms, explosion_tile> custom_explosion_layer;
         std::map<tripoint_bub_ms, std::string> async_anim_layer;
 
-        tripoint_bub_ms bul_pos;
-        std::string bul_id;
+        std::vector<tripoint_bub_ms> bul_pos;
+        std::vector<std::string> bul_id;
+        std::vector<int> bul_rotation;
 
         struct hit_animation {
             weak_ptr_fast<Creature> creature_ptr;

--- a/src/game.h
+++ b/src/game.h
@@ -864,7 +864,11 @@ class game
 
         // Animation related functions
         void draw_bullet( const tripoint_bub_ms &t, int i, const std::vector<tripoint_bub_ms> &trajectory,
-                          char bullet );
+                          char bullet, const std::string &custom_sprite = {} );
+        // Draw the whole projectile trajectory at once as a "gun line" of rotated tracer
+        // sprites (CBN-style), instead of animating a single bullet hopping tile-by-tile.
+        void draw_bullet_line( const std::vector<tripoint_bub_ms> &trajectory, char bullet,
+                               const std::string &custom_sprite = {} );
         void draw_hit_mon( const tripoint_bub_ms &p, const monster &m, bool dead = false );
         void draw_hit_player( const Character &p, int dam ) const;
         void draw_line( const tripoint_bub_ms &p, const tripoint_bub_ms &center_point,

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2302,6 +2302,13 @@ void options_manager::add_options_graphics()
 
         get_option( "ANIMATION_PROJECTILES" ).setPrerequisite( "ANIMATIONS" );
 
+        add( "BULLETS_AS_LASERS", page_id, to_translation( "Draw bullets as lines" ),
+             to_translation( "If true, projectiles are drawn as a line of images along their whole flight path, and the animation lasts only one frame." ),
+             true
+           );
+
+        get_option( "BULLETS_AS_LASERS" ).setPrerequisite( "ANIMATION_PROJECTILES" );
+
         add( "ANIMATION_SCT", page_id, to_translation( "SCT animation" ),
              to_translation( "If true, will display scrolling combat text animations." ),
              true


### PR DESCRIPTION
#### 概述 (Summary)

Features "子弹沿弹道方向显示曳光条,并支持按弹药查专属飞行贴图 / Directional bullet tracers along the trajectory, with per-ammo flight sprite lookup"

#### 改动目的 (Purpose of change)

移植 Cataclysm: Bright Nights 的方向子弹动画。原本子弹是一个对称圆点逐格跳动,看不出飞行方向;本 PR 让子弹沿弹道方向旋转一张方向贴图,整条弹道一帧显示成连续枪线。

Port the directional bullet animation from Cataclysm: Bright Nights. Previously a bullet was a symmetric dot hopping tile-by-tile with no sense of direction; this PR rotates a directional sprite to point along the trajectory and draws the whole flight path as a continuous gun line in a single frame.

#### 解决方案描述 (Describe the solution)

- 渲染端为子弹新增斜角旋转:rota 码 5–8 映射到 45/-45/-135/135 度。仅子弹启用(`allow_diagonal_rota`),地形/墙保持原有 `rota % 4` 行为,互不影响。
- `draw_bullet_line` 用朝上的 `_0deg` 方向曳光贴图,按 `get_bullet_rotation(get_bullet_dir(...))` 逐格旋转;tint 轮廓重放与实际渲染共用同一套角度计算。
- ballistics 移植「按弹药/投掷物 id 查专属飞行贴图」:经 `find_bullet_sprite_id` 查找,源武器由已有的 `wp_attack.weapon` 取得,无需改 `projectile_attack` 签名;找不到时回退到通用 `*`/`#`/`` ` `` 贴图。
- 新增 `BULLETS_AS_LASERS` 选项(整条弹道一帧显示)。

---

- Renderer gains diagonal rotation for bullets: rota codes 5–8 map to 45/-45/-135/135 degrees. Enabled for bullets only (`allow_diagonal_rota`); terrain/walls keep the historical `rota % 4` fold, so they are unaffected.
- `draw_bullet_line` uses an upward `_0deg` directional tracer sprite, rotated per tile via `get_bullet_rotation(get_bullet_dir(...))`; the tint silhouette replay shares the same angle computation as the actual render.
- Ports per-ammo/thrown flight-sprite lookup via `find_bullet_sprite_id`; the source weapon comes from the existing `wp_attack.weapon`, so no `projectile_attack` signature change is needed. Falls back to the generic `*`/`#`/`` ` `` sprite when no per-item art exists.
- Adds a `BULLETS_AS_LASERS` option (whole trajectory drawn in one frame).

需要配套贴图仓库新增的 `animation_bullet_*_0deg` 方向贴图(另一仓库的 PR)。
Requires the new `animation_bullet_*_0deg` directional sprites from the tileset repo (separate PR).

#### 你考虑过的替代方案 (Describe alternatives you've considered)

- 旋转现有的对称圆点子弹贴图:无效,对称图旋转后看不出方向变化。这正是必须引入方向贴图的原因。
- 给每个方向单独烤一张贴图(不旋转):需要 4–8 倍的美术量,且偏离 CBN 的 `rotates:true` + 引擎旋转约定。已弃用。
- 给 `projectile_attack` 新增 `source_weapon` 形参(CBN 的做法):本仓库已把武器存进 `wp_attack.weapon`,直接复用更省,无需改 4 处调用签名。

---

- Rotating the existing symmetric dot sprite: ineffective — a symmetric sprite shows no directional change when rotated. This is exactly why directional sprites are required.
- Baking one sprite per direction (no rotation): 4–8x the art, and diverges from CBN's `rotates:true` + engine-rotation convention. Rejected.
- Adding a `source_weapon` parameter to `projectile_attack` (CBN's approach): this repo already stores the weapon in `wp_attack.weapon`, so reusing it avoids touching 4 call-site signatures.

#### 测试 (Testing)

- TILES 构建下开枪验证:横/竖/斜各方向的曳光条均指向正确,连成枪线;普通弹黄白、燃烧弹橙红、破片灰白。
- 经 `/code-review` 多角度审查并修复:已修复非 TILES 构建下 `is_thrown` 未使用导致的 `-Werror` 报错;还原一处无关的 `item.h` 格式改动。
- 已编译验证通过(提交者本地)。建议审阅者额外在非 TILES(curses)配置下编译确认。

---

- With a TILES build, fired in horizontal/vertical/diagonal directions: tracer bars point correctly and form a continuous gun line; normal = yellow-white, flame = orange-red, shrapnel = grey-white.
- Reviewed via multi-angle `/code-review` and fixed: a non-TILES `-Werror` break from an unused `is_thrown`, and reverted an unrelated `item.h` formatting change.
- Compiles for the submitter locally. Reviewers are encouraged to also build a non-TILES (curses) config to confirm.

#### 补充说明 (Additional context)

斜角(45 度)由引擎旋转 `_0deg` 竖条得到,与 CBN 早期行为一致,可能略有锯齿;如需更干净的斜角,可后续补一张 `_45deg` 专用斜条(CBN 后期做法)。

Diagonals (45°) are produced by engine-rotating the `_0deg` bar, matching early CBN behavior and may show slight aliasing; a dedicated `_45deg` sprite (later CBN approach) can be added later for cleaner diagonals.