### PR TITLE
Bugfixes "修复 SDL3 构建下窗口事件常量缺失导致的 C2051 / Fix C2051 from missing SDL3 window event constants"

### DIFF
--- a/src/sdl_wrappers.h
+++ b/src/sdl_wrappers.h
@@ -421,6 +421,11 @@ Uint32 GetWindowEventID( const SDL_Event &ev );
 
 // Normalized window event constants. Use with switch(GetWindowEventID(ev)).
 #if SDL_MAJOR_VERSION >= 3
+    inline constexpr Uint32 CATA_WINDOWEVENT_SHOWN        = SDL_EVENT_WINDOW_SHOWN;
+    inline constexpr Uint32 CATA_WINDOWEVENT_EXPOSED      = SDL_EVENT_WINDOW_EXPOSED;
+    inline constexpr Uint32 CATA_WINDOWEVENT_MINIMIZED    = SDL_EVENT_WINDOW_MINIMIZED;
+    inline constexpr Uint32 CATA_WINDOWEVENT_RESTORED     = SDL_EVENT_WINDOW_RESTORED;
+    inline constexpr Uint32 CATA_WINDOWEVENT_RESIZED      = SDL_EVENT_WINDOW_RESIZED;
     inline constexpr Uint32 CATA_WINDOWEVENT_FOCUS_LOST   = SDL_EVENT_WINDOW_FOCUS_LOST;
     inline constexpr Uint32 CATA_WINDOWEVENT_FOCUS_GAINED = SDL_EVENT_WINDOW_FOCUS_GAINED;
     inline constexpr Uint32 CATA_WINDOWEVENT_SAFE_AREA_CHANGED = SDL_EVENT_WINDOW_SAFE_AREA_CHANGED;


### PR DESCRIPTION
#### 概述 (Summary)

Bugfixes "恢复 SDL3 分支被误删的窗口事件常量,修复 MSVC C2051 编译错误 / Restore SDL3 window event constants that were accidentally dropped, fixing the MSVC C2051 build error"

#### 改动目的 (Purpose of change)

SDL3 构建在 MSVC 下编译失败,报 `C2051: case expression not constant`,位于 `src/sdltiles.cpp:5353` 与 `5355`(以及会接着报的 `5352`、`545`)。

根因追溯:PR #87442(Android safe-area,merge `8b179a7782`)在 `sdl_wrappers.h` 的 SDL3 分支(`#if SDL_MAJOR_VERSION >= 3`)新增 `CATA_WINDOWEVENT_SAFE_AREA_CHANGED` 时,误删了同一分支原有的 `SHOWN`/`EXPOSED`/`MINIMIZED`/`RESTORED`/`RESIZED` 五个常量。`sdltiles.cpp` 的事件 switch 在无 `#ifdef` 守卫的 `case` 标签里引用这些常量,SDL3 下它们未定义,MSVC 把未声明标识符当隐式 int,在 case 里判为非常量表达式。SDL2 分支保留了这些定义,所以只有 SDL3 CI 报错。

---

The SDL3 build fails under MSVC with `C2051: case expression not constant` at `src/sdltiles.cpp:5353` and `5355` (and subsequently `5352`, `545`).

Root cause: PR #87442 (Android safe-area, merge `8b179a7782`) added `CATA_WINDOWEVENT_SAFE_AREA_CHANGED` to the SDL3 branch (`#if SDL_MAJOR_VERSION >= 3`) of `sdl_wrappers.h` but accidentally removed the existing `SHOWN`/`EXPOSED`/`MINIMIZED`/`RESTORED`/`RESIZED` constants from it. The event switch in `sdltiles.cpp` references these in unguarded `case` labels; under SDL3 they are undefined, and MSVC treats the undeclared identifiers as implicit int, making them non-constant in a case. The SDL2 branch kept the definitions, so only SDL3 CI broke.

#### 解决方案描述 (Describe the solution)

在 `sdl_wrappers.h` 的 SDL3 分支重新加回这五个常量,映射到对应的 `SDL_EVENT_WINDOW_*`(SDL3 命名):`SHOWN`/`EXPOSED`/`MINIMIZED`/`RESTORED`/`RESIZED`。这样跨版本抽象层重新完整,所有 `case` 标签都有合法的编译期常量,无需给每个 case 单独加 `#ifdef` 补丁。

Restores the five constants to the SDL3 branch of `sdl_wrappers.h`, mapped to the corresponding `SDL_EVENT_WINDOW_*` (SDL3 naming): `SHOWN`/`EXPOSED`/`MINIMIZED`/`RESTORED`/`RESIZED`. This makes the cross-version abstraction layer whole again so every `case` label has a valid compile-time constant, avoiding per-case `#ifdef` patches.

#### 你考虑过的替代方案 (Describe alternatives you've considered)

给 `sdltiles.cpp` 里每个相关 `case` 包 `#if SDL_MAJOR_VERSION >= 3` 守卫:能让它编译,但把缺陷扩散到调用点、重复且易漏,治标不治本。修复抽象层本身(本 PR 做法)更彻底。

Guarding each affected `case` in `sdltiles.cpp` with `#if SDL_MAJOR_VERSION >= 3`: would compile, but spreads the defect to call sites, is repetitive and easy to miss. Fixing the abstraction layer itself (this PR) is the deeper fix.

#### 测试 (Testing)

改动为补回常量定义,SDL3 分支现有 8 个、SDL2 分支 7 个 `CATA_WINDOWEVENT_*` 常量,两分支由 `#if/#else` 互斥,无重复定义。已核对 `sdltiles.cpp` 中所有引用点(`5352/5353/5355/5367` 及 `545/555`)在两个 SDL 版本下都能解析到常量。

注:提交者本地未配置 SDL3 开发环境,无法本地复现该 SDL3 构建,需 SDL3 CI 重跑确认。

---

The change only restores constant definitions; the SDL3 branch now has 8 and the SDL2 branch 7 `CATA_WINDOWEVENT_*` constants, mutually exclusive via `#if/#else`, no duplicates. Verified all reference sites in `sdltiles.cpp` (`5352/5353/5355/5367` and `545/555`) resolve to a constant under both SDL versions.

Note: the submitter has no local SDL3 dev setup and cannot reproduce the SDL3 build locally; SDL3 CI re-run is needed to confirm.

#### 补充说明 (Additional context)

仅触及 `src/sdl_wrappers.h`,+5 行。不影响 SDL2 构建与运行期行为。

Touches only `src/sdl_wrappers.h`, +5 lines. No impact on SDL2 builds or runtime behavior.