### PR TITLE
修复 Curses/Android/macOS 三类编译失败

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -581,7 +581,7 @@ jobs:
       - name: Build CDDA (osx, SDL2)
         if: runner.os == 'macOS' && matrix.sdl3 != 1
         run: |
-          make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=0 PCH=0 USE_HOME_DIR=1 FRAMEWORK=1 UNIVERSAL_BINARY=1 WARN_STALE_DATA=1 dmgdist
+          make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} SDL3=0 RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=0 PCH=0 USE_HOME_DIR=1 FRAMEWORK=1 UNIVERSAL_BINARY=1 WARN_STALE_DATA=1 dmgdist
           mv Cataclysm.dmg ccb-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.dmg
       - name: Build CDDA (osx, SDL3)
         if: runner.os == 'macOS' && matrix.sdl3 == 1

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -505,6 +505,7 @@ void draw_bullet_curses( map &m, const tripoint_bub_ms &t, const char bullet,
     bullet_animation().progress();
 }
 
+#if defined(TILES)
 // Direction of travel at trajectory point i (uses the segment leading into i).
 direction get_bullet_dir( const std::vector<tripoint_bub_ms> &trajectory, size_t i )
 {
@@ -576,6 +577,7 @@ int get_bullet_rotation( direction dir )
             return 0;
     }
 }
+#endif // TILES
 
 } // namespace
 
@@ -696,7 +698,7 @@ void game::draw_bullet_line( const std::vector<tripoint_bub_ms> &trajectory, con
     tilecontext->void_bullet();
 }
 #else
-void game::draw_bullet_line( const std::vector<tripoint_bub_ms> &trajectory, const char bullet,
+void game::draw_bullet_line( const std::vector<tripoint_bub_ms> &trajectory, const char /*bullet*/,
                              const std::string &/*custom_sprite*/ )
 {
     if( trajectory.size() < 2 ) {

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -913,7 +913,6 @@ extern "C" {
         ( void )jcls; // unused
         visible_frame_inbox.publish( left, top, right, bottom, visible == JNI_TRUE );
     }
-    }
 
 } // "C"
 


### PR DESCRIPTION
## 摘要

修复昨晚大面积合并后 CI release workflow 的编译失败。第一次 SDL3 修复 (#137) 只解决了 SDL3/Windows 系列,仍有 5 个 job 失败。这 5 个失败分属 **3 个独立根因**,均由 #136「方向性子弹」PR 与 SDL3 默认化共同引入:

| 根因 | 影响的 job | 修复 |
|---|---|---|
| Curses 版 `draw_bullet_line` 的 `bullet` 参数未使用 | Linux/macOS Curses | 注释掉参数名 |
| 4 个 tiles-only 辅助函数在 `TILES=0` 下变 unused-function | Linux/macOS Curses | 用 `#if defined(TILES)` 包裹 |
| `sdltiles.cpp` extern "C" 块多了个 `}` | Android x32/x64 | 删除多余花括号 |
| macOS SDL2 step 漏传 `SDL3=0`,被默认成 SDL3 | macOS Tiles | release.yml 加 `SDL3=0` |

## 改动文件

- `src/animation.cpp` — 注释未使用参数 + `#if defined(TILES)` 包裹 tiles-only 函数
- `src/sdltiles.cpp` — 删除 extern "C" 块多余的 `}`
- `.github/workflows/release.yml` — macOS SDL2 构建显式传 `SDL3=0`

## 测试

本地验证:
- Curses 模式 (`TILES=0`):`animation.o` 编译通过
- Tiles 模式 (`TILES=1 SDL3=0`):`animation.o` + `sdltiles.o` 编译通过

Android (NDK clang) 与 macOS (framework) 环境无法本地复现,由本 PR 的 CI 验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)