### PR TITLE
修复 solder_wire 重复 display_type 导致游戏无法加载

### DIFF
--- a/data/json/items/resources/metal.json
+++ b/data/json/items/resources/metal.json
@@ -449,7 +449,6 @@
     "weight": "2 g",
     "//": "Density ~ 8g/cm³ ~ 2000kg/250ml @ stack 1000 = 2g/unit",
     "flags": [ "UNRECOVERABLE" ],
-    "display_type": "BY_WEIGHT",
     "stackable": true
   },
   {


### PR DESCRIPTION
## 问题

游戏启动时报错无法加载:

```
file data/json/items/resources/metal.json, at line 452:
duplicate entry in json object
```

`solder_wire`(焊锡)物品对象内 `"display_type": "BY_WEIGHT"` 出现了两次(第 446、452 行),JSON 不允许重复键,导致整个数据加载失败、游戏无法启动。

应为昨晚上游同步 cherry-pick 时合并冲突遗留的重复行。

## 修复

删除第 452 行重复的 `display_type`,保留第 446 行原有键(两者值相同,物品行为不变)。

## 验证

用严格模式(检测重复键)重新解析 `metal.json`,确认无重复键、JSON 合法。