### PR TITLE
切换不死人贴图源到 CCB_UNDEAD_PEOPLE 仓库

### DIFF
--- a/.github/workflows/compose-tilesets.yml
+++ b/.github/workflows/compose-tilesets.yml
@@ -116,10 +116,12 @@ jobs:
             tileset_repo: pixel-32/CDDA-tileset
             tileset_src_checkout: ""
           - name: MSX++UndeadPeopleEdition
-            tileset_repo: LYHGLYTX/CCB-UndeadPeople-Tileset
+            tileset_repo: LYHGLYTX/CCB_UNDEAD_PEOPLE
             tileset_dir: .
             precomposed: true
             release_download: true
+            release_zip_glob: 'CCB_UNDEAD_PEOPLE*.zip'
+            release_subdir: UNDEAD_PEOPLE
 
     name: Compose tileset
     runs-on: ubuntu-latest
@@ -153,13 +155,15 @@ jobs:
         if: matrix.release_download == true
         env:
           GH_TOKEN: ${{ github.token }}
+          ZIP_GLOB: ${{ matrix.release_zip_glob }}
+          SUBDIR: ${{ matrix.release_subdir }}
         run: |
           TAG=$(gh release list -R ${{ matrix.tileset_repo }} --limit 1 --json tagName -q '.[0].tagName')
           echo "Downloading release $TAG from ${{ matrix.tileset_repo }}"
-          gh release download "$TAG" -R ${{ matrix.tileset_repo }} -p 'MSX++*.zip' -O tileset.zip
+          gh release download "$TAG" -R ${{ matrix.tileset_repo }} -p "$ZIP_GLOB" -O tileset.zip
           unzip -q tileset.zip
           mkdir -p precomposed-tileset
-          cp -r MSX++UnDeadPeopleEdition/* precomposed-tileset/
+          cp -r "$SUBDIR"/* precomposed-tileset/
 
       - name: Clone precomposed tileset repo
         if: matrix.precomposed == true && matrix.release_download != true


### PR DESCRIPTION
## 摘要

将 CCB 贴图构建流程里的不死人贴图源,从旧仓库 `LYHGLYTX/CCB-UndeadPeople-Tileset` 切换到新仓库 `LYHGLYTX/CCB_UNDEAD_PEOPLE`(Chibi_Ultica 独立包,id 沿用 `UNDEAD_PEOPLE` 以兼容最广模组)。

## 改动

`compose-tilesets.yml` 的 `MSX++UndeadPeopleEdition` 条目:

- `tileset_repo` → `LYHGLYTX/CCB_UNDEAD_PEOPLE`
- 新增两个 matrix 变量,使 download 步骤不再硬编码 MSX++ 命名:
  - `release_zip_glob: 'CCB_UNDEAD_PEOPLE*.zip'`(原 `MSX++*.zip`)
  - `release_subdir: UNDEAD_PEOPLE`(原 `MSX++UnDeadPeopleEdition`)
- download 步骤改用上述变量

## 不变项

- `gfx/` 输出文件夹名仍为 `MSX++UndeadPeopleEdition`,避免影响玩家既有的贴图选择(存档/配置里记录的是该文件夹名,游戏内身份由 tileset.txt 的 NAME=`UNDEAD_PEOPLE` 决定)
- ChibiUltica 条目(从 I-am-Erk 上游实时 compose)保持不动

## 验证

- 新仓库已发布 release,资产 `CCB_UNDEAD_PEOPLE.zip`,解压顶层目录 `UNDEAD_PEOPLE/`,内含成品 `tile_config.json` + atlas + tileset.txt(已实测确认)
- workflow YAML 语法校验通过