### PR TITLE
fix(build): 修复 item_burnt 的 units::volume 与裸 0 比较导致 MSVC 编译失败

### DIFF
--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -696,7 +696,7 @@ double item_burnt_eval(const_dialogue const &d, char scope, std::vector<diag_val
         throw math::runtime_error(R"(Unknown format type "%s" for item_burnt)", format);
     }
     const item &obj = **it;
-    if ( obj.base_volume() <= 0) {
+    if ( obj.base_volume() <= 0_ml) {
         return -1;
     }
     else{
@@ -723,7 +723,7 @@ void item_burnt_ass(double val, dialogue& d, char scope, std::vector<diag_value>
         throw math::runtime_error(R"(Unknown format type "%s" for item_burnt)", format);
     }
     item &obj = **it;
-    if ( obj.base_volume() <= 0) {
+    if ( obj.base_volume() <= 0_ml) {
         throw math::runtime_error( "Zero volume items cannot use item_burnt() assignment" );
     }
     else{


### PR DESCRIPTION
## 摘要
#140 引入的 `item_burnt()` 诊断函数（`src/math_parser_diag.cpp`）将 `units::volume` 与裸整型 `0` 比较：

```cpp
if ( obj.base_volume() <= 0) {
```

`units` 库未提供 `quantity <= int` 的重载，MSVC 下报：

> 二进制“<=”: 没有找到接受“units::volume”类型的左操作数的运算符(或没有可接受的转换)

涉及两处（`item_burnt_eval` 读取与 `item_burnt_ass` 赋值各一处）。

## 改动
两处 `<= 0` 改为 `<= 0_ml`，与 `units::volume` 类型匹配。

## 测试
- 本地 MSVC (Release/x64, SDL3 .sln) 该 TU 编译通过。