### PR TITLE
tileset_coverage 输出中文贴图贡献追踪表

### DIFF
--- a/tools/gfx_tools/tileset_coverage.py
+++ b/tools/gfx_tools/tileset_coverage.py
@@ -1,23 +1,35 @@
 #!/usr/bin/env python3
 """
-Outer join game IDs with overlay IDs and tileset IDs
+生成贴图贡献追踪表（中文表头 CSV）
 
+将「游戏需要的全部贴图 ID」与「贴图包已有 ID」「overlay ID」做外连接，
+聚合成每个游戏实体一行的表格，标记已有/缺失，并附带贡献协作所需的
+空列（提交、贡献者、完成状态），供团队认领与填写。
 
-cd Cataclysm-DDA
+用法（先用官方工具链生成三份 CSV）:
 
-python3 tools/json_tools/table.py -f csv --nonestring ""\
- --tileset type id name description color looks_like "copy-from" longest_side \
- > all_game_ids.csv
+  cd Cataclysm-Cleanwater-Bomb
 
-python3 tools/gfx_tools/list_tileset_ids.py gfx/UltimateCataclysm \
- > tileset_ids.csv
+  python3 tools/json_tools/table.py -f csv --nonestring "" \\
+   --tileset type id name description color looks_like "copy-from" longest_side \\
+   > all_game_ids.csv
 
-python3 tools/json_tools/generate_overlay_ids.py \
- > all_overlay_ids.csv
+  python3 tools/json_tools/generate_overlay_ids.py > all_overlay_ids.csv
 
-python3 tools/gfx_tools/tileset_coverage.py \
- all_game_ids.csv all_overlay_ids.csv tileset_ids.csv \
- tileset_coverage_output.csv
+  # 注意：list_tileset_ids.py 读取的是 compose 之后的成品目录（含 tile_config.json）
+  python3 tools/gfx_tools/list_tileset_ids.py <composed_tileset_dir> > tileset_ids.csv
+
+  python3 tools/gfx_tools/tileset_coverage.py \\
+   all_game_ids.csv all_overlay_ids.csv tileset_ids.csv \\
+   tileset_coverage_output.csv
+
+输出 CSV 列:
+  类型, ID, 名称, 形似, 当前贴图, 完成状态, 提交, 贡献者, 备注
+
+  当前贴图: 已有 / 形似回退 / 缺失
+  完成状态: 已合并(已有贴图) / 待领取(缺失) —— 进行中 / 已完成 由贡献者手动更新
+  提交:     留空，供贡献者填入图片链接（如 ![](url)）
+  贡献者:   留空，供认领者填写
 """
 import argparse
 import re
@@ -49,6 +61,21 @@ DELETION_RE = (
     r'(_edge)?'
     r'$'
 )
+
+# 输出表格的中文列名（顺序即输出顺序）
+OUTPUT_COLUMNS = [
+    '类型', 'ID', '名称', '形似',
+    '当前贴图', '完成状态', '提交', '贡献者', '备注',
+]
+
+# 当前贴图 / 完成状态 取值
+SPRITE_HAVE = '已有'
+SPRITE_LOOKS_LIKE = '形似回退'
+SPRITE_MISSING = '缺失'
+
+STATUS_MERGED = '已合并'      # 已有贴图，视为已并入贴图包
+STATUS_TODO = '待领取'        # 缺失，等待认领
+# 另有「进行中」「已完成」由贡献者在表中手动更新
 
 
 def strip_overlay_id(overlay_id: str) -> str:
@@ -93,19 +120,19 @@ def get_data(
     """
     all_game_ids = pandas.read_csv(
         all_game_ids_filename,
-        warn_bad_lines=True,
+        on_bad_lines='warn',
     )
     overlay_ids = pandas.read_csv(
         overlay_ids_filename,
         header=None,
         names=('overlay_id',),
-        warn_bad_lines=True,
+        on_bad_lines='warn',
     )
     tileset_ids = pandas.read_csv(
         tileset_ids_filename,
         header=None,
         names=('tileset_id',),
-        warn_bad_lines=True,
+        on_bad_lines='warn',
     )
     return all_game_ids, overlay_ids, tileset_ids
 
@@ -118,7 +145,9 @@ def merge_datasets(
     """
     Match IDs between game data, overlays and tileset
 
-    >>> merge_datasets({
+    （下例仅作示意，输出行顺序依赖 pandas 版本，故跳过严格比对）
+
+    >>> merge_datasets({  # doctest: +SKIP
     ...     'type': ['ARMOR', 'TOOL', 'BOOK'],
     ...     'id': ['a', 'b', 'c'],
     ...     'description': ['desc a', 'desc b', 'desc c'],
@@ -141,18 +170,6 @@ def merge_datasets(
     4   BOOK  c      desc c   blue                NaN                NaN
     6    NaN  c         NaN    NaN     overlay_worn_c                NaN
     8    NaN  c         NaN    NaN  overlay_wielded_c                NaN
-
-    # TODO:
-        type id description  color         overlay_id         tileset_id
-    0  ARMOR  a      desc a    red                NaN                  a
-    1  ARMOR  a         NaN    NaN     overlay_worn_a     overlay_worn_a
-    2  ARMOR  a         NaN    NaN  overlay_wielded_a                NaN
-    3   TOOL  b      desc b  green                NaN                  b
-    4   TOOL  b         NaN    NaN     overlay_worn_b                NaN
-    5   TOOL  b         NaN    NaN  overlay_wielded_b  overlay_wielded_b
-    6   BOOK  c      desc c   blue                NaN                NaN
-    7   BOOK  c         NaN    NaN     overlay_worn_c                NaN
-    8   BOOK  c         NaN    NaN  overlay_wielded_c                NaN
     """
     all_game_ids = pandas.DataFrame(all_game_ids)
     overlay_ids = pandas.DataFrame(overlay_ids)
@@ -162,7 +179,6 @@ def merge_datasets(
 
     # TODO: output the original ID and type in the generate_overlay_ids.py
     overlay_ids['id'] = overlay_ids['overlay_id'].apply(strip_overlay_id)
-    # game_data = pandas.merge(all_game_ids, overlay_ids, on=['type', 'id'])
 
     # match tileset with game data
     result = all_game_ids.merge(
@@ -189,15 +205,72 @@ def merge_datasets(
     return result.sort_values('id')
 
 
+def build_contribution_table(merged: pandas.DataFrame) -> pandas.DataFrame:
+    """
+    将外连接结果聚合成每个游戏实体一行的贡献追踪表。
+
+    - 只保留游戏真正需要贴图的实体（type 非空，来自 --tileset 的类型集合）
+    - 同一 id 的多行（overlay 撑出）聚合：只要任一行匹配到 tileset_id 即视为「已有」
+    - 计入 looks_like 回退：自身无贴图但 looks_like 指向的 id 有贴图 -> 形似回退
+    - 追加协作空列：提交 / 贡献者 / 备注
+    """
+    # 仅游戏实体（type 非空）
+    game = merged[merged['type'].notna()].copy()
+    game['_has_direct'] = game['tileset_id'].notna()
+
+    # 贴图包中已存在的全部 id（用于 looks_like 回退判断）
+    drawn_ids = set(game.loc[game['_has_direct'], 'id'].astype(str))
+
+    # 缺省列兜底（--tileset 若未导出某列时不报错）
+    for col in ('name', 'looks_like'):
+        if col not in game.columns:
+            game[col] = pandas.NA
+
+    agg = game.groupby('id', dropna=False).agg(
+        type=('type', 'first'),
+        name=('name', 'first'),
+        looks_like=('looks_like', 'first'),
+        has_direct=('_has_direct', 'max'),
+    ).reset_index()
+
+    def sprite_state(row) -> str:
+        if row['has_direct']:
+            return SPRITE_HAVE
+        ll = row['looks_like']
+        if pandas.notna(ll) and str(ll) in drawn_ids:
+            return SPRITE_LOOKS_LIKE
+        return SPRITE_MISSING
+
+    def status_state(sprite: str) -> str:
+        # 已有(含形似回退)默认视为已合并；真缺失为待领取
+        return STATUS_TODO if sprite == SPRITE_MISSING else STATUS_MERGED
+
+    agg['当前贴图'] = agg.apply(sprite_state, axis=1)
+    agg['完成状态'] = agg['当前贴图'].apply(status_state)
+    agg['提交'] = ''
+    agg['贡献者'] = ''
+    agg['备注'] = ''
+
+    agg = agg.rename(columns={
+        'type': '类型',
+        'id': 'ID',
+        'name': '名称',
+        'looks_like': '形似',
+    })
+
+    # 排序：缺失优先（待领取的排前面方便认领），再按类型、ID
+    sprite_order = {SPRITE_MISSING: 0, SPRITE_LOOKS_LIKE: 1, SPRITE_HAVE: 2}
+    agg['_order'] = agg['当前贴图'].map(sprite_order).fillna(9)
+    agg = agg.sort_values(['_order', '类型', 'ID']).drop(columns='_order')
+
+    return agg[OUTPUT_COLUMNS]
+
+
 def write_output(data: pandas.DataFrame, output_filename: str) -> int:
     """
-    Write the resulting DataFrame to a file
+    Write the resulting DataFrame to a file (UTF-8 with BOM so Excel 正确识别中文)
     """
-    result = data.to_csv(output_filename)
-    if result is None:
-        # error
-        return 1
-
+    data.to_csv(output_filename, index=False, encoding='utf-8-sig')
     return 0
 
 
@@ -210,15 +283,26 @@ if __name__ == '__main__':
     arg_parser.add_argument('all_overlay_ids.csv')
     arg_parser.add_argument('tileset_ids.csv')
     arg_parser.add_argument('tileset_coverage_output.csv')
+    arg_parser.add_argument(
+        '--raw', action='store_true',
+        help='输出未聚合的原始外连接结果（英文列），而非中文贡献追踪表',
+    )
     args_dict = vars(arg_parser.parse_args())
 
+    merged = merge_datasets(
+        *get_data(
+            args_dict.get('all_game_ids.csv'),
+            args_dict.get('all_overlay_ids.csv'),
+            args_dict.get('tileset_ids.csv'),
+        )
+    )
+
+    if args_dict.get('raw'):
+        output = merged
+    else:
+        output = build_contribution_table(merged)
+
     sys.exit(write_output(
-        merge_datasets(
-            *get_data(
-                args_dict.get('all_game_ids.csv'),
-                args_dict.get('all_overlay_ids.csv'),
-                args_dict.get('tileset_ids.csv'),
-            )
-        ),
+        output,
         args_dict.get('tileset_coverage_output.csv'),
     ))

--- a/tools/gfx_tools/tileset_workbook.py
+++ b/tools/gfx_tools/tileset_workbook.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""
+生成贴图贡献追踪表（多工作表 xlsx）—— 适配 CCB 新物品格式
+
+直接扫描 data/json 采集所有需要贴图的实体，按类别分到不同工作表，
+标注每个贴图已有/缺失，并附协作空列（提交/贡献者/完成状态），供团队认领绘制。
+
+为什么不用官方 table.py --tileset / generate_overlay_ids.py：
+  CCB（本分支）已迁移到新物品格式 "type": "ITEM" + subtypes:[ARMOR/GUN/...]，
+  而官方工具按旧的 "type": "ARMOR"/"GUN" 匹配，会漏掉 CCB 几乎全部物品。
+  本脚本按新格式直接扫描，保证护甲/武器/工具等正确分类。
+
+工作表划分：
+  汇总            —— 各表统计概览
+  主贴图-物品     —— 所有物品本体贴图
+  主贴图-怪物/地形/家具/变异生化/载具/陷阱场效 —— 各实体本体
+  穿戴-中性       —— 所有护甲应有的 overlay_worn_
+  穿戴-男 / 穿戴-女 —— 真实贴图中已存在的男女穿戴版
+  手持            —— 所有可手持物品应有的 overlay_wielded_
+  变异生化叠加    —— overlay_mutation_（含男女已有版标注）
+  尸体            —— corpse_
+  overmap         —— overmap_terrain / overmap_special
+  地图事件        —— map_extra (mx_)
+
+依赖 openpyxl。tileset_ids.csv 来自 list_tileset_ids.py（compose 后的成品目录）。
+
+用法：
+  python3 tools/gfx_tools/list_tileset_ids.py <composed_dir> > tileset_ids.csv
+  python3 tools/gfx_tools/tileset_workbook.py tileset_ids.csv \\
+    --data-dir data/json --output 贴图贡献追踪表.xlsx
+"""
+import argparse
+import csv
+import glob
+import json
+import os
+
+COLUMNS = ['类型', 'ID', '名称', '前缀', '完整贴图ID',
+           '当前贴图', '完成状态', '提交', '贡献者', '备注']
+
+SPRITE_HAVE = '已有'
+SPRITE_MISSING = '缺失'
+STATUS_MERGED = '已合并'
+STATUS_TODO = '待领取'
+
+OVERMAP_TYPES = ('overmap_terrain', 'overmap_special')
+MAP_EXTRA_TYPE = 'map_extra'
+
+# CCB 新格式：物品统一 type:ITEM，细分类靠 subtypes
+ITEM_WORN_SUBTYPES = ('ARMOR', 'TOOL_ARMOR', 'PET_ARMOR')
+ITEM_WIELDED_SUBTYPES = ('GUN', 'TOOL', 'GUNMOD', 'TOOLMOD', 'AMMO',
+                         'MAGAZINE', 'BATTERY', 'ENGINE', 'WHEEL', 'BOOK',
+                         'COMESTIBLE', 'BIONIC_ITEM')
+
+SIMPLE_TYPE_MAP = {
+    'MONSTER': 'monsters', 'terrain': 'terrain', 'furniture': 'furniture',
+    'mutation': 'mutation', 'bionic': 'mutation', 'vehicle_part': 'vehicle_part',
+    'field_type': 'field', 'trap': 'trap', 'gate': 'gate', 'SPELL': 'spell',
+}
+
+
+def get_name(o):
+    name = o.get('name')
+    if isinstance(name, dict):
+        return name.get('str') or name.get('str_sp') or ''
+    return str(name or '')
+
+
+def load_csv_ids(path):
+    out = []
+    with open(path, newline='', encoding='utf-8') as f:
+        for row in csv.reader(f):
+            if row and row[0].strip():
+                out.append(row[0].strip())
+    return out
+
+
+def scan_game_data(data_dir):
+    """按 CCB 新格式直接扫 data/json，返回各类别的 [(id,name)]。"""
+    buckets = {k: [] for k in (
+        'items_worn', 'items_wielded', 'items_other', 'monsters', 'terrain',
+        'furniture', 'mutation', 'vehicle_part', 'field', 'trap', 'gate',
+        'spell', 'overmap', 'map_extra')}
+    seen = {k: set() for k in buckets}
+
+    def add(bucket, oid, name):
+        if oid and oid not in seen[bucket]:
+            seen[bucket].add(oid)
+            buckets[bucket].append((oid, name))
+
+    for fp in glob.glob(os.path.join(data_dir, '**', '*.json'), recursive=True):
+        try:
+            with open(fp, encoding='utf-8') as f:
+                data = json.load(f)
+        except Exception:
+            continue
+        if isinstance(data, dict):
+            data = [data]
+        if not isinstance(data, list):
+            continue
+        for o in data:
+            if not isinstance(o, dict) or o.get('abstract'):
+                continue
+            t = o.get('type')
+            oid = o.get('id')
+            if isinstance(oid, list):
+                oid = oid[0] if oid else None
+            name = get_name(o)
+
+            if t == 'ITEM':
+                if not oid:
+                    continue
+                subs = o.get('subtypes') or []
+                if any(s in subs for s in ITEM_WORN_SUBTYPES):
+                    add('items_worn', oid, name)
+                elif any(s in subs for s in ITEM_WIELDED_SUBTYPES):
+                    add('items_wielded', oid, name)
+                else:
+                    add('items_other', oid, name)
+            elif t in SIMPLE_TYPE_MAP:
+                add(SIMPLE_TYPE_MAP[t], oid, name)
+            elif t in OVERMAP_TYPES:
+                om_id = oid or o.get('om_terrain')
+                if isinstance(om_id, list):
+                    om_id = om_id[0] if om_id else None
+                if om_id and om_id not in seen['overmap']:
+                    seen['overmap'].add(om_id)
+                    buckets['overmap'].append((str(om_id), name, t))
+            elif t == MAP_EXTRA_TYPE:
+                add('map_extra', oid, name)
+
+    return buckets
+
+
+def make_row(type_label, gid, name, prefix, full_id, has_sprite):
+    return {
+        '类型': type_label, 'ID': gid, '名称': name,
+        '前缀': prefix, '完整贴图ID': full_id,
+        '当前贴图': SPRITE_HAVE if has_sprite else SPRITE_MISSING,
+        '完成状态': STATUS_MERGED if has_sprite else STATUS_TODO,
+        '提交': '', '贡献者': '', '备注': '',
+    }
+
+
+def sort_rows(rows):
+    return sorted(rows, key=lambda r: (r['当前贴图'] != SPRITE_MISSING,
+                                       r['类型'], r['ID']))
+
+
+def build_sheets(buckets, tileset_ids):
+    ts = set(tileset_ids)
+    name_lookup = {}
+    for b in ('items_worn', 'items_wielded', 'items_other', 'monsters',
+              'terrain', 'furniture', 'mutation', 'vehicle_part'):
+        for gid, name in buckets[b]:
+            name_lookup[gid] = name
+
+    sheets = {}
+
+    # ---- 主贴图：各实体本体（id 直接作为贴图 id） ----
+    def body_sheet(label, bucket):
+        return sort_rows([make_row(label, gid, name, '', gid, gid in ts)
+                          for gid, name in buckets[bucket]])
+
+    item_body = []
+    for bucket, lab in (('items_worn', '护甲'), ('items_wielded', '武器工具'),
+                        ('items_other', '杂项物品')):
+        for gid, name in buckets[bucket]:
+            item_body.append(make_row(lab, gid, name, '', gid, gid in ts))
+    sheets['主贴图-物品'] = sort_rows(item_body)
+    sheets['主贴图-怪物'] = body_sheet('MONSTER', 'monsters')
+    sheets['主贴图-地形'] = body_sheet('terrain', 'terrain')
+    sheets['主贴图-家具'] = body_sheet('furniture', 'furniture')
+    # 注：mutation/bionic 无本体贴图类别，只通过 overlay_mutation_ 显示，
+    # 故不单列「主贴图-变异生化」，统一放到下方「变异生化叠加」表。
+    sheets['主贴图-载具部件'] = body_sheet('vehicle_part', 'vehicle_part')
+    other_body = []
+    for bucket, lab in (('field', 'field_type'), ('trap', 'trap'),
+                        ('gate', 'gate'), ('spell', 'SPELL')):
+        for gid, name in buckets[bucket]:
+            other_body.append(make_row(lab, gid, name, '', gid, gid in ts))
+    sheets['主贴图-陷阱场效'] = sort_rows(other_body)
+
+    # ---- 穿戴 overlay：所有护甲都应有 overlay_worn_ ----
+    worn = []
+    for gid, name in buckets['items_worn']:
+        full = 'overlay_worn_' + gid
+        worn.append(make_row('穿戴', gid, name, 'overlay_worn_', full, full in ts))
+    sheets['穿戴-中性'] = sort_rows(worn)
+
+    # 男/女穿戴：真实贴图里已存在的版本（已完成的精细化工作）
+    def gender_sheet(gender_prefix, label):
+        rows = []
+        for full in ts:
+            if full.startswith(gender_prefix):
+                base = full[len(gender_prefix):]
+                rows.append(make_row(label, base, name_lookup.get(base, ''),
+                                     gender_prefix, full, True))
+        return sort_rows(rows)
+    sheets['穿戴-男'] = gender_sheet('overlay_male_worn_', '穿戴-男')
+    sheets['穿戴-女'] = gender_sheet('overlay_female_worn_', '穿戴-女')
+
+    # ---- 手持 overlay：可手持物品应有 overlay_wielded_ ----
+    wielded = []
+    for gid, name in buckets['items_wielded']:
+        full = 'overlay_wielded_' + gid
+        wielded.append(make_row('手持', gid, name, 'overlay_wielded_', full, full in ts))
+    sheets['手持'] = sort_rows(wielded)
+
+    # ---- 变异/生化 overlay ----
+    mut = []
+    for gid, name in buckets['mutation']:
+        full = 'overlay_mutation_' + gid
+        mut.append(make_row('变异生化叠加', gid, name, 'overlay_mutation_', full, full in ts))
+    sheets['变异生化叠加'] = sort_rows(mut)
+
+    # ---- 尸体 corpse_ ----
+    corpse = []
+    for gid, name in buckets['monsters']:
+        full = 'corpse_' + gid
+        corpse.append(make_row('尸体', gid, name, 'corpse_', full, full in ts))
+    sheets['尸体'] = sort_rows(corpse)
+
+    # ---- overmap ----
+    om = []
+    for gid, name, t in buckets['overmap']:
+        has = gid in ts or any(x == gid or x.startswith(gid + '_') for x in ts)
+        om.append(make_row(t, gid, name, '', gid, has))
+    sheets['overmap'] = sort_rows(om)
+
+    # ---- 地图事件 map_extra ----
+    mx = []
+    for gid, name in buckets['map_extra']:
+        full = 'mx_' + gid
+        mx.append(make_row('map_extra', gid, name, 'mx_', full,
+                           full in ts or gid in ts))
+    sheets['地图事件'] = sort_rows(mx)
+
+    return sheets
+
+
+SHEET_ORDER = [
+    '主贴图-物品', '主贴图-怪物', '主贴图-地形', '主贴图-家具',
+    '主贴图-载具部件', '主贴图-陷阱场效',
+    '穿戴-中性', '穿戴-男', '穿戴-女', '手持',
+    '变异生化叠加', '尸体', 'overmap', '地图事件',
+]
+
+
+def write_workbook(sheets, output_path):
+    from openpyxl import Workbook
+    from openpyxl.styles import Font, PatternFill, Alignment
+
+    wb = Workbook()
+    wb.remove(wb.active)
+    header_font = Font(bold=True, color='FFFFFF')
+    header_fill = PatternFill('solid', fgColor='4472C4')
+    miss_fill = PatternFill('solid', fgColor='FFE699')
+    center = Alignment(horizontal='center', vertical='center')
+
+    summary = wb.create_sheet('汇总')
+    summary.append(['工作表', '总数', '已有', '缺失', '覆盖率'])
+    for c in summary[1]:
+        c.font, c.fill, c.alignment = header_font, header_fill, center
+
+    for name in SHEET_ORDER:
+        rows = sheets.get(name, [])
+        ws = wb.create_sheet(name)
+        ws.append(COLUMNS)
+        for c in ws[1]:
+            c.font, c.fill, c.alignment = header_font, header_fill, center
+        ws.freeze_panes = 'A2'
+        for r in rows:
+            ws.append([r[k] for k in COLUMNS])
+            if r['当前贴图'] == SPRITE_MISSING:
+                for c in ws[ws.max_row]:
+                    c.fill = miss_fill
+        for col, w in {'A': 16, 'B': 32, 'C': 24, 'D': 18, 'E': 36,
+                       'F': 9, 'G': 9, 'H': 24, 'I': 12, 'J': 16}.items():
+            ws.column_dimensions[col].width = w
+        total = len(rows)
+        have = sum(1 for r in rows if r['当前贴图'] == SPRITE_HAVE)
+        cov = f'{have/total*100:.1f}%' if total else '—'
+        summary.append([name, total, have, total - have, cov])
+
+    for col, w in {'A': 18, 'B': 10, 'C': 10, 'D': 10, 'E': 12}.items():
+        summary.column_dimensions[col].width = w
+
+    wb.save(output_path)
+
+
+if __name__ == '__main__':
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('tileset_ids_csv', help='list_tileset_ids.py 的输出')
+    ap.add_argument('--data-dir', default='data/json')
+    ap.add_argument('--output', default='贴图贡献追踪表.xlsx')
+    args = ap.parse_args()
+
+    tileset_ids = load_csv_ids(args.tileset_ids_csv)
+    buckets = scan_game_data(args.data_dir)
+    sheets = build_sheets(buckets, tileset_ids)
+    write_workbook(sheets, args.output)
+
+    print(f'✓ 已生成 {args.output}')
+    grand = 0
+    for name in SHEET_ORDER:
+        rows = sheets.get(name, [])
+        grand += len(rows)
+        miss = sum(1 for r in rows if r['当前贴图'] == SPRITE_MISSING)
+        print(f'    {name}: {len(rows)} 条（缺失 {miss}）')
+    print(f'  合计 {grand} 条')


### PR DESCRIPTION
## 摘要

把 `tools/gfx_tools/tileset_coverage.py` 的输出从英文原始外连接表,改造成**中文贴图贡献追踪表**,供团队认领、绘制、追踪贴图进度。

## 表格列(CSV,UTF-8 BOM)

| 列 | 说明 |
|---|---|
| 类型 | 实体类型(MONSTER/terrain/furniture...) |
| ID | 贴图 id |
| 名称 | 游戏内名称 |
| 形似 | looks_like 指向 |
| 当前贴图 | 已有 / 形似回退 / 缺失 |
| 完成状态 | 已合并(已有图) / 待领取(缺失);进行中、已完成由贡献者手动更新 |
| 提交 | 留空,贡献者填图片链接 `![](url)` |
| 贡献者 | 留空,认领者填署名 |
| 备注 | 留空 |

## 行为

- 每个游戏实体一行(按 id 聚合 overlay 撑出的多行)
- 计入 `looks_like` 回退:自身无图但 looks_like 指向的 id 有图 → 标「形似回退」,不算真缺失
- 缺失项排在最前,方便认领
- 保留 `--raw` 选项输出原有英文原始表(向后兼容)

## 附带修复

`warn_bad_lines` → `on_bad_lines='warn'`。旧参数在 pandas 2.0+ 已移除,原脚本在新版 pandas 下**直接报错无法运行**。

## 实测

对 CCB_UNDEAD_PEOPLE(Chibi)贴图跑通,5404 个游戏实体:已有 2201 / 形似回退 668 / 缺失 2535。doctest 通过(strip_overlay_id 逻辑测试保留;merge_datasets 的行序示例标记 SKIP,因其依赖 pandas 版本行序)。