### PR TITLE
修复 item_burnt_eval 编译错误（非所有路径返回值）

### DIFF
--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -696,19 +696,16 @@ double item_burnt_eval(const_dialogue const &d, char scope, std::vector<diag_val
         throw math::runtime_error(R"(Unknown format type "%s" for item_burnt)", format);
     }
     const item &obj = **it;
-    if ( obj.base_volume() <= 0_ml) {
+    if ( obj.base_volume() <= 0_ml ) {
         return -1;
     }
-    else{
-        if( format == "raw" ) {
-            return static_cast<double>( obj.burnt );
-        }
-        else if( format == "percent" ) {
-            const int vol_units = obj.base_volume() / 250_ml;
-            const int threshold = std::max( vol_units * 3, 1 );
-            return static_cast<double>( obj.burnt ) * 100.0 / static_cast<double>( threshold );
-        }
+    if ( format == "raw" ) {
+        return static_cast<double>( obj.burnt );
     }
+    // format is guaranteed to be "raw" or "percent" (validated above)
+    const int vol_units = obj.base_volume() / 250_ml;
+    const int threshold = std::max( vol_units * 3, 1 );
+    return static_cast<double>( obj.burnt ) * 100.0 / static_cast<double>( threshold );
 }
 
 void item_burnt_ass(double val, dialogue& d, char scope, std::vector<diag_value> const &/*params*/, diag_kwargs const& kwargs)


### PR DESCRIPTION
## 问题

最新 release 构建（run #27194084122，commit 3f7f2905）在 **macOS 和 Linux 全平台编译失败**：

```
src/math_parser_diag.cpp:712:1: error: non-void function does not
return a value in all control paths [-Werror,-Wreturn-type]
```

（Windows/Android 用的编译器对此 warning 不报错，所以侥幸通过，掩盖了问题。）

## 原因

PR #140（`pr/math_item_burnt`）引入的 `item_burnt_eval()`：

```cpp
else {
    if( format == "raw" ) {
        return ...;
    }
    else if( format == "percent" ) {
        return ...;
    }
    // ← else if 之后没有返回，编译器认为存在无返回路径
}
```

虽然函数前面已校验 `format` 只能是 `"raw"` 或 `"percent"`，但编译器无法据此推断 `else if` 一定命中，于是认为存在不返回的控制路径。

## 修复

`format` 既已保证只有两种取值，将 `"percent"` 分支改为**无条件兜底返回**，所有路径都有返回值：

```cpp
if ( format == "raw" ) {
    return static_cast<double>( obj.burnt );
}
// format is guaranteed to be "raw" or "percent" (validated above)
const int vol_units = obj.base_volume() / 250_ml;
...
return ...;
```

行为完全不变，仅消除编译错误。

## 验证

把修复后的控制流单独用 CI 同款 `-Werror -Wreturn-type` 编译通过（无 return-type 报错）。