### PR TITLE
修复 macOS 构建:还原 MAX_ITEM_IN_SQUARE 至 4096

### DIFF
--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -27,8 +27,8 @@ constexpr int EXPLOSION_MULTIPLIER = 7;
 
 constexpr int fov_3d_z_range = 10;
 
-// Change to INT_MAX - 1(because of MULTISALVAGE).
-constexpr int MAX_ITEM_IN_SQUARE = 2147483646;
+// Really just a sanity check for functions not tested beyond this. in theory 4096 works (`InvletInvlet).
+constexpr int MAX_ITEM_IN_SQUARE = 4096;
 // no reason to differ.
 constexpr int MAX_ITEM_IN_VEHICLE_STORAGE = MAX_ITEM_IN_SQUARE;
 // Sanity checks for volume


### PR DESCRIPTION
## 问题

2026-06-09 Experimental Release 的 **macOS Tiles Universal Binary** 构建失败（Linux/Windows/Android 均通过），错误在 `src/game.cpp`：

```
src/game.cpp:6841:9: error: enumerator value 2147483648 is not representable in the underlying type 'int'
src/game.cpp:6925:40: error: comparison of integers of different signs [-Werror,-Wsign-compare]
```

## 根因

PR #144「更改单格物品上限」把 `MAX_ITEM_IN_SQUARE` 从 `4096` 改成 `2147483646`（INT_MAX-1）。`game.cpp` 的 butcher 菜单用了一个匿名枚举：

```cpp
enum : int {
    MULTISALVAGE = MAX_ITEM_IN_SQUARE + 1,  // = INT_MAX
    MULTIBUTCHER,                            // INT_MAX + 1 → 溢出 int ❌
    MULTIDISASSEMBLE_ONE,
    MULTIDISASSEMBLE_ALL,
    NUM_BUTCHER_ACTIONS
};
```

`MULTISALVAGE` 变成 `INT_MAX` 后，下一个枚举值自增即溢出 `int`。macOS clang 的 `-Werror` 将其判为硬错误；Linux GCC 在当前 flag 组合下未拦截，所以只有 macOS 炸。

该 PR 还顺带把 `game_constants.h` 的行尾从 LF 改成了 CRLF，违反仓库 `.gitattributes`（`* text=auto`）。

## 修复

直接从 #144 的父提交还原整个 `game_constants.h`，一步同时修回 `4096` 常量值与 LF 行尾，干净撤销该 PR 对此文件的影响。

- `git diff -w` 确认真实改动仅 `MAX_ITEM_IN_SQUARE` 一行
- 独立验证：`g++ -std=c++17 -Werror` 编译枚举片段，4096 通过 / 2147483646 复现原错
- 本地增量编译 `game.cpp`（GCC）通过

## 备注

物品上限若要大幅提高，需同步调整 `game.cpp` 中基于 `MAX_ITEM_IN_SQUARE` 派生的魔术枚举（改用独立区间或负值），不能简单设为接近 `INT_MAX` 的值。