### PR TITLE
feat(tiles): 生物移动/受击/攻击平滑动画 / smooth creature move, hit and attack animations

### DIFF
--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -755,7 +755,8 @@ void draw_hit_mon_curses( const tripoint_bub_ms &center, const monster &m, const
 } // namespace
 
 #if defined(TILES)
-void game::draw_hit_mon( const tripoint_bub_ms &p, const monster &m, const bool dead )
+void game::draw_hit_mon( const tripoint_bub_ms &p, const monster &m, const bool dead, const int dam,
+                         const Creature *source )
 {
     if( test_mode ) {
         // avoid segfault from null tilecontext in tests
@@ -767,12 +768,23 @@ void game::draw_hit_mon( const tripoint_bub_ms &p, const monster &m, const bool 
         return;
     }
 
-    // Use creature reference to resolve sprite position at draw time
-    tilecontext->init_draw_hit( m );
+    // Use creature reference to resolve sprite position at draw time. A dam of
+    // -1 means the caller didn't supply a damage amount, so use a full reaction.
+    const int max_hp = m.get_hp_max();
+    const float frac = ( dam >= 0 && max_hp > 0 )
+                       ? static_cast<float>( dam ) / max_hp : 1.0f;
+    // Knockback direction: from the attacker toward the victim (victim - source).
+    point dir;
+    if( source ) {
+        const tripoint_rel_ms d = m.pos_abs() - source->pos_abs();
+        dir = point( std::clamp( d.x(), -1, 1 ), std::clamp( d.y(), -1, 1 ) );
+    }
+    tilecontext->init_draw_hit( m, frac, dir, dead );
 }
 
 #else
-void game::draw_hit_mon( const tripoint_bub_ms &p, const monster &m, const bool dead )
+void game::draw_hit_mon( const tripoint_bub_ms &p, const monster &m, const bool dead, const int,
+                         const Creature * )
 {
     draw_hit_mon_curses( p, m, u, dead );
 }
@@ -789,7 +801,8 @@ void draw_hit_player_curses( const game &/* g */, const Character &p, const int 
 } //namespace
 
 #if defined(TILES)
-void game::draw_hit_player( const Character &p, const int dam ) const
+void game::draw_hit_player( const Character &p, const int dam, const float damage_fraction,
+                            const Creature *source ) const
 {
     if( test_mode ) {
     // avoid segfault from null tilecontext in tests
@@ -800,15 +813,37 @@ if( !use_tiles ) {
     draw_hit_player_curses( *this, p, dam );
         return;
     }
+    // Knockback direction: from the attacker toward the victim (victim - source).
+    point dir;
+    if( source ) {
+        const tripoint_rel_ms d = p.pos_abs() - source->pos_abs();
+        dir = point( std::clamp( d.x(), -1, 1 ), std::clamp( d.y(), -1, 1 ) );
+    }
     // Use creature reference to resolve sprite position at draw time
-    tilecontext->init_draw_hit( p );
+    tilecontext->init_draw_hit( p, damage_fraction, dir, false );
     // this creates a blocking delay in user inputs, to give the player time to mentally register the hit
     bullet_animation().progress();
 }
 #else
-void game::draw_hit_player( const Character &p, const int dam ) const
+void game::draw_hit_player( const Character &p, const int dam, const float, const Creature * ) const
 {
     draw_hit_player_curses( *this, p, dam );
+}
+#endif
+
+#if defined(TILES)
+void game::draw_creature_attack( const Creature &attacker, const Creature &target )
+{
+    if( test_mode || !use_tiles || !tilecontext ) {
+        return;
+    }
+    const tripoint_rel_ms d = target.pos_abs() - attacker.pos_abs();
+    const point dir( std::clamp( d.x(), -1, 1 ), std::clamp( d.y(), -1, 1 ) );
+    tilecontext->start_creature_attack_anim( attacker.pos_abs(), dir, attacker.is_avatar() );
+}
+#else
+void game::draw_creature_attack( const Creature &, const Creature & )
+{
 }
 #endif
 

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -402,11 +402,13 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
                          msg_safe_mode );
                 return false;
             }
+            const int hp_before = critter.get_hp();
             you.melee_attack( critter, true );
+            const int dam_dealt = std::max( 0, hp_before - critter.get_hp() );
             if( critter.is_hallucination() ) {
                 critter.die( &m, &you );
             }
-            g->draw_hit_mon( dest_loc, critter, critter.is_dead() );
+            g->draw_hit_mon( dest_loc, critter, critter.is_dead(), dam_dealt, &you );
             return false;
         } else if( critter.has_flag( mon_flag_IMMOBILE ) || critter.has_effect( effect_harnessed ) ||
                    critter.has_effect( effect_ridden ) || critter.has_flag( json_flag_CANNOT_MOVE ) ) {

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -23,6 +23,7 @@
 #include "cached_options.h"
 #include "calendar.h"
 #include "cata_assert.h"
+#include "cata_scope_helpers.h"
 #include "cata_utility.h"
 #include "catacharset.h"
 #include "character.h"
@@ -516,6 +517,10 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
 
     has_animated_tiles_ = false;
 
+    // Advance creature move glides by real elapsed time before drawing so each
+    // sprite's offset reflects the current frame.
+    advance_creature_move_anims();
+
     {
         //set clipping to prevent drawing over stuff we shouldn't
         SDL_Rect clipRect = {dest.x, dest.y, width, height};
@@ -970,6 +975,11 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
     // Multi z-level draw mode
     // Start drawing from the lowest visible z-level (some off-screen tiles
     // are considered visible here to simplify the logic.)
+    // Collect gliding critters during the row loop; they are redrawn on top in a
+    // deferred overlay pass below so terrain painted in later rows can't cover them.
+    m_deferred_glide_critters.clear();
+    m_collecting_glide_critters = !m_creature_anims.empty() || !m_creature_hit_anims.empty() ||
+                                  !m_creature_attack_anims.empty();
     int cur_zlevel = std::max( center.z() - fov_3d_z_range, -OVERMAP_DEPTH );
     bool draw_aborted = false;
     while( cur_zlevel <= center.z() && !draw_aborted ) {
@@ -1346,8 +1356,29 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                 }
             }
         }
+        // --- Per-z-level deferred critter flush ---
+        // A small subset of animating critters defer to here: only those whose
+        // sprite is pushed DOWN/south this frame (see draw_critter_at), because the
+        // southern row that would overdraw them is painted later. Redraw them on top
+        // of this z-level's terrain, but BEFORE the next z-level paints its
+        // fog/shadow overlay (flushing once after the whole z-loop would let a
+        // lower-level animation punch through the inter-z shadow layer). Pure
+        // east/west glides and upward motion are NOT deferred — they draw in place
+        // during the row loop and keep natural painter occlusion (tall terrain and
+        // creatures to the south correctly cover them). All entries collected during
+        // this level's row loop belong to this level, so this drains them.
+        if( m_collecting_glide_critters && !m_deferred_glide_critters.empty() ) {
+            m_collecting_glide_critters = false;
+            for( deferred_glide_critter &c : m_deferred_glide_critters ) {
+                draw_critter_at( c.pos, c.ll, c.height_3d, c.invisible, false );
+            }
+            m_deferred_glide_critters.clear();
+            m_collecting_glide_critters = true;
+        }
         cur_zlevel += 1;
     }
+    m_collecting_glide_critters = false;
+    m_deferred_glide_critters.clear();
 
     // display number of monsters to spawn in mapgen preview
     for( int row = top_any_tile_range.p_min.y; row < top_any_tile_range.p_max.y; row ++ ) {
@@ -1717,13 +1748,251 @@ point cata_tiles::player_to_tile( const point_bub_ms &pos ) const
     }
 }
 
+// Map a 0..1 linear glide progress to the horizontal fraction travelled toward
+// the destination (0 = old tile, 1 = new tile). May leave [0,1] to overshoot.
+static float move_anim_eased( cata_tiles::move_anim_curve curve, float t )
+{
+    t = std::clamp( t, 0.0f, 1.0f );
+    switch( curve ) {
+        case cata_tiles::move_anim_curve::smooth:
+        case cata_tiles::move_anim_curve::parabola:
+            // smoothstep: ease in and out.
+            return t * t * ( 3.0f - 2.0f * t );
+        case cata_tiles::move_anim_curve::leap: {
+            // easeInBack: a subtle backward anticipation, a long hang near the
+            // origin, then a quick rush to the destination. A small overshoot
+            // coefficient keeps the back-step slight (~1% of a tile) and elegant.
+            constexpr float s = 0.6f;
+            return t * t * ( ( s + 1.0f ) * t - s );
+        }
+    }
+    return t;
+}
+
+// Vertical hop fraction (0 = on the ground, 1 = peak height) for the configured
+// curve. Smooth has no hop.
+static float move_anim_hop( cata_tiles::move_anim_curve curve, float t )
+{
+    t = std::clamp( t, 0.0f, 1.0f );
+    switch( curve ) {
+        case cata_tiles::move_anim_curve::smooth:
+            return 0.0f;
+        case cata_tiles::move_anim_curve::parabola:
+            // Symmetric arc, peaking mid-glide.
+            return 4.0f * t * ( 1.0f - t );
+        case cata_tiles::move_anim_curve::leap: {
+            // Physical jump: a fast launch that eases into the apex, a long hang
+            // at the top, then a short gravity-accelerated fall that lands hard.
+            constexpr float rise_end = 0.22f;
+            constexpr float fall_start = 0.78f;
+            if( t < rise_end ) {
+                const float s = t / rise_end;
+                // ease-out: quick launch, velocity settling to zero at the apex.
+                return s * ( 2.0f - s );
+            } else if( t < fall_start ) {
+                return 1.0f;
+            } else {
+                const float s = ( t - fall_start ) / ( 1.0f - fall_start );
+                // gravity: hangs a moment, then accelerates down for a snappy landing.
+                return 1.0f - s * s;
+            }
+        }
+    }
+    return 0.0f;
+}
+
+// "Got hit" bounce height fraction (0 = on the ground, 1 = peak) over 0..1
+// progress: a quick pop up that eases into the apex, then a gravity-accelerated
+// fall that lands hard. Same design language as the leap move curve.
+static float hit_anim_bounce( float t )
+{
+    t = std::clamp( t, 0.0f, 1.0f );
+    constexpr float rise_end = 0.35f;
+    if( t < rise_end ) {
+        const float s = t / rise_end;
+        // ease-out: fast launch settling to zero velocity at the apex.
+        return s * ( 2.0f - s );
+    } else {
+        const float s = ( t - rise_end ) / ( 1.0f - rise_end );
+        // gravity: accelerates downward for a snappy landing.
+        return 1.0f - s * s;
+    }
+}
+
+// Displacement fraction (0 = at rest, 1 = peak offset) for a "lunge out and back"
+// motion over 0..1 progress, shared by the hit knockback and the attack lunge: a
+// fast push out to the peak near the start, then an ease back to rest. Peaks at
+// ~30% progress so the recoil reads as a sharp jab.
+static float lunge_out_and_back( float t )
+{
+    t = std::clamp( t, 0.0f, 1.0f );
+    constexpr float out_end = 0.3f;
+    if( t < out_end ) {
+        const float s = t / out_end;
+        // ease-out push to the peak.
+        return s * ( 2.0f - s );
+    } else {
+        const float s = ( t - out_end ) / ( 1.0f - out_end );
+        // smoothstep ease back to rest.
+        return 1.0f - s * s * ( 3.0f - 2.0f * s );
+    }
+}
+
+void cata_tiles::start_creature_move_anim( const tripoint_abs_ms &from_abs,
+        const tripoint_abs_ms &to_abs, bool is_player )
+{
+    if( !get_option<bool>( "CREATURE_MOVE_ANIM" ) ) {
+        return;
+    }
+    // The avatar's glide is additionally gated on the separate player option.
+    if( is_player && !get_option<bool>( "PLAYER_MOVE_ANIM" ) ) {
+        return;
+    }
+    const tripoint_rel_ms d = from_abs - to_abs;
+    // A no-op "move" to the same tile happens when game::update_map re-sets the
+    // player's position after a real step (to re-express it post map-shift). Must
+    // NOT erase the glide the real move just registered, or the player never
+    // animates. Leave any in-flight animation untouched.
+    if( d.x() == 0 && d.y() == 0 && d.z() == 0 ) {
+        return;
+    }
+    // Snap z-changes and teleports (jumps further than one tile): drop any stale
+    // animation at the destination so the sprite appears instantly.
+    if( d.z() != 0 || std::abs( d.x() ) > 1 || std::abs( d.y() ) > 1 ) {
+        m_creature_anims.erase( to_abs );
+        return;
+    }
+
+    const float total_ms = std::max( 1, get_option<int>( "CREATURE_MOVE_ANIM_TIME" ) );
+
+    creature_move_anim anim;
+    anim.delta_tiles = point( d.x(), d.y() );
+    anim.progress = 0.0f;
+    anim.per_ms = 1.0f / total_ms;
+    const std::string curve_opt = get_option<std::string>( "CREATURE_MOVE_ANIM_CURVE" );
+    if( curve_opt == "parabola" ) {
+        anim.curve = move_anim_curve::parabola;
+    } else if( curve_opt == "leap" ) {
+        anim.curve = move_anim_curve::leap;
+    } else {
+        anim.curve = move_anim_curve::smooth;
+    }
+    // New animation overwrites any prior one for this creature and plays from 0.
+    m_creature_anims[to_abs] = anim;
+}
+
+void cata_tiles::advance_creature_move_anims()
+{
+    if( m_creature_anims.empty() && m_creature_hit_anims.empty() &&
+        m_creature_attack_anims.empty() ) {
+        m_creature_anim_last_ms.reset();
+        return;
+    }
+    const int64_t now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                               std::chrono::steady_clock::now().time_since_epoch() ).count();
+    if( !m_creature_anim_last_ms ) {
+        m_creature_anim_last_ms = now_ms;
+        return;
+    }
+    const int64_t dt_raw = now_ms - *m_creature_anim_last_ms;
+    m_creature_anim_last_ms = now_ms;
+    if( dt_raw <= 0 ) {
+        return;
+    }
+    // Clamp the step. Between registering an animation (progress 0) and the next
+    // draw that actually shows it, an unbounded amount of wall-clock can elapse:
+    // the rest of the turn is processed (monsters act, the map may shift and hit
+    // disk) before control returns to the idle redraw loop. Advancing by that raw
+    // gap would jump a freshly-started glide straight to its end, so the player
+    // sees only the tail of the motion or nothing at all — the "doesn't trigger
+    // reliably" symptom. Capping each step to ~one frame at the floor framerate
+    // (15 FPS -> ~66ms) makes the glide start from near its beginning regardless
+    // of how long the turn took, at the cost of the animation running slightly
+    // longer in real time after a heavy turn (imperceptible, and self-corrects).
+    constexpr int64_t max_step_ms = 1000 / 15;
+    const int64_t dt = std::min( dt_raw, max_step_ms );
+    for( auto it = m_creature_anims.begin(); it != m_creature_anims.end(); ) {
+        it->second.progress += it->second.per_ms * static_cast<float>( dt );
+        if( it->second.progress >= 1.0f ) {
+            it = m_creature_anims.erase( it );
+        } else {
+            ++it;
+        }
+    }
+    for( auto it = m_creature_hit_anims.begin(); it != m_creature_hit_anims.end(); ) {
+        it->second.progress += it->second.per_ms * static_cast<float>( dt );
+        if( it->second.progress >= 1.0f ) {
+            it = m_creature_hit_anims.erase( it );
+        } else {
+            ++it;
+        }
+    }
+    for( auto it = m_creature_attack_anims.begin(); it != m_creature_attack_anims.end(); ) {
+        it->second.progress += it->second.per_ms * static_cast<float>( dt );
+        if( it->second.progress >= 1.0f ) {
+            it = m_creature_attack_anims.erase( it );
+        } else {
+            ++it;
+        }
+    }
+}
+
+void cata_tiles::start_creature_hit_anim( const tripoint_abs_ms &pos_abs, float damage_fraction,
+        const point &dir_tiles, bool is_player )
+{
+    if( !get_option<bool>( "CREATURE_HIT_ANIM" ) ) {
+        return;
+    }
+    if( is_player && !get_option<bool>( "PLAYER_HIT_ANIM" ) ) {
+        return;
+    }
+    const float total_ms = std::max( 1, get_option<int>( "CREATURE_HIT_ANIM_TIME" ) );
+    creature_hit_anim anim;
+    anim.progress = 0.0f;
+    anim.per_ms = 1.0f / total_ms;
+    // Scale reaction magnitude by damage: 0% -> 0.1 tile, 100% -> 0.5 tile.
+    const float frac = std::clamp( damage_fraction, 0.0f, 1.0f );
+    anim.magnitude_tiles = 0.1f + 0.4f * frac;
+    // Use horizontal knockback only when the option asks for it AND we have a
+    // direction; otherwise fall back to the vertical bounce.
+    const bool want_knockback = get_option<std::string>( "CREATURE_HIT_ANIM_CURVE" ) == "knockback";
+    if( want_knockback && ( dir_tiles.x != 0 || dir_tiles.y != 0 ) ) {
+        anim.dir_tiles = dir_tiles;
+    } else {
+        anim.dir_tiles = point::zero;
+    }
+    // Restart from the top if the creature is hit again mid-reaction.
+    m_creature_hit_anims[pos_abs] = anim;
+}
+
+void cata_tiles::start_creature_attack_anim( const tripoint_abs_ms &pos_abs,
+        const point &dir_tiles, bool is_player )
+{
+    if( !get_option<bool>( "CREATURE_ATTACK_ANIM" ) ) {
+        return;
+    }
+    if( is_player && !get_option<bool>( "PLAYER_ATTACK_ANIM" ) ) {
+        return;
+    }
+    if( dir_tiles.x == 0 && dir_tiles.y == 0 ) {
+        return;
+    }
+    const float total_ms = std::max( 1, get_option<int>( "CREATURE_ATTACK_ANIM_TIME" ) );
+    creature_attack_anim anim;
+    anim.progress = 0.0f;
+    anim.per_ms = 1.0f / total_ms;
+    anim.dist_tiles = 0.5f;
+    anim.dir_tiles = dir_tiles;
+    m_creature_attack_anims[pos_abs] = anim;
+}
+
 point cata_tiles::player_to_screen( const point_bub_ms &pos ) const
 {
     const point colrow = player_to_tile( pos );
     if( is_isometric() ) {
         // To ensure the first fully drawn basic tile (col or row = 1, according
         // to the definition in get_window_full_base_tile_range) starts at 0,
-        return op + point{
+        return m_entity_draw_offset + op + point{
             // left = ( col - 1 ) * ( tw / 2.0 ) =>
             divide_round_down( ( colrow.x - 1 ) * tile_width, 2 ),
             // top = ( row - 1 ) * ( tw / 4.0 ) - th + tw / 2.0 =>
@@ -1732,7 +2001,7 @@ point cata_tiles::player_to_screen( const point_bub_ms &pos ) const
             divide_round_down( ( colrow.y + 1 ) * tile_width, 4 ) - tile_height,
         };
     } else {
-        return op + point{ colrow.x * tile_width, colrow.y * tile_height };
+        return m_entity_draw_offset + op + point{ colrow.x * tile_width, colrow.y * tile_height };
     }
 }
 
@@ -3855,6 +4124,84 @@ bool cata_tiles::draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &h
         return false;
     }
 
+    // Apply creature animation offsets (move glide, got-hit reaction, attack lunge)
+    // to this sprite. Guarded so terrain and everything drawn afterward keep a zero
+    // offset. All kinds defer to the post-z-level overlay pass so the offset sprite
+    // sits on top of terrain instead of being overdrawn by rows painted later.
+    restore_on_out_of_scope restore_entity_offset( m_entity_draw_offset );
+    if( !m_creature_anims.empty() || !m_creature_hit_anims.empty() ||
+        !m_creature_attack_anims.empty() ) {
+        const tripoint_abs_ms abs = here.get_abs( p );
+        const auto move_it = m_creature_anims.find( abs );
+        const auto hit_it = m_creature_hit_anims.find( abs );
+        const auto atk_it = m_creature_attack_anims.find( abs );
+        const bool has_move = move_it != m_creature_anims.end();
+        const bool has_hit = hit_it != m_creature_hit_anims.end();
+        const bool has_atk = atk_it != m_creature_attack_anims.end();
+        if( has_move || has_hit || has_atk ) {
+            // Keep the idle redraw heartbeat alive while any animation is active.
+            has_animated_tiles_ = true;
+            // Pixel vector for moving one tile in direction d, in this view's basis
+            // (handles isometric and zoom exactly).
+            const point screen_here = player_to_screen( p.xy() );
+            const auto tile_dir_to_px = [&]( const point & d ) -> point {
+                const point screen_there = player_to_screen( p.xy() + point_rel_ms( d.x, d.y ) );
+                return screen_there - screen_here;
+            };
+            point off( 0, 0 );
+            if( has_move ) {
+                const creature_move_anim &anim = move_it->second;
+                // Remaining fraction of the trip back to the old tile.
+                const float t = move_anim_eased( anim.curve, anim.progress );
+                const float back = 1.0f - t;
+                const point raw_delta = tile_dir_to_px( anim.delta_tiles );
+                off.x += static_cast<int>( raw_delta.x * back );
+                off.y += static_cast<int>( raw_delta.y * back );
+                // Half-tile vertical hop (curve-dependent shape; zero for smooth).
+                const float h = move_anim_hop( anim.curve, anim.progress );
+                if( h != 0.0f ) {
+                    off.y -= static_cast<int>( h * ( tile_height * 0.5f ) );
+                }
+            }
+            if( has_hit ) {
+                const creature_hit_anim &anim = hit_it->second;
+                if( anim.dir_tiles.x != 0 || anim.dir_tiles.y != 0 ) {
+                    // Horizontal knockback: pushed away from the attacker and back.
+                    const float k = lunge_out_and_back( anim.progress ) * anim.magnitude_tiles;
+                    const point dir_px = tile_dir_to_px( anim.dir_tiles );
+                    off.x += static_cast<int>( dir_px.x * k );
+                    off.y += static_cast<int>( dir_px.y * k );
+                } else {
+                    // Vertical pop-and-fall, on top of any glide motion.
+                    const float b = hit_anim_bounce( anim.progress );
+                    off.y -= static_cast<int>( b * ( tile_height * anim.magnitude_tiles ) );
+                }
+            }
+            if( has_atk ) {
+                // Lunge toward the struck target and back.
+                const creature_attack_anim &anim = atk_it->second;
+                const float l = lunge_out_and_back( anim.progress ) * anim.dist_tiles;
+                const point dir_px = tile_dir_to_px( anim.dir_tiles );
+                off.x += static_cast<int>( dir_px.x * l );
+                off.y += static_cast<int>( dir_px.y * l );
+            }
+            // Defer to the post-row overlay pass ONLY when the sprite is pushed DOWN
+            // (off.y > 0), i.e. it visually intrudes into the tile row to the south.
+            // That southern row is painted later, so it would overdraw the intruding
+            // part of this sprite — the "moving up gets covered by the ground"
+            // artifact the deferred pass exists to fix. When the sprite stays put
+            // vertically or moves up/north (off.y <= 0, including pure east/west
+            // glides and upward hops), it only intrudes into already-painted northern
+            // rows, so the normal in-place draw is correct and keeps natural painter
+            // occlusion: tall terrain and creatures south of the mover still cover it.
+            if( m_collecting_glide_critters && off.y > 0 ) {
+                m_deferred_glide_critters.push_back( { p, ll, height_3d, invisible } );
+                return false;
+            }
+            m_entity_draw_offset = off;
+        }
+    }
+
     bool result;
     bool is_player;
     bool sees_player;
@@ -4427,13 +4774,22 @@ void cata_tiles::init_draw_bullets( const std::vector<tripoint_bub_ms> &ps,
     bul_id.insert( bul_id.end(), names.begin(), names.end() );
     bul_rotation.insert( bul_rotation.end(), rotations.begin(), rotations.end() );
 }
-void cata_tiles::init_draw_hit( const Creature &critter )
+void cata_tiles::init_draw_hit( const Creature &critter, float damage_fraction,
+                                const point &dir_tiles, bool dead )
 {
     hit_animation hit;
     hit.timestamp = std::chrono::steady_clock::now();
     hit.creature_ptr = g->shared_from( critter );
     do_draw_hit = true;
     hit_animations.push_front( hit );
+    // Optional "got hit" reaction, sharing the move-animation machinery. Skip it
+    // for a creature that just died: it gets a death animation instead, and a
+    // lingering bounce keyed to this now-empty tile would be wrongly replayed if
+    // another creature (e.g. the player) steps onto the tile within its lifetime.
+    if( !dead ) {
+        start_creature_hit_anim( critter.pos_abs(), damage_fraction, dir_tiles,
+                                 critter.is_avatar() );
+    }
 }
 
 void cata_tiles::init_draw_line( const tripoint_bub_ms &p, std::vector<tripoint_bub_ms> trajectory,

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -771,6 +771,12 @@ class cata_tiles
                               const std::array<bool, 5> &invisible, bool memorize_only );
         bool draw_critter_above( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                                  const std::array<bool, 5> &invisible );
+
+        // Pixel offset to add to the sprite currently being drawn so a creature
+        // appears to glide from its old tile to its new one. Set by
+        // draw_critter_at (guarded so it is restored to zero afterwards) and read
+        // by player_to_screen; zero for terrain/everything else.
+        point m_entity_draw_offset;
         bool draw_zone_mark( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                              const std::array<bool, 5> &invisible, bool memorize_only );
         bool draw_zombie_revival_indicators( const tripoint_bub_ms &pos, lit_level ll, int &height_3d,
@@ -815,11 +821,70 @@ class cata_tiles
         void draw_bullet_frame();
         void void_bullet();
 
-        void init_draw_hit( const Creature &critter );
+        // \p damage_fraction scales the reaction; \p dir_tiles is the knockback
+        // direction (victim - attacker, in tiles; zero if unknown). \p dead skips
+        // the reaction so a freshly-killed creature's bounce can't linger and get
+        // mistakenly triggered when something else later steps onto the tile.
+        void init_draw_hit( const Creature &critter, float damage_fraction = 1.0f,
+                            const point &dir_tiles = point::zero, bool dead = false );
         void draw_hit_frame();
         void void_hit();
         // Prune expired hit animations.  Returns true if any were removed.
         bool expire_hit_animations();
+
+        // --- Creature move animation (opt-in CREATURE_MOVE_ANIM) ---
+        // Interpolation curve for the per-tile glide.
+        enum class move_anim_curve : int {
+            smooth = 0,   // ease-in-out horizontal glide
+            parabola,     // smooth horizontal + symmetric half-tile vertical hop
+            leap,         // backward bob + long hang over origin, then short quick fall
+        };
+        // Register (or restart) a glide for a creature that just moved from
+        // \p from_abs to \p to_abs. New animations overwrite any existing one for
+        // the same creature and play from the start, so they never block the game.
+        // No-op when the option is off, on z-changes, or on jumps further than one
+        // tile (teleports snap instantly). \p is_player gates the avatar's glide on
+        // the separate PLAYER_MOVE_ANIM option.
+        void start_creature_move_anim( const tripoint_abs_ms &from_abs,
+                                       const tripoint_abs_ms &to_abs, bool is_player );
+        // Advance all active glides by real elapsed time and drop finished ones.
+        void advance_creature_move_anims();
+        // True while any creature move glide is in flight. Used by the input loop
+        // to raise its redraw rate so the glide looks smooth instead of stepping.
+        bool has_creature_move_anim() const {
+            return !m_creature_anims.empty();
+        }
+        // Register (or restart) a "got hit" reaction for the creature now standing
+        // at \p pos_abs. No-op when the CREATURE_HIT_ANIM option is off. Shares the
+        // redraw framerate and deferred-overlay path with the move glide.
+        // \p damage_fraction is the hit's damage as a fraction of the creature's max
+        // HP (0..1); it scales the reaction magnitude between a small floor and a
+        // half-tile maximum. \p dir_tiles is the knockback direction (attacker ->
+        // victim, in tiles); when zero, or when the curve option is "bounce", a
+        // vertical pop-and-fall is used instead of a horizontal knockback.
+        // \p is_player gates the avatar's reaction on the separate PLAYER_HIT_ANIM option.
+        void start_creature_hit_anim( const tripoint_abs_ms &pos_abs, float damage_fraction,
+                                      const point &dir_tiles, bool is_player );
+        // True while any hit reaction is in flight.
+        bool has_creature_hit_anim() const {
+            return !m_creature_hit_anims.empty();
+        }
+        // Register (or restart) an attack lunge for the attacker at \p pos_abs that
+        // just struck a target in direction \p dir_tiles (attacker -> target, in
+        // tiles): a quick lunge toward the target and back. No-op when the
+        // CREATURE_ATTACK_ANIM option is off. \p is_player gates the avatar's lunge
+        // on the separate PLAYER_ATTACK_ANIM option.
+        void start_creature_attack_anim( const tripoint_abs_ms &pos_abs,
+                                         const point &dir_tiles, bool is_player );
+        // True while any attack lunge is in flight.
+        bool has_creature_attack_anim() const {
+            return !m_creature_attack_anims.empty();
+        }
+        // True while any creature animation (glide, hit, or attack) is in flight.
+        bool has_creature_anim() const {
+            return has_creature_move_anim() || has_creature_hit_anim() ||
+                   has_creature_attack_anim();
+        }
 
         void draw_footsteps_frame( const tripoint_bub_ms &center );
 
@@ -1014,6 +1079,59 @@ class cata_tiles
         //     its own column, so columns with no creature skip the upward z-scan.
         std::unordered_set<tripoint_bub_ms> m_creature_positions;
         std::unordered_set<point_bub_ms> m_creature_columns;
+
+        // Active per-creature move glides, keyed by the creature's *destination*
+        // absolute position (where it now sits, i.e. where draw_critter_at finds
+        // it). progress runs 0->1: at 0 the sprite is offset back to its old tile,
+        // at 1 it sits on the real (new) tile.
+        struct creature_move_anim {
+            point delta_tiles;         // (old - new) tile delta, converted to pixels at draw time
+            float progress = 0.0f;     // 0..1
+            float per_ms = 0.0f;       // progress increment per millisecond
+            move_anim_curve curve = move_anim_curve::smooth;
+        };
+        std::map<tripoint_abs_ms, creature_move_anim> m_creature_anims;
+        // steady_clock timestamp (ms) of the last advance, for real-time stepping.
+        std::optional<int64_t> m_creature_anim_last_ms;
+
+        // Active per-creature "got hit" reactions, keyed by the creature's absolute
+        // position. Either a vertical pop-and-fall (bounce) or a horizontal
+        // knockback-and-return, sharing the offset injection and deferred-overlay
+        // path with the move glide.
+        struct creature_hit_anim {
+            float progress = 0.0f;     // 0..1
+            float per_ms = 0.0f;       // progress increment per millisecond
+            float magnitude_tiles = 0.5f; // peak displacement in tiles (damage-scaled)
+            // Knockback direction (victim - attacker) in tiles. Zero -> vertical bounce.
+            point dir_tiles;
+        };
+        std::map<tripoint_abs_ms, creature_hit_anim> m_creature_hit_anims;
+
+        // Active per-creature attack lunges, keyed by the attacker's absolute
+        // position: a quick lunge toward the struck target and back.
+        struct creature_attack_anim {
+            float progress = 0.0f;     // 0..1
+            float per_ms = 0.0f;       // progress increment per millisecond
+            float dist_tiles = 0.5f;   // peak lunge distance in tiles
+            point dir_tiles;           // lunge direction (target - attacker) in tiles
+        };
+        std::map<tripoint_abs_ms, creature_attack_anim> m_creature_attack_anims;
+
+        // Gliding critters are drawn in a deferred overlay pass after the whole
+        // z-level row loop, so their offset/parabola sprite sits on top of terrain
+        // instead of being overdrawn by rows painted later (the "moving up gets
+        // blocked by the ground" artifact).
+        struct deferred_glide_critter {
+            tripoint_bub_ms pos;
+            lit_level ll = lit_level::BLANK;
+            int height_3d = 0;
+            std::array<bool, 5> invisible = {};
+        };
+        std::vector<deferred_glide_critter> m_deferred_glide_critters;
+        // True during the main row loop: draw_critter_at records gliding critters
+        // for the deferred pass instead of drawing them in place. False during the
+        // deferred pass itself so they draw normally.
+        bool m_collecting_glide_critters = false;
 
         // Scratch render target for the ortho silhouette mask tint path. Sized
         // to fit the largest batched sprite region; reused across tiles/frames.

--- a/src/character_health.cpp
+++ b/src/character_health.cpp
@@ -2683,7 +2683,9 @@ dealt_damage_instance Character::deal_damage( Creature *source, bodypart_id bp,
 
     // TODO: Pre or post blit hit tile onto "this"'s location here
     if( dam > 0 && get_player_view().sees( here, pos ) ) {
-        g->draw_hit_player( *this, dam );
+        const int bp_max_hp = get_hp_max( bp );
+        const float frac = bp_max_hp > 0 ? static_cast<float>( dam ) / bp_max_hp : 1.0f;
+        g->draw_hit_player( *this, dam, frac, source );
 
         if( is_avatar() && source ) {
             const tripoint_bub_ms source_pos = source->pos_bub( here );

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -74,6 +74,11 @@
 #include "vehicle.h"
 #include "vpart_position.h"
 
+#if defined(TILES)
+#include "sdltiles.h"
+#include "cata_tiles.h"
+#endif
+
 struct mutation_branch;
 
 static const ammo_effect_str_id ammo_effect_APPLY_SAP( "APPLY_SAP" );
@@ -319,7 +324,18 @@ void Creature::set_pos_abs_only( const tripoint_abs_ms &loc )
     location = loc;
 }
 
-void Creature::on_move( const tripoint_abs_ms & ) {}
+void Creature::on_move( const tripoint_abs_ms &old_pos )
+{
+#if defined(TILES)
+    // Register a sprite glide from the old tile to the new one. Cheap and a no-op
+    // when the option is off; non-planar/teleport moves are filtered inside.
+    if( tilecontext ) {
+        tilecontext->start_creature_move_anim( old_pos, pos_abs(), is_avatar() );
+    }
+#else
+    static_cast<void>( old_pos );
+#endif
+}
 
 std::vector<std::string> Creature::get_grammatical_genders() const
 {

--- a/src/game.h
+++ b/src/game.h
@@ -869,8 +869,13 @@ class game
         // sprites (CBN-style), instead of animating a single bullet hopping tile-by-tile.
         void draw_bullet_line( const std::vector<tripoint_bub_ms> &trajectory, char bullet,
                                const std::string &custom_sprite = {} );
-        void draw_hit_mon( const tripoint_bub_ms &p, const monster &m, bool dead = false );
-        void draw_hit_player( const Character &p, int dam ) const;
+        void draw_hit_mon( const tripoint_bub_ms &p, const monster &m, bool dead = false, int dam = -1,
+                           const Creature *source = nullptr );
+        void draw_hit_player( const Character &p, int dam, float damage_fraction = 1.0f,
+                              const Creature *source = nullptr ) const;
+        // Trigger the attacker's optional lunge animation toward \p target. No-op
+        // on curses builds and when the option is off.
+        void draw_creature_attack( const Creature &attacker, const Creature &target );
         void draw_line( const tripoint_bub_ms &p, const tripoint_bub_ms &center_point,
                         const std::vector<tripoint_bub_ms> &points, bool noreveal = false );
         void draw_line( const tripoint_bub_ms &p, const std::vector<tripoint_bub_ms> &points );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -341,8 +341,38 @@ input_context game::get_player_input( std::string &action )
         add_draw_callback( animation_cb );
 
         creature_tracker &creatures = get_creature_tracker();
+        // Discrete step-based animations (weather drops, SCT) advance once per
+        // ~125ms regardless of how fast we redraw, so raising the redraw rate for
+        // a smooth creature glide does not speed them up. Tracks the last step time.
+        std::chrono::steady_clock::time_point last_discrete_step =
+            std::chrono::steady_clock::now();
         do {
-            if( bWeatherEffect && get_option<bool>( "ANIMATION_RAIN" ) ) {
+#if defined(TILES)
+            const bool gliding = tilecontext && tilecontext->has_creature_anim();
+#else
+            const bool gliding = false;
+#endif
+            // While a creature is gliding, redraw at the configured framerate so
+            // the motion looks smooth instead of stepping at 8 FPS.
+            if( gliding ) {
+                const int fps = std::clamp( get_option<int>( "CREATURE_MOVE_ANIM_FPS" ), 15, 144 );
+                ctxt.set_timeout( std::max( 1, 1000 / fps ) );
+            } else {
+                ctxt.set_timeout( 125 );
+            }
+            // Gate the discrete step-based animations to their original cadence.
+            bool do_discrete_step = true;
+            if( gliding ) {
+                const std::chrono::steady_clock::time_point now =
+                    std::chrono::steady_clock::now();
+                if( std::chrono::duration_cast<std::chrono::milliseconds>(
+                        now - last_discrete_step ).count() >= 125 ) {
+                    last_discrete_step = now;
+                } else {
+                    do_discrete_step = false;
+                }
+            }
+            if( do_discrete_step && bWeatherEffect && get_option<bool>( "ANIMATION_RAIN" ) ) {
                 /*
                 Location to add rain drop animation bits! Since it refreshes w_terrain it can be added to the animation section easily
                 Get tile information from above's weather information:
@@ -372,7 +402,8 @@ input_context game::get_player_input( std::string &action )
                 }
             }
             // don't bother calculating SCT if we won't show it
-            if( uquit != QUIT_WATCH && get_option<bool>( "ANIMATION_SCT" ) && !SCT.vSCT.empty() ) {
+            if( do_discrete_step && uquit != QUIT_WATCH && get_option<bool>( "ANIMATION_SCT" ) &&
+                !SCT.vSCT.empty() ) {
                 invalidate_main_ui_adaptor();
 
                 SCT.advanceAllSteps();
@@ -447,6 +478,11 @@ input_context game::get_player_input( std::string &action )
 
             // Animated tiles need periodic redraws to cycle frames
             if( tilecontext->has_animated_tiles() ) {
+                invalidate_main_ui_adaptor();
+            }
+            // A gliding creature must keep redrawing even when its sprite is
+            // currently off-screen (it may scroll back into view mid-glide).
+            if( gliding ) {
                 invalidate_main_ui_adaptor();
             }
 #endif

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -615,6 +615,8 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
 
     melee::melee_stats.attack_count += 1;
     int hit_spread = t.deal_melee_attack( this, hit_roll() );
+    // Optional visual lunge of the attacker toward the target (tiles build only).
+    g->draw_creature_attack( *this, t );
     if( !t.is_avatar() ) {
         // TODO: Per-NPC tracking? Right now monster hit by either npc or player will draw aggro...
         t.add_effect( effect_hit_by_player, 10_minutes ); // Flag as attacked by us for AI

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -2006,9 +2006,11 @@ bool monster::attack_at( const tripoint_bub_ms &p )
         Creature::Attitude attitude = attitude_to( mon );
         // mon_flag_ATTACKMON == hulk behavior, whack everything in your way
         if( attitude == Attitude::HOSTILE || has_flag( mon_flag_ATTACKMON ) ) {
+            const int hp_before = mon.get_hp();
             const bool attacked = melee_attack( mon );
             if( attacked && get_player_view().sees( here, p ) ) {
-                g->draw_hit_mon( p, mon, mon.is_dead() );
+                const int dam_dealt = std::max( 0, hp_before - mon.get_hp() );
+                g->draw_hit_mon( p, mon, mon.is_dead(), dam_dealt, this );
             }
             return attacked;
         }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2194,6 +2194,8 @@ bool monster::melee_attack( Creature &target, float accuracy )
 
     const int monster_hit_roll = melee::melee_hit_range( accuracy );
     int hitspread = target.deal_melee_attack( this, monster_hit_roll );
+    // Optional visual lunge of the attacker toward the target (tiles build only).
+    g->draw_creature_attack( *this, target );
     if( type->melee_dice == 0 ) {
         // We don't hit, so just return
         return true;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2373,6 +2373,93 @@ void options_manager::add_options_graphics()
 
         get_option( "ANIMATION_DELAY" ).setPrerequisite( "ANIMATIONS" );
 
+        add( "CREATURE_MOVE_ANIM", page_id, to_translation( "Creature movement animation" ),
+             to_translation( "If true, creatures (including you) visually glide from tile to tile when they move, instead of snapping instantly." ),
+             false, COPT_CURSES_HIDE
+           );
+
+        get_option( "CREATURE_MOVE_ANIM" ).setPrerequisite( "ANIMATIONS" );
+
+        add( "PLAYER_MOVE_ANIM", page_id, to_translation( "Player movement animation" ),
+             to_translation( "If true, your own movement glide plays.  Turn this off to keep other creatures' movement animation while leaving yourself unanimated." ),
+             true, COPT_CURSES_HIDE
+           );
+
+        get_option( "PLAYER_MOVE_ANIM" ).setPrerequisite( "ANIMATIONS" );
+
+        add( "PLAYER_ATTACK_ANIM", page_id, to_translation( "Player attack animation" ),
+             to_translation( "If true, your own attack lunge plays.  Turn this off to keep other creatures' attack animation while leaving yourself unanimated." ),
+             true, COPT_CURSES_HIDE
+           );
+
+        get_option( "PLAYER_ATTACK_ANIM" ).setPrerequisite( "ANIMATIONS" );
+
+        add( "PLAYER_HIT_ANIM", page_id, to_translation( "Player hit animation" ),
+             to_translation( "If true, your own got-hit reaction plays.  Turn this off to keep other creatures' hit animation while leaving yourself unanimated." ),
+             true, COPT_CURSES_HIDE
+           );
+
+        get_option( "PLAYER_HIT_ANIM" ).setPrerequisite( "ANIMATIONS" );
+
+        add( "CREATURE_MOVE_ANIM_TIME", page_id, to_translation( "Creature movement animation time" ),
+             to_translation( "Time in milliseconds a creature takes to glide across one tile.  Lower is faster." ),
+             50, 2000, 500, COPT_CURSES_HIDE
+           );
+
+        get_option( "CREATURE_MOVE_ANIM_TIME" ).setPrerequisite( "CREATURE_MOVE_ANIM" );
+
+        add( "CREATURE_MOVE_ANIM_CURVE", page_id, to_translation( "Creature movement animation curve" ),
+        to_translation( "Interpolation used for the glide.  Smooth eases in and out; parabola adds a symmetric vertical hop; leap hovers over the origin then drops quickly onto the destination." ), {
+            { "smooth", to_translation( "Smooth" ) },
+            { "parabola", to_translation( "Parabola" ) },
+            { "leap", to_translation( "Leap" ) }
+        }, "parabola", COPT_CURSES_HIDE
+           );
+
+        get_option( "CREATURE_MOVE_ANIM_CURVE" ).setPrerequisite( "CREATURE_MOVE_ANIM" );
+
+        add( "CREATURE_MOVE_ANIM_FPS", page_id, to_translation( "Creature animation framerate" ),
+             to_translation( "Target redraw rate (frames per second) while a creature is gliding, bouncing from a hit, or lunging in an attack.  Higher is smoother but uses more CPU/GPU.  Shared by all creature animations." ),
+             15, 144, 60, COPT_CURSES_HIDE
+           );
+
+        add( "CREATURE_HIT_ANIM", page_id, to_translation( "Creature hit animation" ),
+             to_translation( "If true, a creature (including you) pops up and falls back down when it takes a hit." ),
+             false, COPT_CURSES_HIDE
+           );
+
+        get_option( "CREATURE_HIT_ANIM" ).setPrerequisite( "ANIMATIONS" );
+
+        add( "CREATURE_HIT_ANIM_TIME", page_id, to_translation( "Creature hit animation time" ),
+             to_translation( "Time in milliseconds of the pop-and-fall bounce when a creature is hit.  Lower is faster." ),
+             50, 2000, 300, COPT_CURSES_HIDE
+           );
+
+        get_option( "CREATURE_HIT_ANIM_TIME" ).setPrerequisite( "CREATURE_HIT_ANIM" );
+
+        add( "CREATURE_HIT_ANIM_CURVE", page_id, to_translation( "Creature hit animation style" ),
+        to_translation( "Bounce pops the creature straight up and drops it back down.  Knockback shoves it away from the attacker and back.  Knockback falls back to bounce when the attacker's direction is unknown (traps, fire, etc.)." ), {
+            { "bounce", to_translation( "Bounce" ) },
+            { "knockback", to_translation( "Knockback" ) }
+        }, "bounce", COPT_CURSES_HIDE
+           );
+
+        get_option( "CREATURE_HIT_ANIM_CURVE" ).setPrerequisite( "CREATURE_HIT_ANIM" );
+
+        add( "CREATURE_ATTACK_ANIM", page_id, to_translation( "Creature attack animation" ),
+             to_translation( "If true, a creature (including you) lunges toward its target and back when it makes a melee attack." ),
+             false, COPT_CURSES_HIDE
+           );
+
+        get_option( "CREATURE_ATTACK_ANIM" ).setPrerequisite( "ANIMATIONS" );
+
+        add( "CREATURE_ATTACK_ANIM_TIME", page_id, to_translation( "Creature attack animation time" ),
+             to_translation( "Time in milliseconds of the lunge-and-return when a creature makes a melee attack.  Lower is faster." ),
+             50, 2000, 250, COPT_CURSES_HIDE
+           );
+
+        get_option( "CREATURE_ATTACK_ANIM_TIME" ).setPrerequisite( "CREATURE_ATTACK_ANIM" );
+
         add( "BLINK_SPEED", page_id, to_translation( "Blinking effects speed" ),
              to_translation( "The speed of every blinking effects in ms." ),
              100, 5000, 300


### PR DESCRIPTION
#### 概述 (Summary)

Interface "新增可选的生物移动/受击/攻击平滑动画（仅 tiles，默认关闭）"

#### 改动目的 (Purpose of change)

原版 tiles 后端中，生物移动、受击、攻击都是瞬间换格，没有任何过渡，观感生硬。本 PR 为 SDL tiles 后端加入一套可选的生物动画系统，让移动有滑行、受击有弹跳/击退、攻击有突进，提升战斗与移动的视觉反馈。全部默认关闭，玩家可按需开启，不影响不使用的人。

#### 解决方案描述 (Describe the solution)

三类动画共用同一套机制：

- **偏移注入** — 在 `player_to_screen` 中加入每个精灵的像素偏移 `m_entity_draw_offset`，以 `tripoint_abs_ms` 为键、按真实时间（steady_clock）推进，曲线可配置。绘制单个精灵时用 RAII 临时设置、退出作用域自动恢复，地形与其它精灵不受影响。
- **遮挡正确性** — 仅当精灵被推向南侧（`off.y > 0`、会被后画行覆盖）时才延迟到逐 z 层 overlay 阶段绘制；纯东西移动与向上/向北运动就地绘制，保留高地形（栅栏/墙）与南侧生物的自然画家算法遮挡。
- **帧率与节奏** — 滑行期间按配置帧率重绘以保证流畅；离散步进动画（滚动战斗文字 SCT、天气）仍按 ~125ms 原节奏推进，不被高帧率带快。
- **受击数据** — 受击动画携带伤害比例（决定弹跳幅度）与击退方向（victim − source）；死亡生物不再注册受击动画，避免玩家走到尸体格被误触发。
- **玩家独立开关** — `PLAYER_MOVE_ANIM` / `PLAYER_ATTACK_ANIM` / `PLAYER_HIT_ANIM` 与生物开关分离，玩家可单独控制自身动画。

新增选项（均以 `ANIMATIONS` 为前置项）：`CREATURE_MOVE_ANIM`(+`_TIME`/`_CURVE`/`_FPS`)、`CREATURE_HIT_ANIM`(+`_TIME`/`_CURVE`)、`CREATURE_ATTACK_ANIM`(+`_TIME`)，以及三个玩家开关。Curses 构建下全部为空操作。

#### 你考虑过的替代方案 (Describe alternatives you've considered)

- **延迟绘制范围**：最初让所有动画精灵都延迟到 overlay 阶段绘制，导致南侧高地形和南侧生物的遮挡全部失效（角色画在栅栏前、下方单位消失）。也试过"延迟后重画南侧图层"的事后补丁，但会把南侧单位的地形重画盖回单位身上。最终改为只对真正会被后画行覆盖的精灵（`off.y > 0`）延迟，从根上保留画家算法遮挡。
- **动画进度推进**：曾用原始帧 dt 推进，但回合间隔（怪物行动、地图 shift 读盘）使 wall-clock 不定，一帧就把动画跳到结尾。改为 clamp 每帧 dt 后稳定。

#### 测试 (Testing)

- [ ] 本地 tiles 构建通过
- [ ] 各选项开/关行为符合预期，关闭时无任何动画
- [ ] 移动滑行、近战受击弹跳/击退、攻击突进观感正常
- [ ] 高地形（栅栏/墙）正确遮挡移动中的角色；移动时下方/南侧生物不消失
- [ ] 滚动战斗文字与天气动画节奏不受高帧率影响

#### 补充说明 (Additional context)

仅 SDL tiles 后端，curses 不受影响。后续可在此机制上扩展载具平滑移动动画。