### PR TITLE
fix(tiles): 补充 #153 漏合的受击动画两处修复 / follow-up fixes for hit animation missed in #153

### DIFF
--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -804,13 +804,12 @@ void draw_hit_player_curses( const game &/* g */, const Character &p, const int 
 void game::draw_hit_player( const Character &p, const int dam, const float damage_fraction,
                             const Creature *source ) const
 {
-    if( test_mode ) {
-    // avoid segfault from null tilecontext in tests
-    return;
-}
-
-if( !use_tiles ) {
-    draw_hit_player_curses( *this, p, dam );
+    if( test_mode || !tilecontext ) {
+        // avoid segfault from null tilecontext in tests
+        return;
+    }
+    if( !use_tiles ) {
+        draw_hit_player_curses( *this, p, dam );
         return;
     }
     // Knockback direction: from the attacker toward the victim (victim - source).

--- a/src/character_health.cpp
+++ b/src/character_health.cpp
@@ -2683,8 +2683,11 @@ dealt_damage_instance Character::deal_damage( Creature *source, bodypart_id bp,
 
     // TODO: Pre or post blit hit tile onto "this"'s location here
     if( dam > 0 && get_player_view().sees( here, pos ) ) {
-        const int bp_max_hp = get_hp_max( bp );
-        const float frac = bp_max_hp > 0 ? static_cast<float>( dam ) / bp_max_hp : 1.0f;
+        // Scale the reaction by damage relative to TOTAL max HP, matching the
+        // monster path (draw_hit_mon). Using a single body part's max HP here
+        // would make limb hits over-react and torso hits under-react.
+        const int max_hp = get_hp_max();
+        const float frac = max_hp > 0 ? static_cast<float>( dam ) / max_hp : 1.0f;
         g->draw_hit_player( *this, dam, frac, source );
 
         if( is_avatar() && source ) {


### PR DESCRIPTION
#### 概述 (Summary)

Bugfixes "修复受击动画在 tilecontext 为空时的段错误，并按整体 HP 缩放受击反应"

#### 改动目的 (Purpose of change)

PR #153（生物移动/受击/攻击动画）合并时，合入的是 review 修复之前的提交，导致两处修正没有进入 master。本 PR 把它们补上。

PR #153 (creature move/hit/attack animations) was merged from a commit that predated its review fixes, so two corrections never reached master. This PR restores them.

1. `game::draw_hit_player` 缺少对 `tilecontext` 的判空。当 `use_tiles` 为真但 `tilecontext` 为空时，会在 `tilecontext->init_draw_hit(...)` 处解引用空指针而崩溃。该函数原本仅在 `test_mode` 下提前返回，但同样的空指针风险在非测试场景同样存在。此外该段缩进损坏，可读性差。
2. `Character::deal_damage` 用**单个身体部位**的 max HP 计算受击反应比例，与怪物路径 `draw_hit_mon`（用整体 max HP）不一致，导致肢体受击反应过大、躯干受击反应过小。

#### 解决方案描述 (Describe the solution)

- 把判空条件改为 `if( test_mode || !tilecontext )` 提前返回，并修正该段缩进。
- 把 `get_hp_max( bp )` 改为整体的 `get_hp_max()`，与怪物路径一致。

#### 你考虑过的替代方案 (Describe alternatives you've considered)

段错误修复也可只加一条独立的 `if( !tilecontext ) return;`，但与既有的 `test_mode` 提前返回合并为一个条件更简洁，语义相同。

#### 测试 (Testing)

- [ ] 本地 tiles 构建通过 / local tiles build passes
- [ ] tilecontext 为空场景下受击不再崩溃 / no crash on hit when tilecontext is null
- [ ] 肢体与躯干受击的反应幅度更合理 / limb vs torso hit reaction magnitudes look reasonable

#### 补充说明 (Additional context)

延续已合并的 #153。仅 SDL tiles 受影响，curses 构建不变。

Follow-up to the merged #153. Only the SDL tiles path is affected; curses build unchanged.