### PR TITLE
fix(tiles): 枪线无 0deg 方向贴图时回退原子弹贴图 / fall back to round bullet sprite when 0deg tracer absent

### DIFF
--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -536,16 +536,31 @@ std::string bullet_sprite_id( const char bullet )
 // in the tileset; falls back to the round bullet sprite if absent.
 std::string tracer_sprite_id( const char bullet )
 {
+    std::string directional;
     switch( bullet ) {
         case '*':
-            return "animation_bullet_normal_0deg";
+            directional = "animation_bullet_normal_0deg";
+            break;
         case '#':
-            return "animation_bullet_flame_0deg";
+            directional = "animation_bullet_flame_0deg";
+            break;
         case '`':
-            return "animation_bullet_shrapnel_0deg";
+            directional = "animation_bullet_shrapnel_0deg";
+            break;
         default:
             return bullet_sprite_id( bullet );
     }
+    // Only use the directional streak if the tileset actually provides it
+    // (following looks_like). Otherwise fall back to the round bullet sprite
+    // so the gun line still renders on tilesets without _0deg tracers.
+    if( tilecontext ) {
+        const std::string resolved =
+            tilecontext->find_bullet_sprite_id( directional, TILE_CATEGORY::BULLET );
+        if( !resolved.empty() ) {
+            return resolved;
+        }
+    }
+    return bullet_sprite_id( bullet );
 }
 
 // Map a travel direction to this renderer's rotation index. 0 == sprite's


### PR DESCRIPTION
#### 概述 (Summary)

Bugfixes "为射击枪线的方向曳光贴图补上 fallback：无 `_0deg` 方向贴图时回退圆点 bullet 贴图"

#### 改动目的 (Purpose of change)

`tracer_sprite_id()` 此前无条件返回 `animation_bullet_*_0deg`，但函数注释里承诺的"缺失时回退圆点贴图"从未真正实现。结果是在不含 `_0deg` 方向贴图的图集上，整条枪线无法显示。

`tracer_sprite_id()` previously returned `animation_bullet_*_0deg` unconditionally, while the comment promised a fallback that was never implemented. On tilesets without directional `_0deg` tracers the entire gun line failed to render.

#### 解决方案描述 (Describe the solution)

- `tracer_sprite_id()` 通过既有的 `find_bullet_sprite_id()`（会跟随 `looks_like`）查询 `animation_bullet_*_0deg` 方向贴图是否存在。
- 存在则返回解析后的 id；不存在则回退到圆点 bullet 贴图 `bullet_sprite_id()`。
- 复用 ballistics 里 per-ammo 贴图查找的同一套模式，保持一致。

#### 你考虑过的替代方案 (Describe alternatives you've considered)

也可在 `find_bullet_sprite_id` 非空时直接返回字面 `_0deg` id，但返回解析后的 id 才能正确处理图集仅为 `_0deg` 配置了 `looks_like` 的情况，与 ballistics 路径一致。

#### 测试 (Testing)

- [x] 本地 MSVC tiles 构建通过 / local MSVC tiles build passes
- [x] 运行正常 / runs correctly

#### 补充说明 (Additional context)

仅 SDL tiles 路径受影响，curses 构建不变。

Only the SDL tiles path is affected; curses build unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)