### PR TITLE
Food irradiation can extend overall shelf life, not just the remaining shelf life.

### DIFF
--- a/data/mods/MindOverMatter/powers/photokinesis_eocs.json
+++ b/data/mods/MindOverMatter/powers/photokinesis_eocs.json
@@ -166,7 +166,16 @@
         "true_eocs": [
           {
             "id": "EOC_PHOTOKIN_RADIATION_STERILIZATION_FINALIZE_END",
-            "effect": [ { "npc_unset_flag": "PHOTOKIN_IRRADIATION_READY" }, { "npc_set_flag": "IRRADIATED" } ]
+            "effect": [
+              { "npc_unset_flag": "PHOTOKIN_IRRADIATION_READY" },
+              { "npc_set_flag": "IRRADIATED" },
+              {
+                "if": { "math": [ "n_item_rot() >= 0" ] },
+                "then": [
+                  { "math": [ "n_item_rot() *= 0.25" ] }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -1264,6 +1264,9 @@ void computer_session::action_irradiator()
                     // actual food processing
                     if( !it->rotten() ) {
                         it->set_flag( flag_IRRADIATED );
+                        time_duration rot_val = it->get_rot();
+                        rot_val *= 0.25;
+                        it->set_rot( rot_val );
                     }
                     // critical failure - radiation spike sets off electronic detonators
                     if( it->typeId() == itype_mininuke || it->typeId() == itype_mininuke_act ||


### PR DESCRIPTION
####  (Summary)

[add] Food irradiation will also apply the multiplier to existing rot counters.

####  (Purpose of change)

A long, long time ago, Cataclysm's irradiation process could give food an infinite shelf life.

Obviously, this was unreasonable, so it was balanced. However, when browsing Tieba, I noticed some voices of dissatisfaction; they felt that such a change completely made the irradiation plant location useless, making the rewards of clearing it completely disproportionate to the effort.

Yet another fact is that Cataclysm does not treat the return on investment as its primary design principle; quite the contrary, realism takes precedence. A good design should balance realism and gameplay, which means players shouldn't be frustrated everywhere for the sake of realism, but content completely contradicting reality shouldn't be designed just for gameplay either. If players want stored food with an infinite shelf life... hmm... it seems vacuum-sealed cans already exist.

However, these opinions also prompted me to review the relevant code and literature, and I noticed that the current irradiation process seems to mainly just add an `IRRADIATED` flag to the item. This flag applies a `factor *= 0.25` effect when calculating the accumulation progress of rot val. But if half of the shelf life has already passed, then only the remaining half gets to "enjoy" this bonus.

Although the irradiation process is typically used for newly produced goods, the issue with the current handling method is that it "only slows down speed without reducing pressure." As a single counter, the physical meaning of the `rot` value is almost equivalent to the "microbial load integral." The essence of irradiation is ionizing radiation penetrating food and killing microorganisms, which directly reduces the current microbial load, rather than merely making future bacteria grow slower. Although we have precedents of converting non-microbial degradation, which is inconvenient to simulate, into `rot` at a certain ratio for compensatory simulation, that is not a 1:1 match.

The IAEA technical document "Radiation processing for safe, shelf-stable and ready-to-eat food" confirmed through ready-to-eat meal experiments that after 2 kGy irradiation, the initial microbial load is killed by 1–2 orders of magnitude. During storage, microorganisms regrow from a new low starting point, significantly extending the time required to reach the spoilage threshold. I also saw the source of the `factor *= 0.25` calculation in the comments of `item_degrade.cpp`. This is not a magic number, so this multiplier theoretically does not need to be changed.

On the other hand, if the `rot` counter is treated solely as decay caused by microbial reproduction, the irradiation process should directly reset `rot` to zero... but it's the same issue again; we have more simulation semantics and balance issues. A reasonable approach is to not have the accumulated `rot` completely reset to zero, but instead have it scale by the same factor as the growth multiplier. This serves as a realistic constraint, representing to some extent that chemical deterioration (lipid oxidation, protein denaturation, texture degradation) cannot be reversed by irradiation.

####  (Describe the solution)

Modified the code in `computer_session.cpp` so that during irradiation processing, the `rot val` is set to 0.25 times its current value while adding the `IRRADIATED` flag.

At the same time, modified the EOC for the Gamma Sterilization psychic power under Mind Over Matter's Photokinesis path, keeping it consistent with the irradiation process of the irradiation plant.

####  (Describe alternatives you've considered)

Adjusting the coefficient to `*0` to bring back infinite shelf life? Players might be happy, but realism would probably cry. It is best to remain within the scope of what can be realistic while simultaneously benefiting the players.

####  (Additional context)

[《Radiation processing for safe, shelf-stable and ready-to-eat food》](https://www-pub.iaea.org/MTCD/Publications/PDF/te_1337_web.pdf)