### PR TITLE
fix/borax-box-overflow-152

### DIFF
--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -271,13 +271,15 @@
     "type": "item_group",
     "container-item": "box_small",
     "//": "65 oz",
-    "items": [ { "item": "chem_borax", "count": 532 } ]
+    "items": [ { "item": "chem_borax", "count": 532 } ],
+    "on_overflow": "spill"
   },
   {
     "id": "borax_box_part",
     "type": "item_group",
     "container-item": "box_small",
-    "items": [ { "item": "chem_borax", "count": [ 100, 532 ] } ]
+    "items": [ { "item": "chem_borax", "count": [ 100, 532 ] } ],
+    "on_overflow": "spill"
   },
   {
     "id": "solder_wire_spool",


### PR DESCRIPTION
Fixes #152
Add `on_overflow: spill` to `borax_box` and `borax_box_part`, matching other `box_small` item groups.
## Test plan
- Vanilla mod list, new world load — no borax_box DEBUG popup