### PR TITLE
同步 CDDA 上游 #87508: SDL3 自编译加全后端支持

### DIFF
--- a/.github/actions/setup-sdl3-stack/action.yml
+++ b/.github/actions/setup-sdl3-stack/action.yml
@@ -20,10 +20,11 @@ runs:
         sudo apt-get update
         sudo apt-get install -y libflac-dev libogg-dev libvorbis-dev libmpg123-dev libwavpack-dev \
             libfreetype-dev libharfbuzz-dev libjpeg-dev libpng-dev libwebp-dev libtiff-dev \
-            libpulse-dev pkg-config cmake \
+            libasound2-dev libpulse-dev pkg-config cmake \
             libx11-dev libxext-dev libxcursor-dev libxi-dev libxfixes-dev libxrandr-dev \
-            libxrender-dev libxss-dev libxtst-dev libxkbcommon-dev libwayland-dev \
-            libdecor-0-dev libdrm-dev libgbm-dev libudev-dev libpipewire-0.3-dev \
+            libxrender-dev libxss-dev libxtst-dev libxkbcommon-dev libwayland-dev libwayland-bin \
+            wayland-protocols libdecor-0-dev libdrm-dev libgbm-dev libudev-dev \
+            libegl-dev libgl-dev libgles-dev libvulkan-dev libpipewire-0.3-dev \
             libdbus-1-dev libibus-1.0-dev
 
     - name: Restore SDL3 stack cache
@@ -50,6 +51,33 @@ runs:
         cmake -S sdl3_src -B sdl3_build \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+            -DSDL_DEPS_SHARED=ON \
+            -DSDL_AUDIO=ON \
+            -DSDL_ALSA=ON \
+            -DSDL_ALSA_SHARED=ON \
+            -DSDL_DBUS=ON \
+            -DSDL_GPU=ON \
+            -DSDL_IBUS=ON \
+            -DSDL_KMSDRM=ON \
+            -DSDL_KMSDRM_SHARED=ON \
+            -DSDL_LIBUDEV=ON \
+            -DSDL_OPENGL=ON \
+            -DSDL_OPENGLES=ON \
+            -DSDL_PIPEWIRE=ON \
+            -DSDL_PIPEWIRE_SHARED=ON \
+            -DSDL_PULSEAUDIO=ON \
+            -DSDL_PULSEAUDIO_SHARED=ON \
+            -DSDL_RENDER=ON \
+            -DSDL_RENDER_GPU=ON \
+            -DSDL_RENDER_VULKAN=ON \
+            -DSDL_VIDEO=ON \
+            -DSDL_VULKAN=ON \
+            -DSDL_WAYLAND=ON \
+            -DSDL_WAYLAND_SHARED=ON \
+            -DSDL_WAYLAND_LIBDECOR=ON \
+            -DSDL_WAYLAND_LIBDECOR_SHARED=ON \
+            -DSDL_X11=ON \
+            -DSDL_X11_SHARED=ON \
             -DBUILD_SHARED_LIBS=ON
         cmake --build sdl3_build -j"$(nproc)"
         cmake --install sdl3_build


### PR DESCRIPTION
## 概述

跟进官方平台修复 CDDA #87508(`fix/linux-bundled-sdl3-caps`)。

这是一个**平台级别的官方修复**,解决 Linux 下自编译(bundled)SDL3 因缺少后端支持导致的输入/显示问题(包括 Caps Lock 处理异常)。这类底层问题应当跟随上游。

## 改动

更新 `.github/actions/setup-sdl3-stack/action.yml`,使其与上游一致:

**新增构建依赖**
- `libasound2-dev`(ALSA)、`wayland-protocols`、`libwayland-bin`
- `libegl-dev`、`libgl-dev`、`libgles-dev`、`libvulkan-dev`

**显式开启 SDL3 编译后端开关**
- 音频:ALSA、PulseAudio、PipeWire(均含 shared)
- 显示:Wayland(含 libdecor)、X11、KMSDRM
- 渲染:Vulkan、OpenGL/OpenGL ES、GPU
- 其他:DBus、IBus、libudev

改动后 `action.yml` 与上游 CDDA 完全一致。

## 为何不直接 cherry-pick

上游 #87508 还改动了 `release.yml` 的 SDL3 cache-key(版本号 v1→v2 等),但 CCB 的 SDL3 缓存配置与上游结构不同(CCB 此前未完全迁移上游的 cache-key 方案),直接 cherry-pick 会冲突。因此**仅对齐真正的平台修复部分(action.yml)**,这部分与结构差异无关、可干净应用。

## 验证

- `action.yml` YAML 合法性校验通过。
- 改动后与上游 `action.yml` 逐行一致(diff 为 0)。
- 实际效果需 CI 在 SDL3 构建任务中验证(自编译 SDL3 步骤)。