### PR TITLE
修复 airboat_pilot 莫辛桥夹无法放入腿包

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -2721,7 +2721,7 @@
       "both": {
         "items": [ "beret", "trenchcoat_leather", "longshirt", "pants_leather", "boots_larmor", "gauntlets_larmor", "socks" ],
         "entries": [
-          { "item": "legpouch_large", "contents-group": "mags_rifle_skyfarer" },
+          { "item": "legrig", "contents-group": "mags_rifle_skyfarer" },
           { "item": "762_54R", "charges": 5 },
           { "item": "mosin91_30", "ammo-item": "762_54R", "charges": 5, "contents-item": "shoulder_strap" },
           { "item": "knife_trench", "container-item": "sheath" }


### PR DESCRIPTION
## 问题

启动 airboat_pilot(Airboat Commander)职业时,debug.log 报错:

```
tried to put an item (762R_clip) count (1) in a container (legpouch_large) that cannot contain it:
口袋不可用因为 鞘套内无法装入此类或此种状态的物品
```

## 根因

`airboat_pilot` 职业(`data/json/professions.json`)配置:

```json
{ "item": "legpouch_large", "contents-group": "mags_rifle_skyfarer" }
```

其中 `mags_rifle_skyfarer` 装两个 `762R_clip`(莫辛纳甘 5 发桥夹,配合同职业的 `mosin91_30`)。

但 `legpouch_large` 两个口袋都有 `"flag_restriction": [ "MAG_COMPACT" ]`,而 `762R_clip` 只有 `SPEEDLOADER` flag,没有 `MAG_COMPACT`,因此生成初始装备时桥夹无法放入腿包,触发 `item::put_in` 报错。

该问题由 airship 职业从 CBN 迁移的改动引入。

## 修复

把这一处 `legpouch_large` 换成 `legrig`(drop leg pouch):同样穿在腿上(`leg_l`/`leg_r`、`BELTED`/`OVERSIZE`),但有一个无 flag 限制的 CONTAINER 口袋(30 cm / 2250 ml),可正常装入桥夹。改动一行。

为什么不用其他方案:
- `ammo_pouch` 的口袋是 `ammo_restriction`(只收散弹 `it.is_ammo()`),桥夹是 MAGAZINE 子类型物品,同样会被拒。
- 不给 `762R_clip` 加 `MAG_COMPACT`:全游戏 14 个桥夹/速装器都没有该 flag,加上会破坏全局约定并让桥夹能塞进所有 chestrig/chestpouch。

## 测试

- `professions.json` JSON 解析通过。
- 全职业 pouch/内容物 flag 匹配扫描:修复前 2 处不匹配(airboat_pilot 的两个 `762R_clip`),修复后 0 处。
- 同批迁移的 `aircanoe_pilot` 用 `legpouch_large` + `glock42_mag`(带 `MAG_COMPACT`)本就正常,无需改动。