### PR TITLE
Infrastructure "新增字符串键 enchantment 通道与 enchant_val math 函数 / Add string-keyed enchantment values and the enchant_val math function"

### DIFF
--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -584,6 +584,9 @@ void enchantment::load( const JsonObject &jo, std::string_view,
     load_add_and_multiply_dbl_or_var<skill_id>( jo, "skills", "value", skill_values_add,
             skill_values_multiply );
 
+    load_add_and_multiply_dbl_or_var<std::string>( jo, "custom", "value", custom_values_add,
+            custom_values_multiply );
+
     load_add_and_multiply_dbl_or_var<bodypart_str_id>( jo, "encumbrance_modifier", "part",
             encumbrance_values_add, encumbrance_values_multiply );
 
@@ -655,6 +658,9 @@ void enchant_cache::load( const JsonObject &jo, std::string_view,
 
     load_add_and_multiply<skill_id>( jo, "skills", "value",
                                      skill_values_add, skill_values_multiply );
+
+    load_add_and_multiply<std::string>( jo, "custom", "value",
+                                        custom_values_add, custom_values_multiply );
 
     load_add_and_multiply<bodypart_str_id>( jo, "encumbrance_modifier", "part",
                                             encumbrance_values_add, encumbrance_values_multiply );
@@ -777,6 +783,9 @@ void enchant_cache::serialize( JsonOut &jsout ) const
     save_add_and_multiply<skill_id>( jsout, "skills", "value", skill_values_add,
                                      skill_values_multiply );
 
+    save_add_and_multiply<std::string>( jsout, "custom", "value", custom_values_add,
+                                        custom_values_multiply );
+
     save_add_and_multiply<bodypart_str_id>( jsout, "encumbrance_modifier", "part",
                                             encumbrance_values_add, encumbrance_values_multiply );
 
@@ -861,6 +870,17 @@ void enchant_cache::force_add( const enchant_cache &rhs )
         // values do not multiply against each other, they add.
         // so +10% and -10% will add to 0%
         skill_values_multiply[pair_values.first] += pair_values.second;
+    }
+
+    for( const std::pair<const std::string, double> &pair_values :
+         rhs.custom_values_add ) {
+        custom_values_add[pair_values.first] += pair_values.second;
+    }
+    for( const std::pair<const std::string, double> &pair_values :
+         rhs.custom_values_multiply ) {
+        // values do not multiply against each other, they add.
+        // so +10% and -10% will add to 0%
+        custom_values_multiply[pair_values.first] += pair_values.second;
     }
 
     for( const std::pair<const damage_type_id, double> &pair_values : rhs.damage_values_add ) {
@@ -981,6 +1001,17 @@ void enchant_cache::force_add_with_dialogue( const enchantment &rhs, const const
         // values do not multiply against each other, they add.
         // so +10% and -10% will add to 0%
         skill_values_multiply[pair_values.first] += pair_values.second.evaluate( d );
+    }
+
+    for( const std::pair<const std::string, dbl_or_var> &pair_values :
+         rhs.custom_values_add ) {
+        custom_values_add[pair_values.first] += pair_values.second.evaluate( d );
+    }
+    for( const std::pair<const std::string, dbl_or_var> &pair_values :
+         rhs.custom_values_multiply ) {
+        // values do not multiply against each other, they add.
+        // so +10% and -10% will add to 0%
+        custom_values_multiply[pair_values.first] += pair_values.second.evaluate( d );
     }
 
     for( const std::pair<const bodypart_str_id, dbl_or_var> &pair_values :
@@ -1161,6 +1192,11 @@ double enchant_cache::get_skill_value_add( const skill_id &value ) const
     return get_value<skill_id>( value, skill_values_add );
 }
 
+double enchant_cache::get_custom_value_add( const std::string &value ) const
+{
+    return get_value<std::string>( value, custom_values_add );
+}
+
 int enchant_cache::get_encumbrance_add( const bodypart_str_id &value ) const
 {
     return get_value<bodypart_str_id>( value,
@@ -1190,6 +1226,11 @@ double enchant_cache::get_value_multiply( const enchant_vals::mod value ) const
 double enchant_cache::get_skill_value_multiply( const skill_id &value ) const
 {
     return get_value<skill_id>( value, skill_values_multiply );
+}
+
+double enchant_cache::get_custom_value_multiply( const std::string &value ) const
+{
+    return get_value<std::string>( value, custom_values_multiply );
 }
 
 double enchant_cache::get_encumbrance_multiply( const bodypart_str_id &value ) const
@@ -1270,6 +1311,13 @@ double enchant_cache::modify_value( const skill_id &mod_val, double value ) cons
 {
     value += get_skill_value_add( mod_val );
     value *= 1.0 + get_skill_value_multiply( mod_val );
+    return value;
+}
+
+double enchant_cache::modify_value( const std::string &mod_val, double value ) const
+{
+    value += get_custom_value_add( mod_val );
+    value *= 1.0 + get_custom_value_multiply( mod_val );
     return value;
 }
 
@@ -1488,6 +1536,8 @@ void enchant_cache::clear()
     values_multiply.clear();
     skill_values_add.clear();
     skill_values_multiply.clear();
+    custom_values_add.clear();
+    custom_values_multiply.clear();
     damage_values_add.clear();
     damage_values_multiply.clear();
     armor_values_add.clear();

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -253,6 +253,12 @@ class enchantment
         std::map<skill_id, dbl_or_var> skill_values_add; // NOLINT(cata-serialize)
         std::map<skill_id, dbl_or_var> skill_values_multiply; // NOLINT(cata-serialize)
 
+        // mod-defined string-keyed values. Not interpreted by the engine; read from JSON
+        // math via enchant_val('key'). Lets third-party content add to the same key and
+        // have the engine sum every source automatically (e.g. a custom "qi_max").
+        std::map<std::string, dbl_or_var> custom_values_add; // NOLINT(cata-serialize)
+        std::map<std::string, dbl_or_var> custom_values_multiply; // NOLINT(cata-serialize)
+
         std::map<bodypart_str_id, dbl_or_var> encumbrance_values_add; // NOLINT(cata-serialize)
         std::map<bodypart_str_id, dbl_or_var> encumbrance_values_multiply; // NOLINT(cata-serialize)
 
@@ -310,6 +316,8 @@ class enchant_cache : public enchantment
 
         double modify_value( enchant_vals::mod mod_val, double value ) const;
         double modify_value( const skill_id &mod_val, double value ) const;
+        // applies a mod-defined string-keyed value (add then multiply) to a base value
+        double modify_value( const std::string &mod_val, double value ) const;
         units::energy modify_value( enchant_vals::mod mod_val, units::energy value ) const;
         units::mass modify_value( enchant_vals::mod mod_val, units::mass value ) const;
         units::volume modify_value( enchant_vals::mod mod_val, units::volume value ) const;
@@ -341,11 +349,13 @@ class enchant_cache : public enchantment
         int mult_bonus( enchant_vals::mod value_type, int base_value ) const;
 
         double get_skill_value_add( const skill_id &value ) const;
+        double get_custom_value_add( const std::string &value ) const;
         int get_damage_add( const damage_type_id &value ) const;
         int get_armor_add( const damage_type_id &value ) const;
         int get_encumbrance_add( const bodypart_str_id &value ) const;
         int get_extra_damage_add( const damage_type_id &value ) const;
         double get_skill_value_multiply( const skill_id &value ) const;
+        double get_custom_value_multiply( const std::string &value ) const;
         double get_damage_multiply( const damage_type_id &value ) const;
         double get_armor_multiply( const damage_type_id &value ) const;
         double get_encumbrance_multiply( const bodypart_str_id &value ) const;
@@ -418,6 +428,10 @@ class enchant_cache : public enchantment
         // the exact same as above, though specifically for skills
         std::map<skill_id, double> skill_values_add; // NOLINT(cata-serialize)
         std::map<skill_id, double> skill_values_multiply; // NOLINT(cata-serialize)
+
+        // mod-defined string-keyed values, summed across all sources. See enchantment::custom_values_add.
+        std::map<std::string, double> custom_values_add; // NOLINT(cata-serialize)
+        std::map<std::string, double> custom_values_multiply; // NOLINT(cata-serialize)
 
         std::map<bodypart_str_id, double> encumbrance_values_add; // NOLINT(cata-serialize)
         std::map<bodypart_str_id, double> encumbrance_values_multiply; // NOLINT(cata-serialize)

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -295,7 +295,14 @@ double enchant_val_eval( const_dialogue const &d, char scope,
                          std::vector<diag_value> const &params,
                          diag_kwargs const & /* kwargs */ )
 {
-    return d.const_actor( is_beta( scope ) )->get_enchant_custom_value( params[0].str( d ) );
+    // params[0]: the string key. params[1] (optional): base value the enchantment
+    // add/multiply is applied to (defaults to 0). num_params is -1 (variadic) so the
+    // parser does not enforce arity for us; validate it here.
+    if( params.empty() || params.size() > 2 ) {
+        throw math::runtime_error( R"("enchant_val" takes a key and an optional base value: enchant_val('key'[, base]))" );
+    }
+    double const base = params.size() > 1 ? params[1].dbl( d ) : 0.0;
+    return d.const_actor( is_beta( scope ) )->get_enchant_custom_value( params[0].str( d ), base );
 }
 
 double damage_level_eval( const_dialogue const &d, char scope,
@@ -1959,7 +1966,7 @@ std::map<std::string_view, dialogue_func> const dialogue_funcs{
     { "effect_duration", { "un", 1, effect_duration_eval, {}, { "bodypart", "unit" } } },
     { "limb_score", { "un", 1, limb_score_eval, {}, { "type" } } },
     { "health", { "un", 0, health_eval, health_ass } },
-    { "enchant_val", { "un", 1, enchant_val_eval } },
+    { "enchant_val", { "un", -1, enchant_val_eval } },
     { "encumbrance", { "un", 1, encumbrance_eval } },
     { "energy", { "g", 1, energy_eval } },
     { "event_statistic", { "g", 1, event_statistic_eval } },

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -291,6 +291,13 @@ double artifact_resonance_eval( const_dialogue const &d, char scope,
     return d.const_actor( is_beta( scope ) )->get_artifact_resonance();
 }
 
+double enchant_val_eval( const_dialogue const &d, char scope,
+                         std::vector<diag_value> const &params,
+                         diag_kwargs const & /* kwargs */ )
+{
+    return d.const_actor( is_beta( scope ) )->get_enchant_custom_value( params[0].str( d ) );
+}
+
 double damage_level_eval( const_dialogue const &d, char scope,
                           std::vector<diag_value> const & /* params */,
                           diag_kwargs const & /* kwargs */ )
@@ -1952,6 +1959,7 @@ std::map<std::string_view, dialogue_func> const dialogue_funcs{
     { "effect_duration", { "un", 1, effect_duration_eval, {}, { "bodypart", "unit" } } },
     { "limb_score", { "un", 1, limb_score_eval, {}, { "type" } } },
     { "health", { "un", 0, health_eval, health_ass } },
+    { "enchant_val", { "un", 1, enchant_val_eval } },
     { "encumbrance", { "un", 1, encumbrance_eval } },
     { "energy", { "g", 1, energy_eval } },
     { "event_statistic", { "g", 1, event_statistic_eval } },

--- a/src/talker.h
+++ b/src/talker.h
@@ -160,9 +160,10 @@ class const_talker
         virtual int get_artifact_resonance() const {
             return 0;
         }
-        // mod-defined string-keyed enchantment value, summed across all sources
-        virtual double get_enchant_custom_value( const std::string & ) const {
-            return 0;
+        // mod-defined string-keyed enchantment value, summed across all sources,
+        // applied to the given base value (add then multiply)
+        virtual double get_enchant_custom_value( const std::string &, double base ) const {
+            return base;
         }
         virtual int str_cur() const {
             return 0;

--- a/src/talker.h
+++ b/src/talker.h
@@ -160,6 +160,10 @@ class const_talker
         virtual int get_artifact_resonance() const {
             return 0;
         }
+        // mod-defined string-keyed enchantment value, summed across all sources
+        virtual double get_enchant_custom_value( const std::string & ) const {
+            return 0;
+        }
         virtual int str_cur() const {
             return 0;
         }

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -130,9 +130,10 @@ int talker_character_const::get_artifact_resonance() const
     return me_chr_const->enchantment_cache->get_value_add( enchant_vals::mod::ARTIFACT_RESONANCE );
 }
 
-double talker_character_const::get_enchant_custom_value( const std::string &value ) const
+double talker_character_const::get_enchant_custom_value( const std::string &value,
+        double base ) const
 {
-    return me_chr_const->enchantment_cache->modify_value( value, 0.0 );
+    return me_chr_const->enchantment_cache->modify_value( value, base );
 }
 
 int talker_character_const::str_cur() const

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -130,6 +130,11 @@ int talker_character_const::get_artifact_resonance() const
     return me_chr_const->enchantment_cache->get_value_add( enchant_vals::mod::ARTIFACT_RESONANCE );
 }
 
+double talker_character_const::get_enchant_custom_value( const std::string &value ) const
+{
+    return me_chr_const->enchantment_cache->modify_value( value, 0.0 );
+}
+
 int talker_character_const::str_cur() const
 {
     return me_chr_const->get_str();

--- a/src/talker_character.h
+++ b/src/talker_character.h
@@ -52,7 +52,7 @@ class talker_character_const: virtual public const_talker
 
         // stats, skills, traits, bionics, and magic
         int get_artifact_resonance() const override;
-        double get_enchant_custom_value( const std::string &value ) const override;
+        double get_enchant_custom_value( const std::string &value, double base ) const override;
         int str_cur() const override;
         int dex_cur() const override;
         int int_cur() const override;

--- a/src/talker_character.h
+++ b/src/talker_character.h
@@ -52,6 +52,7 @@ class talker_character_const: virtual public const_talker
 
         // stats, skills, traits, bionics, and magic
         int get_artifact_resonance() const override;
+        double get_enchant_custom_value( const std::string &value ) const override;
         int str_cur() const override;
         int dex_cur() const override;
         int int_cur() const override;


### PR DESCRIPTION
#### 概述 (Summary)

Infrastructure "新增字符串键 enchantment 通道与 enchant_val math 函数 / Add string-keyed enchantment values and the enchant_val math function"

#### 改动目的 (Purpose of change)

原版 enchantment 的数值目标（`enchant_vals::mod`）是一个 C++ 枚举，mod 想新增一个可被多来源叠加的自定义数值属性，只能改引擎枚举——对 mod 作者不可行。jmath 函数虽可由 mod 定义，但**无法叠加多个来源**：第三方想给某个值 +N，只能整个覆写函数，两个 mod 同时覆写就冲突。

enchantment 的核心价值正是引擎自动累加所有来源（特性 / 物品 / 效果 / 义体）。本 PR 把这个能力开放给 mod 定义的、以任意字符串为键的自定义数值。

The vanilla enchantment value targets (`enchant_vals::mod`) are a C++ enum, so a mod cannot add a new stackable custom numeric attribute without editing the engine. A mod-defined jmath function can't stack either—two mods overriding it conflict. This PR opens the engine's "sum across all sources" enchantment behavior to mod-defined, string-keyed values.

#### 解决方案描述 (Describe the solution)

仿照引擎已有的 `skill_values`（已是 string 键 enchantment 的先例）实现：

- `enchantment` 与 `enchant_cache` 各新增 `custom_values_add` / `custom_values_multiply`（`std::map<std::string, ...>`），JSON 键名 `"custom"`，沿用 `"value"` / `"add"` / `"multiply"` 字段（`add`/`multiply` 走 `dbl_or_var`，支持内联 math）。
- 引擎在重算缓存时自动累加所有来源（与 skill_values 完全相同的合并路径）。
- 新增 math 函数 `enchant_val('key'[, base])`，桥接 `enchant_cache::modify_value(string, base)`。可选第二位置参数是基准值，结果为 `(base + Σadd) × (1 + Σmultiply)`；省略时 base 为 0。

由于"可选位置参数"在 math 解析器里不存在（固定 `num_params` 做严格相等校验），该函数注册为变长（`num_params = -1`），并在 eval 内自行校验参数个数为 1 或 2。

这些 map 标记 `// NOLINT(cata-serialize)`，是每次 `recalculate_enchantment_cache()` 重算的运行时缓存、不入存档——与 skill_values 一致，**无存档兼容问题**。

改动文件（6 个，约 91 行纯增量）：
- `src/magic_enchantment.h` / `.cpp` — 数据成员、加载/合并/访问器
- `src/math_parser_diag.cpp` — `enchant_val` 函数与注册
- `src/talker.h` / `talker_character.h` / `.cpp` — talker 桥接

JSON 用法示例：
```jsonc
// 任意 mutation / item / effect 的 enchantments 字段
"enchantments": [
  { "condition": "ALWAYS", "custom": [ { "value": "my_attr", "add": 50 } ] }
]
// math 表达式
"return": "u_enchant_val('my_attr', 100)"   // = (100 + Σadd) × (1 + Σmultiply)
```

#### 你考虑过的替代方案 (Describe alternatives you've considered)

- **扩 `enchant_vals::mod` 枚举**：每加一个属性都要改引擎，mod 无法自助，否决。
- **纯 jmath 覆写**：无法跨来源叠加、多 mod 冲突，否决。
- **kwarg 形式的默认值**（`enchant_val('k', default=100)`）：可行，但第二位置参数 `enchant_val('k', 100)` 更直观；默认值语义统一为"参与 add/multiply 的 base"。

#### 测试 (Testing)

- 全量重新编译（MSVC，Release x64）通过，游戏正常启动运行。
- 一个使用本通道的 total-conversion mod（见配套 mod PR）`--check-mods` 干净通过：`enchant_val` 在 jmath 加载期被解析、未报 unknown function；带可选 base 参数的两参数形式同样解析通过。
- 运行时验证：mutation 携带的 `custom` enchantment 经 `recalculate_enchantment_cache` 正确累加，多来源（两个特性写同一键）叠加生效。

#### 补充说明 (Additional context)

配套有一个 draft mod PR（`immortal_path` 修仙 total conversion）作为本基础设施的首个使用者与端到端验证。本 PR 自身不含任何内容改动，仅引擎能力。