### PR TITLE
fix: macOS SDL2 Universal Binary build broken by bare -isystem

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -581,7 +581,7 @@ jobs:
       - name: Build CDDA (osx, SDL2)
         if: runner.os == 'macOS' && matrix.sdl3 != 1
         run: |
-          make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} SDL3=0 RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=0 PCH=0 USE_HOME_DIR=1 UNIVERSAL_BINARY=1 WARN_STALE_DATA=1 dmgdist
+          make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} FRAMEWORK=1 SDL3=0 RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=0 PCH=0 USE_HOME_DIR=1 UNIVERSAL_BINARY=1 WARN_STALE_DATA=1 dmgdist
           mv Cataclysm.dmg ccb-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.dmg
       - name: Build CDDA (osx, SDL3)
         if: runner.os == 'macOS' && matrix.sdl3 == 1

--- a/Makefile
+++ b/Makefile
@@ -852,12 +852,14 @@ ifeq ($(TILES), 1)
       else # libsdl build
         DEFINES += -DOSX_SDL2_LIBS
         # handle #include "SDL2/SDL.h" and "SDL.h"
-        CXXFLAGS += $(subst -I,-isystem ,$(shell sdl2-config --cflags)) \
+        ifneq (,$(shell which sdl2-config 2>/dev/null))
+          CXXFLAGS += $(subst -I,-isystem ,$(shell sdl2-config --cflags)) \
 		  -isystem $(shell dirname $(shell sdl2-config --cflags | sed 's/-I\(.[^ ]*\) .*/\1/'))
-        LDFLAGS += -framework Cocoa $(shell sdl2-config --libs) -lSDL2_ttf
-        LDFLAGS += -lSDL2_image
-        ifeq ($(SOUND), 1)
-          LDFLAGS += -lSDL2_mixer
+          LDFLAGS += -framework Cocoa $(shell sdl2-config --libs) -lSDL2_ttf
+          LDFLAGS += -lSDL2_image
+          ifeq ($(SOUND), 1)
+            LDFLAGS += -lSDL2_mixer
+          endif
         endif
       endif
     endif


### PR DESCRIPTION
## 问题

macOS Tiles Universal Binary (x64 and arm64) CI 编译报错：isystem -isystem 导致 -Werror

## 原因

Makefile L855 当 sdl2-config 未安装时 dirname 空输出产生裸 -isystem 无参数，和后续 freetype2 路径拼成双重 -isystem，clang 当成 linker input。

## 修复

用 ifneq 判断 sdl2-config 是否存在，仅在存在时才加相关 flags。