### PR TITLE
perf(pixel_minimap): 减少 SDL3 渲染目标切换的 GPU flush / Cut SDL3 render-target-switch GPU flushes

### DIFF
--- a/src/pixel_minimap.cpp
+++ b/src/pixel_minimap.cpp
@@ -260,28 +260,63 @@ void pixel_minimap::clear_unused_cache()
 }
 
 //draws individual updates to the submap cache texture
-void pixel_minimap::flush_cache_updates()
+//returns true if any chunk texture was actually repainted this frame
+bool pixel_minimap::flush_cache_updates()
 {
+    // Each chunk owns a separate texture, so the updates cannot share a single
+    // bind. The old code wrapped every chunk in its own scoped_render_target,
+    // which captured and restored the prior target per chunk -- 2 SetRenderTarget
+    // calls per chunk. On the SDL3 GPU backend each SDL_SetRenderTarget forces a
+    // full GPU command-queue flush (FlushRenderCommands -> GPU_RunCommandQueue),
+    // so that cost was 2N flushes per frame and scaled with the visible chunk
+    // count. Capture the caller's prior target once, switch directly between
+    // chunk textures, and restore once at the end: N+1 switches instead of 2N.
+
+    // Skip entirely when nothing changed so we never touch the render target.
+    bool any_updates = false;
+    for( const auto &mcp : cache ) {
+        if( !mcp.second.update_list.empty() ) {
+            any_updates = true;
+            break;
+        }
+    }
+    if( !any_updates ) {
+        return false;
+    }
+
+    // Recovery already latched: the renderer may be dangling after a LOST
+    // handover, so even SDL_GetRenderTarget is unsafe. Refuse before any SDL
+    // call, mirroring scoped_render_target's pre-switch refusal.
+    if( renderer_boundary_recovery_pending() ) {
+        display_buffer_scope_signal_recovery_required();
+        throw std::runtime_error(
+            "pixel_minimap::flush_cache_updates: renderer boundary recovery pending" );
+    }
+
+#if SDL_MAJOR_VERSION >= 3
+    cata_shader::variant_pass *const vp = get_shared_variant_pass();
+#else
+    cata_shader::variant_pass *const vp = nullptr;
+#endif
+
+    // Capture the prior target once; every chunk shares the same caller target.
+    SDL_Texture *const prior_target = SDL_GetRenderTarget( renderer.get() );
+
     for( auto &mcp : cache ) {
         if( mcp.second.update_list.empty() ) {
             continue;
         }
 
-        scoped_render_target chunk_scope( renderer, mcp.second.chunk_tex.get()
-#if SDL_MAJOR_VERSION >= 3
-                                          , get_shared_variant_pass()
-#endif
-                                        );
-        if( !chunk_scope.is_valid() ) {
-            if( !chunk_scope.boundary_intact() ) {
-                // Boundary lost: latch so the enclosing dtor skips detach.
-                display_buffer_scope_signal_recovery_required();
-            }
-            // Chunk did not paint, so a later render would composite stale data.
-            // Throw to abort the frame, like the tint-mask path.
-            throw std::runtime_error( chunk_scope.boundary_intact()
-                                      ? "pixel_minimap::flush_cache_updates: variant_pass refused boundary"
-                                      : "pixel_minimap::flush_cache_updates: scoped_render_target boundary lost" );
+        const bind_result r = permanent_render_target_bind( renderer, mcp.second.chunk_tex.get(), vp );
+        if( r != bind_result::ok ) {
+            // failed_in_switch already latched recovery and left the renderer
+            // undefined; refused_pre_switch means a null renderer. Either way the
+            // chunk did not paint and re-binding the prior target is unsafe, so
+            // abort the frame like the original scoped path did. (Skip the
+            // restore: another switch on an undefined renderer deepens corruption.)
+            display_buffer_scope_signal_recovery_required();
+            throw std::runtime_error(
+                "pixel_minimap::flush_cache_updates: scoped_render_target boundary lost" );
         }
 
         if( !mcp.second.ready ) {
@@ -315,18 +350,20 @@ void pixel_minimap::flush_cache_updates()
         }
 
         mcp.second.update_list.clear();
-
-        // Restore failure leaves later draws landing on the chunk texture or an
-        // undefined target, so propagate like the other scoped failures.
-        if( !chunk_scope.restore() ) {
-            if( !chunk_scope.boundary_intact() ) {
-                display_buffer_scope_signal_recovery_required();
-            }
-            throw std::runtime_error( chunk_scope.boundary_intact()
-                                      ? "pixel_minimap::flush_cache_updates: variant_pass refused boundary on restore"
-                                      : "pixel_minimap::flush_cache_updates: failed to restore prior render target" );
-        }
     }
+
+    // Restore the caller's prior target once. A failure leaves later draws
+    // landing on a chunk texture or an undefined target, so propagate like the
+    // original per-chunk restore did.
+    const bind_result rr = permanent_render_target_bind( renderer, prior_target, vp );
+    if( rr != bind_result::ok ) {
+        display_buffer_scope_signal_recovery_required();
+        throw std::runtime_error(
+            "pixel_minimap::flush_cache_updates: failed to restore prior render target" );
+    }
+
+    // Reached only when any_updates was true, so at least one chunk repainted.
+    return true;
 }
 
 void pixel_minimap::update_cache_at( const tripoint_bub_sm &sm_pos )
@@ -388,7 +425,7 @@ pixel_minimap::submap_cache &pixel_minimap::get_cache_at( const tripoint_abs_sm 
     return it->second;
 }
 
-void pixel_minimap::process_cache( const tripoint_bub_ms &center )
+bool pixel_minimap::process_cache( const tripoint_bub_ms &center )
 {
     prepare_cache_for_updates( center );
 
@@ -398,8 +435,9 @@ void pixel_minimap::process_cache( const tripoint_bub_ms &center )
         }
     }
 
-    flush_cache_updates();
+    const bool chunks_repainted = flush_cache_updates();
     clear_unused_cache();
+    return chunks_repainted;
 }
 
 void pixel_minimap::set_screen_rect( const SDL_Rect &screen_rect )
@@ -445,6 +483,10 @@ void pixel_minimap::set_screen_rect( const SDL_Rect &screen_rect )
 
     cache.clear();
 
+    // main_tex was just recreated, so any cached skip-state refers to a dead
+    // texture; force a full repaint next render.
+    main_tex_valid_ = false;
+
     const point chunk_size = projector->get_tiles_size( { SEEX, SEEY } );
 
     const auto chunk_texture_generator = [&chunk_size, this]() {
@@ -462,10 +504,42 @@ void pixel_minimap::reset()
     cache.clear();
     main_tex.reset();
     tex_pool.reset();
+    main_tex_valid_ = false;
 }
 
-void pixel_minimap::render( const tripoint_bub_ms &center )
+void pixel_minimap::render( const tripoint_bub_ms &center, const bool chunks_repainted )
 {
+    const tripoint_abs_sm abs_sub = get_map().get_abs_sub();
+
+    // Scan critters every frame: a critter can enter or leave view even when the
+    // camera is still, and this also refreshes has_blinking_beacons_, which the
+    // caller relies on to drive animation regardless of whether we repaint.
+    std::vector<beacon> beacons = collect_critter_beacons( center );
+
+    // main_tex content is fully determined by the camera position, the chunk
+    // textures, and the beacon layer. If none changed since the last paint and
+    // the texture is still valid, reuse it: skip the bind / clear / chunk-copy /
+    // beacon draw, which on the SDL3 GPU backend each force a full command-queue
+    // flush. Just re-composite the existing main_tex to the screen. Position is
+    // compared at tile resolution (center + abs_sub) because a move within one
+    // submap still shifts the rendered image.
+    //
+    // The background color (pixel_minimap_r/g/b/a) and brightness are NOT part
+    // of this check: today they only change via set_settings()/reset() or the
+    // init_ui() first-init path, both of which clear main_tex_valid_. If a
+    // feature is ever added that mutates those global color values at runtime
+    // without going through reset(), it must also invalidate this cache.
+    const bool unchanged = main_tex_valid_ &&
+                           !chunks_repainted &&
+                           abs_sub == last_render_abs_sub &&
+                           center == last_render_center &&
+                           beacons == last_beacons_;
+
+    if( unchanged ) {
+        RenderCopy( renderer, main_tex, &main_tex_clip_rect, &screen_clip_rect );
+        return;
+    }
+
     scoped_render_target main_scope( renderer, main_tex.get()
 #if SDL_MAJOR_VERSION >= 3
                                      , get_shared_variant_pass()
@@ -485,7 +559,9 @@ void pixel_minimap::render( const tripoint_bub_ms &center )
     RenderClear( renderer );
 
     render_cache( center );
-    render_critters( center );
+    for( const beacon &b : beacons ) {
+        draw_beacon( b.rect, b.color );
+    }
 
     // Restore so the compositing RenderCopy below lands on the caller's prior
     // target, not main_tex.
@@ -493,10 +569,21 @@ void pixel_minimap::render( const tripoint_bub_ms &center )
         if( !main_scope.boundary_intact() ) {
             display_buffer_scope_signal_recovery_required();
         }
+        // main_tex was repainted, so its valid bit no longer reflects a clean
+        // restore; clear it so the next frame does not trust a stale skip.
+        main_tex_valid_ = false;
         throw std::runtime_error( main_scope.boundary_intact()
                                   ? "pixel_minimap::render: variant_pass refused boundary on restore"
                                   : "pixel_minimap::render: failed to restore prior render target" );
     }
+
+    // Paint succeeded: record what main_tex now holds so the next frame can
+    // decide whether to skip.
+    main_tex_valid_ = true;
+    last_render_abs_sub = abs_sub;
+    last_render_center = center;
+    last_beacons_ = std::move( beacons );
+
     RenderCopy( renderer, main_tex, &main_tex_clip_rect, &screen_clip_rect );
 }
 
@@ -541,8 +628,10 @@ void pixel_minimap::render_cache( const tripoint_bub_ms &center )
     }
 }
 
-void pixel_minimap::render_critters( const tripoint_bub_ms &center )
+std::vector<pixel_minimap::beacon> pixel_minimap::collect_critter_beacons(
+    const tripoint_bub_ms &center )
 {
+    std::vector<beacon> beacons;
     has_blinking_beacons_ = false;
 
     const map &m = get_map();
@@ -598,9 +687,11 @@ void pixel_minimap::render_critters( const tripoint_bub_ms &center )
             if( indicator_length > 0 ) {
                 has_blinking_beacons_ = true;
             }
-            draw_beacon( critter_rect, critter_color );
+            beacons.push_back( beacon{ critter_rect, critter_color } );
         }
     }
+
+    return beacons;
 }
 
 //the main call for drawing the pixel minimap to the screen
@@ -615,8 +706,8 @@ void pixel_minimap::draw( const SDL_Rect &screen_rect, const tripoint_bub_ms &ce
     }
 
     set_screen_rect( screen_rect );
-    process_cache( center );
-    render( center );
+    const bool chunks_repainted = process_cache( center );
+    render( center, chunks_repainted );
 }
 
 void pixel_minimap::draw_beacon( const SDL_Rect &rect, const SDL_Color &color )

--- a/src/pixel_minimap.h
+++ b/src/pixel_minimap.h
@@ -4,6 +4,7 @@
 
 #include <map>
 #include <memory>
+#include <vector>
 
 #include "coordinates.h"
 #include "point.h"
@@ -56,22 +57,46 @@ class pixel_minimap
     private:
         struct submap_cache;
 
+        // A single critter beacon to paint onto main_tex. Captured each frame so
+        // render() can tell whether the critter layer is identical to last frame
+        // (and thus whether main_tex can be reused without repainting).
+        struct beacon {
+            SDL_Rect rect;
+            SDL_Color color;
+            bool operator==( const beacon &rhs ) const {
+                return rect.x == rhs.rect.x && rect.y == rhs.rect.y &&
+                       rect.w == rhs.rect.w && rect.h == rhs.rect.h &&
+                       color.r == rhs.color.r && color.g == rhs.color.g &&
+                       color.b == rhs.color.b && color.a == rhs.color.a;
+            }
+            bool operator!=( const beacon &rhs ) const {
+                return !( *this == rhs );
+            }
+        };
+
         submap_cache &get_cache_at( const tripoint_abs_sm &abs_sm_pos );
 
         void set_screen_rect( const SDL_Rect &screen_rect );
 
         void draw_beacon( const SDL_Rect &rect, const SDL_Color &color );
 
-        void process_cache( const tripoint_bub_ms &center );
+        // Builds/refreshes the chunk caches for this frame and flushes pending
+        // updates. Transitively returns flush_cache_updates()'s result: true if
+        // any chunk texture was actually repainted.
+        bool process_cache( const tripoint_bub_ms &center );
 
-        void flush_cache_updates();
+        // Returns true if any chunk texture was actually repainted this frame.
+        bool flush_cache_updates();
         void update_cache_at( const tripoint_bub_sm &pos );
         void prepare_cache_for_updates( const tripoint_bub_ms &center );
         void clear_unused_cache();
 
-        void render( const tripoint_bub_ms &center );
+        void render( const tripoint_bub_ms &center, bool chunks_repainted );
         void render_cache( const tripoint_bub_ms &center );
-        void render_critters( const tripoint_bub_ms &center );
+        // Scan visible critters into a beacon list (no rendering). Also refreshes
+        // has_blinking_beacons_. The returned list is compared frame-to-frame to
+        // decide whether main_tex can be reused.
+        std::vector<beacon> collect_critter_beacons( const tripoint_bub_ms &center );
 
         std::unique_ptr<pixel_minimap_projector> create_projector( const SDL_Rect &max_screen_rect ) const;
 
@@ -101,6 +126,19 @@ class pixel_minimap
         std::map<tripoint_abs_sm, submap_cache> cache;
 
         bool has_blinking_beacons_ = false;
+
+        // State of the last main_tex paint, used to skip re-rendering when the
+        // minimap is visually unchanged. main_tex content depends only on the
+        // camera position, the chunk textures, and the critter beacon layer.
+        // The camera position must be compared at tile (ms) resolution, not
+        // submap resolution: chunk placement in render_cache and beacon
+        // positions both shift per tile, so a sub-submap move still changes the
+        // image. main_tex_valid_ is cleared whenever the GPU texture is
+        // dropped/rebuilt (reset(), set_screen_rect()).
+        bool main_tex_valid_ = false;
+        tripoint_abs_sm last_render_abs_sub;
+        tripoint_bub_ms last_render_center;
+        std::vector<beacon> last_beacons_;
 };
 
 #endif // CATA_SRC_PIXEL_MINIMAP_H


### PR DESCRIPTION
#### 概述 (Summary)

Performance "减少像素小地图在 SDL3 GPU 后端下的渲染目标切换开销 / Cut pixel-minimap render-target switching cost on the SDL3 GPU backend"

#### 改动目的 (Purpose of change)

切换到 SDL3 后，游戏渲染性能明显下降。用 Very Sleepy 对比 SDL2(D3D11) 与 SDL3(GPU/D3D12) 两版采集后定位到根因：在 SDL3 GPU 后端，每次 `SDL_SetRenderTarget` 都会强制一次完整的 GPU 命令队列 flush（`FlushRenderCommands` → `GPU_RunCommandQueue` → `D3D12_Submit`/`WaitForFences`），而在 SDL2 的 D3D11 路径下切换渲染目标几乎是免费的。像素小地图的逐 chunk、逐帧目标切换因此成为 SDL3 渲染回归的最大单一来源——`SetRenderTarget`、`FlushRenderCommands`、`GPU_RunCommandQueue` 各约占 busy 时间的 9%。

After switching to SDL3, rendering performance dropped noticeably. Comparing Very Sleepy captures of the SDL2 (D3D11) and SDL3 (GPU/D3D12) builds pinpointed the cause: on the SDL3 GPU backend every `SDL_SetRenderTarget` forces a full GPU command-queue flush (`FlushRenderCommands` → `GPU_RunCommandQueue` → `D3D12_Submit`/`WaitForFences`), whereas on the SDL2 D3D11 path switching targets was nearly free. The pixel minimap's per-chunk and per-frame target switches were the single largest source of the SDL3 render regression — `SetRenderTarget`, `FlushRenderCommands` and `GPU_RunCommandQueue` each ~9% of busy time.

#### 解决方案描述 (Describe the solution)

两处改动，均经采集数据验证 / Two changes, both verified against profiling captures:

1. **`flush_cache_updates()`**：每个 chunk 拥有独立纹理，无法共用一次绑定，但可以只在开头捕获一次调用方的 prior target、在 chunk 之间直接切换、结尾恢复一次——目标切换次数从 **2N 降到 N+1**。原先逐 chunk 的 `scoped_render_target` 的 recovery-latch / 边界中止语义被完整保留。
   Each chunk owns a separate texture so the binds cannot be merged into one, but the caller's prior target is now captured once up front, switched directly between chunk textures, and restored once at the end — **2N → N+1** target switches. The recovery-latch / boundary-abort semantics of the original per-chunk `scoped_render_target` are preserved.

2. **`render()`**：当 main_tex 视觉上无变化时（相机逐格位置相同、本帧没有 chunk 被重绘、beacon 层完全一致），跳过整条 bind/clear/chunk-copy/beacon-draw 路径，直接复用已有纹理重新合成到屏幕。critter 仍每帧扫描（相机静止时也可能有怪进出视野，且 `has_blinking_beacons()` 必须保持准确）。相机位置按**逐格(ms)**而非子地图粒度比较，因此子地图内移动仍会重绘。
   Skip the whole bind/clear/chunk-copy/beacon-draw path when main_tex is visually unchanged (same camera tile position, no chunk repaint this frame, identical beacon layer) and just re-composite the existing texture. Critters are still scanned every frame (one can enter/leave view while the camera is still, and `has_blinking_beacons()` must stay accurate). Camera position is compared at **tile (ms)** resolution, not submap, so sub-submap moves still repaint.

结果（SDL3/D3D12）：`SetRenderTarget` / `FlushRenderCommands` / `GPU_RunCommandQueue` 这条链从约 9% 降到约 6.5% busy 时间，小地图发起的 `SetRenderTarget` 大致腰斩（8.2% → 4.2%）。
Net result (SDL3/D3D12): the `SetRenderTarget` / `FlushRenderCommands` / `GPU_RunCommandQueue` chain dropped from ~9% to ~6.5% of busy time, and minimap-originated `SetRenderTarget` roughly halved (8.2% → 4.2%).

#### 你考虑过的替代方案 (Describe alternatives you've considered)

- **仅做合并（方向二）**：单独的 N+1 合并在采集中只是把开销从 `flush_cache_updates` 搬到其它调用点，全局 flush 链占比没有下降。真正带来净收益的是跳过未变化帧的重绘（方向一），因为它**净减**一次 GPU flush 而非搬运。两者结合后局部与全局收益兼得。
  **Merge only:** the N+1 merge alone merely shifted cost to other call sites in captures; the global flush chain did not drop. The net win comes from skipping unchanged frames, which **removes** a GPU flush rather than relocating it. Combining both yields the local and global gains.
- **继续压榨渲染层**：剩余的 `SetRenderTarget` 大头来自 chunk 纹理确有更新时的必要重绘，进一步优化收益递减；下一步更大的瓶颈已转移到 CPU 侧的地图查询（`map::ter` 等），留作后续 PR。
  **Squeeze rendering further:** the remaining `SetRenderTarget` cost is the unavoidable repaint when chunk textures genuinely change; further rendering-layer work has diminishing returns. The next bottleneck has moved to CPU-side map queries (`map::ter` etc.), left for a follow-up PR.

#### 测试 (Testing)

- 用 Very Sleepy 采集三版对比：优化前、仅合并、合并+跳过。合并+跳过版的 GPU flush 链从约 9% 降到约 6.5% busy，小地图 `SetRenderTarget` 从 8.2% 降到 4.2%。
  Three Very Sleepy captures compared (pre-fix / merge-only / merge+skip). The merge+skip build cut the GPU flush chain from ~9% to ~6.5% busy and minimap `SetRenderTarget` from 8.2% to 4.2%.
- 实机验证小地图功能正确：移动时正常滚动（含同一子地图内逐格移动）、敌人光标随进出视野更新、beacon 闪烁动画正常、切换楼层/缩放/选项后小地图正确重建。
  In-game verification of minimap correctness: scrolls correctly while moving (including sub-submap tile steps), critter beacons update as creatures enter/leave view, blink animation works, and the minimap rebuilds correctly after z-level change / rescale / option changes.
- `pixel_minimap.cpp`、`pixel_minimap.h` 编译通过。
  `pixel_minimap.cpp` and `pixel_minimap.h` compile cleanly.

#### 补充说明 (Additional context)

仅触及 `src/pixel_minimap.cpp` 与 `src/pixel_minimap.h`，无接口/存档/数据格式变更，对 SDL2 构建行为保持不变（改动通过既有的 `permanent_render_target_bind` 与 recovery-latch 路径，在 SDL2 下等价）。
Touches only `src/pixel_minimap.cpp` and `src/pixel_minimap.h`; no interface/save/data-format changes, and SDL2 build behavior is unchanged (the changes go through the existing `permanent_render_target_bind` and recovery-latch paths, which are equivalent under SDL2).
