### PR TITLE
修复 skyfarer 职业弹药袋无法装入弹药

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -484,7 +484,7 @@
     "type": "item_group",
     "subtype": "collection",
     "id": "flintlock_pouch_skyfarer",
-    "entries": [ { "item": "36navy", "charges": 16 } ]
+    "entries": [ { "item": "36paper", "charges": 14 } ]
   },
   {
     "type": "profession_item_substitutions",


### PR DESCRIPTION
## 问题

加载带该职业的世界时,一致性检查报错:

```
item_container.cpp:228 [put_in] tried to put an item (36navy) count (16) in a container (flintlock_pouch) that cannot contain it: 口袋不可用因为 尝试放入过多弹药
```

## 原因

物品组 `flintlock_pouch_skyfarer` 的内容物为 `36navy` x16,但 `flintlock_pouch` 的口袋 `ammo_restriction` 只接受 `flintlock / 36paper / 44paper / blunderbuss`,且上限为 14 发。`36navy` 既不在允许的弹药列表内,数量也超过上限,导致 check_consistency 报错。

## 修改

将弹药袋内容改为 `36paper` x14,与该职业携带的 `colt_navy` 手枪共用弹药,数量贴合口袋上限。