### PR TITLE
Living Paradox can repair charred (but not yet destroyed) items

### DIFF
--- a/data/mods/Xedra_Evolved/eocs/chronomancer_eocs.json
+++ b/data/mods/Xedra_Evolved/eocs/chronomancer_eocs.json
@@ -193,6 +193,16 @@
                     ]
                   }
                 ]
+              },
+              {
+                "if": { "math": [ "n_item_burnt() > 0" ] },
+                "then": [
+                  {
+                    "math": [
+                      " n_item_burnt() -= max( 1, min( n_item_burnt(), xedra_chron_spell_calc( u_spell_level('xedra_chronomancer_reverse_entropy'), 0.1, 1 ) ) ) "
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -291,6 +301,16 @@
                   {
                     "math": [
                       " n_item_rot('format':'raw','unit':'minute') -= min( n_item_rot('format':'raw','unit':'minute'), xedra_chron_spell_calc( u_spell_level('xedra_chronomancer_rewrite_equipment_causality'), 10, 0 ) )"
+                    ]
+                  }
+                ]
+              },
+              {
+                "if": { "math": [ "n_item_burnt() > 0" ] },
+                "then": [
+                  {
+                    "math": [
+                      " n_item_burnt() -= max( 1, min( n_item_burnt(), xedra_chron_spell_calc( u_spell_level('xedra_chronomancer_reverse_entropy'), 10, 0 ) ) ) "
                     ]
                   }
                 ]


### PR DESCRIPTION
####  Summary

[Xedra Evolved] Add effects to the spells `Rewrite Equipment Causality` and `Reverse Entropy` to reduce the charring progress of flammable items. 

#### Purpose of change

Follow-up to PR #93.

After #93 was rolled out, some players approached me. They told me that despite the descriptions of Living Paradox's spells "reversing the second law of thermodynamics" and "modifying item causality," these affected in-game items still had a "damage mechanism" that couldn't be repaired—namely, burn damage caused by fire.

I reviewed the relevant item information and discovered that the `item.burnt` field, just like the previous `item.rot`, was indeed not exposed to the scope that json-only mods could manipulate. Repairing this kind of damage certainly aligns with the kind of overpowered magic described in Living Paradox's lore.

#### Describe the solution

In PR #140, I added `item.burnt` exposure along with the assignment and reading via `u/n_item_burnt()` for EOC math operations. Thanks to the help, validation, and fixes from various developers, the functionality has now been confirmed to be stable.

Using the same operation as PR #93, when the `{ "math": [ "n_item_burnt() > 0" ] }` validation passes, the `n_item_burnt()` math operation is used to reduce `item.burnt`. The data balance is also kept consistent with the original basic durability repair magnitude.

#### Describe alternatives you've considered

None