### PR TITLE
修复 skyfarer 职业 colt_navy 无法放入枪套

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -2754,7 +2754,7 @@
         "items": [ "cowboy_hat", "bandana", "duster_leather", "longshirt", "pants", "socks", "boots_western", "gloves_fingerless" ],
         "entries": [
           { "item": "flintlock_pouch", "contents-group": "flintlock_pouch_skyfarer" },
-          { "item": "colt_navy", "ammo-item": "36navy", "charges": 6, "container-item": "holster" },
+          { "item": "colt_navy", "ammo-item": "36paper", "charges": 6, "container-item": "western_holster" },
           { "item": "hatchet", "container-item": "axe_ring" }
         ]
       },


### PR DESCRIPTION
## 问题

加载带该职业的世界时,一致性检查报错:

```
item_container.cpp:228 [put_in] tried to put an item (colt_navy) count (1) in a container (holster) that cannot contain it: 口袋不可用因为 物品太长
```

## 原因

`colt_navy` 长 351mm,而普通 `holster` 的 `max_item_length` 仅 300mm,装不下该枪。此外 `ammo-item` 误写为 `36navy`,而 `colt_navy` 实际使用的弹药是 `36paper`。

## 修改

- 容器改为 `western_holster`(`max_item_length` 38cm,可容纳 colt_navy,且更贴合 skyfarer 牛仔造型)。
- 弹药修正为 `36paper`。