### PR TITLE
release: 校验 SDL3 着色器产物完整性,避免发布缺失 .dxil 的损坏包

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
       id: sdl
       uses: libsdl-org/setup-sdl@4ebea449684c989388fe6bcea0460e300d13a5ae # main
       with:
-        version: 3.4.4
+        version: 3.4.10
         cmake-generator: Ninja
         install-linux-dependencies: true
 
@@ -306,6 +306,36 @@ jobs:
         with:
           name: cdda-shaders
           path: data/shaders
+      - name: Verify shader artifacts are complete (SDL3)
+        if: matrix.sdl3 == 1
+        shell: bash
+        run: |
+          # compile-shaders is continue-on-error so a broken shader toolchain
+          # never blocks non-SDL3 releases. But that means a partial/empty
+          # artifact can slip through silently and ship a build that crashes
+          # at runtime with "failed to read shader artifact". Fail the SDL3
+          # build here instead: every .frag/.vert source must have a matching
+          # .spv/.dxil/.msl produced by build_shaders.py.
+          missing=0
+          shopt -s nullglob
+          sources=( data/shaders/*.frag data/shaders/*.vert )
+          if [ ${#sources[@]} -eq 0 ]; then
+            echo "::error::no shader sources found under data/shaders"
+            exit 1
+          fi
+          for src in "${sources[@]}"; do
+            for fmt in spv dxil msl; do
+              if [ ! -s "${src}.${fmt}" ]; then
+                echo "::error::missing or empty shader artifact: ${src}.${fmt}"
+                missing=1
+              fi
+            done
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo "::error::shader artifacts incomplete; the compile-shaders job likely failed silently. Refusing to ship a broken SDL3 build."
+            exit 1
+          fi
+          echo "All shader artifacts present for ${#sources[@]} source(s)."
       - name: Mark shader artifacts fresh (SDL3)
         if: matrix.sdl3 == 1
         shell: bash


### PR DESCRIPTION
## 问题

SDL3 + D3D 后端运行时报错、灰度滤镜失效:

```
ERROR : cata_shader: failed to read shader artifact at data/shaders/grayscale.frag.dxil
```

## 原因

这是 release CI 的脆弱性,不是代码或 JSON 问题:

1. `compile-shaders` job 负责把 `data/shaders/*.frag` 编译成 `.spv/.dxil/.msl` 并上传为 `cdda-shaders` artifact。
2. 该 job 标记了 `continue-on-error: true`(本意是不让实验性的着色器工具链阻塞非 SDL3 的 release)。
3. Windows/SDL3 构建自身不编译着色器,完全依赖 `download-artifact` 拉取该 artifact,且**下载后不做任何校验**,`windist.ps1` 直接整包打包。

组合后果:当 `compile-shaders` 部分失败(例如某个 `.dxil` 翻译失败)时,会静默产出**残缺**的 artifact,坏包照常发布,玩家运行时才发现缺少 `grayscale.frag.dxil`。只影响灰度效果,不会崩游戏,但属于损坏的发行包。

## 修改

- **新增完整性校验**:SDL3 构建在 `download-artifact` 之后增加一步检查——每个 `.frag/.vert` 源都必须有对应且非空的 `.spv/.dxil/.msl`,缺失则让该 SDL3 构建失败,从而阻止发布残缺包。非 SDL3 构建不受影响,`continue-on-error` 的初衷得以保留。
- **统一 SDL 版本**:`compile-shaders` 的 `setup-sdl` 从 `3.4.4` 升级到 `3.4.10`,与 `build-sdl3-shaders` action 对齐,消除版本偏移这一潜在诱因。

## 说明

本 PR 仅加固 release 流程、不改动游戏代码或数据。根因(某次 `.dxil` 为何翻译失败)需在下次 release 运行时观察校验步骤的输出进一步定位;在此之前,校验可确保不再发出损坏包。