### PR TITLE
平衡性:提升枪械整体精度与瞄准手感

### DIFF
--- a/data/core/external_options.json
+++ b/data/core/external_options.json
@@ -4,14 +4,14 @@
     "name": "DISPERSION_PER_GUN_DAMAGE",
     "//": "Value that adds to weapon dispersion per weapon damage value.",
     "stype": "int",
-    "value": 30
+    "value": 20
   },
   {
     "type": "EXTERNAL_OPTION",
     "name": "GUN_DISPERSION_DIVIDER",
     "//": "Value that divides total weapon dispersion.  15 means that weapons became 15 times more accurate than default.",
     "stype": "float",
-    "value": 18
+    "value": 26
   },
   {
     "type": "EXTERNAL_OPTION",

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1087,7 +1087,7 @@ aim_speed = std::min( aim_speed, base_aim_speed_cap * aim_cache.aim_factor_from_
 aim_speed = std::min( aim_speed, base_aim_speed_cap * aim_cache.aim_factor_from_length );
 
 // Just a raw scaling factor.
-aim_speed *= 2.4;
+aim_speed *= 3.0;
 
 // Minimum improvement is 0.01MoA.  This is just to prevent data anomalies
 aim_speed = std::max( aim_speed, MIN_RECOIL_IMPROVEMENT );
@@ -3309,13 +3309,13 @@ int Character::get_eff_per() const
 int Character::ranged_dex_mod() const
 {
     ///\EFFECT_DEX <20 increases ranged penalty
-    return std::max( ( 20.0 - get_dex() ) * 0.5, 0.0 );
+    return std::max( ( 20.0 - get_dex() ) * 0.35, 0.0 );
 }
 
 int Character::ranged_per_mod() const
 {
     ///\EFFECT_PER <20 increases ranged aiming penalty.
-    return std::max( ( 20.0 - get_per() ) * 1.2, 0.0 );
+    return std::max( ( 20.0 - get_per() ) * 0.8, 0.0 );
 }
 
 /*

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2649,7 +2649,7 @@ static double dispersion_from_skill( double skill, double weapon_dispersion )
         return 0.0;
     }
     double skill_shortfall = static_cast<double>( MAX_SKILL ) - skill;
-    double dispersion_penalty = 10 * skill_shortfall;
+    double dispersion_penalty = 6 * skill_shortfall;
     double skill_threshold = 5;
     if( skill >= skill_threshold ) {
         double post_threshold_skill_shortfall = static_cast<double>( MAX_SKILL ) - skill;
@@ -2660,7 +2660,7 @@ static double dispersion_from_skill( double skill, double weapon_dispersion )
     // Unskilled shooters suffer greater penalties, still scaling with weapon penalties.
     double pre_threshold_skill_shortfall = skill_threshold - skill;
     dispersion_penalty += weapon_dispersion *
-                          ( 1.25 + pre_threshold_skill_shortfall * 10.0 / skill_threshold );
+                          ( 1.25 + pre_threshold_skill_shortfall * 6.0 / skill_threshold );
 
     return dispersion_penalty;
 }


### PR DESCRIPTION
## 概述

针对枪械前期过于难用、散布过大、瞄准过慢、低属性角色吃亏的问题,综合调整多个数值旋钮,让枪械手感明显提升。高技能角色提升温和,主要利好新手与普通属性角色。

## 改动明细

### 散布(打不准 / 散布大)
- `GUN_DISPERSION_DIVIDER` **18 → 26**:全局降低武器固有散布与技能惩罚基数(精度约 +44%)。
- `DISPERSION_PER_GUN_DAMAGE` **30 → 20**:磨损旧枪的散布惩罚减轻。

### 新手技能惩罚(前期太废)
`dispersion_from_skill`(`ranged.cpp`):
- 基础惩罚系数 **10 → 6**(每差一级的固定散布惩罚)。
- 0–5 级新手对武器散布的额外放大系数 **10.0 → 6.0**。

### 瞄准速度(瞄得太慢)
- `aim_per_move`(`character.cpp`)最终缩放 **2.4 → 3.0**:每回合瞄准收益提升约 25%。

### 属性惩罚(低 DEX/PER 角色太吃亏)
- `ranged_dex_mod` 系数 **0.5 → 0.35**。
- `ranged_per_mod` 系数 **1.2 → 0.8**。

## 说明
- 有效射程随散布下降自然向外推移;射程硬上限(60 格,受视距/地图限制)保持不变。
- 已本地增量编译通过(Release/Tiles)。