### PR TITLE
修复 skyfarer 职业弹药错误引用弹药类型 id（36paper→36navy）

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -484,7 +484,7 @@
     "type": "item_group",
     "subtype": "collection",
     "id": "flintlock_pouch_skyfarer",
-    "entries": [ { "item": "36paper", "charges": 14 } ]
+    "entries": [ { "item": "36navy", "charges": 14 } ]
   },
   {
     "type": "profession_item_substitutions",
@@ -2754,7 +2754,7 @@
         "items": [ "cowboy_hat", "bandana", "duster_leather", "longshirt", "pants", "socks", "boots_western", "gloves_fingerless" ],
         "entries": [
           { "item": "flintlock_pouch", "contents-group": "flintlock_pouch_skyfarer" },
-          { "item": "colt_navy", "ammo-item": "36paper", "charges": 6, "container-item": "western_holster" },
+          { "item": "colt_navy", "ammo-item": "36navy", "charges": 6, "container-item": "western_holster" },
           { "item": "hatchet", "container-item": "axe_ring" }
         ]
       },


### PR DESCRIPTION
## 问题

加载游戏时报错：

```
ERROR : item id 36paper is unknown (in entry within flintlock_pouch_skyfarer)
ERROR : Missing item definition: 36paper
ERROR : can't set ammo 36paper in civil war six-shooter as it is not an ammo
```

## 原因

之前的 PR #180 / #182 在调整 skyfarer 职业时，误把**物品 id** 改成了**弹药类型 id** `36paper`：

- `36paper` 是 **ammotype（弹药类型）**，定义在 `ammo_types.json`，不是可生成的物品；
- `36navy` 才是真实的 **AMMO 物品**（它的 `ammo_type` 正是 `36paper`）。

物品组的 `item` 字段和 `ammo-item` 字段都需要填**真实物品 id**，填弹药类型 id 会导致加载期一致性检查报错。

## 修改

将两处改回真实物品 `36navy`，同时保留 #180/#182 中正确的部分：

- `flintlock_pouch_skyfarer`：`{ "item": "36navy", "charges": 14 }`（数量 14 在 flintlock_pouch 口袋 `ammo_restriction` 上限内）；
- skyfarer 的 colt_navy：`ammo-item: 36navy` + `container-item: western_holster`（western_holster 可容纳 351mm 的 colt_navy）。

`36navy` 的 `ammo_type` 为 `36paper`，正好匹配 colt_navy 的弹药类型与 flintlock_pouch 的口袋限制。

## 验证

- `python3 -c json.load` 校验 professions.json 合法；
- 加载游戏后 `36paper is unknown` / `Missing item definition` / `can't set ammo` 三条错误消失（单元测试初始化日志确认）。