### PR TITLE
性能：怪物 AI 对无幼崽怪物跳过全场护幼扫描（消除 horde O(M²)）

### DIFF
--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -478,6 +478,18 @@ void monster::anger_cub_threatened( monster_plan &mon_plan )
         return;
     }
 
+    // This monster protects no cubs of its own, so the per-tmp `is_baby` check
+    // below (which depends only on THIS monster's baby_type, not on tmp) can
+    // never be true: the loop body would touch nothing. Skip the whole O(M)
+    // scan over all_monsters() — a no-op for the vast majority of monsters
+    // (e.g. zombies), which turns a per-monster O(M) into O(M^2) in hordes.
+    // Behaviour is bit-for-bit identical: no anger/morale/aggro writes, no
+    // rate_target calls, no RNG consumed.
+    if( type->baby_type.baby_monster.is_null() &&
+        type->baby_type.baby_monster_group.is_null() ) {
+        return;
+    }
+
     for( monster &tmp : g->all_monsters() ) {
         bool is_baby = false;
         if( !type->baby_type.baby_monster.is_null() ) {


### PR DESCRIPTION
## 问题

`monster::anger_cub_threatened()`（`src/monmove.cpp`）在 `plan()` 里**对每个能看到玩家的敌对怪物每回合都调用一次**，内部无条件遍历**全场 `g->all_monsters()`（O(M)）**。

但循环体里的 `is_baby` 判定**只依赖本怪物自身的 `type->baby_type`**，与被遍历的对象无关。当本怪物没有 `baby_type`（绝大多数怪物，如僵尸）时，`is_baby` 对任意对象恒为 `false`，整个循环不写 `anger/morale/aggro_character`、也不调用 `rate_target`——是纯 no-op。

horde（尸潮）场景下，M 个无幼崽怪物各自空扫 M 个怪物 = **O(M²) 的纯浪费**。

## 修改

在遍历前加一条早退：本怪物的 `baby_monster` 与 `baby_monster_group` **同时为 null** 时直接 `return`，跳过这段对它而言纯 no-op 的全场扫描。

```cpp
if( type->baby_type.baby_monster.is_null() &&
    type->baby_type.baby_monster_group.is_null() ) {
    return;
}
```

per-monster 的 O(M) 降为 O(1)，消除一处 O(M²)。

## 正确性

**逐字节行为等价**：跳过的循环对无 `baby_type` 怪物本就无任何副作用（不写状态、不调 `rate_target`、不消耗 RNG），不改变怪物处理顺序，满足 CDDA 分支的存档/复现决定性约束。保留 `angers_cub_threatened < 0` 的原有早退不变；早退用 `&&`（两个字段都为 null 才跳过），不影响有幼崽怪物的护幼逻辑。

## 验证

- `build/` 增量编译通过；
- `cata_test-tiles [monster] --rng-seed 1` 全过（**59622 断言 / 50 用例**）。

预期收益：大规模 horde 战斗中等到高；常规小规模战斗收益低但零风险。