### PR TITLE
content: add qi gathering pill

### DIFF
--- a/data/mods/immortal_path/GLOSSARY.md
+++ b/data/mods/immortal_path/GLOSSARY.md
@@ -90,6 +90,7 @@
 | 炼器 | artifact forging | 炼制法器 |
 | 法器 / 法宝 | magic tool / treasure | 修士器物 |
 | 洞府 | cave abode | 修士居所/据点 |
+| 聚气丹 | Qi-Gathering Pill | 基础回灵丹药 |
 
 ## 势力 / Factions（预留）
 

--- a/data/mods/immortal_path/effects_on_condition/grant_meditation.json
+++ b/data/mods/immortal_path/effects_on_condition/grant_meditation.json
@@ -30,6 +30,21 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_immortal_path_ensure_basic_elixir_recipe",
+    "//": "炼气入门后授予基础聚气丹配方。用 RECURRING 兜底，覆盖旧存档与任何非 learn_spell 路径获得境界 spell 的角色；已有配方则跳过。/ Grant the basic Qi-Gathering Pill recipe after entering Qi Refining. RECURRING covers old saves and any non-learn_spell grant path; skip if already known.",
+    "recurrence": [ "30 seconds", "90 seconds" ],
+    "global": true,
+    "run_for_npcs": false,
+    "condition": {
+      "and": [
+        { "math": [ "u_spell_level('realm_qi_refining') > -1" ] },
+        { "not": { "u_know_recipe": "immortal_path_qi_gathering_pill" } }
+      ]
+    },
+    "effect": [ { "u_learn_recipe": "immortal_path_qi_gathering_pill" } ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_immortal_path_bind_art_traits",
     "//": "学功法即授五行/魔功载体特性：监听 character_learns_spell，按已会的吐纳变体 spell 分支授予对应载体特性（草木同春/阳炎附骨/…）。各分支幂等（已有特性即跳过 u_add_trait 不重复）。这些载体特性携带五行被动 enchantment（含属性极化）；境界进度共用 realm_qi_refining，与本绑定无关（境界特性炼气士由上面的 EOC 单独授予）。一个角色可同时修炼多门功法、叠加多个载体特性——是否限制「只能主修一门」留待后续设计。/ Grant the elemental/demonic carrier trait when its breathing variant is learned. Each branch is idempotent. Multiple arts can stack for now; 'one core method only' is a later design choice.",
     "eoc_type": "EVENT",

--- a/data/mods/immortal_path/recipes/qi_gathering.json
+++ b/data/mods/immortal_path/recipes/qi_gathering.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "immortal_path_qi_gathering_pill",
+    "type": "ITEM",
+    "subtypes": [ "COMESTIBLE" ],
+    "category": "drugs",
+    "comestible_type": "MED",
+    "name": {
+      "str_sp": "聚气丹",
+      "//en_us_str": "Qi-Gathering Pill",
+      "//en_us_str_pl": "Qi-Gathering Pills"
+    },
+    "//": "基础回灵丹药：只补灵气，不给炼气修为，避免绕过打坐成长曲线。数值对齐一次吐纳补气量（+60）。/ Basic qi-restoring pill: restores qi only, not Qi Refining cultivation, so it does not bypass the meditation progression curve. Amount matches one meditation cast (+60 qi).",
+    "description": "一枚淡青色小丹，入口后化作温润灵息，汇入丹田。可补充少量灵气，但不能增长修为。",
+    "//en_us_description": "A pale cyan pill that melts into a warm spiritual breath and gathers in the dantian. Restores a small amount of qi, but does not increase cultivation.",
+    "weight": "8 g",
+    "volume": "5 ml",
+    "price": "0 USD",
+    "price_postapoc": "3 USD",
+    "material": [ "junk" ],
+    "symbol": "*",
+    "color": "cyan",
+    "use_action": {
+      "type": "consume_drug",
+      "activation_message": "你服下一枚聚气丹，温润灵息汇入丹田。",
+      "//en_us_activation_message": "You take a Qi-Gathering Pill, and a warm spiritual breath gathers in your dantian.",
+      "vitamins": [ [ "qi", 60 ] ]
+    }
+  },
+  {
+    "result": "immortal_path_qi_gathering_pill",
+    "type": "recipe",
+    "//": "基础聚气丹配方。autolearn:false；由 EOC_immortal_path_ensure_basic_elixir_recipe 在角色踏入炼气后授予。材料沿用早期草木/清水路线，后续可替换为专属灵材。/ Basic Qi-Gathering Pill recipe. Not autolearned; granted by EOC_immortal_path_ensure_basic_elixir_recipe once the character enters Qi Refining. Uses early herb/water components for now; later replaceable with dedicated spirit materials.",
+    "category": "CC_CHEM",
+    "subcategory": "CSC_CHEM_DRUGS",
+    "skill_used": "firstaid",
+    "difficulty": 1,
+    "time": "15 m",
+    "activity_level": "LIGHT_EXERCISE",
+    "autolearn": false,
+    "qualities": [ { "id": "CONTAIN", "level": 1 } ],
+    "components": [ [ [ "wild_herbs", 2 ], [ "tea_bark", 1 ] ], [ [ "water_clean", 1 ], [ "water", 1 ] ] ]
+  }
+]


### PR DESCRIPTION
#### 概述 (Summary)
Content "Add Qi-Gathering Pill for Immortal Path"

#### 改动目的 (Purpose of change)
Add a basic qi-restoring elixir for Immortal Path.

#### 解决方案描述 (Describe the solution)
Added 聚气丹 / Qi-Gathering Pill as a MED comestible that restores 60 qi without increasing cultivation progress. Added its crafting recipe and registered the term in `GLOSSARY.md`. Added a recurring EOC that grants the recipe after the character enters Qi Refining, while skipping characters who already know it.

#### 你考虑过的替代方案 (Describe alternatives you've considered)
Could have tied the recipe to a specific elemental technique, but this is a basic qi recovery item, so granting it after entering Qi Refining is simpler and more generally useful.

#### 测试 (Testing)
Ran `python build-scripts\validate_json.py`.
All 6546 JSON files healthy.
Checked the new Chinese player-facing strings have matching `//en_us_*` comments.

#### 补充说明 (Additional context)
The pill restores qi only and does not grant Qi Refining cultivation, so it does not bypass the meditation progression curve.