### PR TITLE
Features 多档快照存读 + 单世界单角色 / World-snapshot multi-save

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -3605,6 +3605,18 @@
   },
   {
     "type": "keybinding",
+    "name": "Snapshot save/load menu",
+    "category": "DEFAULTMODE",
+    "id": "snapshot_menu"
+  },
+  {
+    "type": "keybinding",
+    "name": "Quit to last snapshot",
+    "category": "DEFAULTMODE",
+    "id": "quit_to_snapshot"
+  },
+  {
+    "type": "keybinding",
     "name": "Move view northeast",
     "category": "DEFAULTMODE",
     "id": "shift_ne",

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -312,6 +312,10 @@ std::string action_ident( action_id act )
             return "quicksave";
         case ACTION_QUICKLOAD:
             return "quickload";
+        case ACTION_SNAPSHOT_MENU:
+            return "snapshot_menu";
+        case ACTION_QUIT_TO_SNAPSHOT:
+            return "quit_to_snapshot";
         case ACTION_SUICIDE:
             return "SUICIDE";
         case ACTION_PL_INFO:
@@ -430,6 +434,8 @@ bool can_action_change_worldstate( const action_id act )
         case ACTION_SAVE:
         case ACTION_QUICKSAVE:
         case ACTION_QUICKLOAD:
+        case ACTION_SNAPSHOT_MENU:
+        case ACTION_QUIT_TO_SNAPSHOT:
         case ACTION_SUICIDE:
         // Info Screens
         case ACTION_PL_INFO:
@@ -1121,6 +1127,8 @@ action_id handle_main_menu()
     REGISTER_ACTION( ACTION_ACTIONMENU );
     REGISTER_ACTION( ACTION_QUICKSAVE );
     REGISTER_ACTION( ACTION_SAVE );
+    REGISTER_ACTION( ACTION_SNAPSHOT_MENU );
+    REGISTER_ACTION( ACTION_QUIT_TO_SNAPSHOT );
     if( hotkey_for_action( ACTION_DEBUG, /*maximum_modifier_count=*/1, false ).has_value() ) {
         REGISTER_ACTION( ACTION_DEBUG, 'D' );
     }

--- a/src/action.h
+++ b/src/action.h
@@ -248,6 +248,10 @@ enum action_id : int {
     ACTION_QUICKSAVE,
     /** Quickload the game */
     ACTION_QUICKLOAD,
+    /** Open the save snapshot (multi-save) menu */
+    ACTION_SNAPSHOT_MENU,
+    /** Restore the most recent snapshot and quit to main menu (discard current progress) */
+    ACTION_QUIT_TO_SNAPSHOT,
     /** Commit suicide */
     ACTION_SUICIDE,
     /**@}*/

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -108,6 +108,9 @@ void zone_manager::clear()
     added_vzones.clear();
     changed_vzones.clear();
     removed_vzones.clear();
+    // Reset personal zone counter, else it accumulates across in-place reloads
+    // (quickload / snapshot restore) since deserialize() only ever increments it.
+    num_personal_zones = 0;
     // Do not clear types since it is needed for the next games.
     area_cache.clear();
     vzone_cache.clear();

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -262,6 +262,7 @@ std::string enum_to_string<debug_menu::debug_menu_index>( debug_menu::debug_menu
         case debug_menu::debug_menu_index::PRINT_NPC_MAGIC: return "PRINT_NPC_MAGIC";
         case debug_menu::debug_menu_index::QUIT_NOSAVE: return "QUIT_NOSAVE";
         case debug_menu::debug_menu_index::QUICKLOAD: return "QUICKLOAD";
+        case debug_menu::debug_menu_index::SNAPSHOT_MENU: return "SNAPSHOT_MENU";
         case debug_menu::debug_menu_index::TEST_WEATHER: return "TEST_WEATHER";
         case debug_menu::debug_menu_index::WRITE_GLOBAL_EOCS: return "WRITE_GLOBAL_EOCS";
         case debug_menu::debug_menu_index::WRITE_GLOBAL_VARS: return "WRITE_GLOBAL_VARS";
@@ -1017,6 +1018,7 @@ static int game_uilist()
         { uilist_entry( debug_menu_index::ACTIVATE_EOC, true, 'E', _( "Activate EOC" ) ) },
         { uilist_entry( debug_menu_index::QUIT_NOSAVE, true, 'Q', _( "Quit to main menu" ) )  },
         { uilist_entry( debug_menu_index::QUICKLOAD, true, 'q', _( "Quickload" ) )  },
+        { uilist_entry( debug_menu_index::SNAPSHOT_MENU, true, 'n', _( "Snapshot save/load menu" ) )  },
     };
 
     return uilist( _( "Game…" ), uilist_initializer );
@@ -4833,6 +4835,13 @@ const std::vector<debug_action_entry> &all_actions()
                     g->quickload();
                     g->save_is_dirty = true;
                 }
+            }
+        },
+        {
+            debug_menu_index::SNAPSHOT_MENU, translate_marker( "Snapshot save/load menu" ),
+            "snapshot save load", "Game", []()
+            {
+                g->snapshot_menu();
             }
         },
         {

--- a/src/debug_menu_types.h
+++ b/src/debug_menu_types.h
@@ -100,6 +100,7 @@ enum class debug_menu_index : int {
     ACTIVATE_EOC,
     WRITE_TIMED_EVENTS,
     QUICKLOAD,
+    SNAPSHOT_MENU,
     IMPORT_FOLLOWER,
     EXPORT_FOLLOWER,
     EXPORT_SELF,

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -691,6 +691,18 @@ void game::setup()
 
     m = map();
 
+    reset_game_state();
+    // back to menu for save loading, new game etc
+}
+
+// Reset all per-game runtime state to a clean slate, so a fresh load can
+// populate it without stale leftovers from a previously played game.
+// Shared by setup() (full reload via main menu) and the in-place reloads
+// (quickload / snapshot restore) which deliberately skip JSON/mod reloading.
+void game::reset_game_state()
+{
+    new_game = true;
+
     next_npc_id = character_id( 1 );
     next_mission_id = 1;
     next_item_uid = 1;
@@ -734,7 +746,56 @@ void game::setup()
     globvars.clear_global_values();
     unique_npcs.clear();
     get_weather().weather_override = WEATHER_NULL;
-    // back to menu for save loading, new game etc
+}
+
+bool game::reload_active_save( const save_t &save_file )
+{
+    // In-place reload: tear down the current game's runtime state and reload
+    // the save WITHOUT bouncing through the main menu (which would re-run the
+    // expensive JSON/mod load). Used by quickload and snapshot restore.
+    // Suppress rendering while state is half-cleared.
+    should_draw = false;
+    on_out_of_scope restore_draw( [this]() {
+        should_draw = true;
+    } );
+
+    set_driving_view_offset( point_rel_ms::zero );
+
+    sfx::fade_audio_channel( sfx::channel::any, 300 );
+    sfx::fade_audio_group( sfx::group::weather, 300 );
+    sfx::fade_audio_group( sfx::group::time_of_day, 300 );
+    sfx::fade_audio_group( sfx::group::context_themes, 300 );
+    sfx::fade_audio_group( sfx::group::low_stamina, 300 );
+
+    zone_manager::get_manager().clear();
+
+    // These are world-level and not reset by reset_game_state(); the full
+    // main-menu reload clears them via teardown, so do it here too.
+    MAPBUFFER.clear();
+    overmap_buffer.clear();
+
+    m = map();
+
+    // Reset all per-game runtime state to a clean slate (sets new_game = true,
+    // resets ID counters, trackers, EOC queues, global variables, etc.).
+    reset_game_state();
+
+    try {
+        if( load( save_file ) ) {
+            // A freshly loaded save is internally consistent again, so a prior
+            // debug-induced "dirty" state no longer applies.
+            save_is_dirty = false;
+            return true;
+        }
+        debugmsg( "In-place reload failed: unable to load save file '%s'", save_file.base_path() );
+    } catch( const std::exception &e ) {
+        debugmsg( "In-place reload failed: %s", e.what() );
+    }
+    // The in-place teardown already cleared the map/overmap and reset runtime
+    // state, so there is nothing playable left in memory. Bail to the main menu
+    // rather than leaving the player stranded in an empty world.
+    uquit = QUIT_NOSAVED;
+    return false;
 }
 
 bool game::has_gametype() const
@@ -2645,6 +2706,8 @@ input_context get_default_mode_input_context()
 #if !defined(RELEASE)
         ctxt.register_action( "quickload" );
 #endif
+        ctxt.register_action( "snapshot_menu" );
+        ctxt.register_action( "quit_to_snapshot" );
         ctxt.register_action( "SUICIDE" );
         ctxt.register_action( "player_data" );
         ctxt.register_action( "map" );
@@ -3334,6 +3397,13 @@ bool game::has_blink_curses()
 
 void game::draw( ui_adaptor &ui )
 {
+    // Skip drawing while an in-place reload (quickload / snapshot restore) is
+    // tearing down and rebuilding game state; drawing then would touch
+    // half-cleared structures.
+    if( !should_draw ) {
+        return;
+    }
+
     map &here = get_map();
 
     if( test_mode ) {

--- a/src/game.h
+++ b/src/game.h
@@ -250,6 +250,23 @@ class game
         void load_mod_interaction_data_from_dir( const cata_path &path, const std::string &src );
     public:
         void setup();
+        /**
+         * Reset all per-game runtime state (ID counters, weather, trackers,
+         * EOC queues, global variables, etc.) to a clean slate. Called by
+         * setup() and by the in-place reloads (quickload / snapshot restore)
+         * that skip JSON/mod reloading.
+         */
+        void reset_game_state();
+
+        /**
+         * Reload a save in place without bouncing through the main menu,
+         * skipping the expensive JSON/mod reload. Tears down runtime state via
+         * reset_game_state(), clears the map/overmap buffers, then load()s the
+         * given save. Suppresses rendering while state is half-cleared.
+         * Used by quickload() and snapshot restore.
+         * @return true on success.
+         */
+        bool reload_active_save( const save_t &save_file );
         /** Saving and loading functions. */
         void serialize_json( std::ostream &fout ); // for save
         void unserialize( std::istream &fin, const cata_path &path ); // for load
@@ -1116,6 +1133,10 @@ class game
     public:
         void quicksave();        // Saves the game without quitting
         void quickload();        // Loads the previously saved game if it exists
+        void snapshot_menu();    // Opens the snapshot (multi-save) save/load menu
+        // Restore the most recent snapshot and quit to the main menu, discarding
+        // progress since that snapshot. No-op (with a prompt) if none exist.
+        void quit_to_last_snapshot();
         void disp_NPCs();        // Currently for debug use.  Lists global NPCs.
 
         void list_missions();       // Listed current, completed and failed missions (mission_ui.cpp)
@@ -1214,6 +1235,10 @@ class game
         bool save_is_dirty; // NOLINT(cata-serialize)
         /** True if the game has just started or loaded, else false. */
         bool new_game = false; // NOLINT(cata-serialize)
+
+        /** When false, game::draw() is skipped. Used to suppress rendering
+         *  during an in-place reload (quickload / snapshot restore). */
+        bool should_draw = true; // NOLINT(cata-serialize)
 
         tripoint_bub_ms ter_view_p; // NOLINT(cata-serialize)
         catacurses::window w_terrain; // NOLINT(cata-serialize)

--- a/src/game_io.cpp
+++ b/src/game_io.cpp
@@ -61,7 +61,6 @@
 #include "json.h"
 #include "loading_ui.h"
 #include "magic_enchantment.h"
-#include "main_menu.h"
 #include "map.h"
 #include "mapbuffer.h"
 #include "memorial_logger.h"
@@ -75,6 +74,7 @@
 #include "pimpl.h"
 #include "popup.h"
 #include "safemode_ui.h"
+#include "save_snapshot.h"
 #if defined(TILES)
     #include "sdltiles.h"
 #endif
@@ -917,25 +917,144 @@ void game::quickload()
     if( active_world == nullptr ) {
         return;
     }
-    std::string const world_name = active_world->world_name;
-    std::string const &save_id = u.get_save_id();
 
-    if( active_world->save_exists( save_t::from_save_id( save_id ) ) ) {
-        if( moves_since_last_save != 0 ) { // See if we need to reload anything
-            moves_since_last_save = 0;
-            last_save_timestamp = std::time( nullptr );
+    const std::string &save_id = u.get_save_id();
+    const save_t save_file = save_t::from_save_id( save_id );
 
-            u.set_moves( 0 );
-            uquit = QUIT_NOSAVED;
+    if( !active_world->save_exists( save_file ) ) {
+        popup_getkey( _( "No saves for current character yet." ) );
+        return;
+    }
 
-            main_menu::queued_world_to_load = world_name;
-            main_menu::queued_save_id_to_load = save_id;
+    if( moves_since_last_save == 0 ) {
+        // Nothing has happened since the last save; no need to reload.
+        return;
+    }
 
+    if( reload_active_save( save_file ) ) {
+        add_msg( _( "Quick load successful!" ) );
+        moves_since_last_save = 0;
+        last_save_timestamp = std::time( nullptr );
+    } else {
+        popup_getkey( _( "Quick load failed!" ) );
+    }
+}
+
+void game::snapshot_menu()
+{
+    WORLD *active_world = world_generator->active_world;
+    if( active_world == nullptr ) {
+        return;
+    }
+    const cata_path world_dir = active_world->folder_path();
+
+    while( true ) {
+        const save_snapshot::menu_selection sel =
+            save_snapshot::query_snapshot_menu( world_dir, _( "Snapshots" ),
+                    _( "Load this snapshot" ) );
+
+        if( sel.action == save_snapshot::menu_action::none ) {
+            return;
         }
 
-    } else {
-        popup_getkey( _( "No saves for current character yet." ) );
+        if( sel.action == save_snapshot::menu_action::create ) {
+            // Persist current progress, then snapshot the whole world directory.
+            if( !save() ) {
+                popup_getkey( _( "Could not save the game before taking a snapshot." ) );
+                continue;
+            }
+            if( save_snapshot::make_snapshot( world_dir, sel.new_name, u.get_name(),
+                                              to_turn<int>( calendar::turn ) ) ) {
+                add_msg( _( "Snapshot \"%s\" saved." ), sel.new_name );
+            } else {
+                popup_getkey( _( "Failed to create the snapshot." ) );
+            }
+            continue;
+        }
+
+        if( sel.action == save_snapshot::menu_action::remove ) {
+            if( query_yn( _( "Permanently delete snapshot \"%s\"?" ), sel.chosen.name ) ) {
+                save_snapshot::delete_snapshot( world_dir, sel.chosen.dir_name );
+            }
+            continue;
+        }
+
+        // menu_action::load
+        if( !query_yn( _( "Load snapshot \"%s\"?  Unsaved progress will be lost." ),
+                       sel.chosen.name ) ) {
+            continue;
+        }
+
+        // Drop in-memory map/overmap buffers BEFORE touching the files on disk.
+        // On Windows the prefetcher can hold mmap handles on maps/*.zzip, which
+        // would make the restore's deletes fail; clearing here releases them.
+        MAPBUFFER.clear();
+        overmap_buffer.clear();
+        m = map();
+
+        if( !save_snapshot::restore_snapshot( world_dir, sel.chosen.dir_name ) ) {
+            popup_getkey( _( "Failed to restore the snapshot." ) );
+            return;
+        }
+        // The on-disk compression state may differ from before; force a re-probe
+        // so load() picks the right codec.
+        active_world->invalidate_compression_cache();
+
+        const save_t save_file = save_t::from_save_id( u.get_save_id() );
+        if( reload_active_save( save_file ) ) {
+            add_msg( _( "Snapshot \"%s\" loaded." ), sel.chosen.name );
+        } else {
+            popup_getkey( _( "Snapshot restored on disk, but reloading failed." ) );
+        }
+        return; // game state reloaded (or bailed to menu); leave the menu
     }
+}
+
+void game::quit_to_last_snapshot()
+{
+    WORLD *active_world = world_generator->active_world;
+    if( active_world == nullptr ) {
+        return;
+    }
+    const cata_path world_dir = active_world->folder_path();
+
+    const std::vector<save_snapshot::snapshot_info> snaps =
+        save_snapshot::list_snapshots( world_dir );
+    if( snaps.empty() ) {
+        popup_getkey( _( "There are no snapshots to return to." ) );
+        return;
+    }
+
+    // list_snapshots() is sorted newest-first.
+    const save_snapshot::snapshot_info &latest = snaps.front();
+
+    if( !query_yn(
+            _( "Quit to the most recent snapshot \"%s\"?  Progress since then will be lost." ),
+            latest.name ) ) {
+        return;
+    }
+
+    // Drop in-memory buffers and the live map BEFORE touching files: it releases
+    // any mmap handles (so the restore's deletes succeed on Windows) and avoids
+    // leaving the map holding freed submap pointers.
+    MAPBUFFER.clear();
+    overmap_buffer.clear();
+    m = map();
+
+    // Restore the snapshot's files over the world, then quit WITHOUT saving so
+    // the discarded progress is never written back. The on-disk world is now a
+    // consistent snapshot state, which avoids the corruption risk of a plain
+    // "quit without saving". The restored save is loaded next time the world is
+    // opened from the main menu. restore_snapshot is atomic: on failure the
+    // world is rolled back intact, but our in-memory state is already torn down,
+    // so quit to the main menu regardless.
+    if( !save_snapshot::restore_snapshot( world_dir, latest.dir_name ) ) {
+        popup_getkey( _( "Failed to restore the snapshot." ) );
+    }
+    active_world->invalidate_compression_cache();
+
+    u.set_moves( 0 );
+    uquit = QUIT_NOSAVED;
 }
 
 void game::autosave()

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -3145,6 +3145,14 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             g->save_is_dirty = true;
             return false;
 
+        case ACTION_SNAPSHOT_MENU:
+            snapshot_menu();
+            return false;
+
+        case ACTION_QUIT_TO_SNAPSHOT:
+            quit_to_last_snapshot();
+            return false;
+
         case ACTION_PL_INFO:
             player_character.disp_info( true );
             break;

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -48,6 +48,7 @@
 #include "path_info.h"
 #include "popup.h"
 #include "safemode_ui.h"
+#include "save_snapshot.h"
 #include "scenario.h"
 #include "sdlsound.h"
 #include "sounds.h"
@@ -508,6 +509,7 @@ void main_menu::init_strings()
     vWorldSubItems.emplace_back( pgettext( "Main Menu|World", "Copy World Sett<i|I>ngs" ) );
     vWorldSubItems.emplace_back( pgettext( "Main Menu|World", "Character to Tem<p|P>late" ) );
     vWorldSubItems.emplace_back( pgettext( "Main Menu|World", "Toggle World <C|c>ompression" ) );
+    vWorldSubItems.emplace_back( pgettext( "Main Menu|World", "S<n|N>apshots" ) );
     vWorldSubItems.emplace_back( pgettext( "Main Menu|World", "<D|d>elete World" ) );
     vWorldSubItems.emplace_back( pgettext( "Main Menu|World", "<R|r>eset World" ) );
 
@@ -980,10 +982,12 @@ bool main_menu::new_character_tab()
                     continue;
                 }
                 if( !world->world_saves.empty() ) {
-                    if( !query_yn(
-                            _( "Many game features will not work correctly with multiple characters in the same world.  Create a new character anyway?" ) ) ) {
-                        return false;
-                    }
+                    // One character per world is enforced (snapshot save system +
+                    // avoiding shared-world-state contamination). Block instead of
+                    // warning-and-allowing.
+                    popup( _( "This world already has a character.  Create a new world "
+                              "for a new character." ) );
+                    return false;
                 }
 
                 world_generator->set_active_world( world );
@@ -1025,10 +1029,12 @@ bool main_menu::new_character_tab()
             return false;
         }
         if( !world->world_saves.empty() ) {
-            if( !query_yn(
-                    _( "Many game features will not work correctly with multiple characters in the same world.  Create a new character anyway?" ) ) ) {
-                return false;
-            }
+            // One character per world is enforced (snapshot save system +
+            // avoiding shared-world-state contamination). Block instead of
+            // warning-and-allowing.
+            popup( _( "This world already has a character.  Create a new world "
+                      "for a new character." ) );
+            return false;
         }
         world_generator->set_active_world( world );
         try {
@@ -1179,7 +1185,7 @@ void main_menu::world_tab( const std::string &worldname )
     uilist mmenu( string_format( _( "Manage world \"%s\"" ), worldname ), {} );
     mmenu.border_color = c_white;
     int opt_val = 0;
-    std::array<char, 6> hotkeys = { 'm', 's', 't', 'c', 'd', 'r' };
+    std::array<char, 7> hotkeys = { 'm', 's', 't', 'c', 'n', 'd', 'r' };
     for( const std::string &it : vWorldSubItems ) {
         mmenu.entries.emplace_back( opt_val, true, hotkeys[opt_val],
                                     remove_color_tags( shortcut_text( c_white, it ) ) );
@@ -1237,18 +1243,77 @@ void main_menu::world_tab( const std::string &worldname )
                 }
             }
             break;
-        case 4: // Delete World
+        case 4: // Snapshots
+            snapshots_tab( worldname );
+            break;
+        case 5: // Delete World
             if( query_yn( _( "Delete the world and all saves within?" ) ) ) {
                 clear_world( true );
             }
             break;
-        case 5: // Reset World
+        case 6: // Reset World
             if( query_yn( _( "Remove all saves and regenerate world?" ) ) ) {
                 clear_world( false );
             }
             break;
         default:
             break;
+    }
+}
+
+void main_menu::snapshots_tab( const std::string &worldname )
+{
+    WORLD *world = world_generator->get_world( worldname );
+    if( world == nullptr ) {
+        return;
+    }
+    const cata_path world_dir = world->folder_path();
+
+    while( true ) {
+        const save_snapshot::menu_selection sel =
+            save_snapshot::query_snapshot_menu(
+                world_dir, string_format( _( "Snapshots of \"%s\"" ), worldname ),
+                _( "Restore this snapshot" ) );
+
+        if( sel.action == save_snapshot::menu_action::none ) {
+            return;
+        }
+
+        if( sel.action == save_snapshot::menu_action::create ) {
+            // No live game here: the on-disk world files already are the saved
+            // state, so snapshot the directory directly. Character name / turn
+            // are unknown from the menu, so leave them blank/0.
+            if( save_snapshot::make_snapshot( world_dir, sel.new_name, std::string(), 0 ) ) {
+                popup_getkey( _( "Snapshot \"%s\" saved." ), sel.new_name );
+            } else {
+                popup_getkey( _( "Failed to create the snapshot." ) );
+            }
+            continue;
+        }
+
+        if( sel.action == save_snapshot::menu_action::remove ) {
+            if( query_yn( _( "Permanently delete snapshot \"%s\"?" ), sel.chosen.name ) ) {
+                save_snapshot::delete_snapshot( world_dir, sel.chosen.dir_name );
+            }
+            continue;
+        }
+
+        // menu_action::load (restore)
+        if( !query_yn( _( "Restore snapshot \"%s\"?  This overwrites the world's "
+                          "current save." ), sel.chosen.name ) ) {
+            continue;
+        }
+        if( save_snapshot::restore_snapshot( world_dir, sel.chosen.dir_name ) ) {
+            // Drop any cached map/overmap so a later load reads the restored
+            // files rather than stale buffers, and re-probe compression state.
+            MAPBUFFER.clear();
+            overmap_buffer.clear();
+            world->invalidate_compression_cache();
+            savegames.clear();
+            popup_getkey( _( "Snapshot \"%s\" restored." ), sel.chosen.name );
+        } else {
+            popup_getkey( _( "Failed to restore the snapshot." ) );
+        }
     }
 }
 

--- a/src/main_menu.h
+++ b/src/main_menu.h
@@ -63,6 +63,8 @@ class main_menu
         bool new_character_tab();
         bool load_character_tab( const std::string &worldname );
         void world_tab( const std::string &worldname );
+        // Snapshot (multi-save) management for a world, from the main menu.
+        void snapshots_tab( const std::string &worldname );
 
         /*
          * Load character templates from template folder

--- a/src/save_snapshot.cpp
+++ b/src/save_snapshot.cpp
@@ -1,0 +1,400 @@
+#include "save_snapshot.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <ctime>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "cata_path.h"
+#include "cata_utility.h"
+#include "calendar.h"
+#include "debug.h"
+#include "filesystem.h"
+#include "json.h"
+#include "output.h"
+#include "string_formatter.h"
+#include "string_input_popup.h"
+#include "translations.h"
+#include "uilist.h"
+
+namespace
+{
+
+// Folder under a world directory that holds all snapshots.
+const std::string SNAPSHOTS_DIR = "snapshots";
+// Per-snapshot metadata file name.
+const std::string SNAPSHOT_META = "snapshot_meta.json";
+// Temp folder used to stage a rollback during restore.
+const std::string RESTORE_BACKUP_DIR = ".snapshot_restore_backup";
+
+// Returns <world_dir>/snapshots .
+cata_path snapshots_root( const cata_path &world_dir )
+{
+    return world_dir / SNAPSHOTS_DIR;
+}
+
+// Collect the immediate children of dir whose filename is NOT in skip.
+// Collecting up front (rather than acting during iteration) avoids the
+// unspecified behavior of mutating a directory while iterating it.
+std::vector<std::filesystem::path> top_level_entries(
+    const std::filesystem::path &dir, const std::vector<std::string> &skip )
+{
+    std::vector<std::filesystem::path> result;
+    std::error_code ec;
+    for( const std::filesystem::directory_entry &entry :
+         std::filesystem::directory_iterator( dir, ec ) ) {
+        const std::string name = entry.path().filename().u8string();
+        if( std::find( skip.begin(), skip.end(), name ) != skip.end() ) {
+            continue;
+        }
+        result.push_back( entry.path() );
+    }
+    return result;
+}
+
+// Recursively copy everything under src_dir into dst_dir, skipping any path
+// whose top-level component name is in skip_top. Returns false on the first
+// failed file copy.
+bool copy_tree( const std::filesystem::path &src_dir,
+                const std::filesystem::path &dst_dir,
+                const std::vector<std::string> &skip_top )
+{
+    std::error_code ec;
+    const std::filesystem::path canon_src = std::filesystem::weakly_canonical( src_dir, ec );
+    const std::filesystem::path src_root = ec ? src_dir : canon_src;
+
+    for( auto iter = std::filesystem::recursive_directory_iterator( src_root, ec );
+         !ec && iter != std::filesystem::recursive_directory_iterator(); iter.increment( ec ) ) {
+        const std::filesystem::path &entry = iter->path();
+        const std::filesystem::path rel = entry.lexically_relative( src_root );
+
+        // Skip excluded top-level subtrees / files.
+        if( !rel.empty() && rel.begin() != rel.end() ) {
+            const std::string top = rel.begin()->u8string();
+            if( std::find( skip_top.begin(), skip_top.end(), top ) != skip_top.end() ) {
+                if( iter->is_directory() ) {
+                    iter.disable_recursion_pending();
+                }
+                continue;
+            }
+        }
+
+        const std::filesystem::path dst = dst_dir / rel;
+        if( iter->is_directory() ) {
+            if( !assure_dir_exist( dst ) ) {
+                debugmsg( "snapshot: failed to create directory '%s'", dst.u8string() );
+                return false;
+            }
+        } else if( iter->is_regular_file() ) {
+            if( !assure_dir_exist( dst.parent_path() ) ) {
+                debugmsg( "snapshot: failed to create directory '%s'", dst.parent_path().u8string() );
+                return false;
+            }
+            if( !copy_file( entry.u8string(), dst.u8string() ) ) {
+                debugmsg( "snapshot: failed to copy '%s'", entry.u8string() );
+                return false;
+            }
+        }
+    }
+    if( ec ) {
+        debugmsg( "snapshot: error walking '%s': %s", src_root.u8string(), ec.message() );
+        return false;
+    }
+    return true;
+}
+
+// Remove every immediate child of dir except those whose name is in keep.
+bool clear_dir_except( const std::filesystem::path &dir,
+                       const std::vector<std::string> &keep )
+{
+    bool ok = true;
+    for( const std::filesystem::path &entry : top_level_entries( dir, keep ) ) {
+        std::error_code rm_ec;
+        // Many world subdirs are non-empty (maps/, overmaps/, dimensions/, the
+        // character <id>/ folder, the <id>.mm1/ map-memory dir), so remove_all()
+        // is needed; it also handles plain files.
+        std::filesystem::remove_all( entry, rm_ec );
+        if( rm_ec ) {
+            debugmsg( "snapshot: failed to remove '%s': %s", entry.u8string(), rm_ec.message() );
+            ok = false;
+        }
+    }
+    return ok;
+}
+
+// Move every immediate child of from_dir (except names in skip) into to_dir,
+// using rename (cheap within one filesystem). Returns false on first failure.
+bool move_entries( const std::filesystem::path &from_dir,
+                   const std::filesystem::path &to_dir,
+                   const std::vector<std::string> &skip )
+{
+    for( const std::filesystem::path &entry : top_level_entries( from_dir, skip ) ) {
+        std::error_code mv_ec;
+        std::filesystem::rename( entry, to_dir / entry.filename(), mv_ec );
+        if( mv_ec ) {
+            debugmsg( "snapshot: failed to move '%s': %s", entry.u8string(), mv_ec.message() );
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace
+
+namespace save_snapshot
+{
+
+bool make_snapshot( const cata_path &world_dir, const std::string &slot_name,
+                    const std::string &character_name, const int turn )
+{
+    const std::string dir_name = ensure_valid_file_name( slot_name );
+    if( dir_name.empty() ) {
+        return false;
+    }
+
+    const cata_path dest = snapshots_root( world_dir ) / dir_name;
+    const std::filesystem::path dest_fs = dest.get_unrelative_path();
+
+    // Replace any existing slot with this name.
+    if( dir_exist( dest_fs ) ) {
+        std::error_code ec;
+        std::filesystem::remove_all( dest_fs, ec );
+        if( ec ) {
+            debugmsg( "snapshot: could not clear existing slot '%s': %s",
+                      dest_fs.u8string(), ec.message() );
+            return false;
+        }
+    }
+    if( !assure_dir_exist( dest_fs ) ) {
+        debugmsg( "snapshot: could not create snapshot directory '%s'", dest_fs.u8string() );
+        return false;
+    }
+
+    // Copy the whole world, excluding the snapshots folder itself (so a snapshot
+    // never nests prior snapshots).
+    if( !copy_tree( world_dir.get_unrelative_path(), dest_fs, { SNAPSHOTS_DIR } ) ) {
+        // Clean up the partial snapshot so it is never presented as restorable.
+        std::error_code ec;
+        std::filesystem::remove_all( dest_fs, ec );
+        return false;
+    }
+
+    // Write metadata. real_time is stamped here to keep the storage layer
+    // self-contained. If the meta write fails, drop the whole snapshot rather
+    // than leave a meta-less directory that would still list as restorable.
+    const cata_path meta_path = dest / SNAPSHOT_META;
+    const int64_t real_time = static_cast<int64_t>( std::time( nullptr ) );
+    const bool meta_ok = write_to_file( meta_path, [&]( std::ostream & fout ) {
+        JsonOut jsout( fout );
+        jsout.start_object();
+        jsout.member( "name", slot_name );
+        jsout.member( "character_name", character_name );
+        jsout.member( "turn", turn );
+        jsout.member( "real_time", real_time );
+        jsout.end_object();
+    }, _( "snapshot metadata" ) );
+    if( !meta_ok ) {
+        std::error_code ec;
+        std::filesystem::remove_all( dest_fs, ec );
+        return false;
+    }
+
+    return true;
+}
+
+std::vector<snapshot_info> list_snapshots( const cata_path &world_dir )
+{
+    std::vector<snapshot_info> result;
+    const cata_path root = snapshots_root( world_dir );
+    if( !dir_exist( root.get_unrelative_path() ) ) {
+        return result;
+    }
+
+    const std::vector<cata_path> dirs = get_directories( root );
+    for( const cata_path &dir : dirs ) {
+        snapshot_info info;
+        info.dir_name = dir.get_relative_path().filename().u8string();
+        info.name = info.dir_name; // fallback if no/invalid meta
+
+        const cata_path meta_path = dir / SNAPSHOT_META;
+        read_from_file_optional_json( meta_path, [&info]( const JsonValue & jsin ) {
+            JsonObject jo = jsin;
+            jo.allow_omitted_members();
+            jo.read( "name", info.name, false );
+            jo.read( "character_name", info.character_name, false );
+            jo.read( "turn", info.turn, false );
+            jo.read( "real_time", info.real_time, false );
+        } );
+        result.push_back( info );
+    }
+
+    // Newest first.
+    std::sort( result.begin(), result.end(),
+    []( const snapshot_info & a, const snapshot_info & b ) {
+        return a.real_time > b.real_time;
+    } );
+    return result;
+}
+
+bool snapshot_exists( const cata_path &world_dir, const std::string &slot_name )
+{
+    const std::string dir_name = ensure_valid_file_name( slot_name );
+    if( dir_name.empty() ) {
+        return false;
+    }
+    const cata_path dest = snapshots_root( world_dir ) / dir_name;
+    return dir_exist( dest.get_unrelative_path() );
+}
+
+bool restore_snapshot( const cata_path &world_dir, const std::string &dir_name )
+{
+    const cata_path snap_path = snapshots_root( world_dir ) / dir_name;
+    const std::filesystem::path snap_fs = snap_path.get_unrelative_path();
+    if( !dir_exist( snap_fs ) ) {
+        debugmsg( "snapshot: '%s' no longer exists", snap_fs.u8string() );
+        return false;
+    }
+
+    const std::filesystem::path world_fs = world_dir.get_unrelative_path();
+    const std::filesystem::path backup_fs =
+        ( world_dir / RESTORE_BACKUP_DIR ).get_unrelative_path();
+
+    // Atomic-ish restore with rollback:
+    //   1. Move the live world's files (except snapshots/ and any old backup)
+    //      into a backup folder — cheap renames, nothing destroyed yet.
+    //   2. Copy the snapshot into the world (excluding its own meta file).
+    //   3. On success, delete the backup. On any failure, move the backup
+    //      contents back so the world is never left half-deleted.
+    const std::vector<std::string> protect = { SNAPSHOTS_DIR, RESTORE_BACKUP_DIR };
+
+    std::error_code ec;
+    std::filesystem::remove_all( backup_fs, ec ); // clear any stale backup
+    if( !assure_dir_exist( backup_fs ) ) {
+        debugmsg( "snapshot: could not create restore backup dir '%s'", backup_fs.u8string() );
+        return false;
+    }
+
+    if( !move_entries( world_fs, backup_fs, protect ) ) {
+        // Roll back whatever we managed to move, then bail.
+        move_entries( backup_fs, world_fs, {} );
+        std::filesystem::remove_all( backup_fs, ec );
+        return false;
+    }
+
+    // Copy the snapshot in, excluding the per-snapshot meta file so it does not
+    // pollute the world root (and snowball into future snapshots).
+    if( !copy_tree( snap_fs, world_fs, { SNAPSHOT_META } ) ) {
+        // Restore failed: wipe the partial copy and move the backup back.
+        clear_dir_except( world_fs, protect );
+        move_entries( backup_fs, world_fs, {} );
+        std::filesystem::remove_all( backup_fs, ec );
+        return false;
+    }
+
+    // Success: discard the backup.
+    std::filesystem::remove_all( backup_fs, ec );
+    return true;
+}
+
+bool delete_snapshot( const cata_path &world_dir, const std::string &dir_name )
+{
+    const cata_path snap_path = snapshots_root( world_dir ) / dir_name;
+    const std::filesystem::path snap_fs = snap_path.get_unrelative_path();
+    if( !dir_exist( snap_fs ) ) {
+        return false;
+    }
+    std::error_code ec;
+    const bool ok = std::filesystem::remove_all( snap_fs, ec ) !=
+                    static_cast<std::uintmax_t>( -1 ) && !ec;
+    if( !ok ) {
+        debugmsg( "snapshot: failed to delete '%s': %s", snap_fs.u8string(), ec.message() );
+    }
+    return ok;
+}
+
+std::string snapshot_info::display_label() const
+{
+    std::string label = name;
+    if( turn > 0 ) {
+        label += string_format( " — %s", to_string( time_point::from_turn( turn ) ) );
+    }
+    if( !character_name.empty() ) {
+        label += string_format( " (%s)", character_name );
+    }
+    return label;
+}
+
+menu_selection query_snapshot_menu( const cata_path &world_dir,
+                                    const std::string &title,
+                                    const std::string &restore_verb )
+{
+    const std::vector<snapshot_info> snaps = list_snapshots( world_dir );
+
+    uilist menu;
+    menu.title = title;
+    menu.text = _( "Snapshots capture the entire world.  Restoring overwrites the "
+                   "world's current save with the snapshot." );
+
+    // Entry 0: create a new snapshot.
+    menu.addentry( 0, true, 'n', _( "Save a new snapshot…" ) );
+
+    // Entries 1..N: existing snapshots.
+    int idx = 1;
+    for( const snapshot_info &s : snaps ) {
+        menu.addentry( idx, true, MENU_AUTOASSIGN, "%s", s.display_label() );
+        ++idx;
+    }
+
+    menu.query();
+    const int ret = menu.ret;
+    if( ret < 0 ) {
+        return menu_selection{};
+    }
+
+    if( ret == 0 ) {
+        string_input_popup popup;
+        const std::string name = popup
+                                 .title( _( "Snapshot name:" ) )
+                                 .width( 30 )
+                                 .max_length( 60 )
+                                 .query_string();
+        if( name.empty() ) {
+            return menu_selection{};
+        }
+        // Warn if this name would silently overwrite an existing slot — including
+        // the case where a different display name sanitizes to the same folder.
+        if( snapshot_exists( world_dir, name ) &&
+            !query_yn( _( "A snapshot with this name already exists.  Overwrite it?" ) ) ) {
+            return menu_selection{};
+        }
+        menu_selection sel;
+        sel.action = menu_action::create;
+        sel.new_name = name;
+        return sel;
+    }
+
+    const size_t i = static_cast<size_t>( ret - 1 );
+    if( i >= snaps.size() ) {
+        return menu_selection{};
+    }
+    const snapshot_info &chosen = snaps[i];
+
+    uilist action;
+    action.title = chosen.name;
+    action.addentry( 0, true, 'l', restore_verb );
+    action.addentry( 1, true, 'd', _( "Delete this snapshot" ) );
+    action.query();
+
+    menu_selection sel;
+    sel.chosen = chosen;
+    if( action.ret == 0 ) {
+        sel.action = menu_action::load;
+    } else if( action.ret == 1 ) {
+        sel.action = menu_action::remove;
+    }
+    return sel;
+}
+
+} // namespace save_snapshot

--- a/src/save_snapshot.h
+++ b/src/save_snapshot.h
@@ -1,0 +1,113 @@
+#pragma once
+#ifndef CATA_SRC_SAVE_SNAPSHOT_H
+#define CATA_SRC_SAVE_SNAPSHOT_H
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+class cata_path;
+
+/**
+ * Snapshot-based multi-save system.
+ *
+ * Because NPCs, factions, missions, the map and the overmap are all
+ * world-level state in CDDA (stored in master.gsav / maps/ / overmaps/),
+ * the only way to capture a self-consistent, isolated save is to snapshot
+ * the ENTIRE world directory. A snapshot is therefore a recursive copy of
+ * a world's folder (excluding the snapshots/ subfolder itself).
+ *
+ * This pairs with the one-character-per-world enforcement: one world holds
+ * exactly one character plus its world state, so a world snapshot is a clean
+ * "save slot".
+ *
+ * These functions operate purely on disk and are decoupled from any running
+ * game: callers that have a live game must persist it (game::save) before
+ * snapshotting and reload it (game::reload_active_save) after restoring.
+ */
+namespace save_snapshot
+{
+
+// Metadata describing a single snapshot slot, read back from its meta file
+// for display in the snapshot menu.
+struct snapshot_info {
+    // Folder name of the snapshot under <world>/snapshots/ (sanitized slot name).
+    std::string dir_name;
+    // Human-readable slot name as entered by the player.
+    std::string name;
+    // Name of the character at snapshot time.
+    std::string character_name;
+    // In-game turn at snapshot time (calendar::turn), 0 if unknown.
+    int turn = 0;
+    // Real-world unix timestamp when the snapshot was taken, 0 if unknown.
+    int64_t real_time = 0;
+
+    // Menu label: "<name> — <date> (<character>)", omitting unknown parts.
+    std::string display_label() const;
+};
+
+// What the user chose in the shared snapshot menu.
+enum class menu_action {
+    none,   // cancelled
+    create, // make a new snapshot (see new_name)
+    load,   // restore the chosen snapshot (see chosen)
+    remove, // delete the chosen snapshot (see chosen)
+};
+
+struct menu_selection {
+    menu_action action = menu_action::none;
+    std::string new_name;   // for create: the raw name the player entered
+    snapshot_info chosen;   // for load/remove: the selected snapshot
+};
+
+/**
+ * Build and run the snapshot list menu for @p world_dir once, returning the
+ * user's intent. Shared by the in-game and main-menu entry points; the caller
+ * performs the context-specific work (saving/reloading vs. plain file ops).
+ * @param title menu title text.
+ * @param restore_verb label for the restore action ("Load" in-game, "Restore"
+ *        from the main menu).
+ */
+menu_selection query_snapshot_menu( const cata_path &world_dir,
+                                    const std::string &title,
+                                    const std::string &restore_verb );
+
+/**
+ * Copy the entire world directory at @p world_dir into a new snapshot slot
+ * named @p slot_name (replacing any existing slot of that name) and write a
+ * meta file describing it. Does NOT save the running game first.
+ * @return true on success.
+ */
+bool make_snapshot( const cata_path &world_dir, const std::string &slot_name,
+                    const std::string &character_name, int turn );
+
+/**
+ * Scan <world_dir>/snapshots/ and return info for every snapshot found,
+ * ordered by real-world capture time (newest first).
+ */
+std::vector<snapshot_info> list_snapshots( const cata_path &world_dir );
+
+/**
+ * Whether a snapshot slot whose folder matches @p slot_name (after the same
+ * filename sanitization make_snapshot applies) already exists. Lets the UI warn
+ * before make_snapshot silently replaces a slot — including the case where two
+ * distinct display names sanitize to the same folder.
+ */
+bool snapshot_exists( const cata_path &world_dir, const std::string &slot_name );
+
+/**
+ * Replace the world files at @p world_dir with the snapshot's copy
+ * (preserving the snapshots/ folder). Does NOT reload the running game.
+ * @return true on success.
+ */
+bool restore_snapshot( const cata_path &world_dir, const std::string &dir_name );
+
+/**
+ * Permanently delete the snapshot @p dir_name under @p world_dir.
+ * @return true on success.
+ */
+bool delete_snapshot( const cata_path &world_dir, const std::string &dir_name );
+
+} // namespace save_snapshot
+
+#endif // CATA_SRC_SAVE_SNAPSHOT_H

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -114,6 +114,16 @@ bool WORLD::save_exists( const save_t &name ) const
 void WORLD::add_save( const save_t &name )
 {
     if( !save_exists( name ) ) {
+        // One character per world is enforced at the UI layer (main_menu blocks
+        // creating a second character, and the snapshot system treats one world
+        // as one save slot). This is just a low-level backstop: silently refuse
+        // a second, different save id rather than debugmsg — a modal error here
+        // would fire on every save after a debug "rename save" and is the wrong
+        // altitude for a policy decision. (Re-saving the same character hits
+        // save_exists() above and returns, so this only blocks genuinely new ids.)
+        if( !world_saves.empty() ) {
+            return;
+        }
         world_saves.push_back( name );
     }
 }
@@ -2106,6 +2116,11 @@ bool WORLD::has_compression_enabled() const
             std::filesystem::exists( ( world_folder_path / "overmaps.dict" ).get_unrelative_path() ) );
     }
     return is_compressed.value();
+}
+
+void WORLD::invalidate_compression_cache()
+{
+    is_compressed.reset();
 }
 
 bool WORLD::set_compression_enabled( bool enabled )

--- a/src/worldfactory.h
+++ b/src/worldfactory.h
@@ -90,6 +90,10 @@ struct WORLD {
 
         bool has_compression_enabled() const;
         bool set_compression_enabled( bool enabled );
+        // Drop the memoized compression state so the next has_compression_enabled()
+        // re-probes the on-disk dictionaries. Needed after the world files are
+        // replaced underneath a loaded WORLD (e.g. snapshot restore).
+        void invalidate_compression_cache();
     private:
         mutable std::optional<bool> is_compressed;
 


### PR DESCRIPTION
#### 概述 (Summary)
Features \"新增基于整 world 目录快照的多档存读档系统,并强制单世界单角色\"

#### 改动目的 (Purpose of change)
中文:原版快速读档是覆盖式单档,磁盘上没有历史存档点。本 PR 提供"随时存/读多个互不干扰快照"的能力。由于 NPC、阵营、任务、地图都是 **world 级**状态(存在 master.gsav / maps/ / overmaps/),唯一自洽的隔离单位是整个 world 目录,因此快照以 world 文件夹为单位;并强制单 world 单角色以保证语义干净,避免多角色共享世界状态互相污染。

English: Vanilla quickload is a single overwriting save with no history. This PR adds the ability to keep multiple independent snapshots and restore any of them. Because NPCs, factions, missions and the map are all **world-level** state (master.gsav / maps/ / overmaps/), the only self-consistent unit to isolate is the whole world directory, so snapshots copy the entire world folder. One-character-per-world is enforced so shared world state can't contaminate across characters.

#### 解决方案描述 (Describe the solution)
中文:
- **src/save_snapshot.{h,cpp}**(新增):`make / list / restore / delete`,整目录递归复制(天然兼容压缩与非压缩存档)。**恢复采用原子流程**:先把活动世界文件 rename 进备份目录 → 拷快照进来 → 成功删备份 / 任何失败把备份移回,杜绝"删一半丢档"。
- **四个入口**:游戏内可绑定键 `snapshot_menu` / ESC 主菜单 / 主菜单 World→Snapshots(`world_tab`)/ debug 菜单。游戏内与主菜单共用 `query_snapshot_menu()` 公共助手。
- **ESC "Quit to last snapshot"**:回退到最近快照后不保存退出(savescum 式),退出前世界已是一致快照态,规避裸 QUIT_NOSAVED 的损坏风险。
- **quickload 重写**为原地重载:抽出公共 `game::reset_game_state()` + 新增 `reload_active_save()`,跳过 JSON/mod 重载;加载失败安全回主菜单而非留空世界。
- **单 world 单角色**:`main_menu` 两处创建第二角色改为硬阻止;`WORLD::add_save` 静默兜底(不再 debugmsg);`zone_manager::clear` 重置 `num_personal_zones`;恢复后调用 `WORLD::invalidate_compression_cache()`。

English:
- **src/save_snapshot.{h,cpp}** (new): `make / list / restore / delete` with recursive directory copy (handles both compressed and uncompressed saves). **Restore is atomic**: rename the live world files into a backup dir → copy the snapshot in → drop the backup on success / move it back on any failure, so a partial copy never destroys the world.
- **Four entry points**: in-game keybind `snapshot_menu` / ESC main menu / main-menu World→Snapshots (`world_tab`) / debug menu. In-game and main-menu paths share a `query_snapshot_menu()` helper.
- **ESC "Quit to last snapshot"**: restore the most recent snapshot then quit without saving (savescum-style); the on-disk world is a consistent snapshot state first, avoiding the corruption risk of a bare QUIT_NOSAVED.
- **quickload rewritten** as in-place reload: extracted shared `game::reset_game_state()` + new `reload_active_save()`, skipping the JSON/mod reload; bails safely to the main menu on load failure instead of leaving an empty world.
- **One character per world**: the two "create a second character" paths in `main_menu` now hard-block; `WORLD::add_save` is a silent backstop (no debugmsg); `zone_manager::clear` resets `num_personal_zones`; `WORLD::invalidate_compression_cache()` is called after restore.

#### 测试 (Testing)
中文:Release(MSVC/x64/SDL3)完整构建通过。运行时端到端验证未完成(本地手测中断)。审阅重点:恢复失败路径(磁盘满/文件锁)世界应完整回滚不丢档;跨压缩态恢复;游戏内/ESC/主菜单三处入口的存/读/删。

English: Full Release build (MSVC/x64/SDL3) passes. End-to-end runtime verification was not completed (local manual test interrupted). Review focus: restore-failure paths (disk full / locked file) must roll the world back intact; cross-compression-state restore; save/load/delete across the in-game, ESC, and main-menu entry points.

#### 补充说明 (Additional context)
中文:经一轮 xhigh code-review,已修复 13 项发现(恢复原子化、恢复前清 MAPBUFFER 规避 Windows mmap 删除失败、reload 失败回主菜单、排除 snapshot_meta 污染 world 根、压缩缓存失效、清 save_is_dirty、先收集再删避免迭代器边删边遍历、名字碰撞警告、add_save 降静默、半成品快照清理、防悬垂 submap、抽公共菜单去重)。

English: After one xhigh code-review pass, 13 findings were fixed (atomic restore, clearing MAPBUFFER before restore to dodge Windows mmap delete failures, reload-failure → main menu, excluding snapshot_meta from polluting the world root, compression-cache invalidation, clearing save_is_dirty, collect-then-delete to avoid mutating a directory while iterating it, name-collision warning, add_save downgraded to silent, partial-snapshot cleanup, dangling-submap guard, shared-menu dedup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)