### PR TITLE
fix(craft): 无人值守制作批量超时销毁 + 等待卡顿 / unattended-craft batch deadline + wait stutter

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6368,11 +6368,18 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
             }
 
             if( plan.choice == step_choice::do_wait ) {
-                // Per-turn env check fast-path.  do_something / set_timer
-                // rely on the periodic env_check wakeup at 1-minute cadence
-                // since no actor runs for those modes.
-                craft_actualize_scheduled( craft, item_wakeup_kind::env_check,
-                                           calendar::turn, craft_item );
+                // Env check fast-path, throttled to the env_check_at cursor.
+                // craft_check_env_step re-arms the cursor to now+1min after each
+                // check, so honoring it here keeps the per-minute cadence instead
+                // of rebuilding the (expensive) nearby inventory every single turn
+                // -- the latter caused severe stutter while waiting on a craft.
+                // do_something / set_timer rely on the periodic env_check wakeup
+                // for the same cadence since no actor runs for those modes.
+                const time_point env_at = craft.get_env_check_at();
+                if( env_at != calendar::before_time_starts && calendar::turn >= env_at ) {
+                    craft_actualize_scheduled( craft, item_wakeup_kind::env_check,
+                                               calendar::turn, craft_item );
+                }
                 crafter.set_moves( 0 );
                 return;
             }

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1777,7 +1777,12 @@ void craft_stamp_passive_entry( item &craft, const Character &crafter, time_poin
         if( cur_step.grace_period.has_value() ) {
             fail_dur += *cur_step.grace_period;
         }
-        craft.set_fail_at( entry_time + fail_dur );
+        // Anchor the destruction deadline to completion (ready_at), not entry.
+        // ready_at already scales with batch size via step_budget_moves, so a
+        // large batch (e.g. boiling 4+ water) no longer hits a fixed max_time
+        // deadline before it can finish.  max_time/grace_period are the buffer
+        // allowed past completion before the craft is destroyed.
+        craft.set_fail_at( craft.get_ready_at() + fail_dur );
     }
     if( plan.choice == step_choice::set_timer && plan.alarm_offset.has_value() ) {
         craft.set_alarm_at( entry_time + *plan.alarm_offset );

--- a/tests/craft_attention_test.cpp
+++ b/tests/craft_attention_test.cpp
@@ -1609,6 +1609,37 @@ TEST_CASE( "craft_env_unpause_alarm_clears_when_already_due",
     CHECK( on_map.get_pause_started_at() == calendar::before_time_starts );
 }
 
+TEST_CASE( "craft_stamp_anchors_fail_at_to_ready_at_not_entry",
+           "[craft][attention][overdue][fail]" )
+{
+    clear_avatar();
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+
+    // Cure step: time 10m, max_time 20m, grace_period 5m, unattended.
+    item ingredient( itype_2x4, calendar::turn );
+    item placed( &recipe_cudgel_test_timeout_recipe.obj(), 1, ingredient );
+    item &on_map = here.add_item( origin, placed );
+    REQUIRE( on_map.is_craft() );
+    on_map.set_current_step( 1 );
+    on_map.set_crafter_id( u.getID() );
+    on_map.set_step_plans( std::vector<attention_plan>( 2 ) );
+
+    item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
+    craft_stamp_passive_entry( on_map, u, calendar::turn, loc );
+
+    // fail_at must be anchored to completion (ready_at + max_time + grace),
+    // NOT to entry_time.  Anchoring to entry made large batches hit a fixed
+    // deadline before ready_at could scale past it (boiling 4+ water vanished).
+    REQUIRE( on_map.get_passive_started_at() == calendar::turn );
+    CHECK( on_map.get_fail_at() == on_map.get_ready_at() + 20_minutes + 5_minutes );
+    CHECK( on_map.get_fail_at() > on_map.get_ready_at() );
+}
+
+
 TEST_CASE( "craft_stamp_arms_env_check_when_step_has_env_requirements",
            "[craft][attention][env_check]" )
 {
@@ -1932,7 +1963,7 @@ TEST_CASE( "craft_actualize_ready_via_helper_still_pauses_on_env_loss",
     CHECK( on_map.get_env_check_at() == calendar::before_time_starts );
 }
 
-TEST_CASE( "craft_activity_do_wait_env_check_fires_per_turn",
+TEST_CASE( "craft_activity_do_wait_env_check_fires_when_cursor_due",
            "[craft][attention][env_check][actor]" )
 {
     clear_avatar();
@@ -1941,7 +1972,9 @@ TEST_CASE( "craft_activity_do_wait_env_check_fires_per_turn",
     map &here = get_map();
     const tripoint_bub_ms origin( 60, 60, 0 );
     u.setpos( here, origin );
-    // No OVEN: per-turn env_check inside do_wait branch must trip pause.
+    // No OVEN: the do_wait env_check must trip a pause -- but only when the
+    // env_check_at cursor is due, not every single turn (the per-turn rebuild
+    // caused severe stutter; the fast-path now honors the 1-minute cursor).
 
     item ingredient( itype_2x4, calendar::turn );
     item placed( &recipe_cudgel_test_unattended_with_qual.obj(), 1, ingredient );
@@ -1964,10 +1997,20 @@ TEST_CASE( "craft_activity_do_wait_env_check_fires_per_turn",
     u.activity = player_activity( craft_actor );
     u.activity.targets.push_back( loc );
 
-    u.activity.do_turn( u );
+    SECTION( "cursor not yet due: env_check is throttled, no pause this turn" ) {
+        // Cursor armed one minute out (as craft_stamp_passive_entry would).
+        on_map.set_env_check_at( t0 + 1_minutes );
+        u.activity.do_turn( u );
+        CHECK( on_map.get_pause_started_at() == calendar::before_time_starts );
+    }
 
-    CHECK( on_map.get_pause_started_at() != calendar::before_time_starts );
-    CHECK( on_map.get_saved_ready_at() == t0 + 10_minutes );
+    SECTION( "cursor due: env_check fires and pauses on the missing quality" ) {
+        // Cursor due now -> the throttled fast-path runs the env check.
+        on_map.set_env_check_at( t0 );
+        u.activity.do_turn( u );
+        CHECK( on_map.get_pause_started_at() != calendar::before_time_starts );
+        CHECK( on_map.get_saved_ready_at() == t0 + 10_minutes );
+    }
 }
 
 TEST_CASE( "reconcile_walks_avatar_inventory_for_env_check",


### PR DESCRIPTION
#### 概述 (Summary)
修复上游 PR #87267(把烧水改为无人值守 steps)暴露的两个独立缺陷:大批量制作"蒸发"和"等待完成"时的严重卡顿。

Fixes two independent defects exposed by upstream #87267 (water boiling made unattended): large-batch "evaporation" and severe stutter while waiting on a craft.

#### 改动目的 (Purpose of change)

**1. 批量超时销毁("蒸发")**
`craft_stamp_passive_entry` 把销毁时限 `fail_at` 锚定到 `entry_time + max_time`(固定值),但完成时间 `ready_at` 经 `step_budget_moves` 随 batch 缩放。大批量(如一次烧 4+ 份水)的 `ready_at` 晚于固定的 `fail_at`,craft 在完成前就被 `craft_actualize_fail` 销毁,表现为"水蒸发消失"。

The destruction deadline `fail_at` was anchored to `entry_time + max_time` (fixed), while completion time `ready_at` scales with batch size via `step_budget_moves`. Large batches had `ready_at` later than the fixed `fail_at`, so the craft was destroyed by `craft_actualize_fail` before it could finish.

**2. 等待卡顿**
玩家选"等待完成"(`do_wait`)时,actor 每回合无条件调用 env_check fast-path,绕过 `env_check_at` 的 1 分钟节流游标,每回合重建昂贵的 `form_from_map`,造成严重卡顿(实测每 ~0.38s 一次重查)。

The `do_wait` fast-path ran the env check every turn, bypassing the `env_check_at` 1-minute cursor and rebuilding the expensive nearby inventory each turn (measured ~0.38s per recheck).

#### 解决方案描述 (Describe the solution)
- `fail_at` 改为锚定 `ready_at + max_time(+grace_period)`,随 batch 缩放;语义变为"完成后允许停留的缓冲时间"。
- `do_wait` fast-path 改为尊重 `env_check_at` 游标(与无人值守 wakeup 路径同样的每分钟节奏)。制作进度由独立的 `ready_check` 推进,不受影响;环境丢失(断电/搬走热源)最多延迟 1 分钟被检测,与"放着干别的"模式一致。

#### 测试 (Testing)
- 新增 `craft_stamp_anchors_fail_at_to_ready_at_not_entry`,断言 `fail_at == ready_at + max_time + grace`。
- 重写 `craft_activity_do_wait_env_check_fires_when_cursor_due`(原 `..._fires_per_turn`),验证节流后语义:游标未到→不查;到点→查并 pause。
- `[attention]` 全套通过:55 用例 / 362 断言。
- MSBuild Release x64 编译通过。

#### 补充说明 / 已知遗留 (Additional context)
另有一个**尚未修复**的相关问题:连接电网的电器(烤箱/电炉 appliance)烧水时反复刷"能量不足"。已确认这与本 PR 的两个缺陷是不同路径(electric appliance 伪工具的电荷暴露链),需进一步用运行时日志定位,留待后续 PR。

A separate **unfixed** issue remains: grid-connected appliances (oven/hotplate) repeatedly report "insufficient charges" when boiling. Confirmed to be a different path (appliance pseudo-tool charge exposure) and left for a follow-up PR pending runtime diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)