### PR TITLE
废除脏存档字段/机制

### DIFF
--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -293,7 +293,6 @@ std::string enum_to_string<debug_menu::debug_menu_index>( debug_menu::debug_menu
         case debug_menu::debug_menu_index::EXPORT_FOLLOWER: return "EXPORT_FOLLOWER";
         case debug_menu::debug_menu_index::EXPORT_SELF: return "EXPORT_SELF";
 		case debug_menu::debug_menu_index::QUICK_SETUP: return "QUICK_SETUP";
-		case debug_menu::debug_menu_index::QUICK_SETUP_FLAG_DIRTY: return "QUICK_SETUP_FLAG_DIRTY";
 		case debug_menu::debug_menu_index::TOGGLE_SETUP_MUTATION: return "TOGGLE_SETUP_MUTATION";
 		case debug_menu::debug_menu_index::NORMALIZE_BODY_STAT: return "NORMALIZE_BODY_STAT";
 		case debug_menu::debug_menu_index::SIX_MILLION_DOLLAR_SURVIVOR: return "SIX_MILLION_DOLLAR_SURVIVOR";
@@ -1099,7 +1098,6 @@ static int quick_setup_uilist()
 {
     const std::vector<uilist_entry> uilist_initializer = {
         { uilist_entry( debug_menu_index::QUICK_SETUP, true, 'Q', _( "Quick setup…" ) ) },
-        { uilist_entry( debug_menu_index::QUICK_SETUP_FLAG_DIRTY, true, 'D', _( "Quick setup and flag save as dirty" ) ) },
         { uilist_entry( debug_menu_index::TOGGLE_SETUP_MUTATION, true, 't', _( "Toggle debug mutations" ) ) },
         { uilist_entry( debug_menu_index::NORMALIZE_BODY_STAT, true, 'n', _( "Normalize body stats" ) ) },
         { uilist_entry( debug_menu_index::SIX_MILLION_DOLLAR_SURVIVOR, true, 'B', _( "Install ALL bionics" ) ) },
@@ -4092,7 +4090,7 @@ void export_save_archive_and_game_report()
     game_report();
 }
 
-void do_debug_quick_setup( bool flag_dirty )
+void do_debug_quick_setup()
 {
     // Turn on debug mode. Some debug information displays require just this to be on, so we want it on. Save a few keypresses.
     debug_mode = true;
@@ -4111,9 +4109,6 @@ void do_debug_quick_setup( bool flag_dirty )
     map_reveal( static_cast<int>( om_vision_level::full ) );
     dialogue d( get_talker_for( get_avatar() ), nullptr );
     effect_on_condition_EOC_DEBUG_QUICK_SETUP->activate( d );
-    if( flag_dirty ) {
-        g->save_is_dirty = true;
-    }
 }
 
 const std::vector<debug_action_entry> &all_actions()
@@ -4831,9 +4826,8 @@ const std::vector<debug_action_entry> &all_actions()
             debug_menu_index::QUICKLOAD, translate_marker( "Quickload" ), "quickload load", "Game", []()
             {
                 if( query_yn(
-                        _( "Quickload without saving?  This will mark save as 'dirty' and disable future saving to prevent accidental overwriting save.  Also this may cause issues such as duplicated or missing items and vehicles!" ) ) ) {
+                        _( "Quickload without saving?  This may cause issues such as duplicated or missing items and vehicles!" ) ) ) {
                     g->quickload();
-                    g->save_is_dirty = true;
                 }
             }
         },

--- a/src/debug_menu.h
+++ b/src/debug_menu.h
@@ -43,7 +43,7 @@ void open_console();
 
 void export_save_archive_and_game_report();
 
-void do_debug_quick_setup( bool flag_dirty = false );
+void do_debug_quick_setup();
 
 /* Splits a string by @param delimiter and push_back's the elements into _Container */
 template<typename Container>

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -460,7 +460,6 @@ game::game() :
     scent( *scent_ptr ),
     timed_events( *timed_event_manager_ptr ),
     uquit( QUIT_NO ),
-    save_is_dirty( false ),
     safe_mode( SAFE_MODE_ON ),
     u_shared_ptr( &u, null_deleter{} ),
     next_npc_id( 1 ),
@@ -782,9 +781,6 @@ bool game::reload_active_save( const save_t &save_file )
 
     try {
         if( load( save_file ) ) {
-            // A freshly loaded save is internally consistent again, so a prior
-            // debug-induced "dirty" state no longer applies.
-            save_is_dirty = false;
             return true;
         }
         debugmsg( "In-place reload failed: unable to load save file '%s'", save_file.base_path() );

--- a/src/game.h
+++ b/src/game.h
@@ -1234,8 +1234,6 @@ class game
 
         /** Used in main.cpp to determine what type of quit is being performed. */
         quit_status uquit; // NOLINT(cata-serialize)
-        /** Flags if the game is currently in an unsupported state and cannot be saved. */
-        bool save_is_dirty; // NOLINT(cata-serialize)
         /** True if the game has just started or loaded, else false. */
         bool new_game = false; // NOLINT(cata-serialize)
 

--- a/src/game_io.cpp
+++ b/src/game_io.cpp
@@ -741,10 +741,6 @@ bool game::save_external_options_record()
 
 bool game::save()
 {
-    if( save_is_dirty ) {
-        popup( _( "The game is in an unsupported state after using debug tools and cannot be saved." ) );
-        return false;
-    }
     std::chrono::seconds time_since_load =
         std::chrono::duration_cast<std::chrono::seconds>(
             std::chrono::steady_clock::now() - time_of_last_load );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -3128,10 +3128,6 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                 if( save() ) {
                     player_character.set_moves( 0 );
                     uquit = QUIT_SAVED;
-                } else if( save_is_dirty && query_yn( _( "Unable to save, quit anyway?" ) ) ) {
-                    // Game refused to save because of unsupported game state. But we don't want to trap them here, so at least let give them the option.
-                    player_character.set_moves( 0 );
-                    uquit = QUIT_NOSAVED;
                 }
             }
             break;
@@ -3142,7 +3138,6 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
 
         case ACTION_QUICKLOAD:
             quickload();
-            g->save_is_dirty = true;
             return false;
 
         case ACTION_SNAPSHOT_MENU:


### PR DESCRIPTION
#### 概述 (Summary)

None

#### 改动目的 (Purpose of change)

DDA的pr83956引入了一个脏存档机制，导致了分支与模组的开发测试产生了非常多的困难和本不应该造成的存档“损坏”。

应项目发起者 @lapp2333xhj 的要求彻底回退该pr修改，删除有关字段。

#### 解决方案描述 (Describe the solution)

仅仅是删除了一些东西