### PR TITLE
Bugfixes: 修复总转换 mod(异星等)区域温度覆盖失效 / Fix region & temperature override for total-conversion mods

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3037,9 +3037,15 @@ void options_manager::add_options_world_default()
 
     add_empty_line();
 
+    // string_input (free text) rather than string_select: total-conversion
+    // mods set this via EXTERNAL_OPTION (e.g. Aftershock -> "default_aftershock"),
+    // and a string_select silently rejects any value not in its candidate list.
+    // The candidate list cannot be pre-populated here because region data loads
+    // after options, so a free-text field is the only form that accepts arbitrary
+    // (mod-provided or player-typed) region ids while staying visible in worldgen.
     add( "DEFAULT_REGION", "world_default", to_translation( "Default region type" ),
-         to_translation( "(WIP feature) Determines terrain, shops, plants, and more." ),
-    { { "default", to_translation( "default" ) } }, "default"
+         to_translation( "(WIP feature) Determines terrain, shops, plants, and more.  Set by total-conversion mods; leave as \"default\" unless you know the id of an installed region." ),
+         "default", 60
        );
 
     add_empty_line();


### PR DESCRIPTION
#### 概述 (Summary)

Bugfixes "修复总转换 mod 通过 EXTERNAL_OPTION 设置 DEFAULT_REGION 失效导致区域/温度覆盖不生效的问题"

#### 改动目的 (Purpose of change)

总转换 mod(如 Aftershock 异星)通过 `EXTERNAL_OPTION` 把 `DEFAULT_REGION` 设为自定义区域 id(如 `default_aftershock`),从而覆盖地形、气候等区域设定。但实测发现 Aftershock 地表温度恒为 ~8℃(地球 `default` 区域 base 11.1℃ 的摆动范围),而非该区域 `base_temperature: -50℃` 应有的极寒——区域覆盖完全失效。

根因:PR #103「恢复世界创建精确选项」把 `DEFAULT_REGION` 重新注册成**候选列表只含 `{default}` 的 `string_select`**。而 `string_select` 的 `setValue` 会校验候选(`getItemPos(...) == -1` 时静默不赋值),`"default_aftershock"` 不在候选里 → 覆盖被悄悄丢弃 → `DEFAULT_REGION` 永远停在 `"default"` → 区域退回地球设定。该问题影响所有依赖自定义 region 的总转换 mod。

A total-conversion mod (e.g. Aftershock) sets `DEFAULT_REGION` to a custom region id (such as `default_aftershock`) via `EXTERNAL_OPTION` to override terrain, climate and other regional settings. In practice the Aftershock surface temperature stayed around ~8℃ (within the swing of Earth's `default` region, base 11.1℃) instead of the bitter cold implied by that region's `base_temperature: -50℃` — the override was silently lost.

Root cause: PR #103 re-registered `DEFAULT_REGION` as a `string_select` whose candidate list only contained `{default}`. `string_select::setValue` validates against the candidate list (it does not assign when `getItemPos(...) == -1`), so `"default_aftershock"` was silently rejected, leaving `DEFAULT_REGION` stuck at `"default"`. This breaks every total-conversion mod that relies on a custom region.

#### 解决方案描述 (Describe the solution)

把 `DEFAULT_REGION` 改注册为 **`string_input`(自由文本)**,默认值仍为 `"default"`。

- 运行时 `get_option("DEFAULT_REGION")` 对 `world_default` 页选项返回的是每世界 `WORLD_OPTIONS` 副本。
- `set_active_world`(设置世界选项指针)发生在 `g->setup()` → `load_world_modfiles()` **之前**,因此加载 mod 时 `load_external_option` 的 `setValue("default_aftershock")` 经 `get_option` **直接写入 `WORLD_OPTIONS`**。
- `string_input` 不做候选校验,覆盖直达运行时实际读取的那份。新建世界 / 已存档世界 / 玩家手动填写三种场景均生效,且该选项在世界创建界面仍可见可编辑(保留 PR #103 的初衷)。

Register `DEFAULT_REGION` as a **`string_input`** (free text) with default `"default"`. At runtime `get_option` returns the per-world `WORLD_OPTIONS` copy for `world_default` options, and `set_active_world` runs before `load_world_modfiles()`, so `load_external_option`'s `setValue` writes straight into `WORLD_OPTIONS`. A `string_input` performs no candidate check, so the override lands. It works for new worlds, existing saves and manual entry, and stays visible/editable in worldgen.

#### 你考虑过的替代方案 (Describe alternatives you've considered)

1. **在 region 加载完成时用 `add_value` 动态填充候选列表**(2013 年原始设计):已弃用。`add_value` 的回填只作用于全局 live `options`,而运行时读取的是 `WORLD_OPTIONS` 快照,够不到;且其回填依赖全局 `options.json` 已存过该值,新建世界首次并不成立。
2. **完全回退 PR #103 对该选项的改动**(回到仅 `enable_json`):可行但会让该选项从世界创建界面消失,违背 PR #103 的初衷。

1. **Dynamically populate the candidate list via `add_value` on region load** (the original 2013 design): rejected. `add_value` only patches the global live `options`, while the runtime reads the `WORLD_OPTIONS` snapshot; it also depends on the value already existing in the global `options.json`, which is not the case on a fresh world.
2. **Fully revert PR #103's change to this option**: works, but removes it from the world-creation screen, against PR #103's intent.

#### 测试 (Testing)

- Release|x64(MSVC / VS18,vcpkg static)编译通过,0 错误。
- 启用 Aftershock 异星 mod 新建世界进入游戏,确认地表温度恢复为该区域设定的极寒值,不再是 ~8℃ 的地球温度。
- 复现原 bug 的前提:启用任一通过 `EXTERNAL_OPTION` 设置 `DEFAULT_REGION` 的总转换 mod,修复前区域覆盖被静默丢弃。

- Builds clean (Release|x64, MSVC/VS18, vcpkg static), 0 errors.
- Started a new world with the Aftershock mod and confirmed the surface temperature returns to the region's intended cold value instead of the ~8℃ Earth value.
- Repro of the original bug: enable any total-conversion mod that sets `DEFAULT_REGION` via `EXTERNAL_OPTION`; before the fix the override was silently dropped.

#### 补充说明 (Additional context)

单文件改动(`src/options.cpp`,+8 −2)。
Single-file change (`src/options.cpp`, +8 −2).