### PR TITLE
Bugfixes: Fix crash when quitting mid-load / 修复加载途中退出导致的崩溃

### DIFF
--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -140,7 +140,18 @@ template<typename T>
 class generic_factory
 {
     public:
-        virtual ~generic_factory() = default;
+        virtual ~generic_factory() {
+            // When a global static factory is destroyed at program exit, its
+            // `deferred` list may still hold JsonObjects with unvisited members
+            // (e.g. the game exited before load_deferred()/reset() ran). Letting
+            // those JsonObjects destruct would call report_unvisited() ->
+            // debugmsg() -> DebugLog() after the debug subsystem has already been
+            // torn down, causing a crash. Suppress the reports first, mirroring
+            // reset().
+            for( std::pair<JsonObject, std::string> &deferred_json : deferred ) {
+                deferred_json.first.allow_omitted_members();
+            }
+        }
 
     private:
         DynamicDataLoader::deferred_json deferred;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -148,6 +148,11 @@ void exit_handler( int s )
     const int old_timeout = inp_mngr.get_timeout();
     inp_mngr.reset_timeout();
     if( s != 2 || query_yn( _( "Really Quit?  All unsaved changes will be lost." ) ) ) {
+        // exit() below runs static destructors without unwinding main()'s stack,
+        // so the json_member_reporting_guard RAII object never fires. Disable the
+        // report here so leftover deferred JsonObjects don't crash in DebugLog
+        // during static destruction.
+        Json::globally_report_unvisited_members( false );
         deinitDebug();
 
         int exit_status = 0;

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -6185,6 +6185,12 @@ static void CheckMessages()
         try_sdl_update();
     }
     if( quit ) {
+        // exit() runs static destructors without unwinding main's stack, so the
+        // RAII guard in main() never fires. If we quit mid-load, global factories
+        // still hold unparsed JsonObjects whose destructors would call
+        // report_unvisited() -> DebugLog() after the debug subsystem is gone,
+        // crashing. Disable the report globally before exiting.
+        Json::globally_report_unvisited_members( false );
         catacurses::endwin();
         exit( 0 );
     }

--- a/src/wincurse.cpp
+++ b/src/wincurse.cpp
@@ -20,6 +20,7 @@
 #include "catacharset.h"
 #include "init.h"
 #include "input.h"
+#include "json.h"
 #include "path_info.h"
 #include "filesystem.h"
 #include "debug.h"
@@ -408,7 +409,10 @@ LRESULT CALLBACK ProcessMessages( HWND__ *hWnd, unsigned int Msg,
             return 0;
 
         case WM_DESTROY:
-            // A messy exit, but easy way to escape game loop
+            // A messy exit, but easy way to escape game loop.
+            // exit() bypasses main()'s unvisited-member guard (no stack unwind),
+            // so disable the report before global JsonObject destructors run.
+            Json::globally_report_unvisited_members( false );
             exit( 0 );
     }
 


### PR DESCRIPTION
#### 概述 (Summary)
Bugfixes "修复在 JSON 加载途中退出游戏导致的崩溃"

#### 改动目的 (Purpose of change)

在 JSON 仍在加载时退出游戏（例如在加载 mod 的进度界面点击窗口关闭按钮），可能在 `DebugLog` 处 `SIGSEGV` 崩溃。崩溃栈在静态析构期出现 `~JsonObject → report_unvisited → debugmsg → DebugLog`，由 `execute_onexit_table` 触发。

Quitting the game while JSON is still loading (e.g. clicking the window close button during the mod-loading screen) can crash with `SIGSEGV` inside `DebugLog`. The stack shows `~JsonObject → report_unvisited → debugmsg → DebugLog` running during static destruction, triggered from `execute_onexit_table`.

**根因 / Root cause:**

`exit()` 直接运行静态析构而**不回卷 `main()` 的调用栈**，因此上游 #65477 引入的 `json_member_reporting_guard`（一个依赖析构触发的 RAII 守卫）**永远不会触发**，全局上报开关保持开启。此时全局工厂（以及 `recipe_dictionary` 的 `deferred` 等其它静态持有者）仍持有未解析的 `JsonObject`，其析构会调用 `report_unvisited() → debugmsg() → DebugLog()`，而 `deinitDebug()` 已将 `DebugFile` 的流 `reset()` 为空 / 调试子系统已被销毁，导致解引用崩溃。

`exit()` runs static destructors **without unwinding `main()`'s stack**, so the `json_member_reporting_guard` RAII object from #65477 never fires and the global reporting flag stays enabled. Global factories (and other static holders such as the `recipe_dictionary` deferred list) still hold unparsed `JsonObject`s whose destructors call `report_unvisited() → debugmsg() → DebugLog()` after `deinitDebug()` has `reset()` the `DebugFile` stream, dereferencing a dead stream.

#### 解决方案描述 (Describe the solution)

在 RAII 守卫够不到的 `exit()` 调用点，于静态析构开始前调用 `Json::globally_report_unvisited_members( false )` 关闭全局未访问成员上报。这一次性覆盖**所有**静态持有者，与持有者数量/类型无关：

Disable global unvisited-member reporting via `Json::globally_report_unvisited_members( false )` at the `exit()` sites the RAII guard cannot reach, before static destruction begins. This covers **all** static holders at once, independent of how many there are:

- `src/sdltiles.cpp` — `CheckMessages()` 的 `SDL_QUIT` 路径（本次崩溃的确切路径 / the exact path in this crash）
- `src/wincurse.cpp` — `WM_DESTROY` 路径（Windows 非 tiles 等价路径 / non-tiles equivalent）
- `src/main.cpp` — `exit_handler()`（菜单 / 游戏内退出 / menu & in-game quit）

此外，加固 `generic_factory` 的析构函数，对其残留的 `deferred` 条目调用 `allow_omitted_members()` 抑制上报，作为纵深防御。

Additionally, harden `generic_factory`'s destructor to call `allow_omitted_members()` on its leftover `deferred` entries as defense in depth.

#### 你考虑过的替代方案 (Describe alternatives you've considered)

- **逐个给静态持有者补析构抑制** / Patch each static holder's destructor：脆弱，新增容器会再次埋雷，且无法覆盖未知持有者。打地鼠。Fragile; every new static container re-introduces the bug. Whack-a-mole.
- **让 `DebugLog` 在静态析构期安全** / Make `DebugLog` safe during static destruction：不可行。`DebugFile` 是 Meyers 单例，跨编译单元析构顺序无保证，可能已被销毁——对已析构对象调成员函数是 UB，判空也救不了。Not viable: cross-TU static destruction order is unspecified; calling a member on an already-destroyed singleton is UB regardless of null checks.

关 flag 从源头掐断"静态析构期调 debugmsg"，与上游 #65477 的设计意图一致，是顺着它补上 `exit()` 这条漏掉的路径。Disabling the flag cuts the problem at its source and is consistent with the intent of #65477, extending it to the `exit()` paths it missed.

#### 测试 (Testing)

复现步骤 / Reproduction:
1. 启动游戏 / Launch the game.
2. 加载一个带较多 mod 的世界 / Load a world with a sizeable mod set.
3. 在加载进度条仍在走时点击窗口关闭按钮 / Click the window close button while the loading bar is still progressing.

修复前：必崩（`SIGSEGV` in `DebugLog`）。修复后：干净退出，无崩溃。
Before: crashes (`SIGSEGV` in `DebugLog`). After: clean exit, no crash.

已通过 MSVC Release x64 全量编译 + 链接验证。
Verified with a full MSVC Release x64 compile + link.

#### 补充说明 (Additional context)

崩溃栈中出现的具体工厂（如 `~generic_factory<fault>`）取决于"退出瞬间哪个工厂的 `deferred` 恰好非空 + 静态析构顺序"，是不稳定的——该 bug 与 `fault` 模块本身无关，任何 `generic_factory<T>` 全局实例都可能命中。

The specific factory shown in the crash stack (e.g. `~generic_factory<fault>`) depends on which factory's `deferred` happens to be non-empty at exit plus static destruction order; it is not stable. The bug is unrelated to the `fault` module itself — any global `generic_factory<T>` can hit it.
