### PR TITLE
Character creation paper-doll preview / 角色创建立绘预览

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -4205,6 +4205,152 @@ bool cata_tiles::draw_vehicle_preview( const catacurses::window &w_disp, const v
     return true;
 }
 
+SDL_Texture *cata_tiles::render_character_preview( const Character &ch, const int scale,
+        int &out_w, int &out_h )
+{
+    // The paper-doll preview reuses the normal map sprite path (draw_entity_with_overlays,
+    // the same routine that paints the player on the map) but redirects the draw origin and
+    // render target at an offscreen texture, the same trick draw_vehicle_preview uses for the
+    // vehicle construction UI. Isometric tilesets use a projection this flat layout does not
+    // handle, so bail and let the caller show nothing.
+    out_w = 0;
+    out_h = 0;
+    if( is_isometric() || scale <= 0 ) {
+        return nullptr;
+    }
+
+    // draw() resets o/op every map frame, so they need no manual restore, but set_draw_scale
+    // persists across frames; capture and restore it like draw_vehicle_preview does.
+    const int saved_zoom = g->get_zoom();
+    set_draw_scale( scale );
+
+    // Character sprites are not tile-sized: they carry per-sprite offsets and overlays (hair,
+    // hats, mutations) that extend above and around the base tile by an amount that varies per
+    // tileset. Rather than guess a headroom that fits every case, draw into a generous work
+    // canvas, then read the rendered pixels back to find the tight non-transparent bounding box
+    // and crop to exactly that. This removes the dead space above the sprite for any tileset.
+    const int work_w = tile_width * 3;
+    const int work_h = tile_height * 3;
+    if( work_w <= 0 || work_h <= 0 ) {
+        set_draw_scale( saved_zoom );
+        return nullptr;
+    }
+
+    if( !char_preview_work_tex || char_preview_work_w != work_w || char_preview_work_h != work_h ) {
+        char_preview_work_tex = CreateTexture( renderer, SDL_PIXELFORMAT_ARGB8888,
+                                               SDL_TEXTUREACCESS_TARGET, work_w, work_h );
+        if( !char_preview_work_tex ) {
+            set_draw_scale( saved_zoom );
+            return nullptr;
+        }
+        SetTextureBlendMode( char_preview_work_tex, SDL_BLENDMODE_BLEND );
+        char_preview_work_w = work_w;
+        char_preview_work_h = work_h;
+    }
+
+    // Place the base tile centred horizontally and one tile up from the bottom, leaving a full
+    // tile of margin on every side so even large overlays land inside the work canvas.
+    op = point( tile_width, work_h - tile_height * 2 );
+    o = point::zero;
+    m_entity_draw_offset = point::zero;
+
+    // Pixel buffer for readback: ARGB8888, 4 bytes per pixel.
+    std::vector<uint32_t> pixels( static_cast<size_t>( work_w ) * work_h, 0 );
+    bool drawn = false;
+    {
+        scoped_render_target preview_scope( renderer, char_preview_work_tex.get()
+#if SDL_MAJOR_VERSION >= 3
+                                            , get_shared_variant_pass()
+#endif
+                                          );
+        if( preview_scope.is_valid() ) {
+            const SDL_Rect clip{ 0, 0, work_w, work_h };
+            RenderSetClipRect( renderer, &clip );
+            SetRenderDrawColor( renderer, 0, 0, 0, 0 );
+            RenderClear( renderer );
+
+            int height_3d = 0;
+            // Force a stable right-facing pose regardless of the avatar's current facing.
+            draw_entity_with_overlays( ch, tripoint_bub_ms( tripoint::zero ), lit_level::BRIGHT,
+                                       height_3d, FacingDirection::RIGHT );
+
+            const SDL_Rect full{ 0, 0, work_w, work_h };
+            drawn = RenderReadPixels( renderer, &full, SDL_PIXELFORMAT_ARGB8888, pixels.data(),
+                                      work_w * 4 );
+            RenderSetClipRect( renderer, nullptr );
+        }
+    }
+
+    if( !drawn ) {
+        set_draw_scale( saved_zoom );
+        return nullptr;
+    }
+
+    // Scan for the bounding box of any non-zero (non-transparent) pixel. The canvas was cleared
+    // to all-zero bytes, so a pixel is "drawn" iff it is non-zero -- no need to assume which byte
+    // is alpha, sidestepping format/endianness concerns.
+    int min_x = work_w;
+    int min_y = work_h;
+    int max_x = -1;
+    int max_y = -1;
+    for( int y = 0; y < work_h; y++ ) {
+        const uint32_t *row = pixels.data() + static_cast<size_t>( y ) * work_w;
+        for( int x = 0; x < work_w; x++ ) {
+            if( row[x] != 0 ) {
+                min_x = std::min( min_x, x );
+                max_x = std::max( max_x, x );
+                min_y = std::min( min_y, y );
+                max_y = std::max( max_y, y );
+            }
+        }
+    }
+
+    if( max_x < min_x || max_y < min_y ) {
+        // Nothing was drawn (e.g. a tileset with no player sprite); show nothing.
+        set_draw_scale( saved_zoom );
+        return nullptr;
+    }
+
+    const int crop_w = max_x - min_x + 1;
+    const int crop_h = max_y - min_y + 1;
+
+    // (Re)allocate the cropped result target at the exact bounding-box size, so ImGui::Image
+    // samples it with default 0..1 UVs and no padding shows around the sprite.
+    if( !char_preview_tex || char_preview_w != crop_w || char_preview_h != crop_h ) {
+        char_preview_tex = CreateTexture( renderer, SDL_PIXELFORMAT_ARGB8888,
+                                          SDL_TEXTUREACCESS_TARGET, crop_w, crop_h );
+        if( !char_preview_tex ) {
+            set_draw_scale( saved_zoom );
+            return nullptr;
+        }
+        SetTextureBlendMode( char_preview_tex, SDL_BLENDMODE_BLEND );
+        char_preview_w = crop_w;
+        char_preview_h = crop_h;
+    }
+
+    SDL_Texture *result = nullptr;
+    {
+        scoped_render_target crop_scope( renderer, char_preview_tex.get()
+#if SDL_MAJOR_VERSION >= 3
+                                         , get_shared_variant_pass()
+#endif
+                                       );
+        if( crop_scope.is_valid() ) {
+            SetRenderDrawColor( renderer, 0, 0, 0, 0 );
+            RenderClear( renderer );
+            const SDL_Rect src{ min_x, min_y, crop_w, crop_h };
+            const SDL_Rect dst{ 0, 0, crop_w, crop_h };
+            RenderCopy( renderer, char_preview_work_tex, &src, &dst );
+            result = char_preview_tex.get();
+            out_w = crop_w;
+            out_h = crop_h;
+        }
+    }
+
+    set_draw_scale( saved_zoom );
+    return result;
+}
+
 bool cata_tiles::draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                                   const std::array<bool, 5> &invisible, const bool memorize_only )
 {

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -818,6 +818,19 @@ class cata_tiles
         bool draw_vehicle_preview( const catacurses::window &w_disp, const vehicle &veh,
                                    const point_rel_ms &cursor_vp_mount, int &cpart );
 
+        /**
+         * Render @p ch (base sprite plus mutation/worn/wielded overlays) into an
+         * internally-owned, offscreen render target, scaled to @p scale (16 == native
+         * tile size). The canvas is sized to fit the scaled sprite exactly, with one
+         * extra tile of headroom above for overlays that draw upward (hair, hats); the
+         * used pixel size is returned in @p out_w / @p out_h so the caller can size its
+         * ImGui::Image to match. The character is centred horizontally and bottom-aligned.
+         * Returns nullptr for isometric tilesets or on render-target failure; the returned
+         * texture is owned by cata_tiles and stays valid until the next call.
+         */
+        SDL_Texture *render_character_preview( const Character &ch, int scale, int &out_w,
+                                               int &out_h );
+
         // Animation layers
         void init_explosion( const tripoint_bub_ms &p, int radius );
         void draw_explosion_frame();
@@ -1180,6 +1193,17 @@ class cata_tiles
         int tint_mask_w = 0;
         int tint_mask_h = 0;
         void ensure_tint_mask_texture( int w, int h );
+
+        // Render targets for the character-creation paper-doll preview. The work target is the
+        // generous canvas the character is drawn into; its non-transparent pixels are read back to
+        // find a tight bounding box, then copied into the cropped target that the caller displays.
+        // Both reused across redraws, reallocated only when their required size changes.
+        SDL_Texture_Ptr char_preview_work_tex;
+        int char_preview_work_w = 0;
+        int char_preview_work_h = 0;
+        SDL_Texture_Ptr char_preview_tex;
+        int char_preview_w = 0;
+        int char_preview_h = 0;
 
         bool in_animation = false;
 

--- a/src/character.h
+++ b/src/character.h
@@ -763,7 +763,10 @@ class Character : public Creature, public visitable
 
         //returns character's profession
         const profession *get_profession() const;
-        void add_profession_items();
+        // Equip the profession's starting items. identify_books controls whether starting books
+        // are run through avatar::identify() (which writes to the message log) -- the character
+        // preview passes false so building its throwaway avatar does not spam messages.
+        void add_profession_items( bool identify_books = true );
         //returns the hobbies
         std::set<const profession *> get_hobbies() const;
 

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -83,6 +83,14 @@
 #include "veh_type.h"
 #include "worldfactory.h"
 
+#if defined(TILES)
+// For the character paper-doll preview: tilecontext / cata_tiles::render_character_preview,
+// the USE_CHARACTER_PREVIEW option, and the use_tiles cache.
+#include "cached_options.h"
+#include "cata_tiles.h"
+#include "sdltiles.h"
+#endif
+
 static const std::string flag_CHALLENGE( "CHALLENGE" );
 static const std::string flag_CITY_START( "CITY_START" );
 static const std::string flag_SECRET( "SECRET" );
@@ -152,10 +160,75 @@ static void set_detail_scroll()
     }
 }
 
+#if defined(TILES)
+static SDL_Texture *character_preview_texture( const avatar &u, int &out_w, int &out_h );
+static void draw_character_preview_cell( const avatar &u );
+
+// The preview occupies its own table column only when tiles + the option are on and the active
+// tileset can actually produce a preview. Isometric tilesets are unsupported by
+// render_character_preview (it always returns null for them), so excluding them here keeps an
+// empty 1px "Preview" column from appearing on every tab. Kept as a predicate so the column count
+// and the per-tab tables stay in agreement.
+static bool character_preview_active()
+{
+    return use_tiles && get_option<bool>( "USE_CHARACTER_PREVIEW" ) && tilecontext &&
+           !tilecontext->is_isometric();
+}
+#endif
+
+// Number of extra table columns the character preview adds (one when active, else none). Owns the
+// #if TILES guard so callers can express their column count as base + this, keeping every table in
+// agreement about when the preview column exists.
+static int preview_extra_columns()
+{
+#if defined(TILES)
+    return character_preview_active() ? 1 : 0;
+#else
+    return 0;
+#endif
+}
+
+// Column count for the per-tab list/detail tables: base of two (placeholder + detail) plus the
+// preview column when it is enabled.
+static int list_detail_columns()
+{
+    return 2 + preview_extra_columns();
+}
+
 static void setup_list_detail_ui( const std::string &header = std::string(),
                                   float uilist_width = 0.33f )
 {
     ImGui::TableSetupScrollFreeze( 0, 1 ); // Make top row always visible
+#if defined(TILES)
+    if( character_preview_active() ) {
+        // Three columns: [placeholder | detail | preview]. The placeholder column must keep its
+        // absolute width (a fraction of the viewport, matching the separate left-hand list window
+        // it sits under) rather than a fraction of the table -- if it stayed a stretch column, the
+        // fixed preview column would shrink it below that fraction and the detail text would slide
+        // left out from under the list (the earlier dropped-character bug). So the placeholder is
+        // pinned to viewport width, the detail column stretches to fill what remains, and the
+        // preview column is fixed to the rendered sprite's width. The preview is ordinary cell
+        // content, so it scrolls with the detail column instead of floating above it.
+        const ImGuiStyle &style = ImGui::GetStyle();
+        const float placeholder_w = uilist_width * ImGui::GetMainViewport()->WorkSize.x;
+        int pw = 0;
+        int ph = 0;
+        character_preview_texture( get_avatar(), pw, ph );
+        const float preview_w = pw > 0 ? pw + style.CellPadding.x * 2.0f + style.ScrollbarSize
+                                : 1.0f;
+        ImGui::TableSetupColumn( "", ImGuiTableColumnFlags_WidthFixed, placeholder_w );
+        ImGui::TableSetupColumn( header.empty() ? _( "No entries found!" ) : header.c_str(),
+                                 ImGuiTableColumnFlags_WidthStretch, 1.0f );
+        ImGui::TableSetupColumn( _( "Preview" ), ImGuiTableColumnFlags_WidthFixed, preview_w );
+        ImGui::TableHeadersRow();
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 2 );
+        draw_character_preview_cell( get_avatar() );
+        ImGui::TableSetColumnIndex( 1 ); // leave the cursor in the detail column for the caller
+        set_detail_scroll();
+        return;
+    }
+#endif
     // reserve space for uilist
     ImGui::TableSetupColumn( "", ImGuiTableColumnFlags_WidthStretch, uilist_width );
     ImGui::TableSetupColumn( header.empty() ? _( "No entries found!" ) : header.c_str(),
@@ -631,7 +704,7 @@ void Character::randomize( const bool random_scenario, bool play_now )
     }
 }
 
-void Character::add_profession_items()
+void Character::add_profession_items( bool identify_books )
 {
     // Our profession should not be a hobby
     if( prof->is_hobby() ) {
@@ -641,7 +714,8 @@ void Character::add_profession_items()
     std::list<item> prof_items = prof->items( outfit, get_mutations() );
     std::list<item> try_adding_again;
 
-    auto attempt_add_items = [this]( std::list<item> &prof_items, std::list<item> &failed_to_add ) {
+    auto attempt_add_items = [this, identify_books]( std::list<item> &prof_items,
+    std::list<item> &failed_to_add ) {
         for( item &it : prof_items ) {
             if( it.has_flag( json_flag_WET ) ) {
                 it.active = true;
@@ -675,7 +749,7 @@ void Character::add_profession_items()
                 success = try_add( it, nullptr, nullptr, false );
             }
 
-            if( it.is_book() && this->is_avatar() ) {
+            if( it.is_book() && identify_books && this->is_avatar() ) {
                 as_avatar()->identify( it );
             }
 
@@ -2792,6 +2866,138 @@ void character_creator_ui_impl::draw_controls()
     cc_uistate.previous_tab = cc_uistate.selected_tab;
 }
 
+#if defined(TILES)
+// Build a throwaway avatar that mirrors the live character's appearance (gender, body,
+// mutations with their variants) and additionally wears the profession's starting outfit, so
+// the preview shows the clothed result. The live creation avatar does not actually wear the
+// profession gear (it is only listed as a preview inventory), so the clothing overlays have to
+// come from a temporary that does. avatar is non-copyable, hence the field-by-field mirror.
+//
+// This must be side-effect-free with respect to the rest of the game: it is a preview, not a
+// commitment. The profession item path (prof->items() and trait enchantment activation) draws
+// from the global RNG, which would otherwise shift the random stream the real creation/worldgen
+// uses, making the result depend on how many times the user previewed. So the whole build runs
+// inside a save/restore of the global RNG engine. Book identification (which writes to the
+// message log) is suppressed via add_profession_items( false ).
+static void build_preview_avatar( const avatar &src, avatar &dst )
+{
+    // Snapshot the global RNG engine and restore it afterwards so previewing consumes no RNG.
+    const cata_default_random_engine saved_rng = rng_get_engine();
+
+    dst.male = src.male;
+    dst.set_body();
+    dst.prof = src.prof;
+
+    // Mirror the visible mutations (with variants) so trait-driven overlays match the live one.
+    dst.clear_mutations();
+    for( const trait_and_var &tv : src.get_mutations_variants() ) {
+        dst.set_mutation( tv.trait, tv.trait->variant( tv.variant ) );
+    }
+    dst.recalc_hp();
+
+    // Wear/wield the profession's starting items onto the temporary so its worn/wielded
+    // overlays populate. Hobbies carry no starting outfit, so this is a no-op for them.
+    // identify_books=false keeps the throwaway from spamming the global message log.
+    if( dst.prof && !dst.prof->is_hobby() ) {
+        dst.add_profession_items( false );
+    }
+
+    rng_get_engine() = saved_rng;
+}
+
+// Produce the character paper-doll preview texture (base sprite plus mutation/worn/wielded
+// overlays) via cata_tiles::render_character_preview -- the same overlay path the map uses --
+// into an offscreen texture. Re-rendering is gated on a cheap appearance signature so the
+// continuously-redrawing creator does not rebuild the texture every frame. Returns the cached
+// texture and writes its pixel size to out_w/out_h, or nullptr (size 0) when the preview is
+// disabled or nothing could be rendered.
+static SDL_Texture *character_preview_texture( const avatar &u, int &out_w, int &out_h )
+{
+    out_w = 0;
+    out_h = 0;
+    if( !use_tiles || !get_option<bool>( "USE_CHARACTER_PREVIEW" ) || !tilecontext ) {
+        return nullptr;
+    }
+
+    // Scale the preview to the screen resolution, like CBN does, so it stays a sensible size on
+    // both small and 4K displays. 6x native (scale 96) at 1080p, scaled by viewport height and
+    // clamped/rounded to a multiple of 16 (set_draw_scale's granularity).
+    const float viewport_h = ImGui::GetMainViewport()->Size.y;
+    int preview_scale = static_cast<int>( std::lround( 96.0f * viewport_h / 1080.0f / 16.0f ) ) * 16;
+    preview_scale = std::clamp( preview_scale, 48, 160 );
+
+    // Appearance signature: gender, profession, mutations, and the scale (so a resolution change
+    // re-renders). When unchanged the cached texture from the previous render is reused as-is.
+    // last_sig starts empty, which no real signature ever equals (they always begin "m|"/"f|"),
+    // so the first call always renders.
+    static std::string last_sig;
+    static SDL_Texture *cached_tex = nullptr;
+    static int cached_w = 0;
+    static int cached_h = 0;
+
+    // This function is called more than once per frame (to size the preview column, then to draw
+    // it) and the creator redraws continuously. Building the signature string -- an allocation plus
+    // a loop over every overlay id -- on each of those calls is pure waste when nothing changed. So
+    // short-circuit when the same avatar is queried again within the same ImGui frame: the scale
+    // and signature cannot have changed since the previous call this frame, so reuse the result.
+    static int last_frame = -1;
+    static const avatar *last_u = nullptr;
+    static int last_scale = 0;
+    const int frame = ImGui::GetFrameCount();
+    if( frame == last_frame && last_u == &u && last_scale == preview_scale ) {
+        out_w = cached_w;
+        out_h = cached_h;
+        return cached_tex;
+    }
+    last_frame = frame;
+    last_u = &u;
+    last_scale = preview_scale;
+
+    std::string sig = std::string( u.male ? "m|" : "f|" ) + ( outfit ? "o1|" : "o0|" ) +
+                      std::to_string( preview_scale ) + "|" +
+                      ( u.prof ? u.prof->ident().str() : "none" ) + "|";
+    for( const std::pair<const std::string, std::string> &ov : u.get_overlay_ids() ) {
+        sig += ov.first;
+        sig += ',';
+    }
+
+    // Gate purely on the signature, NOT on cached_tex being non-null. A render that legitimately
+    // produces nothing (returns null) records its signature too, so it is not retried every frame
+    // -- otherwise build_preview_avatar (RNG snapshot, mutation rebuild, item equip) would run on
+    // every redraw for any character whose sprite fails to render.
+    if( sig != last_sig ) {
+        // Render a temporary clothed copy rather than the live avatar (which is not wearing the
+        // profession outfit during creation). Rebuilt only when the signature changes, so the
+        // per-change avatar construction does not run every frame.
+        avatar preview_av;
+        build_preview_avatar( u, preview_av );
+        cached_tex = tilecontext->render_character_preview( preview_av, preview_scale, cached_w,
+                     cached_h );
+        last_sig = sig;
+    }
+
+    out_w = cached_w;
+    out_h = cached_h;
+    return cached_tex;
+}
+
+// Draw the preview sprite into the current table cell (the list/detail tables' third column,
+// whose column header already reads "Preview"). Unlike the earlier foreground-draw approach this
+// is ordinary cell content, so it participates in layout and scrolls with the detail column
+// instead of floating above everything.
+static void draw_character_preview_cell( const avatar &u )
+{
+    int tex_w = 0;
+    int tex_h = 0;
+    SDL_Texture *tex = character_preview_texture( u, tex_w, tex_h );
+    if( !tex || tex_w <= 0 || tex_h <= 0 ) {
+        return;
+    }
+    ImGui::Image( reinterpret_cast<ImTextureID>( tex ),
+                  ImVec2( static_cast<float>( tex_w ), static_cast<float>( tex_h ) ) );
+}
+#endif // TILES
+
 void character_creator_ui_impl::draw_top_bar( const avatar &u ) const
 {
     auto draw_separator = []() {
@@ -2904,7 +3110,7 @@ void character_creator_ui_impl::draw_scenarios() const
     cc_uistate.recalc_scenario_list( u );
     const scenario *current_scenario = cc_uistate.get_selected_scenario();
 
-    if( ImGui::BeginTable( "SCENARIO_MAIN", 2, CHARACTER_CREATOR_TABLE_FLAGS ) ) {
+    if( ImGui::BeginTable( "SCENARIO_MAIN", list_detail_columns(), CHARACTER_CREATOR_TABLE_FLAGS ) ) {
         if( current_scenario ) {
             std::string scenario_name = current_scenario->gender_appropriate_name( !u.male );
             if( current_scenario == get_scenario() ) {
@@ -2924,7 +3130,7 @@ void character_creator_ui_impl::draw_professions() const
     const avatar &u = get_avatar();
     cc_uistate.recalc_profession_list( u );
 
-    if( ImGui::BeginTable( "PROFESSION_MAIN", 2, CHARACTER_CREATOR_TABLE_FLAGS ) ) {
+    if( ImGui::BeginTable( "PROFESSION_MAIN", list_detail_columns(), CHARACTER_CREATOR_TABLE_FLAGS ) ) {
         const profession_id &selected_profession = cc_uistate.get_selected_profession();
 
         if( !selected_profession.is_null() ) {
@@ -2956,7 +3162,7 @@ void character_creator_ui_impl::draw_backgrounds()
     cc_uistate.recalc_hobby_list( u );
     cc_uistate.recalc_hobbies_taken_list( u );
 
-    if( ImGui::BeginTable( "BACKGROUNDS_MAIN", 2, CHARACTER_CREATOR_TABLE_FLAGS ) ) {
+    if( ImGui::BeginTable( "BACKGROUNDS_MAIN", list_detail_columns(), CHARACTER_CREATOR_TABLE_FLAGS ) ) {
 
         const profession_id selected_hobby = cc_uistate.get_selected_hobby();
         if( !selected_hobby.is_null() ) {
@@ -2986,7 +3192,7 @@ void character_creator_ui_impl::draw_backgrounds()
 
 void character_creator_ui_impl::draw_stats()
 {
-    if( ImGui::BeginTable( "STATS_MAIN", 2, CHARACTER_CREATOR_TABLE_FLAGS ) ) {
+    if( ImGui::BeginTable( "STATS_MAIN", list_detail_columns(), CHARACTER_CREATOR_TABLE_FLAGS ) ) {
         setup_list_detail_ui( char_creation::get_character_stat_header( cc_uistate.selected_stat_index ) );
         ImGui::NewLine();
         char_creation::draw_stat_details( get_avatar() );
@@ -2999,7 +3205,7 @@ void character_creator_ui_impl::draw_traits()
     const avatar &u = get_avatar();
     cc_uistate.recalc_trait_list( u );
     const trait_id selected_trait = cc_uistate.get_selected_trait();
-    if( ImGui::BeginTable( "TRAITS_MAIN", 2, CHARACTER_CREATOR_TABLE_FLAGS ) ) {
+    if( ImGui::BeginTable( "TRAITS_MAIN", list_detail_columns(), CHARACTER_CREATOR_TABLE_FLAGS ) ) {
         if( !selected_trait.is_null() ) {
             std::string trait_name = selected_trait->name();
             if( u.has_trait( selected_trait ) ) {
@@ -3018,7 +3224,7 @@ void character_creator_ui_impl::draw_traits()
 void character_creator_ui_impl::draw_skills()
 {
     cc_uistate.recalc_skill_list();
-    if( ImGui::BeginTable( "SKILLS_MAIN", 2, CHARACTER_CREATOR_TABLE_FLAGS ) ) {
+    if( ImGui::BeginTable( "SKILLS_MAIN", list_detail_columns(), CHARACTER_CREATOR_TABLE_FLAGS ) ) {
         const skill_id selected_skill = cc_uistate.get_selected_skill();
         if( !selected_skill.is_null() ) {
             const avatar &u = get_avatar();
@@ -3045,7 +3251,11 @@ void character_creator_ui_impl::draw_summary()
     const avatar &u = get_avatar();
     const Character &who = get_player_character();
     ImGui::PushStyleVar( ImGuiStyleVar_CellPadding, { 20.0f, 0.0f } );
-    if( ImGui::BeginTable( "DESCRIPTION_MAIN", 3, CHARACTER_CREATOR_TABLE_FLAGS |
+    // One extra content-sized column holds the character preview when it is enabled, matching the
+    // other tabs. This table sizes columns to their content (SizingFixedFit), so the preview simply
+    // occupies its own right-hand column without disturbing the existing three.
+    const int summary_cols = 3 + preview_extra_columns();
+    if( ImGui::BeginTable( "DESCRIPTION_MAIN", summary_cols, CHARACTER_CREATOR_TABLE_FLAGS |
                            ImGuiTableFlags_SizingFixedFit | ImGuiTableFlags_NoHostExtendX | ImGuiTableFlags_BordersInnerV ) ) {
         ImGui::TableNextColumn();
 
@@ -3075,6 +3285,13 @@ void character_creator_ui_impl::draw_summary()
         char_creation::draw_profession_bionics( dummy, _( "Bionics" ), *who.prof );
 
         set_detail_scroll();
+
+#if defined(TILES)
+        if( character_preview_active() ) {
+            ImGui::TableNextColumn();
+            draw_character_preview_cell( u );
+        }
+#endif
 
         ImGui::EndTable();
     }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2649,6 +2649,11 @@ void options_manager::add_options_graphics()
              true, COPT_CURSES_HIDE
            );
 
+        add( "USE_CHARACTER_PREVIEW", page_id, to_translation( "Character creation preview" ),
+             to_translation( "If true, the character creation screen shows a graphical preview of your character's appearance, including mutations." ),
+             true, COPT_CURSES_HIDE
+           );
+
         add( "SWAP_ZOOM", page_id, to_translation( "Zoom Threshold" ),
              to_translation( "Choose when you should swap tileset (lower is more zoomed out)." ),
              1, 4, 2, COPT_CURSES_HIDE
@@ -2661,6 +2666,7 @@ void options_manager::add_options_graphics()
         get_option( "CREATURE_OVERLAY_ICONS" ).setPrerequisite( "USE_TILES" );
         get_option( "VEHICLE_EDIT_TILES" ).setPrerequisite( "USE_TILES" );
         get_option( "VEHICLE_PART_COLOR" ).setPrerequisite( "USE_TILES" );
+        get_option( "USE_CHARACTER_PREVIEW" ).setPrerequisite( "USE_TILES" );
 
         add( "USE_OVERMAP_TILES", page_id, to_translation( "Use tiles to display overmap" ),
              to_translation( "If true, replaces some TTF-rendered text with tiles for overmap display." ),


### PR DESCRIPTION
#### Summary
Features "Character creation paper-doll preview"

#### Purpose of change / 改动目的
The character creation screen had no visual feedback for how mutations, gender, and profession gear actually look on the character. You picked traits and clothing blind. This adds an optional graphical preview, similar to the one in CBN.

角色创建界面此前没有任何关于突变、性别、职业装备实际外观的可视反馈,选特性和衣物全靠盲选。本 PR 新增一个可选的图形预览,类似 CBN 中的实现。

#### Describe the solution / 方案描述
- New `cata_tiles::render_character_preview()` renders the avatar through the normal map overlay path (the same routine that paints the player on the map) into an offscreen render target — the same offscreen trick `draw_vehicle_preview` uses. It reads the rendered pixels back to find a tight non-transparent bounding box and crops to exactly that, so no tileset-specific headroom guessing is needed. The result texture is cached and reused.
  新增 `cata_tiles::render_character_preview()`,通过常规地图叠加路径(即在地图上绘制玩家的同一套流程)将 avatar 渲染到离屏目标——与 `draw_vehicle_preview` 相同的离屏手法。它回读渲染像素以找到紧致的非透明包围盒并精确裁剪,因此无需针对各 tileset 猜测留白。结果纹理会被缓存复用。
- The preview is shown as an extra table column on each character-creation tab (and the summary tab), so it participates in layout and scrolls with the detail pane rather than floating over text.
  预览以额外的表格列形式显示在每个创建标签页(及总结页),因此它参与布局、随详情面板滚动,而不是浮在文字之上。
- Re-rendering is gated on a cheap appearance signature (gender, profession, mutations, scale), so the continuously-redrawing creator does not rebuild the texture every frame.
  重渲染由一个廉价的外观签名(性别、职业、突变、缩放)控制,使持续重绘的创建界面不会每帧重建纹理。

##### Side-effect safety / 副作用安全性
The preview builds a throwaway avatar to populate worn/wielded overlays (the live creation avatar does not actually wear profession gear). This is kept free of world side effects:
预览会构建一个临时 avatar 来填充穿戴/手持叠加层(实际创建用的 avatar 并不真正穿戴职业装备)。该过程不产生世界副作用:
- The global RNG engine is snapshotted and restored around the build, so previewing professions does not perturb the random stream used by real creation / worldgen.
  构建前后快照并还原全局 RNG 引擎,因此预览职业不会扰动真正创建/世界生成所用的随机流。
- Starting-book identification is suppressed (`add_profession_items( false )`), so switching professions no longer spams the global message log with "You skim ..." lines.
  抑制起始书籍的鉴定(`add_profession_items( false )`),因此切换职业不再向全局消息日志刷「You skim ...」之类的杂讯。

##### Robustness / 健壮性
- Isometric tilesets are unsupported by the renderer, so the preview column is hidden for them rather than showing an empty 1px column.
  渲染器不支持等距 tileset,故对其隐藏预览列,而非显示一个空的 1px 列。
- A render that legitimately produces nothing is cached as such, not retried every frame.
  合法地渲染不出内容的结果会被如实缓存,而非每帧重试。

#### Describe alternatives you've considered / 考虑过的替代方案
An earlier iteration drew the preview as a floating panel via the ImGui foreground draw list. It overdrew the tab strip and right-hand description text, so it was replaced with a real table column.
早期版本通过 ImGui 前景绘制列表把预览画成浮动面板,会盖住标签栏和右侧描述文字,故改为真正的表格列。

#### Testing / 测试
- Built and ran with tiles. Verified the preview appears on every creation tab and the summary tab, reflects gender / profession / mutation / clothing changes, and is hidden when the option is off.
  使用 tiles 构建运行。验证预览出现在每个创建标签页与总结页,能反映性别/职业/突变/衣物变化,关闭选项时隐藏。
- Verified that switching professions does not add stray messages to the log and that the preview-off layout is unchanged from before.
  验证切换职业不会向日志添加杂讯消息,且关闭预览时的布局与改动前一致。

#### Additional context / 补充说明
A new graphics option `USE_CHARACTER_PREVIEW` (default on, tiles only, prerequisite `USE_TILES`) controls the feature.
新增图形选项 `USE_CHARACTER_PREVIEW`(默认开启,仅 tiles,前置条件 `USE_TILES`)控制该功能。