### PR TITLE
fix: 正确的容器可用处理机制是 物品≤容量 而非仅判断<

### DIFF
--- a/src/item_container.cpp
+++ b/src/item_container.cpp
@@ -515,7 +515,7 @@ ret_val<void> item::can_contain( const item &it, int &copies_remaining, const bo
             }
 
             // early exit for max length no nested item is gonna fix this
-            if( pkt->max_containable_length() < it.length() ) {
+            if( pkt->max_containable_length() <= it.length() ) {
                 continue;
             }
 

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -383,12 +383,12 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
         if( selected >= 0 ) {
             size_t idx = selected;
             const std::vector<std::pair<itype_id, std::string>> *names = nullptr;
-            if( idx < listed_names.size() ) {
+            if( idx <= listed_names.size() ) {
                 names = &listed_names;
             } else {
                 idx -= listed_names.size();
             }
-            if( !names && idx < nearby_names.size() ) {
+            if( !names && idx <= nearby_names.size() ) {
                 names = &nearby_names;
             }
             if( names ) {
@@ -713,7 +713,7 @@ void item_contents::combine( const item_contents &read_input, const bool convert
     }
 
     for( const item_pocket &pocket : read_input.contents ) {
-        if( pocket_index < contents.size() ) {
+        if( pocket_index <= contents.size() ) {
             if( convert ) {
                 if( pocket.is_type( pocket_type::MIGRATION ) ||
                     pocket.is_type( pocket_type::CORPSE ) ||
@@ -969,7 +969,7 @@ std::pair<item_location, item_pocket *> item_contents::best_pocket( const item &
             std::pair<item_location, item_pocket *const> nested_content_pocket =
                 pocket->best_pocket_in_contents( this_loc, it, avoid, allow_sealed, ignore_settings );
             if( !nested_content_pocket.second ||
-                ( !nested_content_pocket.second->rigid() && pocket->remaining_volume() < it.volume() ) ) {
+                ( !nested_content_pocket.second->rigid() && pocket->remaining_volume() <= it.volume() ) ) {
                 // no nested pocket found, or the nested pocket is soft and the parent is full
                 continue;
             }
@@ -1696,7 +1696,7 @@ bool item_contents::has_unrestricted_pockets() const
             restricted_pockets_qty++;
         }
     }
-    return restricted_pockets_qty < static_cast <int>( get_container_pockets().size() );
+    return restricted_pockets_qty <= static_cast <int>( get_container_pockets().size() );
 }
 
 bool item_contents::has_any_with( const std::function<bool( const item &it )> &filter,
@@ -2276,7 +2276,7 @@ const
             continue;
         }
         bool restriction_condition = pocket.is_type( pocket_type::CONTAINER ) &&
-                                     !pocket.is_ablative() && pocket.weight_capacity() < pocket_data::max_weight_for_container;
+                                     !pocket.is_ablative() && pocket.weight_capacity() <= pocket_data::max_weight_for_container;
         if( unrestricted_pockets_only ) {
             restriction_condition = restriction_condition && !pocket.is_restricted();
         }


### PR DESCRIPTION
# 中文说明
DDA实验版的未知改动导致了如今容器存储物品必须容量的全部数据都完全大于内容物才能进行储存，这否定了人类有严丝合缝地将物品放入专门为其设计的容量内的能力，也导致了大量原设计中物品的重量、体积、长度与专有容器一致的物品生成时的大量报错以及完全无法放入完全为了该物品而设计的容器中的诡异事实。本PR试图将其判断还原为小于等于逻辑。

# English instructions
An unknown change in the DDA experimental version has resulted in the current requirement that a container's remaining storage capacity metrics must be strictly greater than the item being stored for it to be placed inside. This denies the human ability to tightly fit items into capacities specifically designed for them, and has also caused numerous generation errors for a large number of originally designed items whose weight, volume, or length perfectly match their proprietary containers, alongside the bizarre fact that they completely cannot be placed into containers made exactly for them. This PR attempts to revert this logic back to a "less than or equal to" check.