### PR TITLE
fix: 修复角色预览 PR 的 Linux/Mac 编译错误

### DIFF
--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -464,6 +464,7 @@ void explosion_handler::draw_custom_explosion(
         return;
     }
 #else
+    ( void )light_effect;
     ( void )epicenter;
 #endif
 

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -2956,7 +2956,7 @@ static SDL_Texture *character_preview_texture( const avatar &u, int &out_w, int 
     std::string sig = std::string( u.male ? "m|" : "f|" ) + ( outfit ? "o1|" : "o0|" ) +
                       std::to_string( preview_scale ) + "|" +
                       ( u.prof ? u.prof->ident().str() : "none" ) + "|";
-    for( const std::pair<const std::string, std::string> &ov : u.get_overlay_ids() ) {
+    for( const std::pair<std::string, std::string> &ov : u.get_overlay_ids() ) {
         sig += ov.first;
         sig += ',';
     }


### PR DESCRIPTION
## 概要 / Summary
#218(角色创建立绘预览)合入后,master 上的 Linux 与 macOS 构建因两处 `-Werror` 失败。本 PR 修复之。
Two `-Werror` build failures landed on master with #218. This fixes both.

## 改动 / Changes
- **animation.cpp** — `draw_custom_explosion` 的 `light_effect` 形参仅在 `#if defined(TILES)` 内使用,非 tiles(Curses/Linux)构建报 `-Werror=unused-parameter`。在 `#else` 分支补 `( void )light_effect;`。
- **newcharacter.cpp** — `character_preview_texture` 中遍历 `get_overlay_ids()`(返回 `vector<pair<string,string>>`,key 非 const)的循环变量写成 `const std::pair<const std::string, std::string> &`,每个元素都要构造临时对象,Clang 报 `-Werror,-Wrange-loop-construct`(macOS)。去掉 key 上多余的 `const`。

## 测试 / Testing
- 纯编译器告警修复,不改变运行时行为。
- 待 CI 验证 GCC Curses(Linux)与 Apple Clang Tiles(macOS)恢复绿色。

🤖 Generated with [Claude Code](https://claude.com/claude-code)