### PR TITLE
fix: 容量＜物品 才无法装入

### DIFF
--- a/src/item_container.cpp
+++ b/src/item_container.cpp
@@ -515,7 +515,7 @@ ret_val<void> item::can_contain( const item &it, int &copies_remaining, const bo
             }
 
             // early exit for max length no nested item is gonna fix this
-            if( pkt->max_containable_length() <= it.length() ) {
+            if( pkt->max_containable_length() < it.length() ) {
                 continue;
             }
 

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -677,7 +677,7 @@ bool item_contents::bigger_on_the_inside( const units::volume &container_volume 
             }
         }
     }
-    return container_volume <= min_logical_volume;
+    return container_volume < min_logical_volume;
 }
 
 size_t item_contents::size() const


### PR DESCRIPTION
PR #219 后续
发现有部分原有判断并非 物品 ＜ 容器 而是 容器 ≤ 物品。
已修正新发现的缺漏部分。