### PR TITLE
docs: clarify illiterate text

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1938,7 +1938,7 @@
     "type": "mutation",
     "id": "ILLITERATE",
     "name": { "str": "Illiterate" },
-    "description": "You never learned to read!  Books and computers are off-limits to you.",
+    "description": "You struggle to read and understand written language.  Books, complex instructions, and most computer interfaces are effectively off-limits without help.",
     "cancels": [ "FASTREADER", "SLOWREADER", "PROF_DICEMASTER", "LOVES_BOOKS", "HATES_BOOKS" ],
     "points": -6,
     "starting_trait": true,

--- a/src/character_knowledge.cpp
+++ b/src/character_knowledge.cpp
@@ -505,8 +505,8 @@ const Character *Character::get_book_reader( const item &book,
 
     // Check for conditions that disqualify us only if no other Characters can read to us
     if( condition & read_condition_result::ILLITERATE ) {
-        reasons.emplace_back( is_avatar() ? _( "You're illiterate!" ) : string_format(
-                                  _( "%s is illiterate!" ), disp_name() ) );
+        reasons.emplace_back( is_avatar() ? _( "You can't make sense of the text." ) : string_format(
+                                  _( "%s can't make sense of the text." ), disp_name() ) );
     } else if( condition & read_condition_result::NEED_GLASSES ) {
         reasons.emplace_back( is_avatar() ? _( "Your eyes won't focus without reading glasses." ) :
                               string_format( _( "%s's eyes won't focus without reading glasses." ), disp_name() ) );
@@ -538,7 +538,7 @@ const Character *Character::get_book_reader( const item &book,
         // Check for disqualifying factors:
         condition = elem->check_read_condition( book );
         if( condition & read_condition_result::ILLITERATE ) {
-            reasons.push_back( string_format( _( "%s is illiterate!" ),
+            reasons.push_back( string_format( _( "%s can't make sense of the text." ),
                                               elem->disp_name() ) );
         } else if( condition & read_condition_result::CANT_UNDERSTAND ) {
             reasons.push_back( string_format( _( "%s %d needed to understand.  %s has %d" ),

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -5062,7 +5062,7 @@ void iexamine::sign( Character &you, const tripoint_bub_ms &examp )
     // Display existing message, or lack thereof.
     if( here.furn( examp )->has_flag( ter_furn_flag::TFLAG_SIGN_ALWAYS ) || previous_signage_exists ) {
         if( you.has_trait( trait_ILLITERATE ) ) {
-            popup( _( "You're illiterate, and can't read the message on the sign." ) );
+            popup( _( "You can't make sense of the message on the sign." ) );
         } else if( previous_signage_exists ) {
             popup( existing_signage );
         } else {
@@ -5337,7 +5337,7 @@ void iexamine::pay_gas( Character &you, const tripoint_bub_ms &examp )
     const int refund = 4;
 
     if( you.has_trait( trait_ILLITERATE ) ) {
-        popup( _( "You're illiterate, and can't read the screen." ) );
+        popup( _( "You can't make sense of the text on the screen." ) );
     }
 
     fuel_station_fuel_type fuelType = FUEL_TYPE_NONE;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4151,7 +4151,7 @@ std::optional<int> iuse::portable_game( Character *p, item *it, const tripoint_b
         return std::nullopt;
     }
     if( p->has_trait( trait_ILLITERATE ) ) {
-        p->add_msg_if_player( m_info, _( "You're illiterate!" ) );
+        p->add_msg_if_player( m_info, _( "You can't make sense of the text." ) );
         return std::nullopt;
     } else if( it->typeId() != itype_arcade_machine && !it->ammo_sufficient( p ) ) {
         p->add_msg_if_player( m_info, _( "The %s's batteries are dead." ), it->tname() );

--- a/tests/reading_test.cpp
+++ b/tests/reading_test.cpp
@@ -366,7 +366,7 @@ TEST_CASE( "reasons_for_not_being_able_to_read", "[reading][reasons]" )
             REQUIRE( dummy.has_trait( trait_ILLITERATE ) );
 
             CHECK( dummy.get_book_reader( *western, reasons ) == nullptr );
-            expect_reasons = { "You're illiterate!" };
+            expect_reasons = { "You can't make sense of the text." };
             CHECK( reasons == expect_reasons );
         }
 


### PR DESCRIPTION
#### 概述 (Summary)

Clarifies the Illiterate trait description and related failure messages so they describe difficulty understanding written text rather than simply saying the character is illiterate.

#### 改动目的 (Purpose of change)

Addresses #124 by making the wording more nuanced and consistent with the idea that the trait represents severe difficulty reading and understanding written language.

#### 解决方案描述 (Describe the solution)

- Updated the `ILLITERATE` trait description.
- Updated related reading/sign/screen failure messages.
- Updated the matching reading test expectation.

#### 你考虑过的替代方案 (Describe alternatives you've considered)

A larger mechanics change, such as allowing simple pictorial books or guided reading, should be handled separately.

#### 测试 (Testing)

- Verified `data/json/mutations/mutations.json` parses as valid JSON.
- Ran `git diff --check`.
- Checked the updated trait description in a local copied test build.

#### 补充说明 (Additional context)

Suggested zh_CN translation:

> 你很难阅读和理解文字。没有他人帮助时，书籍、复杂说明和大多数电脑界面对你来说基本都无法使用。