### PR TITLE
fix(tiles): D3D12 后端低倍率卡死与走路崩溃 / Fix D3D12 low-zoom freeze and walk crash

### DIFF
--- a/src/cached_options.cpp
+++ b/src/cached_options.cpp
@@ -17,6 +17,7 @@ bool use_pinyin_search;
 bool use_tiles_overmap;
 test_mode_spilling_action_t test_mode_spilling_action = test_mode_spilling_action_t::spill_all;
 bool direct3d_mode;
+bool gpu_d3d12_mode;
 bool pixel_minimap_option;
 int pixel_minimap_r;
 int pixel_minimap_g;

--- a/src/cached_options.h
+++ b/src/cached_options.h
@@ -50,6 +50,13 @@ extern test_mode_spilling_action_t test_mode_spilling_action;
 
 extern bool direct3d_mode;
 
+// True when the live renderer is SDL3's "gpu" renderer backed by the D3D12
+// driver. That backend SIGSEGVs in D3D12_PushFragmentUniformData when a
+// mid-frame render-target switch (scoped_render_target) flushes the command
+// queue. Used to route the colored-light tint overlay away from its
+// render-target-switching silhouette-mask path on that backend.
+extern bool gpu_d3d12_mode;
+
 enum class error_log_format_t {
     human_readable,
     // Output error messages in github action command format (currently json only)

--- a/src/cata_shader.cpp
+++ b/src/cata_shader.cpp
@@ -630,6 +630,24 @@ variant_pass::begin_result variant_pass::try_begin( variant_kind v )
         // Embargo raised: refuse without calling SDL until rebind.
         return begin_result::abort_frame;
     }
+    // The SHADOW/NIGHT/OVEREXPOSED/MEMORY variants are GPU re-implementations of
+    // the pre-baked light-variant atlases (shadow/night/overexposed/memory
+    // tile_values, built unconditionally at load). Binding their fragment shader
+    // defeats the renderer's draw batching, so at low zoom a screen full of dim
+    // (SHADOW) or remembered (MEMORY) tiles degrades to tens of thousands of
+    // individual draws -> multi-second GPU flush stall. Route them to the
+    // pre-baked atlas path (use_atlas -> shader_bound=false -> draw_sprite_at
+    // picks the tinted texture), which batches and is visually equivalent.
+    // MEMORY in particular dominates low-zoom frames (off-screen explored area),
+    // so it MUST take the atlas path too. Cost: memory-map-mode switching now
+    // re-bakes the atlas instead of swapping a shader uniform -- acceptable.
+    if( v == variant_kind::SHADOW || v == variant_kind::NIGHT ||
+        v == variant_kind::OVEREXPOSED || v == variant_kind::MEMORY ) {
+        if( !flush() ) {
+            return begin_result::abort_frame;
+        }
+        return begin_result::use_atlas;
+    }
     if( reprobe_requested() ) {
         reset();
         clear_reprobe();

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1361,7 +1361,15 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
 
                         // Simple: all recorded sprites fit inside the tile rect,
                         // so a flat colored rect matches the sprite extent exactly.
-                        const bool simple = !tp->com.bounds.valid ||
+                        // On the SDL3 gpu/D3D12 backend, ALSO force the simple path:
+                        // the complex silhouette-mask path switches render target
+                        // mid-frame (scoped_render_target), whose command-queue flush
+                        // SIGSEGVs in D3D12_PushFragmentUniformData. The flat rect
+                        // tint is a minor visual downgrade for oversized sprites
+                        // (boxy glow instead of outline-hugging) but avoids the crash;
+                        // other backends keep the precise silhouette mask.
+                        const bool simple = gpu_d3d12_mode ||
+                                            !tp->com.bounds.valid ||
                                             tp->com.tint_sprites.empty() ||
                                             ( tp->com.bounds.x >= tile_rect.x &&
                                               tp->com.bounds.y >= tile_rect.y &&

--- a/src/sdl_wrappers.cpp
+++ b/src/sdl_wrappers.cpp
@@ -431,6 +431,22 @@ scoped_render_target::scoped_render_target( const SDL_Renderer_Ptr &renderer,
     renderer_ = renderer.get();
 #if SDL_MAJOR_VERSION >= 3
     vp_ = vp;
+    // Drain queued draw commands NOW, while the prior render target is still
+    // bound and the variant_pass shader state is still consistent. SDL forces a
+    // queue flush inside SDL_SetRenderTarget; on the SDL3 gpu/D3D12 backend that
+    // late flush has crashed (SIGSEGV in D3D12_PushFragmentUniformData) when the
+    // queue still held sprite draws referencing custom GPU render state that the
+    // vp_->flush() unbind below would invalidate first. Flushing here -- before
+    // the unbind and the target switch -- executes those draws against valid
+    // state, leaving an empty queue for the switch. Other SDL3 backends are
+    // unaffected (a clean flush before a target switch is always correct).
+    if( !SDL_FlushRenderer( renderer_ ) ) {
+        dbg( D_ERROR ) << "scoped_render_target: SDL_FlushRenderer failed: " << SDL_GetError();
+        mark_boundary_lost();
+        renderer_ = nullptr;
+        vp_ = nullptr;
+        return;
+    }
     // Flush the pass FIRST so an embargoed pass refuses before any SDL call;
     // only then capture prior_target_ and switch.
     if( vp_ && !vp_->flush() ) {
@@ -478,6 +494,15 @@ bool scoped_render_target::restore()
         return false;
     }
 #if SDL_MAJOR_VERSION >= 3
+    // Drain queued draws against the current (scratch) target before switching
+    // back, for the same reason as the ctor: SDL_SetRenderTarget's implicit
+    // flush has crashed on the gpu/D3D12 backend. See the ctor comment.
+    if( !SDL_FlushRenderer( renderer_ ) ) {
+        dbg( D_ERROR ) << "scoped_render_target::restore: SDL_FlushRenderer failed: "
+                       << SDL_GetError();
+        mark_boundary_lost();
+        return false;
+    }
     if( vp_ && !vp_->flush() ) {
         // Undefined shader-state bind: do not switch the target.
         dbg( D_ERROR ) << "scoped_render_target::restore: variant_pass flush failed";

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -474,7 +474,26 @@ static void detect_renderer_backend()
     const char *actual_name = props != 0
                               ? SDL_GetStringProperty( props, SDL_PROP_RENDERER_NAME_STRING, "" )
                               : "";
-    dbg( D_INFO ) << "SDL renderer in use: " << ( actual_name ? actual_name : "unknown" );
+    // Diagnostic: the selected renderer name alone is not enough to predict the
+    // mid-frame render-target-switch crash. When the renderer is "gpu", the real
+    // culprit is the backing SDL_gpu device driver (direct3d12 vs vulkan): the
+    // crash was only seen on direct3d12. Use DebugLog(..., DC_ALL) rather than the
+    // file-local dbg() macro: dbg() logs under category D_SDL, which is filtered
+    // out of debug.log by default, so it would never land. DC_ALL always shows.
+    const char *gpu_driver = "n/a";
+    SDL_GPUDevice *gpu_dev = props != 0
+                             ? static_cast<SDL_GPUDevice *>( SDL_GetPointerProperty(
+                                     props, SDL_PROP_RENDERER_GPU_DEVICE_POINTER, nullptr ) )
+                             : nullptr;
+    if( gpu_dev ) {
+        const char *drv = SDL_GetGPUDeviceDriver( gpu_dev );
+        if( drv ) {
+            gpu_driver = drv;
+        }
+    }
+    DebugLog( D_INFO, DC_ALL ) << "SDL renderer in use: "
+                               << ( actual_name ? actual_name : "unknown" )
+                               << "; backing GPU driver: " << gpu_driver;
     if( actual_name && std::string( actual_name ).find( "direct3d" ) != std::string::npos ) {
         direct3d_mode = true;
     }

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -497,6 +497,12 @@ static void detect_renderer_backend()
     if( actual_name && std::string( actual_name ).find( "direct3d" ) != std::string::npos ) {
         direct3d_mode = true;
     }
+    // The "gpu" renderer on the D3D12 driver crashes on mid-frame render-target
+    // switches (see gpu_d3d12_mode doc). Detect that exact combination so the
+    // tint overlay can avoid its render-target-switching path on this backend.
+    gpu_d3d12_mode = actual_name &&
+                     std::string( actual_name ) == "gpu" &&
+                     std::string( gpu_driver ).find( "direct3d12" ) != std::string::npos;
 #endif
 }
 


### PR DESCRIPTION
#### 概述 (Summary)

Performance "修复 ASCIITiles 低倍率卡死与 D3D12 后端走路崩溃"

#### 改动目的 (Purpose of change)

本 fork 在 SDL3 下默认运行于 "gpu" 渲染器（D3D12 驱动），两个相关问题在该后端暴露：

1. **低倍率卡死**：使用 ASCIITiles 等贴图包缩小视野（满屏大量瓦片）时，游戏卡到几乎无法操作，极端情况升级为 GPU 设备丢失崩溃。
2. **走路偶发崩溃**：靠近有彩色光的场景（如沼泽）走动时偶发 SIGSEGV，崩在 `D3D12_PushFragmentUniformData`。

经逐层计时探针定位，两者同源——都由本 fork 的 GPU 光照 shader 系统（`variant_pass`）与 SDL3 D3D12 后端的交互引起：

- 光照变体 shader 绑定 `SDL_GPURenderState` 时会**禁用渲染器的绘制批处理**。低倍率下满屏暗格/记忆格各自退化为独立绘制，数万次 draw call 在帧末 GPU flush 时卡顿数秒。
- 彩色光染色叠加（VFX overlay）为超格 sprite 切换渲染目标构建剪影掩码；该切换强制的命令队列 flush 在 SDL3 D3D12 后端崩溃。探针证实崩溃**与本项目自定义 shader 是否绑定无关**（崩溃前 shader 未绑定），是 SDL3 D3D12 后端对普通绘制命令推送内置 uniform 时的空指针缺陷（同类问题 SDL 仅为 Metal 后端修复，D3D12 未修）。

This fork runs on SDL3's "gpu" renderer (D3D12 driver) by default on Windows. Two issues surface on that backend: a multi-second freeze (escalating to a device-loss crash) when zoomed out with tile-heavy sets like ASCIITiles, and an intermittent SIGSEGV in `D3D12_PushFragmentUniformData` while walking near colored light. Both trace to the fork's GPU light-variant shader (`variant_pass`) interacting with the D3D12 backend: binding a custom `SDL_GPURenderState` disables draw batching (→ tens of thousands of draws at low zoom), and the tint overlay's mid-frame render-target switch crashes the backend's command-queue flush (a D3D12 driver-side defect, not our shader — it fires with no custom state bound).

#### 解决方案描述 (Describe the solution)

两处独立修复，均不依赖修改 SDL 库：

1. **低倍率卡死**（`cata_shader.cpp`）：`variant_pass::try_begin` 对 SHADOW / NIGHT / OVEREXPOSED / MEMORY 四个光照变体直接返回 `use_atlas`，改走预烘焙光照贴图集路径。这些贴图集（`shadow/night/overexposed/memory_tile_values`）在加载时无条件生成，shader 只是其 GPU 重实现，故视觉等价、且恢复批处理。

2. **走路崩溃**（`cached_options.*`、`sdltiles.cpp`、`cata_tiles.cpp`）：新增 `gpu_d3d12_mode` 标志，在 `detect_renderer_backend` 中检测 "gpu" 渲染器 + D3D12 驱动的组合；染色叠加在该后端下强制走矩形填充路径（`RenderFillRect`，不切换渲染目标），绕开崩溃点。其他后端（Vulkan / D3D11 / Metal）保留精细剪影掩码。

Two independent fixes, neither requiring an SDL change:
1. Low-zoom freeze: route the four light variants to the pre-baked atlas path (`use_atlas`), restoring batching with no visual change.
2. Walk crash: detect the gpu/D3D12 backend (`gpu_d3d12_mode`) and force the tint overlay onto its flat-rectangle path, which never switches render target. Other backends keep the precise mask.

#### 你考虑过的替代方案 (Describe alternatives you've considered)

- **切画布前主动 flush**（前一 commit `054660f6e1`）：证实无效——崩溃发生在 flush 自身，提前 flush 只是把崩点从隐式移到主动。该 commit 的 flush 保留作为 `char_preview` 等其他切画布路径的兜底，诊断日志亦保留。
- **D3D12 下用剪影直接上色**（不切画布，逐 sprite 画预烘焙剪影）：尝试三种混合方式均失败（偏浓 / 漏底层地面 / 全屏过度染色），SDL `RenderCopy` 无法在不切画布下复刻掩码的"多 sprite 合并为单覆盖"语义，遂退回矩形方案。
- **强制后端走 Vulkan / 降级 direct3d11**：可从源头避开 D3D12，但需机器具备相应驱动，覆盖面不如"让 D3D12 也安全"的兜底修复。保留为未来可选项。

#### 测试 (Testing)

- **低倍率卡死**：ASCIITiles + 缩到满屏大量瓦片，修复前帧末 GPU flush 卡顿数秒（实测 detach 3–8 秒），修复后流畅；阴影 / 夜视 / 记忆地图视觉正常。
- **走路崩溃**：彩色光场景（沼泽）来回走动，修复前稳定复现 `D3D12_PushFragmentUniformData` SIGSEGV，修复后不再崩溃；彩色光仍显示（超格 sprite 光晕在 D3D12 下为矩形）。
- 高倍率、其他渲染后端无回归。

#### 补充说明 (Additional context)

D3D12 下唯一的视觉降级：被彩色光照射的超尺寸 sprite（站立角色、人形怪、多层装备等），其光晕从贴合轮廓变为矩形色块。其他后端不受影响。GPU shader 框架代码保留，待 SDL3 D3D12 后端成熟后可恢复。
