### PR TITLE
feat(build): headless build target / 无头构建目标 (Phase 0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ set(CMAKE_TLS_VERIFY ON)
 # Build options
 include(CMakeDependentOption)
 option(CURSES "Build curses version." "ON")
+option(HEADLESS "Build headless version (no terminal/SDL; in-memory ImTui text renderer). For tests, replay, and server." "OFF")
 option(SOUND "Support for in-game sounds & music." "OFF")
 option(BACKTRACE "Support for printing stack backtraces on crash" "ON")
 option(LIBBACKTRACE "Print backtrace with libbacktrace." "OFF")
@@ -165,6 +166,14 @@ if (TILES)
     set(CURSES OFF)
 endif ()
 
+# Headless reuses the ImTui text renderer but needs neither real ncurses nor
+# SDL. It is mutually exclusive with both other backends.
+if (HEADLESS)
+    set(CURSES OFF)
+    set(TILES OFF)
+    add_definitions(-DHEADLESS)
+endif ()
+
 # Can't use both home and xdg directories
 if (USE_XDG_DIR)
     set(USE_HOME_DIR OFF)
@@ -218,6 +227,7 @@ message(STATUS "DYNAMIC_LINKING               : ${DYNAMIC_LINKING}")
 message(STATUS "TILES                         : ${TILES}")
 message(STATUS "USE_SDL3                      : ${USE_SDL3}")
 message(STATUS "CURSES                        : ${CURSES}")
+message(STATUS "HEADLESS                      : ${HEADLESS}")
 message(STATUS "SOUND                         : ${SOUND}")
 message(STATUS "BACKTRACE                     : ${BACKTRACE}")
 message(STATUS "LOCALIZE                      : ${LOCALIZE}")

--- a/msvc-full-features/Cataclysm-common.props
+++ b/msvc-full-features/Cataclysm-common.props
@@ -74,8 +74,11 @@
     <ClCompile Condition="!$(Configuration.Contains(NoTiles))">
       <PreprocessorDefinitions>USE_SDL3;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
-    <ClCompile Condition="$(Configuration.Contains(NoTiles))">
+    <ClCompile Condition="$(Configuration.Contains(NoTiles)) And !$(Configuration.Contains(Headless))">
       <PreprocessorDefinitions>USE_PDCURSES;PDC_NCMOUSE;PDC_WIDE;IMTUI;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Condition="$(Configuration.Contains(Headless))">
+      <PreprocessorDefinitions>HEADLESS;IMTUI;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ClCompile Condition="$(_CDDA_BACKTRACE)">
       <PreprocessorDefinitions>BACKTRACE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -151,7 +154,7 @@
         Winmm.lib;
         %(AdditionalDependencies)
       </AdditionalDependencies>
-      <AdditionalDependencies Condition="$(Configuration.Contains(NoTiles))">
+      <AdditionalDependencies Condition="$(Configuration.Contains(NoTiles)) And !$(Configuration.Contains(Headless))">
         pdcurses.lib;
         %(AdditionalDependencies)
       </AdditionalDependencies>

--- a/msvc-full-features/Cataclysm-libAL-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-libAL-vcpkg-static.vcxproj
@@ -13,6 +13,10 @@
       <Configuration>Debug-NoTiles</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug-NoTilesHeadless|x64">
+      <Configuration>Debug-NoTilesHeadless</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|ARM64EC">
       <Configuration>Debug</Configuration>
       <Platform>ARM64EC</Platform>
@@ -35,6 +39,10 @@
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release-NoTiles|x64">
       <Configuration>Release-NoTiles</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release-NoTilesHeadless|x64">
+      <Configuration>Release-NoTilesHeadless</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|ARM64EC">
@@ -78,14 +86,14 @@
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Debug-NoTiles'" Label="Configuration">
+  <PropertyGroup Condition="$(Configuration.StartsWith('Debug-NoTiles'))" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Release-NoTiles'" Label="Configuration">
+  <PropertyGroup Condition="$(Configuration.StartsWith('Release-NoTiles'))" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
@@ -108,18 +116,22 @@
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Debug-NoTiles'">
+  <PropertyGroup Condition="$(Configuration.StartsWith('Debug-NoTiles'))">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Release-NoTiles'">
+  <PropertyGroup Condition="$(Configuration.StartsWith('Release-NoTiles'))">
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>_CONSOLE;SDL_SOUND;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!-- Headless has no audio backend: omit SDL_SOUND so cata_allocator.cpp
+           and friends do not pull SDL headers (the fork is SDL3-only and a
+           headless build links neither SDL nor curses). -->
+      <PreprocessorDefinitions Condition="!$(Configuration.Contains(Headless))">_CONSOLE;SDL_SOUND;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="$(Configuration.Contains(Headless))">_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
@@ -129,7 +141,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug-NoTiles'">
+  <ItemDefinitionGroup Condition="$(Configuration.StartsWith('Debug-NoTiles'))">
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <IntrinsicFunctions>false</IntrinsicFunctions>
@@ -149,7 +161,7 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release-NoTiles'">
+  <ItemDefinitionGroup Condition="$(Configuration.StartsWith('Release-NoTiles'))">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>

--- a/msvc-full-features/Cataclysm-libMZ-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-libMZ-vcpkg-static.vcxproj
@@ -13,6 +13,10 @@
       <Configuration>Debug-NoTiles</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug-NoTilesHeadless|x64">
+      <Configuration>Debug-NoTilesHeadless</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|ARM64EC">
       <Configuration>Debug</Configuration>
       <Platform>ARM64EC</Platform>
@@ -35,6 +39,10 @@
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release-NoTiles|x64">
       <Configuration>Release-NoTiles</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release-NoTilesHeadless|x64">
+      <Configuration>Release-NoTilesHeadless</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|ARM64EC">
@@ -78,14 +86,14 @@
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Debug-NoTiles'" Label="Configuration">
+  <PropertyGroup Condition="$(Configuration.StartsWith('Debug-NoTiles'))" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Release-NoTiles'" Label="Configuration">
+  <PropertyGroup Condition="$(Configuration.StartsWith('Release-NoTiles'))" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
@@ -108,18 +116,22 @@
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Debug-NoTiles'">
+  <PropertyGroup Condition="$(Configuration.StartsWith('Debug-NoTiles'))">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Release-NoTiles'">
+  <PropertyGroup Condition="$(Configuration.StartsWith('Release-NoTiles'))">
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>_CONSOLE;SDL_SOUND;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!-- Headless has no audio backend: omit SDL_SOUND so cata_allocator.cpp
+           and friends do not pull SDL headers (the fork is SDL3-only and a
+           headless build links neither SDL nor curses). -->
+      <PreprocessorDefinitions Condition="!$(Configuration.Contains(Headless))">_CONSOLE;SDL_SOUND;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="$(Configuration.Contains(Headless))">_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <PreBuildEvent>
       <Command>..\msvc-full-features\prebuild.cmd</Command>
@@ -132,7 +144,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug-NoTiles'">
+  <ItemDefinitionGroup Condition="$(Configuration.StartsWith('Debug-NoTiles'))">
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <IntrinsicFunctions>false</IntrinsicFunctions>
@@ -152,7 +164,7 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release-NoTiles'">
+  <ItemDefinitionGroup Condition="$(Configuration.StartsWith('Release-NoTiles'))">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>

--- a/msvc-full-features/Cataclysm-test-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-test-vcpkg-static.vcxproj
@@ -13,6 +13,10 @@
       <Configuration>Debug-NoTiles</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug-NoTilesHeadless|x64">
+      <Configuration>Debug-NoTilesHeadless</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|ARM64EC">
       <Configuration>Debug</Configuration>
       <Platform>ARM64EC</Platform>
@@ -35,6 +39,10 @@
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release-NoTiles|x64">
       <Configuration>Release-NoTiles</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release-NoTilesHeadless|x64">
+      <Configuration>Release-NoTilesHeadless</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|ARM64EC">
@@ -80,14 +88,14 @@
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Debug-NoTiles'" Label="Configuration">
+  <PropertyGroup Condition="$(Configuration.StartsWith('Debug-NoTiles'))" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Release-NoTiles'" Label="Configuration">
+  <PropertyGroup Condition="$(Configuration.StartsWith('Release-NoTiles'))" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
@@ -112,18 +120,22 @@
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Debug-NoTiles'">
+  <PropertyGroup Condition="$(Configuration.StartsWith('Debug-NoTiles'))">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Release-NoTiles'">
+  <PropertyGroup Condition="$(Configuration.StartsWith('Release-NoTiles'))">
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>_CONSOLE;SDL_SOUND;SDL_MAIN_HANDLED;CATCH_CONFIG_ENABLE_BENCHMARKING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!-- Headless has no audio backend: omit SDL_SOUND so cata_allocator.cpp
+           and friends do not pull SDL headers (the fork is SDL3-only and a
+           headless test binary links neither SDL nor curses). -->
+      <PreprocessorDefinitions Condition="!$(Configuration.Contains(Headless))">_CONSOLE;SDL_SOUND;SDL_MAIN_HANDLED;CATCH_CONFIG_ENABLE_BENCHMARKING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="$(Configuration.Contains(Headless))">_CONSOLE;SDL_MAIN_HANDLED;CATCH_CONFIG_ENABLE_BENCHMARKING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -138,7 +150,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug-NoTiles'">
+  <ItemDefinitionGroup Condition="$(Configuration.StartsWith('Debug-NoTiles'))">
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <IntrinsicFunctions>false</IntrinsicFunctions>
@@ -160,7 +172,7 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release-NoTiles'">
+  <ItemDefinitionGroup Condition="$(Configuration.StartsWith('Release-NoTiles'))">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>

--- a/msvc-full-features/Cataclysm-vcpkg-static.sln
+++ b/msvc-full-features/Cataclysm-vcpkg-static.sln
@@ -55,6 +55,8 @@ Global
 		Release|x86 = Release|x86
 		Release-NoTiles|ARM64EC = Release-NoTiles|ARM64EC
 		Release-NoTiles|x64 = Release-NoTiles|x64
+		Debug-NoTilesHeadless|x64 = Debug-NoTilesHeadless|x64
+		Release-NoTilesHeadless|x64 = Release-NoTilesHeadless|x64
 		Release-NoTiles|x86 = Release-NoTiles|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
@@ -92,6 +94,10 @@ Global
 		{19F0BE17-3DAF-40E8-A9D2-904A56382E54}.Release-NoTiles|ARM64EC.Build.0 = Release-NoTiles|ARM64EC
 		{19F0BE17-3DAF-40E8-A9D2-904A56382E54}.Release-NoTiles|x64.ActiveCfg = Release-NoTiles|x64
 		{19F0BE17-3DAF-40E8-A9D2-904A56382E54}.Release-NoTiles|x64.Build.0 = Release-NoTiles|x64
+		{19F0BE17-3DAF-40E8-A9D2-904A56382E54}.Debug-NoTilesHeadless|x64.ActiveCfg = Debug-NoTilesHeadless|x64
+		{19F0BE17-3DAF-40E8-A9D2-904A56382E54}.Debug-NoTilesHeadless|x64.Build.0 = Debug-NoTilesHeadless|x64
+		{19F0BE17-3DAF-40E8-A9D2-904A56382E54}.Release-NoTilesHeadless|x64.ActiveCfg = Release-NoTilesHeadless|x64
+		{19F0BE17-3DAF-40E8-A9D2-904A56382E54}.Release-NoTilesHeadless|x64.Build.0 = Release-NoTilesHeadless|x64
 		{19F0BE17-3DAF-40E8-A9D2-904A56382E54}.Release-NoTiles|x86.ActiveCfg = Release-NoTiles|Win32
 		{19F0BE17-3DAF-40E8-A9D2-904A56382E54}.Release-NoTiles|x86.Build.0 = Release-NoTiles|Win32
 		{2C1ECEE1-9686-4C3C-8DE1-88996EE43378}.Debug|ARM64EC.ActiveCfg = Debug|ARM64EC
@@ -122,6 +128,10 @@ Global
 		{2C1ECEE1-9686-4C3C-8DE1-88996EE43378}.Release-NoTiles|ARM64EC.Build.0 = Release-NoTiles|ARM64EC
 		{2C1ECEE1-9686-4C3C-8DE1-88996EE43378}.Release-NoTiles|x64.ActiveCfg = Release-NoTiles|x64
 		{2C1ECEE1-9686-4C3C-8DE1-88996EE43378}.Release-NoTiles|x64.Build.0 = Release-NoTiles|x64
+		{2C1ECEE1-9686-4C3C-8DE1-88996EE43378}.Debug-NoTilesHeadless|x64.ActiveCfg = Debug-NoTilesHeadless|x64
+		{2C1ECEE1-9686-4C3C-8DE1-88996EE43378}.Debug-NoTilesHeadless|x64.Build.0 = Debug-NoTilesHeadless|x64
+		{2C1ECEE1-9686-4C3C-8DE1-88996EE43378}.Release-NoTilesHeadless|x64.ActiveCfg = Release-NoTilesHeadless|x64
+		{2C1ECEE1-9686-4C3C-8DE1-88996EE43378}.Release-NoTilesHeadless|x64.Build.0 = Release-NoTilesHeadless|x64
 		{2C1ECEE1-9686-4C3C-8DE1-88996EE43378}.Release-NoTiles|x86.ActiveCfg = Release-NoTiles|Win32
 		{2C1ECEE1-9686-4C3C-8DE1-88996EE43378}.Release-NoTiles|x86.Build.0 = Release-NoTiles|Win32
 		{0009BB11-11AD-4C14-A5FC-D882A942C00B}.Debug|ARM64EC.ActiveCfg = Debug|ARM64EC
@@ -158,6 +168,10 @@ Global
 		{0009BB11-11AD-4C14-A5FC-D882A942C00B}.Release-NoTiles|ARM64EC.Build.0 = Release-NoTiles|ARM64EC
 		{0009BB11-11AD-4C14-A5FC-D882A942C00B}.Release-NoTiles|x64.ActiveCfg = Release-NoTiles|x64
 		{0009BB11-11AD-4C14-A5FC-D882A942C00B}.Release-NoTiles|x64.Build.0 = Release-NoTiles|x64
+		{0009BB11-11AD-4C14-A5FC-D882A942C00B}.Debug-NoTilesHeadless|x64.ActiveCfg = Debug-NoTilesHeadless|x64
+		{0009BB11-11AD-4C14-A5FC-D882A942C00B}.Debug-NoTilesHeadless|x64.Build.0 = Debug-NoTilesHeadless|x64
+		{0009BB11-11AD-4C14-A5FC-D882A942C00B}.Release-NoTilesHeadless|x64.ActiveCfg = Release-NoTilesHeadless|x64
+		{0009BB11-11AD-4C14-A5FC-D882A942C00B}.Release-NoTilesHeadless|x64.Build.0 = Release-NoTilesHeadless|x64
 		{0009BB11-11AD-4C14-A5FC-D882A942C00B}.Release-NoTiles|x86.ActiveCfg = Release-NoTiles|Win32
 		{0009BB11-11AD-4C14-A5FC-D882A942C00B}.Release-NoTiles|x86.Build.0 = Release-NoTiles|Win32
 		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Debug|ARM64EC.ActiveCfg = Debug|ARM64EC
@@ -194,6 +208,10 @@ Global
 		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Release-NoTiles|ARM64EC.Build.0 = Release-NoTiles|ARM64EC
 		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Release-NoTiles|x64.ActiveCfg = Release-NoTiles|x64
 		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Release-NoTiles|x64.Build.0 = Release-NoTiles|x64
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Debug-NoTilesHeadless|x64.ActiveCfg = Debug-NoTilesHeadless|x64
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Debug-NoTilesHeadless|x64.Build.0 = Debug-NoTilesHeadless|x64
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Release-NoTilesHeadless|x64.ActiveCfg = Release-NoTilesHeadless|x64
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Release-NoTilesHeadless|x64.Build.0 = Release-NoTilesHeadless|x64
 		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Release-NoTiles|x86.ActiveCfg = Release-NoTiles|Win32
 		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Release-NoTiles|x86.Build.0 = Release-NoTiles|Win32
 		{35D74C75-FC4A-442F-AF44-43BC9D845BAF}.Debug|ARM64EC.ActiveCfg = Debug|x64
@@ -220,6 +238,10 @@ Global
 		{35D74C75-FC4A-442F-AF44-43BC9D845BAF}.Release-NoTiles|ARM64EC.ActiveCfg = Release|x64
 		{35D74C75-FC4A-442F-AF44-43BC9D845BAF}.Release-NoTiles|x64.ActiveCfg = Release|x64
 		{35D74C75-FC4A-442F-AF44-43BC9D845BAF}.Release-NoTiles|x64.Build.0 = Release|x64
+		{35D74C75-FC4A-442F-AF44-43BC9D845BAF}.Debug-NoTilesHeadless|x64.ActiveCfg = Debug|x64
+		{35D74C75-FC4A-442F-AF44-43BC9D845BAF}.Debug-NoTilesHeadless|x64.Build.0 = Debug|x64
+		{35D74C75-FC4A-442F-AF44-43BC9D845BAF}.Release-NoTilesHeadless|x64.ActiveCfg = Release|x64
+		{35D74C75-FC4A-442F-AF44-43BC9D845BAF}.Release-NoTilesHeadless|x64.Build.0 = Release|x64
 		{35D74C75-FC4A-442F-AF44-43BC9D845BAF}.Release-NoTiles|x86.ActiveCfg = Release|Win32
 		{35D74C75-FC4A-442F-AF44-43BC9D845BAF}.Release-NoTiles|x86.Build.0 = Release|Win32
 		{534A4E38-96A1-40E4-BDA7-8D17607F0270}.Debug|ARM64EC.ActiveCfg = Debug|x64
@@ -246,6 +268,10 @@ Global
 		{534A4E38-96A1-40E4-BDA7-8D17607F0270}.Release-NoTiles|ARM64EC.ActiveCfg = Release|x64
 		{534A4E38-96A1-40E4-BDA7-8D17607F0270}.Release-NoTiles|x64.ActiveCfg = Release|x64
 		{534A4E38-96A1-40E4-BDA7-8D17607F0270}.Release-NoTiles|x64.Build.0 = Release|x64
+		{534A4E38-96A1-40E4-BDA7-8D17607F0270}.Debug-NoTilesHeadless|x64.ActiveCfg = Debug|x64
+		{534A4E38-96A1-40E4-BDA7-8D17607F0270}.Debug-NoTilesHeadless|x64.Build.0 = Debug|x64
+		{534A4E38-96A1-40E4-BDA7-8D17607F0270}.Release-NoTilesHeadless|x64.ActiveCfg = Release|x64
+		{534A4E38-96A1-40E4-BDA7-8D17607F0270}.Release-NoTilesHeadless|x64.Build.0 = Release|x64
 		{534A4E38-96A1-40E4-BDA7-8D17607F0270}.Release-NoTiles|x86.ActiveCfg = Release|Win32
 		{534A4E38-96A1-40E4-BDA7-8D17607F0270}.Release-NoTiles|x86.Build.0 = Release|Win32
 		{8A533A64-435D-4D4F-9FF0-1E97AACE9374}.Debug|ARM64EC.ActiveCfg = Debug|ARM64EC
@@ -282,6 +308,10 @@ Global
 		{8A533A64-435D-4D4F-9FF0-1E97AACE9374}.Release-NoTiles|ARM64EC.Build.0 = Release|ARM64EC
 		{8A533A64-435D-4D4F-9FF0-1E97AACE9374}.Release-NoTiles|x64.ActiveCfg = Release|x64
 		{8A533A64-435D-4D4F-9FF0-1E97AACE9374}.Release-NoTiles|x64.Build.0 = Release|x64
+		{8A533A64-435D-4D4F-9FF0-1E97AACE9374}.Debug-NoTilesHeadless|x64.ActiveCfg = Debug|x64
+		{8A533A64-435D-4D4F-9FF0-1E97AACE9374}.Debug-NoTilesHeadless|x64.Build.0 = Debug|x64
+		{8A533A64-435D-4D4F-9FF0-1E97AACE9374}.Release-NoTilesHeadless|x64.ActiveCfg = Release|x64
+		{8A533A64-435D-4D4F-9FF0-1E97AACE9374}.Release-NoTilesHeadless|x64.Build.0 = Release|x64
 		{8A533A64-435D-4D4F-9FF0-1E97AACE9374}.Release-NoTiles|x86.ActiveCfg = Release|Win32
 		{8A533A64-435D-4D4F-9FF0-1E97AACE9374}.Release-NoTiles|x86.Build.0 = Release|Win32
 		{0C0B2BEA-311F-473C-9652-87923EF639E3}.Debug|ARM64EC.ActiveCfg = Debug|ARM64EC
@@ -318,6 +348,10 @@ Global
 		{0C0B2BEA-311F-473C-9652-87923EF639E3}.Release-NoTiles|ARM64EC.Build.0 = Release-NoTiles|ARM64EC
 		{0C0B2BEA-311F-473C-9652-87923EF639E3}.Release-NoTiles|x64.ActiveCfg = Release-NoTiles|x64
 		{0C0B2BEA-311F-473C-9652-87923EF639E3}.Release-NoTiles|x64.Build.0 = Release-NoTiles|x64
+		{0C0B2BEA-311F-473C-9652-87923EF639E3}.Debug-NoTilesHeadless|x64.ActiveCfg = Debug-NoTilesHeadless|x64
+		{0C0B2BEA-311F-473C-9652-87923EF639E3}.Debug-NoTilesHeadless|x64.Build.0 = Debug-NoTilesHeadless|x64
+		{0C0B2BEA-311F-473C-9652-87923EF639E3}.Release-NoTilesHeadless|x64.ActiveCfg = Release-NoTilesHeadless|x64
+		{0C0B2BEA-311F-473C-9652-87923EF639E3}.Release-NoTilesHeadless|x64.Build.0 = Release-NoTilesHeadless|x64
 		{0C0B2BEA-311F-473C-9652-87923EF639E3}.Release-NoTiles|x86.ActiveCfg = Release-NoTiles|Win32
 		{0C0B2BEA-311F-473C-9652-87923EF639E3}.Release-NoTiles|x86.Build.0 = Release-NoTiles|Win32
 		{F49F14C6-B046-41C7-B707-03366F4B1578}.Debug|ARM64EC.ActiveCfg = Debug|ARM64EC
@@ -354,6 +388,10 @@ Global
 		{F49F14C6-B046-41C7-B707-03366F4B1578}.Release-NoTiles|ARM64EC.Build.0 = Release|ARM64EC
 		{F49F14C6-B046-41C7-B707-03366F4B1578}.Release-NoTiles|x64.ActiveCfg = Release|x64
 		{F49F14C6-B046-41C7-B707-03366F4B1578}.Release-NoTiles|x64.Build.0 = Release|x64
+		{F49F14C6-B046-41C7-B707-03366F4B1578}.Debug-NoTilesHeadless|x64.ActiveCfg = Debug|x64
+		{F49F14C6-B046-41C7-B707-03366F4B1578}.Debug-NoTilesHeadless|x64.Build.0 = Debug|x64
+		{F49F14C6-B046-41C7-B707-03366F4B1578}.Release-NoTilesHeadless|x64.ActiveCfg = Release|x64
+		{F49F14C6-B046-41C7-B707-03366F4B1578}.Release-NoTilesHeadless|x64.Build.0 = Release|x64
 		{F49F14C6-B046-41C7-B707-03366F4B1578}.Release-NoTiles|x86.ActiveCfg = Release|Win32
 		{F49F14C6-B046-41C7-B707-03366F4B1578}.Release-NoTiles|x86.Build.0 = Release|Win32
 		{1232212E-8B83-40E9-B502-F25DBC4DB6CF}.Debug|ARM64EC.ActiveCfg = Debug|ARM64EC
@@ -390,6 +428,10 @@ Global
 		{1232212E-8B83-40E9-B502-F25DBC4DB6CF}.Release-NoTiles|ARM64EC.Build.0 = Release|ARM64EC
 		{1232212E-8B83-40E9-B502-F25DBC4DB6CF}.Release-NoTiles|x64.ActiveCfg = Release|x64
 		{1232212E-8B83-40E9-B502-F25DBC4DB6CF}.Release-NoTiles|x64.Build.0 = Release|x64
+		{1232212E-8B83-40E9-B502-F25DBC4DB6CF}.Debug-NoTilesHeadless|x64.ActiveCfg = Debug|x64
+		{1232212E-8B83-40E9-B502-F25DBC4DB6CF}.Debug-NoTilesHeadless|x64.Build.0 = Debug|x64
+		{1232212E-8B83-40E9-B502-F25DBC4DB6CF}.Release-NoTilesHeadless|x64.ActiveCfg = Release|x64
+		{1232212E-8B83-40E9-B502-F25DBC4DB6CF}.Release-NoTilesHeadless|x64.Build.0 = Release|x64
 		{1232212E-8B83-40E9-B502-F25DBC4DB6CF}.Release-NoTiles|x86.ActiveCfg = Release|Win32
 		{1232212E-8B83-40E9-B502-F25DBC4DB6CF}.Release-NoTiles|x86.Build.0 = Release|Win32
 		{F2098959-AAD9-4210-A64C-FC4A09A45556}.Debug|ARM64EC.ActiveCfg = Debug|ARM64EC
@@ -426,6 +468,10 @@ Global
 		{F2098959-AAD9-4210-A64C-FC4A09A45556}.Release-NoTiles|ARM64EC.Build.0 = Release|ARM64EC
 		{F2098959-AAD9-4210-A64C-FC4A09A45556}.Release-NoTiles|x64.ActiveCfg = Release|x64
 		{F2098959-AAD9-4210-A64C-FC4A09A45556}.Release-NoTiles|x64.Build.0 = Release|x64
+		{F2098959-AAD9-4210-A64C-FC4A09A45556}.Debug-NoTilesHeadless|x64.ActiveCfg = Debug|x64
+		{F2098959-AAD9-4210-A64C-FC4A09A45556}.Debug-NoTilesHeadless|x64.Build.0 = Debug|x64
+		{F2098959-AAD9-4210-A64C-FC4A09A45556}.Release-NoTilesHeadless|x64.ActiveCfg = Release|x64
+		{F2098959-AAD9-4210-A64C-FC4A09A45556}.Release-NoTilesHeadless|x64.Build.0 = Release|x64
 		{F2098959-AAD9-4210-A64C-FC4A09A45556}.Release-NoTiles|x86.ActiveCfg = Release|Win32
 		{F2098959-AAD9-4210-A64C-FC4A09A45556}.Release-NoTiles|x86.Build.0 = Release|Win32
 	EndGlobalSection

--- a/msvc-full-features/Cataclysm-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-vcpkg-static.vcxproj
@@ -13,6 +13,10 @@
       <Configuration>Debug-NoTiles</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug-NoTilesHeadless|x64">
+      <Configuration>Debug-NoTilesHeadless</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|ARM64EC">
       <Configuration>Debug</Configuration>
       <Platform>ARM64EC</Platform>
@@ -35,6 +39,10 @@
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release-NoTiles|x64">
       <Configuration>Release-NoTiles</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release-NoTilesHeadless|x64">
+      <Configuration>Release-NoTilesHeadless</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|ARM64EC">
@@ -80,14 +88,14 @@
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Debug-NoTiles'" Label="Configuration">
+  <PropertyGroup Condition="$(Configuration.StartsWith('Debug-NoTiles'))" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Release-NoTiles'" Label="Configuration">
+  <PropertyGroup Condition="$(Configuration.StartsWith('Release-NoTiles'))" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
@@ -157,6 +165,14 @@
     <EmbedManifest>false</EmbedManifest>
     <TargetName>cataclysm-notiles</TargetName>
   </PropertyGroup>
+  <!-- Headless (the *-NoTilesHeadless configs) gets its own exe name so it does
+       not overwrite the curses-backed notiles binary. Placed after the
+       per-config TargetName blocks so it wins (MSBuild last-wins). EmbedManifest
+       is set here too because no exact-match block above covers this config. -->
+  <PropertyGroup Condition="$(Configuration.Contains(Headless))">
+    <EmbedManifest>false</EmbedManifest>
+    <TargetName>cataclysm-headless</TargetName>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="!$(Configuration.Contains(NoTiles))">
     <ClCompile>
       <PreprocessorDefinitions>_WINDOWS;USE_WINMAIN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -185,7 +201,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug-NoTiles'">
+  <ItemDefinitionGroup Condition="$(Configuration.StartsWith('Debug-NoTiles'))">
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <IntrinsicFunctions>false</IntrinsicFunctions>
@@ -206,7 +222,7 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release-NoTiles'">
+  <ItemDefinitionGroup Condition="$(Configuration.StartsWith('Release-NoTiles'))">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>

--- a/msvc-full-features/ImGui-lib-vcpkg-static.vcxproj
+++ b/msvc-full-features/ImGui-lib-vcpkg-static.vcxproj
@@ -37,12 +37,20 @@
       <Configuration>Debug-NoTiles</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug-NoTilesHeadless|x64">
+      <Configuration>Debug-NoTilesHeadless</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release-NoTiles|x64">
       <Configuration>Release-NoTiles</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release-NoTilesHeadless|x64">
+      <Configuration>Release-NoTilesHeadless</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
@@ -76,6 +84,11 @@
     <ClCompile Include="..\src\third-party\imgui\imgui_widgets.cpp" />
     <ClCompile Include="..\src\third-party\imtui\imtui-impl-ncurses.cpp">
       <ExcludedFromBuild Condition="!$(Configuration.Contains(NoTiles))">true</ExcludedFromBuild>
+      <!-- Headless (the *-NoTilesHeadless configs) replaces the ncurses platform
+           layer with the in-memory shim in src/platform_headless.cpp, so exclude
+           the real one. Configuration is an intrinsic property, so this works
+           even though this ItemGroup precedes the Cataclysm-common.props import. -->
+      <ExcludedFromBuild Condition="$(Configuration.Contains(Headless))">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\src\third-party\imtui\imtui-impl-text.cpp">
       <ExcludedFromBuild Condition="!$(Configuration.Contains(NoTiles))">true</ExcludedFromBuild>
@@ -133,6 +146,32 @@
     <VcpkgHostTriplet>$(VcpkgTriplet)</VcpkgHostTriplet>
     <VcpkgConfiguration>$(Configuration)</VcpkgConfiguration>
   </PropertyGroup>
+  <!-- NoTiles configs were missing a static-triplet pin, so vcpkg fell back to
+       the default dynamic triplet (x64-windows) and tried a from-scratch
+       network rebuild of deps. Mirror the static pin used by the other x64
+       configs. (Pre-existing gap, surfaced by the headless NoTiles build.) -->
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug-NoTiles|x64'">
+    <VcpkgTriplet>x64-windows-static</VcpkgTriplet>
+    <VcpkgHostTriplet>$(VcpkgTriplet)</VcpkgHostTriplet>
+    <VcpkgConfiguration>$(Configuration)</VcpkgConfiguration>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Release-NoTiles|x64'">
+    <VcpkgTriplet>x64-windows-static</VcpkgTriplet>
+    <VcpkgHostTriplet>$(VcpkgTriplet)</VcpkgHostTriplet>
+    <VcpkgConfiguration>$(Configuration)</VcpkgConfiguration>
+  </PropertyGroup>
+  <!-- Headless variants share the same static triplet (and reuse the NoTiles
+       installed deps; vcpkg keys the install dir on triplet, not config name). -->
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug-NoTilesHeadless|x64'">
+    <VcpkgTriplet>x64-windows-static</VcpkgTriplet>
+    <VcpkgHostTriplet>$(VcpkgTriplet)</VcpkgHostTriplet>
+    <VcpkgConfiguration>$(Configuration)</VcpkgConfiguration>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Release-NoTilesHeadless|x64'">
+    <VcpkgTriplet>x64-windows-static</VcpkgTriplet>
+    <VcpkgHostTriplet>$(VcpkgTriplet)</VcpkgHostTriplet>
+    <VcpkgConfiguration>$(Configuration)</VcpkgConfiguration>
+  </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -150,7 +189,7 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug-NoTiles'">
+  <ItemDefinitionGroup Condition="$(Configuration.StartsWith('Debug-NoTiles'))">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -175,7 +214,7 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release-NoTiles'">
+  <ItemDefinitionGroup Condition="$(Configuration.StartsWith('Release-NoTiles'))">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -348,6 +348,70 @@ if (CURSES)
     endif()
 endif ()
 
+# Build headless version if requested. Mirrors the curses build but links no
+# terminal/SDL backend: the in-memory ImTui text renderer (third-party imtui
+# headless variant) plus src/platform_headless.cpp supply the present layer.
+if (HEADLESS)
+    add_library(cataclysm-common OBJECT
+            ${CATACLYSM_DDA_SOURCES}
+            ${CATACLYSM_DDA_HEADERS})
+    target_include_directories(cataclysm-common INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+    target_link_libraries(cataclysm-common PUBLIC third-party)
+    target_compile_definitions(cataclysm-common PUBLIC HEADLESS)
+
+    add_executable(cataclysm
+            ${MAIN_CPP}
+            ${MESSAGES_CPP})
+
+    add_dependencies(cataclysm-common get_version)
+    target_link_libraries(cataclysm PRIVATE cataclysm-common)
+
+    if (LOCALIZE)
+        target_include_directories(cataclysm-common PUBLIC
+                ${LIBINTL_INCLUDE_DIR}
+                ${ICONV_INCLUDE_DIR})
+        target_link_libraries(cataclysm-common PUBLIC
+                ${LIBINTL_LIBRARIES}
+                ${ICONV_LIBRARIES})
+    endif ()
+
+    if (CMAKE_USE_PTHREADS_INIT)
+        target_compile_options(cataclysm-common PUBLIC "-pthread")
+    endif ()
+
+    if (CMAKE_THREAD_LIBS_INIT)
+        target_link_libraries(cataclysm-common PUBLIC ${CMAKE_THREAD_LIBS_INIT})
+    endif ()
+
+    if (WIN32)
+        target_link_libraries(cataclysm-common PUBLIC gdi32.lib)
+        target_link_libraries(cataclysm-common PUBLIC winmm.lib)
+        target_link_libraries(cataclysm-common PUBLIC imm32.lib)
+        target_link_libraries(cataclysm-common PUBLIC ole32.lib)
+        target_link_libraries(cataclysm-common PUBLIC oleaut32.lib)
+        target_link_libraries(cataclysm-common PUBLIC version.lib)
+        if (BACKTRACE)
+            target_link_libraries(cataclysm-common PUBLIC dbghelp.lib)
+        endif ()
+    elseif (APPLE)
+        target_link_libraries(cataclysm-common PUBLIC "-framework CoreFoundation")
+    endif ()
+
+    if (LIBBACKTRACE)
+        target_link_libraries(cataclysm-common PUBLIC backtrace)
+    endif ()
+
+    if (RELEASE)
+        install(TARGETS cataclysm RUNTIME)
+    endif ()
+
+    if (TARGET ZLIB::ZLIB)
+        target_link_libraries(cataclysm-common PUBLIC ZLIB::ZLIB)
+    else()
+        target_link_libraries(cataclysm-common PUBLIC ${ZLIB_LIBRARIES})
+    endif()
+endif ()
+
 if (MINGW AND NOT RELEASE)
     # Try to Install shared libraries for dev builds
     # Note: It is specific to MSYS2 and uses hardcoded versions so

--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -24,7 +24,20 @@ static ImGuiKey cata_key_to_imgui( int cata_key );
 #ifdef TUI
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
+#if defined(HEADLESS)
+// Headless has no terminal and thus no curses header. cata_imgui only needs a
+// few curses mouse constants below to build ImTui mouse events, which the
+// headless ImTui platform shim discards. Define them locally instead of
+// pulling in <curses.h>. BUTTON5_PRESSED is intentionally left undefined so the
+// mousewheel branch compiles out.
+#  define KEY_MOUSE        0x199
+#  define BUTTON1_PRESSED  0x0002
+#  define BUTTON1_RELEASED 0x0001
+#  define BUTTON3_PRESSED  0x0800
+#  define BUTTON3_RELEASED 0x0400
+#else
 #include <curses.h>
+#endif
 #pragma GCC diagnostic pop
 #include <imtui/imtui-impl-ncurses.h>
 #include <imtui/imtui-impl-text.h>

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -13,7 +13,7 @@ class nc_color;
 struct input_event;
 using ImGuiInputTextFlags = int;
 
-#if defined(IMTUI) || !(defined(WIN32) || defined(TILES))
+#if defined(IMTUI) || defined(HEADLESS) || !(defined(WIN32) || defined(TILES))
     #define TUI
 #endif
 

--- a/src/crash.cpp
+++ b/src/crash.cpp
@@ -16,7 +16,7 @@
 #include <string>
 #include <typeinfo>
 
-#if !(defined(WIN32) || defined(TILES) || defined(CYGWIN))
+#if !(defined(WIN32) || defined(TILES) || defined(CYGWIN)) && !defined(HEADLESS)
     #include <curses.h>
 #endif
 
@@ -140,7 +140,7 @@ extern "C" {
             default:
                 return;
         }
-#if !(defined(WIN32) || defined(TILES)) && !defined(CYGWIN)
+#if !(defined(WIN32) || defined(TILES)) && !defined(CYGWIN) && !defined(HEADLESS)
         endwin();
 #endif
         if( !isDebuggerActive() ) {

--- a/src/cursesport.h
+++ b/src/cursesport.h
@@ -2,7 +2,7 @@
 #ifndef CATA_SRC_CURSESPORT_H
 #define CATA_SRC_CURSESPORT_H
 
-#if defined(IMTUI) || !(defined(TILES) || defined(WIN32))
+#if defined(IMTUI) || defined(HEADLESS) || !(defined(TILES) || defined(WIN32))
     #define TUI
 #endif
 

--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -192,7 +192,7 @@ void input_context_stack_impl::push( std::shared_ptr<input_context_handle> const
     stack.push_back( context );
 }
 
-#if defined(__ANDROID__) || defined(TILES)
+#if defined(__ANDROID__) || defined(TILES) || defined(IMTUI) || defined(HEADLESS)
     input_context_stack_impl input_context::input_context_stack;
 #endif
 

--- a/src/input_context.h
+++ b/src/input_context.h
@@ -65,7 +65,7 @@ class input_context
         std::shared_ptr<input_context_handle> handle{ new input_context_handle{this} };
 
     public:
-#if defined(__ANDROID__) || defined(TILES)
+#if defined(__ANDROID__) || defined(TILES) || defined(IMTUI) || defined(HEADLESS)
         // Whatever's on top is our current input context.
         static input_context_stack_impl input_context_stack;
 #endif

--- a/src/ncurses_def.cpp
+++ b/src/ncurses_def.cpp
@@ -1,4 +1,4 @@
-#if !(defined(TILES))
+#if !(defined(TILES)) && !defined(HEADLESS)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 

--- a/src/platform_headless.cpp
+++ b/src/platform_headless.cpp
@@ -1,0 +1,355 @@
+// Headless platform backend.
+//
+// Phase 0 of the simulate/present decoupling (see plan
+// sim-render-decoupling-plan.md). This file is the curses-free analogue of
+// ncurses_def.cpp / wincurse.cpp: it provides the catacurses interface, the
+// platform entry points, the input_manager hooks, the nc_color helpers, and
+// the ImTui ncurses-platform shims -- but touches no terminal at all.
+//
+// The design is "headless == the IMTUI build minus real terminal I/O":
+//   * Dear ImGui (cata_imgui.cpp) is an unconditional dependency and is reused
+//     as-is.
+//   * imtui-impl-text.cpp rasterises ImGui draw data into an in-memory
+//     ImTui::TScreen cell buffer with zero curses calls; it is reused as-is.
+//   * Only the terminal-touching layers are swapped out here: the catacurses
+//     window backend (real ncurses ::WINDOW forwarding) and the ImTui ncurses
+//     platform layer (ImTui_ImplNcurses_*).
+//
+// The in-memory TScreen left behind by imtui-impl-text captures only the Dear
+// ImGui-rendered widgets. It is NOT a complete frame buffer: the ASCII map
+// (game::draw_ter -> mvwputch) and the catacurses-drawn sidebar text go through
+// the catacurses primitives, which are no-ops here (and even in the real IMTUI
+// build flow to a parallel ncurses channel, never into the TScreen). So the
+// Phase 0.5 deterministic-replay harness should assert on simulation state
+// directly, not treat this TScreen as a faithful render of the whole screen.
+
+#if defined(HEADLESS)
+
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+#include "cached_options.h"
+#include "cata_imgui.h"
+#include "color.h"
+#include "cursesdef.h"
+#include "game_ui.h"
+#include "input.h"
+#include "output.h"
+#include "point.h"
+#include "ui_manager.h"
+
+// ImTui platform-layer shims. We reuse imtui-impl-text.cpp (the in-memory
+// renderer) but NOT imtui-impl-ncurses.cpp (the terminal driver); the latter
+// is excluded from the imtui build under HEADLESS, so the symbols it would
+// normally export are provided here instead.
+#include "imtui/imtui.h"
+#include "imtui/imtui-impl-ncurses.h"
+#include "imgui/imgui.h"
+
+// The catacurses client (Dear ImGui wrapper) lives in ui_manager.h as a global.
+std::unique_ptr<cataimgui::client> imclient;
+
+// ---------------------------------------------------------------------------
+// catacurses window backing store
+//
+// Under TUI builds cata_cursesport::WINDOW is unavailable (it is gated behind
+// !TUI), and the real ncurses ::WINDOW does not exist here, so we keep a tiny
+// dimensions-only struct. The game only reads geometry back through the
+// catacurses getmax*/getbeg*/getcur* accessors, so this is sufficient.
+// ---------------------------------------------------------------------------
+namespace
+{
+struct headless_window {
+    point pos;
+    int width = 0;
+    int height = 0;
+    point cursor;
+};
+
+headless_window *as_hw( const catacurses::window &win )
+{
+    return win.get<headless_window>();
+}
+} // namespace
+
+int get_window_width()
+{
+    return TERMX;
+}
+
+int get_window_height()
+{
+    return TERMY;
+}
+
+catacurses::window catacurses::newwin( const int nlines, const int ncols, const point &begin )
+{
+    headless_window *const w = new headless_window();
+    w->pos = begin;
+    w->width = ncols;
+    w->height = nlines;
+    return catacurses::window( std::shared_ptr<void>( w, []( void *const p ) {
+        delete static_cast<headless_window *>( p );
+    } ) );
+}
+
+void catacurses::wnoutrefresh( const window & ) { }
+void catacurses::wrefresh( const window & ) { }
+void catacurses::werase( const window & ) { }
+
+int catacurses::getmaxx( const window &win )
+{
+    const headless_window *const w = as_hw( win );
+    return w ? w->width : 0;
+}
+
+int catacurses::getmaxy( const window &win )
+{
+    const headless_window *const w = as_hw( win );
+    return w ? w->height : 0;
+}
+
+int catacurses::getbegx( const window &win )
+{
+    const headless_window *const w = as_hw( win );
+    return w ? w->pos.x : 0;
+}
+
+int catacurses::getbegy( const window &win )
+{
+    const headless_window *const w = as_hw( win );
+    return w ? w->pos.y : 0;
+}
+
+int catacurses::getcurx( const window &win )
+{
+    const headless_window *const w = as_hw( win );
+    return w ? w->cursor.x : 0;
+}
+
+int catacurses::getcury( const window &win )
+{
+    const headless_window *const w = as_hw( win );
+    return w ? w->cursor.y : 0;
+}
+
+void catacurses::wattroff( const window &, const nc_color ) { }
+void catacurses::wattron( const window &, const nc_color & ) { }
+
+void catacurses::wmove( const window &win, const point &p )
+{
+    if( headless_window *const w = as_hw( win ) ) {
+        w->cursor = p;
+    }
+}
+
+void catacurses::mvwprintw( const window &, const point &, const std::string & ) { }
+void catacurses::wprintw( const window &, const std::string & ) { }
+void catacurses::refresh() { }
+
+void refresh_display() { }
+void drain_renderer_recovery() { }
+void refresh_mouse_config() { }
+
+void catacurses::doupdate() { }
+void catacurses::clear() { }
+void catacurses::erase() { }
+
+void catacurses::endwin()
+{
+    ui_manager::reset();
+}
+
+void catacurses::wborder( const window &, const chtype, const chtype, const chtype, const chtype,
+                          const chtype, const chtype, const chtype, const chtype ) { }
+void catacurses::mvwhline( const window &, const point &, const chtype, const int ) { }
+void catacurses::mvwvline( const window &, const point &, const chtype, const int ) { }
+void catacurses::mvwaddch( const window &, const point &, const chtype ) { }
+void catacurses::waddch( const window &, const chtype ) { }
+void catacurses::wredrawln( const window &, const int, const int ) { }
+void catacurses::wclear( const window & ) { }
+void catacurses::curs_set( const int ) { }
+
+void catacurses::init_pair( const short pair, const base_color f, const base_color b )
+{
+    if( imclient ) {
+        imclient->upload_color_pair( pair, static_cast<int>( f ), static_cast<int>( b ) );
+    }
+}
+
+catacurses::window catacurses::stdscr;
+catacurses::window catacurses::newscr;
+
+void catacurses::resizeterm()
+{
+    // KNOWN LIMITATION (Phase 0): this does not resize stdscr's backing
+    // headless_window, and game_ui::init_ui() reads TERMX/TERMY back from
+    // stdscr, so the viewport is effectively frozen at its init_interface
+    // size. Fine for tests/replay (fixed viewport); a server/replay path that
+    // wants a configurable or per-client viewport must recreate stdscr here
+    // (mirroring sdltiles.cpp's newwin-on-resize) before this is useful.
+    game_ui::init_ui();
+    ui_manager::screen_resized();
+}
+
+void catacurses::init_interface()
+{
+    // No terminal: pick a sane default viewport unless one was already set.
+    if( TERMX <= 0 ) {
+        TERMX = EVEN_MINIMUM_TERM_WIDTH;
+    }
+    if( TERMY <= 0 ) {
+        TERMY = EVEN_MINIMUM_TERM_HEIGHT;
+    }
+    stdscr = newwin( TERMY, TERMX, point::zero );
+    imclient = std::make_unique<cataimgui::client>();
+    init_colors();
+}
+
+bool catacurses::supports_256_colors()
+{
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// input_manager
+//
+// There is no input device in headless mode. Tests run with test_mode == true
+// and never call get_input_event (callers skip it); we mirror ncurses_def by
+// throwing if it is reached under test_mode, and returning an error event
+// otherwise so a non-test headless process degrades instead of blocking.
+//
+// KNOWN LIMITATION (Phase 0): the non-test path returns immediately where the
+// ncurses backend would block in getch(). input_context::handle_input() loops
+// on get_input_event() and does not break on an error event, so a future
+// *interactive* headless path (timeout <= 0, context without ANY_INPUT
+// registered) would busy-spin at 100% CPU. Not reachable today (test_mode
+// throws; --jsonverify never calls handle_input). When a non-test interactive
+// headless path is added, give error events here a small sleep or have callers
+// treat error as a terminating condition.
+// ---------------------------------------------------------------------------
+void input_manager::pump_events()
+{
+    previously_pressed_key = 0;
+}
+
+input_event input_manager::get_input_event( const keyboard_mode /*preferred_keyboard_mode*/ )
+{
+    if( test_mode ) {
+        // input should be skipped in caller's code
+        throw std::runtime_error( "input_manager::get_input_event called in test mode" );
+    }
+    previously_pressed_key = 0;
+    input_event rval;
+    rval.type = input_timeout > 0 ? input_event_t::timeout : input_event_t::error;
+    return rval;
+}
+
+void input_manager::set_timeout( const int delay )
+{
+    input_timeout = delay;
+}
+
+// ---------------------------------------------------------------------------
+// nc_color helpers (curses-free bit layout).
+//
+// This is a byte-for-byte copy of the software implementation in
+// cursesport.cpp:525-557 (the SDL-tiles / wincon path). It is NOT the same as
+// ncurses_def.cpp's version, which uses real ncurses COLOR_PAIR()/A_BOLD macros
+// and the 2-arg nc_color ctor. The three backends partition by #if guard so
+// only one nc_color definition ever links.
+//
+// TODO(phase1): the two software copies (here + cursesport.cpp) could share one
+// backend-neutral TU, but the guard union that selects them (TUI / HEADLESS /
+// WIN32-curses) is intricate and most failure modes only surface in configs not
+// built on this machine -- out of scope for Phase 0 (pure-additive, no edits to
+// upstream-hot cursesport.cpp). Deferred deliberately, not forgotten.
+// ---------------------------------------------------------------------------
+static constexpr int A_BLINK = 0x00000800;
+static constexpr int A_BOLD  = 0x00002000;
+static constexpr int A_COLOR = 0x03fe0000;
+
+nc_color nc_color::from_color_pair_index( const int index )
+{
+    return nc_color( index << 17 & A_COLOR );
+}
+
+int nc_color::to_color_pair_index() const
+{
+    return ( attribute_value & A_COLOR ) >> 17;
+}
+
+nc_color nc_color::bold() const
+{
+    return nc_color( attribute_value | A_BOLD );
+}
+
+bool nc_color::is_bold() const
+{
+    return attribute_value & A_BOLD;
+}
+
+nc_color nc_color::blink() const
+{
+    return nc_color( attribute_value | A_BLINK );
+}
+
+bool nc_color::is_blink() const
+{
+    return attribute_value & A_BLINK;
+}
+
+// ---------------------------------------------------------------------------
+// Startup-time terminal helpers used by game::init_ui (game.cpp).
+// Headless has no minimum-size constraint and a guaranteed-UTF-8 environment.
+// ---------------------------------------------------------------------------
+void ensure_term_size(); // NOLINT(cata-static-declarations,misc-use-internal-linkage)
+void check_encoding(); // NOLINT(cata-static-declarations,misc-use-internal-linkage)
+
+void ensure_term_size() { }
+void check_encoding() { }
+
+// NOLINTNEXTLINE(cata-use-string_view): signature mirrors sdltiles/wincurse impls
+void set_title( const std::string & ) { }
+
+// ---------------------------------------------------------------------------
+// ImTui ncurses-platform shims.
+//
+// cata_imgui.cpp's TUI path calls these unconditionally. The real
+// implementations (imtui-impl-ncurses.cpp) drive a terminal; here we keep only
+// the parts the in-memory text renderer depends on:
+//   * Init must allocate the platform user-data (ImTui::ImplImtui_Data), which
+//     owns the TScreen that imtui-impl-text.cpp renders into and that
+//     imtui-impl-text.cpp's Shutdown frees.
+//   * NewFrame must keep ImGui's DisplaySize in sync with the viewport, or
+//     ImGui::NewFrame asserts.
+// Everything else (drawing to a terminal, color pairs, input polling) is inert.
+// ---------------------------------------------------------------------------
+void ImTui_ImplNcurses_Init( float /*fps_active*/, float /*fps_idle*/ )
+{
+    if( ImGui::GetIO().BackendPlatformUserData == nullptr ) {
+        ImGui::GetIO().BackendPlatformUserData = new ImTui::ImplImtui_Data();
+    }
+    ImGui::GetIO().DisplaySize = ImVec2( get_window_width(), get_window_height() );
+}
+
+void ImTui_ImplNcurses_Shutdown() { }
+
+bool ImTui_ImplNcurses_NewFrame( std::vector<std::pair<int, ImTui::mouse_event>> /*key_events*/ )
+{
+    ImGui::GetIO().DisplaySize = ImVec2( get_window_width(), get_window_height() );
+    return false;
+}
+
+void ImTui_ImplNcurses_DrawScreen( bool /*active*/ ) { }
+void ImTui_ImplNcurses_UploadColorPair( short /*p*/, short /*f*/, short /*b*/ ) { }
+void ImTui_ImplNcurses_SetAllocedPairCount( short /*p*/ ) { }
+
+bool ImTui_ImplNcurses_ProcessEvent()
+{
+    return false;
+}
+
+#endif // HEADLESS

--- a/src/third-party/CMakeLists.txt
+++ b/src/third-party/CMakeLists.txt
@@ -193,6 +193,59 @@ if (TILES)
                 )
 endif ()
 
+# ImTUI (headless): reuse Dear ImGui + the in-memory text renderer, but NOT
+# imtui-impl-ncurses.cpp (the terminal driver). The ImTui_ImplNcurses_* symbols
+# are provided instead by src/platform_headless.cpp. No curses dependency.
+if (HEADLESS)
+        add_library(
+                imtui
+                STATIC
+                imgui/imconfig.h
+                imgui/imgui.cpp
+                imgui/imgui.h
+                imgui/imgui_demo.cpp
+                imgui/imgui_draw.cpp
+                imgui/imgui_internal.h
+                imgui/imgui_stdlib.cpp
+                imgui/imgui_stdlib.h
+                imgui/imgui_tables.cpp
+                imgui/imgui_widgets.cpp
+                imtui/imtui-impl-text.cpp
+                imtui/imtui-impl-text.h
+                imtui/imtui.h
+                )
+
+        target_include_directories(
+                imtui
+                SYSTEM
+                PUBLIC
+                ${CMAKE_CURRENT_SOURCE_DIR}
+        )
+        target_include_directories(
+                imtui
+                PRIVATE
+                ${CATA_REPO_ROOT}/src
+        )
+        target_compile_options(
+                imtui
+                PRIVATE
+                -w
+                )
+
+        target_compile_definitions(
+                imtui
+                PUBLIC
+                IMTUI
+                HEADLESS
+                )
+
+        target_link_libraries(
+                third-party
+                INTERFACE
+                imtui
+                )
+endif ()
+
 # ImTUI
 if (CURSES)
         add_library(


### PR DESCRIPTION
#### 概述 (Summary)

Infrastructure "新增无头(headless)构建目标:无终端、无 SDL,复用 ImTui 内存文本渲染器 / Add a headless build target (no terminal, no SDL; reuses the in-memory ImTui text renderer)"

#### 改动目的 (Purpose of change)

本 fork 规划了模拟↔渲染的长期逐步解耦(目标:无头测试、确定性回放、客户端/服务端分离、可替换渲染引擎)。**阶段 0** 是其中最廉价、最自包含的一步——交付一个不链终端、不链 SDL 的构建目标,跑完整模拟。它当下即可用于 CI 测试与 `--jsonverify`,并为后续阶段(确定性回放、ViewSnapshot 缝、`do_turn` 异步化、`RenderBackend` 接口)打下地基,同时把"无头到底要桩掉多少表面积"这个数字落到实处。

This fork plans a gradual, long-term decoupling of simulation from rendering (goals: headless testing, deterministic replay, client/server split, swappable render engines). **Phase 0** is the cheapest, most self-contained step: a build target that links neither a terminal nor SDL yet runs the full simulation. It is usable today for CI tests and `--jsonverify`, lays the foundation for later phases (deterministic replay, a ViewSnapshot seam, async `do_turn`, a `RenderBackend` interface), and pins down exactly how small the "no render backend" surface really is.

#### 解决方案描述 (Describe the solution)

**源码 / Source**
- 新增 `src/platform_headless.cpp`(`#if defined(HEADLESS)`):`ncurses_def.cpp` 的无终端对应物——维度-only 窗口上的 catacurses 后端、输入桩、`nc_color` 助手,以及惰性的 `ImTui_ImplNcurses_*` 平台层桩(复用 `imtui-impl-text` 内存渲染器,不要 ncurses 驱动)。
- 守卫拓宽,使 `HEADLESS` 走 TUI 路径并排除真实 curses 后端:`cata_imgui.{h,cpp}`、`cursesport.h`、`crash.cpp`、`ncurses_def.cpp`。
- `input_context.{h,cpp}`:拓宽 `input_context_stack` 静态存储守卫以覆盖 `IMTUI`/`HEADLESS`(顺带修好 plain `Release-NoTiles` 链接 JSON formatter 的预存问题)。

New `src/platform_headless.cpp` (`#if defined(HEADLESS)`) is the curses-free analogue of `ncurses_def.cpp`: a catacurses backend over a dimensions-only window, input stubs, `nc_color` helpers, and inert `ImTui_ImplNcurses_*` shims (reusing the `imtui-impl-text` in-memory renderer, no ncurses driver). Guard widenings in `cata_imgui.{h,cpp}`, `cursesport.h`, `crash.cpp`, `ncurses_def.cpp` make `HEADLESS` take the TUI path and exclude the real curses backends. `input_context.{h,cpp}` widen the `input_context_stack` storage guard to cover `IMTUI`/`HEADLESS`.

**构建 / Build**
- CMake:`option(HEADLESS)`、无头库块、第三方 imtui 无头变体(仅文本渲染器)。
- MSVC:一等命名配置 `Debug/Release-NoTilesHeadless|x64`,贯穿 5 个 cata 工程 + `.sln`。判定统一为 `Configuration.Contains(Headless)`(内置属性、永不为空);精确 `NoTiles` 条件转 `StartsWith`,使无头零重复地继承 Debug/Release 的优化与运行库设置。无头下去 `SDL_SOUND`/pdcurses,独立 `cataclysm-headless` exe 名。

CMake gains `option(HEADLESS)`, a headless library block, and a third-party imtui headless variant. MSVC gains first-class named configs `Debug/Release-NoTilesHeadless|x64` across the 5 cata projects + `.sln`; selection is uniform `Configuration.Contains(Headless)` and exact `NoTiles` conditions become `StartsWith` so headless inherits the Debug/Release settings with no duplication. Drops `SDL_SOUND`/pdcurses under headless; own `cataclysm-headless` exe name.

**顺带修复 / Incidental fix**
- `ImGui-lib` 缺 `NoTiles` x64 的 static vcpkg triplet 钉(回落动态 triplet → 联网重建),已补。/ `ImGui-lib` lacked a static vcpkg triplet pin for the `NoTiles` x64 configs (fell back to the dynamic triplet → network rebuild); fixed.

#### 你考虑过的替代方案 (Describe alternatives you've considered)

- **属性开关方案(已被取代)**:先以 `/p:CDDA_HEADLESS=true` 叠在 `-NoTiles` 配置上、经派生属性 `_CDDA_HEADLESS` 驱动。零 `.sln` 改动,但派生属性在 IDE 工程加载等受限求值上下文里为空串,裸布尔条件报「不是布尔值」、项目加载失败,且无头不进 VS 下拉框。改用命名配置 + 内置 `Configuration` 属性后从根上消除空串陷阱,并让无头成为 IDE 可选项。
- **新增独立 `*-Headless` 配置(非 NoTiles 衍生)**:会丢掉 `Contains(NoTiles)` 既有逻辑(Console 子系统、imtui-text 纳入)的复用。命名为 `*-NoTilesHeadless` 一名双关,二者皆真,复用最大化。

Property-toggle (superseded): `/p:CDDA_HEADLESS=true` layered on `-NoTiles` via a derived `_CDDA_HEADLESS` property — zero `.sln` change, but the derived property is empty in restricted evaluation contexts (IDE project load), making bare-boolean conditions error out and load fail, and headless never appeared in the VS dropdown. A named config keyed on the intrinsic `Configuration` property removes that trap at the root. A standalone `*-Headless` config (not NoTiles-derived) would lose reuse of the existing `Contains(NoTiles)` logic; `*-NoTilesHeadless` is true for both substrings, maximizing reuse.

#### 测试 (Testing)

- 整解决方案 `Release-NoTilesHeadless|x64` 构建 **0 错误**。/ Full-solution build, 0 errors.
- plain `Release-NoTiles`、plain `Release`、headless 三配置 `restore` 全通过(复现 VS IDE 工程加载路径,确认无布尔陷阱)。/ All three configs restore cleanly (reproduces the IDE project-load path).
- `dumpbin /dependents cataclysm-headless.exe` 仅列 Windows 系统 DLL——无 SDL、无 pdcurses。/ Only Windows system DLLs; no SDL, no pdcurses.
- `cataclysm-headless.exe --jsonverify` 退出码 0(完整 JSON 数据加载、零渲染、不崩)。/ `--jsonverify` exits 0.

#### 补充说明 (Additional context)

**已知限制(有意为之,留待后续)/ Known limitations (intentional, deferred)**
- 非交互 `get_input_event` 立即返回而非阻塞;未来若接交互式无头路径,需在 error 事件上 sleep/终止以避免忙等。视口在初始化后冻结(不支持 resize)。两者均已在代码注释中标注,且 Phase 0 用例(测试 / `--jsonverify`)触达不到。
- Non-interactive `get_input_event` returns immediately rather than blocking; a future interactive headless path would need a sleep/terminate on error events. The viewport is frozen at init size. Both are documented in-code and unreachable from the Phase 0 use cases.

**未来展望 / Future outlook** — 阶段 0 是多阶段路线图的第一步,每阶段小、可编译、可独立交付:
- **0.5** 确定性回放测试台:录制输入+RNG 种子 → 无头回放 → 断言世界态。/ Deterministic replay harness.
- **1** 记忆写回抽离:把 avatar 地图记忆写回移出 draw,使渲染纯读。/ Memory-writeback extraction (rendering becomes pure-read).
- **2** `ViewSnapshot` 缝:sim 与渲染器间的可序列化每帧视图模型,按区域参数化、天生 diff 友好。/ A serializable per-frame view-model, region-parameterized and diff-friendly.
- **3** 拆 `do_turn` 为 simulate/present + 异步:解耦 tick 率与帧率。/ Split `do_turn`; decouple tick rate from frame rate.
- **4** `RenderBackend` 接口:SDL 降格为可替换实现之一,把易崩的 SDL3-GPU 路径变成可换后端。/ SDL becomes one swappable backend among many.

更长期支撑本 fork 的规划方向:自由空间泡、自由视角模拟经营(对标环世界、**mod 中立**)、联机——但每项在渲染之外还各需模拟模型泛化的工作量。/ Longer-term this enables the fork's planned directions (free space bubble, RimWorld-like **mod-neutral** simulation-management, multiplayer), each of which also needs its own simulation-model generalization beyond rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)