### PR TITLE
Add mod gameplay support based on gender contrl

### DIFF
--- a/data/core/external_options.json
+++ b/data/core/external_options.json
@@ -520,5 +520,12 @@
     "//": "The maximum number of overmaps that an intersection can deviate from its gridded position. Cannot be greater than or equal to row / 2 or column / 2, may cause bugs for > row / 4, column / 4.",
     "stype": "int",
     "value": 2
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "PLAYER_ARBITRARY_CHANGE_GENDER",
+    "//": "The default value is true; when this option is false, it prevents players from switching genders in the player_display menu. Some special character json flag can bypass this configuration option.",
+    "stype": "bool",
+    "value": true
   }
 ]

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -3085,5 +3085,15 @@
     "id": "ROBOFAC_LENS_HELMET",
     "type": "json_flag",
     "info": "This item allows you to wear Hub 01 LENS accessories."
+  },
+  {
+    "id": "GENDER_FLUIDITY",
+    "type": "json_flag",
+    "//": "Allows characters to change their gender by bypassing the PLAYER_ARBITRARY_CHANGE_GENDER option."
+  },
+  {
+    "id": "GENDER_INVARIANCE",
+    "type": "json_flag",
+    "//": "Preventing a character from changing their gender will override GENDER_FLUIDITY."
   }
 ]

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -41,6 +41,7 @@
 #include "magic_enchantment.h"
 #include "mutation.h"
 #include "output.h"
+#include "options.h"
 #include "pimpl.h"
 #include "point.h"
 #include "proficiency.h"
@@ -80,6 +81,9 @@ static const std::string title_SKILLS = translate_marker( "SKILLS" );
 static const std::string title_BIONICS = translate_marker( "BIONICS" );
 static const std::string title_TRAITS = translate_marker( "TRAITS" );
 static const std::string title_PROFICIENCIES = translate_marker( "PROFICIENCIES" );
+
+static const json_character_flag json_flag_GENDER_FLUIDITY( "GENDER_FLUIDITY" );
+static const json_character_flag json_flag_GENDER_INVARIANCE( "GENDER_INVARIANCE" );
 
 static const unsigned int grid_width = 26;
 
@@ -1144,8 +1148,13 @@ static void on_customize_character( Character &you )
 
     cmenu.query();
     if( cmenu.ret == 1 ) {
-        you.male = !you.male;
-        popup( _( "Gender set to %s." ), you.male ? _( "Male" ) : _( "Female" ) );
+        if ( ( get_option<bool>( "PLAYER_ARBITRARY_CHANGE_GENDER" ) || you.has_flag( json_flag_GENDER_FLUIDITY ) ) && !you.has_flag( json_flag_GENDER_INVARIANCE ) ) {
+            you.male = !you.male;
+            popup( _( "Gender set to %s." ), you.male ? _( "Male" ) : _( "Female" ) );
+        }
+        else{
+            popup( _( "You can't reset your gender, because %s." ), get_option<bool>( "PLAYER_ARBITRARY_CHANGE_GENDER" ) ? _( "you don't have that ability" ) : _( "option is disabled" ) );
+        }
     } else if( cmenu.ret == 2 ) {
         std::string filterstring = you.play_name.value_or( std::string() );
         string_input_popup popup;


### PR DESCRIPTION
####  Summary

Feature "Allow mods to control whether players can change their gender at any time during the game process through option and character json_flags."

#### Purpose of change

The upstream branch DDA has long since exposed character gender to the EOC system as part of math functions at the request of Xedra Evolved developers. However, the most likely use cases for this change are mostly directed at NPCs in most situations, because the game allows players to change their gender data at any time via the customization function in the player_display menu.

Meanwhile, the generational interpersonal relationships, physiological cycles, pregnancy, and lactation life-process simulation systems proposed in issue #110 also dictate that if these features are to be implemented, their specific functionalities will be highly differentiated based on the character's biological sex. This creates a certain degree of disconnect with the current logic that allows changing gender arbitrarily, because previously, gender in this game was more of a parameter providing immersion, lacking a direct impact on gameplay. We don't even have our own romance system like human pawns do in Rimworld!

Furthermore, those community players who are not proficient in using GitHub often jokingly clamor for us to provide some sort of "CCB mod"(a bit improperly and simply, the **C**oital **C**onduct **B**ackbone mod; its logic is akin to a type of slang, serving as one of the multi-layered derivative meanings of a Chinese internet meme that is related to pinyin initial acronyms and possesses multiple definitions) after learning that this branch's abbreviation is CCB. Although we are unlikely to provide, nor is it suitable to provide, a repository-included mod specifically serving this system—just as the official Rimworld team would not release RimJobWorld, yet their Biotech DLC provided the functionality of producing offspring as one of the expansion contents—we will encounter situations where we need to include and solve the same problems when crafting a more refined sims system. In realistic content of this nature, gender-based gameplay is a part that cannot be easily skipped over, and allowing players to carelessly switch genders will inevitably break this part of the gameplay and the game's immersion.

I am also clearly aware that a one-size-fits-all approach to banning a player's ability before these contents are even developed might not be entirely appropriate, even though its current presence may seem negligible. However, I also feel that preparing for a rainy day is not groundless anxiety; providing configurable interfaces for this type of highly gender-based gameplay is a win-win choice.

#### Describe the solution

Added an `EXTERNAL_OPTION` named `PLAYER_ARBITRARY_CHANGE_GENDER` (which can be found in `data\core\external_options.json`). The default value is true; when this option is false, it prevents players from switching genders in the player_display menu.

If `PLAYER_ARBITRARY_CHANGE_GENDER` is false, attempting to switch genders directly through the menu will prompt: `You can't reset your gender, because option is disabled.`

In addition, two extra json_flags have been added, namely `GENDER_FLUIDITY` and `GENDER_INVARIANCE`. Among them, `GENDER_FLUIDITY` will allow players to switch genders when `PLAYER_ARBITRARY_CHANGE_GENDER` is false. On the other hand, `GENDER_INVARIANCE` will prevent players from directly switching genders through the menu under any circumstances, and prompt: `You can't reset your gender, because you don't have that ability.`

#### Describe alternatives you've considered

Directly removing the feature to customize character gender during the game process, since EOC is available after all... But if we do this before rolling out our built-in, highly gender-based gameplay, would it carry the suspicion of discriminating against players who don't know how to write json configuration files?

I actually also considered expanding the gender parameter options; after all, even in terms of biological sex in the real world, there are more than just two. Even without considering LGBTQIA2S+, individuals with disorders of sex development (DSD) exist as an objective reality. However, the engineering workload involved is too massive and could easily introduce more bugs, so I have temporarily shelved it.