### PR TITLE
refactor(tiles): extract orientation helpers from cata_tiles to map module

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -3481,11 +3481,11 @@ bool cata_tiles::draw_terrain( const tripoint_bub_ms &p, const lit_level ll, int
         const std::bitset<NUM_TERCONN> &rotate_group = t.obj().rotate_to_groups;
 
         if( connect_group.any() ) {
-            get_connect_values( p, subtile, rotation, connect_group, rotate_group, {} );
+            map::get_connect_values( p, subtile, rotation, connect_group, rotate_group, {} );
             // re-memorize previously seen terrain in case new connections have been seen
             here.memory_cache_ter_set_dirty( p, true );
         } else {
-            get_terrain_orientation( p, rotation, subtile, {}, invisible, rotate_group );
+            map::get_terrain_orientation( p, rotation, subtile, {}, invisible, rotate_group );
             // do something to get other terrain orientation values
         }
         if( here.memory_cache_ter_is_dirty( p ) ) {
@@ -3511,10 +3511,10 @@ bool cata_tiles::draw_terrain( const tripoint_bub_ms &p, const lit_level ll, int
             const std::bitset<NUM_TERCONN> &rotate_group = t2.obj().rotate_to_groups;
 
             if( connect_group.any() ) {
-                get_connect_values( p, subtile, rotation, connect_group, rotate_group,
+                map::get_connect_values( p, subtile, rotation, connect_group, rotate_group,
                                     terrain_override );
             } else {
-                get_terrain_orientation( p, rotation, subtile, terrain_override, invisible,
+                map::get_terrain_orientation( p, rotation, subtile, terrain_override, invisible,
                                          rotate_group );
             }
             const std::string &tname = t2.id().str();
@@ -3572,7 +3572,7 @@ bool cata_tiles::draw_furniture( const tripoint_bub_ms &p, const lit_level ll, i
         const std::bitset<NUM_TERCONN> &rotate_group = f.obj().rotate_to_groups;
 
         if( connect_group.any() ) {
-            get_furn_connect_values( p, subtile, rotation, connect_group, rotate_group, {} );
+            map::get_furn_connect_values( p, subtile, rotation, connect_group, rotate_group, {} );
         } else {
             get_tile_values_with_ter( p, f.to_i(), neighborhood, subtile, rotation, rotate_group );
         }
@@ -3613,7 +3613,7 @@ bool cata_tiles::draw_furniture( const tripoint_bub_ms &p, const lit_level ll, i
             const std::bitset<NUM_TERCONN> &rotate_group = f.obj().rotate_to_groups;
 
             if( connect_group.any() ) {
-                get_furn_connect_values( p, subtile, rotation, connect_group, rotate_group, {} );
+                map::get_furn_connect_values( p, subtile, rotation, connect_group, rotate_group, {} );
             } else {
                 get_tile_values_with_ter( p, f.to_i(), neighborhood, subtile, rotation, rotate_group );
             }
@@ -5916,306 +5916,6 @@ void cata_tiles::init_light()
     g->reset_light_level();
 }
 
-void cata_tiles::get_terrain_orientation( const tripoint_bub_ms &p, int &rota, int &subtile,
-        const std::map<tripoint_bub_ms, ter_id> &ter_override, const std::array<bool, 5> &invisible,
-        const std::bitset<NUM_TERCONN> &rotate_group )
-{
-    map &here = get_map();
-    const bool overridden = ter_override.find( p ) != ter_override.end();
-    const auto ter = [&]( const tripoint_bub_ms & q, const bool invis ) -> ter_str_id {
-        const auto override_it = ter_override.find( q );
-        return override_it != ter_override.end() ? override_it->second.id() :
-                                          ( !overridden || !invis ) ? here.ter( q ).id() : ter_str_id::NULL_ID();
-    };
-
-    // get terrain at x,y
-    const ter_id &tid = ter( p, invisible[0] );
-    if( tid == ter_str_id::NULL_ID() ) {
-        subtile = 0;
-        rota = 0;
-        return;
-    }
-
-    // get terrain neighborhood
-    const std::array<ter_id, 4> neighborhood = {
-        ter( p + point::south, invisible[1] ),
-        ter( p + point::east, invisible[2] ),
-        ter( p + point::west, invisible[3] ),
-        ter( p + point::north, invisible[4] )
-    };
-
-    char val = 0;
-
-    // populate connection information
-    for( int i = 0; i < 4; ++i ) {
-        if( neighborhood[i] == tid ) {
-            val += 1 << i;
-        }
-    }
-
-    uint8_t rotation_targets = here.get_known_rotates_to( p, rotate_group, {} );
-    get_rotation_and_subtile( val, rotation_targets, rota, subtile );
-}
-
-void cata_tiles::get_rotation_and_subtile( const char val, const char rot_to, int &rotation,
-        int &subtile )
-{
-    const bool no_rotation = rot_to == CHAR_MAX;
-    switch( val ) {
-        // no connections
-        case 0:
-            subtile = unconnected;
-            if( no_rotation ) {
-                rotation = 0;
-                break;
-            }
-            rotation = get_rotation_unconnected( rot_to );
-            break;
-        // all connections
-        case 15:
-            subtile = center;
-            rotation = 0;
-            break;
-        // end pieces
-        // rotations:
-        //
-        // --> edge index
-        // Nw, Ws, Sw, Es,
-        // Ne, Wn, Se, En,  |
-        // N+, W+, S+, E+,  V  get_rotation_... return index
-        // N-, W-, S-, E-
-        //
-        // (Nw = north end piece, rotated to west)
-        case 8:
-            // vertical end piece S
-            subtile = end_piece;
-            if( no_rotation ) {
-                rotation = 2;
-                break;
-            }
-            rotation = 2 + 4 * get_rotation_edge_ns( rot_to );
-            break;
-        case 4:
-            // horizontal end piece E
-            subtile = end_piece;
-            if( no_rotation ) {
-                rotation = 1;
-                break;
-            }
-            rotation = 1 + 4 * get_rotation_edge_ew( rot_to );
-            break;
-        case 2:
-            // horizontal end piece W
-            subtile = end_piece;
-            if( no_rotation ) {
-                rotation = 3;
-                break;
-            }
-            rotation = 3 + 4 * get_rotation_edge_ew( rot_to );
-            break;
-        case 1:
-            // vertical end piece N
-            subtile = end_piece;
-            if( no_rotation ) {
-                rotation = 0;
-                break;
-            }
-            rotation = 4 * get_rotation_edge_ns( rot_to );
-            break;
-        // edges
-        // rotations:
-        //
-        // --> edge index
-        // NSw, EWs,
-        // NSe, EWn,  |
-        // NS+, EW+,  V  get_rotation_... return index
-        // NS-, EW-,
-        //
-        // (NSw = north-south edge, rotated to west)
-        case 9:
-            // vertical edge
-            subtile = edge;
-            if( no_rotation ) {
-                rotation = 0;
-                break;
-            }
-            rotation = 2 * get_rotation_edge_ns( rot_to );
-            break;
-        case 6:
-            // horizontal edge
-            subtile = edge;
-            if( no_rotation ) {
-                rotation = 1;
-                break;
-            }
-            rotation = 1 + 2 * get_rotation_edge_ew( rot_to );
-            break;
-        // corners
-        case 12:
-            subtile = corner;
-            rotation = 2;
-            break;
-        case 10:
-            subtile = corner;
-            rotation = 3;
-            break;
-        case 3:
-            subtile = corner;
-            rotation = 0;
-            break;
-        case 5:
-            subtile = corner;
-            rotation = 1;
-            break;
-        // all t_connections
-        case 14:
-            subtile = t_connection;
-            rotation = 2;
-            break;
-        case 11:
-            subtile = t_connection;
-            rotation = 3;
-            break;
-        case 7:
-            subtile = t_connection;
-            rotation = 0;
-            break;
-        case 13:
-            subtile = t_connection;
-            rotation = 1;
-            break;
-    }
-}
-
-int cata_tiles::get_rotation_edge_ns( const char rot_to )
-{
-    if( ( rot_to & static_cast<int>( NEIGHBOUR::EAST ) ) == static_cast<int>( NEIGHBOUR::EAST ) ) {
-        if( ( rot_to & static_cast<int>( NEIGHBOUR::WEST ) ) == static_cast<int>( NEIGHBOUR::WEST ) ) {
-            // EW
-            return 2;
-        } else {
-            // Ew
-            return 1;
-        }
-    } else { // east -
-        if( ( rot_to & static_cast<int>( NEIGHBOUR::WEST ) ) == static_cast<int>( NEIGHBOUR::WEST ) ) {
-            // eW
-            return 0;
-        } else {
-            // ew
-            return 3;
-        }
-    }
-}
-
-int cata_tiles::get_rotation_edge_ew( const char rot_to )
-{
-    if( ( rot_to & static_cast<int>( NEIGHBOUR::NORTH ) ) == static_cast<int>( NEIGHBOUR::NORTH ) ) {
-        if( ( rot_to & static_cast<int>( NEIGHBOUR::SOUTH ) ) == static_cast<int>( NEIGHBOUR::SOUTH ) ) {
-            // NS
-            return 2;
-        } else {
-            // Ns
-            return 1;
-        }
-    } else { // north -
-        if( ( rot_to & static_cast<int>( NEIGHBOUR::SOUTH ) ) == static_cast<int>( NEIGHBOUR::SOUTH ) ) {
-            // nS
-            return 0;
-        } else {
-            // ns
-            return 3;
-        }
-    }
-}
-
-int cata_tiles::get_rotation_unconnected( const char rot_to )
-{
-    int rotation = 0;
-    switch( rot_to ) {
-        // Catch no and all first for performance; these are the last sprites!
-        case 0: // NONE
-            rotation = 15;
-            break;
-        case 15: // ALL
-            rotation = 12;
-            break;
-
-        // Cases for single tile to rotate to -> easy
-        case static_cast<int>( NEIGHBOUR::NORTH ):
-            rotation = 2;
-            break;
-        case static_cast<int>( NEIGHBOUR::EAST ):
-            rotation = 1;
-            break;
-        case static_cast<int>( NEIGHBOUR::SOUTH ):
-            rotation = 0;
-            break;
-        case static_cast<int>( NEIGHBOUR::WEST ):
-            rotation = 3;
-            break;
-        // Two tiles, resulting in diagonal
-        case 10: // NE
-            rotation = 6;
-            break;
-        case 3: // SE
-            rotation = 5;
-            break;
-        case 5: // SW
-            rotation = 4;
-            break;
-        case 12: // NW
-            rotation = 7;
-            break;
-        // Cases for three tiles to rotate to -> easy
-        // Arranged to fallback / modulo to fitting index 0-4
-        case 14: // 3 but south --> modulo = north
-            rotation = 10;
-            break;
-        case 11: // 3 but west --> modulo = east
-            rotation = 9;
-            break;
-        case 7: // 3 but north --> modulo = south
-            rotation = 8;
-            break;
-        case 13: // 3 but east --> modulo = west
-            rotation = 11;
-            break;
-        // Two opposing tiles, (No tiles, all tiles; see first cases)
-        case 9: // N-S
-            rotation = 14;
-            break;
-        case 6: // E-W
-            rotation = 13;
-            break;
-    }
-
-    return rotation;
-}
-
-void cata_tiles::get_connect_values( const tripoint_bub_ms &p, int &subtile, int &rotation,
-                                     const std::bitset<NUM_TERCONN> &connect_group,
-                                     const std::bitset<NUM_TERCONN> &rotate_to_group,
-                                     const std::map<tripoint_bub_ms, ter_id> &ter_override )
-{
-    map &here = get_map();
-
-    uint8_t connections = here.get_known_connections( p, connect_group, ter_override );
-    uint8_t rotation_targets = here.get_known_rotates_to( p, rotate_to_group, ter_override );
-    get_rotation_and_subtile( connections, rotation_targets, rotation, subtile );
-}
-
-void cata_tiles::get_furn_connect_values( const tripoint_bub_ms &p, int &subtile, int &rotation,
-        const std::bitset<NUM_TERCONN> &connect_group, const std::bitset<NUM_TERCONN> &rotate_to_group,
-        const std::map<tripoint_bub_ms, furn_id> &furn_override )
-{
-    map &here = get_map();
-
-    uint8_t connections = here.get_known_connections_f( p, connect_group, furn_override );
-    uint8_t rotation_targets = here.get_known_rotates_to_f( p, rotate_to_group, {}, {} );
-    get_rotation_and_subtile( connections, rotation_targets, rotation, subtile );
-}
-
 void cata_tiles::get_tile_values( const int t, const std::array<int, 4> &tn, int &subtile,
                                   int &rotation, const char rotation_targets )
 {
@@ -6227,7 +5927,7 @@ void cata_tiles::get_tile_values( const int t, const std::array<int, 4> &tn, int
             val += 1 << i;
         }
     }
-    get_rotation_and_subtile( val, rotation_targets, rotation, subtile );
+    map::get_rotation_and_subtile( val, rotation_targets, rotation, subtile );
 }
 
 void cata_tiles::get_tile_values_with_ter(
@@ -6240,7 +5940,7 @@ void cata_tiles::get_tile_values_with_ter(
     if( here.has_flag( ter_furn_flag::TFLAG_NO_SELF_CONNECT, p ) ||
         here.has_flag( ter_furn_flag::TFLAG_ALIGN_WORKBENCH, p ) ) {
         //if we don't ever connect to ourself just return unconnected to be used further
-        get_rotation_and_subtile( 0, rotation_targets, rotation, subtile );
+        map::get_rotation_and_subtile( 0, rotation_targets, rotation, subtile );
     } else {
         //if we do connect to ourself (tables, counters etc.) calculate based on neighbours
         get_tile_values( t, tn, subtile, rotation, rotation_targets );

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -130,14 +130,6 @@ const std::unordered_map<std::string, TILE_CATEGORY> to_TILE_CATEGORY = {
     {"overmap_note", TILE_CATEGORY::OVERMAP_NOTE}
 };
 
-enum class NEIGHBOUR {
-    SOUTH = 1,
-    EAST = 2,
-    WEST = 4,
-    NORTH = 8,
-    last
-};
-
 class tile_lookup_res
 {
         // references are stored as pointers to support copy assignment of the class
@@ -730,23 +722,6 @@ class cata_tiles
         void get_tile_values_with_ter( const tripoint_bub_ms &p, int t, const std::array<int, 4> &tn,
                                        int &subtile, int &rotation,
                                        const std::bitset<NUM_TERCONN> &rotate_to_group );
-        static void get_connect_values( const tripoint_bub_ms &p, int &subtile, int &rotation,
-                                        const std::bitset<NUM_TERCONN> &connect_group,
-                                        const std::bitset<NUM_TERCONN> &rotate_to_group,
-                                        const std::map<tripoint_bub_ms, ter_id> &ter_override );
-        static void get_furn_connect_values( const tripoint_bub_ms &p, int &subtile, int &rotation,
-                                             const std::bitset<NUM_TERCONN> &connect_group,
-                                             const std::bitset<NUM_TERCONN> &rotate_to_group,
-                                             const std::map<tripoint_bub_ms, furn_id> &furn_override );
-        void get_terrain_orientation( const tripoint_bub_ms &p, int &rota, int &subtile,
-                                      const std::map<tripoint_bub_ms, ter_id> &ter_override,
-                                      const std::array<bool, 5> &invisible,
-                                      const std::bitset<NUM_TERCONN> &rotate_group );
-
-        static void get_rotation_and_subtile( char val, char rot_to, int &rota, int &subtile );
-        static int get_rotation_unconnected( char rot_to );
-        static int get_rotation_edge_ns( char rot_to );
-        static int get_rotation_edge_ew( char rot_to );
 
         /** Map memory */
         const memorized_tile &get_terrain_memory_at( const tripoint_abs_ms &p ) const;

--- a/src/enums.h
+++ b/src/enums.h
@@ -445,6 +445,17 @@ enum MULTITILE_TYPE {
     num_multitile_types
 };
 
+// Bitmask of cardinal-direction neighbours used by tile orientation helpers.
+// Moved from cata_tiles.h so map-side code can compute orientation without
+// depending on the tiles subsystem (see sim-render-decoupling-plan.md §1).
+enum class NEIGHBOUR {
+    SOUTH = 1,
+    EAST  = 2,
+    WEST  = 4,
+    NORTH = 8,
+    last
+};
+
 enum class reachability_cache_quadrant : int {
     NE, SE, NW, SW
 };

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2478,6 +2478,267 @@ for( int i = 0; i < 4; ++i ) {
     return val;
 }
 
+// ---------------------------------------------------------------------------
+// Sim-side tile orientation helpers — Stage 1 of sim/render decoupling.
+// Verbatim logic extracted from cata_tiles.cpp.  The three map-querying
+// functions (get_connect_values, get_furn_connect_values,
+// get_terrain_orientation) call get_map() just as the cata_tiles originals
+// did; static members have no implicit this, so get_map() is the right call.
+// The four pure-math helpers (get_rotation_and_subtile + 3 rotation helpers)
+// have no map dependency and could live anywhere — they are map:: members
+// only to give them a natural home without a new header.
+// ---------------------------------------------------------------------------
+
+void map::get_rotation_and_subtile( const char val, const char rot_to, int &rotation,
+                                    int &subtile )
+{
+    const bool no_rotation = rot_to == CHAR_MAX;
+    switch( val ) {
+        case 0:
+            subtile = unconnected;
+            if( no_rotation ) {
+                rotation = 0;
+                break;
+            }
+            rotation = get_rotation_unconnected( rot_to );
+            break;
+        case 15:
+            subtile = center;
+            rotation = 0;
+            break;
+        case 8:
+            subtile = end_piece;
+            if( no_rotation ) {
+                rotation = 2;
+                break;
+            }
+            rotation = 2 + 4 * get_rotation_edge_ns( rot_to );
+            break;
+        case 4:
+            subtile = end_piece;
+            if( no_rotation ) {
+                rotation = 1;
+                break;
+            }
+            rotation = 1 + 4 * get_rotation_edge_ew( rot_to );
+            break;
+        case 2:
+            subtile = end_piece;
+            if( no_rotation ) {
+                rotation = 3;
+                break;
+            }
+            rotation = 3 + 4 * get_rotation_edge_ew( rot_to );
+            break;
+        case 1:
+            subtile = end_piece;
+            if( no_rotation ) {
+                rotation = 0;
+                break;
+            }
+            rotation = 4 * get_rotation_edge_ns( rot_to );
+            break;
+        case 9:
+            subtile = edge;
+            if( no_rotation ) {
+                rotation = 0;
+                break;
+            }
+            rotation = 2 * get_rotation_edge_ns( rot_to );
+            break;
+        case 6:
+            subtile = edge;
+            if( no_rotation ) {
+                rotation = 1;
+                break;
+            }
+            rotation = 1 + 2 * get_rotation_edge_ew( rot_to );
+            break;
+        case 12:
+            subtile = corner;
+            rotation = 2;
+            break;
+        case 10:
+            subtile = corner;
+            rotation = 3;
+            break;
+        case 3:
+            subtile = corner;
+            rotation = 0;
+            break;
+        case 5:
+            subtile = corner;
+            rotation = 1;
+            break;
+        case 14:
+            subtile = t_connection;
+            rotation = 2;
+            break;
+        case 11:
+            subtile = t_connection;
+            rotation = 3;
+            break;
+        case 7:
+            subtile = t_connection;
+            rotation = 0;
+            break;
+        case 13:
+            subtile = t_connection;
+            rotation = 1;
+            break;
+    }
+}
+
+int map::get_rotation_edge_ns( const char rot_to )
+{
+    if( ( rot_to & static_cast<int>( NEIGHBOUR::EAST ) ) == static_cast<int>( NEIGHBOUR::EAST ) ) {
+        if( ( rot_to & static_cast<int>( NEIGHBOUR::WEST ) ) == static_cast<int>( NEIGHBOUR::WEST ) ) {
+            return 2;
+        } else {
+            return 1;
+        }
+    } else {
+        if( ( rot_to & static_cast<int>( NEIGHBOUR::WEST ) ) == static_cast<int>( NEIGHBOUR::WEST ) ) {
+            return 0;
+        } else {
+            return 3;
+        }
+    }
+}
+
+int map::get_rotation_edge_ew( const char rot_to )
+{
+    if( ( rot_to & static_cast<int>( NEIGHBOUR::NORTH ) ) == static_cast<int>( NEIGHBOUR::NORTH ) ) {
+        if( ( rot_to & static_cast<int>( NEIGHBOUR::SOUTH ) ) == static_cast<int>( NEIGHBOUR::SOUTH ) ) {
+            return 2;
+        } else {
+            return 1;
+        }
+    } else {
+        if( ( rot_to & static_cast<int>( NEIGHBOUR::SOUTH ) ) == static_cast<int>( NEIGHBOUR::SOUTH ) ) {
+            return 0;
+        } else {
+            return 3;
+        }
+    }
+}
+
+int map::get_rotation_unconnected( const char rot_to )
+{
+    int rotation = 0;
+    switch( rot_to ) {
+        case 0:
+            rotation = 15;
+            break;
+        case 15:
+            rotation = 12;
+            break;
+        case static_cast<int>( NEIGHBOUR::NORTH ):
+            rotation = 2;
+            break;
+        case static_cast<int>( NEIGHBOUR::EAST ):
+            rotation = 1;
+            break;
+        case static_cast<int>( NEIGHBOUR::SOUTH ):
+            rotation = 0;
+            break;
+        case static_cast<int>( NEIGHBOUR::WEST ):
+            rotation = 3;
+            break;
+        case 10:
+            rotation = 6;
+            break;
+        case 3:
+            rotation = 5;
+            break;
+        case 5:
+            rotation = 4;
+            break;
+        case 12:
+            rotation = 7;
+            break;
+        case 14:
+            rotation = 10;
+            break;
+        case 11:
+            rotation = 9;
+            break;
+        case 7:
+            rotation = 8;
+            break;
+        case 13:
+            rotation = 11;
+            break;
+        case 9:
+            rotation = 14;
+            break;
+        case 6:
+            rotation = 13;
+            break;
+    }
+    return rotation;
+}
+
+void map::get_connect_values( const tripoint_bub_ms &p, int &subtile, int &rotation,
+                              const std::bitset<NUM_TERCONN> &connect_group,
+                              const std::bitset<NUM_TERCONN> &rotate_to_group,
+                              const std::map<tripoint_bub_ms, ter_id> &ter_override )
+{
+    map &here = get_map();
+    uint8_t connections = here.get_known_connections( p, connect_group, ter_override );
+    uint8_t rotation_targets = here.get_known_rotates_to( p, rotate_to_group, ter_override );
+    get_rotation_and_subtile( connections, rotation_targets, rotation, subtile );
+}
+
+void map::get_furn_connect_values( const tripoint_bub_ms &p, int &subtile, int &rotation,
+                                   const std::bitset<NUM_TERCONN> &connect_group,
+                                   const std::bitset<NUM_TERCONN> &rotate_to_group,
+                                   const std::map<tripoint_bub_ms, furn_id> &furn_override )
+{
+    map &here = get_map();
+    uint8_t connections = here.get_known_connections_f( p, connect_group, furn_override );
+    uint8_t rotation_targets = here.get_known_rotates_to_f( p, rotate_to_group, {}, {} );
+    get_rotation_and_subtile( connections, rotation_targets, rotation, subtile );
+}
+
+void map::get_terrain_orientation( const tripoint_bub_ms &p, int &rota, int &subtile,
+                                   const std::map<tripoint_bub_ms, ter_id> &ter_override,
+                                   const std::array<bool, 5> &invisible,
+                                   const std::bitset<NUM_TERCONN> &rotate_group )
+{
+    map &here = get_map();
+    const bool overridden = ter_override.find( p ) != ter_override.end();
+    const auto ter = [&]( const tripoint_bub_ms & q, const bool invis ) -> ter_str_id {
+        const auto override_it = ter_override.find( q );
+        return override_it != ter_override.end() ? override_it->second.id() :
+                                          ( !overridden || !invis ) ? here.ter( q ).id() : ter_str_id::NULL_ID();
+    };
+
+    const ter_id &tid = ter( p, invisible[0] );
+    if( tid == ter_str_id::NULL_ID() ) {
+        subtile = 0;
+        rota = 0;
+        return;
+    }
+
+    const std::array<ter_id, 4> neighborhood = {
+        ter( p + point::south, invisible[1] ),
+        ter( p + point::east,  invisible[2] ),
+        ter( p + point::west,  invisible[3] ),
+        ter( p + point::north, invisible[4] )
+    };
+
+    char val = 0;
+    for( int i = 0; i < 4; ++i ) {
+        if( neighborhood[i] == tid ) {
+            val += 1 << i;
+        }
+    }
+
+    uint8_t rotation_targets = here.get_known_rotates_to( p, rotate_group, {} );
+    get_rotation_and_subtile( val, rotation_targets, rota, subtile );
+}
+
 /*
  * Get the results of harvesting this tile's furniture or terrain
  */

--- a/src/map.h
+++ b/src/map.h
@@ -1098,6 +1098,34 @@ class map
                                         const std::map<tripoint_bub_ms, ter_id> &override = {},
                                         const std::map<tripoint_bub_ms, furn_id> &override_f = {} ) const;
 
+        // -----------------------------------------------------------------------
+        // Sim-side tile orientation helpers (Stage 1 of sim/render decoupling).
+        // Extracted from cata_tiles so the memory-update pass in do_turn can
+        // compute subtile/rotation when memorising seen tiles, without depending
+        // on the tiles subsystem.  See sim-render-decoupling-plan.md §1.
+        // -----------------------------------------------------------------------
+        // Pure-math rotation helpers (no map state needed).
+        static void get_rotation_and_subtile( char val, char rot_to, int &rotation, int &subtile );
+        static int  get_rotation_unconnected( char rot_to );
+        static int  get_rotation_edge_ns( char rot_to );
+        static int  get_rotation_edge_ew( char rot_to );
+
+        // Terrain/furniture connection values + orientation — call get_map() internally.
+        // ter_override / furn_override are populated only on the render preview path;
+        // pass empty maps from the sim-side memory-update pass.
+        static void get_connect_values( const tripoint_bub_ms &p, int &subtile, int &rotation,
+                                        const std::bitset<NUM_TERCONN> &connect_group,
+                                        const std::bitset<NUM_TERCONN> &rotate_to_group,
+                                        const std::map<tripoint_bub_ms, ter_id> &ter_override = {} );
+        static void get_furn_connect_values( const tripoint_bub_ms &p, int &subtile, int &rotation,
+                                             const std::bitset<NUM_TERCONN> &connect_group,
+                                             const std::bitset<NUM_TERCONN> &rotate_to_group,
+                                             const std::map<tripoint_bub_ms, furn_id> &furn_override = {} );
+        static void get_terrain_orientation( const tripoint_bub_ms &p, int &rota, int &subtile,
+                                             const std::map<tripoint_bub_ms, ter_id> &ter_override,
+                                             const std::array<bool, 5> &invisible,
+                                             const std::bitset<NUM_TERCONN> &rotate_group );
+
         /**
          * Returns the full harvest list, for spawning.
          */

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3113,7 +3113,7 @@ std::pair<std::string, bool> cata_tiles::get_omt_id_rotation_and_subtile(
             }
         }
 
-        get_rotation_and_subtile( val, -1, rota, subtile );
+        map::get_rotation_and_subtile( val, -1, rota, subtile );
     } else if( ot_type.has_flag( oter_flags::water ) ) {
         // water looks nicer if it connects together
         char val = 0;
@@ -3125,7 +3125,7 @@ std::pair<std::string, bool> cata_tiles::get_omt_id_rotation_and_subtile(
             }
         }
 
-        get_rotation_and_subtile( val, -1, rota, subtile );
+        map::get_rotation_and_subtile( val, -1, rota, subtile );
     } else {
         // 'Regular', nonlinear terrain only needs to worry about rotation, not
         // subtile


### PR DESCRIPTION
#### 概述 (Summary)
Infrastructure "把瓦片朝向计算从 cata_tiles 抽到 map 模块 (extract tile orientation helpers from cata_tiles to map)"

#### 改动目的 (Purpose of change)
为「模拟/渲染解耦」多年重构计划的阶段 1 铺第一块砖（计划 §1 第 1 步）。
阶段 1 的目标是把玩家地图记忆的写回从渲染绘制路径搬到独立的 sim 侧
pass，使渲染变成纯读。但记忆里的 subtile/rotation 朝向当前由
cata_tiles 内部的朝向函数算出——sim 侧要自己写记忆，就得先能调到这些
函数。本 PR 只做这一步「把渲染私有函数变成 map 可调」的**纯重构**，
行为零变化；改写回时机的逻辑改动留给后续 PR，便于单独 review、降低与
上游 cata_tiles（高频改动文件）的冲突面。

Lays the first brick for Stage 1 of the multi-year sim/render decoupling
plan. Stage 1 moves the player map-memory write-back out of the render
draw path into a separate sim-side pass so rendering becomes pure-read.
The memorised subtile/rotation are currently computed by orientation
helpers private to cata_tiles; before the sim side can write memory it
must be able to call them. This PR does only that step — turning
render-private functions into map-callable ones — as a **pure refactor**
with zero behaviour change. The write-back-timing change is deferred to a
follow-up PR, to keep this one trivially reviewable and minimise conflict
surface against cata_tiles (a high-churn upstream file).

#### 解决方案描述 (Describe the solution)
- 把 7 个朝向函数从 `cata_tiles` 搬到 `map::` 静态成员，函数体逐字不变：
  - 纯数学 4 个：`get_rotation_and_subtile` + `get_rotation_unconnected`
    / `get_rotation_edge_ns` / `get_rotation_edge_ew`（无地图依赖）。
  - 查地图 3 个：`get_connect_values` / `get_furn_connect_values` /
    `get_terrain_orientation`（内部调 `get_map()`，与原 cata_tiles 取全局
    地图同一对象；底层 `get_known_connections`/`get_known_rotates_to` 本就
    在 map.cpp）。
- `NEIGHBOUR` 方向位掩码枚举从 cata_tiles.h 移到 enums.h（被旋转 helper
  引用，map 侧需可见）。
- `ter_override`/`furn_override`（仅渲染预览路径用）设默认空参 `= {}`，
  sim 侧调用传空即可，不引入渲染态。
- 全部调用点加 `map::` 前缀：cata_tiles.cpp 8 处 + sdltiles.cpp 2 处
  （overmap 瓦片渲染）。
- `get_tile_values`/`get_tile_values_with_ter`（含 `has_flag` 渲染标志）
  **不动**，留在 cata_tiles，不属本次纯重构范围。

(English: 7 orientation helpers moved verbatim from `cata_tiles` to
`map::` statics — 4 pure-math, 3 map-querying via `get_map()` whose
underlying `get_known_*` already live in map.cpp. The `NEIGHBOUR` bitmask
enum moved cata_tiles.h → enums.h. Render-preview-only override params
default to `= {}`. All call sites prefixed `map::`: 8 in cata_tiles.cpp,
2 in sdltiles.cpp (overmap tile render). `get_tile_values*` left in
cata_tiles, out of scope.)

#### 你考虑过的替代方案 (Describe alternatives you've considered)
- **记忆只存语义 ter_id、丢 subtile/rotation，客户端读记忆后用记忆里的
  邻居重算朝向**：更轻，但记忆是 submap 级稀疏存储、有空洞 → 邻居不全 →
  朝向可能与初见不一致 → 视觉回归。故选择把朝向计算整体搬到 sim 侧，
  记忆保持完整、不丢任何字段。
- **放进独立 helper 函数而非 map:: 成员**：这些函数已几乎只依赖 map
  数据，作为 `map::` 静态成员有自然归属、且无需新增头文件。

(English: considered storing only semantic ter_id and recomputing
orientation from memorised neighbours client-side — lighter, but sparse
submap-level memory yields incomplete neighbourhoods and visual
regressions; chose to move the computation sim-side so memory stays
complete. Also considered free functions over map:: statics — the latter
gives a natural home without a new header.)

#### 测试 (Testing)
- 完整 TILES 配置（Release|x64）编译链接通过，0 错误，产出
  `cataclysm-tiles.exe`。（首轮构建暴露 sdltiles.cpp overmap 渲染 2 处
  漏改的裸调用，已补 `map::` 前缀。）
- 进游戏肉眼比对朝向类渲染与改前一致：墙体连接（直墙/拐角/丁字/十字）、
  地形过渡（道路/水域/地板边缘）、多格家具朝向、overmap 道路/河流连接，
  均无回归。
- 纯重构、行为零变化：8+2 个调用点全部确认加 `map::` 前缀，无残留裸调用；
  函数体逐字搬运未改逻辑。

(English: full TILES Release|x64 builds and links clean, 0 errors; the
first build surfaced 2 missed bare calls in sdltiles.cpp overmap render,
now prefixed. In-game eyeball check confirms no regression in
wall-connection / terrain-transition / multi-tile furniture / overmap
road-river orientation. Pure refactor: all 8+2 call sites prefixed, no
bare calls remain, function bodies moved verbatim.)

#### 补充说明 (Additional context)
- 玩法中立、纯结构重构，不夹带任何数值/玩法改动。
- 此 PR 无法被阶段 0.5 回放测试台覆盖：所有调用点都在 TILES 专属渲染
  路径，headless 不调用，搬出的 `map::` 函数在 headless 下是死代码路径
  → 故采用「完整 TILES 构建 + 肉眼朝向验证」作为验证手段。
- 后续 PR（阶段 1 第 2 步）将新增 sim 侧 memory-update pass 调用这些
  函数写记忆，并删除 cata_tiles draw 路径里的记忆写回，使渲染变纯读。

(English: gameplay-neutral pure structural refactor. Not coverable by the
Stage 0.5 replay harness — all call sites are TILES-only render paths,
never hit headless, so the moved functions are dead-code there; hence
verification is via full TILES build + visual orientation check. A
follow-up PR adds the sim-side memory-update pass and removes the draw-path
write-backs to make rendering pure-read.)