### PR TITLE
refactor(tiles): extract get_tile_values helpers from cata_tiles to map / 把 get_tile_values 朝向函数从 cata_tiles 抽到 map

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -3574,7 +3574,7 @@ bool cata_tiles::draw_furniture( const tripoint_bub_ms &p, const lit_level ll, i
         if( connect_group.any() ) {
             map::get_furn_connect_values( p, subtile, rotation, connect_group, rotate_group, {} );
         } else {
-            get_tile_values_with_ter( p, f.to_i(), neighborhood, subtile, rotation, rotate_group );
+            map::get_tile_values_with_ter( p, f.to_i(), neighborhood, subtile, rotation, rotate_group );
         }
         const std::string &fname = f.id().str();
         if( !( you.get_grab_type() == object_type::FURNITURE
@@ -3615,9 +3615,9 @@ bool cata_tiles::draw_furniture( const tripoint_bub_ms &p, const lit_level ll, i
             if( connect_group.any() ) {
                 map::get_furn_connect_values( p, subtile, rotation, connect_group, rotate_group, {} );
             } else {
-                get_tile_values_with_ter( p, f.to_i(), neighborhood, subtile, rotation, rotate_group );
+                map::get_tile_values_with_ter( p, f.to_i(), neighborhood, subtile, rotation, rotate_group );
             }
-            get_tile_values_with_ter( p, f2.to_i(), neighborhood, subtile, rotation, 0 );
+            map::get_tile_values_with_ter( p, f2.to_i(), neighborhood, subtile, rotation, 0 );
             const std::string &fname = f2.id().str();
             // tile overrides are never memorized
             // tile overrides are always shown with full visibility
@@ -3670,7 +3670,7 @@ bool cata_tiles::draw_trap( const tripoint_bub_ms &p, const lit_level ll, int &h
         };
         int subtile = 0;
         int rotation = 0;
-        get_tile_values( tr.loadid.to_i(), neighborhood, subtile, rotation, 0 );
+        map::get_tile_values( tr.loadid.to_i(), neighborhood, subtile, rotation, 0 );
         const std::string trname = tr.loadid.id().str();
         if( here.memory_cache_dec_is_dirty( p ) ) {
             you.memorize_decoration( here.get_abs( p ), trname, subtile, rotation );
@@ -3703,7 +3703,7 @@ bool cata_tiles::draw_trap( const tripoint_bub_ms &p, const lit_level ll, int &h
             };
             int subtile = 0;
             int rotation = 0;
-            get_tile_values( tr2.to_i(), neighborhood, subtile, rotation, 0 );
+            map::get_tile_values( tr2.to_i(), neighborhood, subtile, rotation, 0 );
             const std::string &trname = tr2.id().str();
             // tile overrides are never memorized
             // tile overrides are always shown with full visibility
@@ -3792,7 +3792,7 @@ bool cata_tiles::draw_field_or_item( const tripoint_bub_ms &p, const lit_level l
             const bool nv = nv_goggles_activated;
             int subtile = 0;
             int rotation = 0;
-            get_tile_values( fld.to_i(), neighborhood, subtile, rotation, 0 );
+            map::get_tile_values( fld.to_i(), neighborhood, subtile, rotation, 0 );
 
             // go through all the layer variants
             for( const layer_context_sprites &layer_var : itt->second ) {
@@ -3905,7 +3905,7 @@ bool cata_tiles::draw_field_or_item( const tripoint_bub_ms &p, const lit_level l
 
                 int subtile = 0;
                 int rotation = 0;
-                get_tile_values( fld.to_i(), neighborhood, subtile, rotation, 0 );
+                map::get_tile_values( fld.to_i(), neighborhood, subtile, rotation, 0 );
 
                 //get field intensity
                 int intensity = fd_pr.second.get_field_intensity();
@@ -3944,7 +3944,7 @@ bool cata_tiles::draw_field_or_item( const tripoint_bub_ms &p, const lit_level l
 
             int subtile = 0;
             int rotation = 0;
-            get_tile_values( fld.to_i(), neighborhood, subtile, rotation, 0 );
+            map::get_tile_values( fld.to_i(), neighborhood, subtile, rotation, 0 );
 
             //get field intensity
             int intensity = fld_overridden ? 0 : here.field_at( p ).displayed_intensity();
@@ -5914,98 +5914,6 @@ void cata_tiles::tile_loading_report_dups()
 void cata_tiles::init_light()
 {
     g->reset_light_level();
-}
-
-void cata_tiles::get_tile_values( const int t, const std::array<int, 4> &tn, int &subtile,
-                                  int &rotation, const char rotation_targets )
-{
-    std::array<bool, 4> connects;
-    char val = 0;
-    for( int i = 0; i < 4; ++i ) {
-        connects[i] = ( tn[i] == t );
-        if( connects[i] ) {
-            val += 1 << i;
-        }
-    }
-    map::get_rotation_and_subtile( val, rotation_targets, rotation, subtile );
-}
-
-void cata_tiles::get_tile_values_with_ter(
-    const tripoint_bub_ms &p, const int t, const std::array<int, 4> &tn, int &subtile, int &rotation,
-    const std::bitset<NUM_TERCONN> &rotate_to_group )
-{
-    map &here = get_map();
-    uint8_t rotation_targets = here.get_known_rotates_to_f( p, rotate_to_group, {} );
-    //check if furniture should connect to itself
-    if( here.has_flag( ter_furn_flag::TFLAG_NO_SELF_CONNECT, p ) ||
-        here.has_flag( ter_furn_flag::TFLAG_ALIGN_WORKBENCH, p ) ) {
-        //if we don't ever connect to ourself just return unconnected to be used further
-        map::get_rotation_and_subtile( 0, rotation_targets, rotation, subtile );
-    } else {
-        //if we do connect to ourself (tables, counters etc.) calculate based on neighbours
-        get_tile_values( t, tn, subtile, rotation, rotation_targets );
-    }
-    // calculate rotation for unconnected tiles based on surrounding walls
-    // if not any rotates_to neighbours
-    if( subtile == unconnected && ( rotation_targets == 0 || rotation_targets == CHAR_MAX ) ) {
-        int val = 0;
-        bool use_furniture = false;
-
-        if( here.has_flag( ter_furn_flag::TFLAG_ALIGN_WORKBENCH, p ) ) {
-            for( int i = 0; i < 4; ++i ) {
-                // align to furniture that has the workbench quality
-                const tripoint_bub_ms &pt = p + four_adjacent_offsets[i];
-                if( here.has_furn( pt ) && here.furn( pt ).obj().workbench ) {
-                    val += 1 << i;
-                    use_furniture = true;
-                }
-            }
-        }
-        // if still unaligned, try aligning to walls
-        if( val == 0 ) {
-            for( int i = 0; i < 4; ++i ) {
-                const tripoint_bub_ms &pt = p + four_adjacent_offsets[i];
-                if( here.has_flag( ter_furn_flag::TFLAG_WALL, pt ) ||
-                    here.has_flag( ter_furn_flag::TFLAG_WINDOW, pt ) ||
-                    here.has_flag( ter_furn_flag::TFLAG_DOOR, pt ) ) {
-                    val += 1 << i;
-                }
-            }
-        }
-
-        switch( val ) {
-            case 4:    // south wall
-            case 14:   // north opening T
-                rotation = 2;
-                break;
-            case 2:    // east wall
-            case 6:    // southeast corner
-            case 5:    // E/W corridor
-            case 7:    // east opening T
-                rotation = 1;
-                break;
-            case 8:    // west wall
-            case 12:   // southwest corner
-            case 13:   // west opening T
-                rotation = 3;
-                break;
-            case 0:    // no walls
-            case 1:    // north wall
-            case 3:    // northeast corner
-            case 9:    // northwest corner
-            case 10:   // N/S corridor
-            case 11:   // south opening T
-            case 15:   // surrounded
-            default:   // just in case
-                rotation = rotate_to_group.none() ? 0 : 15;
-                break;
-        }
-
-        //
-        if( use_furniture ) {
-            rotation = ( rotation + 2 ) % 4;
-        }
-    }
 }
 
 void cata_tiles::do_tile_loading_report()

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -716,12 +716,6 @@ class cata_tiles
                            const point &offset, bool allow_diagonal_rota = false );
 
         /* Tile Picking */
-        void get_tile_values( int t, const std::array<int, 4> &tn, int &subtile, int &rotation,
-                              char rotation_targets );
-        // as get_tile_values, but for unconnected tiles, infer rotation from surrounding walls
-        void get_tile_values_with_ter( const tripoint_bub_ms &p, int t, const std::array<int, 4> &tn,
-                                       int &subtile, int &rotation,
-                                       const std::bitset<NUM_TERCONN> &rotate_to_group );
 
         /** Map memory */
         const memorized_tile &get_terrain_memory_at( const tripoint_abs_ms &p ) const;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2739,6 +2739,98 @@ void map::get_terrain_orientation( const tripoint_bub_ms &p, int &rota, int &sub
     get_rotation_and_subtile( val, rotation_targets, rota, subtile );
 }
 
+void map::get_tile_values( const int t, const std::array<int, 4> &tn, int &subtile,
+                           int &rotation, const char rotation_targets )
+{
+    std::array<bool, 4> connects;
+    char val = 0;
+    for( int i = 0; i < 4; ++i ) {
+        connects[i] = ( tn[i] == t );
+        if( connects[i] ) {
+            val += 1 << i;
+        }
+    }
+    get_rotation_and_subtile( val, rotation_targets, rotation, subtile );
+}
+
+void map::get_tile_values_with_ter(
+    const tripoint_bub_ms &p, const int t, const std::array<int, 4> &tn, int &subtile, int &rotation,
+    const std::bitset<NUM_TERCONN> &rotate_to_group )
+{
+    map &here = get_map();
+    uint8_t rotation_targets = here.get_known_rotates_to_f( p, rotate_to_group, {} );
+    //check if furniture should connect to itself
+    if( here.has_flag( ter_furn_flag::TFLAG_NO_SELF_CONNECT, p ) ||
+        here.has_flag( ter_furn_flag::TFLAG_ALIGN_WORKBENCH, p ) ) {
+        //if we don't ever connect to ourself just return unconnected to be used further
+        get_rotation_and_subtile( 0, rotation_targets, rotation, subtile );
+    } else {
+        //if we do connect to ourself (tables, counters etc.) calculate based on neighbours
+        get_tile_values( t, tn, subtile, rotation, rotation_targets );
+    }
+    // calculate rotation for unconnected tiles based on surrounding walls
+    // if not any rotates_to neighbours
+    if( subtile == unconnected && ( rotation_targets == 0 || rotation_targets == CHAR_MAX ) ) {
+        int val = 0;
+        bool use_furniture = false;
+
+        if( here.has_flag( ter_furn_flag::TFLAG_ALIGN_WORKBENCH, p ) ) {
+            for( int i = 0; i < 4; ++i ) {
+                // align to furniture that has the workbench quality
+                const tripoint_bub_ms &pt = p + four_adjacent_offsets[i];
+                if( here.has_furn( pt ) && here.furn( pt ).obj().workbench ) {
+                    val += 1 << i;
+                    use_furniture = true;
+                }
+            }
+        }
+        // if still unaligned, try aligning to walls
+        if( val == 0 ) {
+            for( int i = 0; i < 4; ++i ) {
+                const tripoint_bub_ms &pt = p + four_adjacent_offsets[i];
+                if( here.has_flag( ter_furn_flag::TFLAG_WALL, pt ) ||
+                    here.has_flag( ter_furn_flag::TFLAG_WINDOW, pt ) ||
+                    here.has_flag( ter_furn_flag::TFLAG_DOOR, pt ) ) {
+                    val += 1 << i;
+                }
+            }
+        }
+
+        switch( val ) {
+            case 4:    // south wall
+            case 14:   // north opening T
+                rotation = 2;
+                break;
+            case 2:    // east wall
+            case 6:    // southeast corner
+            case 5:    // E/W corridor
+            case 7:    // east opening T
+                rotation = 1;
+                break;
+            case 8:    // west wall
+            case 12:   // southwest corner
+            case 13:   // west opening T
+                rotation = 3;
+                break;
+            case 0:    // no walls
+            case 1:    // north wall
+            case 3:    // northeast corner
+            case 9:    // northwest corner
+            case 10:   // N/S corridor
+            case 11:   // south opening T
+            case 15:   // surrounded
+            default:   // just in case
+                rotation = rotate_to_group.none() ? 0 : 15;
+                break;
+        }
+
+        //
+        if( use_furniture ) {
+            rotation = ( rotation + 2 ) % 4;
+        }
+    }
+}
+
 /*
  * Get the results of harvesting this tile's furniture or terrain
  */

--- a/src/map.h
+++ b/src/map.h
@@ -1125,6 +1125,14 @@ class map
                                              const std::map<tripoint_bub_ms, ter_id> &ter_override,
                                              const std::array<bool, 5> &invisible,
                                              const std::bitset<NUM_TERCONN> &rotate_group );
+        // Compute subtile/rotation from a 4-neighbour sameness mask.
+        static void get_tile_values( int t, const std::array<int, 4> &tn, int &subtile, int &rotation,
+                                     char rotation_targets );
+        // as get_tile_values, but for unconnected tiles, infer rotation from surrounding walls
+        static void get_tile_values_with_ter( const tripoint_bub_ms &p, int t,
+                                              const std::array<int, 4> &tn,
+                                              int &subtile, int &rotation,
+                                              const std::bitset<NUM_TERCONN> &rotate_to_group );
 
         /**
          * Returns the full harvest list, for spawning.


### PR DESCRIPTION
#### 概述 (Summary)
Infrastructure "把瓦片选择朝向函数 get_tile_values/get_tile_values_with_ter 从 cata_tiles 抽到 map 模块 (extract tile-picking orientation helpers get_tile_values/get_tile_values_with_ter from cata_tiles to map)"

#### 改动目的 (Purpose of change)
延续「模拟/渲染解耦」重构计划阶段 1：把玩家地图记忆的写回从渲染绘制路径
搬到独立的 sim 侧 pass，使渲染变成纯读。前一个 PR (#241) 已把 7 个朝向
函数搬到 `map::`，但还剩两个「尾巴」函数 `get_tile_values` /
`get_tile_values_with_ter`（陷阱、家具、地块字段绘制路径用来算 subtile/
rotation）留在 cata_tiles 里。sim 侧记忆 pass 要自己算朝向就得能调到它们。
本 PR 只做这一步「把这两个渲染私有函数变成 map 可调」的**纯重构**，行为
零变化；改写回时机的逻辑改动留给后续 PR，便于单独 review。

(English: continues Stage 1 of the sim/render decoupling plan. The prior PR
(#241) moved 7 orientation helpers to `map::`, leaving two "tail" functions —
`get_tile_values` / `get_tile_values_with_ter`, used by the trap / furniture /
field draw paths to compute subtile+rotation — still private to cata_tiles.
The sim-side memory pass must be able to call them. This PR does only that
step as a **pure refactor** with zero behaviour change; the write-back-timing
change is deferred to a follow-up PR for separate review.)

#### 解决方案描述 (Describe the solution)
- 把 2 个朝向函数从 `cata_tiles` 搬到 `map::` 静态成员，函数体逐字不变：
  - `get_tile_values`：纯数学，由 4 邻居同类位掩码算 subtile/rotation，调
    已在 map 的 `map::get_rotation_and_subtile`，零地图依赖。
  - `get_tile_values_with_ter`：查地图算家具/地形朝向，内部依赖全是 sim 侧
    符号 —— `here.has_flag(ter_furn_flag::TFLAG_*)`（sim 地形/家具标志，
    非渲染标志）、`here.has_furn/furn`、`here.get_known_rotates_to_f`、
    `four_adjacent_offsets`、`unconnected`(enums.h)，无任何 tiles 子系统依赖。
- 全部 8 个调用点加 `map::` 前缀（均在 cata_tiles.cpp：陷阱 2 处、家具 3 处、
  地块字段 3 处）。本次 sdltiles.cpp 无调用点（已 grep 全 src 确认）。
- 这两个函数原标记为「中等难度」尾巴；实测 `get_tile_values_with_ter` 的
  `has_flag` 是 sim 地形标志而非渲染标志，连同其余依赖全在 sim 侧，故与
  #241 的其余函数同属【低】难度，可干净搬出。

(English: moved 2 orientation helpers verbatim from `cata_tiles` to `map::`
statics. `get_tile_values` is pure math (calls the already-moved
`map::get_rotation_and_subtile`, no map deps). `get_tile_values_with_ter`
queries the map but all its deps are sim-side — `has_flag(ter_furn_flag::*)`
are sim terrain/furniture flags (NOT render flags), plus `has_furn`/`furn`/
`get_known_rotates_to_f`/`four_adjacent_offsets`/`unconnected` — no tiles
subsystem dependency. All 8 call sites prefixed `map::` (all in
cata_tiles.cpp: 2 trap, 3 furniture, 3 field; no sdltiles.cpp call sites this
time, confirmed by grepping all src). These were earlier labelled
"middle-difficulty"; in practice `has_flag` is a sim flag, so they are as
cleanly movable as the rest of #241.)

#### 你考虑过的替代方案 (Describe alternatives you've considered)
- **留在 cata_tiles，sim 侧记忆 pass 重新实现一份**：会出现两份朝向逻辑、
  易漂移、违背「记忆字段逐字节一致」目标，故选择搬运复用单一实现。
- **放进独立 helper 函数而非 map:: 成员**：与 #241 一致，这些函数依赖的
  全是 map 数据，作为 `map::` 静态成员有自然归属、无需新增头文件。

(English: considered leaving them in cata_tiles and reimplementing in the
sim memory pass — rejected, two copies drift; chose to move and reuse a
single implementation. Also considered free functions over map:: statics —
same reasoning as #241, map:: statics give a natural home.)

#### 测试 (Testing)
- 完整 TILES 配置（Release|x64）编译链接通过，0 错误，产出
  `cataclysm-tiles.exe`。
- 进游戏肉眼比对朝向类渲染与改前一致：墙体连接（直墙/拐角/丁字/十字）、
  多格家具朝向、工作台/桌台对齐、陷阱、地形过渡，均无回归。
- 纯重构、行为零变化：8 个调用点全部确认加 `map::` 前缀，无残留裸调用，
  函数体逐字搬运未改逻辑。

(English: full TILES Release|x64 builds and links clean, 0 errors; in-game
eyeball check confirms no regression in wall-connection / multi-tile
furniture / workbench alignment / trap / terrain-transition orientation.
Pure refactor: all 8 call sites prefixed, no bare calls remain, bodies moved
verbatim.)

#### 补充说明 (Additional context)
- 玩法中立、纯结构重构，不夹带任何数值/玩法改动。
- 此 PR 无法被阶段 0.5 回放测试台覆盖：所有调用点都在 TILES 专属渲染路径，
  headless 不调用，搬出的 `map::` 函数在 headless 下是死代码路径 → 故采用
  「完整 TILES 构建 + 肉眼朝向验证」作为验证手段。
- 后续 PR（阶段 1 第 2 步）将新增 sim 侧 memory-update pass 调用这些函数
  写记忆，并删除 cata_tiles draw 路径里的记忆写回，使渲染变纯读；届时
  0.5 回放台可验记忆字段（ter_id/subtile/rotation/symbol）逐字节一致。

(English: gameplay-neutral pure structural refactor. Not coverable by the
Stage 0.5 replay harness — all call sites are TILES-only render paths, dead
code under headless; hence full TILES build + visual check. A follow-up PR
adds the sim-side memory-update pass calling these to write memory and
removes the draw-path write-backs, making rendering pure-read; the 0.5 replay
harness will then verify memory fields are byte-identical.)
