### PR TITLE
refactor: move map-memory write-back from render path to a sim-side pass (Stage 1)

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1175,20 +1175,20 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                             // Reset height_3d to base when drawing vehicles
                             p.com.height_3d = ( cur_zlevel - center.z() ) * zlevel_height;
                             // Draw
-                            if( !( this->*f )( p.com.pos, ll, p.com.height_3d, invisible, false ) ) {
+                            if( !( this->*f )( p.com.pos, ll, p.com.height_3d, invisible ) ) {
                                 // If no vpart drawn, revert height_3d changes
                                 p.com.height_3d = temp_height_3d;
                             }
                         } else if( f == &cata_tiles::draw_critter_at ) {
                             // Draw
-                            if( !( this->*f )( p.com.pos, ll, p.com.height_3d, invisible, false ) && do_draw_shadow &&
+                            if( !( this->*f )( p.com.pos, ll, p.com.height_3d, invisible ) && do_draw_shadow &&
                                 here.dont_draw_lower_floor( p.com.pos ) ) {
                                 // Draw shadow of flying critters on bottom-most tile if no other critter drawn
                                 draw_critter_above( p.com.pos, ll, p.com.height_3d, invisible );
                             }
                         } else {
                             // Draw
-                            ( this->*f )( p.com.pos, ll, p.com.height_3d, invisible, false );
+                            ( this->*f )( p.com.pos, ll, p.com.height_3d, invisible );
                         }
                     }
                 }
@@ -1473,7 +1473,7 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
         if( m_collecting_glide_critters && !m_deferred_glide_critters.empty() ) {
             m_collecting_glide_critters = false;
             for( deferred_glide_critter &c : m_deferred_glide_critters ) {
-                draw_critter_at( c.pos, c.ll, c.height_3d, c.invisible, false );
+                draw_critter_at( c.pos, c.ll, c.height_3d, c.invisible );
             }
             m_deferred_glide_critters.clear();
             m_collecting_glide_critters = true;
@@ -1521,41 +1521,9 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
     void_vpart_override();
     void_monster_override();
 
-    //Memorize everything the character just saw even if it wasn't displayed.
-    for( int mem_y = min_visible.y; mem_y <= max_visible.y; mem_y++ ) {
-        for( int mem_x = min_visible.x; mem_x <= max_visible.x; mem_x++ ) {
-            const point colrow = player_to_tile( { mem_x, mem_y } );
-            if( is_isometric() && top_any_tile_range.contains( colrow ) ) {
-                continue;
-            }
-            const tripoint_bub_ms p( mem_x, mem_y, center.z() );
-            lit_level lighting = ch.visibility_cache[p.x()][p.y()];
-            // `apply_vision_effects` does not memorize anything so we only need
-            // to call `would_apply_vision_effects` here.
-            if( would_apply_vision_effects( here.get_visibility( lighting, cache ) ) ) {
-                continue;
-            }
-            int height_3d = 0;
-            std::array<bool, 5> invisible;
-            invisible[0] = false;
-            for( int i = 0; i < 4; i++ ) {
-                const tripoint_bub_ms np = p + neighborhood[i];
-                invisible[1 + i] = apply_visible( np, ch, here );
-            }
-            //calling draw to memorize (and only memorize) everything.
-            //bypass cache check in case we learn something new about the terrain's connections
-            draw_terrain( p, lighting, height_3d, invisible, true );
-            if( here.memory_cache_dec_is_dirty( p ) ) {
-                you.memorize_clear_decoration( here.get_abs( p ), "" );
-                draw_furniture( p, lighting, height_3d, invisible, true );
-                draw_trap( p, lighting, height_3d, invisible, true );
-                draw_part_con( p, lighting, height_3d, invisible, true );
-                draw_vpart_no_roof( p, lighting, height_3d, invisible, true );
-                draw_vpart_roof( p, lighting, height_3d, invisible, true );
-                here.memory_cache_dec_set_dirty( p, false );
-            }
-        }
-    }
+    // Map memory is no longer written here: the sim-side map::update_map_memory
+    // pass (run in do_turn) is now the sole writer, so the tiles draw path is
+    // pure-read.
 
     in_animation = do_draw_explosion || do_draw_custom_explosion ||
                    has_explosion_light_anim() ||
@@ -3453,7 +3421,7 @@ void cata_tiles::draw_square_below( const point_bub_ms &p, const nc_color &col,
 }
 
 bool cata_tiles::draw_terrain( const tripoint_bub_ms &p, const lit_level ll, int &height_3d,
-                               const std::array<bool, 5> &invisible, const bool memorize_only )
+                               const std::array<bool, 5> &invisible )
 {
     map &here = get_map();
     const auto override = terrain_override.find( p );
@@ -3467,7 +3435,6 @@ bool cata_tiles::draw_terrain( const tripoint_bub_ms &p, const lit_level ll, int
             }
         }
     }
-    // first memorize the actual terrain
     const ter_id &t = here.ter( p );
     const std::string &tname = t.id().str();
     // Legacy mode does not draw fog sprites
@@ -3482,21 +3449,14 @@ bool cata_tiles::draw_terrain( const tripoint_bub_ms &p, const lit_level ll, int
 
         if( connect_group.any() ) {
             map::get_connect_values( p, subtile, rotation, connect_group, rotate_group, {} );
-            // re-memorize previously seen terrain in case new connections have been seen
-            here.memory_cache_ter_set_dirty( p, true );
         } else {
             map::get_terrain_orientation( p, rotation, subtile, {}, invisible, rotate_group );
             // do something to get other terrain orientation values
         }
-        if( here.memory_cache_ter_is_dirty( p ) ) {
-            get_avatar().memorize_terrain( here.get_abs( p ), tname, subtile, rotation );
-        }
         // draw the actual terrain if there's no override
         if( !neighborhood_overridden ) {
-            return memorize_only
-                   ? false
-                   : draw_from_id_string( tname, TILE_CATEGORY::TERRAIN, empty_string, p, subtile,
-                                          rotation, ll, nv_goggles_activated, height_3d );
+            return draw_from_id_string( tname, TILE_CATEGORY::TERRAIN, empty_string, p, subtile,
+                                        rotation, ll, nv_goggles_activated, height_3d );
         }
     }
     if( invisible[0] ? overridden : neighborhood_overridden ) {
@@ -3522,18 +3482,14 @@ bool cata_tiles::draw_terrain( const tripoint_bub_ms &p, const lit_level ll, int
             // tile overrides are always shown with full visibility
             const lit_level lit = overridden ? lit_level::LIT : ll;
             const bool nv = overridden ? false : nv_goggles_activated;
-            return memorize_only
-                   ? false
-                   : draw_from_id_string( tname, TILE_CATEGORY::TERRAIN, empty_string, p, subtile,
-                                          rotation, lit, nv, height_3d );
+            return draw_from_id_string( tname, TILE_CATEGORY::TERRAIN, empty_string, p, subtile,
+                                        rotation, lit, nv, height_3d );
         }
     } else if( invisible[0] ) {
         // try drawing memory if invisible and not overridden
         const memorized_tile &mt = get_terrain_memory_at( here.get_abs( p ) );
         if( !mt.get_ter_id().empty() ) {
-            return memorize_only
-                   ? false
-                   : draw_from_id_string(
+            return draw_from_id_string(
                        mt.get_ter_id(), TILE_CATEGORY::TERRAIN, empty_string, p, mt.get_ter_subtile(),
                        mt.get_ter_rotation(), lit_level::MEMORIZED, nv_goggles_activated, height_3d );
         }
@@ -3542,9 +3498,8 @@ bool cata_tiles::draw_terrain( const tripoint_bub_ms &p, const lit_level ll, int
 }
 
 bool cata_tiles::draw_furniture( const tripoint_bub_ms &p, const lit_level ll, int &height_3d,
-                                 const std::array<bool, 5> &invisible, const bool memorize_only )
+                                 const std::array<bool, 5> &invisible )
 {
-    avatar &you = get_avatar();
     const auto override = furniture_override.find( p );
     const bool overridden = override != furniture_override.end();
     bool neighborhood_overridden = overridden;
@@ -3557,7 +3512,6 @@ bool cata_tiles::draw_furniture( const tripoint_bub_ms &p, const lit_level ll, i
         }
     }
     map &here = get_map();
-    // first memorize the actual furniture
     const furn_id &f = here.furn( p );
     if( f && !invisible[0] ) {
         const std::array<int, 4> neighborhood = {
@@ -3577,17 +3531,10 @@ bool cata_tiles::draw_furniture( const tripoint_bub_ms &p, const lit_level ll, i
             map::get_tile_values_with_ter( p, f.to_i(), neighborhood, subtile, rotation, rotate_group );
         }
         const std::string &fname = f.id().str();
-        if( !( you.get_grab_type() == object_type::FURNITURE
-               && p == you.pos_bub() + you.grab_point )
-            && here.memory_cache_dec_is_dirty( p ) ) {
-            you.memorize_decoration( here.get_abs( p ), fname, subtile, rotation );
-        }
         // draw the actual furniture if there's no override
         if( !neighborhood_overridden ) {
-            return memorize_only
-                   ? false
-                   : draw_from_id_string( fname, TILE_CATEGORY::FURNITURE, empty_string, p, subtile,
-                                          rotation, ll, nv_goggles_activated, height_3d );
+            return draw_from_id_string( fname, TILE_CATEGORY::FURNITURE, empty_string, p, subtile,
+                                        rotation, ll, nv_goggles_activated, height_3d );
         }
     }
     if( invisible[0] ? overridden : neighborhood_overridden ) {
@@ -3623,18 +3570,14 @@ bool cata_tiles::draw_furniture( const tripoint_bub_ms &p, const lit_level ll, i
             // tile overrides are always shown with full visibility
             const lit_level lit = overridden ? lit_level::LIT : ll;
             const bool nv = overridden ? false : nv_goggles_activated;
-            return memorize_only
-                   ? false
-                   : draw_from_id_string( fname, TILE_CATEGORY::FURNITURE, empty_string, p, subtile,
-                                          rotation, lit, nv, height_3d );
+            return draw_from_id_string( fname, TILE_CATEGORY::FURNITURE, empty_string, p, subtile,
+                                        rotation, lit, nv, height_3d );
         }
     } else if( invisible[0] ) {
         // try drawing memory if invisible and not overridden
         const memorized_tile &mt = get_furniture_memory_at( here.get_abs( p ) );
         if( !mt.get_dec_id().empty() ) {
-            return memorize_only
-                   ? false
-                   : draw_from_id_string(
+            return draw_from_id_string(
                        mt.get_dec_id(), TILE_CATEGORY::FURNITURE, empty_string, p, mt.get_dec_subtile(),
                        mt.get_dec_rotation(), lit_level::MEMORIZED, nv_goggles_activated, height_3d );
         }
@@ -3643,7 +3586,7 @@ bool cata_tiles::draw_furniture( const tripoint_bub_ms &p, const lit_level ll, i
 }
 
 bool cata_tiles::draw_trap( const tripoint_bub_ms &p, const lit_level ll, int &height_3d,
-                            const std::array<bool, 5> &invisible, const bool memorize_only )
+                            const std::array<bool, 5> &invisible )
 {
     const auto override = trap_override.find( p );
     const bool overridden = override != trap_override.end();
@@ -3659,7 +3602,6 @@ bool cata_tiles::draw_trap( const tripoint_bub_ms &p, const lit_level ll, int &h
 
     avatar &you = get_avatar();
     map &here = get_map();
-    // first memorize the actual trap
     const trap &tr = here.tr_at( p );
     if( !tr.is_null() && !invisible[0] && tr.can_see( p, you ) ) {
         const std::array<int, 4> neighborhood = {
@@ -3672,15 +3614,10 @@ bool cata_tiles::draw_trap( const tripoint_bub_ms &p, const lit_level ll, int &h
         int rotation = 0;
         map::get_tile_values( tr.loadid.to_i(), neighborhood, subtile, rotation, 0 );
         const std::string trname = tr.loadid.id().str();
-        if( here.memory_cache_dec_is_dirty( p ) ) {
-            you.memorize_decoration( here.get_abs( p ), trname, subtile, rotation );
-        }
         // draw the actual trap if there's no override
         if( !neighborhood_overridden ) {
-            return memorize_only
-                   ? false
-                   : draw_from_id_string( trname, TILE_CATEGORY::TRAP, empty_string, p, subtile,
-                                          rotation, ll, nv_goggles_activated, height_3d );
+            return draw_from_id_string( trname, TILE_CATEGORY::TRAP, empty_string, p, subtile,
+                                        rotation, ll, nv_goggles_activated, height_3d );
         }
     }
     if( overridden || ( !invisible[0] && neighborhood_overridden &&
@@ -3709,18 +3646,14 @@ bool cata_tiles::draw_trap( const tripoint_bub_ms &p, const lit_level ll, int &h
             // tile overrides are always shown with full visibility
             const lit_level lit = overridden ? lit_level::LIT : ll;
             const bool nv = overridden ? false : nv_goggles_activated;
-            return memorize_only
-                   ? false
-                   : draw_from_id_string( trname, TILE_CATEGORY::TRAP, empty_string, p, subtile,
-                                          rotation, lit, nv, height_3d );
+            return draw_from_id_string( trname, TILE_CATEGORY::TRAP, empty_string, p, subtile,
+                                        rotation, lit, nv, height_3d );
         }
     } else if( invisible[0] ) {
         // try drawing memory if invisible and not overridden
         const memorized_tile &mt = get_trap_memory_at( here.get_abs( p ) );
         if( !mt.get_dec_id().empty() ) {
-            return memorize_only
-                   ? false
-                   : draw_from_id_string(
+            return draw_from_id_string(
                        mt.get_dec_id(), TILE_CATEGORY::TRAP, empty_string, p, mt.get_dec_subtile(),
                        mt.get_dec_rotation(),
                        lit_level::MEMORIZED, nv_goggles_activated, height_3d );
@@ -3730,30 +3663,20 @@ bool cata_tiles::draw_trap( const tripoint_bub_ms &p, const lit_level ll, int &h
 }
 
 bool cata_tiles::draw_part_con( const tripoint_bub_ms &p, const lit_level ll, int &height_3d,
-                                const std::array<bool, 5> &invisible, const bool memorize_only )
+                                const std::array<bool, 5> &invisible )
 {
     map &here = get_map();
     if( here.partial_con_at( p ) != nullptr && !invisible[0] ) {
-        avatar &you = get_avatar();
         std::string const &trname = tr_unfinished_construction.str();
-        if( here.memory_cache_dec_is_dirty( p ) ) {
-            you.memorize_decoration( here.get_abs( p ), trname, 0, 0 );
-        }
-        return memorize_only
-               ? false
-               : draw_from_id_string( trname, TILE_CATEGORY::TRAP, empty_string, p, 0,
-                                      0, ll, nv_goggles_activated, height_3d );
+        return draw_from_id_string( trname, TILE_CATEGORY::TRAP, empty_string, p, 0,
+                                    0, ll, nv_goggles_activated, height_3d );
     }
     return false;
 }
 
 bool cata_tiles::draw_graffiti( const tripoint_bub_ms &p, const lit_level ll, int &height_3d,
-                                const std::array<bool, 5> &invisible, const bool memorize_only )
+                                const std::array<bool, 5> &invisible )
 {
-    if( memorize_only ) {
-        return false;
-    }
-
     map &here = get_map();
     const auto override = graffiti_override.find( p );
     const bool overridden = override != graffiti_override.end();
@@ -3770,12 +3693,8 @@ bool cata_tiles::draw_graffiti( const tripoint_bub_ms &p, const lit_level ll, in
 }
 
 bool cata_tiles::draw_field_or_item( const tripoint_bub_ms &p, const lit_level ll, int &height_3d,
-                                     const std::array<bool, 5> &invisible, const bool memorize_only )
+                                     const std::array<bool, 5> &invisible )
 {
-    if( memorize_only ) {
-        return false;
-    }
-
     const auto fld_override = field_override.find( p );
     const bool fld_overridden = fld_override != field_override.end();
     map &here = get_map();
@@ -4028,24 +3947,23 @@ bool cata_tiles::draw_field_or_item( const tripoint_bub_ms &p, const lit_level l
 }
 
 bool cata_tiles::draw_vpart_no_roof( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
-                                     const std::array<bool, 5> &invisible, const bool memorize_only )
+                                     const std::array<bool, 5> &invisible )
 {
-    return draw_vpart( p, ll, height_3d, invisible, false, memorize_only );
+    return draw_vpart( p, ll, height_3d, invisible, false );
 }
 
 bool cata_tiles::draw_vpart_roof( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
-                                  const std::array<bool, 5> &invisible, const bool memorize_only )
+                                  const std::array<bool, 5> &invisible )
 {
-    return draw_vpart( p, ll, height_3d, invisible, true, memorize_only );
+    return draw_vpart( p, ll, height_3d, invisible, true );
 }
 
 bool cata_tiles::draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
-                             const std::array<bool, 5> &invisible, bool roof, const bool memorize_only )
+                             const std::array<bool, 5> &invisible, bool roof )
 {
     const auto override = vpart_override.find( p );
     const bool overridden = override != vpart_override.end();
     map &here = get_map();
-    // first memorize the actual vpart
     const optional_vpart_position ovp = here.veh_at( p );
     if( ovp && !invisible[0] ) {
         const vehicle &veh = ovp->vehicle();
@@ -4053,23 +3971,14 @@ bool cata_tiles::draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height
         if( !vd.id.is_null() ) {
             const int subtile = vd.is_open ? open_ : vd.is_broken ? broken : 0;
             const int rotation = angle_to_dir4( veh.face.dir() - 270_degrees );
-            avatar &you = get_avatar();
-            if( !veh.forward_velocity() && !veh.player_in_control( here, you )
-                && !( you.get_grab_type() == object_type::VEHICLE
-                      && veh.get_points().count( ( you.pos_abs() + you.grab_point ) ) )
-                && here.memory_cache_dec_is_dirty( p ) ) {
-                you.memorize_decoration( here.get_abs( p ), vd.get_tileset_id(), subtile, rotation );
-            }
             if( !overridden ) {
                 int height_3d_temp = height_3d;
                 // Paint the displayed part with its color while it draws (the tint
                 // is consumed when tile_render_params is built); cleared right after.
                 pending_part_tint_ = get_vpart_tint( veh, ovp->mount_pos() );
-                const bool ret = memorize_only
-                                 ? false
-                                 : draw_from_id_string( "vp_" + vd.id.str(), TILE_CATEGORY::VEHICLE_PART,
-                                                        empty_string, p, subtile, rotation, ll,
-                                                        nv_goggles_activated, height_3d_temp, 0, vd.variant.id );
+                const bool ret = draw_from_id_string( "vp_" + vd.id.str(), TILE_CATEGORY::VEHICLE_PART,
+                                                      empty_string, p, subtile, rotation, ll,
+                                                      nv_goggles_activated, height_3d_temp, 0, vd.variant.id );
                 pending_part_tint_ = std::nullopt;
                 if( ret && vd.has_cargo ) {
                     draw_item_highlight( p, height_3d_temp );
@@ -4099,10 +4008,9 @@ bool cata_tiles::draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height
             // tile overrides are never memorized
             // tile overrides are always shown with full visibility
             int height_3d_temp = height_3d;
-            const bool ret = memorize_only
-                             ? false
-                             : draw_from_id_string( vpname, TILE_CATEGORY::VEHICLE_PART, empty_string, p, subtile,
-                                                    rotation, lit_level::LIT, false, height_3d_temp );
+            const bool ret = draw_from_id_string( vpname, TILE_CATEGORY::VEHICLE_PART, empty_string, p,
+                                                  subtile,
+                                                  rotation, lit_level::LIT, false, height_3d_temp );
             if( ret && draw_highlight ) {
                 draw_item_highlight( p, height_3d_temp );
             }
@@ -4123,9 +4031,7 @@ bool cata_tiles::draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height
                 tvar = tid.substr( variant_separator + 1 );
                 tid = tid.substr( 0, variant_separator );
             }
-            return memorize_only
-                   ? false
-                   : draw_from_id_string(
+            return draw_from_id_string(
                        std::string( tid ), TILE_CATEGORY::VEHICLE_PART, empty_string, p, t.get_dec_subtile(),
                        t.get_dec_rotation(), lit_level::MEMORIZED, nv_goggles_activated, height_3d_temp, 0,
                        std::string( tvar ) );
@@ -4367,13 +4273,9 @@ SDL_Texture *cata_tiles::render_character_preview( const Character &ch, const in
 }
 
 bool cata_tiles::draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
-                                  const std::array<bool, 5> &invisible, const bool memorize_only )
+                                  const std::array<bool, 5> &invisible )
 {
     const map &here = get_map();
-
-    if( memorize_only ) {
-        return false;
-    }
 
     // Fast path: with no creature on this tile (and no debug monster override
     // active), there is nothing to draw here — skip the creature_at hash lookup.
@@ -4712,12 +4614,8 @@ bool cata_tiles::draw_critter_above( const tripoint_bub_ms &p, lit_level ll, int
 }
 
 bool cata_tiles::draw_zone_mark( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
-                                 const std::array<bool, 5> &invisible, const bool memorize_only )
+                                 const std::array<bool, 5> &invisible )
 {
-    if( memorize_only ) {
-        return false;
-    }
-
     if( invisible[0] ) {
         return false;
     }
@@ -4743,12 +4641,8 @@ bool cata_tiles::draw_zone_mark( const tripoint_bub_ms &p, lit_level ll, int &he
 }
 
 bool cata_tiles::draw_zombie_revival_indicators( const tripoint_bub_ms &pos, const lit_level /*ll*/,
-        int &height_3d, const std::array<bool, 5> &invisible, const bool memorize_only )
+        int &height_3d, const std::array<bool, 5> &invisible )
 {
-    if( memorize_only ) {
-        return false;
-    }
-
     map &here = get_map();
     if( tileset_ptr->find_tile_type( ZOMBIE_REVIVAL_INDICATOR ) && !invisible[0] &&
         item_override.find( pos ) == item_override.end() &&

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -728,29 +728,29 @@ class cata_tiles
         bool apply_vision_effects( const tripoint_bub_ms &pos, visibility_type visibility, int &height_3d );
         void draw_square_below( const point_bub_ms &p, const nc_color &col, int sizefactor );
         bool draw_terrain( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
-                           const std::array<bool, 5> &invisible, bool memorize_only );
+                           const std::array<bool, 5> &invisible );
         bool draw_furniture( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
-                             const std::array<bool, 5> &invisible, bool memorize_only );
+                             const std::array<bool, 5> &invisible );
         bool draw_graffiti( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
-                            const std::array<bool, 5> &invisible, bool memorize_only );
+                            const std::array<bool, 5> &invisible );
         bool draw_trap( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
-                        const std::array<bool, 5> &invisible, bool memorize_only );
+                        const std::array<bool, 5> &invisible );
         bool draw_part_con( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
-                            const std::array<bool, 5> &invisible, bool memorize_only );
+                            const std::array<bool, 5> &invisible );
         bool draw_field_or_item( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
-                                 const std::array<bool, 5> &invisible, bool memorize_only );
+                                 const std::array<bool, 5> &invisible );
         bool draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
-                         const std::array<bool, 5> &invisible, bool roof, bool memorize_only );
+                         const std::array<bool, 5> &invisible, bool roof );
         bool draw_vpart_no_roof( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
-                                 const std::array<bool, 5> &invisible, bool memorize_only );
+                                 const std::array<bool, 5> &invisible );
         bool draw_vpart_roof( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
-                              const std::array<bool, 5> &invisible, bool memorize_only );
+                              const std::array<bool, 5> &invisible );
         // Paint color to tint the vehicle part displayed at \p mount of \p veh,
         // or nullopt when it is unpainted or the VEHICLE_PART_COLOR option is off.
         std::optional<RGBColor> get_vpart_tint( const vehicle &veh,
                                                 const point_rel_ms &mount ) const;
         bool draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
-                              const std::array<bool, 5> &invisible, bool memorize_only );
+                              const std::array<bool, 5> &invisible );
         bool draw_critter_above( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                                  const std::array<bool, 5> &invisible );
 
@@ -760,9 +760,9 @@ class cata_tiles
         // by player_to_screen; zero for terrain/everything else.
         point m_entity_draw_offset;
         bool draw_zone_mark( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
-                             const std::array<bool, 5> &invisible, bool memorize_only );
+                             const std::array<bool, 5> &invisible );
         bool draw_zombie_revival_indicators( const tripoint_bub_ms &pos, lit_level ll, int &height_3d,
-                                             const std::array<bool, 5> &invisible, bool memorize_only );
+                                             const std::array<bool, 5> &invisible );
         void draw_zlevel_overlay( const tripoint_bub_ms &p, lit_level ll, int &height_3d );
         void draw_entity_with_overlays( const Character &ch, const tripoint_bub_ms &p, lit_level ll,
                                         int &height_3d, FacingDirection facing_override = FacingDirection::NONE );

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -765,6 +765,13 @@ bool game::do_turn()
     // replenish avatar moves
     u.process_turn();
 
+    // Update player map memory from the current field of view.  This used to
+    // happen lazily inside the tiles draw path; running it here in the sim loop
+    // (after the map cache is built, before the visibility cache is
+    // invalidated) lets rendering become pure-read.  See
+    // sim-render-decoupling-plan.md §1.
+    m.update_map_memory( u );
+
     if( u.get_moves() < 0 && get_option<bool>( "FORCE_REDRAW" ) ) {
         ui_manager::redraw();
         refresh_display();

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -765,11 +765,13 @@ bool game::do_turn()
     // replenish avatar moves
     u.process_turn();
 
+    // Refresh visibility so update_map_memory operates on a current snapshot.
+    m.update_visibility_cache( u.posz() );
+
     // Update player map memory from the current field of view.  This used to
     // happen lazily inside the tiles draw path; running it here in the sim loop
     // (after the map cache is built, before the visibility cache is
-    // invalidated) lets rendering become pure-read.  See
-    // sim-render-decoupling-plan.md §1.
+    // invalidated) lets rendering become pure-read.
     m.update_map_memory( u );
 
     if( u.get_moves() < 0 && get_option<bool>( "FORCE_REDRAW" ) ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -101,6 +101,7 @@
 #include "trap.h"
 #include "ui_manager.h"
 #include "units.h"
+#include "units_utility.h"
 #include "value_ptr.h"
 #include "veh_type.h"
 #include "vehicle.h"
@@ -474,6 +475,176 @@ void map::memory_clear_vehicle_points( const vehicle &veh ) const
         }
         memory_cache_dec_set_dirty( get_bub( p ), true );
         player_character.memorize_clear_decoration( p, "vp_" );
+    }
+}
+
+namespace
+{
+// Sim-side replicas of the per-tile memorise side effects that used to live in
+// cata_tiles::draw_* under memorize_only=true.  Each writes player map memory
+// for one category; orientation comes from the map:: helpers extracted in
+// Stage 1.  The render-only override paths are intentionally omitted: the
+// memorise pass always ran after all tile overrides were voided, so the
+// override branches were dead there.
+
+void memorize_terrain_at( map &here, avatar &you, const tripoint_bub_ms &p,
+                          const std::array<bool, 5> &invisible )
+{
+    const ter_id &t = here.ter( p );
+    if( !t || invisible[0] ) {
+        return;
+    }
+    const std::string &tname = t.id().str();
+    int subtile = 0;
+    int rotation = 0;
+    const std::bitset<NUM_TERCONN> &connect_group = t.obj().connect_to_groups;
+    const std::bitset<NUM_TERCONN> &rotate_group = t.obj().rotate_to_groups;
+    if( connect_group.any() ) {
+        map::get_connect_values( p, subtile, rotation, connect_group, rotate_group, {} );
+        // re-memorize previously seen terrain in case new connections have been seen
+        here.memory_cache_ter_set_dirty( p, true );
+    } else {
+        map::get_terrain_orientation( p, rotation, subtile, {}, invisible, rotate_group );
+    }
+    if( here.memory_cache_ter_is_dirty( p ) ) {
+        you.memorize_terrain( here.get_abs( p ), tname, subtile, rotation );
+    }
+}
+
+void memorize_furniture_at( map &here, avatar &you, const tripoint_bub_ms &p,
+                            const std::array<bool, 5> &invisible )
+{
+    const furn_id &f = here.furn( p );
+    if( !f || invisible[0] ) {
+        return;
+    }
+    const std::array<int, 4> neighborhood = {
+        static_cast<int>( here.furn( p + point::south ) ),
+        static_cast<int>( here.furn( p + point::east ) ),
+        static_cast<int>( here.furn( p + point::west ) ),
+        static_cast<int>( here.furn( p + point::north ) )
+    };
+    int subtile = 0;
+    int rotation = 0;
+    const std::bitset<NUM_TERCONN> &connect_group = f.obj().connect_to_groups;
+    const std::bitset<NUM_TERCONN> &rotate_group = f.obj().rotate_to_groups;
+    if( connect_group.any() ) {
+        map::get_furn_connect_values( p, subtile, rotation, connect_group, rotate_group, {} );
+    } else {
+        map::get_tile_values_with_ter( p, f.to_i(), neighborhood, subtile, rotation, rotate_group );
+    }
+    const std::string &fname = f.id().str();
+    if( !( you.get_grab_type() == object_type::FURNITURE && p == you.pos_bub() + you.grab_point )
+        && here.memory_cache_dec_is_dirty( p ) ) {
+        you.memorize_decoration( here.get_abs( p ), fname, subtile, rotation );
+    }
+}
+
+void memorize_trap_at( map &here, avatar &you, const tripoint_bub_ms &p,
+                       const std::array<bool, 5> &invisible )
+{
+    const trap &tr = here.tr_at( p );
+    if( tr.is_null() || invisible[0] || !tr.can_see( p, you ) ) {
+        return;
+    }
+    const std::array<int, 4> neighborhood = {
+        static_cast<int>( here.tr_at( p + point::south ).loadid ),
+        static_cast<int>( here.tr_at( p + point::east ).loadid ),
+        static_cast<int>( here.tr_at( p + point::west ).loadid ),
+        static_cast<int>( here.tr_at( p + point::north ).loadid )
+    };
+    int subtile = 0;
+    int rotation = 0;
+    map::get_tile_values( tr.loadid.to_i(), neighborhood, subtile, rotation, 0 );
+    if( here.memory_cache_dec_is_dirty( p ) ) {
+        you.memorize_decoration( here.get_abs( p ), tr.loadid.id().str(), subtile, rotation );
+    }
+}
+
+void memorize_part_con_at( map &here, avatar &you, const tripoint_bub_ms &p,
+                           const std::array<bool, 5> &invisible )
+{
+    if( here.partial_con_at( p ) != nullptr && !invisible[0] ) {
+        if( here.memory_cache_dec_is_dirty( p ) ) {
+            you.memorize_decoration( here.get_abs( p ), tr_unfinished_construction.str(), 0, 0 );
+        }
+    }
+}
+
+void memorize_vpart_at( map &here, avatar &you, const tripoint_bub_ms &p,
+                        const std::array<bool, 5> &invisible )
+{
+    const optional_vpart_position ovp = here.veh_at( p );
+    if( !ovp || invisible[0] ) {
+        return;
+    }
+    const vehicle &veh = ovp->vehicle();
+    const vpart_display vd = veh.get_display_of_tile( ovp->mount_pos() );
+    if( vd.id.is_null() ) {
+        return;
+    }
+    const int subtile = vd.is_open ? open_ : vd.is_broken ? broken : 0;
+    const int rotation = angle_to_dir4( veh.face.dir() - 270_degrees );
+    if( !veh.forward_velocity() && !veh.player_in_control( here, you )
+        && !( you.get_grab_type() == object_type::VEHICLE
+              && veh.get_points().count( ( you.pos_abs() + you.grab_point ) ) )
+        && here.memory_cache_dec_is_dirty( p ) ) {
+        you.memorize_decoration( here.get_abs( p ), vd.get_tileset_id(), subtile, rotation );
+    }
+}
+} // namespace
+
+void map::update_map_memory( avatar &you )
+{
+    map &here = *this;
+    const visibility_variables &cache = here.get_visibility_variables_cache();
+    const tripoint_bub_ms you_pos = you.pos_bub( here );
+    // Limit the update area to the maximum view range, matching the render-path
+    // memorise loop: a (MAPSIZE-1)*SEE square anchored on the player's submap.
+    const point min_visible( you_pos.x() % SEEX, you_pos.y() % SEEY );
+    const point max_visible( ( you_pos.x() % SEEX ) + ( MAPSIZE - 1 ) * SEEX,
+                             ( you_pos.y() % SEEY ) + ( MAPSIZE - 1 ) * SEEY );
+    const int z = you.posz();
+    const level_cache &ch = here.access_cache( z );
+
+    // Mirrors cata_tiles::apply_visible: a neighbour is "invisible" for
+    // orientation purposes if it falls outside the view window or fails the
+    // visibility test (anything other than a CLEAR view).
+    const auto neighbour_invisible = [&]( const tripoint_bub_ms & np ) -> bool {
+        return np.y() < min_visible.y || np.y() > max_visible.y ||
+               np.x() < min_visible.x || np.x() > max_visible.x ||
+               here.get_visibility( ch.visibility_cache[np.x()][np.y()], cache ) !=
+               visibility_type::CLEAR;
+    };
+
+    // Memorize everything the character can currently see, even if it was not
+    // displayed this frame.
+    for( int mem_y = min_visible.y; mem_y <= max_visible.y; mem_y++ ) {
+        for( int mem_x = min_visible.x; mem_x <= max_visible.x; mem_x++ ) {
+            const tripoint_bub_ms p( mem_x, mem_y, z );
+            const lit_level lighting = ch.visibility_cache[p.x()][p.y()];
+            // Skip tiles that would have vision effects applied (i.e. not a
+            // CLEAR view); those are never memorized.
+            if( here.get_visibility( lighting, cache ) != visibility_type::CLEAR ) {
+                continue;
+            }
+            std::array<bool, 5> invisible;
+            invisible[0] = false;
+            for( int i = 0; i < 4; i++ ) {
+                invisible[1 + i] = neighbour_invisible( p + neighborhood[i] );
+            }
+            // Bypass the decoration cache check for terrain in case we learn
+            // something new about the terrain's connections.
+            memorize_terrain_at( here, you, p, invisible );
+            if( here.memory_cache_dec_is_dirty( p ) ) {
+                you.memorize_clear_decoration( here.get_abs( p ), "" );
+                memorize_furniture_at( here, you, p, invisible );
+                memorize_trap_at( here, you, p, invisible );
+                memorize_part_con_at( here, you, p, invisible );
+                memorize_vpart_at( here, you, p, invisible );
+                here.memory_cache_dec_set_dirty( p, false );
+            }
+        }
     }
 }
 

--- a/src/map.h
+++ b/src/map.h
@@ -60,6 +60,7 @@ class window;
 } // namespace catacurses
 class Character;
 class Creature;
+class avatar;
 class basecamp;
 class character_id;
 class computer;
@@ -584,6 +585,16 @@ class map
         void memory_cache_ter_set_dirty( const tripoint_bub_ms &p, bool value ) const;
         // clears map memory for points occupied by vehicle and marks "dirty" for re-memorizing
         void memory_clear_vehicle_points( const vehicle &veh ) const;
+
+        // Sim-side map-memory update pass (Stage 1 of sim/render decoupling).
+        // Walks the avatar's current field of view and writes everything just
+        // seen into player map memory (terrain/furniture/trap/partial-construction/
+        // vehicle-part), computing subtile/rotation via the map:: orientation
+        // helpers.  This used to live in the tiles draw path (memorize_only); it
+        // now runs in do_turn so rendering can become pure-read.  Must be called
+        // after the map cache is built and before the visibility cache is
+        // invalidated.  See sim-render-decoupling-plan.md §1.
+        void update_map_memory( avatar &you );
 
         /**
          * A pre-filter for bresenham LOS.

--- a/src/map.h
+++ b/src/map.h
@@ -593,7 +593,7 @@ class map
         // helpers.  This used to live in the tiles draw path (memorize_only); it
         // now runs in do_turn so rendering can become pure-read.  Must be called
         // after the map cache is built and before the visibility cache is
-        // invalidated.  See sim-render-decoupling-plan.md §1.
+        // invalidated.
         void update_map_memory( avatar &you );
 
         /**
@@ -1113,7 +1113,7 @@ class map
         // Sim-side tile orientation helpers (Stage 1 of sim/render decoupling).
         // Extracted from cata_tiles so the memory-update pass in do_turn can
         // compute subtile/rotation when memorising seen tiles, without depending
-        // on the tiles subsystem.  See sim-render-decoupling-plan.md §1.
+        // on the tiles subsystem.
         // -----------------------------------------------------------------------
         // Pure-math rotation helpers (no map state needed).
         static void get_rotation_and_subtile( char val, char rot_to, int &rotation, int &subtile );


### PR DESCRIPTION
#### 概述 (Summary)
Infrastructure "把玩家地图记忆的写回从瓦片渲染路径搬到独立的 sim 侧 pass，使渲染变成纯读 (move player map-memory write-back out of the tiles render path into a dedicated sim-side pass, making rendering pure-read)"

#### 改动目的 (Purpose of change)
「模拟/渲染解耦」重构计划阶段 1 的核心一刀。长期目标是把模拟与渲染拆开
（客户端/服务端分离、异步、可换渲染后端、无头）。当前渲染层有一处反向
侵入 sim 的耦合点：`cata_tiles` 绘制地形/家具/陷阱/施工/载具时，会顺手把
「看到的」写进玩家地图记忆（memorize_terrain/memorize_decoration）。这让
渲染不再是纯读，也让无头构建（不跑绘制）永远填不了地图记忆。

本 PR 切断这个耦合：新增一个 sim 侧的 `map::update_map_memory` pass，在
`do_turn` 里产生地图记忆；然后删除绘制路径里的全部记忆写回，使渲染变纯读。

前置 PR #241 / #242 已把朝向计算函数（subtile/rotation）从 `cata_tiles`
搬到 `map::`，sim 侧 pass 正是复用它们来算记忆里的朝向。

(English: the core step of Stage 1 of the sim/render decoupling plan. The
tiles draw path used to write player map memory as a side effect of drawing
(the only reverse-coupling from render into sim), which kept rendering from
being pure-read and meant headless builds — which never draw — could never
populate map memory. This PR adds a sim-side `map::update_map_memory` pass
that produces map memory in `do_turn`, then removes all memory write-back
from the draw path so rendering becomes pure-read. Prerequisites #241/#242
moved the orientation helpers to `map::`; the sim pass reuses them.)

#### 解决方案描述 (Describe the solution)
分两步（两个提交）：

**1) 新增 sim 侧 pass（feat: add sim-side map-memory update pass）**
- `map::update_map_memory( avatar & )`：遍历玩家当前视野，把地形/家具/陷阱/
  未完成施工/载具部件写进玩家地图记忆，朝向用 #241/#242 搬过来的 `map::`
  函数计算。5 个分类各一个匿名命名空间 helper，逐字复刻原 `cata_tiles`
  draw 路径在 `memorize_only=true` 下的副作用（含 grab/can_see/velocity 等
  全部守卫）。渲染期已 void 掉所有 tile override，故 override 分支在记忆
  路径里本就是死代码，pass 只复刻非-override 分支。
- 在 `game::do_turn` 的 `u.process_turn()` 后、可见性缓存失效前调用，使其
  读到的地图缓存是新鲜的。

**2) 绘制路径变纯读（refactor: make tiles draw path pure-read）**
- 删除 `cata_tiles::draw` 里重走视野的「memorize 循环」。
- 从 11 个绘制层函数移除 `memorize_only` 参数（它们共用一个签名以进函数
  指针表；该参数只为在记忆 pass 期间短路绘制而存在）+ 4 个调用点。
- 移除 draw_terrain/furniture/trap/part_con/vpart 里的 memorize 写回与
  `memory_cache_*_set_dirty` 记账。绘制现在只**读**记忆（invisible tile 的
  `get_*_memory_at` 灰色记忆分支原样保留）并为它绘制的实景 tile 算朝向。
- `do_turn` 在 pass 前加一次 `update_visibility_cache( u.posz() )`，让 sim
  pass 的可见性快照与渲染时序解耦（消除 code-review 指出的快照新鲜度隐患）。

行为保持不变：写进地图记忆的字节相同，只是改由 sim pass 产生而非绘制路径。

(English: two commits. (1) adds `map::update_map_memory(avatar&)` — walks the
avatar FOV and writes terrain/furniture/trap/partial-construction/vehicle-part
memory, computing orientation via the `map::` helpers; five anon-namespace
helpers replicate the original draw-path `memorize_only` side effects verbatim,
including all guards; override branches are omitted as they were dead code in
the memorize path (overrides are voided before it ran). Called in `do_turn`
after `process_turn()`, before the visibility cache is invalidated. (2) deletes
the FOV memorize loop, drops the `memorize_only` param from the 11 drawing-layer
functions + 4 call sites, removes the memorize write-backs and dirty-flag
bookkeeping; draw now only READS memory (the invisible-tile greyed-memory
branches are untouched). `do_turn` calls `update_visibility_cache(u.posz())`
before the pass so its snapshot is decoupled from render timing.)

#### 你考虑过的替代方案 (Describe alternatives you've considered)
- **记忆只存语义 ter_id、客户端读记忆邻居重算朝向**：更轻，但记忆是 submap
  级稀疏存储有空洞 → 邻居不全 → 朝向与初见不一致 → 视觉回归。故选择把朝向
  计算整体搬 sim 侧、记忆保持完整。
- **pass 放 game:: 或 avatar:: 而非 map::**：记忆遍历的是地图数据 + map 的
  可见性缓存，作为 `map::` 成员归属最自然；记忆 API 是 avatar 专属，故签名
  取 `avatar &`。
- **一步到位（加 pass 同时删 draw 写回）**：拆成两个提交便于 bisect 与
  review——第一个提交是纯加法（双写、零行为变化），第二个删旧路径。

(English: considered storing only semantic ter_id and recomputing client-side
— rejected, sparse memory yields incomplete neighbourhoods → visual
regression. Considered game::/avatar:: homes — map:: is the natural owner
(walks map data + map's visibility cache). Split into two commits for
bisectability: the first is purely additive, the second removes the old path.)

#### 测试 (Testing)
- **双构建**：完整 TILES（Release|x64）+ 无头（Release-NoTilesHeadless|x64）
  均编译链接通过，0 错误。
- **进游戏肉眼验证**：走过又离开视野的区域正常变灰（记忆渲染），墙体连接/
  地形过渡/多格家具/载具/陷阱朝向无回归。
- **0.5 确定性回放 A/B（等价性硬证据）**：用阶段 0.5 回放测试台录一段含
  移动探索 + 存档退出的会话（TestAB 世界、固定种子），跨构建对比地图记忆
  文件（`.mm1.{cold,hot,warm}.zzip`）：
  - master-TILES（旧 draw 写）与本分支-headless（新 sim-pass 写）的记忆
    **cold/hot 层逐字节全等、warm 层逐字节全等** → 证明「sim-pass 写的 ==
    draw 写的」。
  - 本分支-headless 记忆比 master-headless（不写新记忆）更大 → 证明 sim-pass
    在无头下确实新增填充记忆（这正是解耦的收益：无头过去绘制不跑、记忆是
    死代码）。
  - 同一 headless 二进制自比对（B vs B2）：除 `.sav`（playtime 墙钟，已知的
    既有非确定）外世界态文件逐字节一致 → 证明本 PR 的 `update_visibility_cache`
    调用 sim-中立、不破回放确定性。

(English: both TILES and headless build clean (0 errors). In-game: explored
areas still render greyed-from-memory with correct orientation. Stage-0.5
deterministic replay A/B: a recorded session (move+explore+save-quit, fixed
seed) replayed across builds shows map-memory files byte-identical between
master-TILES (old draw write) and this branch's headless (new sim-pass write)
→ proves the sim pass writes the same bytes the draw path did; the branch's
headless memory is larger than master-headless (which writes none) → proves
the pass populates memory under headless (the decoupling payoff); and a
same-binary self-replay is byte-identical except `.sav` (playtime wall-clock,
a known pre-existing non-determinism) → proves the added
update_visibility_cache call is sim-neutral.)

#### 补充说明 (Additional context)
- 玩法中立、纯结构重构，不夹带任何数值/玩法改动。
- 净改动以删减为主（绘制路径瘦身）。
- 后续阶段将基于「渲染纯读」继续推进 ViewSnapshot / do_turn 异步化等。
- 已知无关现象：master TILES 在回放退出期偶发 SIGSEGV，是既有的 SDL3
  gpu/D3D12 后端 teardown 崩溃，发生在地图记忆写出之后，与本 PR 无关
  （无头路径 EXIT=0）。

(English: gameplay-neutral pure structural refactor, net deletion-heavy.
Lays the pure-read foundation for later ViewSnapshot / async do_turn work.
Unrelated known issue: master TILES occasionally SIGSEGVs during replay exit
— a pre-existing SDL3 gpu/D3D12 teardown crash that happens after memory is
written, unrelated to this PR; headless exits cleanly.)
