### PR TITLE
调整部分物品的堆叠和显示类型

### DIFF
--- a/data/json/items/ammo/nail.json
+++ b/data/json/items/ammo/nail.json
@@ -50,7 +50,8 @@
     "range": 3,
     "damage": { "damage_type": "bullet", "amount": 3, "armor_penetration": 1 },
     "dispersion": 180,
-    "effects": [ "NON_FOULING", "HURT_WHEN_WIELDED" ]
+    "effects": [ "NON_FOULING", "HURT_WHEN_WIELDED" ],
+    "stackable": true
   },
   {
     "id": "nuts_bolts",
@@ -67,7 +68,8 @@
     "price_postapoc": "2 cent",
     "material": [ "mc_steel" ],
     "symbol": "=",
-    "color": "cyan"
+    "color": "cyan",
+    "stackable": true
   },
   {
     "id": "rivets",
@@ -84,6 +86,7 @@
     "symbol": "=",
     "color": "cyan",
     "count": 100,
-    "stack_size": 100
+    "stack_size": 100,
+    "stackable": true
   }
 ]

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -17,7 +17,8 @@
     "sealed": false,
     "symbol": "!",
     "color": "cyan",
-    "looks_like": "ether"
+    "looks_like": "ether",
+    "display_type": "BY_VOLUME"
   },
   {
     "type": "ITEM",
@@ -310,7 +311,7 @@
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "name": { "str_sp": "sand", "ctxt": "material" },
-    "display_type": "BY_VOLUME",
+    "display_type": "BY_WEIGHT",
     "symbol": "=",
     "color": "dark_gray",
     "description": "A handful of New England sand.  If you had a stoked furnace, you could turn it into glass.  Otherwise, it's only good for making cement.",
@@ -425,7 +426,8 @@
     "charges": 2,
     "category": "chems",
     "freezing_point": -8,
-    "conditional_names": [ { "type": "FLAG", "condition": "DIRTY", "name": "bleach spill" } ]
+    "conditional_names": [ { "type": "FLAG", "condition": "DIRTY", "name": "bleach spill" } ],
+    "display_type": "BY_VOLUME"
   },
   {
     "type": "ITEM",
@@ -445,7 +447,8 @@
     "phase": "liquid",
     "stack_size": 1,
     "category": "chems",
-    "ammo_type": "ammonia_liquid"
+    "ammo_type": "ammonia_liquid",
+    "display_type": "BY_VOLUME"
   },
   {
     "type": "ITEM",
@@ -467,7 +470,8 @@
     "phase": "liquid",
     "charges": 2,
     "category": "chems",
-    "freezing_point": -78
+    "freezing_point": -78,
+    "display_type": "BY_VOLUME"
   },
   {
     "type": "ITEM",
@@ -492,7 +496,8 @@
     "phase": "liquid",
     "charges": 4,
     "category": "chems",
-    "fun": -30
+    "fun": -30,
+    "display_type": "BY_VOLUME"
   },
   {
     "type": "ITEM",
@@ -581,7 +586,9 @@
     "material": [ "powder" ],
     "volume": "1 ml",
     "//2": "Previously 10 doses to a gram, so about 400 to the pound.",
-    "fun": -15
+    "fun": -15,
+    "display_type": "BY_WEIGHT",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -622,7 +629,8 @@
     "phase": "liquid",
     "category": "chems",
     "freezing_point": -2,
-    "fun": -1
+    "fun": -1,
+    "display_type": "BY_VOLUME"
   },
   {
     "type": "ITEM",
@@ -646,7 +654,8 @@
     "phase": "liquid",
     "category": "chems",
     "freezing_point": -2,
-    "fun": -1
+    "fun": -1,
+    "display_type": "BY_VOLUME"
   },
   {
     "type": "ITEM",
@@ -662,7 +671,8 @@
     "material": [ "powder" ],
     "volume": "3 ml",
     "weight": "1760 mg",
-    "container": "bag_plastic_small"
+    "container": "bag_plastic_small",
+    "display_type": "BY_WEIGHT"
   },
   {
     "type": "ITEM",
@@ -677,7 +687,9 @@
     "container": "bag_plastic_small",
     "material": [ "powder_nonflam" ],
     "volume": "1 ml",
-    "weight": "36 mg"
+    "weight": "36 mg",
+    "display_type": "BY_WEIGHT",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -693,7 +705,8 @@
     "material": [ "dense_powder" ],
     "volume": "1 ml",
     "weight": "7140 mg",
-    "//": "Density 7.14g/cm³"
+    "//": "Density 7.14g/cm³",
+    "display_type": "BY_WEIGHT"
   },
   {
     "type": "ITEM",
@@ -709,7 +722,8 @@
     "material": [ "dense_powder" ],
     "volume": "1 ml",
     "weight": "5606 mg",
-    "//": "Density: 5.606 g/cm3"
+    "//": "Density: 5.606 g/cm3",
+    "display_type": "BY_WEIGHT"
   },
   {
     "type": "ITEM",
@@ -725,7 +739,8 @@
     "material": [ "dense_powder" ],
     "volume": "1 ml",
     "weight": "5026 mg",
-    "//": "density: 5.026 g/cm3"
+    "//": "density: 5.026 g/cm3",
+    "display_type": "BY_WEIGHT"
   },
   {
     "type": "ITEM",
@@ -738,7 +753,9 @@
     "description": "A moisturized mixture of zinc chloride and manganese dioxide, slightly acidic.  It can be used in the production of zinc-carbon batteries.",
     "material": [ "powder_nonflam" ],
     "volume": "1 ml",
-    "weight": "500 mg"
+    "weight": "500 mg",
+    "display_type": "BY_WEIGHT",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -753,7 +770,9 @@
     "container": "bag_plastic_small",
     "material": [ "powder_nonflam" ],
     "volume": "1 ml",
-    "weight": "2900 mg"
+    "weight": "2900 mg",
+    "display_type": "BY_WEIGHT",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -768,7 +787,9 @@
     "container": "bag_plastic_small",
     "material": [ "powder_nonflam" ],
     "volume": "1 ml",
-    "weight": "3140 mg"
+    "weight": "3140 mg",
+    "display_type": "BY_WEIGHT",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -784,7 +805,8 @@
     "material": [ "dense_powder" ],
     "volume": "1 ml",
     "weight": "1984 mg",
-    "//": "density: 1.984 g/cm3"
+    "//": "density: 1.984 g/cm3",
+    "display_type": "BY_WEIGHT"
   },
   {
     "type": "ITEM",
@@ -801,7 +823,8 @@
     "volume": "1 ml",
     "weight": "2120 mg",
     "//": "density: 2.12 g/cm3 (25 °C)",
-    "container": "bottle_plastic_small"
+    "container": "bottle_plastic_small",
+    "display_type": "BY_WEIGHT"
   },
   {
     "type": "ITEM",
@@ -823,7 +846,8 @@
     "phase": "liquid",
     "container": "bottle_glass",
     "freezing_point": -36,
-    "drop_action": { "type": "emit_actor", "emits": [ "emit_acid_drop" ], "scale_qty": true }
+    "drop_action": { "type": "emit_actor", "emits": [ "emit_acid_drop" ], "scale_qty": true },
+    "display_type": "BY_VOLUME"
   },
   {
     "type": "ITEM",
@@ -844,7 +868,8 @@
     "phase": "liquid",
     "container": "bottle_glass",
     "freezing_point": -50,
-    "drop_action": { "type": "emit_actor", "emits": [ "emit_acid_drop" ], "scale_qty": true }
+    "drop_action": { "type": "emit_actor", "emits": [ "emit_acid_drop" ], "scale_qty": true },
+    "display_type": "BY_VOLUME"
   },
   {
     "type": "ITEM",
@@ -862,7 +887,8 @@
     "material": [ "acetone" ],
     "ammo_type": "components",
     "phase": "liquid",
-    "container": "bottle_glass"
+    "container": "bottle_glass",
+    "display_type": "BY_VOLUME"
   },
   {
     "type": "ITEM",
@@ -884,7 +910,8 @@
     "phase": "liquid",
     "container": "bottle_glass",
     "freezing_point": -42,
-    "drop_action": { "type": "emit_actor", "emits": [ "emit_acid_drop" ], "scale_qty": true }
+    "drop_action": { "type": "emit_actor", "emits": [ "emit_acid_drop" ], "scale_qty": true },
+    "display_type": "BY_VOLUME"
   },
   {
     "type": "ITEM",
@@ -900,7 +927,8 @@
     "material": [ "powder_nonflam" ],
     "volume": "1 ml",
     "weight": "5220 mg",
-    "//": "density: 5.22 g/cm3"
+    "//": "density: 5.22 g/cm3",
+    "display_type": "BY_WEIGHT"
   },
   {
     "type": "ITEM",
@@ -938,7 +966,8 @@
     "material": [ "dense_powder" ],
     "volume": "1 ml",
     "weight": "2220 mg",
-    "//": "density: 2.22 g/cm3"
+    "//": "density: 2.22 g/cm3",
+    "display_type": "BY_WEIGHT"
   },
   {
     "type": "ITEM",
@@ -954,7 +983,8 @@
     "material": [ "dense_powder" ],
     "volume": "1 ml",
     "weight": "2710 mg",
-    "//": "density: 2.71 g/cm3"
+    "//": "density: 2.71 g/cm3",
+    "display_type": "BY_WEIGHT"
   },
   {
     "type": "ITEM",
@@ -992,7 +1022,8 @@
     "weight": "325 g",
     "ammo_type": "components",
     "phase": "liquid",
-    "container": "bottle_glass"
+    "container": "bottle_glass",
+    "display_type": "BY_VOLUME"
   },
   {
     "type": "ITEM",
@@ -1039,7 +1070,9 @@
     "material": [ "powder_nonflam" ],
     "volume": "1 ml",
     "weight": "1 g",
-    "container": "bag_canvas"
+    "container": "bag_canvas",
+    "display_type": "BY_WEIGHT",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1055,7 +1088,9 @@
     "material": [ "powder_nonflam" ],
     "volume": "1 ml",
     "weight": "1 g",
-    "container": "bag_canvas"
+    "container": "bag_canvas",
+    "display_type": "BY_WEIGHT",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1101,7 +1136,9 @@
     "material": [ "powder_nonflam" ],
     "volume": "5 ml",
     "weight": "13350 mg",
-    "container": "bag_canvas"
+    "container": "bag_canvas",
+    "display_type": "BY_WEIGHT",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1119,7 +1156,8 @@
     "material": [ "acid" ],
     "ammo_type": "components",
     "phase": "liquid",
-    "container": "bottle_glass"
+    "container": "bottle_glass",
+    "display_type": "BY_VOLUME"
   },
   {
     "type": "ITEM",
@@ -1136,7 +1174,8 @@
     "weight": "300 g",
     "ammo_type": "components",
     "phase": "liquid",
-    "container": "bottle_glass"
+    "container": "bottle_glass",
+    "display_type": "BY_VOLUME"
   },
   {
     "type": "ITEM",
@@ -1152,7 +1191,9 @@
     "volume": "5 ml",
     "weight": "10 g",
     "//": "Weight might not be accurate.",
-    "container": "bag_canvas"
+    "container": "bag_canvas",
+    "display_type": "BY_WEIGHT",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1167,7 +1208,9 @@
     "material": [ "powder" ],
     "volume": "1 ml",
     "weight": "1 g",
-    "container": "bag_canvas"
+    "container": "bag_canvas",
+    "display_type": "BY_WEIGHT",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1199,7 +1242,9 @@
     "material": [ "dense_powder" ],
     "//": "Density of RDX/Hexogen is 1.858 g/cm3",
     "volume": "1 ml",
-    "weight": "1858 mg"
+    "weight": "1858 mg",
+    "display_type": "BY_WEIGHT",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1214,7 +1259,9 @@
     "material": [ "dense_powder" ],
     "//": "Density of composition B is 1.65 g/cm3",
     "volume": "1 ml",
-    "weight": "1650 mg"
+    "weight": "1650 mg",
+    "display_type": "BY_WEIGHT",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1230,7 +1277,9 @@
     "//": "Density of RDX is 1.57 g/cm3",
     "volume": "1 ml",
     "weight": "1570 mg",
-    "container": "bag_plastic_small"
+    "container": "bag_plastic_small",
+    "display_type": "BY_WEIGHT",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1246,7 +1295,9 @@
     "//": "Detonation velocity about 2500–3000 m/s near 0.5 g/cm3",
     "volume": "1 ml",
     "weight": "500 mg",
-    "container": "bag_plastic_small"
+    "container": "bag_plastic_small",
+    "display_type": "BY_WEIGHT",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1285,7 +1336,9 @@
     "volume": "2 ml",
     "flags": [ "NO_INGEST", "WATER_DISSOLVE" ],
     "//6": "The ratio of how much water can be purified per tablet (maximum).  Should match the water_purifying recipe",
-    "variables": { "water_per_tablet": 4 }
+    "variables": { "water_per_tablet": 4 },
+    "display_type": "BY_WEIGHT",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1456,7 +1509,8 @@
     "volume": "250 ml",
     "charges": 1,
     "phase": "liquid",
-    "category": "chems"
+    "category": "chems",
+    "display_type": "BY_VOLUME"
   },
   {
     "type": "ITEM",
@@ -1509,7 +1563,8 @@
     "charges": 1,
     "phase": "liquid",
     "category": "chems",
-    "fun": -20
+    "fun": -20,
+    "display_type": "BY_VOLUME"
   },
   {
     "type": "ITEM",
@@ -1531,7 +1586,8 @@
     "charges": 1,
     "phase": "liquid",
     "category": "chems",
-    "fun": -20
+    "fun": -20,
+    "display_type": "BY_VOLUME"
   },
   {
     "type": "ITEM",
@@ -1602,7 +1658,9 @@
     "charges": 1,
     "//": "0.7134 g/cm3",
     "weight": "713 mg",
-    "phase": "liquid"
+    "phase": "liquid",
+    "display_type": "BY_VOLUME",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1624,7 +1682,9 @@
     "charges": 1,
     "//": "1.1004 g/cm3",
     "weight": "1100 mg",
-    "phase": "liquid"
+    "phase": "liquid",
+    "display_type": "BY_VOLUME",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1646,7 +1706,8 @@
     "charges": 1,
     "//": "1.489 g/cm3 at 25C",
     "weight": "1489 mg",
-    "phase": "liquid"
+    "phase": "liquid",
+    "display_type": "BY_VOLUME"
   },
   {
     "type": "ITEM",
@@ -1668,7 +1729,8 @@
     "charges": 1,
     "//": "1.07 g/cm3",
     "weight": "1070 mg",
-    "phase": "liquid"
+    "phase": "liquid",
+    "display_type": "BY_VOLUME"
   },
   {
     "type": "ITEM",
@@ -1689,7 +1751,8 @@
     "charges": 1,
     "phase": "liquid",
     "freezing_point": 5,
-    "flags": [ "INEDIBLE" ]
+    "flags": [ "INEDIBLE" ],
+    "display_type": "BY_VOLUME"
   },
   {
     "type": "ITEM",
@@ -1710,7 +1773,8 @@
     "charges": 1,
     "phase": "liquid",
     "freezing_point": -95,
-    "flags": [ "INEDIBLE" ]
+    "flags": [ "INEDIBLE" ],
+    "display_type": "BY_VOLUME"
   },
   {
     "type": "ITEM",
@@ -1730,7 +1794,8 @@
     "volume": "15 ml",
     "weight": "20 g",
     "charges": 1,
-    "phase": "liquid"
+    "phase": "liquid",
+    "display_type": "BY_VOLUME"
   },
   {
     "type": "ITEM",
@@ -1832,7 +1897,9 @@
     "material": [ "wood" ],
     "symbol": ".",
     "color": "brown",
-    "looks_like": "bb"
+    "looks_like": "bb",
+    "display_type": "BY_WEIGHT",
+    "stackable": true
   },
   {
     "id": "rosin",
@@ -1846,7 +1913,9 @@
     "price_postapoc": "1 cent",
     "material": [ "wood" ],
     "symbol": "=",
-    "color": "yellow"
+    "color": "yellow",
+    "display_type": "BY_WEIGHT",
+    "stackable": true
   },
   {
     "id": "acetylene",
@@ -1868,7 +1937,8 @@
     "phase": "liquid",
     "explode_in_fire": true,
     "explosion": { "power": 20, "shrapnel": 0 },
-    "flags": [ "NO_DROP", "IRREMOVABLE" ]
+    "flags": [ "NO_DROP", "IRREMOVABLE" ],
+    "display_type": "BY_VOLUME"
   },
   {
     "id": "formic_acid",
@@ -1891,7 +1961,8 @@
     "explosion": { "power": 5, "shrapnel": 0 },
     "flags": [ "NUTRIENT_OVERRIDE" ],
     "//": "Needed so calories from alcohol used to produce this aren't carried over to items using this as preservative",
-    "looks_like": "ether"
+    "looks_like": "ether",
+    "display_type": "BY_VOLUME"
   },
   {
     "id": "latex",
@@ -1909,7 +1980,8 @@
     "charges": 1,
     "stack_size": 100,
     "phase": "liquid",
-    "looks_like": "milk"
+    "looks_like": "milk",
+    "display_type": "BY_VOLUME"
   },
   {
     "type": "ITEM",
@@ -2004,7 +2076,9 @@
     "ammo_type": "components",
     "container": "test_tube",
     "symbol": ";",
-    "color": "light_green"
+    "color": "light_green",
+    "display_type": "BY_VOLUME",
+    "stackable": true
   },
   {
     "id": "conc_paralytic",
@@ -2032,7 +2106,8 @@
     "price": "20 USD",
     "price_postapoc": "2 USD",
     "count": 1,
-    "stack_size": 1
+    "stack_size": 1,
+    "display_type": "BY_VOLUME"
   },
   {
     "id": "red_phosphorous",
@@ -2107,7 +2182,8 @@
     "color": "dark_gray",
     "looks_like": "chem_ethanol",
     "//": "1.082 g/cm3",
-    "freezing_point": -73
+    "freezing_point": -73,
+    "display_type": "BY_VOLUME"
   },
   {
     "id": "iodine_crystal",
@@ -2123,7 +2199,8 @@
     "symbol": "=",
     "color": "dark_gray",
     "price": "1 cent",
-    "price_postapoc": "1 cent"
+    "price_postapoc": "1 cent",
+    "display_type": "BY_WEIGHT"
   },
   {
     "type": "ITEM",
@@ -2144,7 +2221,8 @@
     "phase": "liquid",
     "flags": [ "DETERGENT" ],
     "comestible_type": "INVALID",
-    "charges": 5
+    "charges": 5,
+    "display_type": "BY_VOLUME"
   },
   {
     "id": "pine_resin",
@@ -2180,7 +2258,8 @@
     "sealed": true,
     "symbol": "s",
     "color": "light_gray",
-    "flags": [ "UNRECOVERABLE" ]
+    "flags": [ "UNRECOVERABLE" ],
+    "display_type": "BY_VOLUME"
   },
   {
     "type": "ITEM",
@@ -2307,7 +2386,8 @@
     "count": 100,
     "price_postapoc": "5 cents",
     "phase": "liquid",
-    "flags": [ "UNRECOVERABLE", "NO_SALVAGE" ]
+    "flags": [ "UNRECOVERABLE", "NO_SALVAGE" ],
+    "display_type": "BY_VOLUME"
   },
   {
     "id": "glue_strong",


### PR DESCRIPTION
#### 概述 (Summary)
Bugfixes "调整钉类物品、小份化学品和资源物品的堆叠和显示类型"

#### 改动目的 (Purpose of change)

钉子和螺栓螺母，以及小份的化学品没有堆叠导致性能问题。液体化学品只显示数量。

#### 解决方案描述 (Describe the solution)

堆叠钉子、螺栓螺母；补充小份的化学品的堆叠并将显示类型改为重量；以及将液体化学品的显示类型改为体积。

#### 你考虑过的替代方案 (Describe alternatives you've considered)

<!-- 说明你为解决同一问题考虑过的其他方案、不同思路或可能性。 -->

#### 测试 (Testing)

<!-- 描述你采取了哪些步骤来测试这个 PR 是否修复了 bug 或添加了特性，以及你做了哪些测试以确保没有引入回归问题。也请为审阅者和维护者提供测试建议。参见 TESTING_YOUR_CHANGES.md -->

#### 补充说明 (Additional context)

<!-- 在此添加关于这个特性或 bug 修复的其他背景信息（例如原型图、概念验证或截图）。 -->


<!--README: Cataclysm: Cleanwater Bomb (CCB) 以 Creative Commons Attribution ShareAlike 3.0 许可证发布。
游戏的代码与内容可自由用于任何目的的使用、修改和再分发。
通过为本项目做贡献，你即同意该许可证的条款，并同意你所做的任何贡献也将受同一许可证覆盖。
详见 http://creativecommons.org/licenses/by-sa/3.0/ 。 -->