### PR TITLE
Fix: Modify the sleep action logic to delay saving until after option completion.

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1492,8 +1492,9 @@ static void sleep()
        and loop until we get a valid answer. */
     as_m.query();
 
+    bool save_before_sleep = false;
     if( as_m.ret == 1 ) {
-        g->quicksave();
+        save_before_sleep = true;
     } else if( as_m.ret == 2 || as_m.ret < 0 ) {
         return;
     }
@@ -1535,6 +1536,10 @@ static void sleep()
         } else if( as_m.ret < 0 ) {
             return;
         }
+    }
+
+    if( save_before_sleep ) {
+        g->quicksave();
     }
 
     player_character.set_moves( 0 );


### PR DESCRIPTION
####  Summary

Bugfixes "Fix the abnormal design where the sleep action is interrupted by the saving process"

#### Purpose of change

Resolve #228

As stated in the issue, the current sleep logic contradicts normal player operating habits and common sense, forcing players to fully wait for the auto-saving process to complete before they can even decide on their sleep duration to truly start sleeping. In reality, both saving game progress and having a character go to sleep are waiting processes. A common-sense design usually dictates that waiting processes triggered by the same action should be executed together after all option decisions have been made—unless timing is exceptionally critical, but sleeping is clearly not.

#### Describe the solution

Modified the `handle_action.cpp` file by adding a bool variable named `save_before_sleep` within the `sleep()` function. When choosing to save before sleeping, the original quick-save operation is changed to set `save_before_sleep` to `true`, and the quick-save process is moved to just before executing sleep, where it checks `save_before_sleep` to determine whether to execute.

According to issue #228, the adjusted workflow is now as follows:

1. press $ to sleep / save before sleep
2. select sleep time
3. save (user waits for saving to complete)
4. officially start sleeping. In this way, the saving time and the waiting time for sleep are merged together, so users can also take a nap in real life.

This adjustment should fix the issue and make the sleep action logic more aligned with common sense.