### PR TITLE
style(immortal_path): fix qi_gathering.json JSON style / 修复 JSON 风格债

### DIFF
--- a/data/mods/immortal_path/recipes/qi_gathering.json
+++ b/data/mods/immortal_path/recipes/qi_gathering.json
@@ -5,11 +5,7 @@
     "subtypes": [ "COMESTIBLE" ],
     "category": "drugs",
     "comestible_type": "MED",
-    "name": {
-      "str_sp": "聚气丹",
-      "//en_us_str": "Qi-Gathering Pill",
-      "//en_us_str_pl": "Qi-Gathering Pills"
-    },
+    "name": { "str_sp": "聚气丹", "//en_us_str": "Qi-Gathering Pill", "//en_us_str_pl": "Qi-Gathering Pills" },
     "//": "基础回灵丹药：只补灵气，不给炼气修为，避免绕过打坐成长曲线。数值对齐一次吐纳补气量（+60）。/ Basic qi-restoring pill: restores qi only, not Qi Refining cultivation, so it does not bypass the meditation progression curve. Amount matches one meditation cast (+60 qi).",
     "description": "一枚淡青色小丹，入口后化作温润灵息，汇入丹田。可补充少量灵气，但不能增长修为。",
     "//en_us_description": "A pale cyan pill that melts into a warm spiritual breath and gathers in the dantian. Restores a small amount of qi, but does not increase cultivation.",


### PR DESCRIPTION
#### Summary

None

#### 改动目的 (Purpose of change)

修复 `data/mods/immortal_path/recipes/qi_gathering.json` 的既有 JSON 风格债：该文件的 `name` 对象未按 CDDA `JSON_STYLE` 规范收成单行，导致 CI 的 **JSON style check** 失败，连带 macOS / Ubuntu / Windows 等构建任务在编译前的 style 步骤即 `Error 1` 退出。此债**早于本次任何内容改动**（master 本身即存在），会持续阻塞每个 PR 的构建检查。

Fixes pre-existing JSON style debt in `qi_gathering.json`: its `name` object was not collapsed to a single line per CDDA `JSON_STYLE`, failing the CI **JSON style check** and causing the macOS / Ubuntu / Windows build jobs to exit `Error 1` at the pre-compile style step. This debt predates any recent content change (present on master itself) and blocks the build gate on every PR.

#### 解决方案描述 (Describe the solution)

跑官方 `tools/format/json_formatter` 把 `name` 对象收成单行。**纯空白改动，零语义差异**（已用 `json.load` 对比确认前后语义等价，并验证 formatter 幂等）。

Ran the official `tools/format/json_formatter` to collapse the `name` object onto one line. **Whitespace-only, zero semantic difference** (verified semantically equal via `json.load` before/after, and formatter idempotency confirmed).

#### 测试 (Testing)

- `json_formatter` 对该文件再次运行无改动（幂等 = 合规）/ formatter is now idempotent on the file.
- `python json.load` 前后语义等价 / semantically identical before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)