### PR TITLE
Bugfixes "修复怪物盯上行驶车辆时偶发的 SIGSEGV 闪退 (monmove)"

### DIFF
--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -682,7 +682,12 @@ void monster::plan()
         const bool will_throw_self_at_vehicle = !get_pathfinding_settings().avoid_dangerous_fields;
         if( !target_vehicles.empty() && will_throw_self_at_vehicle ) {
             tripoint_bub_ms target_pt = random_entry( target_vehicles );
-            Character *driver = here.veh_at( target_pt )->vehicle().get_driver( here );
+            const optional_vpart_position vp = here.veh_at( target_pt );
+            // target_pt comes from the moving-vehicle part list, but veh_at() can still
+            // return an empty optional for it (out-of-bounds, inactive z-level cache, or a
+            // part-list/cache position mismatch). operator-> would then build a vehicle&
+            // from uninitialized storage and crash in get_driver(); guard the optional.
+            Character *driver = vp ? vp->vehicle().get_driver( here ) : nullptr;
             // NOTE: no hostility check here, we already filtered for that when deciding vehicle targets.
             if( driver ) {
                 mon_plan.target = driver;


### PR DESCRIPTION
#### 概述 (Summary)

Bugfixes "修复怪物以行驶中的车辆为目标时偶发的 SIGSEGV 闪退"

#### 改动目的 (Purpose of change)

游戏高频出现 `SIGSEGV: Segmentation fault` 闪退,崩溃栈为：

```
monster::plan -> vehicle::get_driver -> vehicle::boarded_parts   <- SIGSEGV
```

This crash happens frequently in normal play whenever a monster considers a moving vehicle as a target. The crash stack consistently points at `monster::plan -> vehicle::get_driver -> vehicle::boarded_parts`.

根因 (Root cause)：`monster::plan()` 在 `src/monmove.cpp` 里从 `get_moving_vehicle_targets()` 取一个行驶车辆的目标格,然后直接对 `veh_at( target_pt )` 用 `operator->` 解引用,**没有判空**：

```cpp
Character *driver = here.veh_at( target_pt )->vehicle().get_driver( here );
```

`veh_at()` 返回 `optional_vpart_position`(继承自 `std::optional`)。当它对该格返回空 optional（出界、该 z 层车辆缓存未激活、或部件列表坐标与 `veh_at` 查找错配）时,`operator->` 会在未初始化的存储上构造出一个垃圾 `vehicle&`,随后 `get_driver()` -> `boarded_parts()` 在垃圾 `this` 上解引用而崩溃。

`veh_at()` returns an `optional_vpart_position` (a `std::optional`). When it is empty for that tile, `operator->` reads uninitialized storage, yields a garbage `vehicle&`, and the call chain crashes — exactly matching the observed stack.

该逻辑由上游 commit `3266fad9f4`（"Dumb enemies are attracted to moving vehicles"）引入。

#### 解决方案描述 (Describe the solution)

提取 optional 后先判空再解引用,空则回退为「无司机」(`driver = nullptr`,后续 `if( driver )` 自然跳过)。模式与 `vpart_position.h` 中既有的 `p ? &p->vehicle() : nullptr` 一致。

Hold the optional in a local, check it before dereferencing, and fall back to no driver when empty. Mirrors the existing `p ? &p->vehicle() : nullptr` idiom in `vpart_position.h`.

```cpp
const optional_vpart_position vp = here.veh_at( target_pt );
Character *driver = vp ? vp->vehicle().get_driver( here ) : nullptr;
```

有车位时行为与原逻辑完全等价；仅在原本会崩溃的空 optional 情况下安全退化。零行为回归。

#### 你考虑过的替代方案 (Describe alternatives you've considered)

- 在 `get_moving_vehicle_targets()` 里过滤掉无法 `veh_at` 命中的格子：治标且更分散,核心解引用仍不安全。
- 让 `optional_vpart_position::operator->` 自带断言：影响面太大、超出本次崩溃修复范围。

调用点判空是最小且最贴合代码库现有惯例的修法。

#### 测试 (Testing)

- `g++ -std=c++17 -fsyntax-only`（TILES + SDL3 配置）编译通过。
- 依据崩溃栈逐帧推导确认修复点与崩溃链一致。

⚠️ **试修复 (Tentative fix)**：本修复依据崩溃栈与静态分析推导得出,**尚未在运行的游戏中复现原崩溃并验证**。该崩溃为偶发,稳定复现条件待补。欢迎能复现者帮忙验证。

This is a **tentative fix** derived from the crash stack and static analysis; it has **not yet been reproduced and verified in a running game**, since the crash is intermittent. Verification from anyone who can reproduce it is welcome.

#### 补充说明 (Additional context)

崩溃栈 (crash.log)：

```
#9  vehicle::boarded_parts
#10 vehicle::get_driver
#11 monster::plan
#12 (anonymous namespace)::monmove
#13 game::do_turn
```
