### PR TITLE
尝试修复编译&构建错误

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -650,8 +650,6 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                              ( you_pos.y() % SEEY ) + ( MAPSIZE - 1 ) * SEEY );
     const int draw_min_z = std::max( you.posz() - fov_3d_z_range, -OVERMAP_DEPTH );
 
-    const level_cache &ch = here.access_cache( center.z() );
-
     // Map memory should be at least the size of the view range
     // so that new tiles can be memorized, and at least the size of the display
     // since at farthest zoom displayed area may be bigger than view range.


### PR DESCRIPTION
#### 概述 (Summary)
None

#### 改动目的 (Purpose of change)

修复构建错误。
```log
Error: src/cata_tiles.cpp:653:24: error: unused variable 'ch' [-Werror,-Wunused-variable]
  653 |     const level_cache &ch = here.access_cache( center.z() );
      |                        ^~
1 error generated.
```

#### 解决方案描述 (Describe the solution)

移除未使用变量。


#### 你考虑过的替代方案 (Describe alternatives you've considered)

<!-- 说明你为解决同一问题考虑过的其他方案、不同思路或可能性。 -->

#### 测试 (Testing)

<!-- 描述你采取了哪些步骤来测试这个 PR 是否修复了 bug 或添加了特性，以及你做了哪些测试以确保没有引入回归问题。也请为审阅者和维护者提供测试建议。参见 TESTING_YOUR_CHANGES.md -->

#### 补充说明 (Additional context)

<!-- 在此添加关于这个特性或 bug 修复的其他背景信息（例如原型图、概念验证或截图）。 -->


<!--README: Cataclysm: Cleanwater Bomb (CCB) 以 Creative Commons Attribution ShareAlike 3.0 许可证发布。
游戏的代码与内容可自由用于任何目的的使用、修改和再分发。
通过为本项目做贡献，你即同意该许可证的条款，并同意你所做的任何贡献也将受同一许可证覆盖。
详见 http://creativecommons.org/licenses/by-sa/3.0/ 。 -->