### PR TITLE
Bugfixes: fork 代码审查修复 3 个缺陷并清理注释 / 3 bugfixes + comment cleanup from fork-code review

### DIFF
--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -458,6 +458,11 @@ class tileset
             overexposed_tile_values.clear();
             memory_tile_values.clear();
             silhouette_tile_values.clear();
+            // The tinted-tile cache keys on the raw base-texture pointers we just
+            // freed (see cata_tiles_color.cpp::get_tinted_tile). Leaving it populated
+            // would let a replay-reallocated texture collide with a stale key and
+            // return a dangling/wrong tinted sprite, so drop it alongside the atlases.
+            tinted_tile_values.clear();
         }
 
         tile_type &create_tile_type( const std::string &id, tile_type &&new_tile_type );

--- a/src/enums.h
+++ b/src/enums.h
@@ -447,7 +447,7 @@ enum MULTITILE_TYPE {
 
 // Bitmask of cardinal-direction neighbours used by tile orientation helpers.
 // Moved from cata_tiles.h so map-side code can compute orientation without
-// depending on the tiles subsystem (see sim-render-decoupling-plan.md §1).
+// depending on the tiles subsystem.
 enum class NEIGHBOUR {
     SOUTH = 1,
     EAST  = 2,

--- a/src/explosion_light.h
+++ b/src/explosion_light.h
@@ -90,7 +90,7 @@ struct explosion_light {
         // bright almost immediately rather than easing in).
         float rise = 0.05f;
         // Quick alpha fall when wave 3 (the clear wave) reaches a tile — the fast
-        // "变透明" dissipation.
+        // fade-to-transparent dissipation.
         float fade = 0.1f;
         // Short window over which the hue blends color_a -> color_b at wave 2.
         float blend = 0.05f;

--- a/src/explosion_light.h
+++ b/src/explosion_light.h
@@ -137,9 +137,9 @@ struct explosion_light {
 
         // --- Phase two: screen-space shockwave distortion --------------------
         // A CPU-driven refraction ring that warps the already-rendered frame at
-        // present time (see shockwave.h / the shockwave-distortion plan). Purely
-        // a visual add-on: when unsupported (curses, no RenderGeometryRaw) it is
-        // silently skipped and the light overlay still plays.
+        // present time (see shockwave.h). Purely a visual add-on: when unsupported
+        // (curses, no RenderGeometryRaw) it is silently skipped and the light
+        // overlay still plays.
         bool shockwave = false;
         // Peak UV displacement, as a fraction of a tile's size (converted to
         // pixels at blast time). 0 = no distortion.

--- a/src/input_replay.h
+++ b/src/input_replay.h
@@ -7,7 +7,8 @@
 #include "input_enums.h" // IWYU pragma: keep  (input_event)
 
 // Deterministic input record/replay harness — phase 0.5 of the sim/render
-// decoupling plan (see .claude/plans/sim-render-decoupling-plan.md).
+// decoupling work (a build target that runs the game loop headlessly for tests
+// and reproducible replay).
 //
 // Goal: capture the stream of input_events from an interactive session, then
 // feed the exact same stream back during a headless re-run so that, given the

--- a/src/platform_headless.cpp
+++ b/src/platform_headless.cpp
@@ -1,7 +1,8 @@
 // Headless platform backend.
 //
-// Phase 0 of the simulate/present decoupling (see plan
-// sim-render-decoupling-plan.md). This file is the curses-free analogue of
+// Phase 0 of the simulate/present decoupling: a build target that runs the game
+// loop with no terminal and no SDL, for tests and deterministic replay. This
+// file is the curses-free analogue of
 // ncurses_def.cpp / wincurse.cpp: it provides the catacurses interface, the
 // platform entry points, the input_manager hooks, the nc_color helpers, and
 // the ImTui ncurses-platform shims -- but touches no terminal at all.
@@ -284,10 +285,10 @@ void input_manager::set_timeout( const int delay )
 // nc_color helpers (curses-free bit layout).
 //
 // This is a byte-for-byte copy of the software implementation in
-// cursesport.cpp:525-557 (the SDL-tiles / wincon path). It is NOT the same as
-// ncurses_def.cpp's version, which uses real ncurses COLOR_PAIR()/A_BOLD macros
-// and the 2-arg nc_color ctor. The three backends partition by #if guard so
-// only one nc_color definition ever links.
+// cursesport.cpp (the nc_color helpers in the SDL-tiles / wincon path). It is
+// NOT the same as ncurses_def.cpp's version, which uses real ncurses
+// COLOR_PAIR()/A_BOLD macros and the 2-arg nc_color ctor. The three backends
+// partition by #if guard so only one nc_color definition ever links.
 //
 // TODO(phase1): the two software copies (here + cursesport.cpp) could share one
 // backend-neutral TU, but the guard union that selects them (TUI / HEADLESS /

--- a/src/shockwave.h
+++ b/src/shockwave.h
@@ -9,7 +9,7 @@
 // window once per frame; when a shockwave is active that blit is done through a
 // distorted triangle mesh, refracting the already-rendered scene (including the
 // phase-one light overlay) along an expanding ring. No GPU shader is involved, so
-// it works on both SDL2 and SDL3 — see the shockwave-distortion plan.
+// it works on both SDL2 and SDL3.
 
 // Live shockwave parameters, expressed entirely in screen pixels so the present
 // path can consume them without any tile/coordinate context. The explosion light

--- a/src/submap_prefetch.cpp
+++ b/src/submap_prefetch.cpp
@@ -14,12 +14,11 @@ submap_prefetcher::submap_prefetcher() = default;
 
 submap_prefetcher::~submap_prefetcher()
 {
-    running_ = false;
-    cv_.notify_all();
-    parked_cv_.notify_all();
-    if( worker_.joinable() ) {
-        worker_.join();
-    }
+    // Delegate to stop_worker() rather than re-implementing teardown: it flips
+    // running_/started_ under mutex_ (so the worker can't miss the wakeup and
+    // hang join()) and is idempotent, so this is safe whether or not clear()
+    // already stopped the worker during world teardown.
+    stop_worker();
 }
 
 int submap_prefetcher::quad_dist( const tripoint_abs_omt &a, const tripoint_abs_omt &center )

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -11,6 +11,7 @@
 #include <list>
 #include <memory>
 #include <numeric>
+#include <optional>
 #include <queue>
 #include <set>
 #include <sstream>
@@ -270,7 +271,7 @@ void vehicle::apply_color_palette( const vehicle_prototype &proto )
     if( !proto.color_palette.is_valid() || proto.color_match.empty() ) {
         return;
     }
-    const std::vector<RGBColor> colors = proto.color_palette->pick_colors();
+    const std::vector<std::optional<RGBColor>> colors = proto.color_palette->pick_colors();
     if( colors.empty() ) {
         return;
     }
@@ -280,8 +281,10 @@ void vehicle::apply_color_palette( const vehicle_prototype &proto )
             continue;
         }
         const int idx = it->second;
-        if( idx >= 0 && idx < static_cast<int>( colors.size() ) ) {
-            vp.set_color( colors[idx], colors[idx] );
+        // idx indexes color groups 1:1 (see VehiclePalette::pick_colors); a group
+        // that rolled no color leaves an empty slot, so skip painting that part.
+        if( idx >= 0 && idx < static_cast<int>( colors.size() ) && colors[idx] ) {
+            vp.set_color( *colors[idx], *colors[idx] );
         }
     }
 }

--- a/src/vehicle_palette.cpp
+++ b/src/vehicle_palette.cpp
@@ -86,20 +86,25 @@ int VehiclePalette::fuzzy_to_index( const vpart_id &id ) const
     return -1;
 }
 
-std::vector<RGBColor> VehiclePalette::pick_colors() const
+std::vector<std::optional<RGBColor>> VehiclePalette::pick_colors() const
 {
-    std::vector<RGBColor> result;
+    // One slot per color group, positionally aligned with fuzzy_to_index()'s
+    // return value: a group that rolls nothing (empty / all-zero-weight) keeps an
+    // empty slot instead of being skipped, so a later group is never silently
+    // shifted onto an earlier group's parts.
+    std::vector<std::optional<RGBColor>> result;
+    result.reserve( colors.size() );
     for( const weighted_int_list<std::string> &colorlist : colors ) {
         const std::string *colorstr = colorlist.pick();
         if( !colorstr ) {
+            result.emplace_back();
             continue;
         }
         const std::optional<RGBColor> color = RGBColor::try_parse( *colorstr );
-        if( color ) {
-            result.push_back( *color );
-        } else {
+        if( !color ) {
             debugmsg( "Invalid Color %s in Vehicle Palette %s", *colorstr, id.str() );
         }
+        result.push_back( color );
     }
     return result;
 }

--- a/src/vehicle_palette.h
+++ b/src/vehicle_palette.h
@@ -7,6 +7,7 @@
 // Palettes are defined in data/json/vehicle_palette.json.
 
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -34,8 +35,13 @@ class VehiclePalette
         /** Returns the color-group index a part id belongs to, or -1 if none matches. */
         int fuzzy_to_index( const vpart_id &id ) const;
 
-        /** Rolls one weighted-random color per color group. */
-        std::vector<RGBColor> pick_colors() const;
+        /**
+         * Rolls one weighted-random color per color group. The result is indexed
+         * the SAME way as @ref fuzzy_to_index: result[i] is the color for group i.
+         * A group that rolls nothing (empty / all-zero-weight) yields nullopt in
+         * its slot rather than being dropped, so later groups keep their indices.
+         */
+        std::vector<std::optional<RGBColor>> pick_colors() const;
 
     private:
         vpalette_id id;


### PR DESCRIPTION
#### 概述 (Summary)

Bugfixes "修复预取器析构竞态死锁、载具调色板上色错位、以及 GPU 图集释放后贴色缓存悬空指针"

#### 改动目的 (Purpose of change)

对 fork 相对上游新增的代码做了一轮审查，聚焦两点：注释的自说明性与有效性、以及明显缺陷。本 PR 共 6 个提交：3 个功能修复 + 3 个纯注释清理。

A review pass over fork-introduced code (vs the upstream merge-base), focused on comment self-documentation and obvious bugs. 6 commits: 3 functional fixes + 3 docs-only cleanups.

#### 解决方案描述 (Describe the solution)

**功能修复（请重点审阅）/ Bug fixes (please review):**

1. **`~submap_prefetcher` 析构未持锁导致丢唤醒、`join()` 死锁** (`submap_prefetch.cpp`)
   析构在**不持有 `mutex_`** 的情况下置 `running_ = false` 并 notify 条件变量。尽管 `running_` 是原子量，条件变量的判定式必须在持锁下修改——否则「置值+notify」可能正好落在工作线程「检查判定式」与「进入 `wait(lock)`」之间的缝隙里，唤醒丢失，工作线程永久阻塞，`join()` 死锁。改为委托给已经持锁正确且幂等的 `stop_worker()`。
   The destructor set `running_ = false` and notified the condvars without holding `mutex_`; the store+notify can race into the worker's gap between predicate check and `wait(lock)`, losing the wakeup and deadlocking `join()`. Now delegates to the lock-correct, idempotent `stop_worker()`.

2. **`pick_colors()` 与 `fuzzy_to_index()` 索引错位** (`vehicle_palette.cpp/.h`, `vehicle.cpp`)
   `color_match[part]` 是颜色组向量的下标，`apply_color_palette()` 用同一下标索引 `pick_colors()` 的结果。但 `pick_colors()` 对「空/全零权重」的颜色组会 `continue` 跳过，压缩了结果向量，使被跳过组之后的所有组下标整体前移，零件被涂上错误颜色（原有的越界检查只防崩溃、不防错位）。原版调色板权重全为正故潜伏，但任何含空组的 mod/未来数据都会涂错。改为 `pick_colors()` 按组返回 `std::optional<RGBColor>`、逐组对齐，消费端跳过空槽。
   `pick_colors()` skipped empty/zero-weight color groups, compacting the result and shifting later indices so parts got the wrong color. Latent in vanilla (all-positive weights). Now returns one `std::optional<RGBColor>` per group positionally.

3. **GPU 图集释放后贴色缓存留下悬空指针** (`cata_tiles.h`)
   `get_tinted_tile` 以基础贴图的裸指针为键缓存贴色精灵。`tileset::clear()` 已会连同基础贴图向量一起清该缓存，但 `release_gpu_atlases()`——SDL3 设备丢失/图集重放路径——清了六个基础贴图向量却**没清**贴色缓存。设备丢失+重放（不走 JSON 加载器）后，复用到回收地址的新贴图会与旧键碰撞，返回悬空/错误的贴色精灵。改为该路径也清贴色缓存。（位于 fork 已知的 D3D12 崩溃/恢复区域。）
   `release_gpu_atlases()` (the SDL3 device-loss/atlas-replay path) cleared the base-texture vectors but not the pointer-keyed tint cache, risking a dangling/wrong tinted sprite after replay. Now clears it there too.

**注释清理（纯文档，无逻辑改动）/ Comment cleanups (docs-only):**

- `explosion_light.h`：把英文注释里夹的一处中文措辞改回英文。
- `platform_headless.cpp` / `input_replay.h` / `enums.h`：删除指向 `.claude/plans/sim-render-decoupling-plan.md`（一个未纳入仓库、读者无从查阅的私有规划文件）的悬空引用，并把 `cursesport.cpp:525-557` 这类行号引用改为符号名引用。
- `shockwave.h` / `explosion_light.h`：删除指向「shockwave-distortion plan」的悬空引用。

#### 你考虑过的替代方案 (Describe alternatives you've considered)

`cached_veh_rope` 的 z 坍缩问题（键只含 xy 但跨 z 填充）也在审查中被发现，但其修复牵涉「绳子沿一列下垂」的语义设计、不是一行能改对的，故单独标记、未纳入本 PR。

#### 测试 (Testing)

每个功能改动均对照其调用点验证；注释改动不触碰任何代码。完整构建通过（cataclysm-tiles.exe 链接成功，MSVC Release x64）。

#### 补充说明 (Additional context)

本 PR 为纯代码改动（非格式化）。配套的 astyle 纯格式化清理见 #253。