### PR TITLE
迁移翻译至自有 Transifex 项目 + 署名

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,9 @@ Thumbs.db
 cscope.*
 tags
 
+# Translation files (pulled from Transifex at CI time)
+/lang/po/*.po
+
 # Generated translation source
 /lang/po/*.pot
 

--- a/.tx/config
+++ b/.tx/config
@@ -8,17 +8,26 @@ source_lang  = en
 type         = PO
 minimum_perc = 0
 
-[o:cataclysm-dda-translators:p:cataclysm-dda:r:credits-master]
-file_filter  = data/credits/<lang>.credits
-source_file  = data/credits/en.credits
-source_lang  = en
-type         = TXT
-minimum_perc = 20
+# CDDA credits/motd 资源 —— 暂时停用,避免 pull 时误拉覆盖本仓库文件
+# [o:cataclysm-dda-translators:p:cataclysm-dda:r:credits-master]
+# file_filter  = data/credits/<lang>.credits
+# source_file  = data/credits/en.credits
+# source_lang  = en
+# type         = TXT
+# minimum_perc = 20
 
-[o:cataclysm-dda-translators:p:cataclysm-dda:r:motd-master]
-file_filter  = data/motd/<lang>.motd
-source_file  = data/motd/en.motd
+# [o:cataclysm-dda-translators:p:cataclysm-dda:r:motd-master]
+# file_filter  = data/motd/<lang>.motd
+# source_file  = data/motd/en.motd
+# source_lang  = en
+# type         = TXT
+# minimum_perc = 20
+
+# ── 自有项目 Cataclysm-Cleanwater-Bomb (复制 CDDA 全部翻译的目标) ──
+[o:Cataclysm-Cleanwater-Bomb:p:cataclysm-cleanwater-bomb:r:cataclysm-dda]
+file_filter  = lang/po/<lang>.po
+source_file  = lang/po/cataclysm-dda.pot
 source_lang  = en
-type         = TXT
-minimum_perc = 20
+type         = PO
+minimum_perc = 0
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 本项目继承原作许可协议：
 
 - CC-BY-SA 3.0 及兼容条款
+- 翻译署名：译文复制自 Cataclysm-DDA，原译者信息保留于各语言文件头部，详见 [TRANSLATION_CREDITS.md](./TRANSLATION_CREDITS.md)
 
 ----
 
@@ -81,3 +82,4 @@ We are committed to a collaborative developer-player relationship, reject the "N
 ## License
 This project inherits the license from the original game:
 - CC-BY-SA 3.0 and compatible terms
+- Translation Attribution: Translations derived from Cataclysm-DDA, original translator credits preserved in language file headers, see [TRANSLATION_CREDITS.md](./TRANSLATION_CREDITS.md)

--- a/TRANSLATION_CREDITS.md
+++ b/TRANSLATION_CREDITS.md
@@ -1,0 +1,26 @@
+# Translation Credits / 翻译署名
+
+## 声明
+
+本项目所有译文复制自 [Cataclysm-DDA](https://github.com/CleverRaven/Cataclysm-DDA) 官方 Transifex 翻译项目，属于对 CC BY-SA 3.0 许可作品的再分发。
+
+原译者信息完整保留于各语言 `.po` 文件头部（`# Translators:` 注释及 `Last-Translator` 字段），本项目未对原译者的贡献归属做任何修改或移除。
+
+## Declaration
+
+All translations in this project are derived from the official [Cataclysm-DDA](https://github.com/CleverRaven/Cataclysm-DDA) Transifex translation project, redistributed under the CC BY-SA 3.0 license.
+
+Original translator attribution is preserved in full within each language's `.po` file header (`# Translators:` comments and `Last-Translator` field). No translator contributions have been altered or removed.
+
+## License / 许可证
+
+本项目继承原作许可：CC BY-SA 3.0
+This project inherits the original license: CC BY-SA 3.0
+
+全文见 /  Full text: https://creativecommons.org/licenses/by-sa/3.0/
+
+## Source / 翻译来源
+
+- 上游翻译项目：Transifex `cataclysm-dda-translators/cataclysm-dda`
+- 译文下载日期：2026-06-26
+- 自有翻译项目：Transifex `Cataclysm-Cleanwater-Bomb/cataclysm-cleanwater-bomb`


### PR DESCRIPTION
## 改动

1. **`.tx/config`**: 新增 CCB 自有 Transifex 项目资源段，停用 CDDA credits/motd 避免误拉覆盖
2. **`TRANSLATION_CREDITS.md`**: 翻译署名声明（中英双语，注明 CC BY-SA 3.0 许可，原译者归属）
3. **`README.md`**: 中英两处 License 节加翻译署名行
4. **`.gitignore`**: 忽略本地 `.po` 文件（CI 时从 Transifex 拉取）

## 说明

- 43 种语言译文已从 CDDA Transifex 完整迁移至自有项目 `Cataclysm-Cleanwater-Bomb/cataclysm-cleanwater-bomb`
- 原译者信息完整保留于各语言 PO 文件头部
- 后续 CI 需更新 `TX_TOKEN` 为自有 Transifex Token