### PR TITLE
CI: 翻译管道指向自有 Transifex

### DIFF
--- a/.github/workflows/build-translations.yml
+++ b/.github/workflows/build-translations.yml
@@ -38,7 +38,7 @@ jobs:
           echo "No TX_TOKEN secret set in this repo, not pulling translations from Transifex"
           exit 1
           fi
-          tx pull -a --force -w 2
+          tx pull -t --force cataclysm-cleanwater-bomb.cataclysm-dda
 
       - name: Discard invalid translations
         run: ./lang/discard_invalid_po.sh

--- a/.github/workflows/push-translation-template.yml
+++ b/.github/workflows/push-translation-template.yml
@@ -19,7 +19,7 @@ jobs:
       ${{ github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.conclusion == 'success' &&
       ( github.event.workflow_run.status == 'success' || github.event.workflow_run.status == 'completed' ) &&
-      github.repository == 'CleverRaven/Cataclysm-DDA' }}
+      github.repository == 'LYHGLYTX/Cataclysm-Cleanwater-Bomb' }}
     steps:
       - name: "Install gettext tools"
         run: sudo apt install gettext

--- a/.tx/config
+++ b/.tx/config
@@ -1,12 +1,13 @@
 [main]
 host = https://www.transifex.com
 
-[o:cataclysm-dda-translators:p:cataclysm-dda:r:master-cataclysm-dda]
-file_filter  = lang/po/<lang>.po
-source_file  = lang/po/cataclysm-dda.pot
-source_lang  = en
-type         = PO
-minimum_perc = 0
+# CDDA 主 PO —— 停用，避免误从上游拉取
+# [o:cataclysm-dda-translators:p:cataclysm-dda:r:master-cataclysm-dda]
+# file_filter  = lang/po/<lang>.po
+# source_file  = lang/po/cataclysm-dda.pot
+# source_lang  = en
+# type         = PO
+# minimum_perc = 0
 
 # CDDA credits/motd 资源 —— 暂时停用,避免 pull 时误拉覆盖本仓库文件
 # [o:cataclysm-dda-translators:p:cataclysm-dda:r:credits-master]


### PR DESCRIPTION
## 改动

1. **`build-translations.yml`**: `tx pull -a` → `tx pull -t --force cataclysm-cleanwater-bomb.cataclysm-dda`，只拉取自有项目
2. **`push-translation-template.yml`**: 仓库检查从 `CleverRaven/Cataclysm-DDA` 改为 `LYHGLYTX/Cataclysm-Cleanwater-Bomb`
3. **`.tx/config`**: 停用 CDDA 主 PO 资源段，仅保留 CCB 项目活跃