### PR TITLE
By what right are you angry? This is my RV!

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1499,8 +1499,22 @@ static void sleep()
         return;
     }
 
-    if( !g->warn_player_maybe_anger_local_faction( false, true ) ) {
-        return; // player declined to annoy locals by illegally sleeping in their territory
+    bool may_illegally = false;
+    if( vp ) {
+        vehicle *veh = veh_pointer_or_null( vp );
+        if( veh && !veh->is_owned_by( player_character ) ) {
+            may_illegally = true;
+        }
+    }
+    if( here.has_furn( p ) ) {
+        if( !here.has_flag( "FREE_TO_EXAMINE", p ) ) {
+            may_illegally = true;
+        }
+    }
+    if( may_illegally ) {
+        if( !g->warn_player_maybe_anger_local_faction( false, true ) ) {
+            return; // player declined to annoy locals by illegally sleeping in their territory
+        }
     }
 
     time_duration try_sleep_dur = 24_hours;


### PR DESCRIPTION
####  Summary

Fix the "offensive" logic when sleeping in NPC territory; only illegally occupying facilities should be considered offensive.

#### Purpose of change

I have been bewildered by this since before the inception of CCB, back when I was playing the unstable 0.I releases of DDA. I have always loved the gameplay style of building an RV and wandering across the land. But why is it that when I park my RV outside buildings belonging to NPC factions to rest for the night because it's getting late, the game always prompts me: `You're in the territory of NPCs faction, they probably won't appreciate your actions. Continue anyway?`. This happens near any NPC camp, and it wasn't until I drove my vehicle piece by piece incredibly far away, completely clearing the entire road in front of the Refugee Center, that the prompt finally disappeared... Only then did I realize that I am forbidden from sleeping *anywhere* within territory claimed by NPCs.

By what right are you angry? This is my RV!

Furthermore, the Free Merchants of the Refugee Center, according to the lore, allow beggars who haven't even been accepted as members to sleep in their front lobby. Yet the player is reprimanded just for resting inside their own property merely because they are within the geographical boundaries claimed by these NPCs. This seems highly unreasonable. Is the player's status actually lower than that of a beggar, even after helping the Refugee Center complete so many mission requests?

I looked through the code and found that inside `sleep()`, the logic unconditionally limits the check to `warn_player_maybe_anger_local_faction`. Meanwhile, `warn_player_maybe_anger_local_faction` only checks whether this is a "camp where property cannot be taken freely," which mistakenly treats sleeping in the territory identical to theft, which is bizarre. There is a line of comment following this code that reads: `player declined to annoy locals by illegally sleeping in their territory`. It sounds reasonable on paper, but I don't understand why sleeping remains illegal when the player is so far away from where the NPCs actually rest and isn't even occupying their furniture or other property.

What I find even harder to comprehend is that I located the relevant PR76810 for this chunk of code. The title of this DDA PR is "NPCs get mad if you mess with their property," which sounds logical, but the moment I opened it, I saw a jarring line in the description: "Purpose of change: RUIN THE GAME"??? Why?

Moreover, looking at both the long-standing game behavior and the description of the original PR, this seems to be implemented in the form of a supernatural "telepathy" that requires no eyewitnesses whatsoever. This implementation aligns with neither realism nor gameplay, and I find it quite eerie. However, due to my limited personal capability and the fact that a single PR has its own boundaries, rationalizing modifications for other parts will be left for detailed discussion in the future.

#### Describe the solution

Modified the `sleep()` function by adding a new boolean variable named `may_illegally` before the original `warn_player_maybe_anger_local_faction` check. When a character sleeps inside a vehicle they do not own, or sleeps on furniture that does not allow free interaction (i.e., lacks the `FREE_TO_EXAMINE` flag), `may_illegally` is set to true. The original logic has been changed to execute the faction anger check only when `may_illegally` is true.

This change makes the overall logic much more reasonable, though there might be room for further optimization. The current modification should enhance gameplay while improving realism, but if anyone has better suggestions, feel free to voice them or contribute!

#### Describe alternatives you've considered

Completely reverting the entire upstream PR? However, we still emphasize not deliberately violating realism and adhering to real-world intuition; the logic that an NPC faction gets upset if you mess with their property is fine in principle. It's just... what do you mean by telepathy? What do you mean I'm not even allowed to sleep on the ground outside?

Additionally, I think we can look into adding a feature in the future that allows players to ask NPC factions for lodging permission. If the player possesses such a permit, occupying the NPC camp's furniture during the specified timeframe wouldn't penalize faction relations, since consent was obtained. However, such a feature involves a broader scope of systems and requires further research to implement. When the time comes, we could wrap another `if` statement checking for the "permit" outside the current `may_illegally` check, and if it exists, completely bypass all subsequent "offense" checks.