### PR TITLE
fix(memory): memorize non-connecting terrain reliably (grass rendering black)

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1503,9 +1503,6 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                                                      direction::NORTH ) );
                 }
             }
-            if( !var->invisible[0] ) {
-                here.memory_cache_ter_set_dirty( p.com.pos, false );
-            }
         }
     }
     // tile overrides are already drawn in the previous code

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -645,6 +645,11 @@ bool game::do_turn()
     // avatar processes human input through handle_action()
     if( !u.has_effect( effect_sleep ) || uquit == QUIT_WATCH ) {
         if( u.get_moves() > 0 || uquit == QUIT_WATCH ) {
+            // Tracks the position last memorized inside the step loop below.
+            // Seeded with the turn-start position, which the previous turn's
+            // end-of-turn update_map_memory already recorded, so a turn that is
+            // a single step (the common case) triggers no extra memorise here.
+            tripoint_bub_ms last_memorized_pos = u.pos_bub( m );
             while( u.get_moves() > 0 || uquit == QUIT_WATCH ) {
 
                 // handle_action() may cause map updates, creatures to die
@@ -664,6 +669,24 @@ bool game::do_turn()
                     && ( !u.has_distant_destination() || calendar::once_every( 10_seconds ) ) ) {
                     wait_popup_reset();
                     ui_manager::redraw();
+                    // A single turn can span several steps (roads, speed
+                    // effects, partial-move loops). Each step is rendered by the
+                    // redraw above, but the end-of-turn update_map_memory call
+                    // only sees the avatar's final position, so terrain visible
+                    // only mid-step would never be memorized. That is invisible
+                    // for connecting terrain (re-memorized every pass) but loses
+                    // non-connecting terrain such as grass, which is memorized
+                    // exactly once. Memorize the current field of view whenever
+                    // the avatar has actually moved since the last memorise,
+                    // reusing the visibility cache the redraw just rebuilt. The
+                    // position guard keeps single-step turns (the common case)
+                    // free: their start position was already memorized at the
+                    // previous turn's end.
+                    const tripoint_bub_ms mem_pos = u.pos_bub( m );
+                    if( mem_pos != last_memorized_pos ) {
+                        m.update_map_memory( u );
+                        last_memorized_pos = mem_pos;
+                    }
                 }
 
                 if( queue_screenshot ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -644,6 +644,19 @@ void map::update_map_memory( avatar &you )
                 memorize_vpart_at( here, you, p, invisible );
                 here.memory_cache_dec_set_dirty( p, false );
             }
+            // Clear the terrain-memory dirty flag now that this pass has
+            // memorized the terrain content, mirroring the decoration clear
+            // above. Only in tiles mode: in curses mode the same flag also
+            // gates symbol memorization in map::draw_maptile, which consumes
+            // and clears it there, so clearing it here would starve that path.
+            // (Before, the tiles render path cleared this flag; moving the
+            // clear into this sim pass keeps it in lockstep with the memorize,
+            // so terrain that does not re-dirty itself every pass — anything
+            // without connects_to, e.g. grass — is no longer at risk of having
+            // the flag cleared by a redraw before this pass memorizes it.)
+            if( is_draw_tiles_mode() ) {
+                here.memory_cache_ter_set_dirty( p, false );
+            }
         }
     }
 }


### PR DESCRIPTION
#### 概述 (Summary)
Bugfixes "修复草丛等非连接地形的地图记忆失效——离开视野后渲染成黑 (fix map memory failing for non-connecting terrain such as grass, which rendered black after moving out of view)"

#### 改动目的 (Purpose of change)
玩家报告：草丛（`t_grass` 等**非连接地形**，无 `connects_to`/`rotates_to`）
离开视野后地图记忆失效、渲染成纯黑，而地板/墙/干草正常。这是「模拟/渲染
解耦」阶段 1（#244，把地图记忆写回从渲染路径搬到 sim 侧 pass）留下的两层
回归，已在 master 上。

根因是地形记忆的 dirty 标志（`map_memory_cache_ter`，位语义 true=clean、
false=dirty）被阶段 1 拆成「写入」与「清除」两半且节奏错位。连接地形免疫
（`memorize_terrain_at` 走 `connect_group.any()` 分支每 pass 强制重置脏）；
家具免疫（走独立的、被 `update_map_memory` 正确清除的装饰标志）；非连接
地形只在脏时记忆一次、记完无人补记，没有安全网。两个具体缺陷：

1. **清除位置错**：记忆写入阶段 1 已挪到 sim 侧 `map::update_map_memory`
   （`do_turn` 每回合一次），但清 dirty 标志的代码残留在绘制路径
   `cata_tiles::draw`（每次 redraw 都跑——菜单、动画、FORCE_REDRAW）。任何
   redraw 抢在回合记忆前清了标志 → 该 tile 永不记忆。
2. **节奏漏**：一回合可跨多步（走公路、加速、partial-move 循环——`do_turn`
   的 `while( u.get_moves() > 0 )`），每步都被循环内 redraw 画出，但
   `update_map_memory` 只在循环后跑一次、只看最终位置。只在中间步瞬见的
   草丛漏记。阶段 1 前记忆跑在 `draw` 里**每帧**记，所以每个中间步都捕获；
   挪成每回合单次后丢了这层覆盖。

(English: players reported map memory failing for non-connecting terrain such
as grass (no `connects_to`/`rotates_to`), which renders solid black after
moving out of view, while floors/walls/furniture memorize fine. This is a
two-layer regression from Stage 1 (#244, which moved map-memory write-back out
of the render path into a sim-side pass), already on master. Root cause: the
terrain-memory dirty flag (`map_memory_cache_ter`) had its write and clear
halves split across mismatched cadences. Connecting terrain is immune
(`memorize_terrain_at` force-re-dirties it every pass); furniture is immune
(separate decoration flag, correctly cleared by `update_map_memory`);
non-connecting terrain is memorized exactly once with no safety net. Two
defects: (1) the dirty-flag clear was left behind in the draw path
(`cata_tiles::draw`, every redraw) while the memorize moved to the once-per-turn
sim pass, so any redraw before the turn's memorize clears the flag first and the
memorize is skipped; (2) a turn can span several steps, each rendered by the
in-loop redraw, but `update_map_memory` runs once after the loop and only sees
the final position, so terrain glimpsed only mid-step is never memorized —
before Stage 1 the memorize ran inside `draw` every frame and caught every
step.)

#### 解决方案描述 (Describe the solution)
两个提交：

**1) 把 ter-dirty 清除挪进 sim 记忆 pass（`map.cpp` / `cata_tiles.cpp`）**
- 在 `map::update_map_memory` 里、地形记忆之后清 ter-dirty，与已有的装饰
  标志清除对齐，使「记忆」与「清除」回到同一节奏。
- 用 `is_draw_tiles_mode()` 门控：curses 模式下同一标志还要给
  `map::draw_maptile` 的**符号记忆**用（它在那里消费并自清，且 `map::draw`
  在 tiles 模式 early-return，两条路互不重叠）。不门控会饿死 curses 符号记忆。
- 删除 `cata_tiles::draw` 里残留的清除，使渲染对地图记忆真正纯读
  （正是阶段 1 声称的目标）。

**2) 记忆多步回合的中间步（`do_turn.cpp`）**
- 在循环内 redraw 之后补一次 `update_map_memory`，复用 redraw 刚重建好的
  可见性缓存，恢复阶段 1 之前的逐帧记忆节奏。
- 加位置守卫（`last_memorized_pos`，初值为回合起始位）：仅当玩家相对上次
  记忆**真的移动了**才跑，使单步回合（常见情况）零额外开销，避开
  movement-stutter-perf 老坑。
- 回合末尾的 `update_map_memory` 保留，最终位置与静止回合照常覆盖；总覆盖面
  是旧代码的严格超集。

(English: two commits. (1) Clears ter-dirty inside `map::update_map_memory`
right after the terrain is memorized, mirroring the existing decoration clear,
so memorize and clear share one cadence; gated by `is_draw_tiles_mode()` because
in curses mode the same flag also gates symbol memory in `map::draw_maptile`,
which consumes and clears it there (`map::draw` early-returns in tiles mode, so
the paths never overlap) — without the gate, curses symbol memory would starve.
Removes the orphaned clear from `cata_tiles::draw` so rendering is truly
pure-read. (2) Adds a guarded `update_map_memory` after the in-loop redraw,
reusing the visibility cache the redraw just rebuilt, restoring the pre-Stage-1
per-frame cadence; a position guard skips it when the avatar has not moved since
the last memorize, so single-step turns cost nothing extra. The end-of-turn
`update_map_memory` stays, so the final position and non-movement turns are
still covered — total coverage is a strict superset of the old code.)

#### 你考虑过的替代方案 (Describe alternatives you've considered)
- **直接把绘制路径里的清除改成无条件清+不动 sim pass**：不行——curses 模式
  的符号记忆也靠同一标志，无条件在 sim pass 清会饿死它；必须按 render 模式
  门控。
- **给地形记忆单独再开一个 dirty 标志**：能彻底分离两个消费者，但改动面更
  大、序列化/缓存平移都要跟着加一套，对这个聚焦的 bug 修复不划算。
- **把每步记忆塞回绘制路径**：会重新让渲染对记忆产生写副作用，违背阶段 1
  的纯读目标；改在 sim 循环里复用 redraw 的缓存可保持渲染纯读。

(English: considered making the draw-path clear unconditional and leaving the
sim pass alone — rejected, curses symbol memory rides the same flag and an
unconditional clear in the sim pass would starve it; the clear must be
render-mode-gated. Considered a separate dirty flag for terrain memory — fully
separates the two consumers but is far more invasive (serialization / cache-shift
plumbing) than this focused fix warrants. Considered putting per-step memorize
back in the draw path — that re-introduces a memory write side effect into
rendering, against Stage 1's pure-read goal; reusing the redraw's cache in the
sim loop keeps rendering pure-read.)

#### 测试 (Testing)
- **双构建**：完整 TILES（Release|x64）+ 无头（Release-NoTilesHeadless|x64）
  均编译链接通过，0 错误。
- **进游戏肉眼验证**：走过草丛区（含沿公路快跑、多步穿过）再滚屏离开，草丛
  地图记忆不再变黑；地板/墙/家具记忆无回归。

(English: both TILES (Release|x64) and headless (Release-NoTilesHeadless|x64)
build clean, 0 errors. In-game: walked through grass areas — including fast
multi-step movement along roads — then scrolled away; grass map memory no longer
renders black, and floor/wall/furniture memory shows no regression.)

#### 补充说明 (Additional context)
- 玩法中立的 bug 修复，不夹带数值/玩法改动；净改动 3 文件 +36/−3。
- 是 #244（阶段 1，把记忆写回搬到 sim 侧）的后续修复，与未合并的阶段 2
  ViewSnapshot 工作相互独立。

(English: gameplay-neutral bug fix, no balance/content changes; net 3 files,
+36/−3. A follow-up to #244 (Stage 1, which moved memory write-back to the sim
side), independent of the unmerged Stage 2 ViewSnapshot work.)
