### PR TITLE
fix(memory): prepare the memory region in the sim-side memory pass

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -607,6 +607,18 @@ void map::update_map_memory( avatar &you )
     const int z = you.posz();
     const level_cache &ch = here.access_cache( z );
 
+    // Ensure the player's map-memory cache covers the window this pass is about
+    // to memorize. The render paths (map::draw for curses, cata_tiles for tiles)
+    // prepare this region before memorizing, but Stage 1 moved the memorize into
+    // this sim pass without bringing the prepare along. Without it, set_tile_*
+    // silently no-ops for any tile whose memory submap is not yet allocated
+    // (region edge / freshly entered area), and the dirty flag is still cleared
+    // afterwards — so non-connecting terrain such as grass, which is memorized
+    // exactly once and never re-dirtied, is lost permanently and renders black.
+    you.prepare_map_memory_region(
+        here.get_abs( tripoint_bub_ms( min_visible.x, min_visible.y, z ) ),
+        here.get_abs( tripoint_bub_ms( max_visible.x, max_visible.y, z ) ) );
+
     // Mirrors cata_tiles::apply_visible: a neighbour is "invisible" for
     // orientation purposes if it falls outside the view window or fails the
     // visibility test (anything other than a CLEAR view).


### PR DESCRIPTION
#### 概述 (Summary)
Bugfixes "修复非连接地形（草丛）偶发性丢失地图记忆、离开视野后渲染成黑 (fix intermittent map-memory loss for non-connecting terrain such as grass, rendering black after leaving view)"

#### 改动目的 (Purpose of change)
草丛（`t_grass` 等**非连接地形**，无 `connects_to`）走过、离开视野后**偶发**渲染成纯黑，说明它没被写入玩家地图记忆。连接型地形（墙/地板）从不出问题。这是「模拟/渲染解耦」阶段 1（#244，把地图记忆写入从渲染路径搬到 sim 侧 `map::update_map_memory` pass）留下的又一处漏迁，与已合并的 #262 同源。

根因（用临时探针实机定位）：`update_map_memory` memorize 一个 tile 时调 `avatar::memorize_terrain` → `map_memory::set_tile_terrain`，后者在目标记忆 submap **尚未分配**（`!sm.is_valid()`）时**静默返回、不写记忆**。但 `update_map_memory` 的循环随后**无条件清除该 tile 的 ter-dirty 标志**。于是：记忆没写成功，dirty 却被清了 → 二者失配。连接地形每个 pass 都强制 re-dirty（`memorize_terrain_at` 的 `connect_group.any()` 分支），下个 pass 区域就绪时会重试成功，所以免疫；非连接地形（草丛）一生只在 dirty 时记一次，撞上未分配的 submap 就**永久丢失**，再进视野时 `is_dirty==false` 直接跳过。

记忆缓存区域由 `avatar::prepare_map_memory_region` 预分配。它在两条渲染路径里都被调用——`map::draw`（curses）和 `cata_tiles`（tiles）——会在 memorize 前确保区域覆盖当前视野。但阶段 1 新增的 sim 侧 `update_map_memory` **没有**调用它，直接假设区域已就绪。区域边缘 / 刚进入的新区域的 tile 因此落到未分配的 submap 上，触发上述静默失败。这解释了「偶发」（只在区域边缘触发，取决于移动方向）、「成簇」（沿移动路径成片）、「仅非连接地形」（连接地形靠 re-dirty 重试免疫）。

(English: grass and other non-connecting terrain (`t_grass`, no `connects_to`) intermittently renders solid black after being walked past and leaving view, meaning it was never written to player map memory; connecting terrain never breaks. Another missed migration from Stage 1 (#244, which moved memory writing out of the render path into the sim-side `map::update_map_memory` pass), same family as the merged #262. Root cause, pinned with a temporary probe: when `update_map_memory` memorizes a tile, `map_memory::set_tile_terrain` silently returns without writing if the target memory submap is not yet allocated (`!sm.is_valid()`), yet the loop then unconditionally clears that tile's terrain dirty flag — so the memory was not written but the flag was cleared. Connecting terrain force-re-dirties every pass and retries successfully once the region is ready, hence immune; non-connecting terrain is memorized exactly once and is lost permanently. The memory cache region is pre-allocated by `prepare_map_memory_region`, called by both render paths (`map::draw`, `cata_tiles`) before memorizing, but the Stage-1 sim pass never called it. Tiles at the region edge / freshly entered areas fall on unallocated submaps and hit the silent failure — explaining the intermittent, clustered, non-connecting-only symptom.)

#### 解决方案描述 (Describe the solution)
在 `map::update_map_memory` 的 memorize 循环前，调用 `you.prepare_map_memory_region(...)`，覆盖本 pass 即将遍历的窗口（`min_visible`~`max_visible`，转为绝对坐标），与 `map::draw` / `cata_tiles` 两条渲染路径的做法一致。这样 sim pass memorize 时记忆 submap 必然已分配，`set_tile_terrain` 不再静默失败，草丛在首次可见时即被正确记住。

(English: call `prepare_map_memory_region` over the window this pass is about to iterate (`min_visible`..`max_visible`, converted to absolute coords), just before the memorize loop, mirroring what `map::draw` and `cata_tiles` already do. The memory submap is then guaranteed allocated when the sim pass memorizes, `set_tile_terrain` no longer silently no-ops, and grass is correctly memorized on first sight.)

#### 测试 (Testing)
- 完整 TILES（Release|x64）构建链接通过，0 错误。
- 用临时探针（在 `memorize_terrain_at` 的 `else` 分支记录「可见的非连接地形 dirty=clear 且无现存记忆」的 tile）实机定位：修复前走过草丛区命中 33 条成簇记录；加入本修复后，同样的复现操作探针命中归零，草丛不再变黑。探针为定位用的临时脚手架，未包含在本 PR 中。

(English: full TILES (Release|x64) build links clean, 0 errors. Located with a temporary probe logging visible non-connecting tiles skipped with dirty=clear and no existing memory: 33 clustered hits before the fix when walking through grass; zero hits after the fix on the same repro, and grass no longer renders black. The probe was throwaway diagnostic scaffolding and is not part of this PR.)

#### 补充说明 (Additional context)
玩法中立的 bug 修复，不夹带数值/玩法改动；净改动 1 文件 +12。是 #244（阶段 1）的后续修复，与 #262（草丛记忆节奏回归）同源、互补。

(English: gameplay-neutral bug fix, no balance/content changes; net 1 file, +12. A follow-up to #244 (Stage 1), same family as and complementary to #262 (grass memory cadence regression).)
