### PR TITLE
修复: CI 翻译拉取 tx pull -a（-t 单独不下载文件）

### DIFF
--- a/.github/workflows/build-translations.yml
+++ b/.github/workflows/build-translations.yml
@@ -38,7 +38,7 @@ jobs:
           echo "No TX_TOKEN secret set in this repo, not pulling translations from Transifex"
           exit 1
           fi
-          tx pull -t --force cataclysm-cleanwater-bomb.cataclysm-dda
+          tx pull -a --force -w 2
 
       - name: Discard invalid translations
         run: ./lang/discard_invalid_po.sh


### PR DESCRIPTION
## 问题

PR #256 把 `build-translations.yml` 中的 `tx pull -a --force -w 2` 改成了 `tx pull -t --force cataclysm-cleanwater-bomb.cataclysm-dda`。

但 `tx pull -t` 单独使用不会实际下载翻译文件，导致每次 master CI 构建时 `build-translations` 产出空 artifact（只有 placeholder.po），下游的 `Verify translations` 步骤报错 `No real translations found`。

## 修复

恢复原来 CDDA 的命令 `tx pull -a --force -w 2`。由于 `.tx/config` 中 CDDA 资源已停用，`-a` 只会拉取 CCB 项目，不会误拉 CDDA。

## 验证

本地实测 `tx pull -a` 能正确下载 43 种语言的 .po 文件；CI 构建 12 个目标中除 Android 外均通过。