### PR TITLE
May no need to watch out for Thief Guevara at the expense of performance every single second

### DIFF
--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -572,10 +572,12 @@ bool game::do_turn()
     avatar &u = get_avatar();
     map &m = get_map();
     // If controlling a vehicle that is owned by someone else
-    if( u.in_vehicle && u.controlling_vehicle ) {
-        vehicle *veh = veh_pointer_or_null( m.veh_at( u.pos_bub() ) );
-        if( veh && !veh->handle_potential_theft( u, true ) ) {
-            veh->handle_potential_theft( u, false, false );
+    if( calendar::once_every( 1_minutes ) ) {
+        if( u.in_vehicle && u.controlling_vehicle ) {
+            vehicle *veh = veh_pointer_or_null( m.veh_at( u.pos_bub() ) );
+            if( veh && !veh->handle_potential_theft( u, true ) ) {
+                veh->handle_potential_theft( u, false, false );
+            }
         }
     }
 


### PR DESCRIPTION
####  Summary

Extend the interval of vehicle theft checks in the main process to reduce game stuttering.

#### Purpose of change

Not long ago, we were informed that the content requiring updates every single turn in the code included a `handle_potential_theft` check—which, upon verification, is a function that determines "vehicle theft." None of us in the development team could understand why this function was arranged to "perform tick operations" within the main thread. Since 1 turn in Cataclysm is equivalent to one second, this means it performs operations like map traversal, NPC queries, and faction access once every second.

After a detailed review of the code, I found that this function has a mechanism to completely transfer vehicle ownership based on a time interval. A comment in the relevant code shows: `if there is a marker for having been stolen, but 15 minutes have passed, then officially transfer ownership`. However, this still doesn't answer the question of why it needs to run every second.

Reviewing the calls to the `handle_potential_theft` function, I found that besides the main thread loop in `do_turn`, it is also called in the code of cpp files such as `game`, `map`, `avatar_action`, `veh_interact`, and `handle_action`. This indicates that even if this piece of code is removed from the main thread, the corresponding logic should still execute correctly when the player performs a vehicle theft action. Therefore, it currently appears that the primary purpose of calling this code within the `do_turn` main thread loop—aside from "anti-cheat" (in fact, I don't think such a single-player game has a highly pressing need for anti-cheat)—is that requirement to transfer ownership after 15 minutes. I believe if that's the case, there is absolutely no need to check so frequently.

#### Describe the solution

Within the main thread loop of `do_turn`, wrapped an `if` condition around `handle_potential_theft` using `calendar::once_every( 1_minutes )` as the predicate; this changes the execution frequency from the original once per second to once per minute.

This move should reduce useless performance waste, but since it cannot be 100% guaranteed not to cause subsequent issues, we may still need players to actively cooperate with observations and reports.