### PR TITLE
Bugfixes "修复可堆叠资源在 AIM、拾取信息和 haul 分堆中的数量显示/处理问题"

### DIFF
--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -506,7 +506,7 @@ void advanced_inventory::print_items( side p, bool active )
         }
 
         //print "amount" column
-        int it_amt = sitem.stacks;
+        int it_amt = sitem.amount;
         if( it_amt > 1 ) {
             print_color = thiscolor;
             if( it_amt > 9999 ) {
@@ -682,8 +682,8 @@ struct advanced_inv_sorter {
                 break;
             }
             case SORTBY_STACKS:
-                if( d1.stacks != d2.stacks ) {
-                    return d1.stacks > d2.stacks;
+                if( d1.amount != d2.amount ) {
+                    return d1.amount > d2.amount;
                 }
                 break;
         }

--- a/src/advanced_inv_listitem.cpp
+++ b/src/advanced_inv_listitem.cpp
@@ -15,6 +15,8 @@ advanced_inv_listitem::advanced_inv_listitem( const item_location &an_item, int 
     , contents_count( an_item->aggregated_contents().count )
     , autopickup( get_auto_pickup().has_rule( & * an_item ) )
     , stacks( count )
+    // stacks is always 1 for count_by_charges items, so count * count() == count()
+    , amount( an_item->is_stackable() ? an_item->count() : count )
     , volume( an_item->volume() * stacks )
     , weight( an_item->weight() * stacks )
     , cat( &an_item->get_category_of_contents() )
@@ -35,6 +37,16 @@ advanced_inv_listitem::advanced_inv_listitem( const std::vector<item_location> &
     contents_count( list.front()->aggregated_contents().count ),
     autopickup( get_auto_pickup().has_rule( & * list.front() ) ),
     stacks( list.size() ),
+    amount( [&list]() {
+        int n = 0;
+        for( const item_location &loc : list ) {
+            // Only "stackable" resources fold their charges into the amount
+            // column. Ammo / liquids already show their charge count in the name
+            // (see item::display_name), so counting them here would double up.
+            n += loc->is_stackable() ? loc->count() : 1;
+        }
+        return n;
+    }() ),
     volume( list.front()->volume() * stacks ),
     weight( list.front()->weight() * stacks ),
     cat( &list.front()->get_category_of_contents() ),

--- a/src/advanced_inv_listitem.h
+++ b/src/advanced_inv_listitem.h
@@ -46,10 +46,17 @@ class advanced_inv_listitem
          */
         bool autopickup = false;
         /**
-         * The stack count represented by this item, should be >= 1, should be 1
-         * for anything counted by charges.
+         * The number of item stacks represented by this entry (>= 1).
+         * Used for volume/weight totals.  For display quantity, see @ref amount.
          */
         int stacks = 0;
+        /**
+         * The quantity shown in the amount column. Equals @ref stacks for
+         * discrete items and for ammo/liquids (whose charge count already shows
+         * in the name), but for "stackable" resources it is the summed
+         * charges so the amount column reflects the real quantity.
+         */
+        int amount = 0;
         /**
          * The volume of all the items in this stack, used for sorting.
          */

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -969,7 +969,21 @@ static void haul()
             drop_locations result = selector.execute( true );
             haulable_items.clear();
             for( const drop_location &dl : result ) {
-                haulable_items.push_back( dl.first );
+                if( dl.first->count_by_charges() && dl.second < dl.first->charges ) {
+                    // Partial stack selected: split the item on the ground so the haul
+                    // list gets a correctly-sized item_location.
+                    item_location loc = dl.first;
+                    item_location split_loc = loc.split_stack( dl.second );
+                    if( split_loc ) {
+                        haulable_items.push_back( split_loc );
+                    } else {
+                        debugmsg( "Failed to split %s for hauling, hauling entire stack.",
+                                  dl.first->display_name() );
+                        haulable_items.push_back( dl.first );
+                    }
+                } else {
+                    haulable_items.push_back( dl.first );
+                }
             }
             if( haulable_items != player_character.haul_list ) {
                 player_character.suppress_autohaul = true;

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -58,9 +58,15 @@ static void show_pickup_message( const PickupMap &mapPickup )
 {
     for( const auto &entry : mapPickup ) {
         if( entry.second.first.invlet != 0 ) {
-            add_msg( _( "You pick up: %d %s [%c]" ), entry.second.second,
-                     entry.second.first.display_name( entry.second.second ), entry.second.first.invlet );
-        } else if( entry.second.first.count_by_charges() ) {
+            if( entry.second.first.count_by_charges() && !entry.second.first.is_stackable() ) {
+                // display_name of ammo/liquids already includes the count
+                add_msg( _( "You pick up: %s [%c]" ),
+                         entry.second.first.display_name( entry.second.second ), entry.second.first.invlet );
+            } else {
+                add_msg( _( "You pick up: %d %s [%c]" ), entry.second.second,
+                         entry.second.first.display_name( entry.second.second ), entry.second.first.invlet );
+            }
+        } else if( entry.second.first.count_by_charges() && !entry.second.first.is_stackable() ) {
             add_msg( _( "You pick up: %s" ), entry.second.first.display_name( entry.second.second ) );
         } else {
             add_msg( _( "You pick up: %d %s" ), entry.second.second,


### PR DESCRIPTION
#### 概述 (Summary)
Bugfixes "Fix stackable resource display/count issues in AIM, pickup messages, and haul splitting"
Bugfixes "修复可堆叠资源在 AIM 数量列、拾取信息和 haul 分堆中的数量显示/处理问题"

#### 改动目的 (Purpose of change)

Stackable resources (e.g. firewood, splintered wood) are `count_by_charges() && is_stackable()`, distinct from ammo/liquids (`count_by_charges() && !is_stackable()`) in that their `display_name()` does NOT include the charge count. This caused missing or incorrect quantities in several UIs:

1. **AIM amount column**: always showed 1 (because `stacks` is always 1 for count_by_charges items), making 1 firewood indistinguishable from 50.
2. **Pickup messages**: `"You pick up: firewood"` without any count.
3. **Haul splitting**: user-typed partial stack counts were discarded; the entire stack was always moved.

可堆叠资源（如 firewood、splintered wood）属于 `count_by_charges() && is_stackable()` 类型，与弹药/液体（`count_by_charges() && !is_stackable()`）不同：`display_name()` 不会自带数量。导致：

1. **AIM 数量列**：始终显示 1。
2. **拾取信息**：不显示具体拾取数量。
3. **Haul 分堆**：用户输入的数量被丢弃，整堆被搬走。

#### 解决方案描述 (Describe the solution)

- **AIM**: Added `amount` field to `advanced_inv_listitem`, used in the amount column and `SORTBY_STACKS`. For stackable resources, `amount` = summed charges; for ammo/discrete items, `amount` = `stacks` (preserving existing behavior).
- **Pickup**: All three branches (invlet / ammo / other) now check `&& !is_stackable()`, routing stackable resources to the counted-prefix branch.
- **Haul**: In `haul()` case 2, partial stacks are now physically split on the ground via `item_location::split_stack()` before entering the haul list, so the existing "move all" haul logic handles them correctly.

- **AIM**：新增 `amount` 字段，在数量列和排序中使用。stackable 资源 = 汇总 charges；弹药/离散物品 = `stacks`（保持原行为）。
- **拾取信息**：三处分支均增加 `&& !is_stackable()` 判定。
- **Haul**：case 2 中通过 `split_stack()` 在地面物理拆分后再加入 haul list。

#### 测试 (Testing)

- AIM: stackable resources (firewood) show correct charge count in amount column
- Pickup: "You pick up: 50 firewood" with correct count
- Haul: selecting a partial stack only moves the specified quantity, leaving the remainder
- Ammo/liquids (arrows) unchanged: AIM column still 1, pickup messages don't double-count

- AIM 中 firewood 数量列显示正确 charges 数
- 拾取 firewood 时显示 "You pick up: 50 firewood"
- Haul 选择部分 firewood 后仅搬运指定数量，原地保留剩余
- 弹药（arrows）行为不变：AIM 列仍为 1，拾取信息不重复计数
