### PR TITLE
fix(perf): skip per-turn visibility-cache refresh during view-blocking activities

### DIFF
--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -788,14 +788,20 @@ bool game::do_turn()
     // replenish avatar moves
     u.process_turn();
 
-    // Refresh visibility so update_map_memory operates on a current snapshot.
-    m.update_visibility_cache( u.posz() );
-
     // Update player map memory from the current field of view.  This used to
     // happen lazily inside the tiles draw path; running it here in the sim loop
     // (after the map cache is built, before the visibility cache is
-    // invalidated) lets rendering become pure-read.
-    m.update_map_memory( u );
+    // invalidated) lets rendering become pure-read and keeps memory on the sim
+    // side (required by autodrive / NPC pathing that consume it).
+    // Skip only during view-blocking activities (sleeping / reading / long-wait
+    // / crafting) — the same condition that triggers handle_progress_ui's
+    // wait popup.  During those the player cannot see the world, so per-turn
+    // memorisation is pure waste and the source of the stutter.
+    const bool in_long_wait = u.has_effect( effect_sleep ) ||
+                              static_cast<bool>( u.activity.get_progress_message( u ) );
+    if( !in_long_wait ) {
+        m.update_map_memory( u );
+    }
 
     if( u.get_moves() < 0 && get_option<bool>( "FORCE_REDRAW" ) ) {
         ui_manager::redraw();


### PR DESCRIPTION
#### Summary
Performance "移除等待/活动期间的每回合可见性缓存刷新，消除卡顿"
Performance "Remove per-turn visibility-cache refresh during wait/activity loops to eliminate stutter"

#### Purpose of change

PR #244 将地图记忆更新从 tiles 渲染路径迁移到 do_turn 模拟循环中，
但额外引入的 update_visibility_cache 调用每回合遍历全部 17,424 格
调用 apparent_light_helper，在等待（.）/长等待（|）/读书/睡眠/制作等
活动中造成显著卡顿。

PR #244 moved map-memory update from the tiles draw path into the do_turn
sim loop, but the accompanying update_visibility_cache call iterates all
17,424 tiles per turn calling apparent_light_helper, causing significant
stutter during waiting (.) / long-wait (|) / reading / sleeping /
crafting.

#### Describe the solution

两个改动：
1. 删除 do_turn 中的 update_visibility_cache 调用——该函数已由 game::draw()
   （渲染管线的一部分，通过 handle_progress_ui 自然受活动节流控制）负责刷新。
2. 在视图阻塞活动（与 handle_progress_ui 设置 wait_redraw 完全相同的条件：
   睡眠 / 有进度消息的活动如读书/等待/制作）期间跳过 update_map_memory——
   此时玩家看不见世界，记忆写入纯属浪费。

Two changes:
1. Drop the update_visibility_cache call from do_turn — this is already
   handled by game::draw() (part of the render pipeline, naturally
   throttled during activities by handle_progress_ui).
2. Skip update_map_memory during view-blocking activities (same condition
   that sets handle_progress_ui's wait_redraw: sleeping / any activity
   with a progress message such as reading / waiting / crafting) — the
   player cannot see the world, so memorisation is pure waste.

in_long_wait 判定与 handle_progress_ui 的 wait_redraw 完全一致，
不引入重复逻辑。

The in_long_wait check matches handle_progress_ui's wait_redraw exactly,
introducing no duplicated logic.

#### Describe alternatives you've considered

1. 将 update_map_memory 搬回 game::draw()（渲染路径）——违反 sim-render-decoupling
   规划（规划要求记忆保留在 sim 侧，autodrive/NPC 路径消费它）。
2. 按位置变化跳过——站原地但外界变化（NPC 车辆/建造）时记忆会陈旧。
3. 按 once_every(5_minutes) 节流——重复了 handle_progress_ui 已有的节流分级逻辑。

1. Move update_map_memory back into game::draw() (render path) — violates
   the sim-render-decoupling plan (memory must stay on the sim side;
   autodrive / NPC pathing consume it).
2. Skip by position change — misses external changes (NPC vehicles /
   construction) while stationary.
3. Throttle with once_every(5_minutes) — duplicates handle_progress_ui's
   existing rate-tiering logic.

#### Testing

- 完整 TILES (Release|x64) 编译通过，0 错误。
- 进游戏按 . 等待和 | 长等待，卡顿消失。

- Full TILES (Release|x64) builds clean with 0 errors.
- In-game: wait (.) and long-wait (|) — stutter eliminated.

#### Additional context

Related: PR #244 (feat/stage1-memory-pass-b), commit 486bc6f590
(perf optimization that identified apparent_light_helper as a hotspot).