### PR TITLE
实现智能衡量物品

### DIFF
--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4494,7 +4494,6 @@ void itype::load( const JsonObject &jo, std::string_view src )
     optional( jo, was_loaded, "integral_weight", integral_weight, not_negative_mass, -1_gram );
     optional( jo, was_loaded, "volume", volume );
     optional( jo, was_loaded, "longest_side", longest_side, -1_mm );
-    optional( jo, was_loaded, "display_type", display_type, item_display_type::DEFAULT );
     optional( jo, was_loaded, "price", price, not_negative_money, 0_cent );
     optional( jo, was_loaded, "price_postapoc", price_post, not_negative_money, -1_cent );
     optional( jo, was_loaded, "stackable", stackable_ );
@@ -4583,6 +4582,15 @@ void itype::load( const JsonObject &jo, std::string_view src )
 
     optional( jo, was_loaded, "chat_topics", chat_topics );
     optional( jo, was_loaded, "phase", phase, phase_id::SOLID );
+    item_display_type default_display_type = item_display_type::DEFAULT;
+    if( get_option<bool>( "SMART_DEFAULT_DISPLAY_TYPE" ) ) {
+        if( phase == phase_id::LIQUID ) {
+            default_display_type = item_display_type::BY_VOLUME;
+        } else if( volume < 10_ml && longest_side < 10_mm ) {
+            default_display_type = item_display_type::BY_WEIGHT;
+        }
+    }
+    optional( jo, was_loaded, "display_type", display_type, default_display_type );
 
     optional( jo, was_loaded, "nanofab_template_group", nanofab_template_group );
 

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -137,7 +137,7 @@ std::string itype::item_measure_prefix( unsigned int quantity, item_display_type
         result = weight_to_string( weight * quantity, true, true );
     } else if( display_type == item_display_type::BY_VOLUME || (!force && perfered == item_display_type::BY_VOLUME) ) {
         result = vol_to_string( count_by_charges() &&
-                                stack_size > 0 ? volume : volume * quantity, true, true );
+                                stack_size > 0 ? volume : units::volume(volume * quantity), true, true );
     } else if( display_type == item_display_type::BY_LENGTH || (!force && perfered == item_display_type::BY_LENGTH) ) {
         // Note: item::length() has some special cases where this might not work well!
         result = length_to_string( longest_side * quantity, true );

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -128,30 +128,26 @@ std::string itype::get_item_type_string() const
     return "misc";
 }
 
-std::string itype::item_measure_prefix( unsigned int quantity ) const
+std::string itype::item_measure_prefix( unsigned int quantity, item_display_type perfered ) const
 {
     const std::string option = get_option<std::string>( "MEASURE_PREFIX" );
-    std::string fmt;
-    if( option == "both" ) {
-        fmt = "%1$s,%2$d";
-    } else if( option == "unit" ) {
-        fmt = "%1$s";
-    } else {
-        return std::to_string( quantity );
-    }
-    if( display_type == item_display_type::BY_WEIGHT ) {
-        return string_format( fmt, weight_to_string( weight * quantity, true, true ), quantity );
-    } else if( display_type == item_display_type::BY_VOLUME ) {
-        units::volume volume_per_charge = volume;
-        if( count_by_charges() && stack_size > 0 ) {
-            volume_per_charge = volume / stack_size;
-        }
-        return string_format( fmt, vol_to_string( volume_per_charge * quantity, true, true ), quantity );
-    } else if( display_type == item_display_type::BY_LENGTH ) {
+    const bool force = get_option<bool>( "FORCE_DISPLAY_TYPE" );
+    std::string result;
+    if( display_type == item_display_type::BY_WEIGHT || (!force && perfered == item_display_type::BY_WEIGHT)  ) {
+        result = weight_to_string( weight * quantity, true, true );
+    } else if( display_type == item_display_type::BY_VOLUME || (!force && perfered == item_display_type::BY_VOLUME) ) {
+        result = vol_to_string( count_by_charges() &&
+                                stack_size > 0 ? volume : volume * quantity, true, true );
+    } else if( display_type == item_display_type::BY_LENGTH || (!force && perfered == item_display_type::BY_LENGTH) ) {
         // Note: item::length() has some special cases where this might not work well!
-        return string_format( fmt, length_to_string( longest_side * quantity, true ), quantity );
+        result = length_to_string( longest_side * quantity, true );
+    } else if( option == "count" ) {
+        result = std::to_string( quantity );
     }
-    return std::to_string( quantity );
+    if( option == "both" ) {
+        result += std::to_string( quantity );
+    }
+    return result;
 }
 
 std::string itype::nname( unsigned int quantity ) const

--- a/src/itype.h
+++ b/src/itype.h
@@ -1727,7 +1727,8 @@ struct itype {
 
         std::string get_item_type_string() const;
 
-        std::string item_measure_prefix( unsigned int quantity ) const;
+        std::string item_measure_prefix( unsigned int quantity,
+                                         item_display_type perfered = item_display_type::DEFAULT ) const;
 
         // Returns the name of the item type in the correct language and with respect to its grammatical number,
         // based on quantity (example: item type "anvil", nname(4) would return "anvils" (as in "4 anvils").

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1886,6 +1886,14 @@ void options_manager::add_options_interface()
         { { "both", to_translation( "Both" ) }, { "unit", to_translation( "Unit" ) }, { "count", to_translation( "Count" ) } },
         "both"
            );
+        add( "FORCE_MEASURE_PREFIX", page_id, to_translation( "Force measure prefix" ),
+             to_translation( "Force using Item measure prefix option in some context (current only affect tank/ammo in vehicle UI)." ),
+             false
+           );
+        add( "SMART_DEFAULT_DISPLAY_TYPE", page_id, to_translation( "Smart default display type" ),
+             to_translation( "Auto-eval the default measure display type of item.  Liquid would display by volume.  Item that volume < 10ml and longest side < 10mm would display by weight.  JSON field display_type will override this option." ),
+             true
+           );
     } );
 
     add_empty_line();
@@ -3203,6 +3211,8 @@ void options_manager::add_options_debug()
          false
 #endif
        );
+
+    add_empty_line();
 
     add( "NO_ERROR_POPUP", "debug", to_translation( "No error popup" ),
          to_translation( "If enabled, debug message won't popup on the screen." ),

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -1461,9 +1461,11 @@ void veh_interact::calc_overview( map &here )
                         fmtstring = str_cat( "%s %s ", leak_marker, "%s", leak_marker );
                         offset = 0;
                     }
+                    std::string amoo_left = pt_ammo_cur.item_measure_prefix( pt.ammo_remaining(),
+                                            pt_ammo_cur->phase == phase_id::LIQUID ? item_display_type::BY_VOLUME :
+                                            item_display_type::DEFAULT );
                     right_print( w, y, offset, pt_ammo_cur->color,
-                                 string_format( fmtstring, specials, pt_ammo_cur->nname( 1 ),
-                                                pt_ammo_cur->item_measure_prefix( pt.ammo_remaining() ) ) );
+                                 string_format( fmtstring, specials, pt_ammo_cur->nname( 1 ), amoo_left ) );
                 } else {
                     if( pt.is_leaking() ) {
                         std::string outputstr = str_cat( leak_marker, "      ", leak_marker );
@@ -1474,17 +1476,18 @@ void veh_interact::calc_overview( map &here )
             auto no_tank_details = []( const vehicle_part & pt, const catacurses::window & w, int y ) {
                 if( !pt.ammo_current().is_null() ) {
                     const itype *pt_ammo_cur = item::find_type( pt.ammo_current() );
-                    double vol_L = to_liter( pt.ammo_remaining( ) * 250_ml /
-                                             pt_ammo_cur->stack_size );
+                    const std::string amount = pt_ammo_cur->item_measure_prefix(
+                                                    pt.ammo_remaining(),
+                                                    pt_ammo_cur->phase == phase_id::LIQUID ? item_display_type::BY_VOLUME :
+                                                    item_display_type::DEFAULT );
                     int offset = 1;
-                    std::string fmtstring = "%s  %5.1fL";
+                    std::string fmtstring = "%s  %s";
                     if( pt.is_leaking() ) {
-                        fmtstring = str_cat( "%s  ", leak_marker, "%5.1fL", leak_marker );
+                        fmtstring = str_cat( "%s  ", leak_marker, "%s", leak_marker );
                         offset = 0;
                     }
                     right_print( w, y, offset, pt_ammo_cur->color,
-                                 string_format( fmtstring, item::nname( pt.ammo_current() ),
-                                                round_up( vol_L, 1 ) ) );
+                                 string_format( fmtstring, item::nname( pt.ammo_current() ), amount ) );
                 }
             };
 

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -1461,7 +1461,7 @@ void veh_interact::calc_overview( map &here )
                         fmtstring = str_cat( "%s %s ", leak_marker, "%s", leak_marker );
                         offset = 0;
                     }
-                    std::string amoo_left = pt_ammo_cur.item_measure_prefix( pt.ammo_remaining(),
+                    std::string amoo_left = pt_ammo_cur->item_measure_prefix( pt.ammo_remaining(),
                                             pt_ammo_cur->phase == phase_id::LIQUID ? item_display_type::BY_VOLUME :
                                             item_display_type::DEFAULT );
                     right_print( w, y, offset, pt_ammo_cur->color,


### PR DESCRIPTION
<!-- 使用说明：在下面每个「#### 标题」下填写与你的 PR 相关的信息。
请保留这些标题。像这样的注释可以安全删除。

如果你是在 GitHub 网页界面发起这个 PR，可以用「preview（预览）」按钮查看 PR 对他人显示的样子。

PR 提交准则：
- 让你的改动只聚焦于一个具体的问题或变更，外加为实现它所必需的最小相关改动。
- 一个经验法则：大多数 PR 的改动应少于 500 行。
- 你可以另开 PR 来拆分一次较大的预期改动；如果不确定怎么拆，尽管问。我们很乐意与你协作，并建议合并你 PR 的最佳方式。
-->

#### 概述 (Summary)
Interface "实现智能衡量物品"

<!-- 这一节应当只有一行，请编辑上面那一行。
1. 把「分类」替换为下列具体分类之一：Features、Content、Interface、Mods、Balance、Bugfixes、Performance、Infrastructure、Build、I18N。
2. 把引号内的文字替换为对你改动的简要描述。
如果你不希望生成更新日志条目，把整行替换为单独一个词「None」（不带引号）。
示例：
1. None
2. Bugfixes "修复长矛无法锁定不同楼层敌人的问题"
3. Interface "在制作界面显示制作失败几率"
分类含义详见：
https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/blob/master/doc/CHANGELOG_GUIDELINES.md
合并后，你的概述会被加入项目更新日志：
https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/blob/master/data/changelog.txt -->

#### 改动目的 (Purpose of change)

<!-- 用几句话描述你做这次改动的原因。
如果它与某个已有 issue 相关，可以用「#」加 GitHub issue 编号来关联，例如 #1234。

【重要】当你的 PR 能完全解决某个 issue 时，必须使用 [GitHub 的英文关闭关键字](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
才能在 PR 合并后自动关闭该 issue，例如：Fixes #1234。
只能用以下英文关键词（后面紧跟「#编号」）：
  close / closes / closed
  fix / fixes / fixed
  resolve / resolves / resolved
注意：中文「修复 #1234」不会触发自动关闭，GitHub 只识别上述英文关键词。

如果没有相关 issue，请在这里说明你要解决的问题、特性或其他关注点。如果这是一个 bug 修复，请附上复现原始 bug 的步骤，以便你的修复可以被验证。 -->
- 为物品手动设置 display_type 是一项十分耗时的工作，对于部分特征显著的物品来说没有必要。
- 载具 UI 内的油箱始终遵循“Item measure prefix”选项，不显示内容物体积。

#### 解决方案描述 (Describe the solution)

- 加入“Smart default display type”选项，在加载物品时自动评估物品的默认计量单位显示类型。液体将按体积显示。体积小于 10 毫升且最长边小于 10 毫米的物品将按重量显示。JSON 字段 display_type 将覆盖此选项。默认为开。
- 加入“Force measure prefix”选项，在某些情况下强制使用“Item measure prefix”选项（目前仅影响载具界面中的油箱/弹药）。默认为关。

这些选项可能被删除，如果效果稳定或没有对应的配置需求。

#### 你考虑过的替代方案 (Describe alternatives you've considered)

- 为油箱手动格式化体积，不使用此辅助函数（回滚 DDA 的更改）。

#### 测试 (Testing)

<!-- 描述你采取了哪些步骤来测试这个 PR 是否修复了 bug 或添加了特性，以及你做了哪些测试以确保没有引入回归问题。也请为审阅者和维护者提供测试建议。参见 TESTING_YOUR_CHANGES.md -->
- 注：油箱显示的体积会与使用衡量方法之前不一致，因为二者使用了不同的格式化方法。

#### 补充说明 (Additional context)

<!-- 在此添加关于这个特性或 bug 修复的其他背景信息（例如原型图、概念验证或截图）。 -->


<!--README: Cataclysm: Cleanwater Bomb (CCB) 以 Creative Commons Attribution ShareAlike 3.0 许可证发布。
游戏的代码与内容可自由用于任何目的的使用、修改和再分发。
通过为本项目做贡献，你即同意该许可证的条款，并同意你所做的任何贡献也将受同一许可证覆盖。
详见 http://creativecommons.org/licenses/by-sa/3.0/ 。 -->