### PR TITLE
补充PR #240 遗漏的doc文件

### DIFF
--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -491,6 +491,8 @@ Character flags can be `trait_id`, `json_flag_id` or `flag_id`.  Some of these a
 - ```WEB_WALKER``` Removes the movement speed demerit while walking through webs.
 - ```WINGGLIDE``` You can glide using some part of your body and strenuous physical effort.
 - ```mycus``` acts as `THRESH_MYCUS`, makes all monsters with FUNGUS species friendly, fungicidal gas & antifungal pills cause worse effects.  Mutate when eating mycus fruit, or when sleeping.
+- ```GENDER_FLUIDITY``` Allows characters to change their gender by bypassing the `PLAYER_ARBITRARY_CHANGE_GENDER` option.
+- ```GENDER_INVARIANCE``` Preventing players from directly switching genders through the menu under any circumstances. It will override `GENDER_FLUIDITY` flag.
 
 
 ### Mutation Categories


### PR DESCRIPTION
在巡检过去的pr时，我发现我曾经的pr #240 新增了两个与性别切换控制有关的character json flags，但仅仅在`flags.json`文件里填写了注释，没有更新项目doc文档说明。本pr是对此缺漏进行的补充。