### PR TITLE
feral human is no longer a Guinness World Record holder for stone throwing

### DIFF
--- a/data/json/monster_special_attacks/monster_gun.json
+++ b/data/json/monster_special_attacks/monster_gun.json
@@ -167,7 +167,7 @@
     "to_hit": { "grip": "solid", "length": "hand", "surface": "any", "balance": "neutral" },
     "loudness": 2,
     "range": 6,
-    "dispersion": 150,
+    "dispersion": 975,
     "durability": 8,
     "pocket_data": [
       {


### PR DESCRIPTION
####  Summary

Balance: Massively increase the Base Dispersion of the fake gun used by the feral human's "stone throwing" attack action.

#### Purpose of change

I am sick and tired of players mocking the game design by saying, "The rocks thrown carelessly by feral humans in this game are more accurate than an AK-47." I originally wanted to refute them, but when I opened our json data, I was shocked to find that the AK-47 has a Base Dispersion of 180, while the fake gun used by our glorious feral humans for casual rock throwing has a Base Dispersion of only 150! Oh my sweet Holy Mary, the homemade firearms made out of seamless steel tubes by our @ have a minimum dispersion of 500+, so how on earth do these feral humans manage to rival "feeble firearms" relying solely on their mortal flesh and blood without any mechanical modifications? Is this the divine power of the blob?

I checked how the other branch CBN handled this. They dealt with this issue a month ago, and this is what they said in their PR:

```
As of now, feral humans are apparently all pro mlb pitchers who are able to consistently hit the player with thrown rocks. This isn't very accurate to how well an average person would actually be able to throw a rock at another person. We also don't use ferals throwing rocks to be annoying like in dda, as they can't actually spawn until at least a week or two has passed, so the whole thing of having a weak ranged attack to discourage roof camping is moot anyways.

...

Massively increases the dispersion of the hurled rubble fake gun to 6000 from 150, so they actually miss about half the time like some random person throwing rocks at you would. For reference, 150 dispersion is about equivalent to an actual gun.
```

Given that our CCB (Cataclysm: Cleanwater Bomb) has just recently split from DDA, our feral humans also spawn right from the start. Feral humans are indeed part of the intended challenge, but we do not share the philosophy of "having a weak ranged attack to discourage roof camping." Neither keeping the current world-class professional athlete level nor directly adopting CBN's ultra-high dispersion seems entirely appropriate, so I decided to take a middle ground.

#### Describe the solution

Found that the base dispersion of homemade shotgun-type firearms falls roughly within the range of 855 to 900. Now, the base dispersion of the fake gun `feral_human_thrown_rock` is set to 975. This will make the accuracy of the feral human's rock-throwing attack almost completely incomparable to any firearm, yet it still retains a certain degree of accuracy.

#### Test

Only modified a single piece of json data; no issues were found during testing.