### PR TITLE
Infrastructure "瞬态视觉层：handle 系统 + bubble 生命周期 + 异步 SCT/高亮 (Stage 2D)" / Transient visual layer: handle system + bubble lifecycle + async SCT/highlights

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2060,9 +2060,12 @@ effect_handle cata_tiles::start_creature_move_anim( const tripoint_abs_ms &from_
         anim.curve = move_anim_curve::smooth;
     }
     // New animation overwrites any prior one for this creature and plays from 0.
+    // If a glide was already in flight to this tile, drop its stale handle.
+    if( auto old = m_creature_anims.find( to_abs ); old != m_creature_anims.end() ) {
+        m_handle_index.erase( old->second.handle );
+    }
     m_creature_anims[to_abs] = anim;
-    const effect_handle h = alloc_handle( effect_kind::creature_move,
-                                          &m_creature_anims[to_abs] );
+    const effect_handle h = alloc_handle( effect_kind::creature_move );
     m_creature_anims[to_abs].handle = h;
     return h;
 }
@@ -2126,7 +2129,12 @@ void cata_tiles::advance_creature_move_anims()
     }
     for( auto it = m_creature_attack_anims.begin(); it != m_creature_attack_anims.end(); ) {
         it->second.progress += it->second.per_ms * static_cast<float>( dt );
-        if( it->second.progress >= 1.0f ) {
+        bool erase_this = ( it->second.progress >= 1.0f );
+        if( !erase_this && !here.inbounds( here.get_bub( it->first ) ) ) {
+            erase_this = true;
+        }
+        if( erase_this ) {
+            m_handle_index.erase( it->second.handle );
             it = m_creature_attack_anims.erase( it );
         } else {
             ++it;
@@ -2159,24 +2167,27 @@ effect_handle cata_tiles::start_creature_hit_anim( const tripoint_abs_ms &pos_ab
         anim.dir_tiles = point::zero;
     }
     // Restart from the top if the creature is hit again mid-reaction.
+    // If a hit reaction was already playing, drop its stale handle first.
+    if( auto old = m_creature_hit_anims.find( pos_abs ); old != m_creature_hit_anims.end() ) {
+        m_handle_index.erase( old->second.handle );
+    }
     m_creature_hit_anims[pos_abs] = anim;
-    const effect_handle h = alloc_handle( effect_kind::creature_hit,
-                                          &m_creature_hit_anims[pos_abs] );
+    const effect_handle h = alloc_handle( effect_kind::creature_hit );
     m_creature_hit_anims[pos_abs].handle = h;
     return h;
 }
 
-void cata_tiles::start_creature_attack_anim( const tripoint_abs_ms &pos_abs,
+effect_handle cata_tiles::start_creature_attack_anim( const tripoint_abs_ms &pos_abs,
         const point &dir_tiles, bool is_player )
 {
     if( !get_option<bool>( "CREATURE_ATTACK_ANIM" ) ) {
-        return;
+        return 0;
     }
     if( is_player && !get_option<bool>( "PLAYER_ATTACK_ANIM" ) ) {
-        return;
+        return 0;
     }
     if( dir_tiles.x == 0 && dir_tiles.y == 0 ) {
-        return;
+        return 0;
     }
     const float total_ms = std::max( 1, get_option<int>( "CREATURE_ATTACK_ANIM_TIME" ) );
     creature_attack_anim anim;
@@ -2184,7 +2195,14 @@ void cata_tiles::start_creature_attack_anim( const tripoint_abs_ms &pos_abs,
     anim.per_ms = 1.0f / total_ms;
     anim.dist_tiles = 0.5f;
     anim.dir_tiles = dir_tiles;
+    // If an attack lunge was already playing, drop its stale handle first.
+    if( auto old = m_creature_attack_anims.find( pos_abs ); old != m_creature_attack_anims.end() ) {
+        m_handle_index.erase( old->second.handle );
+    }
     m_creature_attack_anims[pos_abs] = anim;
+    const effect_handle h = alloc_handle( effect_kind::creature_attack );
+    m_creature_attack_anims[pos_abs].handle = h;
+    return h;
 }
 
 point cata_tiles::player_to_screen( const point_bub_ms &pos ) const
@@ -5090,8 +5108,7 @@ effect_handle cata_tiles::init_explosion_light( const std::map<tripoint_bub_ms, 
     a.shock_target = shock_target;
     a.shock_half_angle = shock_half_angle;
     m_explosion_lights.push_back( std::move( a ) );
-    const effect_handle h = alloc_handle( effect_kind::explosion_light,
-                                          &m_explosion_lights.back() );
+    const effect_handle h = alloc_handle( effect_kind::explosion_light );
     m_explosion_lights.back().handle = h;
     return h;
 }
@@ -5185,8 +5202,8 @@ effect_handle cata_tiles::init_bullet_anim( const std::vector<tripoint_bub_ms> &
     anim.start_delay_ms = std::min( max_stagger_ms,
                                     burst_gap_ms * static_cast<float>( pending ) );
     m_bullet_anims.push_back( std::move( anim ) );
-    const effect_handle h = alloc_handle( effect_kind::bullet,
-                                          &m_bullet_anims.back() );
+    const effect_handle h = alloc_handle( effect_kind::bullet );
+
     m_bullet_anims.back().handle = h;
     return h;
 }
@@ -5371,8 +5388,9 @@ void cata_tiles::void_custom_explosion()
 }
 void cata_tiles::void_explosion_light()
 {
-    // Drop every active blast at once (scene reset / renderer recovery). Normal
-    // completion is handled per-blast by advance_explosion_lights().
+    for( const active_explosion_light &a : m_explosion_lights ) {
+        m_handle_index.erase( a.handle );
+    }
     m_explosion_lights.clear();
     m_explosion_light_last_ms.reset();
     clear_shockwaves();
@@ -5447,8 +5465,8 @@ effect_handle cata_tiles::init_sct( const tripoint_bub_ms &pos, const std::strin
     eff.elapsed_ms = 0.0f;
     eff.screen_y_offset = 0.0f;
     m_sct_effects.push_back( std::move( eff ) );
-    const effect_handle h = alloc_handle( effect_kind::sct,
-                                          &m_sct_effects.back() );
+    const effect_handle h = alloc_handle( effect_kind::sct );
+
     m_sct_effects.back().handle = h;
     return h;
 }
@@ -5523,10 +5541,10 @@ void cata_tiles::draw_sct_frame( int view_z,
 
 // --- Handle system ---
 
-effect_handle cata_tiles::alloc_handle( effect_kind kind, void *ptr )
+effect_handle cata_tiles::alloc_handle( effect_kind kind )
 {
     const effect_handle h = m_next_handle++;
-    m_handle_index[h] = { kind, ptr };
+    m_handle_index[h] = { kind };
     return h;
 }
 
@@ -5558,6 +5576,11 @@ void cata_tiles::cancel_effect( effect_handle h )
         case effect_kind::creature_hit:
             for( auto e = m_creature_hit_anims.begin(); e != m_creature_hit_anims.end(); ++e ) {
                 if( e->second.handle == h ) { m_creature_hit_anims.erase( e ); return; }
+            }
+            break;
+        case effect_kind::creature_attack:
+            for( auto e = m_creature_attack_anims.begin(); e != m_creature_attack_anims.end(); ++e ) {
+                if( e->second.handle == h ) { m_creature_attack_anims.erase( e ); return; }
             }
             break;
         case effect_kind::sct:
@@ -5604,8 +5627,8 @@ effect_handle cata_tiles::add_highlight( const tripoint_bub_ms &pos, float durat
     h.pos = pos;
     h.life_ms = duration_ms;
     m_highlights.push_back( h );
-    const effect_handle hl = alloc_handle( effect_kind::highlight,
-                                           &m_highlights.back() );
+    const effect_handle hl = alloc_handle( effect_kind::highlight );
+
     m_highlights.back().handle = hl;
     return hl;
 }
@@ -5998,6 +6021,9 @@ void cata_tiles::draw_bullet_anim_frame( int view_z )
 }
 void cata_tiles::void_bullet_anim()
 {
+    for( const active_bullet_anim &a : m_bullet_anims ) {
+        m_handle_index.erase( a.handle );
+    }
     m_bullet_anims.clear();
     m_bullet_anim_last_ms.reset();
 }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -601,6 +601,8 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
     advance_explosion_lights();
     // Advance asynchronous bullet animations the same way.
     advance_bullet_anims();
+    // Advance asynchronous SCT floating labels the same way.
+    advance_sct();
     // Advance the sound-driven screen shake decay.
     advance_screen_shake_frame();
 
@@ -1630,7 +1632,8 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                    has_bullet_anim() ||
                    do_draw_bullet || do_draw_hit || do_draw_line ||
                    do_draw_cursor || do_draw_highlight || do_draw_weather ||
-                   do_draw_sct || do_draw_zones || do_draw_async_anim;
+                   do_draw_sct || do_draw_zones || do_draw_async_anim ||
+                   has_sct();
 
     draw_footsteps_frame( center );
     if( in_animation ) {
@@ -1666,6 +1669,9 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
         if( do_draw_sct ) {
             draw_sct_frame( overlay_strings );
             void_sct();
+        }
+        if( has_sct() ) {
+            draw_sct_frame( center.z(), overlay_strings );
         }
         if( do_draw_zones ) {
             draw_zones_frame();
@@ -5395,6 +5401,83 @@ void cata_tiles::void_weather()
 void cata_tiles::void_sct()
 {
     do_draw_sct = false;
+}
+
+// --- Asynchronous SCT (Scrolling Combat Text) ---
+
+void cata_tiles::init_sct( const tripoint_bub_ms &pos, const std::string &text,
+                           nc_color color, float duration_ms )
+{
+    sct_effect eff;
+    eff.pos = pos;
+    eff.text = text;
+    eff.color = color;
+    eff.duration_ms = duration_ms;
+    eff.elapsed_ms = 0.0f;
+    eff.screen_y_offset = 0.0f;
+    m_sct_effects.push_back( std::move( eff ) );
+}
+
+void cata_tiles::advance_sct()
+{
+    if( m_sct_effects.empty() ) {
+        m_sct_last_ms.reset();
+        return;
+    }
+    const int64_t dt = capped_frame_dt_ms( m_sct_last_ms );
+    if( dt <= 0 ) {
+        return;
+    }
+    const float dt_s = static_cast<float>( dt ) / 1000.0f;
+    for( auto it = m_sct_effects.begin(); it != m_sct_effects.end(); ) {
+        it->elapsed_ms += static_cast<float>( dt );
+        it->screen_y_offset -= it->rise_speed_px_per_s * dt_s;
+        if( it->elapsed_ms >= it->duration_ms ) {
+            it = m_sct_effects.erase( it );
+        } else {
+            ++it;
+        }
+    }
+}
+
+void cata_tiles::draw_sct_frame( int view_z,
+                                 std::multimap<point, formatted_text> &overlay_strings )
+{
+    const bool use_font = get_option<bool>( "ANIMATION_SCT_USE_FONT" );
+    for( const sct_effect &eff : m_sct_effects ) {
+        if( eff.pos.z() != view_z ) {
+            continue;
+        }
+        const float alpha = 1.0f - ( eff.elapsed_ms / eff.duration_ms );
+        if( alpha <= 0.0f ) {
+            continue;
+        }
+
+        const point screen_p = player_to_screen( eff.pos.xy() ) +
+                               point( 0, static_cast<int>( eff.screen_y_offset ) );
+        const int FG = eff.color.to_color_pair_index();
+
+        if( use_font ) {
+            overlay_strings.emplace(
+                screen_p,
+                formatted_text( eff.text, FG, text_alignment::center ) );
+        } else {
+            int cx = 0;
+            for( const char ch : eff.text ) {
+                const std::string generic_id = get_ascii_tile_id(
+                    static_cast<uint32_t>( static_cast<unsigned char>( ch ) ), FG, -1 );
+                if( tileset_ptr->find_tile_type( generic_id ) ) {
+                    const point char_p = screen_p + point( cx * tile_width, 0 );
+                    if( const std::optional<point> tile_p = tile_to_player( char_p ) ) {
+                        draw_from_id_string( generic_id, TILE_CATEGORY::NONE, empty_string,
+                                             tripoint_bub_ms( point_bub_ms( *tile_p ), eff.pos.z() ),
+                                             0, 0, lit_level::LIT, false );
+                    }
+                }
+                ++cx;
+            }
+        }
+    }
 }
 void cata_tiles::void_zones()
 {

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -594,17 +594,11 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
 
     has_animated_tiles_ = false;
 
-    // Advance creature move glides by real elapsed time before drawing so each
-    // sprite's offset reflects the current frame.
-    advance_creature_move_anims();
-    // Advance asynchronous explosion light overlays the same way.
-    advance_explosion_lights();
-    // Advance asynchronous bullet animations the same way.
-    advance_bullet_anims();
-    // Advance asynchronous SCT floating labels the same way.
-    advance_sct();
-    // Advance the sound-driven screen shake decay.
-    advance_screen_shake_frame();
+    // Advance all real-time transient effects (explosion lights, bullet
+    // tracers, creature glides, SCT labels, highlights, screen shake)
+    // by the elapsed wall-clock time before drawing so every sprite
+    // reflects the current frame.
+    advance_all_transient_effects();
 
     {
         //set clipping to prevent drawing over stuff we shouldn't
@@ -1633,7 +1627,7 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                    do_draw_bullet || do_draw_hit || do_draw_line ||
                    do_draw_cursor || do_draw_highlight || do_draw_weather ||
                    do_draw_sct || do_draw_zones || do_draw_async_anim ||
-                   has_sct();
+                   has_sct() || has_highlight();
 
     draw_footsteps_frame( center );
     if( in_animation ) {
@@ -1684,6 +1678,9 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
         if( do_draw_highlight ) {
             draw_highlight();
             void_highlight();
+        }
+        if( has_highlight() ) {
+            draw_highlights( center.z() );
         }
         if( do_draw_async_anim ) {
             draw_async_anim();
@@ -2023,15 +2020,15 @@ static float lunge_out_and_back( float t )
     }
 }
 
-void cata_tiles::start_creature_move_anim( const tripoint_abs_ms &from_abs,
+effect_handle cata_tiles::start_creature_move_anim( const tripoint_abs_ms &from_abs,
         const tripoint_abs_ms &to_abs, bool is_player )
 {
     if( !get_option<bool>( "CREATURE_MOVE_ANIM" ) ) {
-        return;
+        return 0;
     }
     // The avatar's glide is additionally gated on the separate player option.
     if( is_player && !get_option<bool>( "PLAYER_MOVE_ANIM" ) ) {
-        return;
+        return 0;
     }
     const tripoint_rel_ms d = from_abs - to_abs;
     // A no-op "move" to the same tile happens when game::update_map re-sets the
@@ -2039,13 +2036,13 @@ void cata_tiles::start_creature_move_anim( const tripoint_abs_ms &from_abs,
     // NOT erase the glide the real move just registered, or the player never
     // animates. Leave any in-flight animation untouched.
     if( d.x() == 0 && d.y() == 0 && d.z() == 0 ) {
-        return;
+        return 0;
     }
     // Snap z-changes and teleports (jumps further than one tile): drop any stale
     // animation at the destination so the sprite appears instantly.
     if( d.z() != 0 || std::abs( d.x() ) > 1 || std::abs( d.y() ) > 1 ) {
         m_creature_anims.erase( to_abs );
-        return;
+        return 0;
     }
 
     const float total_ms = std::max( 1, get_option<int>( "CREATURE_MOVE_ANIM_TIME" ) );
@@ -2064,6 +2061,10 @@ void cata_tiles::start_creature_move_anim( const tripoint_abs_ms &from_abs,
     }
     // New animation overwrites any prior one for this creature and plays from 0.
     m_creature_anims[to_abs] = anim;
+    const effect_handle h = alloc_handle( effect_kind::creature_move,
+                                          &m_creature_anims[to_abs] );
+    m_creature_anims[to_abs].handle = h;
+    return h;
 }
 
 void cata_tiles::advance_creature_move_anims()
@@ -2096,9 +2097,15 @@ void cata_tiles::advance_creature_move_anims()
     // longer in real time after a heavy turn (imperceptible, and self-corrects).
     constexpr int64_t max_step_ms = 1000 / 15;
     const int64_t dt = std::min( dt_raw, max_step_ms );
+    map &here = get_map();
     for( auto it = m_creature_anims.begin(); it != m_creature_anims.end(); ) {
         it->second.progress += it->second.per_ms * static_cast<float>( dt );
-        if( it->second.progress >= 1.0f ) {
+        bool erase_this = ( it->second.progress >= 1.0f );
+        if( !erase_this && !here.inbounds( here.get_bub( it->first ) ) ) {
+            erase_this = true;
+        }
+        if( erase_this ) {
+            m_handle_index.erase( it->second.handle );
             it = m_creature_anims.erase( it );
         } else {
             ++it;
@@ -2106,7 +2113,12 @@ void cata_tiles::advance_creature_move_anims()
     }
     for( auto it = m_creature_hit_anims.begin(); it != m_creature_hit_anims.end(); ) {
         it->second.progress += it->second.per_ms * static_cast<float>( dt );
-        if( it->second.progress >= 1.0f ) {
+        bool erase_this = ( it->second.progress >= 1.0f );
+        if( !erase_this && !here.inbounds( here.get_bub( it->first ) ) ) {
+            erase_this = true;
+        }
+        if( erase_this ) {
+            m_handle_index.erase( it->second.handle );
             it = m_creature_hit_anims.erase( it );
         } else {
             ++it;
@@ -2122,14 +2134,14 @@ void cata_tiles::advance_creature_move_anims()
     }
 }
 
-void cata_tiles::start_creature_hit_anim( const tripoint_abs_ms &pos_abs, float damage_fraction,
+effect_handle cata_tiles::start_creature_hit_anim( const tripoint_abs_ms &pos_abs, float damage_fraction,
         const point &dir_tiles, bool is_player )
 {
     if( !get_option<bool>( "CREATURE_HIT_ANIM" ) ) {
-        return;
+        return 0;
     }
     if( is_player && !get_option<bool>( "PLAYER_HIT_ANIM" ) ) {
-        return;
+        return 0;
     }
     const float total_ms = std::max( 1, get_option<int>( "CREATURE_HIT_ANIM_TIME" ) );
     creature_hit_anim anim;
@@ -2148,6 +2160,10 @@ void cata_tiles::start_creature_hit_anim( const tripoint_abs_ms &pos_abs, float 
     }
     // Restart from the top if the creature is hit again mid-reaction.
     m_creature_hit_anims[pos_abs] = anim;
+    const effect_handle h = alloc_handle( effect_kind::creature_hit,
+                                          &m_creature_hit_anims[pos_abs] );
+    m_creature_hit_anims[pos_abs].handle = h;
+    return h;
 }
 
 void cata_tiles::start_creature_attack_anim( const tripoint_abs_ms &pos_abs,
@@ -5050,14 +5066,14 @@ void cata_tiles::init_custom_explosion_layer( const std::map<tripoint_bub_ms, ex
     do_draw_custom_explosion = true;
     custom_explosion_layer = layer;
 }
-void cata_tiles::init_explosion_light( const std::map<tripoint_bub_ms, float> &intensity,
-                                       const explosion_light_str_id &effect,
-                                       const tripoint_bub_ms &center, float radius_tiles,
-                                       float per_ms, float end_progress,
-                                       bool circular_shockwave,
-                                       shockwave_state::sw_shape shock_shape,
-                                       const tripoint_bub_ms &shock_target,
-                                       float shock_half_angle )
+effect_handle cata_tiles::init_explosion_light( const std::map<tripoint_bub_ms, float> &intensity,
+        const explosion_light_str_id &effect,
+        const tripoint_bub_ms &center, float radius_tiles,
+        float per_ms, float end_progress,
+        bool circular_shockwave,
+        shockwave_state::sw_shape shock_shape,
+        const tripoint_bub_ms &shock_target,
+        float shock_half_angle )
 {
     // Append a new asynchronous blast; existing ones keep playing (concurrent
     // overlap). It advances itself each frame via advance_explosion_lights().
@@ -5074,6 +5090,10 @@ void cata_tiles::init_explosion_light( const std::map<tripoint_bub_ms, float> &i
     a.shock_target = shock_target;
     a.shock_half_angle = shock_half_angle;
     m_explosion_lights.push_back( std::move( a ) );
+    const effect_handle h = alloc_handle( effect_kind::explosion_light,
+                                          &m_explosion_lights.back() );
+    m_explosion_lights.back().handle = h;
+    return h;
 }
 // Elapsed steady-clock ms since the last tick stored in \p last_ms, capped so a
 // long stall (pause, heavy turn) advances at most one frame's worth instead of
@@ -5112,7 +5132,13 @@ void cata_tiles::advance_explosion_lights()
     }
     for( auto it = m_explosion_lights.begin(); it != m_explosion_lights.end(); ) {
         it->progress += it->per_ms * static_cast<float>( dt );
-        if( it->progress >= it->end_progress ) {
+        bool erase_this = ( it->progress >= it->end_progress );
+        // A centred blast leaves the bubble together with its centre.
+        if( !erase_this && !get_map().inbounds( it->center ) ) {
+            erase_this = true;
+        }
+        if( erase_this ) {
+            m_handle_index.erase( it->handle );
             it = m_explosion_lights.erase( it );
         } else {
             ++it;
@@ -5136,13 +5162,13 @@ void cata_tiles::advance_screen_shake_frame()
     }
     advance_screen_shake( dt );
 }
-void cata_tiles::init_bullet_anim( const std::vector<tripoint_bub_ms> &points,
-                                   const std::vector<std::string> &sprites,
-                                   const std::vector<int> &rotations,
-                                   bool as_line, float per_ms )
+effect_handle cata_tiles::init_bullet_anim( const std::vector<tripoint_bub_ms> &points,
+        const std::vector<std::string> &sprites,
+        const std::vector<int> &rotations,
+        bool as_line, float per_ms )
 {
     if( points.empty() ) {
-        return;
+        return 0;
     }
     active_bullet_anim anim;
     anim.points = points;
@@ -5150,13 +5176,6 @@ void cata_tiles::init_bullet_anim( const std::vector<tripoint_bub_ms> &points,
     anim.rotations = rotations;
     anim.as_line = as_line;
     anim.per_ms = per_ms;
-    // Stagger full-auto bursts: every round of a burst registers in the same game
-    // tick (the fire_gun loop never yields a frame mid-burst), so without an offset
-    // they'd all start sweeping at once. Delay each new shot by a fixed gap times
-    // the number of rounds already queued in this same batch, capped so a big volley
-    // (many units in one turn) still wraps up promptly instead of dribbling out over
-    // seconds. Only count anims not yet advanced (head/life still zero) so a shot
-    // still flying from a previous turn doesn't inflate this burst's spacing.
     constexpr float burst_gap_ms = 55.0f;
     constexpr float max_stagger_ms = 275.0f;
     const auto pending = std::count_if( m_bullet_anims.begin(), m_bullet_anims.end(),
@@ -5166,6 +5185,10 @@ void cata_tiles::init_bullet_anim( const std::vector<tripoint_bub_ms> &points,
     anim.start_delay_ms = std::min( max_stagger_ms,
                                     burst_gap_ms * static_cast<float>( pending ) );
     m_bullet_anims.push_back( std::move( anim ) );
+    const effect_handle h = alloc_handle( effect_kind::bullet,
+                                          &m_bullet_anims.back() );
+    m_bullet_anims.back().handle = h;
+    return h;
 }
 void cata_tiles::advance_bullet_anims()
 {
@@ -5196,6 +5219,7 @@ void cata_tiles::advance_bullet_anims()
             // The whole gun-line shows at once; per_ms counts its short life to 1.
             it->life += it->per_ms * step_ms;
             if( it->life >= 1.0f ) {
+                m_handle_index.erase( it->handle );
                 it = m_bullet_anims.erase( it );
                 continue;
             }
@@ -5203,9 +5227,16 @@ void cata_tiles::advance_bullet_anims()
             // The dot sweeps one point per per_ms step; done past the last point.
             it->head += it->per_ms * step_ms;
             if( it->head >= static_cast<float>( it->points.size() ) ) {
+                m_handle_index.erase( it->handle );
                 it = m_bullet_anims.erase( it );
                 continue;
             }
+        }
+        // Drop the tracer if all its path tiles have left the reality bubble.
+        if( !it->points.empty() && !any_tile_in_bubble( it->points ) ) {
+            m_handle_index.erase( it->handle );
+            it = m_bullet_anims.erase( it );
+            continue;
         }
         ++it;
     }
@@ -5405,8 +5436,8 @@ void cata_tiles::void_sct()
 
 // --- Asynchronous SCT (Scrolling Combat Text) ---
 
-void cata_tiles::init_sct( const tripoint_bub_ms &pos, const std::string &text,
-                           nc_color color, float duration_ms )
+effect_handle cata_tiles::init_sct( const tripoint_bub_ms &pos, const std::string &text,
+                                    nc_color color, float duration_ms )
 {
     sct_effect eff;
     eff.pos = pos;
@@ -5416,6 +5447,10 @@ void cata_tiles::init_sct( const tripoint_bub_ms &pos, const std::string &text,
     eff.elapsed_ms = 0.0f;
     eff.screen_y_offset = 0.0f;
     m_sct_effects.push_back( std::move( eff ) );
+    const effect_handle h = alloc_handle( effect_kind::sct,
+                                          &m_sct_effects.back() );
+    m_sct_effects.back().handle = h;
+    return h;
 }
 
 void cata_tiles::advance_sct()
@@ -5429,10 +5464,16 @@ void cata_tiles::advance_sct()
         return;
     }
     const float dt_s = static_cast<float>( dt ) / 1000.0f;
+    map &here = get_map();
     for( auto it = m_sct_effects.begin(); it != m_sct_effects.end(); ) {
         it->elapsed_ms += static_cast<float>( dt );
         it->screen_y_offset -= it->rise_speed_px_per_s * dt_s;
-        if( it->elapsed_ms >= it->duration_ms ) {
+        bool erase_this = ( it->elapsed_ms >= it->duration_ms );
+        if( !erase_this && !here.inbounds( it->pos ) ) {
+            erase_this = true;
+        }
+        if( erase_this ) {
+            m_handle_index.erase( it->handle );
             it = m_sct_effects.erase( it );
         } else {
             ++it;
@@ -5479,6 +5520,132 @@ void cata_tiles::draw_sct_frame( int view_z,
         }
     }
 }
+
+// --- Handle system ---
+
+effect_handle cata_tiles::alloc_handle( effect_kind kind, void *ptr )
+{
+    const effect_handle h = m_next_handle++;
+    m_handle_index[h] = { kind, ptr };
+    return h;
+}
+
+void cata_tiles::cancel_effect( effect_handle h )
+{
+    auto it = m_handle_index.find( h );
+    if( it == m_handle_index.end() ) {
+        return;
+    }
+    const effect_kind kind = it->second.kind;
+    m_handle_index.erase( it );
+
+    switch( kind ) {
+        case effect_kind::explosion_light:
+            for( auto e = m_explosion_lights.begin(); e != m_explosion_lights.end(); ++e ) {
+                if( e->handle == h ) { m_explosion_lights.erase( e ); return; }
+            }
+            break;
+        case effect_kind::bullet:
+            for( auto e = m_bullet_anims.begin(); e != m_bullet_anims.end(); ++e ) {
+                if( e->handle == h ) { m_bullet_anims.erase( e ); return; }
+            }
+            break;
+        case effect_kind::creature_move:
+            for( auto e = m_creature_anims.begin(); e != m_creature_anims.end(); ++e ) {
+                if( e->second.handle == h ) { m_creature_anims.erase( e ); return; }
+            }
+            break;
+        case effect_kind::creature_hit:
+            for( auto e = m_creature_hit_anims.begin(); e != m_creature_hit_anims.end(); ++e ) {
+                if( e->second.handle == h ) { m_creature_hit_anims.erase( e ); return; }
+            }
+            break;
+        case effect_kind::sct:
+            for( auto e = m_sct_effects.begin(); e != m_sct_effects.end(); ++e ) {
+                if( e->handle == h ) { m_sct_effects.erase( e ); return; }
+            }
+            break;
+        case effect_kind::highlight:
+            for( auto e = m_highlights.begin(); e != m_highlights.end(); ++e ) {
+                if( e->handle == h ) { m_highlights.erase( e ); return; }
+            }
+            break;
+    }
+}
+
+bool cata_tiles::any_tile_in_bubble( const std::vector<tripoint_bub_ms> &tiles ) const
+{
+    map &here = get_map();
+    for( const tripoint_bub_ms &t : tiles ) {
+        if( here.inbounds( t ) ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// --- Unified transient-effect advance ---
+
+void cata_tiles::advance_all_transient_effects()
+{
+    advance_creature_move_anims();
+    advance_explosion_lights();
+    advance_bullet_anims();
+    advance_sct();
+    advance_highlights();
+    advance_screen_shake_frame();
+}
+
+// --- Asynchronous highlight overlay ---
+
+effect_handle cata_tiles::add_highlight( const tripoint_bub_ms &pos, float duration_ms )
+{
+    highlight_effect h;
+    h.pos = pos;
+    h.life_ms = duration_ms;
+    m_highlights.push_back( h );
+    const effect_handle hl = alloc_handle( effect_kind::highlight,
+                                           &m_highlights.back() );
+    m_highlights.back().handle = hl;
+    return hl;
+}
+
+void cata_tiles::advance_highlights()
+{
+    if( m_highlights.empty() ) {
+        m_highlights_last_ms.reset();
+        return;
+    }
+    const int64_t dt = capped_frame_dt_ms( m_highlights_last_ms );
+    if( dt <= 0 ) {
+        return;
+    }
+    map &here = get_map();
+    for( auto it = m_highlights.begin(); it != m_highlights.end(); ) {
+        it->life_ms -= static_cast<float>( dt );
+        bool erase_this = ( it->life_ms <= 0.0f );
+        if( !erase_this && !here.inbounds( it->pos ) ) {
+            erase_this = true;
+        }
+        if( erase_this ) {
+            m_handle_index.erase( it->handle );
+            it = m_highlights.erase( it );
+        } else {
+            ++it;
+        }
+    }
+}
+
+void cata_tiles::draw_highlights( int view_z )
+{
+    for( const highlight_effect &h : m_highlights ) {
+        if( h.pos.z() != view_z ) {
+            continue;
+        }
+        draw_from_id_string( "highlight", h.pos, 0, 0, lit_level::LIT, false );
+    }
+}
+
 void cata_tiles::void_zones()
 {
     do_draw_zones = false;

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -963,16 +963,19 @@ class cata_tiles
         // just struck a target in direction \p dir_tiles (attacker -> target, in
         // tiles): a quick lunge toward the target and back. No-op when the
         // CREATURE_ATTACK_ANIM option is off. \p is_player gates the avatar's lunge
-        // on the separate PLAYER_ATTACK_ANIM option.
-        void start_creature_attack_anim( const tripoint_abs_ms &pos_abs,
-                                         const point &dir_tiles, bool is_player );
+        // on the separate PLAYER_ATTACK_ANIM option.  Returns a handle so the
+        // caller can cancel the lunge mid-flight via cancel_effect().
+        effect_handle start_creature_attack_anim( const tripoint_abs_ms &pos_abs,
+                                                  const point &dir_tiles, bool is_player );
         // True while any attack lunge is in flight.
         bool has_creature_attack_anim() const {
             return !m_creature_attack_anims.empty();
         }
-        // True while any transient visual effect (creature glide, hit, attack,
+        // True while any creature or overlay animation (glide, hit, attack,
         // SCT label, or highlight) is in flight.  Used by the input loop to
         // raise its redraw rate so animations look smooth instead of stepping.
+        // (Explosion lights and bullet tracers have their own independent
+        // has_* gates that are checked separately in the in_animation gate.)
         bool has_creature_anim() const {
             return has_creature_move_anim() || has_creature_hit_anim() ||
                    has_creature_attack_anim() || has_sct() || has_highlight();
@@ -1005,9 +1008,10 @@ class cata_tiles
         void draw_highlights( int view_z );
 
         // --- Handle system ---
-        // Allocate a new handle for a freshly-created effect, registering it
-        // in the handle index so cancel_effect() can later find and erase it.
-        effect_handle alloc_handle( effect_kind kind, void *ptr );
+        // Allocate a new handle for a freshly-created effect, registering
+        // its category in the handle index so cancel_effect() can later
+        // dispatch to the correct container.
+        effect_handle alloc_handle( effect_kind kind );
         // Cancel an effect by its handle.  No-op if unknown.  Walks the
         // matching container and erases the entry whose handle matches.
         void cancel_effect( effect_handle h );
@@ -1238,6 +1242,7 @@ class cata_tiles
         // Active per-creature attack lunges, keyed by the attacker's absolute
         // position: a quick lunge toward the struck target and back.
         struct creature_attack_anim {
+            effect_handle handle = 0;  // for cancel_effect(); zero until registered
             float progress = 0.0f;     // 0..1
             float per_ms = 0.0f;       // progress increment per millisecond
             float dist_tiles = 0.5f;   // peak lunge distance in tiles
@@ -1379,12 +1384,13 @@ class cata_tiles
         std::optional<int64_t> m_highlights_last_ms;
 
         // --- Handle infrastructure ---
-        // Entry stored in the handle-to-pointer index.
-        struct handle_entry { effect_kind kind; void *ptr; };
+        // Entry in the handle index: stores only the effect category so
+        // cancel_effect() knows which container to search.
+        struct handle_entry { effect_kind kind; };
         // Monotonically-increasing handle counter.  Zero means "no handle".
         effect_handle m_next_handle = 1;
-        // Maps each allocated handle to its effect kind and container pointer,
-        // so cancel_effect() can dispatch to the right container.
+        // Maps each allocated handle to its effect kind so cancel_effect()
+        // can dispatch to the correct container.
         std::unordered_map<effect_handle, handle_entry> m_handle_index;
 
         std::vector<tripoint_bub_ms> bul_pos;

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -37,6 +37,8 @@
 #include "sct_effect.h"
 #include "sdl_wrappers.h"
 #include "shockwave.h"
+#include "transient_effect.h"
+#include "transient_visual_layer.h"
 #include "type_id.h"
 #include "units.h"
 #include "weather.h"
@@ -822,16 +824,17 @@ class cata_tiles
         // Registers (appends) a new asynchronous blast that advances itself each
         // frame; several may overlap. \p radius_tiles is the blast's max extent in
         // tiles (used to size the shockwave ring). \p per_ms / \p end_progress
-        // drive the real-time sweep.
-        void init_explosion_light( const std::map<tripoint_bub_ms, float> &intensity,
-                                   const explosion_light_str_id &effect,
-                                   const tripoint_bub_ms &center, float radius_tiles,
-                                   float per_ms, float end_progress,
-                                   bool circular_shockwave = true,
-                                   shockwave_state::sw_shape shock_shape =
-                                       shockwave_state::sw_shape::disc,
-                                   const tripoint_bub_ms &shock_target = tripoint_bub_ms(),
-                                   float shock_half_angle = 0.0f );
+        // drive the real-time sweep.  Returns a handle so the caller can cancel
+        // the blast mid-flight via cancel_effect().
+        effect_handle init_explosion_light( const std::map<tripoint_bub_ms, float> &intensity,
+                                            const explosion_light_str_id &effect,
+                                            const tripoint_bub_ms &center, float radius_tiles,
+                                            float per_ms, float end_progress,
+                                            bool circular_shockwave = true,
+                                            shockwave_state::sw_shape shock_shape =
+                                                shockwave_state::sw_shape::disc,
+                                            const tripoint_bub_ms &shock_target = tripoint_bub_ms(),
+                                            float shock_half_angle = 0.0f );
         // Advance all active explosion lights by real elapsed time and drop the
         // finished ones. Called once at the start of each draw().
         void advance_explosion_lights();
@@ -853,10 +856,11 @@ class cata_tiles
         //            false -> a single bullet sprite sweeps tile-to-tile along the
         //                     path (the classic moving-dot look).
         // per_ms drives the sweep (dot) or the life countdown (line).
-        void init_bullet_anim( const std::vector<tripoint_bub_ms> &points,
-                               const std::vector<std::string> &sprites,
-                               const std::vector<int> &rotations,
-                               bool as_line, float per_ms );
+        // Returns a handle so the caller can cancel the tracer mid-flight.
+        effect_handle init_bullet_anim( const std::vector<tripoint_bub_ms> &points,
+                                        const std::vector<std::string> &sprites,
+                                        const std::vector<int> &rotations,
+                                        bool as_line, float per_ms );
         // Advance all active bullet animations by real elapsed time, dropping the
         // finished ones. Called once at the start of each draw().
         void advance_bullet_anims();
@@ -876,12 +880,20 @@ class cata_tiles
         // the caller registers a label and returns immediately; the label advances
         // every draw frame and is cleaned up when its duration expires.  Lives
         // alongside the legacy overlay_strings SCT path (init_draw_sct / void_sct).
-        void init_sct( const tripoint_bub_ms &pos, const std::string &text, nc_color color,
-                       float duration_ms = 800.0f );
+        // Returns a handle so the caller can cancel the label mid-flight.
+        effect_handle init_sct( const tripoint_bub_ms &pos, const std::string &text, nc_color color,
+                                float duration_ms = 800.0f );
         void advance_sct();
         bool has_sct() const { return !m_sct_effects.empty(); }
         void draw_sct_frame( int view_z,
                              std::multimap<point, formatted_text> &overlay_strings );
+
+        // --- Unified transient-effect advance ---
+        // Advances all transient effects (explosion lights, bullet tracers,
+        // creature move glides, SCT labels, highlights, screen shake) by real
+        // elapsed time.  Called once at the start of draw() in place of the
+        // individual advance_* calls.
+        void advance_all_transient_effects();
 
         // Advance the sound-driven screen shake by real elapsed time. Called once at
         // the start of each draw(), alongside the other wall-clock animations.
@@ -920,9 +932,10 @@ class cata_tiles
         // the same creature and play from the start, so they never block the game.
         // No-op when the option is off, on z-changes, or on jumps further than one
         // tile (teleports snap instantly). \p is_player gates the avatar's glide on
-        // the separate PLAYER_MOVE_ANIM option.
-        void start_creature_move_anim( const tripoint_abs_ms &from_abs,
-                                       const tripoint_abs_ms &to_abs, bool is_player );
+        // the separate PLAYER_MOVE_ANIM option.  Returns a handle so the caller
+        // can cancel the glide mid-flight via cancel_effect().
+        effect_handle start_creature_move_anim( const tripoint_abs_ms &from_abs,
+                                                const tripoint_abs_ms &to_abs, bool is_player );
         // Advance all active glides by real elapsed time and drop finished ones.
         void advance_creature_move_anims();
         // True while any creature move glide is in flight. Used by the input loop
@@ -939,8 +952,9 @@ class cata_tiles
         // victim, in tiles); when zero, or when the curve option is "bounce", a
         // vertical pop-and-fall is used instead of a horizontal knockback.
         // \p is_player gates the avatar's reaction on the separate PLAYER_HIT_ANIM option.
-        void start_creature_hit_anim( const tripoint_abs_ms &pos_abs, float damage_fraction,
-                                      const point &dir_tiles, bool is_player );
+        // Returns a handle so the caller can cancel via cancel_effect().
+        effect_handle start_creature_hit_anim( const tripoint_abs_ms &pos_abs, float damage_fraction,
+                                               const point &dir_tiles, bool is_player );
         // True while any hit reaction is in flight.
         bool has_creature_hit_anim() const {
             return !m_creature_hit_anims.empty();
@@ -956,10 +970,12 @@ class cata_tiles
         bool has_creature_attack_anim() const {
             return !m_creature_attack_anims.empty();
         }
-        // True while any creature animation (glide, hit, or attack) is in flight.
+        // True while any transient visual effect (creature glide, hit, attack,
+        // SCT label, or highlight) is in flight.  Used by the input loop to
+        // raise its redraw rate so animations look smooth instead of stepping.
         bool has_creature_anim() const {
             return has_creature_move_anim() || has_creature_hit_anim() ||
-                   has_creature_attack_anim();
+                   has_creature_attack_anim() || has_sct() || has_highlight();
         }
 
         void draw_footsteps_frame( const tripoint_bub_ms &center );
@@ -977,6 +993,28 @@ class cata_tiles
         void init_draw_highlight( const tripoint_bub_ms &p );
         void draw_highlight();
         void void_highlight();
+
+        // --- Asynchronous highlight overlay ---
+        // Fire-and-forget highlight that fades over real time, following the
+        // same async model as explosion lights.  Lives alongside the legacy
+        // synchronous path (init_draw_highlight / void_highlight).
+        effect_handle add_highlight( const tripoint_bub_ms &pos,
+                                     float duration_ms = 500.0f );
+        void advance_highlights();
+        bool has_highlight() const { return !m_highlights.empty(); }
+        void draw_highlights( int view_z );
+
+        // --- Handle system ---
+        // Allocate a new handle for a freshly-created effect, registering it
+        // in the handle index so cancel_effect() can later find and erase it.
+        effect_handle alloc_handle( effect_kind kind, void *ptr );
+        // Cancel an effect by its handle.  No-op if unknown.  Walks the
+        // matching container and erases the entry whose handle matches.
+        void cancel_effect( effect_handle h );
+        // True if at least one tile in `tiles` is inside the loaded map grid
+        // (the reality bubble).  Used by advance_* to drop effects that have
+        // left the player's vicinity.
+        bool any_tile_in_bubble( const std::vector<tripoint_bub_ms> &tiles ) const;
 
         void init_draw_weather( weather_printable weather, std::string name );
         void draw_weather_frame();
@@ -1173,6 +1211,7 @@ class cata_tiles
         // it). progress runs 0->1: at 0 the sprite is offset back to its old tile,
         // at 1 it sits on the real (new) tile.
         struct creature_move_anim {
+            effect_handle handle = 0;  // for cancel_effect(); zero until registered
             point delta_tiles;         // (old - new) tile delta, converted to pixels at draw time
             float progress = 0.0f;     // 0..1
             float per_ms = 0.0f;       // progress increment per millisecond
@@ -1187,6 +1226,7 @@ class cata_tiles
         // knockback-and-return, sharing the offset injection and deferred-overlay
         // path with the move glide.
         struct creature_hit_anim {
+            effect_handle handle = 0;  // for cancel_effect(); zero until registered
             float progress = 0.0f;     // 0..1
             float per_ms = 0.0f;       // progress increment per millisecond
             float magnitude_tiles = 0.5f; // peak displacement in tiles (damage-scaled)
@@ -1268,6 +1308,7 @@ class cata_tiles
         // player can act immediately. Several can overlap (concurrent blasts in one
         // turn). progress runs 0..end_progress; finished entries are dropped.
         struct active_explosion_light {
+            effect_handle handle = 0;  // for cancel_effect(); zero until registered
             std::map<tripoint_bub_ms, float> radial; // per-tile radial coord (0..1)
             explosion_light_str_id effect;
             tripoint_bub_ms center;
@@ -1300,6 +1341,7 @@ class cata_tiles
         // lights), so several concurrent shots overlap without blocking the turn.
         // Finished entries are dropped in advance_bullet_anims().
         struct active_bullet_anim {
+            effect_handle handle = 0;  // for cancel_effect(); zero until registered
             std::vector<tripoint_bub_ms> points; // visible flight path tiles
             std::vector<std::string> sprites;    // per-point sprite id
             std::vector<int> rotations;          // per-point rotation
@@ -1324,6 +1366,26 @@ class cata_tiles
         std::vector<sct_effect> m_sct_effects;
         // steady_clock timestamp (ms) of the last SCT advance.
         std::optional<int64_t> m_sct_last_ms;
+
+        // Active asynchronous highlight overlays.  Each fades over real time
+        // and is dropped when its life expires or it leaves the reality bubble.
+        struct highlight_effect {
+            tripoint_bub_ms pos;
+            float life_ms = 0.0f;          // remaining life
+            effect_handle handle = 0;       // for cancel_effect()
+        };
+        std::vector<highlight_effect> m_highlights;
+        // steady_clock timestamp (ms) of the last highlight advance.
+        std::optional<int64_t> m_highlights_last_ms;
+
+        // --- Handle infrastructure ---
+        // Entry stored in the handle-to-pointer index.
+        struct handle_entry { effect_kind kind; void *ptr; };
+        // Monotonically-increasing handle counter.  Zero means "no handle".
+        effect_handle m_next_handle = 1;
+        // Maps each allocated handle to its effect kind and container pointer,
+        // so cancel_effect() can dispatch to the right container.
+        std::unordered_map<effect_handle, handle_entry> m_handle_index;
 
         std::vector<tripoint_bub_ms> bul_pos;
         std::vector<std::string> bul_id;

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -34,6 +34,7 @@
 #include "pimpl.h"
 #include "point.h"
 #include "sdl_geometry.h"
+#include "sct_effect.h"
 #include "sdl_wrappers.h"
 #include "shockwave.h"
 #include "type_id.h"
@@ -869,6 +870,19 @@ class cata_tiles
         // metrics don't paint onto the rebuilt scene.
         void void_bullet_anim();
 
+        // --- Asynchronous SCT (Scrolling Combat Text) ---
+        // Fire-and-forget floating combat-text labels that rise and fade over real
+        // time.  Follows the same async model as explosion lights and bullet anims:
+        // the caller registers a label and returns immediately; the label advances
+        // every draw frame and is cleaned up when its duration expires.  Lives
+        // alongside the legacy overlay_strings SCT path (init_draw_sct / void_sct).
+        void init_sct( const tripoint_bub_ms &pos, const std::string &text, nc_color color,
+                       float duration_ms = 800.0f );
+        void advance_sct();
+        bool has_sct() const { return !m_sct_effects.empty(); }
+        void draw_sct_frame( int view_z,
+                             std::multimap<point, formatted_text> &overlay_strings );
+
         // Advance the sound-driven screen shake by real elapsed time. Called once at
         // the start of each draw(), alongside the other wall-clock animations.
         void advance_screen_shake_frame();
@@ -1304,6 +1318,12 @@ class cata_tiles
         std::vector<active_bullet_anim> m_bullet_anims;
         // steady_clock timestamp (ms) of the last bullet-anim advance.
         std::optional<int64_t> m_bullet_anim_last_ms;
+
+        // Active asynchronous SCT labels.  Each rises from its tile and fades
+        // over real time.  Finished entries are dropped in advance_sct().
+        std::vector<sct_effect> m_sct_effects;
+        // steady_clock timestamp (ms) of the last SCT advance.
+        std::optional<int64_t> m_sct_last_ms;
 
         std::vector<tripoint_bub_ms> bul_pos;
         std::vector<std::string> bul_id;

--- a/src/sct_effect.h
+++ b/src/sct_effect.h
@@ -6,6 +6,7 @@
 
 #include "color.h"
 #include "coords_fwd.h"
+#include "transient_effect.h"
 
 /** Floating combat-text label that rises from a tile and fades out over real
  *  time.  Managed asynchronously by cata_tiles so the caller can fire-and-
@@ -20,6 +21,8 @@ struct sct_effect {
     float elapsed_ms    = 0.0f;    // wall-clock ms since creation
     float rise_speed_px_per_s = 30.0f;
     float screen_y_offset     = 0.0f;  // current vertical offset in screen px
+
+    effect_handle handle = 0;  // for cancel_effect(); zero until registered
 };
 
 #endif

--- a/src/sct_effect.h
+++ b/src/sct_effect.h
@@ -1,0 +1,25 @@
+#pragma once
+#ifndef CATA_SRC_SCT_EFFECT_H
+#define CATA_SRC_SCT_EFFECT_H
+
+#include <string>
+
+#include "color.h"
+#include "coords_fwd.h"
+
+/** Floating combat-text label that rises from a tile and fades out over real
+ *  time.  Managed asynchronously by cata_tiles so the caller can fire-and-
+ *  forget (no blocking wait).  Independent of the legacy overlay_strings SCT
+ *  path and the message log.
+ */
+struct sct_effect {
+    tripoint_bub_ms pos;       // world tile the label floats above
+    std::string    text;       // displayed string
+    nc_color       color = c_white;
+    float duration_ms   = 800.0f;  // total life before expiry
+    float elapsed_ms    = 0.0f;    // wall-clock ms since creation
+    float rise_speed_px_per_s = 30.0f;
+    float screen_y_offset     = 0.0f;  // current vertical offset in screen px
+};
+
+#endif

--- a/src/transient_effect.h
+++ b/src/transient_effect.h
@@ -16,6 +16,7 @@ enum class effect_kind : uint8_t {
     bullet,
     creature_move,
     creature_hit,
+    creature_attack,
     sct,
     highlight,
 };

--- a/src/transient_effect.h
+++ b/src/transient_effect.h
@@ -1,0 +1,23 @@
+#pragma once
+#ifndef CATA_SRC_TRANSIENT_EFFECT_H
+#define CATA_SRC_TRANSIENT_EFFECT_H
+
+#include <cstdint>
+
+/** Opaque handle for a transient visual effect.  Zero means "no handle".
+ *  Callers receive one from init_*() and may pass it to cancel_effect()
+ *  to abort the effect mid-flight. */
+using effect_handle = uint32_t;
+
+/** Categories of transient visual effects tracked by the handle system.
+ *  Drives cancel_effect() dispatch to the correct container. */
+enum class effect_kind : uint8_t {
+    explosion_light,
+    bullet,
+    creature_move,
+    creature_hit,
+    sct,
+    highlight,
+};
+
+#endif

--- a/src/transient_visual_layer.h
+++ b/src/transient_visual_layer.h
@@ -5,12 +5,12 @@
 /** Forward skeleton for a unified transient-effect catalogue.
  *
  *  Currently the handle index, bubble helpers, and per-effect containers
- *  live directly in cata_tiles.  Once the client-server boundary is
- *  established (stage 5+) this class will become the authoritative owner
+ *  live directly in cata_tiles.  Once the rendering layer is split into a
+ *  separate compilation unit this class will become the authoritative owner
  *  of all transient visual effects and their lifecycle management.
  *
- *  TODO(stage-5): migrate alloc_handle / cancel_effect / bubble helpers /
- *                 and container ownership from cata_tiles into this class.
+ *  TODO: migrate alloc_handle / cancel_effect / bubble helpers and
+ *        container ownership from cata_tiles into this class.
  */
 class transient_visual_layer {
 };

--- a/src/transient_visual_layer.h
+++ b/src/transient_visual_layer.h
@@ -1,0 +1,18 @@
+#pragma once
+#ifndef CATA_SRC_TRANSIENT_VISUAL_LAYER_H
+#define CATA_SRC_TRANSIENT_VISUAL_LAYER_H
+
+/** Forward skeleton for a unified transient-effect catalogue.
+ *
+ *  Currently the handle index, bubble helpers, and per-effect containers
+ *  live directly in cata_tiles.  Once the client-server boundary is
+ *  established (stage 5+) this class will become the authoritative owner
+ *  of all transient visual effects and their lifecycle management.
+ *
+ *  TODO(stage-5): migrate alloc_handle / cancel_effect / bubble helpers /
+ *                 and container ownership from cata_tiles into this class.
+ */
+class transient_visual_layer {
+};
+
+#endif


### PR DESCRIPTION
#### 概述 (Summary)
Infrastructure "瞬态视觉层：handle 系统 + bubble 生命周期 + 异步 SCT/高亮 (Stage 2D)" / Transient visual layer: handle system + bubble lifecycle + async SCT/highlights

#### 改动目的 (Purpose of change)

**zhCN**: 为 sim-render 解耦长期路线图的阶段 2 补齐瞬态视觉层基础设施。现有爆炸光/弹道/生物动画已异步，但缺少统一的 handle 取消机制、reality bubble 离开自动清理、异步 SCT 浮动伤害文字和异步高亮叠加。本次一次性补齐四个子阶段（2D1-2D4）。

**enUS**: Complete the transient visual layer infrastructure for Stage 2 of the sim-render decoupling roadmap. Existing explosion lights, bullet tracers, and creature animations are already asynchronous, but lacked a unified handle cancellation mechanism, automatic cleanup on reality-bubble departure, async SCT floating damage text, and async highlight overlays. This PR delivers all four sub-stages (2D1-2D4) in one batch.

**与上一轮 revert 的区别 / Difference from the reverted PR #273**: 上一轮将 2D+2E 捆绑提交且管理混乱。本次严格拆分、注释全英文自明、无计划文档引用泄露。

#### 解决方案描述 (Describe the solution)

**2D1 — 异步 SCT 浮动文字 / Async SCT labels:**
- `src/sct_effect.h`: 轻量 `sct_effect` 结构体（pos/text/color/duration/rise speed/screen offset）
- `cata_tiles`: `init_sct` / `advance_sct` / `has_sct` / `draw_sct_frame(int view_z, overlay_strings)` 
- font 模式写 overlay_strings，tile 模式逐字符绘制（与旧版 SCT 一致）
- 与 legacy `init_draw_sct` / `void_sct` 同步路径共存

**2D2 — Handle 系统 / Handle system:**
- `src/transient_effect.h`: `effect_handle` (uint32_t) + `effect_kind` 枚举（7 种：explosion_light/bullet/creature_move/creature_hit/creature_attack/sct/highlight）
- `cata_tiles`: `alloc_handle(kind)` / `cancel_effect(handle)` + `m_handle_index` 索引
- `cancel_effect` 6 路 switch dispatch 到正确容器后按 handle 字段查找删除
- 所有 `init_*` / `start_*` 签名改为返回 `effect_handle`（现有调用点忽略返回值，零破坏）
- 所有效果 struct 加 `effect_handle handle = 0` 字段

**2D3 — 统一 advance + bubble 生命周期 / Unified advance + bubble lifecycle:**
- `advance_all_transient_effects()` 取代 draw() 中 6 个独立 `advance_*` 调用
- 双层生命周期清理：时间到期 OR reality bubble 离开（`map::inbounds` / `map::get_bub`）
- 覆盖全部 7 种效果类型的 advance 循环：explosion/bullet/creature_move/creature_hit/creature_attack/sct/highlight
- `any_tile_in_bubble( tiles )` 辅助；`void_explosion_light` / `void_bullet_anim` 清理 handle index

**2D4 — 异步高亮 / Async highlights:**
- `highlight_effect` 结构体（pos/life_ms/handle）+ `m_highlights` 容器
- `add_highlight` / `advance_highlights` / `draw_highlights(int view_z)`
- 与 legacy `init_draw_highlight` / `void_highlight` 同步路径共存
- `has_highlight()` 接入 `in_animation` gate 和 `has_creature_anim()`

**骨架 / Forward skeleton**:
- `src/transient_visual_layer.h`: 未来 handle index / bubble 助手的归属类（空壳，TODO 注释全英文自明）

#### 你考虑过的替代方案 (Describe alternatives you've considered)

- 曾考虑将 handle_entry 存 void* 容器指针做 O(1) 删除，但因 vector realloc 会使指针悬垂，改为只存 kind 做 switch 分发、按 handle 字段遍历查找（O(n)，但容器极小且 cancel 为罕见操作）。
- 曾考虑 creature_attack_anim 暂不接入 handle 系统，但审查发现不一致——已一并接入。

#### 测试 (Testing)

**zhCN**:
- MSBuild (VS18) Release|x64: 0 错误，6 预存 warning
- 编译目标: `msbuild msvc-full-features/Cataclysm-vcpkg-static.sln -m:1 -p:Configuration=Release -p:Platform=x64`
- 代码审查 2 轮，修复 6 项问题（死代码删除、handle 泄漏修复、plan-代码分离、attack_anim 接入）
- 所有现有 `init_*` 调用点零破坏（返回值被忽略）

**enUS**:
- MSBuild (VS18) Release|x64: 0 errors, 6 pre-existing warnings
- 2 rounds of code review, 6 findings fixed (dead code removal, handle leak fixes, plan-code separation, attack_anim integration)
- All existing `init_*` call sites unaffected (return values ignored)

#### 补充说明 (Additional context)

**zhCN**: 本 PR 是 sim-render-decoupling-plan 阶段 2D 的完整交付。与 #272（view_snapshot 类型）互补——#272 冻结静态层的语义快照，本 PR 构建快照之上的瞬态视觉基础设施。阶段 2E（field per-frame 捕获）将作为独立 PR 后续提交。

**enUS**: This PR delivers the complete Stage 2D of the sim-render-decoupling plan. It complements #272 (view_snapshot type): #272 freezes the semantic snapshot for static layers, while this PR builds the transient visual infrastructure that sits on top of the snapshot. Stage 2E (field per-frame capture) will follow as a separate PR.

**文件清单 / Files changed (5 files, +471/−70):**
| 文件 | 改动 |
|------|------|
| `src/sct_effect.h` | 新 / New |
| `src/transient_effect.h` | 新 / New |
| `src/transient_visual_layer.h` | 新 / New (skeleton) |
| `src/cata_tiles.h` | +~130 行 / lines |
| `src/cata_tiles.cpp` | +~320 行 / lines |
