### PR TITLE
feat(render): per-frame field capture — switch draw_field_or_item to cache

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1127,6 +1127,33 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
         m_creature_columns.insert( cpos.xy() );
     }
 
+    // Refresh the per-tile field cache every frame.  Fields can appear
+    // between the dirty-gated rebuild and the layer loop (e.g. an
+    // intermediate draw during handle_action consumes the dirty flag
+    // before a later action creates the field), so a one-shot
+    // rebuild-time capture is insufficient.  The same row / z-level
+    // bounds as the rebuild are used.
+    {
+        map &here = get_map();
+        for( int zlevel = center.z(); zlevel >= draw_min_z; zlevel-- ) {
+            for( int row = min_row; row < max_row; row++ ) {
+                for( tile_render_info &tri : here.draw_points_cache.tiles[zlevel][row] ) {
+                    tile_render_info::sprite *const var =
+                        std::get_if<tile_render_info::sprite>( &tri.var );
+                    if( !var || var->invisible[0] ) {
+                        continue;
+                    }
+                    const field &f = here.field_at( tri.com.pos );
+                    const field_type_id disp_fld = f.displayed_field_type();
+                    if( disp_fld ) {
+                        var->set_field_content( disp_fld,
+                                               f.displayed_intensity() );
+                    }
+                }
+            }
+        }
+    }
+
     // List all layers for a single z-level
     const std::array<decltype( &cata_tiles::draw_furniture ), 11> drawing_layers = {{
             &cata_tiles::draw_terrain, &cata_tiles::draw_furniture, &cata_tiles::draw_graffiti, &cata_tiles::draw_trap, &cata_tiles::draw_part_con,
@@ -3856,10 +3883,18 @@ bool cata_tiles::draw_field_or_item( const tripoint_bub_ms &p, const lit_level l
 {
     const auto fld_override = field_override.find( p );
     const bool fld_overridden = fld_override != field_override.end();
+    // Primary field type from the per-frame draw-points cache.
+    // fd_null means no displayable field is present on this tile.
+    const tile_render_info::sprite &cap =
+        std::get<tile_render_info::sprite>( m_cur_tile->var );
+    const field_type_id &cached_fld = cap.field_content;
+    const field_type_id &fld = fld_overridden ?
+                               fld_override->second : cached_fld;
+    // The full field object is still read live — it is needed for
+    // per-field-entry iteration in the non-override path below.
     map &here = get_map();
     const field &f = here.field_at( p );
-    const field_type_id &fld = fld_overridden ?
-                               fld_override->second : f.displayed_field_type();
+
     bool ret_draw_field = false;
     bool ret_draw_items = false;
 

--- a/src/view_snapshot.h
+++ b/src/view_snapshot.h
@@ -125,8 +125,8 @@ struct tile_render_info {
         // Only the static layers are captured here — terrain, furniture, trap,
         // partial construction, graffiti — because the rebuild runs only when
         // the cache is marked dirty (player action), which matches how often
-        // these change. Dynamic content (fields, items, vehicles, creatures)
-        // changes every turn and is left on the live path for now.
+        // these change.  Fields are captured per-frame in draw(); items,
+        // vehicles, and creatures remain on the live path for now.
         //
         // A null/empty content field means nothing was captured for that layer
         // (memory / override / invisible tiles, or simply nothing present).
@@ -145,6 +145,16 @@ struct tile_render_info {
         bool graffiti_captured = false;
         std::string graffiti_content;
         int graffiti_content_rotation = 0;
+
+        // Field data captured every frame just before the layer loop.
+        // Fields can appear between the dirty-gated rebuild and draw
+        // time (an intermediate draw during handle_action can consume
+        // the dirty flag before a later action creates the field),
+        // so a one-shot rebuild-time capture is insufficient.
+        // Default-constructed field_type_id (null) means no displayable
+        // field is present on this tile.
+        field_type_id field_content;
+        int field_intensity = 0;
 
         sprite( const lit_level ll, const std::array<bool, 5> &inv )
             : ll( ll ), invisible( inv ) {}
@@ -168,6 +178,10 @@ struct tile_render_info {
             graffiti_captured = true;
             graffiti_content = text;
             graffiti_content_rotation = rotation;
+        }
+        void set_field_content( const field_type_id &fid, const int intensity ) {
+            field_content = fid;
+            field_intensity = intensity;
         }
     };
 
@@ -232,6 +246,11 @@ class draw_points_cache_t
                         r.clear(); // keep capacity
                     }
                 }
+                // Range-based for support for per-z-level row iteration.
+                auto begin()       { return rows.begin(); }
+                auto end()         { return rows.end(); }
+                auto begin() const { return rows.begin(); }
+                auto end()   const { return rows.end(); }
             private:
                 int row_base = 0;
                 bool initialized = false;


### PR DESCRIPTION
#### 概述 (Summary)

Infrastructure "draw_field_or_item 的正常可见分支从 per-frame 缓存读 primary field type，不再 live-read displayed_field_type()"
/ Infrastructure "normal visible branch of draw_field_or_item reads primary field type from per-frame cache instead of live displayed_field_type()"

#### 改动目的 (Purpose of change)

draw_field_or_item 的 field 段每帧 live-read here.field_at(p) 来获取 primary field type。
field 可在中间帧 draw() 消耗 draw_points_cache_dirty 标志后、后续 action 创建 field 前产生，
导致渲染器读到不一致的 sim 态。

本 PR 将 field type 和 intensity 捕获到 per-frame 缓存（与 creature position 同级），
layer loop 前最后一刻刷新，draw_field_or_item 的正常可见分支直接读缓存。

后续 item / vpart / creature 动态层同理捕获。

---
The field section of draw_field_or_item live-reads here.field_at(p) every frame
for the primary field type.  Fields can appear after an intermediate draw consumes
the draw_points_cache_dirty flag but before a later action creates the field,
causing the renderer to see inconsistent sim state.

This PR captures the field type and intensity into a per-frame cache (same tier
as creature positions), refreshed right before the layer loop, so the normal
visible branch reads the cache.  Item / vpart / creature dynamic layers will
follow the same pattern.

#### 解决方案描述 (Describe the solution)

1. tile_render_info::sprite 新增 field_content (field_type_id) + field_intensity (int) +
   set_field_content() 辅助方法

2. draw() 内新增 per-frame 捕获段（creature position 重建后、layer loop 前），
   使用 operator[] + min_row/max_row 索引（与 dirty-gated 重建相同模式）

3. draw_field_or_item 正常可见分支改为从 m_cur_tile->var 读 field_content，
   替代 f.displayed_field_type()

4. field 条目迭代和 4 邻过渡渲染保持 live（L1-L2 表现层 / 需全量 entry 访问）

5. level_rows 新增 begin()/end()（per-z-level 行迭代）

---
1. Added field_content (field_type_id) + field_intensity (int) + set_field_content()
   to tile_render_info::sprite

2. Per-frame capture loop in draw() between creature-position rebuild and layer loop,
   using operator[] + min_row/max_row (same pattern as dirty-gated rebuild)

3. draw_field_or_item normal visible branch reads field_content from
   m_cur_tile->var instead of f.displayed_field_type()

4. Field-entry iteration and 4-neighbour transition reads stay live
   (L1-L2 presentation layer / require full entry access)

5. level_rows::begin()/end() for per-z-level row iteration

#### 你考虑过的替代方案 (Describe alternatives you've considered)

- **dirty-gated 重建内捕获**: 中间帧 draw() 会先消耗 dirty 标志再建 field → 导致缓存过期。
  选 per-frame 以避免此竞态。
  / dirty-gated rebuild capture: intermediate draws consume the dirty flag before
  field creation → stale cache.  Chose per-frame to avoid this race.

- **自检脚手架**: 开发期使用 CATA_VERIFY_FIELD_CACHE 环境变量做旁路比对，验证通过后已删除。
  / Scaffolding: used CATA_VERIFY_FIELD_CACHE env var for cross-checking during
  development, removed after verification.

#### 测试 (Testing)

- MSVC Release|x64 3 次连续构建 0 错误
- 正常游玩：火焰/烟雾/血迹/酸液/电场无回归
- 缩放、z-level 切换正常
- Headless (Release-NoTilesHeadless) 构建通过（改动全在 #if defined(TILES) 内）
---
- MSVC Release|x64 3 consecutive builds 0 errors
- Normal gameplay: fire/smoke/blood/acid/electric fields no regression
- Zoom and z-level switching normal
- Headless build passes (all changes under #if defined(TILES))

#### 补充说明 (Additional context)

2 文件 +58/-4 行，全部在 #if defined(TILES) 内。
---
2 files +58/-4 lines, all under #if defined(TILES).