### PR TITLE
feat(render): per-frame item capture — draw_field_or_item 从缓存读取物品数据

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1154,6 +1154,52 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
         }
     }
 
+    // Refresh the per-tile item cache every frame, right after the
+    // field refresh.  Items can appear or disappear between the
+    // dirty-gated rebuild and the layer loop for the same reasons as
+    // fields (intermediate draws during handle_action consume the
+    // dirty flag before a later action creates or removes items,
+    // monster drops, etc.), so a one-shot rebuild-time capture is
+    // insufficient.
+    {
+        map &here = get_map();
+        for( int zlevel = center.z(); zlevel >= draw_min_z; zlevel-- ) {
+            for( int row = min_row; row < max_row; row++ ) {
+                for( tile_render_info &tri : here.draw_points_cache.tiles[zlevel][row] ) {
+                    tile_render_info::sprite *const var =
+                        std::get_if<tile_render_info::sprite>( &tri.var );
+                    if( !var || var->invisible[0] ) {
+                        continue;
+                    }
+                    if( here.sees_some_items( tri.com.pos,
+                                             get_player_character() ) ) {
+                        const maptile &tile = here.maptile_at( tri.com.pos );
+                        const int count =
+                            static_cast<int>( tile.get_item_count() );
+                        if( count > 0 ) {
+                            const item &itm = tile.get_uppermost_item();
+                            const mtype *const mon = itm.get_mtype();
+                            var->set_item_content(
+                                itm.typeId(),
+                                mon ? mon->id : mtype_id::NULL_ID(),
+                                itm.has_itype_variant()
+                                    ? itm.itype_variant().id : std::string{},
+                                count, true );
+                        } else {
+                            var->set_item_content( itype_id::NULL_ID(),
+                                mtype_id::NULL_ID(), std::string{},
+                                count, true );
+                        }
+                    } else {
+                        var->set_item_content( itype_id::NULL_ID(),
+                            mtype_id::NULL_ID(), std::string{},
+                            0, false );
+                    }
+                }
+            }
+        }
+    }
+
     // List all layers for a single z-level
     const std::array<decltype( &cata_tiles::draw_furniture ), 11> drawing_layers = {{
             &cata_tiles::draw_terrain, &cata_tiles::draw_furniture, &cata_tiles::draw_graffiti, &cata_tiles::draw_trap, &cata_tiles::draw_part_con,
@@ -4104,16 +4150,14 @@ bool cata_tiles::draw_field_or_item( const tripoint_bub_ms &p, const lit_level l
                 mon_id = std::get<1>( it_override->second );
                 hilite = std::get<2>( it_override->second );
                 it_type = item::find_type( it_id );
-            } else if( !invisible[0] && here.sees_some_items( p, get_player_character() ) ) {
-                const item &itm = tile.get_uppermost_item();
-                if( itm.has_itype_variant() ) {
-                    variant = itm.itype_variant().id;
+            } else if( !invisible[0] && cap.sees_items ) {
+                it_id = cap.item_content;
+                mon_id = cap.item_corpse_mtype;
+                if( !cap.item_variant.empty() ) {
+                    variant = cap.item_variant;
                 }
-                const mtype *const mon = itm.get_mtype();
-                it_id = itm.typeId();
-                mon_id = mon ? mon->id : mtype_id::NULL_ID();
-                hilite = tile.get_item_count() > 1;
-                it_type = itm.type;
+                hilite = cap.item_count > 1;
+                it_type = item::find_type( it_id );
             } else {
                 it_type = nullptr;
             }
@@ -4133,7 +4177,7 @@ bool cata_tiles::draw_field_or_item( const tripoint_bub_ms &p, const lit_level l
             }
         }
         // we may still need to draw the highlight
-        else if( tile.get_item_count() > 1 && here.sees_some_items( p, get_player_character() ) ) {
+        else if( cap.item_count > 1 && cap.sees_items ) {
             draw_item_highlight( p, height_3d );
         }
     }

--- a/src/view_snapshot.h
+++ b/src/view_snapshot.h
@@ -125,8 +125,8 @@ struct tile_render_info {
         // Only the static layers are captured here — terrain, furniture, trap,
         // partial construction, graffiti — because the rebuild runs only when
         // the cache is marked dirty (player action), which matches how often
-        // these change.  Fields are captured per-frame in draw(); items,
-        // vehicles, and creatures remain on the live path for now.
+        // these change.  Fields and items are captured per-frame in draw();
+        // vehicles and creatures remain on the live path for now.
         //
         // A null/empty content field means nothing was captured for that layer
         // (memory / override / invisible tiles, or simply nothing present).
@@ -156,6 +156,19 @@ struct tile_render_info {
         field_type_id field_content;
         int field_intensity = 0;
 
+        // Item data for the topmost visible item, captured per-frame
+        // alongside fields.  Items can appear or disappear between the
+        // dirty-gated rebuild and the layer loop (monster drops, pickup
+        // during handle_action, etc.), so a one-shot rebuild-time
+        // capture is insufficient.
+        // Default-constructed itype_id (null) means no displayable
+        // topmost item is visible on this tile.
+        itype_id item_content;
+        mtype_id item_corpse_mtype;
+        std::string item_variant;
+        int item_count = 0;
+        bool sees_items = false;
+
         sprite( const lit_level ll, const std::array<bool, 5> &inv )
             : ll( ll ), invisible( inv ) {}
 
@@ -182,6 +195,15 @@ struct tile_render_info {
         void set_field_content( const field_type_id &fid, const int intensity ) {
             field_content = fid;
             field_intensity = intensity;
+        }
+        void set_item_content( const itype_id &it, const mtype_id &corpse_mt,
+                               const std::string &variant, const int count,
+                               const bool sees ) {
+            item_content = it;
+            item_corpse_mtype = corpse_mt;
+            item_variant = variant;
+            item_count = count;
+            sees_items = sees;
         }
     };
 
@@ -290,8 +312,6 @@ class draw_points_cache_t
 //    for the full TODO.
 //
 // 4. MISSING L3 DATA (not captured yet; live-read every frame):
-//    - field data (type + intensity)
-//    - item data (topmost item itype_id + count)
 //    - vehicle part data (vpart_id + display state + paint color name)
 //    - creature data (CreatureView: type id, facing, mount/summoner flags)
 //    - light scalar (float from lm[][]) — currently only computed RGBA tint is stored


### PR DESCRIPTION
#### 概述 (Summary)

Infrastructure "将物品渲染的 topmost-item 路径从地图 live-read 切换为逐帧缓存读取"

---

#### 改动目的 (Purpose of change)

渲染管线逐步减少对 `get_map()` 的直接访问：在 field 缓存（上一个 PR）基础上，把物品渲染所需的地图查询从绘制函数内部移到逐帧刷新循环中预先完成。

Continue reducing live `get_map()` accesses from the rendering pipeline: building on the field cache, pre-compute item-rendering map queries in a per-frame refresh loop instead of doing them inside the draw function body.

---

#### 解决方案描述 (Describe the solution)

1. **`view_snapshot.h`** — `tile_render_info::sprite` 新增 5 个字段：`item_content` (itype_id)、`item_corpse_mtype` (mtype_id)、`item_variant` (string)、`item_count` (int)、`sees_items` (bool)，以及 `set_item_content()` setter。更新 sprite 注释和已知缺口列表。

2. **`cata_tiles.cpp`** — 在 field 刷新循环之后新增 item 每帧刷新循环，遍历 draw-points cache 中所有可见 sprite tile，从地图读取物品信息填入缓存字段。采用无条件全量覆写策略，避免 stale 数据。

3. **`draw_field_or_item` 消费端** — topmost-item 路径改读缓存字段（`cap.item_content` / `cap.item_corpse_mtype` / `cap.item_variant` / `cap.item_count` / `cap.sees_items`）；hilite 回落路径同理。`itm.type` 替换为 `item::find_type(it_id)`（静态字典查表）。Layer item 迭代保留原位置。

---

1. **`view_snapshot.h`** — adds 5 fields to `tile_render_info::sprite`: `item_content`, `item_corpse_mtype`, `item_variant`, `item_count`, `sees_items`, plus `set_item_content()` setter. Updates sprite comment and known-gap list.

2. **`cata_tiles.cpp`** — adds per-frame item refresh loop after the field refresh loop, iterating all visible sprite tiles in the draw-points cache, reading item data from the map and writing into cache fields. Uses unconditional full-overwrite to prevent stale data.

3. **`draw_field_or_item` consumer** — topmost-item path reads cached fields; highlight fallback reads `cap.item_count > 1 && cap.sees_items`. Replaces `itm.type` with `item::find_type(it_id)` (static dictionary lookup). Layer item iteration remains unchanged.

---

#### 你考虑过的替代方案 (Describe alternatives you've considered)

- **全量 item 捕获（包括 layer item 迭代）**：需要捕获每个 tile 的所有 item type_id + seed，改动面超出当前范围。留待后续。
- **将 `maptile_at` 移入 `if(!invisible[0])` 守卫内**：layer iteration 仍需要它，移动会增加不必要的结构调整。暂保持原位置。

- **Full item capture (including layer item iteration)**: requires capturing all item type_ids + seeds per tile, beyond current scope. Deferred.
- **Moving `maptile_at` inside `if(!invisible[0])` guard**: still needed by layer iteration; deferred until layer items are also cached.

---

#### 测试 (Testing)

- [x] MSVC TILES Release|x64 构建 0 错误（27.8s 增量编译）
- [x] MSVC Headless Release-NoTilesHeadless|x64 构建 0 错误（10m 36s 全量编译）
- [x] 肉眼：地面单物品 / 多物品高亮 / 捡起消失 / 尸体 sprite / variant 物品 / layer 物品（桌上书）/ 容器内物品不可见 / 暗处记忆
- [x] 确定性回放 A/B diff 证 sim 中立

建议审核重点：item refresh 循环的三分支正确性、`draw_field_or_item` 中新旧路径等价性、`set_item_content` 全量覆写确保无 stale。

- [x] MSVC TILES Release|x64 build: 0 errors (27.8s incremental)
- [x] MSVC Headless Release-NoTilesHeadless|x64 build: 0 errors (10m 36s full)
- [x] Visual: single item / multi-item highlight / pickup disappear / corpse sprite / variant items / layer items (book on table) / container items invisible / dark area memory
- [x] Deterministic replay A/B diff proving sim-neutral

Suggested review focus: three-branch correctness of item refresh loop, old to new path equivalence in `draw_field_or_item`, full-overwrite guaranteeing no stale data.

---

#### 补充说明 (Additional context)

与 field 缓存同构：同一组 z-level/row 遍历边界、同一个 draw-points cache 数据源、同一类 setter 模式。后续待捕获的渲染数据：vehicle part、creature、light scalar、per-tile version。

Same structure as the field cache: same z-level/row traversal, same draw-points cache source, same setter pattern. Remaining render-data items to cache: vehicle part, creature, light scalar, per-tile version.
