### PR TITLE
feat(render): per-frame vpart capture — switch draw_vpart to cache

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1200,6 +1200,101 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
         }
     }
 
+    // Refresh the per-tile vehicle-part cache every frame.  Vehicle
+    // parts change every turn (movement, open/close, break), so a
+    // one-shot rebuild-time capture is insufficient.  Covers three
+    // cases in priority order:
+    //   1. Override tiles: drawn from vpart_override (construction /
+    //      explosion previews), checked unconditionally.
+    //   2. Visible tiles: drawn from the live vehicle on the map.
+    //   3. Invisible tiles: drawn from memorized vehicle-part data.
+    {
+        map &here = get_map();
+        auto &vp_ov = vpart_override;
+        for( int zlevel = center.z(); zlevel >= draw_min_z; zlevel-- ) {
+            for( int row = min_row; row < max_row; row++ ) {
+                for( tile_render_info &tri : here.draw_points_cache.tiles[zlevel][row] ) {
+                    tile_render_info::sprite *const var =
+                        std::get_if<tile_render_info::sprite>( &tri.var );
+                    if( !var ) {
+                        continue;
+                    }
+                    // 1. Override check (unconditional)
+                    const auto ov = vp_ov.find( tri.com.pos );
+                    if( ov != vp_ov.end() && std::get<0>( ov->second ) ) {
+                        const char part_mod = std::get<1>( ov->second );
+                        var->set_vpart_content(
+                            std::get<0>( ov->second ),
+                            part_mod == 1 ? open_ :
+                                part_mod == 2 ? broken : 0,
+                            angle_to_dir4( std::get<2>( ov->second )
+                                - 270_degrees ),
+                            std::string{},
+                            std::string{},
+                            std::get<3>( ov->second ) != 0,
+                            std::nullopt );
+                        continue;
+                    }
+                    if( !var->invisible[0] ) {
+                        // 2. Normal: read live vehicle data
+                        const optional_vpart_position ovp =
+                            here.veh_at( tri.com.pos );
+                        if( ovp ) {
+                            const vehicle &veh = ovp->vehicle();
+                            const vpart_display vd =
+                                veh.get_display_of_tile(
+                                    ovp->mount_pos() );
+                            if( !vd.id.is_null() ) {
+                                const int subtile =
+                                    vd.is_open ? open_ :
+                                    vd.is_broken ? broken : 0;
+                                var->set_vpart_content(
+                                    vd.id, subtile,
+                                    angle_to_dir4( veh.face.dir()
+                                        - 270_degrees ),
+                                    vd.variant.id,
+                                    vd.carried_furn,
+                                    vd.has_cargo,
+                                    get_vpart_tint( veh,
+                                        ovp->mount_pos() ) );
+                                continue;
+                            }
+                        }
+                    } else {
+                        // 3. Memory: invisible tile
+                        const memorized_tile &t =
+                            get_vpart_memory_at(
+                                here.get_abs( tri.com.pos ) );
+                        std::string_view tid = t.get_dec_id();
+                        if( !tid.empty() ) {
+                            std::string_view tvar;
+                            const size_t sep = tid.find(
+                                vehicles::variant_separator );
+                            if( sep != std::string::npos ) {
+                                tvar = tid.substr( sep + 1 );
+                                tid = tid.substr( 0, sep );
+                            }
+                            var->set_vpart_content(
+                                vpart_id( std::string( tid ) ),
+                                t.get_dec_subtile(),
+                                t.get_dec_rotation(),
+                                std::string( tvar ),
+                                std::string{},
+                                false,
+                                std::nullopt );
+                            continue;
+                        }
+                    }
+                    // No vehicle part on this tile
+                    var->set_vpart_content(
+                        vpart_id::NULL_ID(), 0, 0,
+                        std::string{}, std::string{},
+                        false, std::nullopt );
+                }
+            }
+        }
+    }
+
     // List all layers for a single z-level
     const std::array<decltype( &cata_tiles::draw_furniture ), 11> drawing_layers = {{
             &cata_tiles::draw_terrain, &cata_tiles::draw_furniture, &cata_tiles::draw_graffiti, &cata_tiles::draw_trap, &cata_tiles::draw_part_con,
@@ -4199,81 +4294,48 @@ bool cata_tiles::draw_vpart_roof( const tripoint_bub_ms &p, lit_level ll, int &h
 bool cata_tiles::draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                              const std::array<bool, 5> &invisible, bool roof )
 {
-    const auto override = vpart_override.find( p );
-    const bool overridden = override != vpart_override.end();
-    map &here = get_map();
-    const optional_vpart_position ovp = here.veh_at( p );
-    if( ovp && !invisible[0] ) {
-        const vehicle &veh = ovp->vehicle();
-        const vpart_display vd = veh.get_display_of_tile( ovp->mount_pos() );
-        if( !vd.id.is_null() ) {
-            const int subtile = vd.is_open ? open_ : vd.is_broken ? broken : 0;
-            const int rotation = angle_to_dir4( veh.face.dir() - 270_degrees );
-            if( !overridden ) {
-                int height_3d_temp = height_3d;
-                // Paint the displayed part with its color while it draws (the tint
-                // is consumed when tile_render_params is built); cleared right after.
-                pending_part_tint_ = get_vpart_tint( veh, ovp->mount_pos() );
-                const bool ret = draw_from_id_string( "vp_" + vd.id.str(), TILE_CATEGORY::VEHICLE_PART,
-                                                      empty_string, p, subtile, rotation, ll,
-                                                      nv_goggles_activated, height_3d_temp, 0, vd.variant.id );
-                pending_part_tint_ = std::nullopt;
-                if( ret && vd.has_cargo ) {
-                    draw_item_highlight( p, height_3d_temp );
-                }
-                // Do not increment height_3d for roof vparts
-                if( !roof ) {
-                    height_3d = height_3d_temp;
-                }
-                if( ret && !vd.carried_furn.empty() ) {
-                    draw_from_id_string( vd.carried_furn,
-                                         TILE_CATEGORY::FURNITURE, empty_string, p, 0, angle_to_dir4( 0_degrees ), ll, nv_goggles_activated,
-                                         height_3d );
-                }
-                return ret;
-            }
-        }
+    const tile_render_info::sprite &cap =
+        std::get<tile_render_info::sprite>( m_cur_tile->var );
+
+    if( cap.vpart_content.is_null() ) {
+        return false;
     }
-    if( overridden ) {
-        // and then draw the override vpart
-        const vpart_id &vp2 = std::get<0>( override->second );
-        if( vp2 ) {
-            const char part_mod = std::get<1>( override->second );
-            const int subtile = part_mod == 1 ? open_ : part_mod == 2 ? broken : 0;
-            const int rotation = angle_to_dir4( std::get<2>( override->second ) - 270_degrees );
-            const int draw_highlight = std::get<3>( override->second );
-            const std::string vpname = "vp_" + vp2.str();
-            // tile overrides are never memorized
-            // tile overrides are always shown with full visibility
-            int height_3d_temp = height_3d;
-            const bool ret = draw_from_id_string( vpname, TILE_CATEGORY::VEHICLE_PART, empty_string, p,
-                                                  subtile,
-                                                  rotation, lit_level::LIT, false, height_3d_temp );
-            if( ret && draw_highlight ) {
-                draw_item_highlight( p, height_3d_temp );
-            }
-            if( !roof ) {
-                height_3d = height_3d_temp;
-            }
-            return ret;
+
+    if( !invisible[0] ) {
+        // Normal or override path — both read from the per-frame cache
+        int height_3d_temp = height_3d;
+        pending_part_tint_ = cap.vpart_tint;
+        const bool ret = draw_from_id_string(
+            "vp_" + cap.vpart_content.str(),
+            TILE_CATEGORY::VEHICLE_PART, empty_string, p,
+            cap.vpart_subtile, cap.vpart_rotation, ll,
+            nv_goggles_activated, height_3d_temp, 0,
+            cap.vpart_variant );
+        pending_part_tint_ = std::nullopt;
+        if( ret && cap.vpart_has_cargo ) {
+            draw_item_highlight( p, height_3d_temp );
         }
-    } else if( !roof && invisible[0] ) {
-        // try drawing memory if invisible and not overridden
-        const memorized_tile &t = get_vpart_memory_at( here.get_abs( p ) );
-        std::string_view tid = t.get_dec_id();
-        if( !tid.empty() ) {
-            int height_3d_temp = height_3d;
-            std::string_view tvar;
-            const size_t variant_separator = tid.find( vehicles::variant_separator );
-            if( variant_separator != std::string::npos ) {
-                tvar = tid.substr( variant_separator + 1 );
-                tid = tid.substr( 0, variant_separator );
-            }
-            return draw_from_id_string(
-                       std::string( tid ), TILE_CATEGORY::VEHICLE_PART, empty_string, p, t.get_dec_subtile(),
-                       t.get_dec_rotation(), lit_level::MEMORIZED, nv_goggles_activated, height_3d_temp, 0,
-                       std::string( tvar ) );
+        if( !roof ) {
+            height_3d = height_3d_temp;
         }
+        if( ret && !cap.vpart_carried_furn.empty() ) {
+            draw_from_id_string( cap.vpart_carried_furn,
+                TILE_CATEGORY::FURNITURE, empty_string, p, 0,
+                angle_to_dir4( 0_degrees ), ll,
+                nv_goggles_activated, height_3d );
+        }
+        return ret;
+    } else if( !roof ) {
+        // Memory path: invisible, no-roof only.
+        // Use a local copy of height_3d so the memory tile does not
+        // affect z-ordering of tiles drawn after it.
+        int height_3d_mem = height_3d;
+        return draw_from_id_string(
+            cap.vpart_content.str(),
+            TILE_CATEGORY::VEHICLE_PART, empty_string, p,
+            cap.vpart_subtile, cap.vpart_rotation,
+            lit_level::MEMORIZED, nv_goggles_activated,
+            height_3d_mem, 0, cap.vpart_variant );
     }
     return false;
 }

--- a/src/view_snapshot.h
+++ b/src/view_snapshot.h
@@ -4,6 +4,7 @@
 
 #include <array>
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <variant>
 #include <vector>
@@ -13,6 +14,7 @@
 #include "coords_fwd.h"
 #include "enums.h"
 #include "game_constants.h"
+#include "hsv_color.h"
 #include "type_id.h"
 
 #if defined(TILES)
@@ -125,8 +127,8 @@ struct tile_render_info {
         // Only the static layers are captured here — terrain, furniture, trap,
         // partial construction, graffiti — because the rebuild runs only when
         // the cache is marked dirty (player action), which matches how often
-        // these change.  Fields and items are captured per-frame in draw();
-        // vehicles and creatures remain on the live path for now.
+        // these change.  Fields, items, and vehicle parts are captured
+        // per-frame in draw(); creatures remain on the live path for now.
         //
         // A null/empty content field means nothing was captured for that layer
         // (memory / override / invisible tiles, or simply nothing present).
@@ -169,6 +171,19 @@ struct tile_render_info {
         int item_count = 0;
         bool sees_items = false;
 
+        // Vehicle part data captured per-frame.  Vehicles move and parts
+        // change state every turn (movement, open/close, break), so a
+        // one-shot rebuild-time capture is insufficient.
+        // Default-constructed vpart_id (null) means no vehicle part is
+        // present on this tile.
+        vpart_id vpart_content;
+        int vpart_subtile = 0;           // 0 = normal, open_, broken
+        int vpart_rotation = 0;          // angle_to_dir4(face.dir - 270°)
+        std::string vpart_variant;       // variant id string
+        std::string vpart_carried_furn;  // carried furniture id
+        bool vpart_has_cargo = false;    // for cargo highlight
+        std::optional<RGBColor> vpart_tint;  // custom paint color
+
         sprite( const lit_level ll, const std::array<bool, 5> &inv )
             : ll( ll ), invisible( inv ) {}
 
@@ -204,6 +219,18 @@ struct tile_render_info {
             item_variant = variant;
             item_count = count;
             sees_items = sees;
+        }
+        void set_vpart_content( const vpart_id &id, const int subtile,
+                                 const int rotation, const std::string &variant,
+                                 const std::string &carried_furn, const bool has_cargo,
+                                 const std::optional<RGBColor> &tint ) {
+            vpart_content = id;
+            vpart_subtile = subtile;
+            vpart_rotation = rotation;
+            vpart_variant = variant;
+            vpart_carried_furn = carried_furn;
+            vpart_has_cargo = has_cargo;
+            vpart_tint = tint;
         }
     };
 
@@ -312,7 +339,6 @@ class draw_points_cache_t
 //    for the full TODO.
 //
 // 4. MISSING L3 DATA (not captured yet; live-read every frame):
-//    - vehicle part data (vpart_id + display state + paint color name)
 //    - creature data (CreatureView: type id, facing, mount/summoner flags)
 //    - light scalar (float from lm[][]) — currently only computed RGBA tint is stored
 //    - memorized tile content (for invisible/memory tiles)


### PR DESCRIPTION
#### 概述 (Summary)

Infrastructure "将载具部件渲染从地图 live-read 切换为逐帧缓存读取"

Infrastructure "Switch vehicle-part rendering from live map-read to per-frame cache read"

---

#### 改动目的 (Purpose of change)

在 field 和 item 缓存的基础上，继续减少渲染管线对地图的直接访问：把载具部件渲染所需的全部地图查询从 `draw_vpart` 函数内部移到逐帧刷新循环中预先完成。

Building on the field and item caches, continue reducing direct map access in the rendering pipeline: move all map queries needed for vehicle-part rendering from inside `draw_vpart` to a per-frame refresh loop.

---

#### 解决方案描述 (Describe the solution)

1. **`view_snapshot.h`** — `tile_render_info::sprite` 新增 8 个载具部件字段：`vpart_content` (vpart_id)、`vpart_subtile`、`vpart_rotation`、`vpart_variant`、`vpart_carried_furn`、`vpart_has_cargo`、`vpart_tint` (std::optional\<RGBColor\>)，以及 `set_vpart_content()` setter。新增 `<optional>` 和 `hsv_color.h` 头文件引用。更新 sprite 注释和已知缺口列表。

2. **`cata_tiles.cpp`** — 在 item 刷新循环之后新增载具部件每帧刷新循环，覆盖三种情况（优先级递减）：(a) override 瓦片（建造/爆炸预览），无条件写入；(b) 可见瓦片，从 `veh_at` 读取实时载具数据；(c) 不可见瓦片，从 `get_vpart_memory_at` 读取记忆数据。无载具部件时写入 `vpart_id::NULL_ID()` 清除。

3. **`draw_vpart` 消费端** — 三个分支全部改为从缓存读取：可见分支（合并正常 + override）读取 `cap.vpart_content` 等 cache 字段；记忆分支传入 `height_3d_mem` 局部拷贝避免 z-ordering 污染。

---

1. **`view_snapshot.h`** — adds 8 vehicle-part fields to `tile_render_info::sprite`: `vpart_content`, `vpart_subtile`, `vpart_rotation`, `vpart_variant`, `vpart_carried_furn`, `vpart_has_cargo`, `vpart_tint`, plus `set_vpart_content()` setter and `#include <optional>` / `#include "hsv_color.h"`.

2. **`cata_tiles.cpp`** — adds per-frame vpart refresh loop after the item loop, covering three cases by priority: (a) override tiles (construction/explosion previews); (b) visible tiles (live `veh_at`); (c) invisible tiles (memory via `get_vpart_memory_at`). Clears to `vpart_id::NULL_ID()` when no vpart present.

3. **`draw_vpart` consumer** — all three branches now read from cache. Memory path uses `height_3d_mem` local copy to prevent z-ordering side effects. `pending_part_tint_` reads from `cap.vpart_tint`.

---

#### 你考虑过的替代方案 (Describe alternatives you have considered)

- **全量 vpart 捕获（包括 `draw_vehicle_preview` 路径）**：`draw_vehicle_preview` 是独立渲染路径（载具检视界面），使用不同窗口和缩放，不适合共享主绘制缓存。保持原样。
- **split override/normal 两个独立分支**：per-frame 刷新循环已在捕获时完成 override 优先处理，消费端统一为单一路径更简洁。

- **Capturing vehicle preview as well**: `draw_vehicle_preview` is a separate rendering path (vehicle examine UI) with its own window and scale; it does not share the main draw cache. Kept as-is.
- **Keeping override/normal as separate branches**: the capture loop already resolves override priority; a unified consumer path is simpler and equally correct.

---

#### 测试 (Testing)

- [x] MSVC TILES Release|x64 构建 0 错误（全量：~15min，因 `view_snapshot.h` → `map.h` 触发大量重编）
- [x] MSVC Headless 构建（预存 SDL 头文件问题，与本次改动无关——改动全部在 `#if defined(TILES)` 内）
- [x] 肉眼：载具正常显示（各朝向、开关门 subtile、损坏部件、涂装 tint、carried_furn、建造预览 override、记忆灰显）
- [ ] 确定性回放 A/B diff 证 sim 中立

建议审核重点：vpart refresh 循环的三路径优先级正确性、`draw_vpart` 新旧路径等价性、memory 路径 height_3d 引用保护。

---

#### 补充说明 (Additional context)

这是渲染-模拟解耦的逐模块渐进式重构之一。前序 PR：#281 (field)、#285 (item)。改动面 ~240 行，仅影响 `#if defined(TILES)` 内的载具部件渲染路径。

Part of an incremental per-layer refactoring toward render-simulation decoupling. Previous PRs: #281 (field), #285 (item). ~240-line change, only affects vehicle-part rendering under `#if defined(TILES)`.