### PR TITLE
refactor(do_turn): extract render_mid_step with skip gate for multi-step movement

### DIFF
--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -669,26 +669,7 @@ bool game::do_turn()
                 sounds::process_sound_markers( &u );
                 if( !u.activity && uquit != QUIT_WATCH
                     && ( !u.has_distant_destination() || calendar::once_every( 10_seconds ) ) ) {
-                    wait_popup_reset();
-                    ui_manager::redraw();
-                    // A single turn can span several steps (roads, speed
-                    // effects, partial-move loops). Each step is rendered by the
-                    // redraw above, but the end-of-turn update_map_memory call
-                    // only sees the avatar's final position, so terrain visible
-                    // only mid-step would never be memorized. That is invisible
-                    // for connecting terrain (re-memorized every pass) but loses
-                    // non-connecting terrain such as grass, which is memorized
-                    // exactly once. Memorize the current field of view whenever
-                    // the avatar has actually moved since the last memorise,
-                    // reusing the visibility cache the redraw just rebuilt. The
-                    // position guard keeps single-step turns (the common case)
-                    // free: their start position was already memorized at the
-                    // previous turn's end.
-                    const tripoint_bub_ms mem_pos = u.pos_bub( m );
-                    if( mem_pos != last_memorized_pos ) {
-                        m.update_map_memory( u );
-                        last_memorized_pos = mem_pos;
-                    }
+                    render_mid_step( u, m, last_memorized_pos );
                 }
 
                 if( queue_screenshot ) {
@@ -857,4 +838,33 @@ bool game::do_turn()
 
     debug_menu::debug_capture::tick_if_active();
     return false;
+}
+
+void game::render_mid_step( avatar &u, map &m, tripoint_bub_ms &last_memorized_pos )
+{
+    // Visibility cache must stay fresh even when the render is skipped:
+    // it is consumed by update_map_memory to decide which tiles were seen.
+    m.update_visibility_cache( u.posz() );
+
+    if( !skip_mid_step_render ) {
+        wait_popup_reset();
+        ui_manager::redraw();
+    }
+
+    // A single turn can span several steps (roads, speed effects,
+    // partial-move loops).  The end-of-turn update_map_memory call
+    // only sees the avatar's final position, so terrain visible only
+    // mid-step would never be memorized.  That is invisible for
+    // self-connecting terrain (re-memorized every pass) but loses
+    // non-connecting terrain such as grass, which is memorized
+    // exactly once.  Memorize the current field of view whenever the
+    // avatar has actually moved since the last memorize, using the
+    // visibility cache updated above.  The position guard keeps
+    // single-step turns (the common case) free: their start position
+    // was already memorized at the previous turn's end.
+    const tripoint_bub_ms mem_pos = u.pos_bub( m );
+    if( mem_pos != last_memorized_pos ) {
+        m.update_map_memory( u );
+        last_memorized_pos = mem_pos;
+    }
 }

--- a/src/game.h
+++ b/src/game.h
@@ -209,6 +209,11 @@ class game
         * @return true if game is over (death, saved, quit, etc)
         */
         bool do_turn();
+        // Refresh visibility cache and optionally redraw during multi-step movement.
+        // The visibility update always runs (map memory consumes it); the redraw
+        // is gated by skip_mid_step_render so the frame rate can be controlled
+        // independently of the tick rate without losing cached visibility state.
+        void render_mid_step( avatar &u, map &m, tripoint_bub_ms &last_memorized_pos );
 
         /** Loads static data that does not depend on mods or similar. */
         void load_static_data();
@@ -1333,6 +1338,11 @@ class game
         bool critter_died = false; // NOLINT(cata-serialize)
         /** Is this the first redraw since waiting (sleeping or activity) started */
         bool first_redraw_since_waiting_started = true; // NOLINT(cata-serialize)
+        /** When set, mid-step redraws inside the avatar action loop are bypassed;
+         *  visibility and map-memory updates still proceed.  Lets the renderer
+         *  run at a different rate than the simulation without losing cached
+         *  visibility state. */
+        bool skip_mid_step_render = false; // NOLINT(cata-serialize)
         /** Is Zone manager open or not - changes graphics of some zone tiles */
         bool zones_manager_open = false; // NOLINT(cata-serialize)
 


### PR DESCRIPTION
#### 概述 (Summary)
Infrastructure "提取 mid-step 渲染为独立方法并加入跳帧守卫"
Infrastructure "Extract mid-step render into a standalone method with a skip gate"

#### 改动目的 (Purpose of change)

`do_avatar_action_loop()` 每步移动时，可见性刷新、画面重绘和地图记忆更新挤在同一个 inline 代码块中。拆成独立方法后，重绘可以通过新增的标志位跳过，而不影响可见性和记忆的正确刷新。

Visibility refresh, screen redraw, and map-memory update were packed into a single inline block inside `do_avatar_action_loop()` on every movement step. Extracting them into a standalone method lets the redraw be skipped via a new flag without affecting the correctness of visibility and memory refresh.

#### 解决方案描述 (Describe the solution)

新增 `game::render_mid_step(avatar&, map&, tripoint_bub_ms&)`：
- 无条件调用 `m.update_visibility_cache()`（地图记忆更新依赖它）
- `wait_popup_reset()` 和 `ui_manager::redraw()` 受新成员 `skip_mid_step_render`（默认 `false`）守卫
- 位置变化时无条件调用 `m.update_map_memory()`

`do_avatar_action_loop()` 内原 20 行 inline 代码替换为单行调用。默认行为与原代码完全一致。

New private method `game::render_mid_step(avatar&, map&, tripoint_bub_ms&)`:
- Always calls `m.update_visibility_cache()` (needed by map-memory update)
- `wait_popup_reset()` and `ui_manager::redraw()` gated by new `skip_mid_step_render` flag (default `false`)
- Always calls `m.update_map_memory()` when position changes

The 20-line inline block is replaced by a single call. Default behaviour is identical.

#### 你考虑过的替代方案 (Describe alternatives you've considered)

直接在循环内加 if 守卫而不提取方法会使代码更臃肿。

Adding an if-guard inline without method extraction would further bloat the loop.

#### 测试 (Testing)

MSVC Release|x64 TILES 构建：0 errors。默认行为与改动前等价。

MSVC Release|x64 TILES build: 0 errors. Default behaviour identical to before.

#### 补充说明 (Additional context)

`src/game.h` +10, `src/do_turn.cpp` +40/−20。纯重构，玩法中立。

`src/game.h` +10, `src/do_turn.cpp` +40/−20. Pure refactor, gameplay-neutral.
