### PR TITLE
refactor(do_turn): extract four phase methods from monolithic do_turn()

### DIFF
--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -542,6 +542,18 @@ bool game::do_turn()
 
     drain_renderer_recovery();
 
+    simulate_turn_prefix();
+    if( do_avatar_action_loop() ) {
+        return turn_handler::cleanup_at_end();
+    }
+    simulate_turn_suffix();
+    present_turn();
+
+    return false;
+}
+
+void game::simulate_turn_prefix()
+{
     weather_manager &weather = get_weather();
 
     // Increment game turn
@@ -643,6 +655,12 @@ bool game::do_turn()
     if( u.is_deaf() ) {
         sfx::do_hearing_loss();
     }
+}
+
+bool game::do_avatar_action_loop()
+{
+    avatar &u = get_avatar();
+    map &m = get_map();
 
     // avatar processes human input through handle_action()
     if( !u.has_effect( effect_sleep ) || uquit == QUIT_WATCH ) {
@@ -683,7 +701,7 @@ bool game::do_turn()
                 }
 
                 if( is_game_over() ) {
-                    return turn_handler::cleanup_at_end();
+                    return true;
                 }
 
                 if( uquit == QUIT_WATCH ) {
@@ -723,6 +741,13 @@ bool game::do_turn()
             }
         }
     }
+    return false;
+}
+
+void game::simulate_turn_suffix()
+{
+    avatar &u = get_avatar();
+    map &m = get_map();
 
     if( driving_view_offset.x() != 0 || driving_view_offset.y() != 0 ) {
         // Still have a view offset, but might not be driving anymore,
@@ -785,14 +810,20 @@ bool game::do_turn()
     if( !in_long_wait ) {
         m.update_map_memory( u );
     }
+}
+
+void game::present_turn()
+{
+    avatar &u = get_avatar();
+    map &m = get_map();
 
     if( u.get_moves() < 0 && get_option<bool>( "FORCE_REDRAW" ) ) {
         ui_manager::redraw();
         refresh_display();
     }
 
-    if( levz >= 0 && !u.is_underwater() ) {
-        handle_weather_effects( weather.weather_id );
+    if( m.get_abs_sub().z() >= 0 && !u.is_underwater() ) {
+        handle_weather_effects( get_weather().weather_id );
     }
 
     handle_progress_ui();
@@ -800,6 +831,7 @@ bool game::do_turn()
     m.invalidate_visibility_cache();
 
     u.update_bodytemp();
+    weather_manager &weather = get_weather();
     u.update_body_wetness( *weather.weather_precise );
     u.apply_wetness_morale( weather.temperature );
 
@@ -837,7 +869,6 @@ bool game::do_turn()
 #endif
 
     debug_menu::debug_capture::tick_if_active();
-    return false;
 }
 
 void game::render_mid_step( avatar &u, map &m, tripoint_bub_ms &last_memorized_pos )

--- a/src/game.h
+++ b/src/game.h
@@ -215,6 +215,12 @@ class game
         // independently of the tick rate without losing cached visibility state.
         void render_mid_step( avatar &u, map &m, tripoint_bub_ms &last_memorized_pos );
 
+        // do_turn decomposition — each method handles a distinct phase of the game loop.
+        void simulate_turn_prefix();       // world progression: calendar, weather, NPCs, hordes
+        bool do_avatar_action_loop();      // player input & action; returns true if game over
+        void simulate_turn_suffix();       // post-action simulation: creatures, map cache, memory
+        void present_turn();               // rendering, audio, UI, cleanup
+
         /** Loads static data that does not depend on mods or similar. */
         void load_static_data();
 


### PR DESCRIPTION
#### 概述 (Summary)
Infrastructure "拆分 do_turn 单体函数为四个阶段方法"
Infrastructure "Split monolithic do_turn() into four phase methods"

#### 改动目的 (Purpose of change)

`do_turn()` 是一个 333 行的单体函数，把世界推进、玩家输入、渲染和音频焊在一起。拆成四个独立方法后，每个方法只处理一个阶段，后续可以独立调整渲染帧率或替换渲染后端而不影响模拟逻辑。

`do_turn()` was a 333-line monolithic function that welded world progression, player input, rendering, and audio together. Splitting it lets each phase be reasoned about independently and allows future rendering changes without touching the simulation.

#### 解决方案描述 (Describe the solution)

提取四个 `game::` 私有方法：
- `simulate_turn_prefix()` — 日历推进、天气更新、NPC 生成、horde 移动等前置模拟
- `do_avatar_action_loop()` — 玩家输入处理与动作循环（返回 `true` 表示游戏结束）
- `simulate_turn_suffix()` — 怪物移动、地图缓存重建、地图记忆更新等后置模拟
- `present_turn()` — 渲染、音频、体力/士气更新等呈现

`do_turn()` 变为 ~25 行骨架依次调用这四个方法。

Extracts four private `game::` methods:
- `simulate_turn_prefix()` — calendar, weather, NPC spawn, horde movement
- `do_avatar_action_loop()` — player input/action loop (returns `true` on game over)
- `simulate_turn_suffix()` — monster movement, map cache, memory update
- `present_turn()` — rendering, audio, body/morale updates

`do_turn()` becomes a ~25-line skeleton that calls them in order.

#### 你考虑过的替代方案 (Describe alternatives you've considered)

保持单体函数不变。但后续无论做异步渲染还是 RenderBackend 替换都必须在已拆分的结构上进行，长痛不如短痛。

Keep the monolithic function. But any later async rendering or RenderBackend work would require splitting it anyway.

#### 测试 (Testing)

MSVC Release|x64 构建：0 errors。方法内部代码是从原函数逐行复制后删除，零行为变化。

MSVC Release|x64 build: 0 errors. Method bodies are copy-pasted from the original then deleted — zero behaviour change.

#### 补充说明 (Additional context)

`src/game.h` +6, `src/do_turn.cpp` +41/−4。纯重构，玩法中立。

`src/game.h` +6, `src/do_turn.cpp` +41/−4. Pure refactor, gameplay-neutral.
