### PR TITLE
refactor(do_turn): move world-state updates to sim side; present_turn is pure render

### DIFF
--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -810,30 +810,22 @@ void game::simulate_turn_suffix()
     if( !in_long_wait ) {
         m.update_map_memory( u );
     }
-}
 
-void game::present_turn()
-{
-    avatar &u = get_avatar();
-    map &m = get_map();
-
-    if( u.get_moves() < 0 && get_option<bool>( "FORCE_REDRAW" ) ) {
-        ui_manager::redraw();
-        refresh_display();
-    }
-
-    if( m.get_abs_sub().z() >= 0 && !u.is_underwater() ) {
+    // Per-turn world-state updates previously ran inside present_turn().
+    // Moving them here keeps simulation advancing every tick regardless of
+    // whether the renderer is gated.
+    if( levz >= 0 && !u.is_underwater() ) {
         handle_weather_effects( get_weather().weather_id );
     }
-
-    handle_progress_ui();
 
     m.invalidate_visibility_cache();
 
     u.update_bodytemp();
-    weather_manager &weather = get_weather();
-    u.update_body_wetness( *weather.weather_precise );
-    u.apply_wetness_morale( weather.temperature );
+    {
+        weather_manager &weather = get_weather();
+        u.update_body_wetness( *weather.weather_precise );
+        u.apply_wetness_morale( weather.temperature );
+    }
 
     if( calendar::once_every( 1_minutes ) ) {
         u.update_morale();
@@ -847,6 +839,25 @@ void game::present_turn()
         u.check_and_recover_morale();
     }
 
+    // reset player noise
+    u.volume = 0;
+
+    // Calculate bionic power balance
+    u.power_balance = u.get_power_level() - u.power_prev_turn;
+    u.power_prev_turn = u.get_power_level();
+}
+
+void game::present_turn()
+{
+    avatar &u = get_avatar();
+
+    if( u.get_moves() < 0 && get_option<bool>( "FORCE_REDRAW" ) ) {
+        ui_manager::redraw();
+        refresh_display();
+    }
+
+    handle_progress_ui();
+
     if( !u.is_deaf() ) {
         sfx::remove_hearing_loss();
     }
@@ -854,13 +865,6 @@ void game::present_turn()
     sfx::do_vehicle_engine_sfx();
     sfx::do_vehicle_exterior_engine_sfx();
     sfx::do_low_stamina_sfx();
-
-    // reset player noise
-    u.volume = 0;
-
-    // Calculate bionic power balance
-    u.power_balance = u.get_power_level() - u.power_prev_turn;
-    u.power_prev_turn = u.get_power_level();
 
 #if defined(EMSCRIPTEN)
     // This will cause a prompt to be shown if the window is closed, until the

--- a/src/game.h
+++ b/src/game.h
@@ -219,7 +219,7 @@ class game
         void simulate_turn_prefix();       // world progression: calendar, weather, NPCs, hordes
         bool do_avatar_action_loop();      // player input & action; returns true if game over
         void simulate_turn_suffix();       // post-action simulation: creatures, map cache, memory
-        void present_turn();               // rendering, audio, UI, cleanup
+        void present_turn();               // rendering, audio, UI
 
         /** Loads static data that does not depend on mods or similar. */
         void load_static_data();
@@ -1349,6 +1349,7 @@ class game
          *  run at a different rate than the simulation without losing cached
          *  visibility state. */
         bool skip_mid_step_render = false; // NOLINT(cata-serialize)
+
         /** Is Zone manager open or not - changes graphics of some zone tiles */
         bool zones_manager_open = false; // NOLINT(cata-serialize)
 


### PR DESCRIPTION
#### 概述 (Summary)
Infrastructure "将回合末世界态更新从渲染函数迁入模拟侧，present_turn 变纯渲染 (move end-of-turn world-state updates from render function to sim side; present_turn becomes pure render)"

#### 改动目的 (Purpose of change)
`present_turn()` 原本混杂了两类操作：画面呈现（redraw、UI、音频）和世界态更新（天气效果、体温、士气、湿度、噪音、仿生电力）。这种混合使帧率无法独立控制——每次要用帧率限速或跳帧时，世界态也被跳过。本 PR 把七项世界态更新迁到 `simulate_turn_suffix()`，让 `present_turn()` 变成纯渲染，世界态每 tick 必定推进，不受帧率影响。

`present_turn()` mixed two kinds of work: visual presentation (redraw, UI, audio) and world-state mutation (weather effects, body temperature, morale, wetness, noise, bionic power). This coupling made independent frame-rate control impossible — any frame-rate limit or skip-gate also skipped world-state progression. This PR moves the seven world-state mutations into `simulate_turn_suffix()`, leaving `present_turn()` as pure rendering; world state always advances every tick regardless of the render gate.

#### 解决方案描述 (Describe the solution)
- `simulate_turn_suffix()` 末尾新增七项每回合状态更新：`handle_weather_effects`、`invalidate_visibility_cache`、`update_bodytemp`、`update_body_wetness` / `apply_wetness_morale`、士气更新、`volume = 0`、电力结算。
- `present_turn()` 简化为纯渲染 + 音频 + UI。移除 `map &m`（不再需要）。
- `game.h` 中 `present_turn()` 注释从 "rendering, audio, UI, cleanup" 改为 "rendering, audio, UI"。

- Seven per-turn state mutations appended to `simulate_turn_suffix()`: `handle_weather_effects`, `invalidate_visibility_cache`, `update_bodytemp`, `update_body_wetness` / `apply_wetness_morale`, morale tick, noise reset, power-balance calculation.
- `present_turn()` reduced to pure rendering + audio + UI. Dropped `map &m` local.
- `game.h` comment for `present_turn()` updated accordingly.

#### 你考虑过的替代方案 (Describe alternatives you have considered)
- **在 do_turn() 骨架中加 end-of-turn 时间门控来限帧**：这样 `present_turn()` 被跳过时世界态也停了，且造成视口滞后（移动后画面不更新）和长时间动作刷新间隔异常。正确做法是让 mid-step render gate（先前 PR #291）做帧率分离，end-of-turn present 保持无条件。

- **Adding an end-of-turn time-gate in do_turn() to limit frame-rate**: rejected — skipping present_turn() also skipped world-state, caused viewport lag (screen behind avatar position) and broken progress-UI refresh timing. The correct place for frame-rate decoupling is the mid-step render gate from PR #291; end-of-turn present must remain unconditional.

#### 测试 (Testing)
- MSVC Release|x64 完整构建，0 errors，6 预存 warnings。
- 进游戏走路、开车、睡眠、等待：画面正常无闪退；天气淋湿、体温/士气/噪音/电力变化正常。
- 无头 `--jsonverify` exit 0。
- 纯重构性质的行为迁动：所有七项调用的条件和参数与原代码逐字一致，仅换执行位置（仍在 suffix→present 的同一调用链内）。

- MSVC Release|x64 full build, 0 errors, 6 pre-existing warnings.
- In-game walking, driving, sleeping, waiting: no crash or visual regression; weather wetness, body temp, morale, noise, bionic power all update correctly.
- Headless `--jsonverify` exits 0.
- Pure-relocation refactor: all seven calls use identical conditions and arguments verbatim, only the execution site changes (still within the same suffix→present call chain).

#### 补充说明 (Additional context)
- 本 PR 与 #291（mid-step render 提取 + 跳帧守卫）配套：3B 解除多步移动中间的渲染耦合，3C 解除回合末渲染函数内的状态耦合。两个 PR 独立，可分别 review/合并。
- 改动量：2 文件，+30 / −25 行。

- Companion to #291 (mid-step render extraction + skip gate): 3B decouples the render inside multi-step movement, 3C decouples state mutations inside the end-of-turn render function. The two PRs are independent and can be reviewed/merged separately.
- Diff stats: 2 files, +30 / −25 lines.