### PR TITLE
fix #296 物品组和物品混淆

### DIFF
--- a/data/json/itemgroups/SUS/domestic.json
+++ b/data/json/itemgroups/SUS/domestic.json
@@ -844,7 +844,7 @@
           },
           { "group": "birth_control", "prob": 50 },
           { "group": "estrogen_hrt", "prob": 2 },
-          { "group": "testosterone", "prob": 1 }
+          { "group": "testosterone_hrt", "prob": 1 }
         ],
         "prob": 95
       },

--- a/data/json/npcs/NC_REFUGEE_DOCTOR.json
+++ b/data/json/npcs/NC_REFUGEE_DOCTOR.json
@@ -123,7 +123,7 @@
       { "item": "syringe", "prob": 20 },
       { "group": "birth_control", "prob": 25 },
       { "group": "estrogen_hrt", "prob": 1 },
-      { "group": "testosterone", "prob": 1 }
+      { "group": "testosterone_hrt", "prob": 1 }
     ]
   }
 ]


### PR DESCRIPTION
修复pr #296 中物品组条目配置部分物品组和物品混淆导致的报错