### PR TITLE
bugfix: 删除车辆狭小空间检测对huge体型的重复判定

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -284,11 +284,6 @@ bool Creature::will_be_cramped_in_vehicle_tile( map &here, const tripoint_abs_ms
             return true;
         }
 
-        if( size == creature_size::huge &&
-            !vp_there.part_with_feature( "HUGE_OK", false ) ) {
-            return true;
-        }
-
         // free_cargo * 0.75 < critter_volume && critter_volume <= free_cargo
         if( free_cargo * 0.75 < critter_volume ) {
             if( !mon || !( mon->type->bodytype == "snake" || mon->type->bodytype == "blob" ||


### PR DESCRIPTION
#### 概述 (Summary)

None

#### 改动目的 (Purpose of change)

当前游戏用`will_be_cramped_in_vehicle_tile`函数来判断角色或怪物是否在载具的特定图格上是“身处狭小空间”。但我检阅了相关代码，发现这里有两段判断：
```
        if( size == creature_size::huge &&
            !vp_there.part_with_feature( "HUGE_OK", false ) ) {
            return true;
        }
```
和
```
        if( size == creature_size::huge && !vp_there.part_with_feature( "AISLE", false ) &&
            !vp_there.part_with_feature( "HUGE_OK", false ) ) {
            return true;
        }
```
很显然它们做了同一件事情，但后出现的第二个判断条件范围更广一些……不过由于它是第二个出现的，所以有的时候逻辑根本走不到这里面，导致它并没有完全按照预期工作。

另外我觉得这个函数的判断逻辑用剩余载货量判断空间大小其实稍微有点诡异，但我一时半会没想出怎么改比较合适，就先只修bug了。

#### 解决方案描述 (Describe the solution)

删除重复判断语句，只留下第二个。