### PR TITLE
Add Neurosoft: Airframe and Powerplant Mechanic CBM

### DIFF
--- a/data/mods/aftershock_exoplanet/itemgroups/bionics_groups.json
+++ b/data/mods/aftershock_exoplanet/itemgroups/bionics_groups.json
@@ -10,6 +10,7 @@
         [ "afs_bio_linguistic_coprocessor", 10 ],
         [ "afs_bio_dopamine_stimulators", 10 ],
         [ "afs_bio_neurosoft_aeronautics", 5 ],
+        [ "afs_bio_neurosoft_aircraft_mechanic", 5 ],
         [ "bio_shield_weak", 25 ],
         [ "afs_bio_translocator", 5 ],
         [ "bio_shock_absorber", 2 ],
@@ -86,6 +87,7 @@
     "extend": {
       "items": [
         [ "afs_bio_neurosoft_aeronautics", 10 ],
+        [ "afs_bio_neurosoft_aircraft_mechanic", 10 ],
         [ "afs_bio_beavy_batteries", 10 ],
         [ "afs_bio_melee_counteraction", 10 ],
         [ "afs_bio_melee_optimization_unit", 10 ],
@@ -157,6 +159,7 @@
       [ "afs_bio_monowhip", 10 ],
       [ "afs_bio_melee_optimization_unit", 10 ],
       [ "afs_bio_neurosoft_aeronautics", 10 ],
+      [ "afs_bio_neurosoft_aircraft_mechanic", 10 ],
       [ "afs_bio_dopamine_stimulators", 10 ],
       [ "bio_shield_heavy", 1 ],
       [ "afs_bio_translocator", 5 ],
@@ -174,6 +177,7 @@
         [ "afs_bio_melee_counteraction", 10 ],
         [ "afs_bio_melee_optimization_unit", 10 ],
         [ "afs_bio_neurosoft_aeronautics", 10 ],
+        [ "afs_bio_neurosoft_aircraft_mechanic", 10 ],
         [ "afs_bio_dopamine_stimulators", 10 ],
         [ "afs_bio_monowhip", 10 ],
         [ "afs_bio_blood_plus", 10 ],

--- a/data/mods/aftershock_exoplanet/items/cbms.json
+++ b/data/mods/aftershock_exoplanet/items/cbms.json
@@ -178,6 +178,17 @@
     "difficulty": 8
   },
   {
+    "id": "afs_bio_neurosoft_aircraft_mechanic",
+    "copy-from": "bionic_general",
+    "type": "ITEM",
+    "subtypes": [ "BIONIC_ITEM" ],
+    "name": { "str": "Neurosoft: Airframe and Powerplant Mechanic CBM" },
+    "description": "A brain implant that grants instinctual knowledge about the repair of flying machines.",
+    "price": "10 kUSD",
+    "price_postapoc": "1 kUSD",
+    "difficulty": 8
+  },
+  {
     "id": "afs_bio_cranialbomb",
     "copy-from": "bionic_general",
     "type": "ITEM",

--- a/data/mods/aftershock_exoplanet/player/bionics.json
+++ b/data/mods/aftershock_exoplanet/player/bionics.json
@@ -340,6 +340,14 @@
     "learned_proficiencies": [ "prof_helicopter_pilot" ]
   },
   {
+  "id": "afs_bio_neurosoft_aircraft_mechanic",
+  "type": "bionic",
+  "name": { "str": "Neurosoft: Airframe and Powerplant Mechanic" },
+  "description": "A brain implant that grants instinctual knowledge about the repair of flying machines.",
+  "occupied_bodyparts": [ [ "head", 2 ] ],
+  "learned_proficiencies": [ "prof_aircraft_mechanic" ]
+  },
+  {
     "id": "afs_bio_translocator",
     "type": "bionic",
     "name": { "str": "Implanted Translocator" },


### PR DESCRIPTION
####  Summary

[ASF] Add Neurosoft: Airframe and Powerplant Mechanic

#### Purpose of change

Our players have requested a way to acquire knowledge on maintaining aircraft, specifically asking for a CBM, especially since we previously made the helicopter pilot proficiency learnable when porting the CBN airships.

Since the "Aftershock: Exoplanet" mod already contains a CBM named "Neurosoft: Aeronautics", we are currently adding its counterpart, "Neurosoft: Airframe and Powerplant Mechanic", to this mod first.

#### Describe the solution

Added a CBM named `Neurosoft: Airframe and Powerplant Mechanic` to the Aftershock mod; installing it allows the character to acquire the aircraft mechanic proficiency.

#### Describe alternatives you've considered

I actually wanted to port these elements into the core module, but the DDA worldbuilding has significantly nerfed the technological level of Earth's humanity, and our branch founder is against modifying the background lore. If we were to logically port these things into the core module, it might force us to alter the lore, thereby creating a conflict.

How the core should add a means to acquire the aircraft mechanic proficiency will be left for discussion in a later PR; alternatively, I might ask other developers if it would be appropriate to simply move these two CBMs into the Exodii's trade list.