### PR TITLE
停止对 BY_WEIGHT 显示类型自动求值

### DIFF
--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4596,10 +4596,8 @@ void itype::load( const JsonObject &jo, std::string_view src )
     optional( jo, was_loaded, "phase", phase, phase_id::SOLID );
     item_display_type default_display_type = item_display_type::DEFAULT;
     if( get_option<bool>( "SMART_DEFAULT_DISPLAY_TYPE" ) ) {
-        if( phase == phase_id::LIQUID ) {
+        if( phase == phase_id::LIQUID && volume > 0_ml ) {
             default_display_type = item_display_type::BY_VOLUME;
-        } else if( volume < 10_ml && longest_side < 10_mm ) {
-            default_display_type = item_display_type::BY_WEIGHT;
         }
     }
     optional( jo, was_loaded, "display_type", display_type, default_display_type );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1887,7 +1887,7 @@ void options_manager::add_options_interface()
         "both"
            );
         add( "SMART_DEFAULT_DISPLAY_TYPE", page_id, to_translation( "Smart default display type" ),
-             to_translation( "Auto-eval the default measure display type of item.  Liquid would display by volume.  Item that volume < 10ml and longest side < 10mm would display by weight.  JSON field display_type will override this option." ),
+             to_translation( "Auto-eval the default measure display type of item.  Liquid would display by volume.  JSON field display_type will override this option." ),
              false
            );
     } );


### PR DESCRIPTION
#### 概述 (Summary)
None

#### 改动目的 (Purpose of change)

智能判断默认显示类型造成造成了弹匣中以及其他的显示错误。

#### 解决方案描述 (Describe the solution)

停止对 BY_WEIGHT 显示类型自动求值。仍保留 BY_VOLUME，智能判断默认显示类型仍默认关闭。

#### 你考虑过的替代方案 (Describe alternatives you've considered)

我仔细检查了 JSON 文件，发现根本无法通过一个物品的体积和长度判断它是否能以重量显示，所以只能移除此功能。

#### 测试 (Testing)

<!-- 描述你采取了哪些步骤来测试这个 PR 是否修复了 bug 或添加了特性，以及你做了哪些测试以确保没有引入回归问题。也请为审阅者和维护者提供测试建议。参见 TESTING_YOUR_CHANGES.md -->

#### 补充说明 (Additional context)

<!-- 在此添加关于这个特性或 bug 修复的其他背景信息（例如原型图、概念验证或截图）。 -->


<!--README: Cataclysm: Cleanwater Bomb (CCB) 以 Creative Commons Attribution ShareAlike 3.0 许可证发布。
游戏的代码与内容可自由用于任何目的的使用、修改和再分发。
通过为本项目做贡献，你即同意该许可证的条款，并同意你所做的任何贡献也将受同一许可证覆盖。
详见 http://creativecommons.org/licenses/by-sa/3.0/ 。 -->