### PR TITLE
修复 #299 的cbm数据json缩进不规范

### DIFF
--- a/data/mods/aftershock_exoplanet/player/bionics.json
+++ b/data/mods/aftershock_exoplanet/player/bionics.json
@@ -340,12 +340,12 @@
     "learned_proficiencies": [ "prof_helicopter_pilot" ]
   },
   {
-  "id": "afs_bio_neurosoft_aircraft_mechanic",
-  "type": "bionic",
-  "name": { "str": "Neurosoft: Airframe and Powerplant Mechanic" },
-  "description": "A brain implant that grants instinctual knowledge about the repair of flying machines.",
-  "occupied_bodyparts": [ [ "head", 2 ] ],
-  "learned_proficiencies": [ "prof_aircraft_mechanic" ]
+    "id": "afs_bio_neurosoft_aircraft_mechanic",
+    "type": "bionic",
+    "name": { "str": "Neurosoft: Airframe and Powerplant Mechanic" },
+    "description": "A brain implant that grants instinctual knowledge about the repair of flying machines.",
+    "occupied_bodyparts": [ [ "head", 2 ] ],
+    "learned_proficiencies": [ "prof_aircraft_mechanic" ]
   },
   {
     "id": "afs_bio_translocator",


### PR DESCRIPTION
修复 #299 的cbm数据json缩进不规范。
只是有个笨蛋留下了格式问题没处理好，现在这位笨蛋回来打补丁了。