### PR TITLE
No “Still not quite like Kevin”

### DIFF
--- a/data/json/achievements.json
+++ b/data/json/achievements.json
@@ -911,8 +911,8 @@
   {
     "id": "achievement_lvl_10_computer",
     "type": "achievement",
-    "name": "Still not quite like Kevin",
-    "description": "It's not cheating.  It's debugging.",
+    "name": "Baldness and Wigs",
+    "description": "No stereotype! So are you from the Neumann school or the Turing school?",
     "requirements": [
       {
         "event_statistic": "num_gains_computer_level_10",


### PR DESCRIPTION
####  Summary

Redesign the level 10 computer skill achievement

#### Purpose of change

The original level 10 computer skill achievement was named "Still not quite like Kevin".

Many people believe that contrasting the achievement name with a real-world, living person and stating "you are not quite as good as him" (regardless of who the actual player might be) could potentially be offensive. While we all know that Kevin is the main maintainer and "The Great Old One" of CDDA, the largest Cataclysm branch, hehe. However, it isn't impossible that some players are actual heavyweights in the computer science field, who just happen to play Cataclysm out of boredom to pass the time.

#### Describe the solution

Modified the achievement unlocked upon reaching computer skill Level 10 to a less offensive internet meme. The current design is as follows:

Name: Baldness and Wigs

Description: No stereotype! So are you from the Neumann school or the Turing school?

By simultaneously mentioning two of the most renowned founding fathers in the field of computer science, it should be less controversial than keeping the format of "Still not quite like one of the fathers of computer science"... right?