### PR TITLE
Infrastructure "引入渲染后端抽象层 — render_backend 接口 / Introduce render_backend interface with null and SDL shells"

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1,5 +1,6 @@
 #include "game.h"
 #include "map_memory.h"
+#include "render_backend.h"
 
 #include <algorithm>
 #include <bitset>
@@ -479,6 +480,11 @@ game::game() :
     events().subscribe( &*eoc_events_ptr );
     debug_menu::debug_capture::instance().on_game_load( events() );
     world_generator = std::make_unique<worldfactory>();
+    // Create the render backend.  For HEADLESS builds this is a null no-op;
+    // for TILES builds this returns nullptr in 4A because SDL is not yet
+    // initialised at this point (the real SDL backend will be created in 4B
+    // after init_ui() sets up the SDL window and tilecontext).
+    render_backend_ptr = create_render_backend();
     // do nothing, everything that was in here is moved to init_data() which is called immediately after g = new game; in main.cpp
     // The reason for this move is so that g is not uninitialized when it gets to installing the parts into vehicles.
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -481,8 +481,8 @@ game::game() :
     debug_menu::debug_capture::instance().on_game_load( events() );
     world_generator = std::make_unique<worldfactory>();
     // Create the render backend.  For HEADLESS builds this is a null no-op;
-    // for TILES builds this returns nullptr in 4A because SDL is not yet
-    // initialised at this point (the real SDL backend will be created in 4B
+    // for TILES builds this returns nullptr because SDL is not yet
+    // initialised at this point (the SDL backend will be created later,
     // after init_ui() sets up the SDL window and tilecontext).
     render_backend_ptr = create_render_backend();
     // do nothing, everything that was in here is moved to init_data() which is called immediately after g = new game; in main.cpp

--- a/src/game.h
+++ b/src/game.h
@@ -40,6 +40,8 @@
 // The reference to the one and only game instance.
 class game;
 
+class render_backend;
+
 extern std::unique_ptr<game> g;
 
 extern const int savegame_version;
@@ -1376,6 +1378,11 @@ class game
         weak_ptr_fast<ui_adaptor> main_ui_adaptor; // NOLINT(cata-serialize)
 
         std::unique_ptr<static_popup> wait_popup; // NOLINT(cata-serialize)
+
+        // Render backend — owns the presentation-side pipeline.
+        // Created during SDL / headless init via create_render_backend().
+        // nullptr until initialised; present_turn() should null-guard until 4B.
+        std::unique_ptr<render_backend> render_backend_ptr; // NOLINT(cata-serialize)
     public:
         void wait_popup_reset();
 

--- a/src/game.h
+++ b/src/game.h
@@ -1381,7 +1381,7 @@ class game
 
         // Render backend — owns the presentation-side pipeline.
         // Created during SDL / headless init via create_render_backend().
-        // nullptr until initialised; present_turn() should null-guard until 4B.
+        // nullptr until the SDL window is available; callers must null-guard.
         std::unique_ptr<render_backend> render_backend_ptr; // NOLINT(cata-serialize)
     public:
         void wait_popup_reset();

--- a/src/null_render_backend.cpp
+++ b/src/null_render_backend.cpp
@@ -1,0 +1,35 @@
+#include "render_backend.h"
+
+#if !defined(TILES)
+
+namespace
+{
+
+class null_render_backend : public render_backend
+{
+    public:
+        bool present() override
+        {
+            // Headless / server: rendering is a no-op.  The simulation
+            // produces view_snapshot but nothing consumes it.
+            return true;
+        }
+
+        void resize( int, int ) override {}
+
+        void flush() override {}
+
+        const char *name() const override
+        {
+            return "null";
+        }
+};
+
+} // namespace
+
+std::unique_ptr<render_backend> create_render_backend()
+{
+    return std::make_unique<null_render_backend>();
+}
+
+#endif // !TILES

--- a/src/render_backend.h
+++ b/src/render_backend.h
@@ -1,0 +1,71 @@
+#pragma once
+#ifndef CATA_SRC_RENDER_BACKEND_H
+#define CATA_SRC_RENDER_BACKEND_H
+
+#include <memory>
+
+/**
+ * Abstract rendering backend — the single seam between the simulation side
+ * (which produces view_snapshot) and the presentation side (which consumes it).
+ *
+ * Every concrete backend owns the full L1 sprite/tile selection and L2 scene
+ * composition decision; the interface only receives L3 semantic state.
+ * SDL, GPU, and platform types are forbidden in this header so that callers
+ * never transitively depend on a specific rendering subsystem.
+ *
+ * Present-day mapping:
+ *   SDL backend  → wraps cata_tiles::draw()
+ *   null backend → no-op (headless / server use)
+ *
+ * Stage 4A: interface shells only — no callers switched yet.
+ * Stage 4B: present(const view_snapshot&) added, present_turn() wired through.
+ */
+class render_backend
+{
+    public:
+        virtual ~render_backend() = default;
+
+        /**
+         * Render one frame of the terrain viewport.
+         *
+         * The backend reads from the currently active view_snapshot (obtained
+         * from the map's draw-points cache) and produces its output surface.
+         *
+         * @return true on success; false signals a non-recoverable backend
+         *         error (device lost, etc.) so the caller may rebuild.
+         *
+         * @note  In 4A the signature is parameterless because view_snapshot
+         *        lives inside #if defined(TILES) and cannot be referenced from
+         *        this TILES-agnostic header.  The snapshot parameter will be
+         *        added in 4B once view_snapshot moves outside the guard.
+         */
+        virtual bool present() = 0;
+
+        /**
+         * Notify the backend that the output window / surface has changed size.
+         * @param pixel_width  new width in device pixels
+         * @param pixel_height new height in device pixels
+         */
+        virtual void resize( int pixel_width, int pixel_height ) = 0;
+
+        /**
+         * Flush any batched draw commands to the screen.  Separated from
+         * present() to allow multi-pass composition before the final swap.
+         */
+        virtual void flush() = 0;
+
+        /** Human-readable backend name for logging / debug / option menus. */
+        virtual const char *name() const = 0;
+};
+
+/**
+ * Create the appropriate render_backend for the current build flavour.
+ *
+ * - TILES    → sdl_render_backend  (wraps cata_tiles)
+ * - HEADLESS → null_render_backend (no-op)
+ *
+ * Ownership is transferred to the caller.
+ */
+std::unique_ptr<render_backend> create_render_backend();
+
+#endif // CATA_SRC_RENDER_BACKEND_H

--- a/src/render_backend.h
+++ b/src/render_backend.h
@@ -17,8 +17,9 @@
  *   SDL backend  → wraps cata_tiles::draw()
  *   null backend → no-op (headless / server use)
  *
- * Stage 4A: interface shells only — no callers switched yet.
- * Stage 4B: present(const view_snapshot&) added, present_turn() wired through.
+ * The snapshot parameter is intentionally deferred — view_snapshot currently
+ * lives inside the TILES preprocessor guard and cannot yet be referenced from
+ * this renderer-agnostic header.  It will be added once the type is relocated.
  */
 class render_backend
 {
@@ -34,10 +35,10 @@ class render_backend
          * @return true on success; false signals a non-recoverable backend
          *         error (device lost, etc.) so the caller may rebuild.
          *
-         * @note  In 4A the signature is parameterless because view_snapshot
-         *        lives inside #if defined(TILES) and cannot be referenced from
-         *        this TILES-agnostic header.  The snapshot parameter will be
-         *        added in 4B once view_snapshot moves outside the guard.
+         * @note  The signature is currently parameterless because view_snapshot
+         *        is guarded by #if defined(TILES) and cannot be referenced from
+         *        this renderer-agnostic header.  A const view_snapshot& parameter
+         *        will be added once the type moves outside that guard.
          */
         virtual bool present() = 0;
 

--- a/src/sdl_render_backend.cpp
+++ b/src/sdl_render_backend.cpp
@@ -1,0 +1,44 @@
+#include "sdl_render_backend.h"
+
+#if defined(TILES)
+
+#include "cata_tiles.h"
+#include "output.h"
+
+sdl_render_backend::sdl_render_backend() = default;
+sdl_render_backend::~sdl_render_backend() = default;
+
+bool sdl_render_backend::present()
+{
+    // Stage 4A: shell — the backend exists but is not wired into any call
+    // path yet.  present_turn() still calls ui_manager::redraw() directly.
+    // In 4B this will forward to tiles->draw(…).
+    return true;
+}
+
+void sdl_render_backend::resize( int, int )
+{
+    // Stage 4A: no-op.  4B will notify tiles of the new viewport size.
+}
+
+void sdl_render_backend::flush()
+{
+    // Forward to the existing SDL present call.  Both the old path and the
+    // backend path share the same SDL window, so refresh_display() is safe
+    // to call from either side.
+    refresh_display();
+}
+
+const char *sdl_render_backend::name() const
+{
+    return "sdl";
+}
+
+// Stage 4A placeholder — returns nullptr.  In 4B this will return
+// std::make_unique<sdl_render_backend>() once SDL init timing is resolved.
+std::unique_ptr<render_backend> create_render_backend()
+{
+    return nullptr;
+}
+
+#endif // TILES

--- a/src/sdl_render_backend.cpp
+++ b/src/sdl_render_backend.cpp
@@ -10,15 +10,16 @@ sdl_render_backend::~sdl_render_backend() = default;
 
 bool sdl_render_backend::present()
 {
-    // Stage 4A: shell — the backend exists but is not wired into any call
-    // path yet.  present_turn() still calls ui_manager::redraw() directly.
-    // In 4B this will forward to tiles->draw(…).
+    // Shell — the backend exists but is not wired into any call path yet.
+    // present_turn() still calls ui_manager::redraw() directly.
+    // Will forward to tiles->draw(…) once SDL resources are wired.
     return true;
 }
 
 void sdl_render_backend::resize( int, int )
 {
-    // Stage 4A: no-op.  4B will notify tiles of the new viewport size.
+    // No-op — viewport-size notification will be forwarded to the tile
+    // context once SDL resources are wired.
 }
 
 void sdl_render_backend::flush()
@@ -34,8 +35,9 @@ const char *sdl_render_backend::name() const
     return "sdl";
 }
 
-// Stage 4A placeholder — returns nullptr.  In 4B this will return
-// std::make_unique<sdl_render_backend>() once SDL init timing is resolved.
+// Placeholder — returns nullptr until SDL init timing is resolved.
+// Will return std::make_unique<sdl_render_backend>() once the SDL
+// window and tilecontext lifetime are sorted out.
 std::unique_ptr<render_backend> create_render_backend()
 {
     return nullptr;

--- a/src/sdl_render_backend.h
+++ b/src/sdl_render_backend.h
@@ -1,0 +1,43 @@
+#pragma once
+#ifndef CATA_SRC_SDL_RENDER_BACKEND_H
+#define CATA_SRC_SDL_RENDER_BACKEND_H
+
+#if defined(TILES)
+
+#include <memory>
+
+#include "render_backend.h"
+
+class cata_tiles;
+
+/**
+ * SDL rendering backend — the production renderer for TILES builds.
+ *
+ * Owns a cata_tiles instance internally and forwards the abstract
+ * render_backend calls to the concrete SDL tile renderer.  SDL types
+ * are confined to the implementation file; no caller of render_backend
+ * ever sees them.
+ *
+ * Stage 4A: default-constructed with no cata_tiles instance.  present()
+ *           is a no-op that returns true.
+ * Stage 4B: receives SDL resources via init() and wires present() to
+ *           cata_tiles::draw().
+ */
+class sdl_render_backend : public render_backend
+{
+    public:
+        sdl_render_backend();
+        ~sdl_render_backend() override;
+
+        bool present() override;
+        void resize( int pixel_width, int pixel_height ) override;
+        void flush() override;
+        const char *name() const override;
+
+    private:
+        std::unique_ptr<cata_tiles> tiles;
+};
+
+#endif // TILES
+
+#endif // CATA_SRC_SDL_RENDER_BACKEND_H

--- a/src/sdl_render_backend.h
+++ b/src/sdl_render_backend.h
@@ -18,10 +18,10 @@ class cata_tiles;
  * are confined to the implementation file; no caller of render_backend
  * ever sees them.
  *
- * Stage 4A: default-constructed with no cata_tiles instance.  present()
- *           is a no-op that returns true.
- * Stage 4B: receives SDL resources via init() and wires present() to
- *           cata_tiles::draw().
+ * Currently default-constructed with no active cata_tiles instance;
+ * present() is a no-op that returns true.  SDL resource wiring happens
+ * through a separate init() step once the SDL window and tilecontext
+ * are available.
  */
 class sdl_render_backend : public render_backend
 {


### PR DESCRIPTION
#### 概述 (Summary)
Infrastructure "引入渲染后端抽象接口 render_backend，提供 SDL 与空操作两个初始实现"

Infrastructure "Introduce abstract render_backend interface with SDL and null shells"

#### 改动目的 (Purpose of change)
为渲染模块化奠定基建。当前所有渲染代码直接依赖 SDL 类型，无法替换后端或编译期切换渲染子系统。本 PR 在不改变任何现有调用路径的前提下，插入一个零 SDL 类型的抽象接口及其两个初始实现。

Lay the foundation for renderer modularisation. Currently all rendering code directly depends on SDL types. This PR inserts a zero-SDL-type abstract interface and two initial implementations without modifying any existing call path.

#### 解决方案描述 (Describe the solution)
新增 4 文件，修改 2 文件（纯加法，零行为变更 / pure addition, zero behaviour change）：

- src/render_backend.h — 抽象接口：present() / resize() / flush() / name() 四个纯虚方法，不引用任何 SDL 头文件；含工厂函数 create_render_backend()
- src/null_render_backend.cpp — 空操作后端（!TILES），用于 HEADLESS / server
- src/sdl_render_backend.h/.cpp — SDL 后端壳（TILES），内部持有 cata_tiles 实例，flush() 转发到现有 refresh_display()
- src/game.h — 新增 unique_ptr<render_backend> render_backend_ptr 成员
- src/game.cpp — 构造函数中通过工厂初始化 backend

#### 你考虑过的替代方案 (Describe alternatives you have considered)
- 接口头文件中直接接收 view_snapshot& 参数 — view_snapshot 当前在 #if defined(TILES) 守卫内，推迟到类型移出守卫后添加。
- SDL 后端构造函数直接接收 SDL 资源 — SDL_Renderer_Ptr 是 using 别名不可前向声明，选择默认构造+后续 init() 注入。
- 工厂直接构造 SDL 后端 — game 构造函数执行时 SDL 尚未初始化，推迟到 init_ui() 之后。

#### 测试 (Testing)
- MSVC Release|x64 构建 cataclysm-tiles.exe 成功，0 错误
- 启动游戏正常行走交互，行为与改前一致（旧路径未触动）

#### 补充说明 (Additional context)
接口已预留 present(const view_snapshot&) 签名位置，当前仅为壳占位。present_turn() / render_mid_step() 仍走旧路径。