### PR TITLE
core mod name changes to CCB(?)

### DIFF
--- a/data/mods/dda/modinfo.json
+++ b/data/mods/dda/modinfo.json
@@ -2,8 +2,8 @@
   {
     "type": "MOD_INFO",
     "id": "dda",
-    "name": "Dark Days Ahead",
-    "description": "Core content for Cataclysm-DDA",
+    "name": "Cataclysm Comes Being",
+    "description": "Core content for Cataclysm-CB",
     "category": "content",
     "core": true,
     "path": "../../json"


### PR DESCRIPTION
#### Summary

Modify the mod name of the core content

#### Purpose of change

The core content module's name and ID for Cataclysm: Cleanwater Bomb is still called Dark Days Ahead, and it says that it is the core of DDA.

#### Describe the solution

Rename the mod name.

I think calling the core module a "cleanwater bomb" is kind of weird.... so it now named Cataclysm Comes Being. Anyway, the short name is still CCB.

Due to mod compatibility and other possible problem, I haven't changed the mod ID yet.