### PR TITLE
New explanation for the CCB name?

### DIFF
--- a/data/mods/dda/modinfo.json
+++ b/data/mods/dda/modinfo.json
@@ -2,7 +2,7 @@
   {
     "type": "MOD_INFO",
     "id": "dda",
-    "name": "Cataclysm Comes Being",
+    "name": "Catharsis Covenant Basemodule",
     "description": "Core content for Cataclysm-CB",
     "category": "content",
     "core": true,


### PR DESCRIPTION
#### Summary

Modify the mod name of the core content

#### Purpose of change

PR #313 Changed the name of the core module to clearly indicate that this is the core of the branch.

But players aren't happy with this; they want the name of the core module to be translated into the Chinese name for this branch, which is "Jing Hua Xie Yi(It means something like a purification agreement)"

#### Describe the solution

Rename the mod name.

Keep CCB as the abbreviation and find the combination that makes sense. Change the temporary expression from Cataclysm Comes Being to Catharsis Covenant Basemodule.

I looked it up in the dictionary and catharsis means to purify through things like performing plays, so I guess that counts. Covenant also means a contract or agreement. Let's just leave it at that for now.

It might still be a bit rough, and if anyone wants to make any changes they can do it themselves...