### PR TITLE
Joint Torsion Ratchet missing normal debuff repair(CBMs Rationality Balance Restoration Part 3)

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4387,9 +4387,9 @@ void Character::recalc_limb_energy_usage()
     }
     for( const bionic_id &bid : get_bionic_fueled_with_muscle() ) {
         if( has_active_bionic( bid ) ) {
-            bionic_powercost = bionic_powercost * 25;
+            bionic_powercost = bionic_powercost * 20;
         } else {
-            bionic_powercost = bionic_powercost * 5;
+            bionic_powercost = bionic_powercost * 2;
         }
     }
     arms_power_use = bionic_powercost;
@@ -4419,9 +4419,9 @@ void Character::recalc_limb_energy_usage()
     }
     for( const bionic_id &bid : get_bionic_fueled_with_muscle() ) {
         if( has_active_bionic( bid ) ) {
-            bionic_powercost = bionic_powercost * 25;
+            bionic_powercost = bionic_powercost * 20;
         } else {
-            bionic_powercost = bionic_powercost * 5;
+            bionic_powercost = bionic_powercost * 2;
         }
     }
     legs_power_use = bionic_powercost;


### PR DESCRIPTION
####  Summary

#310 did not handle the penalty of the Joint Torsion Ratchet when it is in its default disabled state.

#### Purpose of change

Balance adjustments regarding row [129](https://docs.qq.com/sheet/DZVJad2t0SkVFcHB0?tab=BB08J2&type=1&rangeid=1489799978) of the player feedback spreadsheet. Most of the context requiring explanation has already been discussed in #310.

#### Describe the solution

Joint Torsion Ratchet: Halved the bionic power consumption penalty multiplier when cybernetic limbs cooperate with muscle-type passive fuels, reducing it to 40% for original. This includes both when it is enabled and when it is disabled (310 only handled the enabled state).