### PR TITLE
修复机器人欢迎工作流程

### DIFF
--- a/.github/workflows/greet-first-time-comment.yml
+++ b/.github/workflows/greet-first-time-comment.yml
@@ -24,8 +24,8 @@ jobs:
         run: |
           commenter="${GITHUB_EVENT_COMMENT_USER_LOGIN}"
           echo "Debug: Checking comment counts for... $commenter"
-          comment_count_all_PR=$(gh search prs --repo=CleverRaven/Cataclysm-DDA --commenter $commenter --json id | jq 'length')
-          num_PRs_authored=$(gh search prs --repo=CleverRaven/Cataclysm-DDA --author $commenter --json id | jq 'length')
+          comment_count_all_PR=$(gh search prs --repo=LYHGLYTX/Cataclysm-Cleanwater-Bomb --commenter $commenter --json id | jq 'length')
+          num_PRs_authored=$(gh search prs --repo=LYHGLYTX/Cataclysm-Cleanwater-Bomb --author $commenter --json id | jq 'length')
           
           num_times_commented=$(gh pr view $PR_NUMBER --json comments --jq "[.comments.[].author.login | match(\"$commenter\")] | length")
 
@@ -42,6 +42,6 @@ jobs:
           # I have no earthly idea how to pass the commenter on from the previous run (I have tried), so let's just re-acquire it.
           commenter_name="${GITHUB_EVENT_COMMENT_USER_LOGIN}"
           # We 'hardcode' the URLs here because doing a dynamic url points to OWNER/REPO/pull/code_of_conduct.md. Why is the 'pull' there? No idea.
-          gh pr comment $PR_NUMBER --body "Hi @$commenter_name, welcome to CleverRaven! We see that this is your first time commenting here. Check out [how development works](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/development_process.md) and be sure to follow the [code of conduct](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/CODE_OF_CONDUCT.md)! We hope to see you around!"
+          gh pr comment $PR_NUMBER --body "Hi @$commenter_name, welcome to Cataclysm: Cleanwater Bomb! We see that this is your first time commenting here. Check out [how development works](https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/blob/master/doc/development_process.md) and be sure to follow the [code of conduct](https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/blob/master/CODE_OF_CONDUCT.md)! We hope to see you around!"
         env:
           GITHUB_EVENT_COMMENT_USER_LOGIN: ${{ github.event.comment.user.login }}


### PR DESCRIPTION
<img width="872" height="574" alt="4`9CLWY1}PN3~Z7TFV_UBAL" src="https://github.com/user-attachments/assets/0445ba17-7e57-4028-9e07-8f52a8678f4f" />
我不知道我是第几次在我们仓库各地发言了……
但我们的机器人还在欢迎我来到聪明渡鸦。
很显然这是因为我们的欢迎流程直接ctrlC~V了DDA的然后一字没改配合其他bug导致的。
我把欢迎工作的action改成我们自己的仓库了