### PR TITLE
Highly efficient synthetic lungs which replace the user's own. (CBMs Rationality Balance Restoration Part 4)

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1336,7 +1336,7 @@
     "cant_remove_reason": "The CBM has replaced the patient's lungs and cannot be removed.",
     "canceled_mutations": [ "GOODCARDIO", "BADCARDIO", "GOODCARDIO2", "PERSISTENCE_HUNTER", "PERSISTENCE_HUNTER2", "ASTHMA" ],
     "enchantments": [
-      { "condition": "ALWAYS", "values": [ { "value": "MOD_HEALTH", "add": -1 }, { "value": "MOD_HEALTH_CAP", "add": -20 } ] }
+      { "condition": "ALWAYS", "values": [ { "value": "MOD_HEALTH", "add": -1 }, { "value": "MOD_HEALTH_CAP", "add": -10 } ] }
     ]
   },
   {

--- a/src/character_health.cpp
+++ b/src/character_health.cpp
@@ -2409,9 +2409,9 @@ int Character::get_cardiofit() const
     float cardio_modifier = ench_mod + athletics_mod + prof_mod + health_mod;
     if( has_bionic( bio_synlungs ) ) {
         // If you have synthetic lung bionics, your cardioaccuracy multiplier will be calculated using a special algorithm.
-        cardio_modifier = ( 4 + cardio_modifier + ench_mod ) / 3.0f;
+        cardio_modifier = ( 2.0f + cardio_modifier + ench_mod ) / 3.0f;
     }
-    
+
     // Modify cardio accumulator by our cardio mods.
     const int cardio_fitness = static_cast<int>( cardio_base * cardio_modifier );
 

--- a/src/character_health.cpp
+++ b/src/character_health.cpp
@@ -2411,8 +2411,16 @@ int Character::get_cardiofit() const
         // If you have synthetic lung bionics, your cardioaccuracy multiplier will be calculated using a special algorithm.
         cardio_modifier = ( 4 + cardio_modifier + ench_mod ) / 3.0f;
     }
+    
     // Modify cardio accumulator by our cardio mods.
     const int cardio_fitness = static_cast<int>( cardio_base * cardio_modifier );
+
+    if( has_bionic( bio_synlungs ) ) {
+        // If you have synthetic lung bionics, your cardioaccuracy will have a minimum guaranteed value.
+        if( cardio_fitness < 3 * get_cardio_acc_base() ) {
+            return 3 * get_cardio_acc_base();
+        }
+    }
 
     return cardio_fitness;
 }

--- a/src/character_health.cpp
+++ b/src/character_health.cpp
@@ -2409,7 +2409,7 @@ int Character::get_cardiofit() const
     float cardio_modifier = ench_mod + athletics_mod + prof_mod + health_mod;
     if( has_bionic( bio_synlungs ) ) {
         // If you have synthetic lung bionics, your cardioaccuracy multiplier will be calculated using a special algorithm.
-        cardio_modifier = ( 2.0f + cardio_modifier + ench_mod ) / 3.0f;
+        cardio_modifier = ( 2.5f + cardio_modifier + ench_mod ) / 3.0f;
     }
 
     // Modify cardio accumulator by our cardio mods.

--- a/src/character_health.cpp
+++ b/src/character_health.cpp
@@ -2389,15 +2389,10 @@ int Character::get_cardiofit() const
         return 2 * get_cardio_acc_base();
     }
 
-    if( has_bionic( bio_synlungs ) ) {
-        // If you have the synthetic lungs bionic your cardioacc is forced to a specific value
-        return 3 * get_cardio_acc_base();
-    }
-
     const int cardio_base = get_cardio_acc();
 
-    // Mut mod contains the base 1.0f for all modifiers
-    const float mut_mod = enchantment_cache->modify_value( enchant_vals::mod::CARDIO_MULTIPLIER, 1 );
+    // Ench mod contains the base 1.0f for all modifiers
+    const float ench_mod = enchantment_cache->modify_value( enchant_vals::mod::CARDIO_MULTIPLIER, 1 );
     // 1 point of athletics skill = 1% more cardio, up to 10% cardio
     const float athletics_mod = get_skill_level( skill_swimming ) / 100.0f;
     // At some point we might have proficiencies that affect this.
@@ -2411,7 +2406,11 @@ int Character::get_cardiofit() const
     }
 
     // Add up all of our cardio mods.
-    float cardio_modifier = mut_mod + athletics_mod + prof_mod + health_mod;
+    float cardio_modifier = ench_mod + athletics_mod + prof_mod + health_mod;
+    if( has_bionic( bio_synlungs ) ) {
+        // If you have synthetic lung bionics, your cardioaccuracy multiplier will be calculated using a special algorithm.
+        cardio_modifier = ( 4 + cardio_modifier + ench_mod ) / 3.0f;
+    }
     // Modify cardio accumulator by our cardio mods.
     const int cardio_fitness = static_cast<int>( cardio_base * cardio_modifier );
 


### PR DESCRIPTION
####  Summary

Improve the performance of synthetic lungs to make them truly worthwhile.

#### Purpose of change

PR #310, #315, and #316 have already attempted balance adjustments regarding row [129](https://docs.qq.com/sheet/DZVJad2t0SkVFcHB0?tab=BB08J2&type=1&rangeid=1489799978) of the player feedback spreadsheet.

Following those changes, we conducted follow-ups and waited a while for player feedback. From this, we learned that one of the main sources of the bizarre sentiment that "CBMs feel more like torture than enhancements" stems from the design of the synthetic lungs. This has also been reflected in the newly collected player suggestion feedback spreadsheet, specifically under row [169](https://docs.qq.com/sheet/DZVJad2t0SkVFcHB0?tab=BB08J2&type=1&rangeid=4136127221). Although row 129 and row 169 are inherently different matters—the former being dissatisfaction with nerfs, and the latter being dissatisfaction with a new design—both manifest the players' discontent with the CBM system. Therefore, I decided to proceed with Part 4 of the improvements.

Reading the item description of the Synthetic Lungs CBM, the original text states: `Highly efficient synthetic lungs which replace the user's own.` However, the player feedback we gathered suggests that players perceive this phrase as a sarcastic irony. I browsed the original [PR67008](https://github.com/CleverRaven/Cataclysm-DDA/pull/67008) that added this item, and its initial design did indeed seem to align with the item description; its early iteration could bypass factors like exercise and health to elevate the player close to the core human limit of 4000 cardio (that PR mentioned the native human cap is 4650 cardio, if without course mutations mod). At the same time, it automatically eliminated most respiratory mutations, including asthma but also positive ones.

However, on one hand, that PR ultimately nerfed this value down to 3000, with the original text stating: `lowered it to 3000. This is enough that if you want to munchkin your character you probably don't want this bionic, it's an immediate benefit over starting levels of cardio but even without indefatigable you can still go as high as 3900.` On the other hand, subsequent adjustments in that PR also added a negative effect on health as a penalty for this bionic.

Of course, as a replacement for lung issues, such an organ is entirely reasonable, and I think if its design philosophy were to serve as a medical device used for severe organ damage similar to the real world, it would actually be a bit too strong. But the problem is that the item description "Highly efficient synthetic lungs which replace the user's own." was left unchanged, indicating that this design is meant to be an enhancement, rather than a desperate alternative or a form of torture. It is self-contradictory.

Furthermore, to quote an excerpt from a reply in the original PR: "Raising effective cardiac output is not primarily lung-limited, the meat of cardio comes from cardiovascular changes." I agree with this point. Simply replacing the lungs and locking cardio to a fixed value, causing all other enhancements granted by heart-related CBMs or mutations via the enchantment system to vanish, is equally unreasonable.

#### Describe the solution

Modified the design of this bionic, resetting the logic for determining the cardioaccuracy value when a player has synthetic lung bionics:
 - Now, if you have synthetic lung bionics, your cardioaccuracy multiplier will be calculated using a special algorithm. It takes the average of a 2.5x multiplier (the native human cap seems to be 1.55x without considering enchantments, so it is a enhancement), the regular adjustment multiplier, and the multiplier provided solely by the enchantment system (the default value for this system is 1.0f, so it is actually already included in the regular multiplier as a base value) to serve as the actual multiplier after installing the bionic.
  + In tandem, modified the variable names in the code. The source code named the data provided by the enchantment system as `mut_mod`. I know what it means, because this enchantment data is currently only used by mutations within the core module, but the enchantment system is actually used by things other than mutations. Even disregarding various spells or enhancers in mods, other CBMs in the core module also utilize the enchantment system. Such naming can easily be misleading, so I changed it to `ench_mod`.
 - Added a clamp to the modified `get_cardiofit()` function, turning the originally designed fixed value into a minimum value. If the value remains below 3000 after applying the multiplier algorithm, it returns the 3000 designed by the upstream branch.

Additionally, halved the lower bound of this bionic's health level penalty (referring to the minimum health val modifier value that this penalty can reach).

#### Describe alternatives you've considered

Another method would be to modify the lore text so that it truly becomes nothing more than a slightly better alternative to a rotten flesh lung. However, DDA has already nerfed humanity enough, and our branch is not dedicated solely to nerfing or buffing. Out of rationality considerations, we believe that the performance of CBMs in-game lags behind what would be expected from a civilization at an equivalent real-world productivity level but following a different technological trajectory. While this is primarily due to real-world technological baselines rising over time, applying sensible reasoning makes buffing this CBM's performance far more intuitive.