### PR TITLE
 堆叠少量遗漏物品

### DIFF
--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -658,7 +658,9 @@
     "fun": -18,
     "use_action": [ "POISON" ],
     "contamination": [ { "disease": "bad_food", "probability": 100 } ],
-    "vitamins": [ [ "meat_allergen", 1 ] ]
+    "vitamins": [ [ "meat_allergen", 1 ] ],
+    "display_type": "BY_WEIGHT",
+    "stackable": true
   },
   {
     "id": "meat_cooked",

--- a/data/json/items/comestibles/seed.json
+++ b/data/json/items/comestibles/seed.json
@@ -14,8 +14,7 @@
     "symbol": ".",
     "color": "brown",
     "//": "Note that in most cases this item typically represents many seeds, enough to fill an entire tile with plants.",
-    "vitamins": [ [ "veggy_allergen", 1 ] ],
-    "stackable": true
+    "vitamins": [ [ "veggy_allergen", 1 ] ]
   },
   {
     "abstract": "seed_fruit",

--- a/data/json/items/comestibles/seed.json
+++ b/data/json/items/comestibles/seed.json
@@ -14,7 +14,8 @@
     "symbol": ".",
     "color": "brown",
     "//": "Note that in most cases this item typically represents many seeds, enough to fill an entire tile with plants.",
-    "vitamins": [ [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "abstract": "seed_fruit",

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -3031,7 +3031,8 @@
     "flags": [ "NO_SALVAGE" ],
     "weight": "3 g",
     "volume": "23 ml",
-    "category": "spare_parts"
+    "category": "spare_parts",
+    "stackable": true
   },
   {
     "id": "light_bulb",

--- a/data/json/items/resources/plastic.json
+++ b/data/json/items/resources/plastic.json
@@ -107,7 +107,8 @@
     "material": [ "nylon" ],
     "symbol": ",",
     "color": "white",
-    "flags": [ "NO_SALVAGE" ]
+    "flags": [ "NO_SALVAGE" ],
+    "stackable": true
   },
   {
     "id": "lycra_patch",

--- a/data/json/items/resources/tailoring.json
+++ b/data/json/items/resources/tailoring.json
@@ -204,7 +204,8 @@
     "price_postapoc": "10 cent",
     "description": "A small bolt of garishly-colored faux fur, roughly six inches square.  Can be made into patchwork faux fur sheets or used to repair faux fur fabric.",
     "flags": [ "NO_SALVAGE" ],
-    "material": [ "faux_fur" ]
+    "material": [ "faux_fur" ],
+    "stackable": true
   },
   {
     "type": "ITEM",

--- a/data/json/items/tool/toiletries.json
+++ b/data/json/items/tool/toiletries.json
@@ -155,7 +155,8 @@
       },
       "WASH_HARD_ITEMS"
     ],
-    "flags": [ "NO_SALVAGE" ]
+    "flags": [ "NO_SALVAGE" ],
+    "stackable": true
   },
   {
     "type": "ITEM",


### PR DESCRIPTION

#### 概述 (Summary)
None

#### 改动目的 (Purpose of change)

在游戏过程中发现了少量未堆叠物品。

#### 解决方案描述 (Describe the solution)

 堆叠屠宰残渣和漏掉的布片（部分布片已有）。顺便让屠宰残渣显示重量。

#### 你考虑过的替代方案 (Describe alternatives you've considered)

<!-- 说明你为解决同一问题考虑过的其他方案、不同思路或可能性。 -->

#### 测试 (Testing)

<!-- 描述你采取了哪些步骤来测试这个 PR 是否修复了 bug 或添加了特性，以及你做了哪些测试以确保没有引入回归问题。也请为审阅者和维护者提供测试建议。参见 TESTING_YOUR_CHANGES.md -->

#### 补充说明 (Additional context)

<!-- 在此添加关于这个特性或 bug 修复的其他背景信息（例如原型图、概念验证或截图）。 -->


<!--README: Cataclysm: Cleanwater Bomb (CCB) 以 Creative Commons Attribution ShareAlike 3.0 许可证发布。
游戏的代码与内容可自由用于任何目的的使用、修改和再分发。
通过为本项目做贡献，你即同意该许可证的条款，并同意你所做的任何贡献也将受同一许可证覆盖。
详见 http://creativecommons.org/licenses/by-sa/3.0/ 。 -->