### PR TITLE
Cosplay-related items converted to flags, similar to the legacy FANCY flag

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -512,7 +512,7 @@
   {
     "id": "COSPLAY_PROPS",
     "type": "json_flag",
-    "info": "This clothing is <info>cosplay prop</info>.",
+    "info": "This item is <info>cosplay prop</info>.",
     "conflicts": [ "COSPLAY_COSTUME" ]
   },
   {

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -506,13 +506,13 @@
   {
     "id": "COSPLAY_COSTUME",
     "type": "json_flag",
-    "info": "This clothing is <info>cosplay costume</info>. It is unlikely to designed for high-intensity combat or sports.",
+    "info": "This clothing is <info>cosplay costume</info>.",
     "conflicts": [ "COSPLAY_PROPS" ]
   },
   {
     "id": "COSPLAY_PROPS",
     "type": "json_flag",
-    "info": "This clothing is <info>cosplay prop</info>. It may be fragile or not durable, or completely unusable as a weapon.",
+    "info": "This clothing is <info>cosplay prop</info>.",
     "conflicts": [ "COSPLAY_COSTUME" ]
   },
   {

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -504,6 +504,16 @@
     "type": "json_flag"
   },
   {
+    "id": "COSPLAY_COSTUME",
+    "type": "json_flag",
+    "info": "This clothing is <info>cosplay costume</info>. It is unlikely to designed for high-intensity combat or sports."
+  },
+  {
+    "id": "COSPLAY_PROPS",
+    "type": "json_flag",
+    "info": "This clothing is <info>cosplay prop</info>. It may be fragile or not durable."
+  },
+  {
     "id": "ONE_PER_LAYER",
     "type": "json_flag",
     "info": "<info>Only one</info> item can be worn on this clothing layer."

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -506,12 +506,14 @@
   {
     "id": "COSPLAY_COSTUME",
     "type": "json_flag",
-    "info": "This clothing is <info>cosplay costume</info>. It is unlikely to designed for high-intensity combat or sports."
+    "info": "This clothing is <info>cosplay costume</info>. It is unlikely to designed for high-intensity combat or sports.",
+    "conflicts": [ "COSPLAY_PROPS" ]
   },
   {
     "id": "COSPLAY_PROPS",
     "type": "json_flag",
-    "info": "This clothing is <info>cosplay prop</info>. It may be fragile or not durable, or completely unusable as a weapon."
+    "info": "This clothing is <info>cosplay prop</info>. It may be fragile or not durable, or completely unusable as a weapon.",
+    "conflicts": [ "COSPLAY_COSTUME" ]
   },
   {
     "id": "ONE_PER_LAYER",

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -511,7 +511,7 @@
   {
     "id": "COSPLAY_PROPS",
     "type": "json_flag",
-    "info": "This clothing is <info>cosplay prop</info>. It may be fragile or not durable."
+    "info": "This clothing is <info>cosplay prop</info>. It may be fragile or not durable, or completely unusable as a weapon."
   },
   {
     "id": "ONE_PER_LAYER",

--- a/data/json/items/armor/cloaks.json
+++ b/data/json/items/armor/cloaks.json
@@ -1712,7 +1712,7 @@
     "warmth": 10,
     "material_thickness": 0.2,
     "environmental_protection": 1,
-    "flags": [ "OVERSIZE", "HOOD", "BELTED", "ALLOWS_GASTROPOD_FOOT" ],
+    "flags": [ "OVERSIZE", "HOOD", "BELTED", "ALLOWS_GASTROPOD_FOOT", "COSPLAY_COSTUME" ],
     "armor": [
       { "encumbrance": 2, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
       {

--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -1757,7 +1757,7 @@
     ],
     "warmth": 10,
     "material_thickness": 0.2,
-    "flags": [ "OUTER", "VARSIZE", "POCKETS", "ALLOWS_GASTROPOD_FOOT" ]
+    "flags": [ "OUTER", "VARSIZE", "POCKETS", "ALLOWS_GASTROPOD_FOOT", "COSPLAY_COSTUME" ]
   },
   {
     "id": "jacket_leather",
@@ -2641,7 +2641,7 @@
     ],
     "warmth": 8,
     "material_thickness": 0.1,
-    "flags": [ "UNRESTRICTED", "OUTER", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_GASTROPOD_FOOT" ]
+    "flags": [ "UNRESTRICTED", "OUTER", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_GASTROPOD_FOOT", "COSPLAY_COSTUME" ]
   },
   {
     "id": "ghost_robe_sheet",
@@ -2750,7 +2750,7 @@
     },
     "warmth": 10,
     "material_thickness": 0.1,
-    "flags": [ "UNRESTRICTED", "OUTER", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_GASTROPOD_FOOT" ]
+    "flags": [ "UNRESTRICTED", "OUTER", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_GASTROPOD_FOOT", "COSPLAY_COSTUME" ]
   },
   {
     "id": "grim_reaper_robe_faceless",
@@ -2870,7 +2870,7 @@
     ],
     "warmth": 15,
     "material_thickness": 1.5,
-    "flags": [ "VARSIZE", "OUTER", "HOOD", "ALLOWS_GASTROPOD_FOOT" ]
+    "flags": [ "VARSIZE", "OUTER", "HOOD", "ALLOWS_GASTROPOD_FOOT", "COSPLAY_COSTUME" ]
   },
   {
     "id": "samghati",
@@ -2978,7 +2978,7 @@
     ],
     "warmth": 40,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "COSPLAY_COSTUME" ]
   },
   {
     "id": "santa_jacket_short",
@@ -3022,7 +3022,7 @@
     ],
     "warmth": 15,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "OUTER" ]
+    "flags": [ "VARSIZE", "OUTER", "COSPLAY_COSTUME" ]
   },
   {
     "id": "ski_jacket",

--- a/data/json/items/armor/suits_clothes.json
+++ b/data/json/items/armor/suits_clothes.json
@@ -21,7 +21,7 @@
     "warmth": 20,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "COSPLAY_COSTUME" ]
   },
   {
     "id": "bodysuit_lycra",
@@ -39,7 +39,7 @@
     "color": "blue",
     "warmth": 15,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT", "WATER_FRIENDLY" ],
+    "flags": [ "VARSIZE", "SKINTIGHT", "WATER_FRIENDLY", "COSPLAY_COSTUME" ],
     "armor": [
       {
         "coverage": 100,
@@ -184,7 +184,7 @@
     ],
     "warmth": 10,
     "material_thickness": 0.1,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "COSPLAY_COSTUME" ]
   },
   {
     "id": "denim_overalls",
@@ -254,7 +254,7 @@
   },
   {
     "copy-from": "jumpsuit",
-    "extend": { "flags": [ "HOOD" ] },
+    "extend": { "flags": [ "HOOD", "COSPLAY_COSTUME" ] },
     "relative": { "weight": "50 g" },
     "id": "flag_jumpsuit",
     "type": "ITEM",
@@ -475,7 +475,7 @@
     },
     "warmth": 10,
     "material_thickness": 0.2,
-    "extend": { "flags": [ "HOOD" ] }
+    "extend": { "flags": [ "HOOD", "COSPLAY_COSTUME" ] }
   },
   {
     "id": "jumpsuit_skeleton_zipped",
@@ -519,7 +519,7 @@
     ],
     "warmth": 10,
     "material_thickness": 0.2,
-    "flags": [ "VARSIZE", "POCKETS", "HOOD" ]
+    "flags": [ "VARSIZE", "POCKETS", "HOOD", "COSPLAY_COSTUME" ]
   },
   {
     "id": "technician_coveralls",
@@ -774,7 +774,7 @@
     "warmth": 50,
     "material_thickness": 2,
     "environmental_protection": 2,
-    "flags": [ "OUTER" ],
+    "flags": [ "OUTER", "COSPLAY_COSTUME" ],
     "variant_type": "generic",
     "variants": [
       {

--- a/data/json/items/armor/torso_clothes.json
+++ b/data/json/items/armor/torso_clothes.json
@@ -1794,7 +1794,7 @@
     "faults": [ { "fault_group": "fabric_cotton" } ],
     "warmth": 5,
     "material_thickness": 0.2,
-    "flags": [ "VARSIZE" ],
+    "flags": [ "VARSIZE", "COSPLAY_COSTUME" ],
     "armor": [
       { "covers": [ "torso", "arm_l", "arm_r" ], "coverage": 85, "encumbrance": 4 },
       {
@@ -1825,7 +1825,7 @@
     "faults": [ { "fault_group": "fabric_cotton" } ],
     "warmth": 5,
     "material_thickness": 0.2,
-    "flags": [ "VARSIZE" ],
+    "flags": [ "VARSIZE", "COSPLAY_COSTUME" ],
     "armor": [
       { "covers": [ "torso" ], "coverage": 85, "encumbrance": 4 },
       {
@@ -1950,7 +1950,7 @@
     "faults": [ { "fault_group": "fabric_cotton" } ],
     "warmth": 20,
     "material_thickness": 0.4,
-    "flags": [ "VARSIZE" ],
+    "flags": [ "VARSIZE", "COSPLAY_COSTUME" ],
     "armor": [
       { "covers": [ "torso" ], "coverage": 95, "encumbrance": 10 },
       { "covers": [ "arm_l", "arm_r" ], "coverage": 95, "encumbrance": 8 },
@@ -1980,7 +1980,7 @@
     "faults": [ { "fault_group": "fabric_cotton" } ],
     "warmth": 25,
     "material_thickness": 0.8,
-    "flags": [ "VARSIZE" ],
+    "flags": [ "VARSIZE", "COSPLAY_COSTUME" ],
     "armor": [
       { "covers": [ "torso" ], "coverage": 85, "encumbrance": 8 },
       { "covers": [ "arm_l", "arm_r" ], "coverage": 85, "encumbrance": 6 },
@@ -2007,7 +2007,7 @@
     "faults": [ { "fault_group": "fabric_cotton" } ],
     "warmth": 15,
     "material_thickness": 0.2,
-    "flags": [ "VARSIZE" ],
+    "flags": [ "VARSIZE", "COSPLAY_COSTUME" ],
     "armor": [
       { "covers": [ "torso" ], "coverage": 75, "encumbrance": 4 },
       {

--- a/data/json/items/armor/torso_clothes.json
+++ b/data/json/items/armor/torso_clothes.json
@@ -513,7 +513,7 @@
     ],
     "warmth": 10,
     "material_thickness": 0.2,
-    "flags": [ "VARSIZE", "POCKETS", "HOOD" ]
+    "flags": [ "VARSIZE", "POCKETS", "HOOD", "COSPLAY_COSTUME" ]
   },
   {
     "id": "blazer",
@@ -1667,7 +1667,7 @@
     ],
     "warmth": 10,
     "material_thickness": 0.1,
-    "flags": [ "VARSIZE" ]
+    "flags": [ "VARSIZE", "COSPLAY_COSTUME" ]
   },
   {
     "id": "maid_dress_xl",
@@ -1731,7 +1731,7 @@
     ],
     "warmth": 2,
     "material_thickness": 0.1,
-    "flags": [ "VARSIZE" ]
+    "flags": [ "VARSIZE", "COSPLAY_COSTUME" ]
   },
   {
     "id": "maid_dress_short_xl",
@@ -1773,7 +1773,7 @@
       { "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ], "coverage": 40 }
     ],
     "material_thickness": 0.1,
-    "flags": [ "VARSIZE", "SKINTIGHT", "FRAGILE" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "FRAGILE", "COSPLAY_COSTUME" ]
   },
   {
     "id": "ninja_dress",

--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -495,7 +495,7 @@
     "material": [ "wood", "aluminum" ],
     "to_hit": { "grip": "weapon", "length": "short", "surface": "any", "balance": "neutral" },
     "price_postapoc": "1 USD 50 cent",
-    "extend": { "flags": [ "WATER_BREAK_ACTIVE" ] },
+    "extend": { "flags": [ "WATER_BREAK_ACTIVE", "COSPLAY_PROPS" ] },
     "charges_per_use": 1,
     "use_action": {
       "type": "transform",

--- a/data/json/items/tool/landscaping.json
+++ b/data/json/items/tool/landscaping.json
@@ -182,7 +182,8 @@
     "longest_side": "150 cm",
     "price": "30 USD",
     "price_postapoc": "5 cent",
-    "material": [ "plastic" ]
+    "material": [ "plastic" ],
+    "flags": [ "COSPLAY_PROPS" ]
   },
   {
     "id": "shovel",

--- a/data/json/starting_missions.json
+++ b/data/json/starting_missions.json
@@ -371,6 +371,7 @@
     "goal": "MGOAL_CONDITION",
     "goal_condition": {
       "or": [
+        { "u_has_item_with_flag": "COSPLAY_COSTUME" },
         { "u_has_item": "flag_jumpsuit" },
         { "u_has_item": "jumpsuit_skeleton" },
         { "u_has_item": "mummy_jumpsuit" },

--- a/data/json/starting_missions.json
+++ b/data/json/starting_missions.json
@@ -369,11 +369,7 @@
     "name": { "str": "Find some cosplay suits" },
     "description": "The world could have ended, but there are still some fantastic costumes out there, just waiting for you to wear them.  Search them until you find them.",
     "goal": "MGOAL_CONDITION",
-    "goal_condition": {
-      "or": [
-        { "u_has_item_with_flag": "COSPLAY_COSTUME" }
-      ]
-    },
+    "goal_condition": { "u_has_item_with_flag": "COSPLAY_COSTUME" },
     "difficulty": 2,
     "value": 0,
     "end": {

--- a/data/json/starting_missions.json
+++ b/data/json/starting_missions.json
@@ -371,12 +371,7 @@
     "goal": "MGOAL_CONDITION",
     "goal_condition": {
       "or": [
-        { "u_has_item_with_flag": "COSPLAY_COSTUME" },
-        { "u_has_item": "ninja_dress" },
-        { "u_has_item": "ninja_dress_sleeveless" },
-        { "u_has_item": "santa_dress" },
-        { "u_has_item": "santa_dress_short" },
-        { "u_has_item": "santa_dress_long" }
+        { "u_has_item_with_flag": "COSPLAY_COSTUME" }
       ]
     },
     "difficulty": 2,

--- a/data/json/starting_missions.json
+++ b/data/json/starting_missions.json
@@ -372,8 +372,6 @@
     "goal_condition": {
       "or": [
         { "u_has_item_with_flag": "COSPLAY_COSTUME" },
-        { "u_has_item": "cloak_vampire" },
-        { "u_has_item": "cloak_vampire_red" },
         { "u_has_item": "robe_wizard" },
         { "u_has_item": "ninja_dress" },
         { "u_has_item": "ninja_dress_sleeveless" },

--- a/data/json/starting_missions.json
+++ b/data/json/starting_missions.json
@@ -372,14 +372,6 @@
     "goal_condition": {
       "or": [
         { "u_has_item_with_flag": "COSPLAY_COSTUME" },
-        { "u_has_item": "flag_jumpsuit" },
-        { "u_has_item": "jumpsuit_skeleton" },
-        { "u_has_item": "mummy_jumpsuit" },
-        { "u_has_item": "bodysuit_lycra" },
-        { "u_has_item": "fursuit" },
-        { "u_has_item": "bondage_suit" },
-        { "u_has_item": "clown_suit" },
-        { "u_has_item": "jumpsuit_skeleton_zipped" },
         { "u_has_item": "maid_dress" },
         { "u_has_item": "mummy_dress" },
         { "u_has_item": "bee_dress" },

--- a/data/json/starting_missions.json
+++ b/data/json/starting_missions.json
@@ -372,9 +372,6 @@
     "goal_condition": {
       "or": [
         { "u_has_item_with_flag": "COSPLAY_COSTUME" },
-        { "u_has_item": "maid_dress" },
-        { "u_has_item": "mummy_dress" },
-        { "u_has_item": "bee_dress" },
         { "u_has_item": "cloak_vampire" },
         { "u_has_item": "cloak_vampire_red" },
         { "u_has_item": "robe_wizard" },

--- a/data/json/starting_missions.json
+++ b/data/json/starting_missions.json
@@ -372,20 +372,11 @@
     "goal_condition": {
       "or": [
         { "u_has_item_with_flag": "COSPLAY_COSTUME" },
-        { "u_has_item": "robe_wizard" },
         { "u_has_item": "ninja_dress" },
         { "u_has_item": "ninja_dress_sleeveless" },
-        { "u_has_item": "jacket_ninja" },
         { "u_has_item": "santa_dress" },
         { "u_has_item": "santa_dress_short" },
-        { "u_has_item": "santa_dress_long" },
-        { "u_has_item": "santa_jacket" },
-        { "u_has_item": "santa_jacket_short" },
-        { "u_has_item": "grim_reaper_robe" },
-        { "u_has_item": "grim_reaper_robe_faceless" },
-        { "u_has_item": "ghost_robe" },
-        { "u_has_item": "jedi_cloak" },
-        { "u_has_item": "zentai" }
+        { "u_has_item": "santa_dress_long" }
       ]
     },
     "difficulty": 2,

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -189,6 +189,7 @@ Some armor flags, such as `WATCH` and `ALARMCLOCK` are compatible with other ite
 - ```CANT_WEAR``` This item can't be worn directly.
 - ```COLLAR``` This piece of clothing has a wide collar that can keep your mouth warm when it is mostly unencumbered.
 - ```COMBAT_TOGGLEABLE``` This item is meant to be toggled during combat.  Used by NPCs to determine if they will toggle it on during combat.  This only supports simple `transform` actions.
+- ```COSPLAY_COSTUME``` This flag indicates that the outfit is a cosplay costume. It's somewhat of a continuation of the old 'FANCY', but currently it's only used for the 'Find some cosplay suits' quest and doesn't mean the stylish trait will be revived.
 - ```DEAF``` Makes the player deaf.
 - ```DECAY_EXPOSED_ATMOSPHERE``` Consumable will go bad once exposed to the atmosphere (such as MREs).
 - ```ELECTRIC_IMMUNE``` This gear completely protects you from electric discharges.
@@ -826,6 +827,7 @@ These flags can be applied via JSON item definition to most items.  Not to be co
 - ```CRUTCHES``` Item with this flag helps characters not to fall down if their legs are broken.
 - ```CUSTOM_EXPLOSION``` Flag, automatically applied to items that has defined `explosion` data in definition.  See `JSON_INFO.md`.
 - ```CUT_HARVEST``` You need a grass-cutting tool like sickle to harvest this plant.
+- ```COSPLAY_PROPS``` This flag implies that the outfit is a cosplay prop. Currently, it's purely descriptive, similar to `COSPLAY_COSTUME`.
 - ```DAMAGE_VEHICLE_WHEELS``` This item can damage a vehicle's wheels when it is run over.
 - ```DANGEROUS``` NPCs will not accept this item.  Explosion iuse actor implies this flag.  Implies `NPC_THROW_NOW`.
 - ```DETERGENT``` This item can be used as a detergent in a washing machine.


### PR DESCRIPTION
####  Summary

Migrate the "Find some cosplay suits" quest to a flag-based control system.

#### Purpose of change

I must admit, I never closely studied the stylish trait before it was deleted; I simply viewed it as a fun roleplaying element without diving into its underlying mechanics or bonus algorithms. However, someone mentioned to me that the character background quest many of us didn't know how to complete—"Find some cosplay suits"—used to rely on the stylish-related `FANCY` flag for detection long ago. I am not entirely sure if this is true, and there is a chance the player misunderstood it. Nonetheless, connecting it to the concept of `FANCY`, I believe converting "Find some cosplay suits" to a flag-controlled system is a better approach. This way, we can utilize the flag's info field to let players intuitively know which items "meet the quest requirements," instead of forcing them to dig through JSON files to figure out what the quest expects.

Additionally, I reviewed [PR79745](https://github.com/CleverRaven/Cataclysm-DDA/pull/79745), which deprecated the stylish trait. Kevin noted that "The intended effect is the player compromises defense/effectiveness/etc of their clothing to gain a bonus to morale." However, some players would "wear the smallest amount of non-impactful stylish clothing possible to get the bonus they want such as jewelry, or lobby for more practical clothing to get added to the stylish list."

Well, min-maxing and rabbit heads ruined it, but I think we might be able to revive a similar logic down the line. Flagging cosplay items could be the first step in this new logic chain. In the future, we could design a trait that only grants bonuses if the majority of the outfit consists of cosplay attire, thereby achieving the original design intent. Well, just a "maybe."

#### Describe the solution

Added two flags:
- `COSPLAY_COSTUME`: This flag indicates that the outfit is a cosplay costume. It's somewhat of a continuation of the old 'FANCY', but currently it's only used for the 'Find some cosplay suits' quest and doesn't mean the stylish trait will be revived.
- `COSPLAY_PROPS`: This flag implies that the outfit is a cosplay prop. Currently, it's purely descriptive, similar to `COSPLAY_COSTUME`.

In tandem, added the `COSPLAY_COSTUME` flag to all clothing pieces listed under the `MISSION_COSPLAY` ("Find some cosplay suits") quest in `starting_missions.json`. Migrated its target condition from a long `u_has_item` list to `{ "u_has_item_with_flag": "COSPLAY_COSTUME" }`, allowing for decentralized maintenance and mod expandability.

Additionally, assigned the `COSPLAY_PROPS` flag to the grim reaper's scythe and the wizard cane.

#### Additional context

More items, especially those from within mods, may still need these flags added; players are welcome to provide feedback to let us know.

Furthermore, while this PR can serve as a potential groundwork for bringing back the stylish trait, it does not guarantee we will do so. Please do not get your hopes up too high—though anyone interested is free to contribute. After all, I enjoy dressing up my character even without the stylish trait; I see it as a nice little extra rather than a core gameplay feature.