### PR TITLE
Physical damage has absolutely no reason not to be used for destroying terrain or furniture

### DIFF
--- a/data/json/damage_types.json
+++ b/data/json/damage_types.json
@@ -34,6 +34,7 @@
     "magic_color": "light_gray",
     "name": { "ctxt": "damage_type", "str": "cut" },
     "skill": "cutting",
+    "bash_conversion_factor": 0.75,
     "mon_difficulty": true,
     "material_required": true,
     "immune_flags": { "character": [ "CUT_IMMUNE" ] }
@@ -59,6 +60,7 @@
     "magic_color": "light_red",
     "name": { "ctxt": "damage_type", "str": "pierce" },
     "skill": "stabbing",
+    "bash_conversion_factor": 0.6,
     "mon_difficulty": true,
     "//2": "derived from cut only for monster defs",
     "derived_from": [ "cut", 0.8 ],
@@ -81,6 +83,7 @@
     "type": "damage_type",
     "physical": true,
     "magic_color": "light_red",
+    "bash_conversion_factor": 0.5,
     "mon_difficulty": true,
     "name": { "ctxt": "damage_type", "str": "ballistic" },
     "material_required": true,

--- a/data/json/damage_types.json
+++ b/data/json/damage_types.json
@@ -192,6 +192,7 @@
     "type": "damage_type",
     "physical": false,
     "magic_color": "green",
+    "bash_conversion_factor": 0.0,
     "name": { "ctxt": "damage_type", "str": "biological" },
     "immune_flags": { "character": [ "BIO_IMMUNE" ], "monster": [ "BIOLOGICALPROOF" ] },
     "no_resist": true

--- a/data/mods/Magiclysm/damage_types.json
+++ b/data/mods/Magiclysm/damage_types.json
@@ -85,6 +85,7 @@
     "physical": false,
     "magic_color": "h_white",
     "name": { "ctxt": "damage_type", "str": "sonic" },
+    "bash_conversion_factor": 0.4,
     "derived_from": [ "bash", 0.4 ],
     "mon_difficulty": true,
     "material_required": false
@@ -129,6 +130,7 @@
     "physical": false,
     "magic_color": "white_magenta",
     "name": { "ctxt": "damage_type", "str": "gravity" },
+    "bash_conversion_factor": 0.8,
     "mon_difficulty": true,
     "material_required": false
   },

--- a/data/mods/MindOverMatter/damage_types.json
+++ b/data/mods/MindOverMatter/damage_types.json
@@ -56,6 +56,7 @@
     "magic_color": "yellow",
     "name": { "ctxt": "damage_type", "str": "telekinetic" },
     "skill": "metaphysics",
+    "bash_conversion_factor": 0.9,
     "derived_from": [ "bash", 0.9 ],
     "immune_flags": { "character": [ "TELEKIN_SHIELD" ], "monster": [ "TELEKIN_IMMUNE" ] },
     "ondamage_eocs": [ "EOC_TELEKINETIC_DAMAGE_KNOCKDOWN_CHANCE", "EOC_TELEKINETIC_DAMAGE_STAGGER_CHANCE" ]
@@ -100,6 +101,7 @@
     "magic_color": "white",
     "name": { "ctxt": "damage_type", "str": "telepathic" },
     "skill": "metaphysics",
+    "bash_conversion_factor": 0.0,
     "immune_flags": { "character": [ "TEEPSHIELD", "PSYSHIELD_PROTECT" ], "monster": [ "TEEP_IMMUNE" ] },
     "ondamage_eocs": [ "EOC_TELEPATHIC_DAMAGE_PSYSHIELD_CHECK", "EOC_TELEPATHIC_DAMAGE_STUN_HIVE_CHANCE" ]
   },

--- a/data/mods/Xedra_Evolved/damage_types.json
+++ b/data/mods/Xedra_Evolved/damage_types.json
@@ -6,6 +6,7 @@
     "magic_color": "light_gray",
     "name": "cold iron cut",
     "skill": "cutting",
+    "bash_conversion_factor": 0.75,
     "derived_from": [ "cut", 1 ],
     "immune_flags": { "character": [ "IRONSWORN" ], "monster": [ "IRONWROUGHT" ] }
   },
@@ -48,6 +49,7 @@
     "magic_color": "light_gray",
     "name": "cold iron stab",
     "skill": "stabbing",
+    "bash_conversion_factor": 0.6,
     "derived_from": [ "stab", 1 ],
     "immune_flags": { "character": [ "IRONSWORN" ], "monster": [ "IRONWROUGHT" ] }
   },

--- a/data/mods/aftershock_exoplanet/damage_types.json
+++ b/data/mods/aftershock_exoplanet/damage_types.json
@@ -4,6 +4,7 @@
     "type": "damage_type",
     "physical": true,
     "magic_color": "pink",
+    "bash_conversion_factor": 0.4,
     "name": { "ctxt": "damage_type", "str": "plasma" },
     "derived_from": [ "heat", 0.4 ]
   },
@@ -23,6 +24,7 @@
     "type": "damage_type",
     "physical": true,
     "magic_color": "red",
+    "bash_conversion_factor": 0.4,
     "name": { "ctxt": "damage_type", "str": "laser" },
     "derived_from": [ "heat", 1 ]
   },
@@ -46,6 +48,7 @@
     "magic_color": "red",
     "name": { "ctxt": "damage_type", "str": "heat" },
     "skill": "cutting",
+    "bash_conversion_factor": 0.7,
     "mon_difficulty": true,
     "derived_from": [ "heat", 1 ],
     "immune_flags": { "character": [ "CUT_IMMUNE" ] }
@@ -125,6 +128,7 @@
     "magic_color": "yellow",
     "name": { "ctxt": "damage_type", "str": "telekinetic" },
     "skill": "metaphysics",
+    "bash_conversion_factor": 0.9,
     "derived_from": [ "bash", 0.9 ],
     "immune_flags": { "character": [ "TELEKIN_SHIELD" ], "monster": [ "TELEKIN_IMMUNE" ] },
     "ondamage_eocs": [ "EOC_TELEKINETIC_DAMAGE_KNOCKDOWN_CHANCE", "EOC_TELEKINETIC_DAMAGE_STAGGER_CHANCE" ]

--- a/src/damage.cpp
+++ b/src/damage.cpp
@@ -128,7 +128,7 @@ void damage_type::load( const JsonObject &jo, std::string_view src )
     optional( jo, was_loaded, "material_required", material_required );
     optional( jo, was_loaded, "mon_difficulty", mon_difficulty );
     optional( jo, was_loaded, "no_resist", no_resist );
-    optional( jo, was_loaded, "bash_conversion_factor", bash_conversion_factor, 0.0 );
+    optional( jo, was_loaded, "bash_conversion_factor", bash_conversion_factor, physical ? 0.5 : 0.1 );
     if( jo.has_object( "immune_flags" ) ) {
         JsonObject jsobj = jo.get_object( "immune_flags" );
         if( jsobj.has_array( "monster" ) ) {


### PR DESCRIPTION
####  Summary

Redesign `bash_conversion_factor` to establish a reasonable set of default logic rather than the bizarre "all of 0.0" approach.

#### Purpose of change

DDA's [PR81838](https://github.com/CleverRaven/Cataclysm-DDA/pull/81838) introduced a system called `bash_damage_profile` to set conversion ratios for damage when destroying furniture/terrain, under the rationale that "Fire axes should be better for smashing wooden doors."

Excellent—that is indeed a great leap forward for realism, if one only looks at the "Purpose of change." However, that PR very cleverly set a new key in the `damage_type` data module, `bash_conversion_factor`, to serve as the default value when a specific `bash_damage_profile` is not configured. Up to this point, these operations seemed quite sensible. But tracing it back to the source code reveals that, first of all, the fallback `bash_damage_profile` (i.e., `default`) only configures `"profile": { "bash": 1.0 }`. This means all other damage types fall back to the default `bash_conversion_factor`. Now, leaving `map_accessories.cpp` to look at `damage.cpp`, we discover that if `bash_conversion_factor` is not explicitly set, its default value is 0.0. Excellent, the plot thickens. Let’s look at the JSON data for `damage_type`—only `bash` is configured!

Wonderful: "Right now, only bash damage is counted unless overridden by the profile." 

Consequently, picture this brilliant scenario: you are locked in a glass room with no doors, only windows. But hey, you happen to possess an ultra-futuristic, high-tech ship-slaying sword that deals a whopping 9,999,999 cutting damage. All you need to do is dismantle this non-wooden fabric sofa (which isn't wooden) in front of you to escape through a hidden underground hatch. Sounds incredibly simple, right? Yet, you soon discover that this magnificent blade, capable of one-shotting literally any monster in existence, cannot inflict a single scratch on a mere sofa. You try to smash the glass window to escape, but it won't budge. Infuriated, you hack furiously at the walls, but the glass facade remains completely unfazed. Out of sheer despair, you toss away this sword—whose net worth is literally hundreds of times yours—huddle in the corner, and start bawling your eyes out, convinced you're going to rot in this room for the rest of your life. Then, completely by accident, your fist happens to slam into the window, and the glass shatters instantly. Happy ending.

This story sounds like a terrible joke, but I must inform you that it is a direct adaptation of a real, agonizing experience endured by one of our players.

#### Describe the solution

Changed the formula for `bash_conversion_factor` so that the default value is no longer 0. If `physical` is true (meaning it is physical damage), it now defaults to 0.5; otherwise, it defaults to 0.1. Now, a value of 0 must be explicitly configured, ensuring that there is at least a 10% conversion ratio by default in all scenarios.

Additionally, initialized baseline values for several damage types across the core module and warehouse-integrated mods:
 - `cut` is set to 0.75, indicating it is slightly less efficient.
 - `stab` is set to 0.6, which is 80% of `cut` (matching its armor conversion ratio), signifying it is better suited for precise penetration rather than structural destruction.
 - `bullet` is set to the default 0.5.
 - `biological` is set to 0. While there seem to be weapons capable of dealing this damage type, it is inherently a biochemical affliction rather than a form of physical destruction.
 - Xedra Evolved's `cold iron` damage has synced and replicated the data of its baseline damage type.
 - Aftershock's `plasma` and `laser` damage types, as physicalized variants of thermal energy, are set to 0.4. This is because thermal damage types do not seem to possess general physical entity-destroying properties, acting more like a "barbecue feast" for organic matter.
 - Aftershock's `heat melee` appears to be intended specifically for plasma blades. Its archetype is the `cut` type, so it has been given a 0.7, slightly lower than `cut`.
 - Other Aftershock damage types where `physical` is true utilize the default values.
 - Aftershock's `telekinetic` damage is set to 0.9. This can be considered a variant of `bash` damage, though perhaps less direct.
 - Mind Over Matter's `telekinetic` damage is identical to Aftershock's; rather, Aftershock's telekinetic damage originally stems from Mind Over Matter.
 - Mind Over Matter's `telepathic` damage is set to 0, as it is entirely mental.
 - Magiclysm's `sonic` damage is set to 0.4. Even though it is magical, acoustic resonance does indeed seem to be an effective means of destroying items. Furthermore, its default armor bypass scaling is 0.4 times that of `bash`, so this data was mirrored.
 - Magiclysm's `gravity` damage is set to 0.8. I feel its design shares similarities with telekinesis, and the associated spells do resemble the stereotypes of an earth elemental mage.

#### Additional context

I hope there are no bugs. I am not particularly proficient in the C++ department, and I feel its differences from C# or Java are truly immense.
However, I believe the author of the original PR didn't lack coding knowledge, but was simply too lazy or failed to consider a wider variety of circumstances.