### PR TITLE
Balance: Rationalize the configuration of certain vehicle parts (shock absorber & superalloy)

### DIFF
--- a/data/json/vehicleparts/armor.json
+++ b/data/json/vehicleparts/armor.json
@@ -25,7 +25,7 @@
     "type": "vehicle_part",
     "item": "spring_plate",
     "description": "A makeshift combination of springs and scrap that protects a particular section of a vehicle from the shock of impacts.  The springs can absorb a surprising amount of damage.",
-    "location": "armor",
+    "location": "damping",
     "categories": [ "warfare" ],
     "color": "dark_gray",
     "broken_color": "dark_gray",

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -2012,7 +2012,7 @@
       },
       "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 6 ] ] }
     },
-    "flags": [ "ARMOR" ],
+    "flags": [ "ARMOR", "SHOCK_RESISTANT" ],
     "breaks_into": [
       { "item": "ch_steel_lump", "count": [ 4, 6 ] },
       { "item": "ch_steel_chunk", "count": [ 4, 6 ] },

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -1995,7 +1995,7 @@
     "categories": [ "warfare" ],
     "color": "dark_gray",
     "broken_color": "dark_gray",
-    "durability": 600,
+    "durability": 660,
     "item": "alloy_plate",
     "location": "armor",
     "//": "240 cm weld to install, 60 cm weld per damage quadrant",


### PR DESCRIPTION
####  Summary

Rationalize the configuration adjustments for certain vehicle parts (shock absorber & superalloy).

#### Purpose of change

Currently, the configuration of several vehicle parts has certain issues that make them rather counterintuitive.

Shock absorbers share the same installation location as armor plating. However, they fulfill an entirely different, non-overlapping purpose: plating protects the parts from direct damage on that specific tile, while shock absorbers protect them from shock damage when a collision happens elsewhere. Furthermore, shock absorbers currently seem to be the oddest outlier under the `"location": "armor"` slot, as it is the only part there that isn't actual armor.

Superalloy boasts a formidable-sounding name and comes with an acquisition method in-game that seems a bit difficult and scarce. Yet, this uncraftable material is essentially on par with ordinary steel, aside from its lower density. When it comes to vehicle parts, the performance of superalloy plating is even worse than regular steel plating, leaving me wondering what makes it so "super" in the first place. Meanwhile, the item description for the base superalloy material states: `A sheet of sturdy superalloy; incredibly hard, yet incredibly malleable.` This characteristic is entirely unrepresented, reducing it to mere trash loot that exists in name only.

#### Describe the solution

Changed the installation location of shock absorbers to a standalone `damping` slot, allowing it to be installed alongside other standard `armor` vehicle parts.

Adjusted the performance of superalloy plating to match that of steel plating, and assigned it the same `SHOCK_RESISTANT` flag as shock absorbers. This grants it a slight competitive edge by eliminating the need to install separate shock absorbers—after all, it is supposed to be `yet incredibly malleable`.

#### Additional context

Whether superalloy as a whole requires further buffs remains up for debate. Even though its current in-game performance seems unworthy of its acquisition difficulty and lore descriptions, this material is tied to a vast number of items, and making widespread changes would heavily impact balance.