### PR TITLE
[MoM] Migrate the psionic awakening rate bonus of the Alpha mutation line's `Noetic Flexibility` to a custom enchantment

### DIFF
--- a/data/mods/MindOverMatter/jmath.json
+++ b/data/mods/MindOverMatter/jmath.json
@@ -139,13 +139,13 @@
     "type": "jmath_function",
     "id": "matrix_awakening_odds",
     "num_args": 1,
-    "return": "100 * (e ^ ( ( _0 - max( (u_has_trait('MORE_PSI_ALPHA') * 0.75), 0) ) / -1.7) )"
+    "return": "100 * (e ^ ( ( _0 - max( (u_enchant_val('awakening_odds_traits_mod', 0) * 0.75), 0) ) / -1.7) )"
   },
   {
     "type": "jmath_function",
     "id": "portal_storm_awakening_odds",
     "num_args": 1,
-    "return": "100 * (e ^ ( ( _0 - max( (u_has_trait('MORE_PSI_ALPHA') * 0.75), 0) ) / -3) )"
+    "return": "100 * (e ^ ( ( _0 - max( (u_enchant_val('awakening_odds_traits_mod', 0) * 0.75), 0) ) / -3) )"
   },
   {
     "type": "jmath_function",

--- a/data/mods/MindOverMatter/mutations/path_mutations.json
+++ b/data/mods/MindOverMatter/mutations/path_mutations.json
@@ -8,6 +8,9 @@
     "description": "Your expanded mind is far more capable of understanding Netherum Mathematics than a mere human's.  You have an greater chance of awakening new psionic paths.",
     "prereqs": [ "INT_ALPHA" ],
     "threshreq": [ "THRESH_ALPHA" ],
-    "category": [ "ALPHA" ]
+    "category": [ "ALPHA" ],
+    "enchantments": [
+      { "condition": "ALWAYS", "custom": [ { "value": "awakening_odds_traits_mod", "add": 1 } ] }
+    ]
   }
 ]


### PR DESCRIPTION
####  Summary

[MoM] Migrate the psionic awakening rate bonus of the Alpha mutation line's `Noetic Flexibility` to a custom enchantment

#### Purpose of change

Back when I was writing a mod for DDA's 0.I version, I discovered that the Mind Over Matter mod added a mutation to the `ALPHA` mutation line, which was described as making psionic awakening easier. Excitedly, I wanted to reference its implementation to set up similar mutations for my own mod as cross-mod content. Unfortunately, I eventually found out that this mutation itself actually had zero effect. In reality, Mind Over Matter's formula for calculating awakening probability (`jmath_function`) simply used the return value of `u_has_trait('MORE_PSI_ALPHA')` as part of a *semi-hardcoded* check—essentially just returning a 0 or 1 as a parameter for the formula calculation. Even though this isn't genuine C++ hardcoding but rather JSON configuration, other mods cannot effectively modify these formula contents through compatibility patches; even if they could, it's impossible to ensure compatibility with other mods making the same modifications simultaneously, because it requires a complete override rather than a "patch."

The good news, however, is that our Cleanwater Bomb branch introduced a custom enchantment system driven purely by JSON string-key enchantments in PR #166, which supports retrieval via math calculations. This made me realize that an improvement could finally be implemented.

#### Describe the solution

Added an enchantment to Noetic Flexibility (id: `MORE_PSI_ALPHA`) with the following content: `{ "condition": "ALWAYS", "custom": [ { "value": "awakening_odds_traits_mod", "add": 1 } ] }`. This grants the mutation a custom enchantment attribute with the key `awakening_odds_traits_mod`.

Modified MoM's `jmath` to replace `u_has_trait('MORE_PSI_ALPHA')` within `matrix_awakening_odds` and `portal_storm_awakening_odds` with `u_enchant_val('awakening_odds_traits_mod', 0)`.

Currently, this handling won't change anything in a standalone MoM environment, but utilizing a custom enchantment attribute allows other mod extensions or compatibility patches to add more mutations that can influence psionic awakening probabilities.