### PR TITLE
fix(ci): 修复三个 CI 编译错误

### DIFF
--- a/msvc-full-features/Cataclysm-common.props
+++ b/msvc-full-features/Cataclysm-common.props
@@ -54,7 +54,7 @@
       <CompileAsManaged>false</CompileAsManaged>
       <AdditionalOptions>/bigobj /utf-8 %(AdditionalOptions)</AdditionalOptions>
       <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)..\pch;$(MSBuildThisFileDirectory)..\src;$(MSBuildThisFileDirectory)..\src\third-party;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)..\pch;$(MSBuildThisFileDirectory)..\src;$(MSBuildThisFileDirectory)..\src\third-party;$(MSBuildThisFileDirectory)..\src\third-party\asio\asio\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4661;4819;4146;26495;26444;26451;4068;6319;6237</DisableSpecificWarnings>
       <PreprocessorDefinitions>_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;WIN32_LEAN_AND_MEAN;LOCALIZE;USE_VCPKG;ZSTD_STATIC_LINKING_ONLY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10505,19 +10505,18 @@ static void prefetch_leading_edge( const map &here, const point_rel_sm &shift )
         MAPBUFFER.prefetch_quad( entry.first, entry.second );
     }
 
-    // Also dispatch full OMT loads to the thread pool.  Each worker thread
-    // reads + deserializes the quad directly into the in-memory buffer,
-    // skipping the byte-buffer round-trip.  Uniform terrain is generated too.
-    // Duplicate submaps are deferred to pending_destroy_submaps_ and drained
-    // on the main thread in do_turn().
-    cata_thread_pool &pool = get_thread_pool();
-    if( pool.num_workers() > 0 ) {
-        for( const auto &entry : quads ) {
-            pool.submit( [omt = entry.first]() {
-                MAPBUFFER.preload_omt( omt );
-            } );
-        }
-    }
+    // TODO: preload_omt() was planned as a thread-pool-based direct
+    // deserialisation path but was never implemented in mapbuffer.  The
+    // existing submap_prefetcher (prefetch_quad above) already handles
+    // background loading via its own dedicated worker thread.
+    // cata_thread_pool &pool = get_thread_pool();
+    // if( pool.num_workers() > 0 ) {
+    //     for( const auto &entry : quads ) {
+    //         pool.submit( [omt = entry.first]() {
+    //             MAPBUFFER.preload_omt( omt );
+    //         } );
+    //     }
+    // }
 }
 
 point_rel_sm game::update_map( int &x, int &y, bool z_level_changed )

--- a/tests/monster_ai_determinism_test.cpp
+++ b/tests/monster_ai_determinism_test.cpp
@@ -7,6 +7,7 @@
 #include "creature.h"
 #include "map.h"
 #include "map_helpers.h"
+#include "map_helpers_tests.h"
 #include "monster.h"
 #include "monster_helpers.h"
 #include "point.h"


### PR DESCRIPTION
## 概述

修复 GitHub Action CI 编译失败的三个错误。

## 错误来源

两次 CI run 的编译错误:
- [Run 28754583188](https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/actions/runs/28754583188) (PR #332 合并后): Linux 4 个 job 失败
- [Run 28766325087](https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/actions/runs/28766325087) (PR #334 合并后): 30 个错误,跨 Linux/macOS/Windows/Android

## 修复内容

### 1. `fix(game): disable unimplemented preload_omt() call`

`game.cpp` 调用了 `MAPBUFFER.preload_omt()`，但该函数从未在 `mapbuffer` 中实现。这是多线程基础设施 (#271) 中规划但未完成的功能，导致**所有平台**编译失败。

上方已有的 `MAPBUFFER.prefetch_quad()` 通过 `submap_prefetcher` 的专用 worker 线线处理后台加载，功能上是冗余的。注释掉该代码块。

### 2. `fix(msvc): add asio include path for multiplayer builds`

联机代码 (`mp_client_conn.cpp`, `mp_server.cpp`) `#include <asio.hpp>`，asio 库在 `src/third-party/asio/asio/include/`。

CMake 构建已通过 `src/third-party/CMakeLists.txt` 配置了该路径，但 MSVC 项目文件 (`Cataclysm-common.props`) 的 `AdditionalIncludeDirectories` 只有 `src\third-party`，缺少 asio 子路径。导致 Windows MSVC 构建报错：

```
Cannot open include file: 'asio.hpp': No such file or directory
```

添加 `src\third-party\asio\asio\include` 到 MSVC include 路径。

### 3. `fix(tests): add missing include for spawn_test_monster`

`monster_ai_determinism_test.cpp` (PR #190) 调用 `spawn_test_monster()`，该函数声明在 `tests/map_helpers_tests.h`，但测试文件只 include 了 `map_helpers.h`。导致 Linux 编译报错：

```
'spawn_test_monster' was not declared in this scope
```

添加 `#include "map_helpers_tests.h"`。

## 本地验证

- `cataclysm-tiles` 编译通过 ✓
- `cata_test-tiles` 编译通过 ✓