### PR TITLE
[codex] Fix async mapgen unused-state build error

### DIFF
--- a/src/mapgen_async.cpp
+++ b/src/mapgen_async.cpp
@@ -1,26 +1,7 @@
 #include "mapgen_async.h"
 
-#include <mutex>
-#include <utility>
-#include <vector>
-
-#include "auto_note.h"
-#include "map_extras.h"
-#include "options.h"
-#include "overmapbuffer.h"
-
 namespace mapgen_defer
 {
-
-namespace
-{
-
-std::mutex                     g_autonote_mutex;
-std::vector<string_id<map_extra>> g_pending_extras;
-
-// TODO: Lua hooks will be added when CCB ports Lua integration
-
-} // namespace
 
 void drain()
 {

--- a/src/mapgen_async.h
+++ b/src/mapgen_async.h
@@ -1,12 +1,6 @@
 #pragma once
 
-#include <atomic>
-#include <mutex>
-#include <string>
-#include <vector>
-
 #include "coordinates.h"
-#include "int_id.h"
 #include "string_id.h"
 
 class map_extra;


### PR DESCRIPTION
## Summary

Fixes the Actions build regression caused by unused async mapgen placeholder state:

- removes unused `g_autonote_mutex` and `g_pending_extras`
- removes now-unused includes from `mapgen_async.cpp` and `mapgen_async.h`

## Root Cause

The async mapgen placeholder kept unused globals after the Lua hook implementation was deferred. Release builds compile with `-Werror`, so the unused variable warning failed CI.

## Validation

- `make COMPILER=clang++ -j2 TILES=0 SOUND=0 SDL3=0 RELEASE=1 LOCALIZE=0 BACKTRACE=0 PCH=0 WARN_STALE_DATA=1 ASTYLE=0 LINTJSON=0 TESTS=0 obj/mapgen_async.o`
- `make COMPILER=clang++ -j2 TILES=0 SOUND=0 SDL3=0 RELEASE=1 LOCALIZE=0 BACKTRACE=0 PCH=0 WARN_STALE_DATA=1 ASTYLE=0 LINTJSON=0 TESTS=0 cataclysm`