### PR TITLE
[codex] Fix startup data errors and single-player turn regressions

### DIFF
--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -216,13 +216,13 @@
     "type": "item_group",
     "container-item": "jug_plastic",
     "//": "128 oz",
-    "items": [ { "item": "bleach", "count": 30 } ]
+    "items": [ { "item": "bleach", "charges": 30 } ]
   },
   {
     "id": "bleach_jug_part",
     "type": "item_group",
     "container-item": "jug_plastic",
-    "items": [ { "item": "bleach", "count": [ 1, 30 ] } ]
+    "items": [ { "item": "bleach", "charges": [ 1, 30 ] } ]
   },
   {
     "id": "bleach_jug",

--- a/data/json/vehicle_part_locations.json
+++ b/data/json/vehicle_part_locations.json
@@ -16,6 +16,14 @@
   },
   {
     "type": "vehicle_part_location",
+    "id": "damping",
+    "name": "Damping",
+    "//": "Shock absorber plates share the armor display layer.",
+    "z_order": -2,
+    "list_order": 2
+  },
+  {
+    "type": "vehicle_part_location",
     "id": "on_roof",
     "name": "On Roof",
     "z_order": 9,

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -796,9 +796,11 @@ void game::simulate_turn_prefix()
     while( u.get_moves() > 0 && u.activity ) {
         u.activity.do_turn( u );
     }
-    // Ticks effects/needs once per elapsed game-turn, discards process_turn's move
-    // regen (client moves come from server grants).
-    cata_mp::mp_do_turn_process_turn( u );
+    // Client-only: tick effects/needs once per elapsed host turn, without granting
+    // local moves. SP/host process_turn() still runs in simulate_turn_suffix().
+    if( cata_mp::is_client_mode() ) {
+        cata_mp::mp_do_turn_process_turn( u );
+    }
     // Client: if a wait activity consumed the server-granted moves this turn,
     // dispatch "wait" so the server advances its timeline in sync.
     if( cata_mp::is_client_mode() && pre_activity_moves > 0 && u.get_moves() <= 0 ) {

--- a/src/mp_gamestate.cpp
+++ b/src/mp_gamestate.cpp
@@ -298,18 +298,17 @@ void mp_do_turn_update_body( Character &u )
     s_last_update_body = calendar::turn;
 }
 
-// Per-turn processing (effects, needs, move regen), called from do_turn.cpp.
-// SP/host: one plain process_turn(). Client: process_turn() ticks effects/needs
-// exactly one turn per call with no catch-up, so calling it on every locked-spin
-// iteration over-applied them (confirmed: bleed/pain climbing while locked) and
-// a multi-turn jump under-applied them. Tick once per ELAPSED game-turn (skip on
-// locked spin, capped catch-up on jumps); discard the move regen — the client's
-// moves come from server grants.
+// Client per-turn processing (effects, needs, move regen), called from do_turn.cpp.
+// SP/host run their normal process_turn() in simulate_turn_suffix(). Client:
+// process_turn() ticks effects/needs exactly one turn per call with no catch-up,
+// so calling it on every locked-spin iteration over-applied them (confirmed:
+// bleed/pain climbing while locked) and a multi-turn jump under-applied them.
+// Tick once per ELAPSED game-turn (skip on locked spin, capped catch-up on
+// jumps); discard the move regen — the client's moves come from server grants.
 void mp_do_turn_process_turn( Character &u )
 {
     const int pre_moves = u.get_moves();
     if( !is_client_mode() ) {
-        u.process_turn();
         return;
     }
     static time_point s_last_proc = calendar::before_time_starts;

--- a/src/mp_gamestate.h
+++ b/src/mp_gamestate.h
@@ -467,7 +467,8 @@ void mp_log_safemode_check( int newseen, int mostseen, int safe_mode );
 
 // Per-turn callouts invoked from do_turn.cpp (an SP file) so the MP per-turn
 // catch-up/gating logic lives here, not inline in the SP loop (rule 4, minimize
-// upstream merge conflicts). Non-client (SP/host) path = a single plain update.
+// upstream merge conflicts). Non-client (SP/host) process_turn() still happens
+// in the normal SP suffix path.
 // mp_do_turn_update_body: catches up the host-driven calendar's jumps (stamina
 //   regen, suffers, cravings). mp_do_turn_process_turn: ticks effects/needs once
 //   per elapsed game-turn (skip on locked spin, capped catch-up on jumps) and

--- a/src/thread_pool.cpp
+++ b/src/thread_pool.cpp
@@ -90,11 +90,13 @@ cata_thread_pool &get_thread_pool()
         // Respect the "disable multi-threading" setting.  This is read via
         // get_option<bool>() directly (not the cached parallel_enabled global)
         // because cache_to_globals() has not yet run at pool-init time.
-        if( has_option( "MULTITHREADING_ENABLED" ) && !get_option<bool>( "MULTITHREADING_ENABLED" ) )
+        if( !has_option( "MULTITHREADING_ENABLED" ) ||
+            !get_option<bool>( "MULTITHREADING_ENABLED" ) )
         {
             return 0u;
         }
-        const int workers_opt = get_option<int>( "THREAD_POOL_WORKERS" );
+        const int workers_opt = has_option( "THREAD_POOL_WORKERS" ) ?
+                                get_option<int>( "THREAD_POOL_WORKERS" ) : 0;
         if( workers_opt > 0 )
         {
             return static_cast<unsigned int>( workers_opt );


### PR DESCRIPTION
## Summary

Fixes startup/runtime regressions seen in `config/debug.log` after the recent multiplayer and multithreading merges:

- defines the missing `damping` vehicle part location used by shock absorber armor
- changes bleach jug item groups from spawning multiple contained bleach items to spawning liquid charges
- keeps client-only turn processing out of single-player/host turn flow
- guards thread-pool option reads before options are fully registered

## Root Cause

`spring_plate` referenced a `damping` vehicle part location that did not exist. The bleach jug groups used `count`, which produced multiple bleach items with their default plastic jug container and then tried to put those jugs inside another jug. Multiplayer turn processing was invoked from the shared turn prefix, causing non-client games to run `Character::process_turn()` before the normal suffix path. The thread pool could also be initialized before `THREAD_POOL_WORKERS` had been registered.

## Validation

- `python3 -m json.tool data/json/vehicle_part_locations.json`
- `python3 -m json.tool data/json/itemgroups/supplies.json`
- `tools/format/json_formatter.cgi data/json/vehicle_part_locations.json`
- `tools/format/json_formatter.cgi data/json/itemgroups/supplies.json`
- `make COMPILER=clang++ -j2 TILES=0 SOUND=0 SDL3=0 RELEASE=1 LOCALIZE=0 BACKTRACE=0 PCH=0 WARN_STALE_DATA=1 ASTYLE=0 LINTJSON=0 TESTS=0 obj/do_turn.o obj/mp_gamestate.o obj/thread_pool.o`
- `make COMPILER=clang++ -j2 TILES=0 SOUND=0 SDL3=0 RELEASE=1 LOCALIZE=0 BACKTRACE=0 PCH=0 WARN_STALE_DATA=1 ASTYLE=0 LINTJSON=0 TESTS=0 cataclysm`
- `./cataclysm --jsonverify`

Latest `config/debug.log` entries from `./cataclysm --jsonverify` only show startup, locale setup, and shutdown, with no new `damping`, `bleach_jug`, or `THREAD_POOL_WORKERS` errors.