### PR TITLE
修复安卓图标与启动/游戏主题显示问题

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -27,7 +27,8 @@
          An example Java class can be found in README-android.md
     -->
     <application android:label="@string/app_name"
-        android:icon="@drawable/ic_launcher"
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
         android:allowBackup="true"
         android:theme="@style/AppTheme"
         android:hardwareAccelerated="true"
@@ -40,6 +41,7 @@
 
         <activity android:name="SplashScreen"
                   android:label="@string/app_name"
+                  android:theme="@style/AppTheme"
                   android:launchMode="singleInstance"
                   android:keepScreenOn="true"
                   android:screenOrientation="userLandscape"
@@ -53,6 +55,7 @@
         </activity>
         <activity android:name="CataclysmDDA"
                   android:label="@string/app_name"
+                  android:theme="@style/GameTheme"
                   android:launchMode="singleInstance"
                   android:keepScreenOn="true"
                   android:screenOrientation="userLandscape"

--- a/android/app/src/main/java/com/lyhglytx/cataclysmcb/CDDADocumentsProvider.java
+++ b/android/app/src/main/java/com/lyhglytx/cataclysmcb/CDDADocumentsProvider.java
@@ -114,7 +114,7 @@ public class CDDADocumentsProvider extends DocumentsProvider {
             } else if (DocumentsContract.Root.COLUMN_DOCUMENT_ID.equals(col)) {
                 rowValues[i] = ROOT_DOCUMENT_ID;
             } else if (DocumentsContract.Root.COLUMN_ICON.equals(col)) {
-                rowValues[i] = R.drawable.ic_launcher;
+                rowValues[i] = R.mipmap.ic_launcher;
             } else if (DocumentsContract.Root.COLUMN_AVAILABLE_BYTES.equals(col)) {
                 // Available on API 23+
                 rowValues[i] = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) ? externalDataRoot.getFreeSpace() : 0L;

--- a/android/app/src/main/java/com/lyhglytx/cataclysmcb/SplashScreen.java
+++ b/android/app/src/main/java/com/lyhglytx/cataclysmcb/SplashScreen.java
@@ -314,10 +314,11 @@ public class SplashScreen extends Activity {
 
         private ScrollView createSettingsView() {
             ScrollView scrollView = new ScrollView(SplashScreen.this);
+            scrollView.setFillViewport(true);
             LinearLayout layout = new LinearLayout(SplashScreen.this);
             layout.setOrientation(LinearLayout.VERTICAL);
             int padding = (int)(24 * getResources().getDisplayMetrics().density);
-            layout.setPadding(padding, 0, padding, 0);
+            layout.setPadding(padding, padding, padding, padding);
 
             TextView displayModeLabel = new TextView(SplashScreen.this);
             displayModeLabel.setText(getString(R.string.androidSystemUiMode));

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -8,6 +8,14 @@
         <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
     </style>
 
+    <style name="GameTheme" parent="@android:style/Theme.Material.NoActionBar">
+        <item name="android:windowBackground">@android:color/black</item>
+        <item name="android:colorAccent">@color/accent_material_dark</item>
+        <item name="android:colorPrimary">@color/primary_material_dark</item>
+        <item name="android:colorBackground">@color/background_material_dark</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
+
     <style name="AlertDialogTheme" parent="@android:style/Theme.Material.Dialog.Alert" >
         <item name="android:colorAccent">#F2F2F2</item>
     </style>


### PR DESCRIPTION
## 变更内容
- 将应用图标入口从旧的 `@drawable/ic_launcher` 切换到 `@mipmap/ic_launcher`，并补上 `roundIcon`
- 为 SDL 游戏活动单独使用 `GameTheme`，避免游戏界面未完全覆盖时继续露出启动页背景
- 修正文档提供器使用的图标资源引用
- 调整启动页设置界面的 `ScrollView` 与内边距，减少底部内容贴边和露出问题

## 修复原因
安卓端当前同时存在两个问题：
1. 桌面图标仍然走旧资源入口，导致没有正确使用 CCB 的应用图标
2. 游戏活动沿用了启动页主题，SDL 画面没有完全覆盖窗口时，会把启动页背景继续显示出来，看起来像底部漏出一块错误背景

这次改动把启动页和游戏页的主题职责分开，同时统一图标资源入口，先把最明显的显示错误收掉。

## 影响范围
- 安卓桌面图标与圆形图标
- 安卓启动页设置界面显示
- 安卓进入游戏后的窗口背景显示
- DocumentsProvider 展示图标

## 验证情况
- 已检查提交范围，仅包含 4 个安卓相关文件
- 未在本机完成完整 Android 构建验证：当前环境尚未配置好 Android SDK / NDK 构建链

## 后续计划
- 继续推进 SDL3 路径收敛，减少 SDL2/SDL3 双轨维护成本
- 单独开分支重构安卓专用 UI，避免继续在现有启动页和 SDLActivity 包装层上叠补丁