### PR TITLE
简化 experimental Release 标签与标题

### DIFF
--- a/.github/workflows/release-android-bundle.yaml
+++ b/.github/workflows/release-android-bundle.yaml
@@ -17,10 +17,11 @@ jobs:
       - name: Generate build variables
         id: vars
         run: |
-          timestamp=$(date -u "+%Y-%m-%d-%H%M")
+          timestamp=$(TZ=Asia/Shanghai date "+%Y-%m-%d-%H%M")
+          title_time=$(TZ=Asia/Shanghai date "+%Y-%m-%d %H:%M")
           echo "timestamp=$timestamp" >> $GITHUB_OUTPUT
-          echo "tag_name=cdda-experimental-aab-bundle-$timestamp" >> $GITHUB_OUTPUT
-          echo "release_name=Cataclysm-DDA experimental Android bundle $timestamp" >> $GITHUB_OUTPUT
+          echo "tag_name=android-aab-$timestamp" >> $GITHUB_OUTPUT
+          echo "release_name=Android AAB $title_time" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -46,14 +47,14 @@ jobs:
           export UPSTREAM_BUILD_NUMBER="$((11581 + ${{ github.run_number }}))"
           chmod +x gradlew
           ./gradlew -Pj=$((`nproc`+0)) bundleExperimentalRelease
-          mv ./app/build/outputs/bundle/experimentalRelease/*.aab ../cdda-android-bundle-${STEPS_VARS_OUTPUTS_TIMESTAMP}-${{ github.sha }}.aab
+          mv ./app/build/outputs/bundle/experimentalRelease/*.aab ../ccb-android-bundle-${STEPS_VARS_OUTPUTS_TIMESTAMP}-${{ github.sha }}.aab
         env:
           STEPS_VARS_OUTPUTS_TIMESTAMP: ${{ steps.vars.outputs.timestamp }}
 
       - name: Create GitHub release
         run: |
           gh release create ${STEPS_VARS_OUTPUTS_TAG_NAME} \
-            cdda-android-bundle-${STEPS_VARS_OUTPUTS_TIMESTAMP}-${{ github.sha }}.aab \
+            ccb-android-bundle-${STEPS_VARS_OUTPUTS_TIMESTAMP}-${{ github.sha }}.aab \
             --prerelease \
             --title "${STEPS_VARS_OUTPUTS_RELEASE_NAME}" \
             --target "${{ github.sha }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,14 +31,16 @@ jobs:
     permissions: write-all
     outputs:
       timestamp: ${{ steps.meta.outputs.time }}
+      tag_name: ${{ steps.meta.outputs.tag_name }}
     steps:
       - name: Generate release metadata
         id: meta
         run: |
           time=$(TZ=Asia/Shanghai /bin/date "+%Y-%m-%d-%H%M")
+          title_time=$(TZ=Asia/Shanghai /bin/date "+%Y-%m-%d %H:%M")
           echo "time=$time" >> $GITHUB_OUTPUT
-          echo "tag_name=ccb-experimental-${time}" >> $GITHUB_OUTPUT
-          echo "release_name=Cataclysm-Cleanwater-Bomb experimental build ${time}" >> $GITHUB_OUTPUT
+          echo "tag_name=${time}" >> $GITHUB_OUTPUT
+          echo "release_name=Experimental ${title_time}" >> $GITHUB_OUTPUT
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
@@ -779,4 +781,4 @@ jobs:
                mv ./app/build/outputs/apk/experimental/release/*.apk ../ccb-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.apk 
           fi
       - run: |
-          gh release upload ccb-experimental-${{ needs.release.outputs.timestamp }} ccb-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.${{ matrix.ext }}
+          gh release upload '${{ needs.release.outputs.tag_name }}' ccb-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.${{ matrix.ext }}


### PR DESCRIPTION
## 变更内容
- 将主 experimental Release 的 tag 从 `ccb-experimental-YYYY-MM-DD-HHMM` 简化为 `YYYY-MM-DD-HHMM`
- 将主 experimental Release 标题改为 `Experimental YYYY-MM-DD HH:MM`
- 将 artifact 上传步骤改为使用 release job 输出的 `tag_name`，避免继续硬编码旧前缀
- 顺手修正手动 Android AAB 发布：
  - tag 改为 `android-aab-YYYY-MM-DD-HHMM`
  -标题改为 `Android AAB YYYY-MM-DD HH:MM`
  - 产物名从 `cdda-android-bundle-*` 改为 `ccb-android-bundle-*`

## 处理原因
GitHub Release 列表里原来的 `ccb-experimental-...` 前缀过长，可读性差。Release 仍然需要 tag 才能创建，但 tag 可以使用更短的时间戳格式。

## 验证
- 使用 `rg` 检查旧的 `ccb-experimental` / `cdda-experimental` 发布命名引用已移除
- 使用 Ruby `YAML.load_file` 验证两个 workflow 文件语法可解析

Closes #328