### PR TITLE
修复 ImGui 空窗口名崩溃、bleach_jug 容器报错和 overmap 死锁

### DIFF
--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -214,14 +214,12 @@
   {
     "id": "bleach_jug",
     "type": "item_group",
-    "container-item": "jug_plastic",
     "//": "128 oz",
     "items": [ { "item": "bleach", "charges": 30 } ]
   },
   {
     "id": "bleach_jug_part",
     "type": "item_group",
-    "container-item": "jug_plastic",
     "items": [ { "item": "bleach", "charges": [ 1, 30 ] } ]
   },
   {

--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -985,7 +985,8 @@ cataimgui::window::window( int window_flags )
 cataimgui::window::window( const std::string &id_, int window_flags ) : window( window_flags )
 {
     p_impl = std::make_unique<cataimgui::window_impl>( this );
-    id = id_ + "##" + std::to_string( uint64_t( this ) );
+    const std::string &safe_id = id_.empty() ? "window" : id_;
+    id = safe_id + "##" + std::to_string( uint64_t( this ) );
     is_open = true;
 }
 

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -2455,7 +2455,7 @@ void reset_scenario( avatar &u, const scenario *scen )
 }
 
 character_creator_ui_impl::character_creator_ui_impl( character_creator_ui *parent ) :
-    cataimgui::window( "",
+    cataimgui::window( "CHARACTER_CREATOR",
                        ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
                        ImGuiWindowFlags_NoNav )
 {

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -116,6 +116,7 @@ overmap &overmapbuffer::get( const point_abs_om &p )
     }
 
     // Cache miss: upgrade to exclusive (write) lock
+    overmap *new_om_ptr;
     {
         std::unique_lock<std::shared_mutex> lk( overmaps_mutex_ );
         // Double-check: another thread may have inserted while upgrading
@@ -126,13 +127,14 @@ overmap &overmapbuffer::get( const point_abs_om &p )
 
         overmap &new_om = *( overmaps[ p ] = std::make_unique<overmap>( p ) );
         global_state.overmap_count++;
-        new_om.populate();
-        fix_mongroups( new_om );
-        fix_npcs( new_om );
-
+        new_om_ptr = &new_om;
         last_requested_overmap = &new_om;
-        return new_om;
     }
+
+    new_om_ptr->populate();
+    fix_mongroups( *new_om_ptr );
+    fix_npcs( *new_om_ptr );
+    return *new_om_ptr;
 }
 
 void overmapbuffer::create_custom_overmap( const point_abs_om &p, overmap_special_batch &specials )


### PR DESCRIPTION
#### Summary
修复 3 类运行时错误：ImGui 空窗口名断言崩溃、bleach_jug 物品组容器装载失败、overmap 生成时 shared_mutex 重入死锁。

## 修复内容

### 1. ImGui SIGABRT 断言崩溃
- **`src/cata_imgui.cpp`**: window 构造函数中 `id_` 为空时兜底为 `"window"`，确保 `ImGui::Begin` 的首字符非空，不再触发 `name[0] != '\0'` 断言
- **`src/newcharacter.cpp`**: `character_creator_ui_impl` 的显式空标题 `""` 改为 `"CHARACTER_CREATOR"`，`NoTitleBar` 标志已隐藏标题栏

### 2. bleach_jug 容器装载失败
- **`data/json/itemgroups/supplies.json`**: 去掉 `bleach_jug` / `bleach_jug_part` 的 `container-item: jug_plastic`，因为 `bleach` 自身已定义 `"container": "jug_plastic"`，不再重复套容器，修复 `jug_plastic` 的 32ml 单物品体积限制导致的装载失败

### 3. overmap 生成死锁
- **`src/overmapbuffer.cpp`**: `overmapbuffer::get()` 中将 `populate()` / `fix_mongroups()` / `fix_npcs()` 移出 `unique_lock` 持有范围，这三者内部会再次调用 `get()`，避免同线程重入 `std::shared_mutex` 导致的 `Resource deadlock avoided`

## 本地验证
- `make -j$(nproc) RELEASE=1 TESTS=0 LOCALIZE=0 TILES=0 ASTYLE=0 LINTJSON=0` 编译通过