### PR TITLE
修复 V 键周围物品菜单长按快速循环时的 SIGSEGV 崩溃

### DIFF
--- a/src/surroundings_menu.cpp
+++ b/src/surroundings_menu.cpp
@@ -341,7 +341,8 @@ int item_tab_data::get_max_entity_width()
 
 std::optional<tripoint_rel_ms> item_tab_data::get_selected_pos()
 {
-    if( !selected_entry ) {
+    if( !selected_entry ||
+        std::find( filtered_list.begin(), filtered_list.end(), selected_entry ) == filtered_list.end() ) {
         return std::nullopt;
     }
 
@@ -492,7 +493,8 @@ int monster_tab_data::get_max_entity_width()
 
 std::optional<tripoint_rel_ms> monster_tab_data::get_selected_pos()
 {
-    if( !selected_entry ) {
+    if( !selected_entry ||
+        std::find( filtered_list.begin(), filtered_list.end(), selected_entry ) == filtered_list.end() ) {
         return std::nullopt;
     }
 
@@ -680,7 +682,8 @@ int terfurn_tab_data::get_max_entity_width()
 
 std::optional<tripoint_rel_ms> terfurn_tab_data::get_selected_pos()
 {
-    if( !selected_entry ) {
+    if( !selected_entry ||
+        std::find( filtered_list.begin(), filtered_list.end(), selected_entry ) == filtered_list.end() ) {
         return std::nullopt;
     }
 


### PR DESCRIPTION
#### Summary
修复 Windows 版两个问题：
1. 按 V 打开周围物品菜单后，长按方向键快速循环时 SIGSEGV 崩溃
2. MSVC 编译报错导致 Windows 构建失败

## 修复内容

### 1. V 键菜单快速循环崩溃 (src/surroundings_menu.cpp)
items/monsters/terfurn 三个 tab 的 `get_selected_pos()` 新增 `filtered_list` 成员校验：`selected_entry` 为 null 或不在当前 `filtered_list` 中时返回 `nullopt`，避免 `draw_item_tab()` 阶段修改 `selected_entry` 导致野指针访问。

### 2. Windows MSVC 编译错误 (src/math_parser_diag.cpp:1569)
`const auto *iter = std::find_if(...)` 改为 `auto iter = std::find_if(...)`。MSVC 不允许用指针类型接收 iterator，GCC/Clang 宽松放过。