### PR TITLE
修复 Windows MSVC 编译错误：const auto * 无法从 iterator 推导类型

### DIFF
--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -1566,7 +1566,7 @@ void item_rot_ass( double val, dialogue &d, char scope, std::vector<diag_value> 
             double turns = val;
             if( !unit_val.is_empty() ) {
                 std::string_view unit = unit_val.str( d );
-                const auto *iter = std::find_if( time_duration::units.cbegin(), time_duration::units.cend(),
+                auto iter = std::find_if( time_duration::units.cbegin(), time_duration::units.cend(),
                 [&unit]( std::pair<std::string_view, time_duration> const & u ) {
                     return u.first == unit;
                 } );


### PR DESCRIPTION
#### Summary
修复 Windows MSVC 构建失败（C3535/C2440/C2679），位于 `src/math_parser_diag.cpp:1569`。

## 问题
```cpp
const auto *iter = std::find_if( time_duration::units.cbegin(), ... );
```
`std::find_if` 返回的是 iterator 而非 pointer。MSVC 严格禁止用 `const auto *` 接收 iterator 类型，报 C3535/C2440/C2679 三个错误。GCC/Clang 宽松放过。

## 修复
改为 `auto iter = std::find_if(...)`。后续 `iter == .end()` 和 `iter->second` 不受影响。

## 影响范围
1 个文件，1 行改动。