### PR TITLE
修复 experimental release notes 累积问题

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,14 +43,23 @@ jobs:
           echo "release_name=Experimental ${title_time}" >> $GITHUB_OUTPUT
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          fetch-depth: 0
+          fetch-tags: true
           persist-credentials: false
+      - name: Find previous release tag
+        id: previous
+        run: |
+          previous_tag=$(git describe --tags --abbrev=0 \
+            --match '20[0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9][0-9][0-9][0-9]' \
+            --match 'ccb-experimental-*' HEAD^ 2>/dev/null || true)
+          echo "previous_tag=${previous_tag}" >> $GITHUB_OUTPUT
       - name: Generate Release Notes
         run: |
           npm install @actions/github@8
-          node build-scripts/generate-release-notes.js '${{ secrets.GITHUB_TOKEN }}' '${{ steps.meta.outputs.tag_name }}' "$(git log -1 --format='%H')" > notes.txt
+          node build-scripts/generate-release-notes.js '${{ secrets.GITHUB_TOKEN }}' '${{ steps.meta.outputs.tag_name }}' "$(git log -1 --format='%H')" '${{ steps.previous.outputs.previous_tag }}' > notes.txt
       - name: Create GitHub Release
         run: |
-          gh release create '${{ steps.meta.outputs.tag_name }}' --notes-file notes.txt --prerelease --title '${{ steps.meta.outputs.release_name }}' --target "$(git log -1 --format='%H')"
+          gh release create '${{ steps.meta.outputs.tag_name }}' --notes-file notes.txt --prerelease --latest --title '${{ steps.meta.outputs.release_name }}' --target "$(git log -1 --format='%H')"
 
   compose-tilesets:
     uses: ./.github/workflows/compose-tilesets.yml

--- a/build-scripts/generate-release-notes.js
+++ b/build-scripts/generate-release-notes.js
@@ -9,10 +9,12 @@ const github = require('@actions/github');
  * 1 - github_token
  * 2 - new version
  * 3 - commit SHA of new release
+ * 4 - previous release tag
  */
 const token = process.argv[2];
 const version = process.argv[3];
 const comittish = process.argv[4];
+let previousTag = process.argv[5];
 const repo = process.env.REPOSITORY_NAME
 const owner = process.env.GITHUB_REPOSITORY_OWNER
 
@@ -39,24 +41,32 @@ function format_request_error(error) {
 async function main() {
   const client = github.getOctokit(token);
 
-  const latestReleaseResponse = await client.request(
-    'GET /repos/{owner}/{repo}/releases',
-    {
-      owner: owner,
-      repo: repo,
-      headers: {
-        'X-GitHub-Api-Version': '2022-11-28',
-      },
-    }
-  ).catch((e) =>{
-    throw `${format_request_error(e)} ...when getting latest release`;
-  })
+  if (!previousTag) {
+    const latestReleaseResponse = await client.request(
+      'GET /repos/{owner}/{repo}/releases',
+      {
+        owner: owner,
+        repo: repo,
+        headers: {
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      }
+    ).catch((e) =>{
+      throw `${format_request_error(e)} ...when getting latest release`;
+    })
 
-  if (latestReleaseResponse.data) {
-    for (const responseData of latestReleaseResponse.data) {
-      if (responseData.draft == false && responseData.prerelease == true) {
-        previousTag = responseData.tag_name;
-	break;
+    if (latestReleaseResponse.data) {
+      const releases = latestReleaseResponse.data
+        .filter((responseData) =>
+          responseData.draft == false &&
+          responseData.prerelease == true &&
+          responseData.tag_name !== version
+        )
+        .sort((a, b) =>
+          new Date(b.published_at || b.created_at) - new Date(a.published_at || a.created_at)
+        );
+      if (releases.length > 0) {
+        previousTag = releases[0].tag_name;
       }
     }
   }


### PR DESCRIPTION
## 改动内容

- `release.yml` checkout 时拉取完整提交历史和 tags。
- 新增 `Find previous release tag` 步骤，通过 git tag 拓扑从 `HEAD^` 找上一版 CCB experimental tag。
- `generate-release-notes.js` 优先使用 workflow 传入的上一版 tag；没有传入时才回退 GitHub Releases API，并按发布时间排序。
- 创建 release 时显式加 `--latest`，避免 GitHub 自动判断把旧 experimental release 顶在 Release 列表前面。

## 问题原因

原逻辑是调用 GitHub `/releases`，然后拿返回列表里第一个 `draft == false && prerelease == true` 的 release 当作 `previous_tag_name`。实际 GitHub 返回顺序不是严格的“最新发布时间顺序”，例如 `2026-07-08-0353 / 0252 / 0202 / 0051` 都生成了，但 API/页面排序里旧的 `ccb-experimental-2026-07-07-2253` 仍然排在这些新 tag 前面。

结果就是后续 release notes 一直用 `ccb-experimental-2026-07-07-2253` 作为起点，所以 #343、#346、#347 等内容会反复累计到后面的 release notes。

## 验证

- `node --check build-scripts/generate-release-notes.js`
- `git describe --tags --abbrev=0 --match '20[0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9][0-9][0-9][0-9]' --match 'ccb-experimental-*' HEAD^`
- `git diff --check`