### PR TITLE
Adjust the positioning order of Quickload in the main menu.

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -1132,13 +1132,13 @@ action_id handle_main_menu()
     REGISTER_ACTION( ACTION_WORLD_MODS );
     REGISTER_ACTION( ACTION_ACTIONMENU );
     REGISTER_ACTION( ACTION_QUICKSAVE );
-    REGISTER_ACTION( ACTION_QUICKLOAD );
     REGISTER_ACTION( ACTION_SAVE );
     REGISTER_ACTION( ACTION_SNAPSHOT_MENU );
     REGISTER_ACTION( ACTION_QUIT_TO_SNAPSHOT );
     if( hotkey_for_action( ACTION_DEBUG, /*maximum_modifier_count=*/1, false ).has_value() ) {
         REGISTER_ACTION( ACTION_DEBUG, 'D' );
     }
+    REGISTER_ACTION( ACTION_QUICKLOAD );
 
     // Special handling: This one is not a keybind, so we emplace it manually with a descriptive name.
     entries.emplace_back( ACTION_EXPORT_BUG_REPORT_ARCHIVE, true, 'd',


### PR DESCRIPTION
####  Summary

Adjust the positioning order of Quickload in the main menu.

#### Purpose of change

Players have consistently reported that these two buttons are too close together, making accidental clicks extremely easy.

#### Describe the solution

Moved `REGISTER_ACTION( ACTION_QUICKLOAD );` in handle_main_menu() to be registered after `ACTION_DEBUG`.

#### Describe alternatives you've considered

Completely delete `ACTION_QUICKLOAD`, considering that this feature currently has bugs and the contributor has yet to provide a fix.