### PR TITLE
Delete the Nudist conduct.

### DIFF
--- a/data/json/conducts.json
+++ b/data/json/conducts.json
@@ -155,12 +155,6 @@
     "hidden_by": [ "conduct_vegan" ]
   },
   {
-    "id": "conduct_nudist",
-    "type": "conduct",
-    "name": "Nudist",
-    "requirements": [ { "event_statistic": "num_avatar_wears_item", "is": "<=", "target": 0, "description": "Wear no clothing" } ]
-  },
-  {
     "id": "conduct_speed_limit_35",
     "type": "conduct",
     "name": "Residential speed limit",


### PR DESCRIPTION
####  Summary

Delete the Nudist conduct.

#### Purpose of change

In the vast majority of scenarios, players start the game with equipment such as clothing. However, the Nudist conduct is evaluated based on whether `avatar_wears_item` counts as greater than or equal to 0. In fact, I find this somewhat counterintuitive; if I only wear a ring, which covers absolutely nothing, it should logically still count as being nude. Yet, from a brief look at the code, it seems that equipping literally any wearable item breaks this nudism rule.

Consequently, this conduct ends up lacking any practical purpose—outside of explicitly choosing a Naked Brutality style start to challenge oneself, players will immediately break the Nudist conduct no matter what. Some of our prospective developers claimed that when they invited friends to play Cataclysm, the red log notification popping up right at the start of the game (the broken conduct warning) made them think they had broken something. This genuinely made me laugh out loud. However, since they mentioned it's currently inconvenient for them to use GitHub, they asked me to help remove this ineffective conduct first.

#### Describe the solution

Deleted `conduct_nudist` from `conducts.json`.

#### Additional context

Personally, I feel that Nudist is much better suited to appear as a trait that enhances roleplaying immersion rather than a universal conduct, for the specific reasons I've stated. If a conduct or rule is violated by the vast majority of people the exact microsecond they start the game, then its design is fundamentally flawed. After all, this isn't an achievement, is it? Furthermore, the current check logic has its own issues; even if we wanted to retain it, it would be best to "shelve" it for now and bring it back once it has been refined.

I think RimWorld's design for Nudists is quite good. A Nudist in RimWorld enjoys the feeling of freedom that comes from being nude. They can handle clothing, but will be happier without it. RimWorld's check determines that if a Nudist only wears clothes that do not cover the torso or private parts (or have specific compatibility tags), or if they wear absolutely nothing at all, they receive a positive "Happily nude" moodlet; otherwise, they get a negative "Constraining clothes" moodlet. I think this is far more logical than a simple, crude `avatar_wears_item` check, but that would require us to write a bit more code to determine which clothes qualify as "nudist-friendly." Let's save that research for a future PR, shall we?