### PR TITLE
交换中文标题和 alt1 标题

### DIFF
--- a/data/title/zh_CN.alt1
+++ b/data/title/zh_CN.alt1
@@ -1,18 +1,17 @@
-<color_light_cyan>                  **                  **                  **                    </color>
-<color_light_cyan>                  **                  **            **************              </color>
-<color_light_cyan>                  **            **************           * **                   </color>
-<color_light_cyan>             *************     **     *      **        ***  * *                 </color>
-<color_light_cyan>                  **            *  *  **  *  *       *** *  * ***               </color>
-<color_light_cyan>                  * *              ** ** **         *   ******* **              </color>
-<color_light_cyan>                 ** **             ** **                *    **                 </color>
-<color_light_blue>                 **  ***             ** **               ** **                  </color>
-<color_light_blue>               ***    ****          ***  ***              ****            </color><color_light_green>.-.   </color>
-<color_light_blue>           ******      *****      ****    *****       *****  ******   </color><color_light_green>_  </color><color_light_green>|   `  </color>
-<color_light_blue>            ***         ****   *****       *****   *****       *****   </color><color_light_green>',|    \ </color>
-<color_white>     ***                 </color><color_light_blue>*                  ***           </color><color_light_green>_..    </color><color_light_blue>**  </color><color_light_green>-.,,'-., / </color>
-<color_white>    *   *  /-\                                       </color><color_light_green>,,,,/   |           |    \ </color>
-<color_white>     *** =========='      <color_red>----               ----        </color><color_light_green>`  _/`'.,       \ _--  </color>
-<color_white>     ||'''/ |                                        </color><color_light_green>`````'-    /```''-    | |  </color>
-<color_white>     ,\.    |                                                </color><color_light_green>'.-_`,,,,,,,,,\.\--</color>
-<color_white>    /  |    ^          ___,,,,,,,,,,...-------''''''``````````                  </color>
-<color_brown>*------'''''*``````````                                                         </color>
+<color_light_blue>     +              :      *         .*      +          #.      .-  .=       
+<color_light_blue>       %:  -@.......      =@      @         .@.    .@         .@.      =%  -%       
+<color_light_blue>       @:  *@@@@@@@@=    :@@      @    --   .@.  %%%@%%* .-   .@.  :   =%  #=       
+<color_light_blue>       @:         :%.   .%+@      @   =%-   .@.  :-+%--%+=#    -   **  =% .@.       
+<color_light_blue>       :   :------*%.   +*.@      @  *%:   .:@:.   =*  +#-#  ..    .%- :* -%        
+<color_light_blue>          .%@@@@@@@@@.     @      @.%#    :@@@@% + *+  +#:%  *@%.   -%.   *+        
+<color_light_blue>               *+   %=     @     .@%+      .-@:. %.%=  +#.%   .%-    +#  :%.        
+<color_light_blue>        .      *+   %=     @    .*@-        .@. .@ %-  +#.@    %-     %+ #*         
+<color_light_blue>       :@ %@@@@@@@@@@@:    @   +@#@         .@. -%.@:  +# @    %-     .@=@:         
+<color_light_blue>       ** :::::#*:::%+     @ :%#:.@         .@. +*.@.  +# @.   %-      =@+          
+<color_light_blue>       @-      *+   %=     @ .-   @         .@. %=-%   +# @.   %-      =@*          
+<color_light_blue>      :@.  :---#*--=@:     @      @         .@..%:**   +# %:   %-     .@=%=         
+<color_light_blue>      =%   #%%%@@%%#-      @      @         .@.:@.@.   +# %:   %-     %+ :%:        
+<color_light_blue>      *+       *+          @      @         .@..--%    +# %-   %-   .%*   +%        
+<color_light_blue>      @.       *+          @      @         .@.  **    +* %-   %=  .%#     %+       
+<color_light_blue>      :      *#@.          @      *%*+++:   .@.  @:  =*@= -    =@#.%+      .%-      
+<color_light_blue>            .++:           =      .=++++:   .*   -   =+-        -= :        :.      

--- a/data/title/zh_CN.title
+++ b/data/title/zh_CN.title
@@ -1,17 +1,18 @@
-<color_light_blue>     +              :      *         .*      +          #.      .-  .=       
-<color_light_blue>       %:  -@.......      =@      @         .@.    .@         .@.      =%  -%       
-<color_light_blue>       @:  *@@@@@@@@=    :@@      @    --   .@.  %%%@%%* .-   .@.  :   =%  #=       
-<color_light_blue>       @:         :%.   .%+@      @   =%-   .@.  :-+%--%+=#    -   **  =% .@.       
-<color_light_blue>       :   :------*%.   +*.@      @  *%:   .:@:.   =*  +#-#  ..    .%- :* -%        
-<color_light_blue>          .%@@@@@@@@@.     @      @.%#    :@@@@% + *+  +#:%  *@%.   -%.   *+        
-<color_light_blue>               *+   %=     @     .@%+      .-@:. %.%=  +#.%   .%-    +#  :%.        
-<color_light_blue>        .      *+   %=     @    .*@-        .@. .@ %-  +#.@    %-     %+ #*         
-<color_light_blue>       :@ %@@@@@@@@@@@:    @   +@#@         .@. -%.@:  +# @    %-     .@=@:         
-<color_light_blue>       ** :::::#*:::%+     @ :%#:.@         .@. +*.@.  +# @.   %-      =@+          
-<color_light_blue>       @-      *+   %=     @ .-   @         .@. %=-%   +# @.   %-      =@*          
-<color_light_blue>      :@.  :---#*--=@:     @      @         .@..%:**   +# %:   %-     .@=%=         
-<color_light_blue>      =%   #%%%@@%%#-      @      @         .@.:@.@.   +# %:   %-     %+ :%:        
-<color_light_blue>      *+       *+          @      @         .@..--%    +# %-   %-   .%*   +%        
-<color_light_blue>      @.       *+          @      @         .@.  **    +* %-   %=  .%#     %+       
-<color_light_blue>      :      *#@.          @      *%*+++:   .@.  @:  =*@= -    =@#.%+      .%-      
-<color_light_blue>            .++:           =      .=++++:   .*   -   =+-        -= :        :.      
+<color_light_cyan>                  **                  **                  **                    </color>
+<color_light_cyan>                  **                  **            **************              </color>
+<color_light_cyan>                  **            **************           * **                   </color>
+<color_light_cyan>             *************     **     *      **        ***  * *                 </color>
+<color_light_cyan>                  **            *  *  **  *  *       *** *  * ***               </color>
+<color_light_cyan>                  * *              ** ** **         *   ******* **              </color>
+<color_light_cyan>                 ** **             ** **                *    **                 </color>
+<color_light_blue>                 **  ***             ** **               ** **                  </color>
+<color_light_blue>               ***    ****          ***  ***              ****            </color><color_light_green>.-.   </color>
+<color_light_blue>           ******      *****      ****    *****       *****  ******   </color><color_light_green>_  </color><color_light_green>|   `  </color>
+<color_light_blue>            ***         ****   *****       *****   *****       *****   </color><color_light_green>',|    \ </color>
+<color_white>     ***                 </color><color_light_blue>*                  ***           </color><color_light_green>_..    </color><color_light_blue>**  </color><color_light_green>-.,,'-., / </color>
+<color_white>    *   *  /-\                                       </color><color_light_green>,,,,/   |           |    \ </color>
+<color_white>     *** =========='      <color_red>----               ----        </color><color_light_green>`  _/`'.,       \ _--  </color>
+<color_white>     ||'''/ |                                        </color><color_light_green>`````'-    /```''-    | |  </color>
+<color_white>     ,\.    |                                                </color><color_light_green>'.-_`,,,,,,,,,\.\--</color>
+<color_white>    /  |    ^          ___,,,,,,,,,,...-------''''''``````````                  </color>
+<color_brown>*------'''''*``````````                                                         </color>


### PR DESCRIPTION
## 变更内容

交换 `data/title/zh_CN.title` 与 `data/title/zh_CN.alt1` 的标题内容，让默认中文标题和备用标题使用预期的版本。

## 影响

只影响中文标题画面文本，不涉及游戏逻辑或资源加载。

## 验证

- 已检查提交范围仅包含两个 zh_CN 标题文件。