### PR TITLE
修复终端模式联机日志漏出

### DIFF
--- a/src/mp_gamestate.cpp
+++ b/src/mp_gamestate.cpp
@@ -122,7 +122,6 @@ void mp_log( const std::string &msg )
                    tmv.tm_hour, tmv.tm_min, tmv.tm_sec, wms );
     const std::string line = std::string( tbuf ) + "[+" +
                              std::to_string( delta_ms ) + "ms] " + msg;
-    std::cout << line << std::endl;
 
     // Also append to /tmp/cdda-mp-{server,client}.log so log capture doesn't
     // require launching via start-mp.sh's stdout-tee.  Opens lazily on the
@@ -173,9 +172,6 @@ void mp_log( const std::string &msg )
         current_path = desired_path;
         log_file << "\n[cdda-mp] ===================== LOG OPENED ====================="
                  << std::endl;
-        // Echo so the user can find it (esp. on Windows where the path varies).
-        std::cout << "[cdda-mp] log file: " << desired_path
-                  << ( log_file.is_open() ? "" : "  (OPEN FAILED)" ) << std::endl;
     }
     if( log_file.is_open() ) {
         log_file << line << '\n';

--- a/src/mp_gamestate.h
+++ b/src/mp_gamestate.h
@@ -452,9 +452,10 @@ void set_client_turn_activity( const std::string &activity_id_str );
 // means "we last told the host: no activity".
 const std::string &get_client_turn_activity();
 
-// Write a [cdda-mp] log line to stdout AND to /tmp/cdda-mp-server.log or
+// Write a [cdda-mp] log line to /tmp/cdda-mp-server.log or
 // /tmp/cdda-mp-client.log (depending on mode).  Use this for any event that
-// should be readable after a session without stopping the process.
+// should be readable after a session without stopping the process.  Do not echo
+// to stdout: in curses builds that writes through the active terminal UI.
 void mp_log( const std::string &msg );
 
 // DIAGNOSTIC (temporary, 2026-06-23, for #5 assist-distraction / client safe-mode):


### PR DESCRIPTION
## 内容

修复终端 / curses 模式下联机诊断日志直接显示在游戏画面上的问题。

## 原因

`cata_mp::mp_log()` 之前会同时写入 `stdout` 和 `/tmp/cdda-mp-*.log`。在 curses 界面运行时，`stdout` 会绕过 curses 屏幕缓冲，导致 `CLI-DRAIN-END` 等联机日志直接覆盖地图画面。

## 修改

- `mp_log()` 不再向 `stdout` 输出联机诊断日志。
- 日志仍保留在 `/tmp/cdda-mp-client.log` 或 `/tmp/cdda-mp-server.log`。
- 更新头文件注释，明确不要向 stdout 输出，避免终端 UI 被打穿。

## 验证

- `git diff --check`
- `make -j2 RELEASE=1 TESTS=0 LOCALIZE=0 ASTYLE=0 LINTJSON=0`