### PR TITLE
新增安卓自定义按键

### DIFF
--- a/android/app/src/main/java/com/lyhglytx/cataclysmcb/CataclysmDDA.java
+++ b/android/app/src/main/java/com/lyhglytx/cataclysmcb/CataclysmDDA.java
@@ -2,25 +2,75 @@ package com.lyhglytx.cataclysmcb;
 
 import org.libsdl.app.SDLActivity;
 
+import android.annotation.SuppressLint;
+import android.app.AlertDialog;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
+import android.graphics.drawable.GradientDrawable;
 import android.graphics.Insets;
 import android.graphics.Rect;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
 import android.os.Vibrator;
 import android.preference.PreferenceManager;
 import android.util.Log;
+import android.view.Gravity;
+import android.view.KeyEvent;
+import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewConfiguration;
+import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 import android.view.WindowInsets;
 import android.view.WindowInsetsController;
 import android.view.WindowManager;
+import android.widget.Button;
+import android.widget.CheckBox;
+import android.widget.CompoundButton;
+import android.widget.EditText;
+import android.widget.FrameLayout;
+import android.widget.HorizontalScrollView;
+import android.widget.LinearLayout;
+import android.widget.RelativeLayout;
+import android.widget.SeekBar;
+import android.widget.TextView;
 import android.widget.Toast;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Semaphore;
 
 public class CataclysmDDA extends SDLActivity {
     private static final String TAG = "CDDA";
+    private static final String EXTRA_BUTTON_PREFS = "extra_buttons";
+    private static final String EXTRA_BUTTONS_KEY = "buttons";
+    private static final float DEFAULT_BUTTON_TEXT_SIZE = 14f;
+    private static final int DEFAULT_BUTTON_TEXT_COLOR = 0xFFFFFFFF;
+    private static final int DEFAULT_BUTTON_BG_COLOR = 0x00000000;
+    private static final int[] BUTTON_PRESET_COLORS = {
+        0x00000000,
+        0xFFFFFFFF,
+        0xFF000000,
+        0xFF607D8B,
+        0xFFF44336,
+        0xFFE91E63,
+        0xFF9C27B0,
+        0xFF3F51B5,
+        0xFF2196F3,
+        0xFF00BCD4,
+        0xFF4CAF50,
+        0xFFFFEB3B,
+        0xFFFF9800,
+        0xFF795548,
+        0xFF9E9E9E
+    };
     public static final String PREF_SYSTEM_UI_MODE = "Android system UI mode";
     public static final String PREF_FORCE_FULLSCREEN = "Force fullscreen";
     public static final String SYSTEM_UI_MODE_SYSTEM_BARS = "system_bars";
@@ -33,6 +83,12 @@ public class CataclysmDDA extends SDLActivity {
     private int lastImeRight = -1;
     private int lastImeBottom = -1;
     private boolean lastImeVisible = false;
+    private final Set<View> editorButtons = new HashSet<>();
+    private final Set<View> playButtons = new HashSet<>();
+    private final Semaphore buttonManageSemaphore = new Semaphore(0, true);
+    private View buttonManageLayout;
+    private FrameLayout buttonEditorContainer;
+    private boolean deleteButtonMode = false;
 
     // libmain.so must load first so cata_allocator binds before SDL's malloc.
     // SDL3 dlsym's SDL_main from getMainSharedObject(), which we point at libmain.so.
@@ -60,6 +116,7 @@ public class CataclysmDDA extends SDLActivity {
         }
         setImeInsetListener();
         applySystemUiMode();
+        loadExtraButtons(false);
     }
 
     @Override
@@ -200,6 +257,8 @@ public class CataclysmDDA extends SDLActivity {
     private static native void onNativeImeInsetsChanged(
         int left, int top, int right, int bottom, boolean visible);
 
+    private static native void nativeButtonClick(String text);
+
     public void setSystemUiMode(final String mode) {
         final String normalizedMode = normalizeSystemUiMode(mode);
         PreferenceManager.getDefaultSharedPreferences(getApplicationContext())
@@ -253,6 +312,7 @@ public class CataclysmDDA extends SDLActivity {
                     if (mLayout != null) {
                         mLayout.setVisibility(View.VISIBLE);
                     }
+                    reloadPlayButtons();
                 }
             });
         } catch(Exception e) {
@@ -279,5 +339,580 @@ public class CataclysmDDA extends SDLActivity {
 
     public NativeUI getNativeUI() {
         return nativeUI;
+    }
+
+    public void showButtonManage() {
+        runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                removePlayButtons();
+                showButtonManageLayout();
+            }
+        });
+        try {
+            buttonManageSemaphore.acquire();
+        } catch(InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Override
+    public boolean dispatchKeyEvent(KeyEvent event) {
+        if (event.getKeyCode() == KeyEvent.KEYCODE_BACK &&
+                event.getAction() == KeyEvent.ACTION_DOWN &&
+                buttonManageLayout != null) {
+            showButtonManageMenu();
+            return true;
+        }
+        return super.dispatchKeyEvent(event);
+    }
+
+    private void showButtonManageLayout() {
+        if (buttonManageLayout != null) {
+            return;
+        }
+        deleteButtonMode = false;
+        buttonManageLayout = getLayoutInflater().inflate(R.layout.button_manage, null);
+        buttonEditorContainer = buttonManageLayout.findViewById(R.id.container);
+        addContentView(buttonManageLayout, new RelativeLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.MATCH_PARENT));
+        loadExtraButtons(true);
+        toast("编辑模式：返回键打开管理菜单，拖动移动，长按编辑属性");
+    }
+
+    private void showButtonManageMenu() {
+        String[] menuItems = {
+            "新增按钮",
+            deleteButtonMode ? "关闭删除模式" : "开启删除模式",
+            "退出管理面板"
+        };
+        new AlertDialog.Builder(this)
+            .setTitle("按键管理菜单")
+            .setItems(menuItems, new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    switch(which) {
+                        case 0:
+                            showNewButtonDialog();
+                            break;
+                        case 1:
+                            deleteButtonMode = !deleteButtonMode;
+                            toast(deleteButtonMode ? "删除模式：点击按钮即可删除" :
+                                  "编辑模式：拖动移动，长按编辑属性");
+                            break;
+                        case 2:
+                            showSaveDialog();
+                            break;
+                        default:
+                            break;
+                    }
+                }
+            })
+            .show();
+    }
+
+    private void showNewButtonDialog() {
+        final EditText input = new EditText(this);
+        new AlertDialog.Builder(this)
+            .setTitle("新建按钮")
+            .setMessage("支持单个字符（含 emoji）、两个字符的“键盘”、三个字符的“tab”。")
+            .setView(input)
+            .setPositiveButton("确定", new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    String text = input.getText().toString();
+                    if (isValidButtonText(text)) {
+                        createNewEditorButton(text);
+                    } else {
+                        showInvalidButtonDialog();
+                    }
+                }
+            })
+            .setNegativeButton("取消", null)
+            .show();
+    }
+
+    private boolean isValidButtonText(String text) {
+        if (text == null || text.isEmpty()) {
+            return false;
+        }
+        int codePoints = text.codePointCount(0, text.length());
+        return codePoints == 1 || "键盘".equals(text) || "tab".equals(text);
+    }
+
+    private void showInvalidButtonDialog() {
+        new AlertDialog.Builder(this)
+            .setTitle("无效的按钮文本")
+            .setMessage("请输入单个字符、emoji、“tab”或“键盘”。")
+            .setPositiveButton("确定", null)
+            .show();
+    }
+
+    private void createNewEditorButton(String text) {
+        final Button button = new Button(this);
+        JSONObject data = createDefaultButtonData(text);
+        float x = getWindow().getDecorView().getWidth() * 0.5f;
+        float y = getWindow().getDecorView().getHeight() * 0.5f;
+        try {
+            data.put("x", x);
+            data.put("y", y);
+        } catch(JSONException e) {
+            Log.e(TAG, "Failed to initialize extra button position", e);
+        }
+        button.setTag(data);
+        button.setText(text);
+        button.setLayoutParams(new FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.WRAP_CONTENT,
+            FrameLayout.LayoutParams.WRAP_CONTENT));
+        button.setX(x);
+        button.setY(y);
+        applyButtonStyle(button, data);
+        attachEditorButtonListener(button);
+        editorButtons.add(button);
+        buttonEditorContainer.addView(button);
+    }
+
+    private JSONObject createDefaultButtonData(String text) {
+        JSONObject data = new JSONObject();
+        try {
+            data.put("text", text);
+            data.put("textSize", DEFAULT_BUTTON_TEXT_SIZE);
+            data.put("textColor", DEFAULT_BUTTON_TEXT_COLOR);
+            data.put("bgColor", DEFAULT_BUTTON_BG_COLOR);
+            data.put("rapidFire", false);
+        } catch(JSONException e) {
+            Log.e(TAG, "Failed to create extra button data", e);
+        }
+        return data;
+    }
+
+    private void applyButtonStyle(Button button, JSONObject data) {
+        button.setAllCaps(false);
+        button.setText(data.optString("text", button.getText().toString()));
+        button.setTextSize((float)data.optDouble("textSize", DEFAULT_BUTTON_TEXT_SIZE));
+        button.setTextColor(data.optInt("textColor", DEFAULT_BUTTON_TEXT_COLOR));
+        button.setBackgroundColor(data.optInt("bgColor", DEFAULT_BUTTON_BG_COLOR));
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    private void attachEditorButtonListener(final Button button) {
+        final int touchSlop = ViewConfiguration.get(this).getScaledTouchSlop();
+        button.setOnTouchListener(new View.OnTouchListener() {
+            float deltaX;
+            float deltaY;
+            float startRawX;
+            float startRawY;
+            boolean moved;
+            boolean longPressed;
+            final Handler handler = new Handler();
+            final Runnable longPressRunnable = new Runnable() {
+                @Override
+                public void run() {
+                    if (!moved && !deleteButtonMode) {
+                        longPressed = true;
+                        showButtonPropertiesDialog(button);
+                    }
+                }
+            };
+
+            @Override
+            public boolean onTouch(View view, MotionEvent event) {
+                switch(event.getAction()) {
+                    case MotionEvent.ACTION_DOWN:
+                        if (deleteButtonMode) {
+                            editorButtons.remove(button);
+                            buttonEditorContainer.removeView(button);
+                            return true;
+                        }
+                        moved = false;
+                        longPressed = false;
+                        startRawX = event.getRawX();
+                        startRawY = event.getRawY();
+                        deltaX = view.getX() - event.getRawX();
+                        deltaY = view.getY() - event.getRawY();
+                        handler.postDelayed(longPressRunnable, 500);
+                        return true;
+                    case MotionEvent.ACTION_MOVE:
+                        if (longPressed) {
+                            return true;
+                        }
+                        if (Math.abs(event.getRawX() - startRawX) > touchSlop ||
+                                Math.abs(event.getRawY() - startRawY) > touchSlop) {
+                            moved = true;
+                            handler.removeCallbacks(longPressRunnable);
+                        }
+                        view.setX(event.getRawX() + deltaX);
+                        view.setY(event.getRawY() + deltaY);
+                        return true;
+                    case MotionEvent.ACTION_UP:
+                    case MotionEvent.ACTION_CANCEL:
+                        handler.removeCallbacks(longPressRunnable);
+                        return true;
+                    default:
+                        return false;
+                }
+            }
+        });
+    }
+
+    private void showButtonPropertiesDialog(final Button button) {
+        final JSONObject data = (JSONObject)button.getTag();
+        if (data == null) {
+            return;
+        }
+        final float[] textSize = { (float)data.optDouble("textSize", DEFAULT_BUTTON_TEXT_SIZE) };
+        final int[] textColor = { data.optInt("textColor", DEFAULT_BUTTON_TEXT_COLOR) };
+        final int[] bgColor = { data.optInt("bgColor", DEFAULT_BUTTON_BG_COLOR) };
+        final boolean[] rapidFire = { data.optBoolean("rapidFire", false) };
+
+        LinearLayout layout = new LinearLayout(this);
+        layout.setOrientation(LinearLayout.VERTICAL);
+        int padding = (int)(20 * getResources().getDisplayMetrics().density);
+        layout.setPadding(padding, padding, padding, padding);
+
+        TextView sizeLabel = new TextView(this);
+        sizeLabel.setText("文字大小");
+        layout.addView(sizeLabel);
+
+        LinearLayout sizeRow = new LinearLayout(this);
+        sizeRow.setOrientation(LinearLayout.HORIZONTAL);
+        sizeRow.setGravity(Gravity.CENTER_VERTICAL);
+        final SeekBar sizeSeekBar = new SeekBar(this);
+        sizeSeekBar.setMax(40);
+        sizeSeekBar.setProgress(Math.max(0, (int)textSize[0] - 8));
+        sizeSeekBar.setLayoutParams(new LinearLayout.LayoutParams(
+            0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f));
+        final TextView sizeValue = new TextView(this);
+        sizeValue.setText(String.valueOf((int)textSize[0]));
+        sizeValue.setMinWidth(60);
+        sizeValue.setGravity(Gravity.CENTER);
+        sizeSeekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+            @Override
+            public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
+                textSize[0] = progress + 8;
+                sizeValue.setText(String.valueOf(progress + 8));
+                button.setTextSize(textSize[0]);
+            }
+
+            @Override
+            public void onStartTrackingTouch(SeekBar seekBar) {
+            }
+
+            @Override
+            public void onStopTrackingTouch(SeekBar seekBar) {
+            }
+        });
+        sizeRow.addView(sizeSeekBar);
+        sizeRow.addView(sizeValue);
+        layout.addView(sizeRow);
+
+        TextView textColorLabel = new TextView(this);
+        textColorLabel.setText("文字颜色");
+        layout.addView(textColorLabel);
+        layout.addView(createColorPicker(textColor[0], new ColorSelectedCallback() {
+            @Override
+            public void onColorSelected(int color) {
+                textColor[0] = color;
+                button.setTextColor(color);
+            }
+        }));
+
+        TextView bgColorLabel = new TextView(this);
+        bgColorLabel.setText("背景颜色");
+        layout.addView(bgColorLabel);
+        layout.addView(createColorPicker(bgColor[0], new ColorSelectedCallback() {
+            @Override
+            public void onColorSelected(int color) {
+                bgColor[0] = color;
+                button.setBackgroundColor(color);
+            }
+        }));
+
+        final CheckBox rapidFireCheck = new CheckBox(this);
+        rapidFireCheck.setText("连发模式（按住持续触发）");
+        rapidFireCheck.setChecked(rapidFire[0]);
+        rapidFireCheck.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                rapidFire[0] = isChecked;
+            }
+        });
+        layout.addView(rapidFireCheck);
+
+        new AlertDialog.Builder(this)
+            .setTitle("按钮属性")
+            .setView(layout)
+            .setPositiveButton("确定", new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    try {
+                        data.put("textSize", textSize[0]);
+                        data.put("textColor", textColor[0]);
+                        data.put("bgColor", bgColor[0]);
+                        data.put("rapidFire", rapidFire[0]);
+                    } catch(JSONException e) {
+                        Log.e(TAG, "Failed to update extra button data", e);
+                    }
+                    applyButtonStyle(button, data);
+                }
+            })
+            .setNegativeButton("取消", new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    applyButtonStyle(button, data);
+                }
+            })
+            .show();
+    }
+
+    private interface ColorSelectedCallback {
+        void onColorSelected(int color);
+    }
+
+    private HorizontalScrollView createColorPicker(int currentColor, final ColorSelectedCallback callback) {
+        HorizontalScrollView scroll = new HorizontalScrollView(this);
+        LinearLayout row = new LinearLayout(this);
+        row.setOrientation(LinearLayout.HORIZONTAL);
+        final View[] swatches = new View[BUTTON_PRESET_COLORS.length];
+        final int[] selected = { -1 };
+        int size = (int)(36 * getResources().getDisplayMetrics().density);
+        int margin = (int)(4 * getResources().getDisplayMetrics().density);
+        for (int i = 0; i < BUTTON_PRESET_COLORS.length; i++) {
+            final int idx = i;
+            final int color = BUTTON_PRESET_COLORS[i];
+            final View swatch = new View(this);
+            LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(size, size);
+            params.setMargins(margin, margin, margin, margin);
+            swatch.setLayoutParams(params);
+            swatch.setBackground(makeColorSwatch(color, color == currentColor));
+            if (color == currentColor) {
+                selected[0] = idx;
+            }
+            swatch.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View view) {
+                    if (selected[0] >= 0) {
+                        swatches[selected[0]].setBackground(makeColorSwatch(
+                            BUTTON_PRESET_COLORS[selected[0]], false));
+                    }
+                    selected[0] = idx;
+                    swatch.setBackground(makeColorSwatch(color, true));
+                    callback.onColorSelected(color);
+                }
+            });
+            swatches[i] = swatch;
+            row.addView(swatch);
+        }
+        scroll.setBackgroundColor(0xFFEEEEEE);
+        scroll.addView(row);
+        return scroll;
+    }
+
+    private GradientDrawable makeColorSwatch(int color, boolean selected) {
+        GradientDrawable drawable = new GradientDrawable();
+        drawable.setColor(color);
+        if (selected) {
+            drawable.setStroke(4, 0xFF000000);
+        }
+        return drawable;
+    }
+
+    private void showSaveDialog() {
+        new AlertDialog.Builder(this)
+            .setTitle("是否保存")
+            .setMessage("是否保存所有扩展按键？")
+            .setPositiveButton("确定", new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    saveButtonsData();
+                    closeButtonManageLayout();
+                }
+            })
+            .setNegativeButton("取消", new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    closeButtonManageLayout();
+                }
+            })
+            .show();
+    }
+
+    private void closeButtonManageLayout() {
+        removeButtonManageLayout();
+        editorButtons.clear();
+        reloadPlayButtons();
+        buttonManageSemaphore.release();
+    }
+
+    private void removeButtonManageLayout() {
+        if (buttonManageLayout == null) {
+            return;
+        }
+        ViewGroup parent = (ViewGroup)buttonManageLayout.getParent();
+        if (parent != null) {
+            parent.removeView(buttonManageLayout);
+        }
+        buttonManageLayout = null;
+        buttonEditorContainer = null;
+    }
+
+    private void saveButtonsData() {
+        SharedPreferences.Editor editor = getSharedPreferences(EXTRA_BUTTON_PREFS, MODE_PRIVATE).edit();
+        JSONArray buttons = new JSONArray();
+        for (View view : editorButtons) {
+            if (!(view instanceof Button) || view.getTag() == null) {
+                continue;
+            }
+            JSONObject data = (JSONObject)view.getTag();
+            try {
+                data.put("text", ((Button)view).getText().toString());
+                data.put("x", view.getX());
+                data.put("y", view.getY());
+                buttons.put(data);
+            } catch(JSONException e) {
+                Log.e(TAG, "Failed to save extra button", e);
+            }
+        }
+        editor.putString(EXTRA_BUTTONS_KEY, buttons.toString());
+        editor.apply();
+    }
+
+    private void reloadPlayButtons() {
+        removePlayButtons();
+        loadExtraButtons(false);
+    }
+
+    private void removePlayButtons() {
+        if (mLayout == null) {
+            playButtons.clear();
+            return;
+        }
+        for (View button : playButtons) {
+            mLayout.removeView(button);
+        }
+        playButtons.clear();
+    }
+
+    private void loadExtraButtons(boolean editorMode) {
+        SharedPreferences preferences = getSharedPreferences(EXTRA_BUTTON_PREFS, MODE_PRIVATE);
+        String saved = null;
+        try {
+            saved = preferences.getString(EXTRA_BUTTONS_KEY, null);
+        } catch(ClassCastException e) {
+            Log.i(TAG, "Loading legacy extra button data");
+        }
+        if (saved != null && saved.startsWith("[")) {
+            try {
+                JSONArray buttons = new JSONArray(saved);
+                for (int i = 0; i < buttons.length(); i++) {
+                    createButtonFromData(buttons.getJSONObject(i), editorMode);
+                }
+                return;
+            } catch(JSONException e) {
+                Log.e(TAG, "Failed to load extra button JSON", e);
+            }
+        }
+
+        Set<String> legacyButtons;
+        try {
+            legacyButtons = preferences.getStringSet(EXTRA_BUTTONS_KEY, null);
+        } catch(ClassCastException e) {
+            Log.e(TAG, "Extra button data has an unsupported format", e);
+            return;
+        }
+        if (legacyButtons == null) {
+            return;
+        }
+        for (String legacy : legacyButtons) {
+            String[] parts = legacy.split("\\|");
+            if (parts.length != 3) {
+                continue;
+            }
+            JSONObject data = createDefaultButtonData(parts[0]);
+            try {
+                data.put("x", Float.parseFloat(parts[1]));
+                data.put("y", Float.parseFloat(parts[2]));
+            } catch(JSONException | NumberFormatException e) {
+                Log.e(TAG, "Failed to load legacy extra button", e);
+            }
+            createButtonFromData(data, editorMode);
+        }
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    private void createButtonFromData(JSONObject data, boolean editorMode) {
+        final Button button = new Button(this);
+        button.setTag(data);
+        button.setText(data.optString("text", ""));
+        button.setLayoutParams(new FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.WRAP_CONTENT,
+            FrameLayout.LayoutParams.WRAP_CONTENT));
+        button.setX((float)data.optDouble("x", 0));
+        button.setY((float)data.optDouble("y", 0));
+        applyButtonStyle(button, data);
+
+        if (editorMode) {
+            attachEditorButtonListener(button);
+            editorButtons.add(button);
+            buttonEditorContainer.addView(button);
+        } else if (mLayout != null) {
+            attachPlayButtonListener(button, data.optBoolean("rapidFire", false));
+            playButtons.add(button);
+            mLayout.addView(button);
+        }
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    private void attachPlayButtonListener(final Button button, final boolean rapidFire) {
+        final Handler handler = new Handler();
+        final Runnable[] rapidFireRunnable = new Runnable[1];
+        final boolean[] firing = { false };
+        button.setOnTouchListener(new View.OnTouchListener() {
+            @Override
+            public boolean onTouch(View view, MotionEvent event) {
+                switch(event.getAction()) {
+                    case MotionEvent.ACTION_DOWN:
+                        firing[0] = true;
+                        performButtonClick(button);
+                        if (rapidFire) {
+                            rapidFireRunnable[0] = new Runnable() {
+                                @Override
+                                public void run() {
+                                    if (firing[0]) {
+                                        performButtonClick(button);
+                                        handler.postDelayed(this, 80);
+                                    }
+                                }
+                            };
+                            handler.postDelayed(rapidFireRunnable[0], 200);
+                        }
+                        return true;
+                    case MotionEvent.ACTION_UP:
+                    case MotionEvent.ACTION_CANCEL:
+                        firing[0] = false;
+                        if (rapidFireRunnable[0] != null) {
+                            handler.removeCallbacks(rapidFireRunnable[0]);
+                            rapidFireRunnable[0] = null;
+                        }
+                        return true;
+                    default:
+                        return false;
+                }
+            }
+        });
+    }
+
+    private void performButtonClick(Button button) {
+        String text = button.getText().toString();
+        if ("tab".equals(text)) {
+            dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_TAB));
+            dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_TAB));
+        } else if ("键盘".equals(text)) {
+            dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_BACK));
+            dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_BACK));
+        } else {
+            nativeButtonClick(text);
+        }
     }
 }

--- a/android/app/src/main/res/layout/button_manage.xml
+++ b/android/app/src/main/res/layout/button_manage.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#80000000">
+
+    <FrameLayout
+        android:id="@+id/container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</RelativeLayout>

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -382,6 +382,8 @@ std::string action_ident( action_id act )
             return "high_five";
         case ACTION_COOP_CHAT:
             return "coop_chat";
+        case ACTION_MANAGE_ANDROID_EXTRA_BUTTONS:
+            return "manage_android_extra_buttons";
         case ACTION_ITEMACTION:
             return "item_action_menu";
         case ACTION_SELECT:
@@ -464,6 +466,7 @@ bool can_action_change_worldstate( const action_id act )
         case ACTION_WORLD_MODS:
         case ACTION_DISTRACTION_MANAGER:
         case ACTION_EXPORT_BUG_REPORT_ARCHIVE:
+        case ACTION_MANAGE_ANDROID_EXTRA_BUTTONS:
         // Debug Functions
         case ACTION_TOGGLE_FULLSCREEN:
         case ACTION_DEBUG:
@@ -1131,6 +1134,10 @@ action_id handle_main_menu()
     REGISTER_ACTION( ACTION_COLOR );
     REGISTER_ACTION( ACTION_WORLD_MODS );
     REGISTER_ACTION( ACTION_ACTIONMENU );
+#if defined(__ANDROID__)
+    entries.emplace_back( ACTION_MANAGE_ANDROID_EXTRA_BUTTONS, true, std::nullopt,
+                          _( "Manage extra buttons" ) );
+#endif
     REGISTER_ACTION( ACTION_QUICKSAVE );
     REGISTER_ACTION( ACTION_SAVE );
     REGISTER_ACTION( ACTION_SNAPSHOT_MENU );

--- a/src/action.h
+++ b/src/action.h
@@ -365,6 +365,7 @@ enum action_id : int {
     ACTION_COOP_CHAT,
     ACTION_PASS_ITEM,
     ACTION_HIGH_FIVE,
+    ACTION_MANAGE_ANDROID_EXTRA_BUTTONS,
     /** Not an action, serves as count of enumerated actions */
     NUM_ACTIONS
     /**@}*/

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -118,6 +118,11 @@ enum class direction : unsigned int;
     #include "screen_shake.h"
     #include "sdltiles.h"
 #endif
+#if defined(__ANDROID__)
+    #include <jni.h>
+
+    #include "sdl_wrappers.h"
+#endif
 
 static const bionic_id bio_remote( "bio_remote" );
 
@@ -2503,8 +2508,34 @@ static const std::set<action_id> host_ui_actions = {
     ACTION_KEYBINDINGS,
     ACTION_MAIN_MENU,
     ACTION_EXPORT_BUG_REPORT_ARCHIVE,
+    ACTION_MANAGE_ANDROID_EXTRA_BUTTONS,
     ACTION_COOP_CHAT,
 };
+#endif
+
+#if defined(__ANDROID__)
+static void manage_android_extra_buttons()
+{
+    JNIEnv *env = ( JNIEnv * )GetAndroidJNIEnv();
+    jobject activity = ( jobject )GetAndroidActivity();
+    if( env == nullptr || activity == nullptr ) {
+        return;
+    }
+    jclass clazz( env->GetObjectClass( activity ) );
+    if( clazz == nullptr ) {
+        env->DeleteLocalRef( activity );
+        return;
+    }
+    jmethodID method_id = env->GetMethodID( clazz, "showButtonManage", "()V" );
+    if( env->ExceptionCheck() ) {
+        env->ExceptionClear();
+    }
+    if( method_id != nullptr ) {
+        env->CallVoidMethod( activity, method_id );
+    }
+    env->DeleteLocalRef( activity );
+    env->DeleteLocalRef( clazz );
+}
 #endif
 
 bool game::do_regular_action( action_id &act, avatar &player_character,
@@ -3166,6 +3197,12 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
         case ACTION_MAIN_MENU:
         case ACTION_KEYBINDINGS:
             break;
+
+#if defined(__ANDROID__)
+        case ACTION_MANAGE_ANDROID_EXTRA_BUTTONS:
+            manage_android_extra_buttons();
+            break;
+#endif
 
         case ACTION_TIMEOUT:
 #ifdef MP_ENABLED

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -17,12 +17,14 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <deque>
 #include <exception>
 #include <fstream>
 #include <iterator>
 #include <limits>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <set>
 #include <stack>
@@ -950,15 +952,56 @@ static_assert( std::atomic<uint32_t>::is_always_lock_free,
                "visible-frame inbox needs lock-free uint32 atomics on every shipped ABI" );
 
 static android_visible_frame_inbox visible_frame_inbox;
+static std::mutex extra_button_input_mutex;
+static std::deque<input_event> extra_button_inputs;
 
 extern "C" {
+
+    static void on_native_ime_insets_changed( jint left, jint top, jint right, jint bottom,
+            jboolean visible )
+    {
+        visible_frame_inbox.publish( left, top, right, bottom, visible == JNI_TRUE );
+    }
+
+    JNIEXPORT void JNICALL Java_com_lyhglytx_cataclysmcb_CataclysmDDA_onNativeImeInsetsChanged(
+        JNIEnv *env, jclass jcls, jint left, jint top, jint right, jint bottom, jboolean visible )
+    {
+        ( void )env;
+        ( void )jcls;
+        on_native_ime_insets_changed( left, top, right, bottom, visible );
+    }
 
     JNIEXPORT void JNICALL Java_com_cleverraven_cataclysmdda_CataclysmDDA_onNativeImeInsetsChanged(
         JNIEnv *env, jclass jcls, jint left, jint top, jint right, jint bottom, jboolean visible )
     {
-        ( void )env; // unused
-        ( void )jcls; // unused
-        visible_frame_inbox.publish( left, top, right, bottom, visible == JNI_TRUE );
+        ( void )env;
+        ( void )jcls;
+        on_native_ime_insets_changed( left, top, right, bottom, visible );
+    }
+
+    JNIEXPORT void JNICALL Java_com_lyhglytx_cataclysmcb_CataclysmDDA_nativeButtonClick(
+        JNIEnv *env, jclass jcls, jstring text )
+    {
+        ( void )jcls;
+        if( text == nullptr ) {
+            return;
+        }
+
+        const char *raw_text = env->GetStringUTFChars( text, nullptr );
+        if( raw_text == nullptr ) {
+            return;
+        }
+
+        const std::string text_s( raw_text );
+        env->ReleaseStringUTFChars( text, raw_text );
+        if( text_s.empty() ) {
+            return;
+        }
+
+        input_event event( UTF8_getch( text_s ), input_event_t::keyboard_char );
+        event.text = text_s;
+        std::lock_guard<std::mutex> lock( extra_button_input_mutex );
+        extra_button_inputs.push_back( event );
     }
 
 } // "C"
@@ -5342,6 +5385,22 @@ static void focus_aware_stop_text_input()
 #endif
 }
 
+static bool pop_extra_button_input( input_event &event )
+{
+#if defined(__ANDROID__)
+    std::lock_guard<std::mutex> lock( extra_button_input_mutex );
+    if( extra_button_inputs.empty() ) {
+        return false;
+    }
+    event = extra_button_inputs.front();
+    extra_button_inputs.pop_front();
+    return true;
+#else
+    ( void )event;
+    return false;
+#endif
+}
+
 //Check for any window messages (keypress, paint, mousemove, etc)
 static void CheckMessages()
 {
@@ -5661,6 +5720,11 @@ static void CheckMessages()
 #endif
 
     last_input = input_event();
+
+    if( pop_extra_button_input( last_input ) ) {
+        text_refresh = true;
+        return;
+    }
 
     using cata::options::mouse;
 


### PR DESCRIPTION
## 来源

本 PR 移植自 WhiteCloud0123/CDDA-Breeze 的安卓扩展按键相关实现，主要参考其扩展按键管理、按钮属性配置、emoji/连发支持等功能思路，并按 CCB 当前 Android 入口 `com.lyhglytx.cataclysmcb.CataclysmDDA` 和 SDL3/JNI 结构做了适配。

## 变更内容

- 新增安卓扩展按键管理面板，可从游戏主菜单进入。
- 支持新增、删除、拖动自定义按键。
- 支持单字符和 emoji 按键。
- 支持特殊按钮 `tab` 与 `键盘`。
- 支持调整按钮文字大小、文字颜色、背景颜色。
- 支持连发模式，长按时持续触发。
- 使用 SharedPreferences JSON 保存按钮配置，并兼容旧 StringSet 格式。
- 新增 JNI 输入队列，将 Java 侧自定义按键注入为游戏输入事件。
- 补充当前包名的 IME inset JNI 入口，同时保留旧包名入口兼容。

## 验证

- `make -j2 RELEASE=1 TESTS=0 LOCALIZE=0 ASTYLE=0 LINTJSON=0`
- `./gradlew assembleDebug`
- `git diff --check`

## 说明

不额外添加 Signed-off-by。这里属于功能移植与适配，来源已在 PR 描述中说明。