### PR TITLE
Assign cosplay flags to more items that meet the criteria.

### DIFF
--- a/data/json/items/armor/masks.json
+++ b/data/json/items/armor/masks.json
@@ -352,7 +352,7 @@
     "warmth": 5,
     "material_thickness": 0.2,
     "environmental_protection": 1,
-    "flags": [ "WATER_FRIENDLY" ],
+    "flags": [ "WATER_FRIENDLY", "COSPLAY_PROPS" ],
     "armor": [ { "encumbrance": 10, "coverage": 95, "covers": [ "eyes", "mouth" ] } ],
     "variant_type": "generic",
     "variants": [
@@ -519,7 +519,7 @@
     "warmth": 5,
     "material_thickness": 0.5,
     "environmental_protection": 1,
-    "flags": [ "FRAGILE" ],
+    "flags": [ "FRAGILE", "COSPLAY_PROPS" ],
     "armor": [ { "encumbrance": 14, "coverage": 95, "covers": [ "head", "mouth" ] } ]
   },
   {
@@ -538,7 +538,7 @@
     "warmth": 5,
     "material_thickness": 0.5,
     "environmental_protection": 1,
-    "flags": [ "FRAGILE" ],
+    "flags": [ "FRAGILE", "COSPLAY_PROPS" ],
     "armor": [ { "encumbrance": 8, "coverage": 95, "covers": [ "head", "mouth" ] } ],
     "variant_type": "generic",
     "variants": [

--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -426,7 +426,7 @@
     "material": [ "plastic" ],
     "to_hit": { "grip": "weapon", "length": "short", "surface": "any", "balance": "neutral" },
     "price_postapoc": "10 cent",
-    "extend": { "flags": [ "FRAGILE_MELEE" ] },
+    "extend": { "flags": [ "FRAGILE_MELEE", "COSPLAY_PROPS" ] },
     "melee_damage": { "bash": 2 }
   },
   {
@@ -442,7 +442,7 @@
     "material": [ "plastic" ],
     "to_hit": { "grip": "weapon", "length": "short", "surface": "any", "balance": "neutral" },
     "price_postapoc": "20 cent",
-    "extend": { "flags": [ "FRAGILE_MELEE", "WATER_BREAK_ACTIVE" ] },
+    "extend": { "flags": [ "FRAGILE_MELEE", "WATER_BREAK_ACTIVE", "COSPLAY_PROPS" ] },
     "charges_per_use": 1,
     "use_action": {
       "type": "transform",

--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -2515,7 +2515,7 @@
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Sheath sword", "holster_msg": "You sheath your %s" },
-    "flags": [ "CRUTCHES" ],
+    "flags": [ "CRUTCHES", "COSPLAY_PROPS" ],
     "weapon_category": [ "BATONS" ],
     "techniques": [ "PRECISE", "RAPID", "WBLOCK_2" ],
     "faults": [ { "fault_group": "staff_short" } ],

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -4680,7 +4680,7 @@
       "need_charges": 1,
       "need_charges_msg": "The batteries are dead."
     },
-    "flags": [ "OUTER", "SUN_GLASSES" ],
+    "flags": [ "OUTER", "SUN_GLASSES", "COSPLAY_PROPS" ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",

--- a/data/mods/Magiclysm/items/enchanted.json
+++ b/data/mods/Magiclysm/items/enchanted.json
@@ -144,7 +144,7 @@
     "color": "dark_gray",
     "warmth": 30,
     "material_thickness": 3,
-    "flags": [ "OVERSIZE", "HOOD", "OUTER", "NO_REPAIR", "STURDY", "TRADER_KEEP_EQUIPPED" ],
+    "flags": [ "OVERSIZE", "HOOD", "OUTER", "NO_REPAIR", "STURDY", "TRADER_KEEP_EQUIPPED", "COSPLAY_COSTUME" ],
     "armor": [ { "encumbrance": 4, "coverage": 85, "covers": [ "torso", "head", "arm_l", "arm_r", "leg_l", "leg_r" ] } ],
     "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "BONUS_DODGE", "add": 1 } ] } ]
   },

--- a/data/mods/Magiclysm/items/enchanted_clothes.json
+++ b/data/mods/Magiclysm/items/enchanted_clothes.json
@@ -25,7 +25,7 @@
     ],
     "material": [ "parabolan_wool" ],
     "material_thickness": 0.5,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "RAINPROOF", "STURDY", "TRADER_KEEP_EQUIPPED" ],
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "RAINPROOF", "STURDY", "TRADER_KEEP_EQUIPPED", "COSPLAY_COSTUME" ],
     "passive_effects": [ { "id": "ench_parabolan_blouse" } ]
   },
   {
@@ -44,7 +44,7 @@
     "color": "brown",
     "armor": [ { "encumbrance": 2, "coverage": 95, "covers": [ "leg_l", "leg_r" ] } ],
     "material_thickness": 0.5,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "RAINPROOF", "STURDY", "TRADER_KEEP_EQUIPPED" ],
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "RAINPROOF", "STURDY", "TRADER_KEEP_EQUIPPED", "COSPLAY_COSTUME" ],
     "passive_effects": [
       {
         "has": "WORN",

--- a/data/mods/aftershock_exoplanet/items/armor.json
+++ b/data/mods/aftershock_exoplanet/items/armor.json
@@ -67,7 +67,7 @@
     "color": "dark_gray",
     "warmth": 30,
     "material_thickness": 1,
-    "flags": [ "OVERSIZE", "HOOD", "OUTER", "NO_REPAIR", "STURDY" ],
+    "flags": [ "OVERSIZE", "HOOD", "OUTER", "NO_REPAIR", "STURDY", "COSPLAY_COSTUME" ],
     "armor": [ { "encumbrance": 4, "coverage": 85, "covers": [ "torso", "head", "arm_l", "arm_r", "leg_l", "leg_r" ] } ],
     "passive_effects": [
       {

--- a/data/mods/aftershock_exoplanet/items/armor/cyberpunk.json
+++ b/data/mods/aftershock_exoplanet/items/armor/cyberpunk.json
@@ -40,7 +40,7 @@
     "color": "yellow",
     "warmth": 10,
     "material_thickness": 1,
-    "flags": [ "VARSIZE" ],
+    "flags": [ "VARSIZE", "COSPLAY_COSTUME" ],
     "armor": [ { "encumbrance": 3, "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ] } ]
   },
   {
@@ -59,7 +59,7 @@
     "color": "yellow",
     "warmth": 10,
     "material_thickness": 1,
-    "flags": [ "VARSIZE" ],
+    "flags": [ "VARSIZE", "COSPLAY_COSTUME" ],
     "armor": [ { "encumbrance": 3, "coverage": 75, "covers": [ "torso", "leg_l", "leg_r" ] } ]
   },
   {


### PR DESCRIPTION
####  Summary

Assign cosplay flags to more items that meet the criteria.

#### Purpose of change

I introduced flags related to cosplay items in PR #324, but currently, it only covers the specific quest objectives directly listed in `MISSION_COSPLAY` ("Find some cosplay suits").

#### Describe the solution

Core module:
Added the `COSPLAY_PROPS` flag to the following items:
 - data\json\items\melee\bludgeons.json:
   + sinister cane
   + cleap wizard cane
 - data\json\items\armor\masks.json:
   + skull mask
   + pumpkin mask
   + zombie mask
 - data\json\items\melee\swords_and_blades.json:
   + hollow cane
 - data\json\items\tool_armor.json
   + Foodperson mask

Mods:
Added the `COSPLAY_COSTUME` flag to the following items:
 - Aftershock:
   + data\mods\aftershock_exoplanet\items\armor\cyberpunk.json
     - nanoweave formal shirt
     - nanoweave dress
   + data\mods\aftershock_exoplanet\items\armor.json
     - sentinel-lx cloak
 - Magiclysm:
   + data\mods\Magiclysm\items\enchanted.json:
     - Cloak of Morthylla the Lamia
   + data\mods\Magiclysm\items\enchanted_clothes.json:
     - enchanted parabolan wool blouse
     - enchanted parabolan wool breeches
	 
#### Additional context

Essentially, the mod items receiving the `COSPLAY_COSTUME` flag this time are those that previously possessed the `SUPER_FANCY` flag.