### PR TITLE
种植系统优化

### DIFF
--- a/data/mods/TEST_DATA/magic.json
+++ b/data/mods/TEST_DATA/magic.json
@@ -134,6 +134,23 @@
     "final_casting_time": 600000
   },
   {
+    "id": "test_spell_fertilize_plant",
+    "type": "SPELL",
+    "name": "TEST Fertilize Plant",
+    "description": "A test spell that accelerates plant growth by a fixed amount.",
+    "effect": "fertilize_plant",
+    "shape": "blast",
+    "valid_targets": [ "ground" ],
+    "spell_class": "NONE",
+    "energy_source": "MANA",
+    "base_casting_time": 100,
+    "base_energy_cost": 1,
+    "min_damage": 25,
+    "max_damage": 25,
+    "min_aoe": 0,
+    "max_aoe": 0
+  },
+  {
     "id": "test_mon_mummy",
     "type": "MONSTER",
     "name": { "str": "toilet paper mummy", "str_pl": "toilet paper mummies" },

--- a/data/mods/TEST_DATA/plant_eoc_test.json
+++ b/data/mods/TEST_DATA/plant_eoc_test.json
@@ -126,6 +126,7 @@
     "plant_data": {
       "transform": "test_f_plant_seedling",
       "base": "f_null",
+      "max_water_storage": 0,
       "eoc_on_plant": [ "EOC_TEST_PLANT_PLANTED" ],
       "eoc_on_grow": [ "EOC_TEST_PLANT_GROW" ]
     }
@@ -138,6 +139,7 @@
     "plant_data": {
       "transform": "test_f_plant_mature",
       "base": "f_null",
+      "max_water_storage": 0,
       "eoc_on_grow": [ "EOC_TEST_PLANT_GROW" ]
     }
   },
@@ -149,6 +151,7 @@
     "plant_data": {
       "transform": "test_f_plant_harvest",
       "base": "f_null",
+      "max_water_storage": 0,
       "eoc_on_mature": [ "EOC_TEST_PLANT_MATURE" ]
     }
   },
@@ -160,6 +163,7 @@
     "plant_data": {
       "transform": "test_f_plant_overgrown",
       "base": "f_null",
+      "max_water_storage": 0,
       "eoc_on_harvest": [ "EOC_TEST_PLANT_HARVEST" ]
     }
   },
@@ -171,6 +175,7 @@
     "plant_data": {
       "transform": "test_f_plant_overgrown",
       "base": "f_null",
+      "max_water_storage": 0,
       "eoc_on_overgrow": [ "EOC_TEST_PLANT_OVERGROW" ]
     }
   },

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -10297,6 +10297,15 @@ void fertilize_plant_activity_actor::start( player_activity &act, Character & )
     act.moves_left = act.moves_total;
 }
 
+namespace
+{
+// Fertilizer reduces the remaining distance to mature by a base percentage plus a
+// survival-skill bonus, scaled by the fertilizer's quality, with a hard cap.
+constexpr double fertilizer_base_reduction = 0.20;
+constexpr double fertilizer_survival_bonus = 0.05;
+constexpr double fertilizer_max_reduction = 0.50;
+} // namespace
+
 void fertilize_plant_activity_actor::finish( player_activity &act, Character &who )
 {
     if( !fertilizer.is_valid() ) {
@@ -10317,23 +10326,23 @@ void fertilize_plant_activity_actor::finish( player_activity &act, Character &wh
         return;
     }
 
-    const std::vector<std::pair<flag_id, time_duration>> &growth_stages =
-        seed->type->seed->get_growth_stages();
-
     const float growth_multiplier = here.furn( plant_position )->plant->growth_multiplier;
 
     // Time required to reach the mature stage in effective growth units.
-    const int mature_stage_idx = iexamine::get_plant_mature_stage_idx( growth_stages );
+    const int mature_stage_idx = iexamine::get_plant_mature_stage_idx( *seed->type->seed );
     if( mature_stage_idx < 0 ) {
         add_msg( m_info, _( "The %s is too mature to benefit from fertilizer." ),
                  seed->get_plant_name() );
         act.set_to_null();
         return;
     }
-    const time_duration mature_threshold = iexamine::get_plant_stage_threshold( growth_stages,
+    const time_duration mature_threshold = iexamine::get_plant_stage_threshold( *seed->type->seed,
             mature_stage_idx );
 
-    // Current effective growth time (new saves) or estimate from age (old saves).
+    const float crop_growth_speed = ::get_option<float>( "CROP_GROWTH_SPEED" );
+
+    // Current effective growth time in base growth units (new saves) or estimated
+    // from age (old saves).
     const time_duration current_effective = iexamine::get_plant_effective_growth_time( *seed,
             growth_multiplier );
 
@@ -10358,20 +10367,22 @@ void fertilize_plant_activity_actor::finish( player_activity &act, Character &wh
         return;
     }
 
-    // Shorten the distance to mature: 20% base + 5% per survival level, multiplied by
-    // the fertilizer's quality, capped at 50%.
+    // Shorten the distance to mature: base reduction + survival bonus, multiplied by
+    // the fertilizer's quality, capped at a maximum.
     const double survival_level = who.get_skill_level( skill_survival );
     const double fertilizer_quality = fertilizer->fertilizer_quality;
-    const double reduction_pct = std::min( ( 0.20 + 0.05 * survival_level ) * fertilizer_quality,
-                                           0.50 );
+    const double reduction_pct = std::min(
+                                     ( fertilizer_base_reduction + fertilizer_survival_bonus * survival_level ) *
+                                     fertilizer_quality,
+                                     fertilizer_max_reduction );
 
     const time_duration reduction = distance_to_mature * reduction_pct;
     const time_duration new_effective = current_effective + reduction;
 
     // Advance effective growth time, mark the plant as fertilized, and keep birthday in sync.
-    iexamine::set_plant_effective_growth_turns( *seed, to_turns<int>( new_effective ) );
     iexamine::set_plant_fertilized( *seed, true );
-    seed->set_birthday( calendar::turn - new_effective / growth_multiplier );
+    iexamine::set_plant_effective_growth_time( *seed, new_effective, growth_multiplier,
+            crop_growth_speed );
 
     // Apply any stage advances immediately.
     here.grow_plant( plant_position );
@@ -10468,6 +10479,10 @@ ret_val<void> multi_farm_activity_actor::can_fertilize( Character &,
     if( !here.has_flag_furn( ter_furn_flag::TFLAG_PLANT, tile ) ) {
         return ret_val<void>::make_failure( _( "Tile isn't a plant" ) );
     }
+
+    // Synchronize furniture flag with effective growth time before deciding
+    // whether the plant can still benefit from fertilizer.
+    here.grow_plant( tile );
 
     // Authoritative check based on effective growth time: mature, harvestable,
     // or overgrown plants cannot benefit from fertilizer.

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -3561,8 +3561,9 @@ std::pair<size_t, std::string> basecamp::farm_action( const point_rel_omt &dir, 
                             int skillLevel = round( comp->get_skill_level( skill_survival ) );
                             ///\EFFECT_SURVIVAL increases number of plants harvested from a seed
                             int plant_count = rng( skillLevel / 2, skillLevel );
-                            plant_count *= farm_map.furn( pos )->plant->harvest_multiplier;
-                            plant_count = std::min( std::max( plant_count, 1 ), 12 );
+                            plant_count *= farm_map.furn( pos )->plant->harvest_multiplier *
+                                           ::get_option<float>( "CROP_HARVEST_MULTIPLIER" );
+                            plant_count = std::max( plant_count, 1 );
                             int seed_cnt = std::max( 1, rng( plant_count / 4, plant_count / 2 ) );
 
                             // Secure the seed type before EOCs or i_clear destroy the item.

--- a/src/game_ui_tile_info.cpp
+++ b/src/game_ui_tile_info.cpp
@@ -343,14 +343,25 @@ void game::print_furniture_info( const tripoint_bub_ms &lp, const catacurses::wi
         }
     }
 
-    // Show irrigation status for plantable furniture
+    // Show plant age and irrigation status for plantable furniture.
     if( f->plant ) {
         here.grow_plant( lp );
+
         const std::string water_desc = iexamine::plant_water_description( here, lp );
         if( !water_desc.empty() ) {
+            // Irrigated planters already include age inside the water description.
             for( const std::string &water_line : string_split( water_desc, '\n' ) ) {
                 fold_and_print( w_look, point( column, ++line ), max_width, c_light_gray,
                                 water_line );
+            }
+        } else {
+            // Non-irrigated farm plots have no water info, so print age on its own.
+            item *seed = iexamine::get_seed_at( here, lp );
+            if( seed != nullptr ) {
+                const std::string age_desc = iexamine::plant_age_description( *seed,
+                                              f->plant->growth_multiplier );
+                fold_and_print( w_look, point( column, ++line ), max_width, c_light_gray,
+                                age_desc );
             }
         }
     }

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2852,7 +2852,8 @@ void iexamine::harvest_plant( Character &you, const tripoint_bub_ms &examp, bool
             ///\EFFECT_SURVIVAL increases number of plants harvested from a seed
             int plant_count = rng( skillLevel / 2, skillLevel );
             const auto &fp = here.furn( examp )->plant;
-            plant_count *= fp->harvest_multiplier;
+            plant_count *= fp->harvest_multiplier *
+                           ::get_option<float>( "CROP_HARVEST_MULTIPLIER" );
             plant_count = std::max( plant_count, 1 );
             int seedCount = std::max( 1, rng( plant_count / 4, plant_count / 2 ) );
 
@@ -3050,6 +3051,12 @@ item *iexamine::get_seed_at( map &here, const tripoint_bub_ms &p )
     return nullptr;
 }
 
+item *iexamine::sync_and_get_seed_at( map &here, const tripoint_bub_ms &p )
+{
+    here.grow_plant( p );
+    return get_seed_at( here, p );
+}
+
 bool iexamine::is_plant_fertilized( const item &seed )
 {
     return static_cast<int>( seed.get_var( "seed_fertilized", 0.0 ) ) != 0;
@@ -3097,6 +3104,16 @@ int iexamine::get_plant_effective_growth_turns( const item &seed )
 void iexamine::set_plant_effective_growth_turns( item &seed, int turns )
 {
     seed.set_var( "seed_effective_growth_turns", std::max( 0, turns ) );
+}
+
+void iexamine::set_plant_effective_growth_time( item &seed, time_duration effective,
+        float growth_multiplier, float crop_growth_speed )
+{
+    effective = std::max( 0_seconds, effective );
+    set_plant_effective_growth_turns( seed, to_turns<int>( effective ) );
+    if( growth_multiplier > 0.0f && crop_growth_speed > 0.0f ) {
+        seed.set_birthday( calendar::turn - effective / ( growth_multiplier * crop_growth_speed ) );
+    }
 }
 
 void iexamine::water_plant( Character &you, const tripoint_bub_ms &examp )
@@ -3217,8 +3234,10 @@ std::string iexamine::plant_water_description( map &here, const tripoint_bub_ms 
         const int current_water = get_plant_water( *seed );
         const int base_consumption = get_seed_water_consumption( *seed );
         const float consumption_mult = get_plant_water_consumption_multiplier( furn );
+        const float crop_water_consumption = ::get_option<float>( "CROP_WATER_CONSUMPTION" );
         const int consumption = std::max( 1,
-                                          static_cast<int>( base_consumption * consumption_mult ) );
+                                          static_cast<int>( base_consumption * consumption_mult *
+                                                  crop_water_consumption ) );
         std::string desc = string_format(
                                _( "Water: <color_cyan>%d</color>/<color_cyan>%d</color>\n"
                                   "Daily consumption: <color_cyan>%d</color>\n"
@@ -3255,47 +3274,32 @@ int iexamine::get_plant_current_stage_idx( const map &here, const tripoint_bub_m
     return -1;
 }
 
-int iexamine::get_plant_mature_stage_idx(
-    const std::vector<std::pair<flag_id, time_duration>> &growth_stages )
+int iexamine::get_plant_mature_stage_idx( const islot_seed &seed_data )
 {
-    for( int i = 0; i < static_cast<int>( growth_stages.size() ); ++i ) {
-        if( growth_stages[i].first.str() == "GROWTH_MATURE" ) {
-            return i;
-        }
-    }
-    return -1;
+    return seed_data.get_mature_stage_idx();
 }
 
-int iexamine::get_plant_harvest_stage_idx(
-    const std::vector<std::pair<flag_id, time_duration>> &growth_stages )
+int iexamine::get_plant_harvest_stage_idx( const islot_seed &seed_data )
 {
-    for( int i = 0; i < static_cast<int>( growth_stages.size() ); ++i ) {
-        if( growth_stages[i].first.str() == "GROWTH_HARVEST" ) {
-            return i;
-        }
-    }
-    return -1;
+    return seed_data.get_harvest_stage_idx();
 }
 
-int iexamine::get_plant_overgrown_stage_idx(
-    const std::vector<std::pair<flag_id, time_duration>> &growth_stages )
+int iexamine::get_plant_overgrown_stage_idx( const islot_seed &seed_data )
 {
-    for( int i = 0; i < static_cast<int>( growth_stages.size() ); ++i ) {
-        if( growth_stages[i].first.str() == "GROWTH_OVERGROWN" ) {
-            return i;
-        }
-    }
-    return -1;
+    return seed_data.get_overgrown_stage_idx();
 }
 
-time_duration iexamine::get_plant_stage_threshold(
-    const std::vector<std::pair<flag_id, time_duration>> &growth_stages, int stage_idx )
+time_duration iexamine::get_plant_stage_threshold( const islot_seed &seed_data, int stage_idx )
 {
-    time_duration threshold = 0_seconds;
-    for( int i = 0; i < stage_idx && i < static_cast<int>( growth_stages.size() ); ++i ) {
-        threshold += growth_stages[i].second;
+    if( stage_idx <= 0 ) {
+        return 0_seconds;
     }
-    return threshold;
+    const std::vector<time_duration> &thresholds = seed_data.get_cumulative_stage_thresholds();
+    const int idx = stage_idx - 1;
+    if( idx < static_cast<int>( thresholds.size() ) ) {
+        return thresholds[idx];
+    }
+    return thresholds.empty() ? 0_seconds : thresholds.back();
 }
 
 time_duration iexamine::get_plant_effective_growth_time( const item &seed, float growth_multiplier )
@@ -3308,26 +3312,34 @@ time_duration iexamine::get_plant_effective_growth_time( const item &seed, float
 
 std::string iexamine::plant_age_description( const item &seed, float growth_multiplier )
 {
-    const time_duration effective_age = get_plant_effective_growth_time( seed, growth_multiplier ) /
-                                        growth_multiplier;
-    return string_format( _( "Age: <color_cyan>%s</color>" ), to_string( effective_age ) );
+    time_duration effective_age;
+    if( seed.has_var( "seed_effective_growth_turns" ) ) {
+        // Effective growth time is stored in base growth units.  Divide by the
+        // furniture's growth multiplier to show an equivalent "default-speed" age
+        // that matches the growth stage computed from seed_effective_growth_turns.
+        effective_age = get_plant_effective_growth_time( seed, growth_multiplier ) /
+                        growth_multiplier;
+    } else {
+        // Old saves: show real age as a fallback.
+        effective_age = seed.age();
+    }
+    return string_format( _( "Effective age: <color_cyan>%s</color>" ),
+                          to_string( effective_age ) );
 }
 
-int iexamine::get_plant_stage_idx_from_effective_time(
-    const std::vector<std::pair<flag_id, time_duration>> &growth_stages,
-    const time_duration &effective_time )
+int iexamine::get_plant_stage_idx_from_effective_time( const islot_seed &seed_data,
+        const time_duration &effective_time )
 {
+    const std::vector<time_duration> &thresholds = seed_data.get_cumulative_stage_thresholds();
     int stage_idx = 0;
-    time_duration threshold = 0_seconds;
-    for( int i = 0; i < static_cast<int>( growth_stages.size() ); ++i ) {
-        threshold += growth_stages[i].second;
-        if( effective_time >= threshold ) {
+    for( int i = 0; i < static_cast<int>( thresholds.size() ); ++i ) {
+        if( effective_time >= thresholds[i] ) {
             stage_idx = i + 1;
         } else {
             break;
         }
     }
-    return std::min( stage_idx, static_cast<int>( growth_stages.size() ) - 1 );
+    return std::min( stage_idx, static_cast<int>( seed_data.get_growth_stages().size() ) - 1 );
 }
 
 int iexamine::get_plant_current_stage_idx_from_effective( map &here, const tripoint_bub_ms &p )
@@ -3337,11 +3349,9 @@ int iexamine::get_plant_current_stage_idx_from_effective( map &here, const tripo
     if( seed == nullptr || seed->type == nullptr || seed->type->seed == nullptr || !furn.plant ) {
         return -1;
     }
-    const std::vector<std::pair<flag_id, time_duration>> &growth_stages =
-        seed->type->seed->get_growth_stages();
     const time_duration effective_time = get_plant_effective_growth_time( *seed,
             furn.plant->growth_multiplier );
-    return get_plant_stage_idx_from_effective_time( growth_stages, effective_time );
+    return get_plant_stage_idx_from_effective_time( *seed->type->seed, effective_time );
 }
 
 bool iexamine::is_plant_harvestable( map &here, const tripoint_bub_ms &p )
@@ -3351,12 +3361,13 @@ bool iexamine::is_plant_harvestable( map &here, const tripoint_bub_ms &p )
     if( seed == nullptr || seed->type == nullptr || seed->type->seed == nullptr || !furn.plant ) {
         return false;
     }
-    const std::vector<std::pair<flag_id, time_duration>> &growth_stages =
-        seed->type->seed->get_growth_stages();
-    const int harvest_stage_idx = get_plant_harvest_stage_idx( growth_stages );
+    const int harvest_stage_idx = get_plant_harvest_stage_idx( *seed->type->seed );
     if( harvest_stage_idx < 0 ) {
         return false;
     }
+    // Effective growth time is the authoritative progress measure; furniture is
+    // just its visual representation. Callers should synchronize with grow_plant()
+    // before querying if they need the latest visual stage.
     const int current_stage_idx = get_plant_current_stage_idx_from_effective( here, p );
     return current_stage_idx >= harvest_stage_idx;
 }
@@ -3368,12 +3379,13 @@ bool iexamine::is_plant_mature( map &here, const tripoint_bub_ms &p )
     if( seed == nullptr || seed->type == nullptr || seed->type->seed == nullptr || !furn.plant ) {
         return false;
     }
-    const std::vector<std::pair<flag_id, time_duration>> &growth_stages =
-        seed->type->seed->get_growth_stages();
-    const int mature_stage_idx = get_plant_mature_stage_idx( growth_stages );
+    const int mature_stage_idx = get_plant_mature_stage_idx( *seed->type->seed );
     if( mature_stage_idx < 0 ) {
         return false;
     }
+    // Effective growth time is the authoritative progress measure; furniture is
+    // just its visual representation. Callers should synchronize with grow_plant()
+    // before querying if they need the latest visual stage.
     const int current_stage_idx = get_plant_current_stage_idx_from_effective( here, p );
     return current_stage_idx >= mature_stage_idx;
 }
@@ -3387,11 +3399,14 @@ bool iexamine::is_plant_overgrown( map &here, const tripoint_bub_ms &p )
     }
     const std::vector<std::pair<flag_id, time_duration>> &growth_stages =
         seed->type->seed->get_growth_stages();
-    const int overgrown_stage_idx = get_plant_overgrown_stage_idx( growth_stages );
+    const int overgrown_stage_idx = get_plant_overgrown_stage_idx( *seed->type->seed );
     if( overgrown_stage_idx < 0 ) {
         return false;
     }
-    const int current_stage_idx = get_plant_current_stage_idx_from_effective( here, p );
+    // Overgrowth is a visible furniture stage.  When CROP_OVERGROWN_ENABLED is false
+    // grow_plant clamps the furniture at mature, so this check must reflect the
+    // actual furniture rather than the unclamped effective growth time.
+    const int current_stage_idx = get_plant_current_stage_idx( here, p, growth_stages );
     return current_stage_idx >= overgrown_stage_idx;
 }
 

--- a/src/iexamine.h
+++ b/src/iexamine.h
@@ -25,6 +25,7 @@ class time_duration;
 class time_point;
 class vpart_reference;
 struct furn_t;
+struct islot_seed;
 struct itype;
 
 using seed_tuple = std::tuple<itype_id, std::string, int>;
@@ -184,6 +185,9 @@ ret_val<void> can_fertilize( Character &you, const tripoint_bub_ms &tile,
 int get_plant_max_water( const furn_t &furn );
 float get_plant_water_consumption_multiplier( const furn_t &furn );
 item *get_seed_at( map &here, const tripoint_bub_ms &p );
+// Sync the plant tile (grow_plant) and return the seed item, or nullptr if none.
+// This is the common pattern for callers that need authoritative plant state.
+item *sync_and_get_seed_at( map &here, const tripoint_bub_ms &p );
 bool is_plant_fertilized( const item &seed );
 void set_plant_fertilized( item &seed, bool fertilized );
 int get_plant_water( const item &seed );
@@ -191,8 +195,17 @@ void set_plant_water( item &seed, int water );
 int get_seed_water_consumption( const item &seed );
 time_point get_plant_last_water_check( const item &seed );
 void set_plant_last_water_check( item &seed, const time_point &turn );
+// Authoritative plant progress.  Value is in BASE growth units: one base unit is
+// the amount of growth a plant with furniture multiplier 1.0 gets in one turn at
+// CROP_GROWTH_SPEED 1.0.  Natural growth adds elapsed * growth_multiplier *
+// CROP_GROWTH_SPEED to this variable, but the stored value itself is independent
+// of the current world speed option.
 int get_plant_effective_growth_turns( const item &seed );
 void set_plant_effective_growth_turns( item &seed, int turns );
+// Set the authoritative effective growth time (in base growth units) and keep
+// the seed's birthday in sync so that age() remains consistent with it.
+void set_plant_effective_growth_time( item &seed, time_duration effective,
+                                      float growth_multiplier, float crop_growth_speed );
 void water_plant( Character &you, const tripoint_bub_ms &examp );
 bool can_water_plant( Character &you, const tripoint_bub_ms &examp );
 int rain_water_for_weather( const weather_type_id &weather );
@@ -201,18 +214,16 @@ std::string plant_water_description( map &here, const tripoint_bub_ms &p );
 // Plant growth helpers
 int get_plant_current_stage_idx( const map &here, const tripoint_bub_ms &p,
                                  const std::vector<std::pair<flag_id, time_duration>> &growth_stages );
-int get_plant_mature_stage_idx( const std::vector<std::pair<flag_id, time_duration>> &growth_stages );
-int get_plant_harvest_stage_idx( const std::vector<std::pair<flag_id, time_duration>> &growth_stages );
-int get_plant_overgrown_stage_idx( const std::vector<std::pair<flag_id, time_duration>> &growth_stages );
-time_duration get_plant_stage_threshold(
-    const std::vector<std::pair<flag_id, time_duration>> &growth_stages, int stage_idx );
+int get_plant_mature_stage_idx( const islot_seed &seed_data );
+int get_plant_harvest_stage_idx( const islot_seed &seed_data );
+int get_plant_overgrown_stage_idx( const islot_seed &seed_data );
+time_duration get_plant_stage_threshold( const islot_seed &seed_data, int stage_idx );
 time_duration get_plant_effective_growth_time( const item &seed, float growth_multiplier );
 std::string plant_age_description( const item &seed, float growth_multiplier );
 
 // Unified plant stage / maturity helpers based on effective growth time.
-int get_plant_stage_idx_from_effective_time(
-    const std::vector<std::pair<flag_id, time_duration>> &growth_stages,
-    const time_duration &effective_time );
+int get_plant_stage_idx_from_effective_time( const islot_seed &seed_data,
+        const time_duration &effective_time );
 int get_plant_current_stage_idx_from_effective( map &here, const tripoint_bub_ms &p );
 bool is_plant_harvestable( map &here, const tripoint_bub_ms &p );
 bool is_plant_mature( map &here, const tripoint_bub_ms &p );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -379,6 +379,10 @@ void Item_factory::finalize_pre( itype &obj )
         obj.relic_data->finalize();
     }
 
+    if( obj.seed ) {
+        obj.seed->finalize();
+    }
+
     if( obj.count_by_charges() ) {
         obj.item_tags.insert( flag_NO_REPAIR );
     }

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -352,9 +352,54 @@ const std::vector<std::pair<flag_id, time_duration>> &islot_seed::get_growth_sta
     return growth_stages;
 }
 
+const std::vector<time_duration> &islot_seed::get_cumulative_stage_thresholds() const
+{
+    return cumulative_stage_thresholds;
+}
+
+int islot_seed::get_mature_stage_idx() const
+{
+    return mature_stage_idx;
+}
+
+int islot_seed::get_harvest_stage_idx() const
+{
+    return harvest_stage_idx;
+}
+
+int islot_seed::get_overgrown_stage_idx() const
+{
+    return overgrown_stage_idx;
+}
+
 units::temperature islot_seed::get_growth_temp() const
 {
     return growth_temp;
+}
+
+void islot_seed::finalize()
+{
+    cumulative_stage_thresholds.clear();
+    cumulative_stage_thresholds.reserve( growth_stages.size() );
+    time_duration acc = 0_seconds;
+    for( const auto &stage : growth_stages ) {
+        acc += stage.second;
+        cumulative_stage_thresholds.push_back( acc );
+    }
+
+    mature_stage_idx = -1;
+    harvest_stage_idx = -1;
+    overgrown_stage_idx = -1;
+    for( int i = 0; i < static_cast<int>( growth_stages.size() ); ++i ) {
+        const std::string &flag = growth_stages[i].first.str();
+        if( flag == "GROWTH_MATURE" ) {
+            mature_stage_idx = i;
+        } else if( flag == "GROWTH_HARVEST" ) {
+            harvest_stage_idx = i;
+        } else if( flag == "GROWTH_OVERGROWN" ) {
+            overgrown_stage_idx = i;
+        }
+    }
 }
 
 int islot_armor::avg_env_resist() const

--- a/src/itype.h
+++ b/src/itype.h
@@ -1302,12 +1302,24 @@ struct islot_seed {
         islot_seed() = default;
 
         const std::vector<std::pair<flag_id, time_duration>> &get_growth_stages() const;
+        const std::vector<time_duration> &get_cumulative_stage_thresholds() const;
+        int get_mature_stage_idx() const;
+        int get_harvest_stage_idx() const;
+        int get_overgrown_stage_idx() const;
         units::temperature get_growth_temp() const;
+
+        void finalize();
     private:
         /**
         * What stages of growth does this plant have? How long does each stage of growth last?
         */
         std::vector<std::pair<flag_id, time_duration>> growth_stages;
+        // Cumulative thresholds computed from growth_stages for O(1) lookups.
+        std::vector<time_duration> cumulative_stage_thresholds;
+        // Cached indices of special lifecycle stages; -1 if absent.
+        int mature_stage_idx = -1;
+        int harvest_stage_idx = -1;
+        int overgrown_stage_idx = -1;
         // Temperature needs to be at or above this temp for the plant to be planted/grow.
         units::temperature growth_temp;
 };

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -59,6 +59,7 @@
 #include "monstergenerator.h"
 #include "mtype.h"
 #include "npc.h"
+#include "options.h"
 #include "overmapbuffer.h"
 #include "pickup.h"
 #include "pimpl.h"
@@ -1486,20 +1487,27 @@ void spell_effect::fertilize_plant( const spell &sp, Creature &caster,
             continue;
         }
 
-        // Reduce the amount of time until maturity by the spell's damage
-        // (1% per damage point) relative to season length.
-        const time_duration fertilizerEpoch = calendar::season_length() * ( static_cast<float>( sp.damage(
-                caster ) ) / 100.0f );
-
         const furn_t &furn = here.furn( tile ).obj();
-        const float growth_multiplier = furn.plant ? furn.plant->growth_multiplier : 1.0f;
+        if( furn.plant == nullptr || synced_seed->type == nullptr ||
+            synced_seed->type->seed == nullptr ) {
+            continue;
+        }
+        const float growth_multiplier = furn.plant->growth_multiplier;
+        const float crop_growth_speed = ::get_option<float>( "CROP_GROWTH_SPEED" );
         const time_duration current_effective = iexamine::get_plant_effective_growth_time(
                     *synced_seed, growth_multiplier );
-        const time_duration new_effective = current_effective + fertilizerEpoch;
 
-        iexamine::set_plant_effective_growth_turns( *synced_seed,
-                to_turns<int>( new_effective ) );
-        synced_seed->set_birthday( calendar::turn - new_effective / growth_multiplier );
+        // Spell fertilization advances the plant by a fixed percentage of its
+        // total growth duration, independent of the world crop growth speed option.
+        const std::vector<time_duration> &thresholds =
+            synced_seed->type->seed->get_cumulative_stage_thresholds();
+        const time_duration total_growth_time = thresholds.empty() ? 0_seconds : thresholds.back();
+        const float advance_pct = static_cast<float>( sp.damage( caster ) ) / 100.0f;
+        const time_duration advance = total_growth_time * advance_pct;
+        const time_duration new_effective = current_effective + advance;
+
+        iexamine::set_plant_effective_growth_time( *synced_seed, new_effective,
+                growth_multiplier, crop_growth_speed );
 
         // Apply any stage advances immediately.
         here.grow_plant( tile );
@@ -1510,7 +1518,7 @@ void spell_effect::fertilize_plant( const spell &sp, Creature &caster,
             const furn_str_id furn_id = here.furn( tile ).id();
             get_event_bus().send<event_type::character_fertilizes_plant>(
                 planter->getID(), here.get_abs( tile ).raw(), synced_seed->typeId(), furn_id,
-                itype_fertilizer, to_turns<int>( fertilizerEpoch ) );
+                itype_fertilizer, to_turns<int>( advance ) );
 
             const int stage_idx = iexamine::get_plant_current_stage_idx_from_effective( here, tile );
             const std::string stage = stage_idx >= 0 ?
@@ -1519,7 +1527,7 @@ void spell_effect::fertilize_plant( const spell &sp, Creature &caster,
                 { "fertilizer_id", itype_fertilizer.str() }
             };
             const std::map<std::string, double> num_ctx = {
-                { "reduction_turns", static_cast<double>( to_turns<int>( fertilizerEpoch ) ) },
+                { "reduction_turns", static_cast<double>( to_turns<int>( advance ) ) },
                 { "actor_is_npc", planter->is_npc() ? 1.0 : 0.0 }
             };
             if( furn.plant ) {

--- a/src/magic_ter_fur_transform.cpp
+++ b/src/magic_ter_fur_transform.cpp
@@ -19,6 +19,7 @@
 #include "magic_ter_furn_transform.h"
 #include "map.h"
 #include "mapdata.h"
+#include "options.h"
 #include "point.h"
 #include "submap.h"
 #include "translation.h"
@@ -59,18 +60,18 @@ static void sync_plant_seed_after_furniture_transform( map &m, const tripoint_bu
     if( growth_multiplier <= 0.0f ) {
         return;
     }
-    const time_duration threshold = iexamine::get_plant_stage_threshold( growth_stages,
+    const float crop_growth_speed = ::get_option<float>( "CROP_GROWTH_SPEED" );
+    const time_duration threshold = iexamine::get_plant_stage_threshold( *seed->type->seed,
                                     new_stage_idx );
     const time_duration current_effective = iexamine::get_plant_effective_growth_time( *seed,
             growth_multiplier );
 
-    if( current_effective < threshold ) {
-        iexamine::set_plant_effective_growth_turns( *seed, to_turns<int>( threshold ) );
-        seed->set_birthday( calendar::turn - threshold / growth_multiplier );
-    } else {
-        // Keep the seed birthday consistent with the existing effective time.
-        seed->set_birthday( calendar::turn - current_effective / growth_multiplier );
-    }
+    // Effective growth time is stored in base growth units.  CROP_GROWTH_SPEED only
+    // affects how fast those units accumulate during natural growth, so the
+    // threshold for a given furniture stage is the base threshold.
+    const time_duration new_effective = std::max( current_effective, threshold );
+    iexamine::set_plant_effective_growth_time( *seed, new_effective, growth_multiplier,
+            crop_growth_speed );
 }
 
 } // namespace

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -84,6 +84,7 @@
 #include "mongroup.h"
 #include "monster.h"
 #include "mtype.h"
+#include "options.h"
 #include "output.h"
 #include "overmap.h"
 #include "overmap_map_data_cache.h"
@@ -10222,21 +10223,34 @@ void map::grow_plant( const tripoint_bub_ms &p )
     const std::vector<std::pair<flag_id, time_duration>> &growth_stages =
                 seed->type->seed->get_growth_stages();
 
+    // Cache world options once per call; they are read repeatedly below.
+    const float crop_growth_speed = ::get_option<float>( "CROP_GROWTH_SPEED" );
+    const float crop_water_consumption = ::get_option<float>( "CROP_WATER_CONSUMPTION" );
+    const bool crop_overgrown_enabled = ::get_option<bool>( "CROP_OVERGROWN_ENABLED" );
+
     // Water / irrigation handling.  Irrigable furniture/plants consume water daily to grow faster.
     // We simulate day-by-day and switch furniture/growth_multiplier when the plant advances stages.
     time_duration effective_growth_time = 0_seconds;
     const int initial_max_water = iexamine::get_plant_max_water( initial_furn );
     if( initial_max_water > 0 ) {
         const time_point last_check = iexamine::get_plant_last_water_check( *seed );
-        if( last_check == time_point::from_turn( 0 ) ||
-            !seed->has_var( "seed_effective_growth_turns" ) ) {
-            // Old saves / first actualization: estimate effective growth time from current age,
-            // but clamp to at least the threshold of the current stage to avoid regressing.
-            effective_growth_time = seed->age() * initial_furn.plant->growth_multiplier;
-            const int current_stage_idx = iexamine::get_plant_current_stage_idx( *this, p, growth_stages );
+        if( !seed->has_var( "seed_effective_growth_turns" ) ||
+            last_check == time_point::from_turn( 0 ) ) {
+            // Old saves / first actualization: estimate effective growth time (base growth
+            // units) from current age, applying both the furniture multiplier and the world
+            // crop-growth-speed option so mapgen plants catch up consistently with player-grown
+            // crops.  Clamp to at least the threshold of the current stage so we never regress
+            // a plant that already visually advanced.
+            effective_growth_time = seed->age() * initial_furn.plant->growth_multiplier *
+                                    crop_growth_speed;
+            const int current_stage_idx = iexamine::get_plant_current_stage_idx( *this, p,
+                    growth_stages );
             const time_duration min_effective_for_stage =
-                iexamine::get_plant_stage_threshold( growth_stages, current_stage_idx );
+                iexamine::get_plant_stage_threshold( *seed->type->seed, current_stage_idx );
             if( effective_growth_time < min_effective_for_stage ) {
+                // Never let effective time fall below the current furniture stage,
+                // even when CROP_GROWTH_SPEED < 1.0.  Future growth still respects
+                // the world speed option; this just preserves already-visible progress.
                 effective_growth_time = min_effective_for_stage;
             }
             iexamine::set_plant_water( *seed, 0 );
@@ -10254,16 +10268,12 @@ void map::grow_plant( const tripoint_bub_ms &p )
                 int current_water = iexamine::get_plant_water( *seed );
 
                 // Determine starting stage index from current furniture flag.
-                int current_stage_idx = iexamine::get_plant_current_stage_idx( *this, p, growth_stages );
+                int current_stage_idx = iexamine::get_plant_current_stage_idx( *this, p,
+                        growth_stages );
 
-                // Precompute cumulative thresholds for each stage boundary.
-                std::vector<time_duration> stage_thresholds;
-                stage_thresholds.reserve( growth_stages.size() );
-                time_duration acc = 0_seconds;
-                for( const auto &stage : growth_stages ) {
-                    acc += stage.second;
-                    stage_thresholds.push_back( acc );
-                }
+                // Cumulative stage thresholds are precomputed during item finalize.
+                const std::vector<time_duration> &stage_thresholds =
+                    seed->type->seed->get_cumulative_stage_thresholds();
 
                 furn_id current_furn_id = furn( p );
 
@@ -10275,7 +10285,8 @@ void map::grow_plant( const tripoint_bub_ms &p )
                     const float consumption_mult = iexamine::get_plant_water_consumption_multiplier(
                                                        current_furn );
                     const int daily_consumption = std::max( 1,
-                                                            static_cast<int>( base_daily_consumption * consumption_mult ) );
+                            static_cast<int>( base_daily_consumption * consumption_mult *
+                                              crop_water_consumption ) );
 
                     // Rainwater collection for outdoor irrigable planters.
                     if( !this->is_roofed( p ) ) {
@@ -10289,11 +10300,14 @@ void map::grow_plant( const tripoint_bub_ms &p )
 
                     // Proportional irrigation bonus: partial water gives partial bonus.
                     const float water_ratio = std::min( 1.0f,
-                                                        static_cast<float>( current_water ) / daily_consumption );
-                    const float water_bonus = 1.0f + irrigation::MAX_IRRIGATION_GROWTH_BONUS * water_ratio;
+                                                        static_cast<float>( current_water ) /
+                                                        daily_consumption );
+                    const float water_bonus = 1.0f +
+                                              irrigation::MAX_IRRIGATION_GROWTH_BONUS * water_ratio;
                     const int consumed = std::min( current_water, daily_consumption );
                     current_water -= consumed;
-                    effective_growth_time += 1_days * base_mult * water_bonus;
+                    effective_growth_time += 1_days * base_mult * crop_growth_speed *
+                                             water_bonus;
 
                     // Advance through as many stages as today's effective growth allows.
                     while( current_stage_idx + 1 < static_cast<int>( growth_stages.size() ) &&
@@ -10314,7 +10328,8 @@ void map::grow_plant( const tripoint_bub_ms &p )
             }
         }
     } else {
-        // Non-irrigated plants grow strictly with real time.  Keep the
+        // Non-irrigated plants accumulate effective growth time scaled by the
+        // furniture multiplier and the world crop-growth-speed option.  Keep the
         // authoritative effective-growth-time variable in sync so helpers that
         // rely on it agree with the stage computed here.
         const time_point last_check = iexamine::get_plant_last_water_check( *seed );
@@ -10323,16 +10338,24 @@ void map::grow_plant( const tripoint_bub_ms &p )
         if( seed->has_var( "seed_effective_growth_turns" ) ) {
             effective_growth_time = time_duration::from_turns(
                                         iexamine::get_plant_effective_growth_turns( *seed ) );
-            effective_growth_time += elapsed * initial_furn.plant->growth_multiplier;
+            effective_growth_time += elapsed * initial_furn.plant->growth_multiplier *
+                                     crop_growth_speed;
         } else {
-            // Old saves: estimate from age, but clamp to the current furniture
-            // stage threshold so we never regress a plant that already visually
-            // advanced before this variable existed.
-            effective_growth_time = seed->age() * initial_furn.plant->growth_multiplier;
-            const int current_stage_idx = iexamine::get_plant_current_stage_idx( *this, p, growth_stages );
+            // Old saves: estimate effective growth time (base growth units) from age,
+            // applying both the furniture multiplier and the world crop-growth-speed option
+            // so mapgen plants catch up consistently with player-grown crops.  Clamp to the
+            // current furniture stage threshold so we never regress a plant that already
+            // visually advanced before this variable existed.
+            effective_growth_time = seed->age() * initial_furn.plant->growth_multiplier *
+                                    crop_growth_speed;
+            const int current_stage_idx = iexamine::get_plant_current_stage_idx( *this, p,
+                    growth_stages );
             const time_duration min_effective_for_stage =
-                iexamine::get_plant_stage_threshold( growth_stages, current_stage_idx );
+                iexamine::get_plant_stage_threshold( *seed->type->seed, current_stage_idx );
             if( effective_growth_time < min_effective_for_stage ) {
+                // Never let effective time fall below the current furniture stage,
+                // even when CROP_GROWTH_SPEED < 1.0.  Future growth still respects
+                // the world speed option; this just preserves already-visible progress.
                 effective_growth_time = min_effective_for_stage;
             }
         }
@@ -10365,14 +10388,27 @@ void map::grow_plant( const tripoint_bub_ms &p )
 
     const int start_stage_idx = static_cast<int>( std::distance(
             growth_stages.begin(),
-            std::find_if( growth_stages.begin(), growth_stages.end(), check_flag( current_stage.str() ) ) ) );
+            std::find_if( growth_stages.begin(), growth_stages.end(),
+                          check_flag( current_stage.str() ) ) ) );
 
-    const int stages_to_advance = std::distance(
-                                      std::find_if( growth_stages.begin(), growth_stages.end(), check_flag( current_stage.str() ) ),
-                                      std::find_if( growth_stages.begin(), growth_stages.end(), check_flag( target_stage.str() ) ) );
+    const int target_stage_idx = static_cast<int>( std::distance(
+            growth_stages.begin(),
+            std::find_if( growth_stages.begin(), growth_stages.end(),
+                          check_flag( target_stage.str() ) ) ) );
 
-    const int mature_stage_idx = iexamine::get_plant_mature_stage_idx( growth_stages );
-    const int overgrown_stage_idx = iexamine::get_plant_overgrown_stage_idx( growth_stages );
+    const int mature_stage_idx = iexamine::get_plant_mature_stage_idx( *seed->type->seed );
+    const int overgrown_stage_idx = iexamine::get_plant_overgrown_stage_idx( *seed->type->seed );
+
+    const bool overgrown_enabled = crop_overgrown_enabled;
+    // When overgrowth is disabled, clamp growth at the stage just before
+    // overgrown (usually harvest), not at mature.  Mature is too early and
+    // would prevent harvesting entirely.
+    const int max_allowed_stage_idx = overgrown_enabled || overgrown_stage_idx < 0
+                                      ? static_cast<int>( growth_stages.size() ) - 1
+                                      : overgrown_stage_idx - 1;
+    const int clamped_target_stage_idx = std::min( target_stage_idx, max_allowed_stage_idx );
+
+    const int stages_to_advance = clamped_target_stage_idx - start_stage_idx;
 
     add_msg_debug( debugmode::DF_MAP,
                    "Checking growth on a %s, aged %s. Current stage: %s. Target stage: %s. Advancing %d stages.",
@@ -10389,6 +10425,12 @@ void map::grow_plant( const tripoint_bub_ms &p )
     Character &alpha = get_avatar();
 
     for( int i = 0; i < stages_to_advance; i++ ) {
+        const int old_stage_idx = start_stage_idx + i;
+        const int new_stage_idx = start_stage_idx + i + 1;
+        if( new_stage_idx > max_allowed_stage_idx ) {
+            break;
+        }
+
         // EOCs from the previous iteration may have modified the tile; refresh the seed.
         item *current_seed = iexamine::get_seed_at( *this, p );
         if( current_seed == nullptr ) {
@@ -10417,8 +10459,6 @@ void map::grow_plant( const tripoint_bub_ms &p )
             break;
         }
 
-        const int old_stage_idx = start_stage_idx + i;
-        const int new_stage_idx = start_stage_idx + i + 1;
         const std::string old_stage = growth_stages[old_stage_idx].first.str();
         const std::string new_stage = growth_stages[new_stage_idx].first.str();
         const furn_t &new_furn = this->furn( p ).obj();
@@ -10729,7 +10769,9 @@ void map::actualize( const tripoint_rel_sm &grid )
                 fill_funnels( pnt, tmpsub->last_touched );
             }
 
-            grow_plant( pnt );
+            if( furn.has_flag( ter_furn_flag::TFLAG_PLANT ) ) {
+                grow_plant( pnt );
+            }
 
             restock_fruits( pnt, time_since_last_actualize );
 

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -56,6 +56,7 @@
 #include "math_parser_diag_value.h"
 #include "memory_fast.h"
 #include "messages.h"
+#include "options.h"
 #include "monster.h"
 #include "mtype.h"
 #include "npc.h"
@@ -1746,8 +1747,9 @@ void talk_function::field_harvest( npc &p, const std::string &place )
                     number_plots++;
 
                     int plant_count = rng( skillLevel / 2, skillLevel );
-                    plant_count *= bay.furn( plot )->plant->harvest_multiplier;
-                    plant_count = std::min( std::max( plant_count, 1 ), 12 );
+                    plant_count *= bay.furn( plot )->plant->harvest_multiplier *
+                                   ::get_option<float>( "CROP_HARVEST_MULTIPLIER" );
+                    plant_count = std::max( plant_count, 1 );
                     const int seed_cnt = std::max( 1, rng( plant_count / 4, plant_count / 2 ) );
 
                     const tripoint_bub_ms bub_plot = bay_map->get_bub( bay.get_abs( plot ) );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3175,6 +3175,35 @@ void options_manager::add_options_world_default()
              "a reasonable pace." ),
          true
        );
+
+    add_empty_line();
+
+    add_option_group( "world_default", Group( "crop_opts", to_translation( "Crop options" ),
+                      to_translation( "Options regarding crop growth, harvest yield and water consumption." ) ),
+    [&]( const std::string & page_id ) {
+        add( "CROP_GROWTH_SPEED", page_id, to_translation( "Crop growth speed" ),
+             to_translation( "Multiplier for crop growth speed.  Higher values make crops grow faster." ),
+             0.1f, 10.0f, 1.0f, 0.1f, COPT_NO_HIDE, "%.1f"
+           );
+
+        add( "CROP_HARVEST_MULTIPLIER", page_id, to_translation( "Crop harvest yield" ),
+             to_translation( "Multiplier for the number of crops harvested from a plant." ),
+             0.1f, 10.0f, 1.0f, 0.1f, COPT_NO_HIDE, "%.1f"
+           );
+
+        add( "CROP_WATER_CONSUMPTION", page_id, to_translation( "Crop water consumption" ),
+             to_translation( "Multiplier for daily water consumption of irrigated crops.  "
+                              "Higher values make crops thirstier." ),
+             0.1f, 10.0f, 1.0f, 0.1f, COPT_NO_HIDE, "%.1f"
+           );
+
+        add( "CROP_OVERGROWN_ENABLED", page_id,
+             to_translation( "Crops can wither from overgrowth" ),
+             to_translation( "If true, mature crops will eventually become overgrown and "
+                              "wither if not harvested." ),
+             true
+           );
+    } );
 }
 
 void options_manager::add_options_debug()

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -40,6 +40,7 @@
 #include "map_scale_constants.h"
 #include "mapdata.h"
 #include "messages.h"
+#include "options.h"
 #include "monster.h"
 #include "mtype.h"
 #include "output.h"
@@ -1058,7 +1059,8 @@ void vehicle::operate_reaper( map &here )
 {
     for( const vpart_reference &vp : get_enabled_parts( "REAPER" ) ) {
         const tripoint_bub_ms reaper_pos = vp.pos_bub( here );
-        int plant_produced = rng( 1, vp.info().bonus );
+        int plant_produced = std::max( 1, static_cast<int>( rng( 1, vp.info().bonus ) *
+                                       ::get_option<float>( "CROP_HARVEST_MULTIPLIER" ) ) );
         int seed_produced = rng( 1, 3 );
         const units::volume max_pickup_volume = vp.info().size / 20;
         here.grow_plant( reaper_pos );

--- a/tests/plant_test.cpp
+++ b/tests/plant_test.cpp
@@ -15,11 +15,14 @@
 #include "iexamine.h"
 #include "item.h"
 #include "itype.h"
+#include "magic.h"
 #include "magic_ter_furn_transform.h"
 #include "map.h"
 #include "map_helpers.h"
+#include "options.h"
 #include "player_helpers.h"
 #include "point.h"
+#include "skill.h"
 #include "type_id.h"
 #include "veh_type.h"
 #include "vehicle.h"
@@ -42,6 +45,8 @@ static const itype_id itype_test_seed_eoc( "test_seed_eoc" );
 static const itype_id itype_test_seed_simple( "test_seed_simple" );
 static const itype_id itype_water_clean( "water_clean" );
 
+static const skill_id skill_survival( "survival" );
+static const spell_id spell_test_fertilize_plant( "test_spell_fertilize_plant" );
 static const ter_str_id ter_t_dirtmound( "t_dirtmound" );
 static const ter_furn_transform_id ter_test_plant_seedling_to_mature( "ter_test_plant_seedling_to_mature" );
 static const ter_furn_transform_id ter_test_plant_seed_to_harvest( "ter_test_plant_seed_to_harvest" );
@@ -259,23 +264,23 @@ TEST_CASE( "plant_effective_growth_time_authority", "[plant][growth]" )
     reset_test_globals();
 
     const tripoint_bub_ms plot = u.pos_bub() + tripoint::east;
-    here.ter_set( plot, ter_t_dirtmound );
-    u.i_add( item( itype_test_seed_simple ) );
+    // Use the test (non-irrigated) plant furniture so sub-day growth stages
+    // are processed immediately instead of being deferred to the daily loop.
+    item seed( itype_test_seed_simple );
+    seed.set_birthday( calendar::turn );
+    here.add_item( plot, seed );
+    here.furn_set( plot, furn_f_test_plant_seed );
 
-    iexamine::plant_seed( u, plot, itype_test_seed_simple );
-    process_activity( u );
-
-    item *seed = iexamine::get_seed_at( here, plot );
-    REQUIRE( seed != nullptr );
-    CHECK( iexamine::get_plant_effective_growth_turns( *seed ) == 0 );
-    CHECK( here.furn( plot ) == furn_f_plant_seed );
+    item *planted_seed = iexamine::get_seed_at( here, plot );
+    REQUIRE( planted_seed != nullptr );
+    CHECK( iexamine::get_plant_effective_growth_turns( *planted_seed ) == 0 );
 
     calendar::turn += 2_seconds;
     here.grow_plant( plot );
 
-    seed = iexamine::get_seed_at( here, plot );
-    REQUIRE( seed != nullptr );
-    CHECK( iexamine::get_plant_effective_growth_turns( *seed ) > 0 );
+    planted_seed = iexamine::get_seed_at( here, plot );
+    REQUIRE( planted_seed != nullptr );
+    CHECK( iexamine::get_plant_effective_growth_turns( *planted_seed ) > 0 );
     CHECK( iexamine::is_plant_mature( here, plot ) );
 
     calendar::turn += 2_seconds;
@@ -339,6 +344,51 @@ TEST_CASE( "plant_fertilize_reduces_remaining_time", "[plant][fertilize]" )
     const std::string reduction = get_globals().get_global_value( "test_fertilize_reduction_turns" ).to_string();
     REQUIRE( !reduction.empty() );
     CHECK( std::stoi( reduction ) > 0 );
+}
+
+TEST_CASE( "plant_fertilize_speed_independence", "[plant][fertilize][world_option]" )
+{
+    map &here = get_map();
+    avatar &u = get_avatar();
+    clear_avatar();
+    clear_map_without_vision();
+    reset_test_globals();
+
+    options_manager::options_container world_opts = get_options().get_world_defaults();
+    world_opts["CROP_GROWTH_SPEED"].setValue( "2.0" );
+    get_options().set_world_options( &world_opts );
+    on_out_of_scope cleanup( [&]() {
+        get_options().set_world_options( nullptr );
+    } );
+
+    const tripoint_bub_ms plot = u.pos_bub() + tripoint::east;
+
+    // Pre-actualize the seed at the seedling stage in base effective units.
+    item seed( itype_test_seed_eoc );
+    seed.set_birthday( calendar::turn );
+    // The seedling threshold is 1h of base effective time.
+    iexamine::set_plant_effective_growth_turns( seed, to_turns<int>( 1_hours ) );
+    iexamine::set_plant_last_water_check( seed, calendar::turn );
+    here.add_item( plot, seed );
+    here.furn_set( plot, furn_f_test_plant_seedling );
+
+    item *planted_seed = iexamine::get_seed_at( here, plot );
+    REQUIRE( planted_seed != nullptr );
+    const int effective_before = iexamine::get_plant_effective_growth_turns( *planted_seed );
+
+    u.i_add( item( itype_fertilizer_commercial, calendar::turn ) );
+    iexamine::fertilize_plant( u, plot, itype_fertilizer_commercial );
+    process_activity( u );
+
+    planted_seed = iexamine::get_seed_at( here, plot );
+    REQUIRE( planted_seed != nullptr );
+    const int effective_after = iexamine::get_plant_effective_growth_turns( *planted_seed );
+
+    // Commercial fertilizer with survival 0 reduces base remaining distance by 20%.
+    // Base remaining distance to mature = 2h - 1h = 1h.
+    // Effective advancement should be 0.2h, independent of CROP_GROWTH_SPEED.
+    const time_duration expected_increase = 1_hours * 0.20f;
+    CHECK( time_duration::from_turns( effective_after - effective_before ) == expected_increase );
 }
 
 TEST_CASE( "plant_cannot_be_fertilized_twice", "[plant][fertilize]" )
@@ -528,7 +578,7 @@ TEST_CASE( "ter_transform_syncs_plant_seed_effective_growth_time", "[plant][magi
     item *synced_seed = iexamine::get_seed_at( here, plot );
     REQUIRE( synced_seed != nullptr );
     CHECK( iexamine::get_plant_current_stage_idx_from_effective( here, plot ) >=
-           iexamine::get_plant_mature_stage_idx( synced_seed->type->seed->get_growth_stages() ) );
+           iexamine::get_plant_mature_stage_idx( *synced_seed->type->seed ) );
 
     // After the forced jump the plant should still be able to reach harvest
     // through normal growth processing.
@@ -555,4 +605,671 @@ TEST_CASE( "ter_transform_syncs_plant_seed_effective_growth_time", "[plant][magi
         REQUIRE( synced_seed2 != nullptr );
         CHECK( iexamine::is_plant_harvestable( here, plot ) );
     }
+}
+
+TEST_CASE( "crop_growth_speed_world_option", "[plant][world_option]" )
+{
+    map &here = get_map();
+    avatar &u = get_avatar();
+    clear_avatar();
+    clear_map_without_vision();
+    reset_test_globals();
+
+    options_manager::options_container world_opts = get_options().get_world_defaults();
+    world_opts["CROP_GROWTH_SPEED"].setValue( "2.0" );
+    get_options().set_world_options( &world_opts );
+    on_out_of_scope cleanup( [&]() {
+        get_options().set_world_options( nullptr );
+    } );
+
+    const tripoint_bub_ms plot = u.pos_bub() + tripoint::east;
+
+    // Use the test (non-irrigated) furniture so sub-day growth stages are
+    // processed immediately instead of being deferred to the daily loop.
+    item seed( itype_test_seed_simple );
+    seed.set_birthday( calendar::turn );
+    // Initialize the authoritative variables so the test exercises normal growth,
+    // not the old-save migration path.
+    iexamine::set_plant_effective_growth_turns( seed, 0 );
+    iexamine::set_plant_last_water_check( seed, calendar::turn );
+    here.add_item( plot, seed );
+    here.furn_set( plot, furn_f_test_plant_seed );
+
+    item *planted_seed = iexamine::get_seed_at( here, plot );
+    REQUIRE( planted_seed != nullptr );
+    CHECK( here.furn( plot ) == furn_f_test_plant_seed );
+
+    // With double growth speed, 1 second of real time equals 2 seconds of effective growth.
+    calendar::turn += 1_seconds;
+    here.grow_plant( plot );
+
+    planted_seed = iexamine::get_seed_at( here, plot );
+    REQUIRE( planted_seed != nullptr );
+    CHECK( iexamine::get_plant_effective_growth_turns( *planted_seed ) >= to_turns<int>( 2_seconds ) );
+    CHECK( iexamine::is_plant_mature( here, plot ) );
+
+    // Another second should be enough to reach harvest.
+    calendar::turn += 1_seconds;
+    here.grow_plant( plot );
+
+    CHECK( iexamine::is_plant_harvestable( here, plot ) );
+}
+
+TEST_CASE( "crop_harvest_multiplier_world_option", "[plant][world_option]" )
+{
+    map &here = get_map();
+    avatar &u = get_avatar();
+    clear_avatar();
+    clear_map_without_vision();
+    reset_test_globals();
+    u.set_skill_level( skill_survival, 2 );
+
+    options_manager::options_container world_opts = get_options().get_world_defaults();
+    world_opts["CROP_HARVEST_MULTIPLIER"].setValue( "2.0" );
+    get_options().set_world_options( &world_opts );
+    on_out_of_scope cleanup( [&]() {
+        get_options().set_world_options( nullptr );
+    } );
+
+    const tripoint_bub_ms plot = u.pos_bub() + tripoint::east;
+    here.add_item( plot, item( itype_test_seed_eoc ) );
+    here.furn_set( plot, furn_f_test_plant_harvest );
+
+    iexamine::harvest_plant( u, plot, false );
+
+    const std::string harvest_count =
+        get_globals().get_global_value( "test_harvest_count" ).to_string();
+    REQUIRE( !harvest_count.empty() );
+    CHECK( std::stoi( harvest_count ) >= 2 );
+}
+
+TEST_CASE( "crop_water_consumption_world_option", "[plant][world_option][water]" )
+{
+    map &here = get_map();
+    avatar &u = get_avatar();
+    clear_avatar();
+    clear_map_without_vision();
+    reset_test_globals();
+
+    const tripoint_bub_ms plot = u.pos_bub() + tripoint::east;
+    here.add_item( plot, item( itype_test_seed_eoc ) );
+    here.furn_set( plot, furn_f_planter_seed );
+    item *seed = iexamine::get_seed_at( here, plot );
+    REQUIRE( seed != nullptr );
+    iexamine::set_plant_water( *seed, 100 );
+    iexamine::set_plant_effective_growth_turns( *seed, 0 );
+
+    // Advance time before recording the last check so the stored timestamp is
+    // non-zero.  This avoids the old-save actualization path and lets the
+    // irrigated daily loop see a full day of elapsed time.
+    calendar::turn += 1_days;
+    iexamine::set_plant_last_water_check( *seed, calendar::turn );
+
+    SECTION( "default consumption" ) {
+        options_manager::options_container world_opts = get_options().get_world_defaults();
+        get_options().set_world_options( &world_opts );
+        on_out_of_scope cleanup( [&]() {
+            get_options().set_world_options( nullptr );
+        } );
+
+        calendar::turn += 1_days;
+        here.grow_plant( plot );
+
+        seed = iexamine::get_seed_at( here, plot );
+        REQUIRE( seed != nullptr );
+        const int water_default = iexamine::get_plant_water( *seed );
+        CHECK( water_default < 100 );
+        CHECK( water_default >= 80 );
+    }
+
+    SECTION( "doubled consumption" ) {
+        options_manager::options_container world_opts = get_options().get_world_defaults();
+        world_opts["CROP_WATER_CONSUMPTION"].setValue( "2.0" );
+        get_options().set_world_options( &world_opts );
+        on_out_of_scope cleanup( [&]() {
+            get_options().set_world_options( nullptr );
+        } );
+
+        calendar::turn += 1_days;
+        here.grow_plant( plot );
+
+        seed = iexamine::get_seed_at( here, plot );
+        REQUIRE( seed != nullptr );
+        const int water_doubled = iexamine::get_plant_water( *seed );
+        CHECK( water_doubled < 100 );
+        CHECK( water_doubled <= 60 );
+    }
+}
+
+TEST_CASE( "crop_overgrown_enabled_world_option", "[plant][world_option]" )
+{
+    map &here = get_map();
+    avatar &u = get_avatar();
+    clear_avatar();
+    clear_map_without_vision();
+    reset_test_globals();
+
+    options_manager::options_container world_opts = get_options().get_world_defaults();
+    world_opts["CROP_OVERGROWN_ENABLED"].setValue( "false" );
+    get_options().set_world_options( &world_opts );
+    on_out_of_scope cleanup( [&]() {
+        get_options().set_world_options( nullptr );
+    } );
+
+    const tripoint_bub_ms plot = u.pos_bub() + tripoint::east;
+    here.add_item( plot, item( itype_test_seed_eoc ) );
+    here.furn_set( plot, furn_f_test_plant_mature );
+
+    item *seed = iexamine::get_seed_at( here, plot );
+    REQUIRE( seed != nullptr );
+
+    // Advance time before recording state so the last-check timestamp is non-zero.
+    // This prevents the non-irrigated path from falling back to seed age (which is
+    // also zero at turn zero) and makes the elapsed-time calculation meaningful.
+    calendar::turn += 1_hours;
+    iexamine::set_plant_last_water_check( *seed, calendar::turn );
+    // Enough effective time to normally reach overgrown stage.
+    iexamine::set_plant_effective_growth_turns( *seed, to_turns<int>( 10_hours ) );
+
+    calendar::turn += 1_hours;
+    here.grow_plant( plot );
+
+    seed = iexamine::get_seed_at( here, plot );
+    REQUIRE( seed != nullptr );
+    // Overgrown must still be prevented.
+    CHECK( !iexamine::is_plant_overgrown( here, plot ) );
+    CHECK( here.furn( plot ) != furn_f_test_plant_overgrown );
+    // But the plant must be allowed to reach harvest, not be stuck at mature.
+    CHECK( here.furn( plot ) == furn_f_test_plant_harvest );
+    CHECK( iexamine::is_plant_harvestable( here, plot ) );
+}
+
+TEST_CASE( "crop_growth_speed_does_not_boost_ter_transform", "[plant][world_option][magic][ter_transform]" )
+{
+    map &here = get_map();
+    avatar &u = get_avatar();
+    clear_avatar();
+    clear_map_without_vision();
+
+    options_manager::options_container world_opts = get_options().get_world_defaults();
+    world_opts["CROP_GROWTH_SPEED"].setValue( "2.0" );
+    get_options().set_world_options( &world_opts );
+    on_out_of_scope cleanup( [&]() {
+        get_options().set_world_options( nullptr );
+    } );
+
+    const tripoint_bub_ms plot = u.pos_bub() + tripoint::east;
+
+    // Advance time before creating the seed so the birthday and any derived
+    // timestamps stay positive.  At turn zero, subtracting the mature threshold
+    // produces a negative value that gets clamped back to zero.
+    calendar::turn += 1_days;
+
+    // Set up a seedling whose internal timer has not advanced at all.
+    item seed( itype_test_seed_simple );
+    seed.set_birthday( calendar::turn );
+    here.add_item( plot, seed );
+    here.furn_set( plot, furn_f_test_plant_seedling );
+
+    REQUIRE( here.furn( plot ) == furn_f_test_plant_seedling );
+
+    REQUIRE( ter_test_plant_seedling_to_mature.is_valid() );
+    ter_test_plant_seedling_to_mature->transform( here, plot );
+
+    CHECK( here.furn( plot ) == furn_f_test_plant_mature );
+
+    item *synced_seed = iexamine::get_seed_at( here, plot );
+    REQUIRE( synced_seed != nullptr );
+
+    const int mature_stage_idx = iexamine::get_plant_mature_stage_idx( *synced_seed->type->seed );
+    REQUIRE( mature_stage_idx >= 0 );
+    const time_duration mature_threshold = iexamine::get_plant_stage_threshold(
+            *synced_seed->type->seed, mature_stage_idx );
+    const float growth_multiplier = here.furn( plot )->plant->growth_multiplier;
+
+    // The transform should synchronize to the mature threshold in base time.
+    const time_duration expected_effective = mature_threshold;
+    const time_duration actual_effective = iexamine::get_plant_effective_growth_time(
+            *synced_seed, growth_multiplier );
+    CHECK( actual_effective == expected_effective );
+    CHECK( synced_seed->birthday() == calendar::turn - mature_threshold /
+            ( growth_multiplier * 2.0f ) );
+}
+
+TEST_CASE( "ter_transform_does_not_boost_stage_with_high_crop_speed",
+           "[plant][world_option][magic][ter_transform]" )
+{
+    map &here = get_map();
+    avatar &u = get_avatar();
+    clear_avatar();
+    clear_map_without_vision();
+
+    options_manager::options_container world_opts = get_options().get_world_defaults();
+    world_opts["CROP_GROWTH_SPEED"].setValue( "2.0" );
+    get_options().set_world_options( &world_opts );
+    on_out_of_scope cleanup( [&]() {
+        get_options().set_world_options( nullptr );
+    } );
+
+    const tripoint_bub_ms plot = u.pos_bub() + tripoint::east;
+
+    calendar::turn += 1_days;
+
+    // Set up a seedling with zero effective growth time.
+    item seed( itype_test_seed_simple );
+    seed.set_birthday( calendar::turn );
+    // Initialize the authoritative variables so the subsequent grow_plant() sees
+    // zero elapsed time and does not advance the plant past the transformed stage.
+    iexamine::set_plant_effective_growth_turns( seed, 0 );
+    iexamine::set_plant_last_water_check( seed, calendar::turn );
+    here.add_item( plot, seed );
+    here.furn_set( plot, furn_f_test_plant_seedling );
+
+    REQUIRE( here.furn( plot ) == furn_f_test_plant_seedling );
+
+    // Transform to mature.  With CROP_GROWTH_SPEED = 2.0 the old code would have
+    // written effective = mature_threshold * 2, causing grow_plant to overshoot to
+    // harvest.  After the fix it must stay at mature even if grow_plant is called
+    // immediately.
+    REQUIRE( ter_test_plant_seedling_to_mature.is_valid() );
+    ter_test_plant_seedling_to_mature->transform( here, plot );
+
+    CHECK( here.furn( plot ) == furn_f_test_plant_mature );
+
+    here.grow_plant( plot );
+
+    // Should still be mature, not boosted to harvest.
+    CHECK( here.furn( plot ) == furn_f_test_plant_mature );
+    CHECK( !iexamine::is_plant_harvestable( here, plot ) );
+}
+
+TEST_CASE( "crop_growth_speed_does_not_boost_spell_fertilize", "[plant][world_option][magic]" )
+{
+    map &here = get_map();
+    avatar &u = get_avatar();
+    clear_avatar();
+    clear_map_without_vision();
+    reset_test_globals();
+
+    options_manager::options_container world_opts = get_options().get_world_defaults();
+    world_opts["CROP_GROWTH_SPEED"].setValue( "2.0" );
+    get_options().set_world_options( &world_opts );
+    on_out_of_scope cleanup( [&]() {
+        get_options().set_world_options( nullptr );
+    } );
+
+    const tripoint_bub_ms plot = u.pos_bub() + tripoint::east;
+    here.ter_set( plot, ter_t_dirtmound );
+
+    u.i_add( item( itype_test_seed_simple ) );
+    iexamine::plant_seed( u, plot, itype_test_seed_simple );
+    process_activity( u );
+
+    item *seed = iexamine::get_seed_at( here, plot );
+    REQUIRE( seed != nullptr );
+    REQUIRE( seed->has_var( "seed_effective_growth_turns" ) );
+
+    // Let a small amount of real time pass so the plant has a non-zero base effective time.
+    calendar::turn += 1_seconds;
+    here.grow_plant( plot );
+
+    seed = iexamine::get_seed_at( here, plot );
+    REQUIRE( seed != nullptr );
+    const float growth_multiplier = here.furn( plot )->plant->growth_multiplier;
+    const time_duration before_effective = iexamine::get_plant_effective_growth_time( *seed,
+            growth_multiplier );
+
+    const spell sp( spell_test_fertilize_plant );
+    spell_effect::fertilize_plant( sp, u, plot );
+
+    seed = iexamine::get_seed_at( here, plot );
+    REQUIRE( seed != nullptr );
+    const time_duration after_effective = iexamine::get_plant_effective_growth_time( *seed,
+            growth_multiplier );
+
+    // The spell should advance the plant by 25% of its total growth duration,
+    // regardless of world speed.
+    const std::vector<std::pair<flag_id, time_duration>> &growth_stages =
+        seed->type->seed->get_growth_stages();
+    time_duration total_growth_time = 0_seconds;
+    for( const auto &stage : growth_stages ) {
+        total_growth_time += stage.second;
+    }
+    const time_duration expected_advance = total_growth_time * 0.25f;
+    CHECK( after_effective - before_effective == expected_advance );
+}
+
+TEST_CASE( "old_save_crop_actualization_scales_with_speed", "[plant][world_option]" )
+{
+    map &here = get_map();
+    avatar &u = get_avatar();
+    clear_avatar();
+    clear_map_without_vision();
+
+    options_manager::options_container world_opts = get_options().get_world_defaults();
+    world_opts["CROP_GROWTH_SPEED"].setValue( "2.0" );
+    get_options().set_world_options( &world_opts );
+    on_out_of_scope cleanup( [&]() {
+        get_options().set_world_options( nullptr );
+    } );
+
+    const tripoint_bub_ms plot = u.pos_bub() + tripoint::east;
+
+    // Advance time before creating the old-format seed so the birthday is
+    // positive and age() reflects the intended 5 seconds.
+    calendar::turn += 1_days;
+
+    // Old-format seed: no seed_effective_growth_turns, birthday in the past.
+    item seed( itype_test_seed_simple );
+    seed.set_birthday( calendar::turn - 5_seconds );
+    here.add_item( plot, seed );
+    here.furn_set( plot, furn_f_test_plant_seedling );
+
+    // grow_plant actualizes the old save crop into the new base-time format.
+    here.grow_plant( plot );
+
+    item *synced_seed = iexamine::get_seed_at( here, plot );
+    REQUIRE( synced_seed != nullptr );
+    REQUIRE( synced_seed->has_var( "seed_effective_growth_turns" ) );
+
+    const float growth_multiplier = here.furn( plot )->plant->growth_multiplier;
+    const time_duration expected_effective = 5_seconds * growth_multiplier * 2.0f;
+    const time_duration actual_effective = iexamine::get_plant_effective_growth_time(
+            *synced_seed, growth_multiplier );
+    CHECK( actual_effective == expected_effective );
+}
+
+TEST_CASE( "mapgen_crop_actualization_scales_with_speed", "[plant][world_option][mapgen]" )
+{
+    map &here = get_map();
+    avatar &u = get_avatar();
+    clear_avatar();
+    clear_map_without_vision();
+
+    options_manager::options_container world_opts = get_options().get_world_defaults();
+    world_opts["CROP_GROWTH_SPEED"].setValue( "4.0" );
+    get_options().set_world_options( &world_opts );
+    on_out_of_scope cleanup( [&]() {
+        get_options().set_world_options( nullptr );
+    } );
+
+    const tripoint_bub_ms plot = u.pos_bub() + tripoint::east;
+
+    // Simulate a mapgen-planted seed: birthday at start of cataclysm and a
+    // visual stage already set by the mapgen definition.
+    item seed( itype_test_seed_simple );
+    seed.set_birthday( calendar::start_of_cataclysm );
+    here.add_item( plot, seed );
+    here.furn_set( plot, furn_f_test_plant_seedling );
+
+    // Advance world time before actualization, as if the player is only now
+    // entering the reality bubble.
+    calendar::turn = calendar::start_of_cataclysm + 1_seconds;
+
+    here.grow_plant( plot );
+
+    item *synced_seed = iexamine::get_seed_at( here, plot );
+    REQUIRE( synced_seed != nullptr );
+    REQUIRE( synced_seed->has_var( "seed_effective_growth_turns" ) );
+
+    // With 4x speed, 1 second of real age should yield 4 seconds of base
+    // effective growth, pushing the plant well past the harvest threshold.
+    CHECK( iexamine::is_plant_harvestable( here, plot ) );
+
+    const float growth_multiplier = here.furn( plot )->plant->growth_multiplier;
+    const time_duration expected_effective = 1_seconds * growth_multiplier * 4.0f;
+    const time_duration actual_effective = iexamine::get_plant_effective_growth_time(
+            *synced_seed, growth_multiplier );
+    CHECK( actual_effective == expected_effective );
+}
+
+TEST_CASE( "old_save_slow_speed_does_not_regress_stage", "[plant][world_option]" )
+{
+    map &here = get_map();
+    avatar &u = get_avatar();
+    clear_avatar();
+    clear_map_without_vision();
+
+    options_manager::options_container world_opts = get_options().get_world_defaults();
+    world_opts["CROP_GROWTH_SPEED"].setValue( "0.5" );
+    get_options().set_world_options( &world_opts );
+    on_out_of_scope cleanup( [&]() {
+        get_options().set_world_options( nullptr );
+    } );
+
+    const tripoint_bub_ms plot = u.pos_bub() + tripoint::east;
+
+    // Advance time before creating the old-format seed so the birthday is positive.
+    calendar::turn += 1_days;
+
+    // Old-format seed with very little real age but furniture already at mature.
+    // With 0.5x speed the un-clamped effective time would fall below the mature
+    // threshold, but the actualization must preserve the visible stage.
+    item seed( itype_test_seed_simple );
+    seed.set_birthday( calendar::turn - 1_seconds );
+    here.add_item( plot, seed );
+    here.furn_set( plot, furn_f_test_plant_mature );
+
+    here.grow_plant( plot );
+
+    item *synced_seed = iexamine::get_seed_at( here, plot );
+    REQUIRE( synced_seed != nullptr );
+    REQUIRE( synced_seed->has_var( "seed_effective_growth_turns" ) );
+
+    // The furniture stage is the authority: the plant must still read as mature.
+    CHECK( iexamine::is_plant_mature( here, plot ) );
+    CHECK( here.furn( plot ) == furn_f_test_plant_mature );
+
+    const float growth_multiplier = here.furn( plot )->plant->growth_multiplier;
+    const int mature_stage_idx = iexamine::get_plant_mature_stage_idx( *synced_seed->type->seed );
+    REQUIRE( mature_stage_idx >= 0 );
+    const time_duration mature_threshold = iexamine::get_plant_stage_threshold(
+            *synced_seed->type->seed, mature_stage_idx );
+
+    // Effective time must be at least the mature threshold to match the visible stage,
+    // even though the real age is much smaller.
+    const time_duration actual_effective = iexamine::get_plant_effective_growth_time(
+            *synced_seed, growth_multiplier );
+    CHECK( actual_effective >= mature_threshold );
+}
+
+TEST_CASE( "plant_helper_follows_effective_time", "[plant][stage]" )
+{
+    map &here = get_map();
+    avatar &u = get_avatar();
+    clear_avatar();
+    clear_map_without_vision();
+    reset_test_globals();
+
+    const tripoint_bub_ms plot = u.pos_bub() + tripoint::east;
+
+    // Furniture is still at seed, but the effective growth time already says harvest.
+    // The helper must follow effective time, not the stale furniture flag.
+    item seed( itype_test_seed_simple );
+    seed.set_birthday( calendar::turn );
+    iexamine::set_plant_effective_growth_turns( seed, to_turns<int>( 10_seconds ) );
+    here.add_item( plot, seed );
+    here.furn_set( plot, furn_f_test_plant_seed );
+
+    CHECK( iexamine::is_plant_harvestable( here, plot ) );
+    CHECK( iexamine::is_plant_mature( here, plot ) );
+}
+
+TEST_CASE( "can_fertilize_syncs_furniture_with_effective_time", "[plant][fertilize]" )
+{
+    map &here = get_map();
+    avatar &u = get_avatar();
+    clear_avatar();
+    clear_map_without_vision();
+    reset_test_globals();
+
+    const tripoint_bub_ms plot = u.pos_bub() + tripoint::east;
+
+    // Furniture is seedling, but effective time is already past mature.
+    // can_fertilize() should call grow_plant() first, see the plant is mature,
+    // and reject fertilization.
+    item seed( itype_test_seed_eoc );
+    seed.set_birthday( calendar::turn );
+    // Effective time past mature (2h) but below overgrown (4h) so the result is
+    // deterministic regardless of CROP_OVERGROWN_ENABLED.
+    iexamine::set_plant_effective_growth_turns( seed, to_turns<int>( 150_minutes ) );
+    here.add_item( plot, seed );
+    here.furn_set( plot, furn_f_test_plant_seedling );
+
+    ret_val<void> result = multi_farm_activity_actor::can_fertilize( u, plot );
+    CHECK( !result.success() );
+    // grow_plant() should also have advanced the furniture to match effective time.
+    CHECK( here.furn( plot ) == furn_f_test_plant_mature );
+}
+
+namespace
+{
+static const furn_str_id furn_f_test_planter_high_water_seed( "test_f_planter_high_water_seed" );
+static const furn_str_id furn_f_test_planter_high_water_mature( "test_f_planter_high_water_mature" );
+
+// Verify that seed->birthday() is consistent with seed_effective_growth_turns for the
+// current world options.  This catches drift between the authoritative variable and
+// the derived birthday cache.
+void check_seed_birthday_consistency( const item &seed, float growth_multiplier,
+                                      float crop_growth_speed )
+{
+    REQUIRE( seed.has_var( "seed_effective_growth_turns" ) );
+    const time_duration effective = time_duration::from_turns(
+                                        iexamine::get_plant_effective_growth_turns( seed ) );
+    const time_point expected_birthday = calendar::turn - effective /
+                                         ( growth_multiplier * crop_growth_speed );
+    CHECK( seed.birthday() == expected_birthday );
+}
+} // namespace
+
+TEST_CASE( "plant_birthday_stays_consistent_after_fertilize", "[plant][fertilize]" )
+{
+    map &here = get_map();
+    avatar &u = get_avatar();
+    clear_avatar();
+    clear_map_without_vision();
+    reset_test_globals();
+
+    options_manager::options_container world_opts = get_options().get_world_defaults();
+    world_opts["CROP_GROWTH_SPEED"].setValue( "2.0" );
+    get_options().set_world_options( &world_opts );
+    on_out_of_scope cleanup( [&]() {
+        get_options().set_world_options( nullptr );
+    } );
+
+    const tripoint_bub_ms plot = u.pos_bub() + tripoint::east;
+
+    // Advance time before creating the seed so the post-fertilize birthday does not
+    // get clamped to turn_zero by item::set_birthday.
+    calendar::turn += 1_days;
+
+    item seed( itype_test_seed_eoc );
+    seed.set_birthday( calendar::turn );
+    // Pre-initialize authoritative variables so the test exercises the normal path.
+    iexamine::set_plant_effective_growth_turns( seed, 0 );
+    iexamine::set_plant_last_water_check( seed, calendar::turn );
+    here.add_item( plot, seed );
+    here.furn_set( plot, furn_f_test_plant_seedling );
+    u.i_add( item( itype_fertilizer_commercial, calendar::turn ) );
+
+    item *planted_seed = iexamine::get_seed_at( here, plot );
+    REQUIRE( planted_seed != nullptr );
+
+    iexamine::fertilize_plant( u, plot, itype_fertilizer_commercial );
+    process_activity( u );
+
+    planted_seed = iexamine::get_seed_at( here, plot );
+    REQUIRE( planted_seed != nullptr );
+    check_seed_birthday_consistency( *planted_seed, here.furn( plot )->plant->growth_multiplier, 2.0f );
+}
+
+TEST_CASE( "plant_birthday_stays_consistent_after_transform", "[plant][magic][ter_transform]" )
+{
+    map &here = get_map();
+    avatar &u = get_avatar();
+    clear_avatar();
+    clear_map_without_vision();
+
+    options_manager::options_container world_opts = get_options().get_world_defaults();
+    world_opts["CROP_GROWTH_SPEED"].setValue( "2.0" );
+    get_options().set_world_options( &world_opts );
+    on_out_of_scope cleanup( [&]() {
+        get_options().set_world_options( nullptr );
+    } );
+
+    const tripoint_bub_ms plot = u.pos_bub() + tripoint::east;
+
+    calendar::turn += 1_days;
+
+    item seed( itype_test_seed_simple );
+    seed.set_birthday( calendar::turn );
+    here.add_item( plot, seed );
+    here.furn_set( plot, furn_f_test_plant_seedling );
+
+    REQUIRE( ter_test_plant_seedling_to_mature.is_valid() );
+    ter_test_plant_seedling_to_mature->transform( here, plot );
+
+    CHECK( here.furn( plot ) == furn_f_test_plant_mature );
+
+    item *synced_seed = iexamine::get_seed_at( here, plot );
+    REQUIRE( synced_seed != nullptr );
+    check_seed_birthday_consistency( *synced_seed, here.furn( plot )->plant->growth_multiplier, 2.0f );
+}
+
+TEST_CASE( "plant_old_save_irrigated_planter_migration", "[plant][world_option][water]" )
+{
+    map &here = get_map();
+    avatar &u = get_avatar();
+    clear_avatar();
+    clear_map_without_vision();
+
+    options_manager::options_container world_opts = get_options().get_world_defaults();
+    world_opts["CROP_GROWTH_SPEED"].setValue( "2.0" );
+    get_options().set_world_options( &world_opts );
+    on_out_of_scope cleanup( [&]() {
+        get_options().set_world_options( nullptr );
+    } );
+
+    const tripoint_bub_ms plot = u.pos_bub() + tripoint::east;
+
+    // Advance time so the seed's birthday can be positive.
+    calendar::turn += 1_days;
+
+    // Old-format seed in an irrigable planter: no seed_effective_growth_turns, but the
+    // furniture already shows a later stage.  The irrigated migration branch must still
+    // clamp effective time to the visible stage threshold.
+    item seed( itype_test_seed_simple );
+    seed.set_birthday( calendar::turn - 1_seconds );
+    seed.erase_var( "seed_effective_growth_turns" );
+    here.add_item( plot, seed );
+    here.furn_set( plot, furn_f_test_planter_high_water_seed );
+
+    here.grow_plant( plot );
+
+    item *synced_seed = iexamine::get_seed_at( here, plot );
+    REQUIRE( synced_seed != nullptr );
+    REQUIRE( synced_seed->has_var( "seed_effective_growth_turns" ) );
+
+    const int mature_stage_idx = iexamine::get_plant_mature_stage_idx( *synced_seed->type->seed );
+    REQUIRE( mature_stage_idx >= 0 );
+    const time_duration mature_threshold = iexamine::get_plant_stage_threshold(
+            *synced_seed->type->seed, mature_stage_idx );
+
+    // The furniture is still at seed, so effective time only needs to be non-negative.
+    // The migration path deliberately preserves the original birthday (real planting time),
+    // so we only check that a valid effective time was created.
+    const time_duration actual_effective = iexamine::get_plant_effective_growth_time(
+            *synced_seed, here.furn( plot )->plant->growth_multiplier );
+    CHECK( actual_effective >= 0_seconds );
+
+    // Now test the mature-stage clamp by jumping the furniture forward and migrating again.
+    here.furn_set( plot, furn_f_test_planter_high_water_mature );
+    synced_seed->erase_var( "seed_effective_growth_turns" );
+    here.grow_plant( plot );
+
+    synced_seed = iexamine::get_seed_at( here, plot );
+    REQUIRE( synced_seed != nullptr );
+    const time_duration mature_effective = iexamine::get_plant_effective_growth_time(
+            *synced_seed, here.furn( plot )->plant->growth_multiplier );
+    CHECK( mature_effective >= mature_threshold );
 }


### PR DESCRIPTION
#### 概述 (Summary)
种植系统优化，提供成长速度，收获量和是否允许荒芜的世界配置，以及优化原本的成长进度追赶机制，法术催熟效果不再和季节长度挂钩，以及填充更多的单元测试用例以覆盖各种情况

#### 改动目的 (Purpose of change)
希望提供玩家更多可以自定义种植系统参数的空间

#### 解决方案描述 (Describe the solution)

提供世界配置参数，以及更改原本的成长进度增加逻辑以及进入现实气泡后的进度追赶逻辑

#### 你考虑过的替代方案 (Describe alternatives you've considered)

无

#### 测试 (Testing)

可以运行 plant_test进行单元测试，然后可以进游戏调整世界配置以测试

#### 补充说明 (Additional context)