### PR TITLE
fix(windows): restore SDL2 release variant

### DIFF
--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -149,7 +149,7 @@ jobs:
 
     - name: Build
       run: |
-          msbuild -m -p:Configuration=Release -p:Platform=x64 "-target:Cataclysm-vcpkg-static;Cataclysm-test-vcpkg-static;JsonFormatter-vcpkg-static;zzip" msvc-full-features/Cataclysm-vcpkg-static.sln
+          msbuild -m -p:Configuration=Release -p:Platform=x64 -p:UseSDL3=true "-target:Cataclysm-vcpkg-static;Cataclysm-test-vcpkg-static;JsonFormatter-vcpkg-static;zzip" msvc-full-features/Cataclysm-vcpkg-static.sln
 
     - name: Get ccache cache age cutoff
       id: get-cache-age

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -724,7 +724,7 @@ jobs:
           CDDA_RELEASE_BUILD: 1
           VCPKG_OVERLAY_TRIPLETS: ${{ github.workspace }}\.github\vcpkg_triplets
         run: |
-          msbuild -m -p:Configuration=Release -p:Platform=${{ matrix.arch }} "-target:Cataclysm-vcpkg-static;JsonFormatter-vcpkg-static;zzip" msvc-full-features\Cataclysm-vcpkg-static.sln
+          msbuild -m -p:Configuration=Release -p:Platform=${{ matrix.arch }} -p:UseSDL3=false "-target:Cataclysm-vcpkg-static;JsonFormatter-vcpkg-static;zzip" msvc-full-features\Cataclysm-vcpkg-static.sln
           .\build-scripts\windist.ps1
           mv cataclysmdda-0.J.zip ccb-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.zip
       - name: Build CDDA (windows msvc, SDL3)
@@ -734,7 +734,7 @@ jobs:
           CDDA_RELEASE_BUILD: 1
           VCPKG_OVERLAY_TRIPLETS: ${{ github.workspace }}\.github\vcpkg_triplets
         run: |
-          msbuild -m -p:Configuration=Release -p:Platform=${{ matrix.arch }} "-target:Cataclysm-vcpkg-static;JsonFormatter-vcpkg-static;zzip" msvc-full-features\Cataclysm-vcpkg-static.sln
+          msbuild -m -p:Configuration=Release -p:Platform=${{ matrix.arch }} -p:UseSDL3=true "-target:Cataclysm-vcpkg-static;JsonFormatter-vcpkg-static;zzip" msvc-full-features\Cataclysm-vcpkg-static.sln
           .\build-scripts\windist.ps1 -SDL3
           mv cataclysmdda-0.J.zip ccb-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.zip
       - name: Build CDDA (osx, SDL2)

--- a/doc/c++/COMPILING.md
+++ b/doc/c++/COMPILING.md
@@ -175,7 +175,9 @@ To build the SDL2 fallback explicitly, pass `SDL3=0`:
 
     make -j2 TILES=1 SOUND=1 SDL3=0 RELEASE=1 USE_HOME_DIR=1
 
-For CMake, `-DTILES=ON` also defaults to SDL3; pass `-DUSE_SDL3=OFF` to build the SDL2 fallback.
+For CMake, `-DTILES=ON` also defaults to SDL3; pass `-DUSE_SDL3=OFF` to build the SDL2 fallback. For Windows MSVC, tiled configurations default to SDL3; pass `-p:UseSDL3=false` to build the SDL2 fallback.
+
+The Windows release builds use the same MSVC project for both variants: pass `-p:UseSDL3=false` for the SDL2 package and `-p:UseSDL3=true` for the SDL3 package.
 
 The -j2 flag means it will compile with two parallel processes. It can be omitted or changed to -j4 in a more modern processor. If there is no desire to have sound, those flags can also be omitted. The USE_HOME_DIR flag places the user files, like configurations and saves, into the home folder, making it easier for backups, and can also be omitted.
 

--- a/msvc-full-features/Cataclysm-common.props
+++ b/msvc-full-features/Cataclysm-common.props
@@ -22,9 +22,15 @@
     <_CDDA_ENABLE_THIN_ARCHIVES Condition="'$(CDDA_ENABLE_THIN_ARCHIVES)'!=''">true</_CDDA_ENABLE_THIN_ARCHIVES>
     <_CDDA_USE_LLD_LINK>false</_CDDA_USE_LLD_LINK>
     <_CDDA_USE_LLD_LINK Condition="'$(CDDA_USE_LLD_LINK)'!='' Or $(_CDDA_ENABLE_THIN_ARCHIVES)">true</_CDDA_USE_LLD_LINK>
+    <_UseSDL3>false</_UseSDL3>
+    <_UseSDL3 Condition="'$(UseSDL3)'=='' And !$(Configuration.Contains(NoTiles))">true</_UseSDL3>
+    <_UseSDL3 Condition="'$(UseSDL3)'=='true'">true</_UseSDL3>
+    <_UseSDL3 Condition="'$(UseSDL3)'=='false'">false</_UseSDL3>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgAdditionalInstallOptions>--clean-after-build</VcpkgAdditionalInstallOptions>
+    <VcpkgAdditionalInstallOptions Condition="$(_UseSDL3)">$(VcpkgAdditionalInstallOptions) --x-feature=sdl3</VcpkgAdditionalInstallOptions>
+    <VcpkgAdditionalInstallOptions Condition="!$(_UseSDL3) And !$(Configuration.Contains(NoTiles))">$(VcpkgAdditionalInstallOptions) --x-feature=sdl2</VcpkgAdditionalInstallOptions>
     <CustomBuildAfterTargets>VcpkgInstallManifestDependencies</CustomBuildAfterTargets>
   </PropertyGroup>
   <PropertyGroup Condition="$(_CDDA_USE_CCACHE)">
@@ -71,7 +77,7 @@
     <ClCompile Condition="!$(Configuration.Contains(NoTiles))">
       <PreprocessorDefinitions>TILES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
-    <ClCompile Condition="!$(Configuration.Contains(NoTiles))">
+    <ClCompile Condition="!$(Configuration.Contains(NoTiles)) And $(_UseSDL3)">
       <PreprocessorDefinitions>USE_SDL3;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ClCompile Condition="$(Configuration.Contains(NoTiles)) And !$(Configuration.Contains(Headless))">
@@ -114,7 +120,7 @@
       <AdditionalLibraryDirectories Condition="$(Configuration.StartsWith(Release))">
         $(ProjectDir)vcpkg_installed\$(VcpkgTripet)\$(VcpkgTriplet)\lib;%(AdditionalLibraryDirectories)
       </AdditionalLibraryDirectories>
-      <AdditionalDependencies>
+      <AdditionalDependencies Condition="$(_UseSDL3)">
         brotlicommon.lib;
         brotlidec.lib;
         brotlienc.lib;
@@ -139,6 +145,46 @@
         vorbisenc.lib;
         vorbisfile.lib;
         zs$(VcpkgLibSuffix).lib;
+        <!-- win32 deps of the vcpkg deps -->
+        Advapi32.lib;
+        Cfgmgr32.lib;
+        Gdi32.lib;
+        Imm32.lib;
+        Ole32.lib;
+        OleAut32.lib;
+        Setupapi.lib;
+        Shell32.lib;
+        Shlwapi.lib;
+        User32.lib;
+        Version.lib;
+        Winmm.lib;
+        %(AdditionalDependencies)
+      </AdditionalDependencies>
+      <AdditionalDependencies Condition="!$(_UseSDL3) And !$(Configuration.Contains(NoTiles))">
+        brotlicommon.lib;
+        brotlidec.lib;
+        brotlienc.lib;
+        bz2$(VcpkgLibSuffix).lib;
+        FLAC.lib;
+        FLAC++.lib;
+        freetype$(VcpkgLibSuffix).lib;
+        jpeg.lib;
+        libpng16$(VcpkgLibSuffix).lib;
+        libwavpack.lib;
+        mpg123.lib;
+        ogg.lib;
+        out123.lib;
+        pdcurses.lib;
+        SDL2_image-static$(VcpkgLibSuffix).lib;
+        SDL2_mixer-static$(VcpkgLibSuffix).lib;
+        SDL2_ttf$(VcpkgLibSuffix).lib;
+        SDL2-static$(VcpkgLibSuffix).lib;
+        syn123.lib;
+        turbojpeg.lib;
+        vorbis.lib;
+        vorbisenc.lib;
+        vorbisfile.lib;
+        zlib$(VcpkgLibSuffix).lib;
         <!-- win32 deps of the vcpkg deps -->
         Advapi32.lib;
         Cfgmgr32.lib;

--- a/msvc-full-features/Cataclysm-libMZ-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-libMZ-vcpkg-static.vcxproj
@@ -128,13 +128,12 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <!-- Headless has no audio backend: omit SDL_SOUND so cata_allocator.cpp
-           and friends do not pull SDL headers (the fork is SDL3-only and a
-           headless build links neither SDL nor curses). -->
+           and friends do not pull SDL headers. -->
       <PreprocessorDefinitions Condition="!$(Configuration.Contains(Headless))">_CONSOLE;SDL_SOUND;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="$(Configuration.Contains(Headless))">_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <PreBuildEvent>
-      <Command>..\msvc-full-features\prebuild.cmd</Command>
+      <Command>..\msvc-full-features\prebuild.cmd $(_UseSDL3)</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
@@ -213,6 +212,7 @@
       <Command>.\vcpkg_installed\x64-windows-static\x64-windows-static\tools\glslang\glslangValidator.exe --quiet -V -S frag -o %(SpvOutput) %(Identity) &amp;&amp; .\vcpkg_installed\x64-windows-static\x64-windows-static\tools\sdl3-shadercross\shadercross.exe %(SpvOutput) -s SPIRV -d DXIL -o %(DxilOutput)</Command>
       <Outputs>%(SpvOutput);%(DxilOutput)</Outputs>
       <AdditionalInputs>vcpkg_installed\x64-windows-static\x64-windows-static\tools\glslang\glslangValidator.exe;vcpkg_installed\x64-windows-static\x64-windows-static\tools\sdl3-shadercross\shadercross.exe;vcpkg_installed\x64-windows-static\x64-windows-static\tools\sdl3-shadercross\dxcompiler.dll</AdditionalInputs>
+      <ExcludedFromBuild Condition="!$(_UseSDL3)">true</ExcludedFromBuild>
       <Message>%(Identity) -^&gt; %(DxilOutput)</Message>
       <BuildInParallel>true</BuildInParallel>
     </CustomBuild>

--- a/msvc-full-features/ImGui-lib-vcpkg-static.vcxproj
+++ b/msvc-full-features/ImGui-lib-vcpkg-static.vcxproj
@@ -61,8 +61,18 @@
   <ItemGroup>
     <ClInclude Include="..\src\third-party\imgui\imconfig.h" />
     <ClInclude Include="..\src\third-party\imgui\imgui.h" />
-    <ClInclude Include="..\src\third-party\imgui\imgui_impl_sdl3.h" />
-    <ClInclude Include="..\src\third-party\imgui\imgui_impl_sdlrenderer3.h" />
+    <ClInclude Include="..\src\third-party\imgui\imgui_impl_sdl2.h">
+      <ExcludedFromBuild Condition="$(_UseSDL3)">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\src\third-party\imgui\imgui_impl_sdlrenderer2.h">
+      <ExcludedFromBuild Condition="$(_UseSDL3)">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\src\third-party\imgui\imgui_impl_sdl3.h">
+      <ExcludedFromBuild Condition="!$(_UseSDL3)">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\src\third-party\imgui\imgui_impl_sdlrenderer3.h">
+      <ExcludedFromBuild Condition="!$(_UseSDL3)">true</ExcludedFromBuild>
+    </ClInclude>
     <ClInclude Include="..\src\third-party\imgui\imgui_internal.h" />
     <ClInclude Include="..\src\third-party\imgui\imstb_rectpack.h" />
     <ClInclude Include="..\src\third-party\imgui\imgui_stdlib.h" />
@@ -77,8 +87,18 @@
     <ClCompile Include="..\src\third-party\imgui\imgui_demo.cpp" />
     <ClCompile Include="..\src\third-party\imgui\imgui_draw.cpp" />
     <ClCompile Include="..\src\third-party\imgui\imgui_freetype.cpp" />
-    <ClCompile Include="..\src\third-party\imgui\imgui_impl_sdl3.cpp" />
-    <ClCompile Include="..\src\third-party\imgui\imgui_impl_sdlrenderer3.cpp" />
+    <ClCompile Include="..\src\third-party\imgui\imgui_impl_sdl2.cpp">
+      <ExcludedFromBuild Condition="$(_UseSDL3)">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\src\third-party\imgui\imgui_impl_sdlrenderer2.cpp">
+      <ExcludedFromBuild Condition="$(_UseSDL3)">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\src\third-party\imgui\imgui_impl_sdl3.cpp">
+      <ExcludedFromBuild Condition="!$(_UseSDL3)">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\src\third-party\imgui\imgui_impl_sdlrenderer3.cpp">
+      <ExcludedFromBuild Condition="!$(_UseSDL3)">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\src\third-party\imgui\imgui_stdlib.cpp" />
     <ClCompile Include="..\src\third-party\imgui\imgui_tables.cpp" />
     <ClCompile Include="..\src\third-party\imgui\imgui_widgets.cpp" />

--- a/msvc-full-features/vcpkg.json
+++ b/msvc-full-features/vcpkg.json
@@ -1,18 +1,36 @@
 {
   "name": "cdda-vcpkg-dependencies",
   "version-string": "0.J",
-  "port-version": 1,
   "dependencies": [
-    { "name": "pdcurses", "version>=": "3.9#4", "platform": "windows" },
-    "sdl3",
-    { "name": "sdl3-image", "features": [ "jpeg", "png" ] },
-    "sdl3-ttf",
-    { "name": "sdl3-mixer",
-      "features": [ "libflac", "mpg123", "wavpack", "libvorbis" ],
-      "default-features": false
-    },
-    { "name": "glslang", "features": [ "tools" ] },
-    "sdl3-shadercross"
+    { "name": "pdcurses", "version>=": "3.9#4", "platform": "windows" }
   ],
+  "features": {
+    "sdl2": {
+      "description": "Build against SDL2.",
+      "dependencies": [
+        "libvorbis",
+        { "name": "sdl2", "version>=": "2.26.4#0" },
+        { "name": "sdl2-image", "features": [ "libjpeg-turbo" ] },
+        { "name": "sdl2-mixer", "features": [ "libflac", "mpg123", "wavpack" ],
+          "default-features": false
+        },
+        "sdl2-ttf"
+      ]
+    },
+    "sdl3": {
+      "description": "Build against SDL3 instead of SDL2.",
+      "dependencies": [
+        "sdl3",
+        { "name": "sdl3-image", "features": [ "jpeg", "png" ] },
+        "sdl3-ttf",
+        { "name": "sdl3-mixer",
+          "features": [ "libflac", "mpg123", "wavpack", "libvorbis" ],
+          "default-features": false
+        },
+        { "name": "glslang", "features": [ "tools" ] },
+        "sdl3-shadercross"
+      ]
+    }
+  },
   "builtin-baseline": "f6672d8e480ccdecddfad3fd1b838ba369ffe6cd"
 }


### PR DESCRIPTION
## Fixes

- Restore Windows MSVC SDL2/SDL3 vcpkg feature selection.
- Build the ordinary Windows release with `UseSDL3=false` and the SDL3 release with `UseSDL3=true`.
- Restore conditional SDL2/SDL3 ImGui backends and linker libraries.
- Skip SDL3 shader custom builds for SDL2 and document the Windows switch.

This fixes the ordinary Windows graphics-and-sounds package being mislabeled while still containing an SDL3 build.

## Validation

- `python3 -m json.tool msvc-full-features/vcpkg.json`
- XML validation for the modified MSVC project/property files
- YAML parsing for both modified workflows
- SDL2 core path compile with `SDL3=0`
- SDL3 core path compile with `SDL3=1`
- `git diff --check`