### PR TITLE
revert(android): separate gesture PRs

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4,7 +4,6 @@
 #include "render_backend.h"
 
 #include <algorithm>
-#include <array>
 #include <bitset>
 #include <chrono>
 #include <climits>
@@ -2867,7 +2866,7 @@ bool game::try_get_left_click_action( action_id &act, const tripoint_bub_ms &mou
     return true;
 }
 
-bool game::try_get_right_click_action( action_id &act, tripoint_bub_ms &mouse_target )
+bool game::try_get_right_click_action( action_id &act, const tripoint_bub_ms &mouse_target )
 {
     map &here = get_map();
 
@@ -2881,79 +2880,6 @@ bool game::try_get_right_click_action( action_id &act, tripoint_bub_ms &mouse_ta
         // of right-click canceling an auto move before it is initiated.
         return false;
     }
-
-#if defined(__ANDROID__)
-    // A stationary long press arrives as a synthetic secondary click.  Use it
-    // only to seed a visible cursor: releasing the finger must never immediately
-    // execute an action on a possibly obscured or misidentified tile.
-    const int previous_zoom = get_zoom();
-    const int configured_min = get_option<int>( "ANDROID_ZOOM_MIN" );
-    const int configured_max = get_option<int>( "ANDROID_ZOOM_MAX" );
-    const int minimum_zoom = std::min( configured_min, configured_max );
-    const int maximum_zoom = std::max( configured_min, configured_max );
-    const int selection_zoom = std::clamp( get_option<int>( "ANDROID_CONTEXT_ZOOM" ),
-                                           minimum_zoom, maximum_zoom );
-    const int temporary_zoom = std::max( previous_zoom, selection_zoom );
-    if( temporary_zoom != previous_zoom ) {
-        set_zoom( temporary_zoom );
-        mark_main_ui_adaptor_resize();
-    }
-
-    tripoint_bub_ms center = mouse_target;
-    look_around_result selected = look_around( /*show_window=*/true, center, mouse_target,
-                                  /*has_first_point=*/false, /*select_zone=*/false,
-                                  /*peeking=*/false, /*is_moving_zone=*/false,
-                                  tripoint_bub_ms::zero, /*change_lv=*/false );
-
-    // Restore an automatic temporary zoom, but preserve an explicit pinch made
-    // while the selection cursor was open.
-    if( get_zoom() == temporary_zoom && previous_zoom != temporary_zoom ) {
-        set_zoom( previous_zoom );
-        mark_main_ui_adaptor_resize();
-    }
-    if( !selected.position ) {
-        return false;
-    }
-    mouse_target = *selected.position;
-
-    static constexpr std::array<action_id, 8> contextual_actions = {
-        ACTION_EXAMINE, ACTION_PICKUP, ACTION_OPEN, ACTION_CLOSE,
-        ACTION_BUTCHER, ACTION_CHAT, ACTION_MOVE_UP, ACTION_MOVE_DOWN
-    };
-    const auto has_contextual_action = [&]( const tripoint_bub_ms & pos ) {
-        return std::any_of( contextual_actions.begin(), contextual_actions.end(),
-        [&]( const action_id candidate ) {
-            return can_interact_at( candidate, here, pos );
-        } );
-    };
-
-    // If the finger landed on empty ground, snap to the nearest visible actionable
-    // tile in a one-tile halo.  The highlighted cursor still gives the player a
-    // chance to adjust before this point.
-    if( !has_contextual_action( mouse_target ) ) {
-        std::optional<tripoint_bub_ms> snapped;
-        int best_distance = INT_MAX;
-        for( const tripoint_bub_ms &candidate : here.points_in_radius( mouse_target, 1 ) ) {
-            if( candidate.z() != mouse_target.z() || !u.sees( here, candidate ) ||
-                !has_contextual_action( candidate ) ) {
-                continue;
-            }
-            const int distance = square_dist( mouse_target.xy(), candidate.xy() );
-            if( distance < best_distance ) {
-                best_distance = distance;
-                snapped = candidate;
-            }
-        }
-        if( !snapped ) {
-            add_msg( _( "Nothing relevant near the selected tile." ) );
-            return false;
-        }
-        mouse_target = *snapped;
-    }
-
-    act = handle_interact( here, mouse_target );
-    return act != ACTION_NULL;
-#endif
 
     const bool is_adjacent = square_dist( mouse_target.xy(), u.pos_bub().xy() ) <= 1;
     const bool is_self = square_dist( mouse_target.xy(), u.pos_bub().xy() ) <= 0;

--- a/src/game.h
+++ b/src/game.h
@@ -1133,7 +1133,7 @@ class game
         bool do_regular_action( action_id &act, avatar &player_character,
                                 const std::optional<tripoint_bub_ms> &mouse_target );
         bool handle_action();
-        bool try_get_right_click_action( action_id &act, tripoint_bub_ms &mouse_target );
+        bool try_get_right_click_action( action_id &act, const tripoint_bub_ms &mouse_target );
         bool try_get_left_click_action( action_id &act, const tripoint_bub_ms &mouse_target );
         // If loc is empty then use all the items in character inventory including bionics.
         void item_action_menu( item_location loc = item_location() ); // Displays item action menu

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3449,33 +3449,6 @@ void options_manager::add_options_android()
                                         to_translation( "Android gestures options" ),
                                         to_translation( "Options regarding Android gestures." ) ),
     [&]( const std::string & page_id ) {
-        add( "ANDROID_LONG_PRESS_CONTEXT", page_id,
-             to_translation( "Long press selects a map tile" ),
-             to_translation( "If true, holding one finger still during gameplay opens precise tile selection instead of repeatedly sending the tap key." ),
-             true
-           );
-
-        add( "ANDROID_CONTEXT_ZOOM", page_id, to_translation( "Tile selection zoom" ),
-             to_translation( "Temporarily enlarge map tiles to at least this scale while selecting a tile after a long press." ),
-             4, 64, 48
-           );
-
-        add( "ANDROID_CONTINUOUS_ZOOM", page_id,
-             to_translation( "Continuous pinch zoom" ),
-             to_translation( "If true, pinch gestures resize map tiles continuously instead of changing one large zoom step after release." ),
-             true
-           );
-
-        add( "ANDROID_ZOOM_MIN", page_id, to_translation( "Minimum map zoom" ),
-             to_translation( "The smallest map tile scale allowed during continuous Android pinch zoom." ),
-             4, 64, 4
-           );
-
-        add( "ANDROID_ZOOM_MAX", page_id, to_translation( "Maximum map zoom" ),
-             to_translation( "The largest map tile scale allowed during continuous Android pinch zoom." ),
-             4, 64, 64
-           );
-
         add( "ANDROID_TAP_KEY", page_id, to_translation( "Tap key (in-game)" ),
              to_translation( "The key to press when tapping during gameplay." ),
              ".", 1

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -139,9 +139,6 @@ std::unique_ptr<cata_tiles> overmap_tilecontext;
 static uint32_t lastupdate = 0;
 static uint32_t interval = 25;
 static bool needupdate = false;
-// Synthetic Android touch clicks carry their own coordinates.  Preserve them
-// instead of replacing them with the (usually stale) hardware mouse position.
-static bool last_input_has_explicit_mouse_pos = false;
 static bool need_invalidate_framebuffers = false;
 palette_array windowsPalette;
 
@@ -4541,9 +4538,6 @@ static uint32_t finger_down_time = 0;
 static uint32_t finger_repeat_time = 0;
 // the last time a single tap was detected. used for double-tap detection.
 static uint32_t last_tap_time = 0;
-static float pinch_start_distance = 0.0f;
-static int pinch_start_zoom = 0;
-static bool pinch_zoom_handled = false;
 // when did the hardware back button start being pressed? 0 if not touching, otherwise the time in milliseconds.
 static uint32_t ac_back_down_time = 0;
 // has a second finger touched the screen while the first was touching?
@@ -4557,57 +4551,6 @@ static bool quick_shortcuts_toggle_handled = false;
 uint32_t finger_repeat_delay = 500;
 // should we make sure the sdl surface is visible? set to true whenever the SDL window is shown.
 static bool needs_sdl_surface_visibility_refresh = true;
-
-input_context touch_input_context;
-static bool android_has_active_world();
-static void android_request_repaint();
-
-static bool android_map_zoom_context()
-{
-    const std::string &category = touch_input_context.get_category();
-    return android_has_active_world() && ( category == "DEFAULTMODE" || category == "LOOK" );
-}
-
-static void android_begin_pinch_zoom()
-{
-    pinch_start_distance = std::hypot( finger_down_x - second_finger_down_x,
-                                      finger_down_y - second_finger_down_y );
-    pinch_start_zoom = g ? g->get_zoom() : 0;
-    pinch_zoom_handled = false;
-}
-
-static void android_update_pinch_zoom()
-{
-    if( !get_option<bool>( "ANDROID_CONTINUOUS_ZOOM" ) || !android_map_zoom_context() ||
-        !g || pinch_start_distance <= 0.0f || pinch_start_zoom <= 0 ) {
-        return;
-    }
-
-    const float current_distance = std::hypot( finger_curr_x - second_finger_curr_x,
-                                   finger_curr_y - second_finger_curr_y );
-    if( current_distance <= 0.0f ) {
-        return;
-    }
-
-    const int configured_min = get_option<int>( "ANDROID_ZOOM_MIN" );
-    const int configured_max = get_option<int>( "ANDROID_ZOOM_MAX" );
-    const int minimum_zoom = std::min( configured_min, configured_max );
-    const int maximum_zoom = std::max( configured_min, configured_max );
-    int target_zoom = static_cast<int>( std::lround( pinch_start_zoom * current_distance /
-                      pinch_start_distance ) );
-    // Two-unit steps feel continuous while avoiding a resize for every pixel of motion.
-    target_zoom = 2 * static_cast<int>( std::lround( target_zoom / 2.0f ) );
-    target_zoom = std::clamp( target_zoom, minimum_zoom, maximum_zoom );
-
-    if( target_zoom != g->get_zoom() ) {
-        g->set_zoom( target_zoom );
-        g->mark_main_ui_adaptor_resize();
-        android_request_repaint();
-        ui_manager::redraw_invalidated();
-        needupdate = true;
-        pinch_zoom_handled = true;
-    }
-}
 
 // SDL_FingerID is an opaque per-touch ID, not a 0-based index, so map raw
 // IDs to local slots 0/1/2 here.
@@ -4652,6 +4595,8 @@ std::map<std::string, quick_shortcuts_t> quick_shortcuts_map;
 // A copy of the last known input_context from the input manager. It's important this is a copy, as there are times
 // the input manager has an empty input_context (eg. when player is moving over slow objects) and we don't want our
 // quick shortcuts to disappear momentarily.
+input_context touch_input_context;
+
 static bool android_has_active_world()
 {
     return world_generator && world_generator->active_world;
@@ -5820,14 +5765,7 @@ static void CheckMessages()
             finger_down_time > 0 &&
             ticks - finger_down_time > static_cast<uint32_t>
             ( get_option<int>( "ANDROID_INITIAL_DELAY" ) ) ) {
-            const float held_distance = std::hypot( finger_curr_x - finger_down_x,
-                                        finger_curr_y - finger_down_y );
-            const float hold_deadzone = get_option<float>( "ANDROID_DEADZONE_RANGE" ) *
-                                        std::max( WindowWidth, WindowHeight );
-            const bool precision_hold = is_default_mode &&
-                                        get_option<bool>( "ANDROID_LONG_PRESS_CONTEXT" ) &&
-                                        held_distance < hold_deadzone;
-            if( !precision_hold && ticks - finger_repeat_time > finger_repeat_delay ) {
+            if( ticks - finger_repeat_time > finger_repeat_delay ) {
                 handle_finger_input( ticks );
                 finger_repeat_time = ticks;
                 // Prevent repeating inputs on the next call to this function if there is a fingerup event
@@ -5873,9 +5811,6 @@ static void CheckMessages()
 #endif
 
     last_input = input_event();
-#if defined(__ANDROID__)
-    last_input_has_explicit_mouse_pos = false;
-#endif
 
     if( pop_extra_button_input( last_input ) ) {
         text_refresh = true;
@@ -6260,16 +6195,9 @@ static void CheckMessages()
                             }
                         }
 
-                        if( is_two_finger_touch ) {
-                            android_update_pinch_zoom();
-                        }
-
                     } else if( slot == 1 ) {
                         second_finger_curr_x = GetFingerX( ev, WindowWidth );
                         second_finger_curr_y = GetFingerY( ev, WindowHeight );
-                        if( is_two_finger_touch ) {
-                            android_update_pinch_zoom();
-                        }
                     } else if( slot == 2 ) {
                         third_finger_curr_x = GetFingerX( ev, WindowWidth );
                         third_finger_curr_y = GetFingerY( ev, WindowHeight );
@@ -6293,7 +6221,6 @@ static void CheckMessages()
                             second_finger_down_x = second_finger_curr_x = GetFingerX( ev, WindowWidth );
                             second_finger_down_y = second_finger_curr_y = GetFingerY( ev, WindowHeight );
                             is_two_finger_touch = true;
-                            android_begin_pinch_zoom();
                         }
                     } else if( finger_slot_for( GetFingerID( ev ), true ) == 2 ) {
                         if( !is_quick_shortcut_touch ) {
@@ -6301,9 +6228,6 @@ static void CheckMessages()
                             third_finger_down_y = third_finger_curr_y = GetFingerY( ev, WindowHeight );
                             is_three_finger_touch = true;
                             is_two_finger_touch = false;
-                            pinch_start_distance = 0.0f;
-                            pinch_start_zoom = 0;
-                            pinch_zoom_handled = false;
                         }
                     }
                     break;
@@ -6339,7 +6263,7 @@ static void CheckMessages()
                         } else {
                             if( is_two_finger_touch ) {
                                 // handle zoom in/out
-                                if( !pinch_zoom_handled && is_default_mode ) {
+                                if( is_default_mode ) {
                                     float x1 = ( finger_curr_x - finger_down_x );
                                     float y1 = ( finger_curr_y - finger_down_y );
                                     float d1 = std::sqrt( x1 * x1 + y1 * y1 );
@@ -6462,29 +6386,9 @@ static void CheckMessages()
                                     }
                                 }
 
-                            } else {
-                                const float held_distance = std::hypot( finger_curr_x - finger_down_x,
-                                                            finger_curr_y - finger_down_y );
-                                const float hold_deadzone = get_option<float>( "ANDROID_DEADZONE_RANGE" ) *
-                                                            std::max( WindowWidth, WindowHeight );
-                                const bool precision_hold = is_default_mode &&
-                                                            get_option<bool>( "ANDROID_LONG_PRESS_CONTEXT" ) &&
-                                                            ticks - finger_down_time > static_cast<uint32_t>(
-                                                                    get_option<int>( "ANDROID_INITIAL_DELAY" ) ) &&
-                                                            held_distance < hold_deadzone;
-                                if( precision_hold ) {
-                                    last_input = input_event( MouseInput::RightButtonReleased,
-                                                              input_event_t::mouse );
-                                    const SDL_Point touch_point = window_to_display_buffer_coords( SDL_Point{
-                                        static_cast<int>( std::lround( finger_curr_x ) ),
-                                        static_cast<int>( std::lround( finger_curr_y ) )
-                                    } );
-                                    last_input.mouse_pos = point( touch_point.x, touch_point.y );
-                                    last_input_has_explicit_mouse_pos = true;
-                                } else if( ticks - finger_down_time <= static_cast<uint32_t>(
-                                               get_option<int>( "ANDROID_INITIAL_DELAY" ) ) ) {
-                                    handle_finger_input( ticks );
-                                }
+                            } else if( ticks - finger_down_time <= static_cast<uint32_t>(
+                                           get_option<int>( "ANDROID_INITIAL_DELAY" ) ) ) {
+                                handle_finger_input( ticks );
                             }
                         }
                         third_finger_down_x = third_finger_curr_x = second_finger_down_x = second_finger_curr_x =
@@ -6493,9 +6397,6 @@ static void CheckMessages()
                                                   finger_down_y = finger_curr_y = -1.0f;
                         is_two_finger_touch = false;
                         is_three_finger_touch = false;
-                        pinch_start_distance = 0.0f;
-                        pinch_start_zoom = 0;
-                        pinch_zoom_handled = false;
                         finger_down_time = 0;
                         finger_repeat_time = 0;
                         // ensure virtual joystick and quick shortcuts are updated properly
@@ -6958,16 +6859,13 @@ input_event input_manager::get_input_event( const keyboard_mode preferred_keyboa
     // Sample the raw mouse position (window coords) and convert into
     // display_buffer coords so canonical gameplay picking matches the
     // domain ImGui and tile draws use.
-    if( !last_input_has_explicit_mouse_pos ) {
+    {
         point raw;
         GetMouseState( &raw.x, &raw.y );
         const SDL_Point buf_pt = window_to_display_buffer_coords( SDL_Point{ raw.x, raw.y } );
         last_input.mouse_pos.x = buf_pt.x;
         last_input.mouse_pos.y = buf_pt.y;
     }
-#if defined(__ANDROID__)
-    last_input_has_explicit_mouse_pos = false;
-#endif
     if( last_input.type == input_event_t::keyboard_char ) {
         previously_pressed_key = last_input.get_first_input();
 #if defined(__ANDROID__)


### PR DESCRIPTION
Reverts the Android continuous-pinch and precise-long-press changes that were unintentionally included when PR #368 merged. Keeps the #368 version/input/layout fixes and the #370 Windows SDL2 restoration intact. The gesture work will be reintroduced through PRs #366 and #367 after this revert is merged.