### PR TITLE
Fix unloading nested containers in AIM

### DIFF
--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1829,18 +1829,16 @@ void advanced_inventory::action_examine( advanced_inv_listitem *sitem,
 }
 
 bool advanced_inventory::action_unload( advanced_inv_listitem *sitem,
-                                        advanced_inventory_pane &spane, advanced_inventory_pane &dpane )
+                                        advanced_inventory_pane &/*spane*/, advanced_inventory_pane &dpane )
 {
     avatar &u = get_avatar();
-    item_location src = spane.container;
     item_location dest = dpane.container;
 
-    if( !src && sitem ) {
-        src = sitem->items.front();
-    } else {
+    if( !sitem ) {
         add_msg( m_info, _( "Nothing to unload." ) );
         return false;
     }
+    item_location src = sitem->items.front();
 
     do_return_entry();
     // always exit to proc do_return_entry, even when no activity was assigned

--- a/tests/advanced_inventory_test.cpp
+++ b/tests/advanced_inventory_test.cpp
@@ -27,6 +27,7 @@
 
 
 static const itype_id itype_backpack( "backpack" );
+static const itype_id itype_bag_plastic( "bag_plastic" );
 static const itype_id itype_debug_backpack( "debug_backpack" );
 static const itype_id itype_knife_combat( "knife_combat" );
 static const itype_id itype_test_9mm_ammo( "test_9mm_ammo" );
@@ -114,6 +115,50 @@ static int u_carry_amount( item &it )
         amount = std::min( weightmax, amount );
     }
     return amount;
+}
+
+TEST_CASE( "AIM_unload_nested_container_from_container_view", "[items][advanced_inv]" )
+{
+    avatar &u = get_avatar();
+    clear_avatar();
+    clear_map_without_vision();
+
+    // Give unloaded contents somewhere to go instead of dropping at the avatar's feet.
+    u.worn.wear_item( u, item( itype_debug_backpack ), false, false );
+
+    item inner_container( itype_bag_plastic );
+    REQUIRE( inner_container.put_in( item( itype_knife_combat ),
+                                     pocket_type::CONTAINER ).success() );
+    item outer_container( itype_backpack );
+    REQUIRE( outer_container.put_in( inner_container, pocket_type::CONTAINER ).success() );
+
+    map &here = get_map();
+    const tripoint_bub_ms pos = u.pos_bub();
+    item &outer_on_map = here.add_item_or_charges( pos, outer_container );
+
+    advanced_inventory advinv;
+    advinv.init();
+    init_panes( advinv, aim_location::AIM_CENTER, aim_location::AIM_INVENTORY );
+
+    advanced_inventory_pane &spane = advinv.get_pane( advinv.get_src() );
+    REQUIRE( spane.get_cur_item_ptr() );
+    REQUIRE( spane.get_cur_item_ptr()->items.front().get_item() == &outer_on_map );
+
+    advinv.process_action( "ITEMS_CONTAINER" );
+    recalc_panes( advinv );
+
+    REQUIRE( spane.get_area() == aim_location::AIM_CONTAINER );
+    REQUIRE( spane.get_cur_item_ptr() );
+    REQUIRE( spane.get_cur_item_ptr()->items.front()->typeId() == itype_bag_plastic );
+    REQUIRE_FALSE( spane.get_cur_item_ptr()->items.front()->empty_container() );
+
+    advinv.process_action( "UNLOAD_CONTAINER" );
+    REQUIRE( u.activity );
+    process_activity( u );
+
+    REQUIRE_FALSE( u.activity );
+    REQUIRE( u.has_amount( itype_knife_combat, 1 ) );
+    REQUIRE( outer_on_map.all_items_top().front()->empty_container() );
 }
 
 

--- a/tests/advanced_inventory_test.cpp
+++ b/tests/advanced_inventory_test.cpp
@@ -1,11 +1,12 @@
 #include <algorithm>
 #include <climits>
-#include <initializer_list>
-#include <string>
-#include <vector>
-#include <map>
-#include <utility>
 #include <cstddef>
+#include <initializer_list>
+#include <list>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "advanced_inv.h"
 #include "advanced_inv_area.h"
@@ -15,15 +16,16 @@
 #include "cata_catch.h"
 #include "character_attire.h"
 #include "coordinates.h"
-#include "item_location.h"
 #include "item.h"
-#include "map_helpers.h"
+#include "item_location.h"
 #include "map.h"
+#include "map_helpers.h"
 #include "player_helpers.h"
+#include "pocket_type.h"
+#include "ret_val.h"
 #include "rng.h"
-
-#include "units.h"
 #include "type_id.h"
+#include "units.h"
 
 
 static const itype_id itype_backpack( "backpack" );


### PR DESCRIPTION
## Summary

- make the advanced inventory unload action operate on the currently selected item while browsing a container
- add a regression test for unloading an inner container after entering an outer container with `C`

## Root cause

`advanced_inventory::action_unload` initialized its source from the pane's active container. When the pane was in container view, that location was non-null and the function immediately followed its failure branch instead of using the selected list item. As a result, a valid inner container could not be unloaded.

## Impact

Players can now use the unload action on a selected nested container from inside an outer container, matching its behavior in inventory, nearby-item, and single-tile views.

## Validation

- `git diff --check`
- `make -B obj/advanced_inv.o LOCALIZE=1 ASTYLE=0 LINTJSON=0 CCACHE=0`
- `tests/advanced_inventory_test.cpp` compiled successfully in the focused test build

A full local `cata_test` build was blocked by an unrelated existing non-Tiles compile error in `tests/tint_overlay_test.cpp` (`sprite_screen_bounds` is only defined under `TILES`) and stale mixed-PCH build artifacts. The new regression test itself compiles successfully.