### PR TITLE
Fix the `item_group` subtype issues in the `pride_items` mod.

### DIFF
--- a/data/mods/pride_items/itemgroups.json
+++ b/data/mods/pride_items/itemgroups.json
@@ -21,13 +21,14 @@
     "id": "accesories_personal_unisex",
     "copy-from": "accesories_personal_unisex",
     "type": "item_group",
+    "subtype": "collection",
     "extend": { "items": [ { "item": "pride_flag", "prob": 1 } ] }
   },
   {
     "id": "costume_cloacks",
     "copy-from": "costume_cloacks",
     "type": "item_group",
-    "extend": { "entries": [ { "item": "pride_flag", "prob": 2 } ] }
+    "extend": { "items": [ [ "pride_flag", 2 ] ] }
   },
   {
     "id": "music_shop",
@@ -57,12 +58,14 @@
     "id": "map_extra_college_camping_corpse",
     "copy-from": "map_extra_college_camping_corpse",
     "type": "item_group",
+    "subtype": "collection",
     "extend": { "entries": [ { "item": "pride_flag", "prob": 5 } ] }
   },
   {
     "id": "map_extra_college_sports_corpse",
     "copy-from": "map_extra_college_sports_corpse",
     "type": "item_group",
+    "subtype": "collection",
     "extend": { "entries": [ { "item": "pride_flag", "prob": 2 } ] }
   },
   {


### PR DESCRIPTION
####  Summary

Fix the `item_group` subtype issues in the `pride_items` mod.

#### Purpose of change

Players reported that the `pride_items` mod triggers item group errors when loading into a world. Investigation revealed that this triggers the `make_group_or_throw` function in `item_factory.cpp`. The root cause is that the `subtype` data was not specified for the expanded item groups, causing them to default to the `distribution` type, which subsequently throws an item group subtype conflict error.

#### Describe the solution

Explicitly set the `subtype` for item groups that were originally intended to be the `collection` subtype. Meanwhile, fixed a bug where a `distribution` type group incorrectly utilized `entries` for expansion.

#### Test

Downloaded an experimental version compiled today, replaced the modified files, and launched the game; I can now load into the world normally without any errors.