### PR TITLE
Fix ebook scan crash after loading

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3675,6 +3675,17 @@ void ebooksave_activity_actor::start( player_activity &act, Character &/*who*/ )
 
 void ebooksave_activity_actor::do_turn( player_activity &act, Character &who )
 {
+    // The device may have disappeared, or its item_location may have failed to
+    // resolve after loading a save.  Do not dereference a lost (or legacy
+    // index-mismatched) target.
+    if( !ereader || !ereader->is_estorage() ) {
+        who.add_msg_player_or_npc(
+            _( "You no longer have the e-book reader!" ),
+            _( "<npcname> no longer has the e-book reader!" ) );
+        act.set_to_null();
+        return;
+    }
+
     // only consume charges every pages_per_charge pages
     if( calendar::once_every( pages_per_charge * time_per_page ) ) {
         if( !ereader->ammo_sufficient( &who ) ) {

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -90,6 +90,7 @@ static const itype_id itype_test_backpack( "test_backpack" );
 static const itype_id itype_test_battery_disposable( "test_battery_disposable" );
 static const itype_id itype_test_boltcutter( "test_boltcutter" );
 static const itype_id itype_test_boltcutter_elec( "test_boltcutter_elec" );
+static const itype_id itype_test_eink_tablet_pc( "test_eink_tablet_pc" );
 static const itype_id itype_test_efile_copiable( "test_efile_copiable" );
 static const itype_id itype_test_hacksaw( "test_hacksaw" );
 static const itype_id itype_test_hacksaw_elec( "test_hacksaw_elec" );
@@ -1932,6 +1933,21 @@ TEST_CASE( "edevice", "[activity][edevice]" )
         REQUIRE( laptop_with_files->get_saved_recipes().empty() );
         REQUIRE( combined.size() == edevice_without_files->get_saved_recipes().size() );
     }
+}
+
+TEST_CASE( "ebooksave_activity_stops_if_ereader_is_lost", "[activity][ebooksave]" )
+{
+    avatar dummy;
+    item_location ereader = dummy.i_add( item( itype_test_eink_tablet_pc ) );
+    ebooksave_activity_actor actor( {}, ereader );
+    player_activity act( actor );
+
+    dummy.remove_item( *ereader );
+    REQUIRE_FALSE( ereader );
+
+    act.do_turn( dummy );
+
+    CHECK_FALSE( act );
 }
 
 static liquid_dest_opt dest_opt; // Defaults to LD_NULL, which is good enough when not used.


### PR DESCRIPTION
## Summary

- validate the e-book reader before the ebook-save activity dereferences it
- stop the activity safely when its saved `item_location` can no longer resolve
- add a regression test for an e-book reader disappearing during the activity

## Root cause

An autosave could persist `ACT_EBOOKSAVE` while scanning books. If the reader's `item_location` failed to resolve after loading, `ebooksave_activity_actor::do_turn` still called `ammo_sufficient()` through the invalid location. This dereferenced a null item and crashed in `item::count_by_charges`.

## Impact

Affected saves now cancel the interrupted scan with a message instead of crashing. The rest of the save remains playable.

## Validation

- rebuilt `src/activity_actor.o` with `-Werror`
- rebuilt `tests/player_activities_test.o` with `-Werror`
- `git diff --check` passed for the two changed files

A full test binary run was not completed because the local Make setup required a broad rebuild.