### PR TITLE
Sync CCB website and project lead credits across locales

### DIFF
--- a/data/credits/cs.credits
+++ b/data/credits/cs.credits
@@ -1,8 +1,8 @@
 # Lines longer than 78 characters will be wrapped automatically
 # The following line is for reference
 ##############################################################################
-<color_white>Původní autor:</color>    <color_white>Projektový Manažer:</color>
-<color_yellow> Whales </color> (<color_dark_gray>neaktivní </color>)   <color_yellow>KevinGranade</color>  
+<color_white>Původní autor:</color>    <color_white>Projektový Manažer:</color>    <color_white>Správce projektu CCB:</color>
+<color_yellow> Whales </color> (<color_dark_gray>neaktivní </color>)   <color_yellow>KevinGranade</color>     <color_yellow>g1ytx</color>
 
 <color_white>Aktuální hlavní vývojáři:</color>
 <color_yellow>mlangsdorf</color> - Vehicles, boats, basecamps and modding guides.

--- a/data/credits/de.credits
+++ b/data/credits/de.credits
@@ -2,8 +2,8 @@
 # Die folgende Zeile dient als Referenz
 ##############################################################################
 (<color_cyan>0.I</color>):</color>
-<color_white>Ursprünglicher Autor:</color>    <color_white>Projektmanager:</color>
-<color_yellow>Whales</color> (<color_dark_gray>im Ruhestand</color>)    <color_yellow>KevinGranade</color>
+<color_white>Ursprünglicher Autor:</color>    <color_white>Projektmanager:</color>    <color_white>CCB-Projektmanager:</color>
+<color_yellow>Whales</color> (<color_dark_gray>im Ruhestand</color>)    <color_yellow>KevinGranade</color>       <color_yellow>g1ytx</color>
 
 <color_white>Besonderer Dank an:</color>
 <color_yellow>Standing-Storm</color> - Creator and maintainer of the enormous 'Mind over Matter' mod and numerous contributions to other mods (fair folk and espers and wizards, oh my!)

--- a/data/credits/el.credits
+++ b/data/credits/el.credits
@@ -2,8 +2,8 @@
 # Η παρακάτω είναι γραμμή αναφοράς
 ##############################################################################
 (<color_cyan>0.I</color>):</color>
-<color_white>Αρχικός δημιουργός:</color>    <color_white>Πρότζεκτ Μάνατζερ:</color>
-<color_yellow>Whales</color> (<color_dark_gray>αποχώρησε</color>)    <color_yellow>KevinGranade</color>
+<color_white>Αρχικός δημιουργός:</color>    <color_white>Πρότζεκτ Μάνατζερ:</color>    <color_white>Διαχειριστής έργου CCB:</color>
+<color_yellow>Whales</color> (<color_dark_gray>αποχώρησε</color>)    <color_yellow>KevinGranade</color>           <color_yellow>g1ytx</color>
 
 <color_white>Ιδιαίτερες ευχαριστίες στους:</color>
 <color_yellow>Standing-Storm</color> - Creator and maintainer of the enormous 'Mind over Matter' mod and numerous contributions to other mods (fair folk and espers and wizards, oh my!)

--- a/data/credits/es_AR.credits
+++ b/data/credits/es_AR.credits
@@ -2,8 +2,8 @@
 # La línea siguiente es para referencia
 ##############################################################################
 (<color_cyan>0.I</color>):</color>
-<color_white>Autor original:</color>    <color_white>Director del proyecto:</color>
-<color_yellow>Whales</color> (<color_dark_gray>retirado</color>)    <color_yellow>KevinGranade</color>
+<color_white>Autor original:</color>    <color_white>Director del proyecto:</color>    <color_white>Director del proyecto CCB:</color>
+<color_yellow>Whales</color> (<color_dark_gray>retirado</color>)    <color_yellow>KevinGranade</color>            <color_yellow>g1ytx</color>
 
 <color_white>Agradecimientos especiales:</color>
 <color_yellow>Standing-Storm</color> - Creador y mantenedor del enorme mod ' Mente sobre materia' y numerosas contribuciones a otros mods (¡hadas, espers y magos, oh, Dios mío!)

--- a/data/credits/es_ES.credits
+++ b/data/credits/es_ES.credits
@@ -2,8 +2,8 @@
 # La siguiente línea es de referencia
 ##############################################################################
 (<color_cyan>0.I</color>):</color>
-<color_white>Autor original:</color>    <color_white>Jefe de Proyecto:</color>
-<color_yellow>Whales</color> (<color_dark_gray>retirado</color>)    <color_yellow>KevinGranade</color>
+<color_white>Autor original:</color>    <color_white>Jefe de Proyecto:</color>    <color_white>Jefe de Proyecto CCB:</color>
+<color_yellow>Whales</color> (<color_dark_gray>retirado</color>)    <color_yellow>KevinGranade</color>       <color_yellow>g1ytx</color>
 
 <color_white>Agradecimientos especiales a:</color>
 <color_yellow>Standing-Storm</color> - Creador y mantenedor del enorme mod ' Mente sobre materia' y numerosas contribuciones a otros mods (¡hadas, espers y magos, oh, Dios mío!)

--- a/data/credits/fil_PH.credits
+++ b/data/credits/fil_PH.credits
@@ -1,8 +1,8 @@
 # Lines longer than 78 characters will be wrapped automatically
 # The following line is for reference
 ##############################################################################
-<color_white>Orihinal na awtor:</color>    <color_white>Project Manager:</color>
-<color_yellow>Whales</color> (<color_dark_gray>retirado</color>)    <color_yellow>KevinGranade</color>
+<color_white>Orihinal na awtor:</color>    <color_white>Project Manager:</color>    <color_white>CCB Project Manager:</color>
+<color_yellow>Whales</color> (<color_dark_gray>retirado</color>)    <color_yellow>KevinGranade</color>         <color_yellow>g1ytx</color>
 
 <color_white>Kasalukuyang Main Developer:</color>
 <color_yellow>I-am-Erk</color> - Ultica, lore writing, ideas guy.

--- a/data/credits/fr.credits
+++ b/data/credits/fr.credits
@@ -2,8 +2,8 @@
 # La ligne qui suit sert de référence
 ##############################################################################
 (<color_cyan>0.I</color>):</color>
-<color_white>Auteur original</color><color_white>Chef de projet</color>
-<color_yellow>Whales</color>(<color_dark_gray>inactif</color>) <color_yellow>KevinGranade</color>
+<color_white>Auteur original</color>    <color_white>Chef de projet</color>    <color_white>Chef de projet CCB</color>
+<color_yellow>Whales</color> (<color_dark_gray>inactif</color>)    <color_yellow>KevinGranade</color>     <color_yellow>g1ytx</color>
 
 <color_white>Remerciements spéciaux:</color>
 <color_yellow>Standing-Storm</color> - Creator and maintainer of the enormous 'Mind over Matter' mod and numerous contributions to other mods (fair folk and espers and wizards, oh my!)

--- a/data/credits/hu.credits
+++ b/data/credits/hu.credits
@@ -2,8 +2,8 @@
 # Az alábbi sor hivatkozásként szolgál.
 ##############################################################################
 (<color_cyan>0.I</color>):</color>
-<color_white>Eredeti szerző:</color>    <color_white>Projektmenedzser:</color>
-<color_yellow>Whales</color> (<color_dark_gray>visszavonult</color>)    <color_yellow>KevinGranade</color>
+<color_white>Eredeti szerző:</color>    <color_white>Projektmenedzser:</color>     <color_white>CCB projektmenedzser:</color>
+<color_yellow>Whales</color> (<color_dark_gray>visszavonult</color>)    <color_yellow>KevinGranade</color>    <color_yellow>g1ytx</color>
 
 <color_white>Külön köszönet:</color>
 <color_yellow>Standing-Storm</color> - A hatalmas „Mind over Matter” mod alkotója és karbantartója, valamint számos más modhoz is hozzájárult (tündérek, telepaták és varázslók, ó, jaj!).

--- a/data/credits/it_IT.credits
+++ b/data/credits/it_IT.credits
@@ -2,8 +2,8 @@
 # Questa riga è per riferimento
 ##############################################################################
 (<color_cyan>0.I</color>):</color>
-<color_white>Autore originale</color><color_white>Responsabile del Progetto</color>
-<color_yellow>Whales</color> (<color_dark_gray>ritirato</color>)    <color_yellow>KevinGranade</color>
+<color_white>Autore originale</color>    <color_white>Responsabile del Progetto</color>    <color_white>Responsabile del Progetto CCB</color>
+<color_yellow>Whales</color> (<color_dark_gray>ritirato</color>)    <color_yellow>KevinGranade</color>                <color_yellow>g1ytx</color>
 
 <color_white>Un ringraziamento speciale a:</color>
 <color_yellow>Standing-Storm</color> - Creator and maintainer of the enormous 'Mind over Matter' mod and numerous contributions to other mods (fair folk and espers and wizards, oh my!)

--- a/data/credits/ja.credits
+++ b/data/credits/ja.credits
@@ -2,8 +2,8 @@
 # 次の行は参照用です
 ##############################################################################
 (<color_cyan>0.I</color>):</color>
-<color_white>オリジナルの作者:</color>    <color_white>プロジェクト管理者:</color>
-<color_yellow>Whales</color> (<color_dark_gray>引退</color>)    <color_yellow>KevinGranade</color>
+<color_white>オリジナルの作者:</color>    <color_white>プロジェクト管理者:</color>    <color_white>CCBプロジェクト管理者:</color>
+<color_yellow>Whales</color> (<color_dark_gray>引退</color>)    <color_yellow>KevinGranade</color>               <color_yellow>g1ytx</color>
 
 <color_white>スペシャルサンクス:</color>
 <color_yellow>Standing-Storm</color> - 大規模MOD「Mind over Matter」の作成と保守管理、その他MOD(妖精、超能力者、魔法使い！)にも多数貢献。

--- a/data/credits/ko.credits
+++ b/data/credits/ko.credits
@@ -2,8 +2,8 @@
 # The following line is for reference
 ##############################################################################
 (<color_cyan>0.I</color>):</color>
-<color_white>원작자:</color>    <color_white>프로젝트 매니저:</color>
-<color_yellow>Whales</color> (<color_dark_gray>은퇴</color>)    <color_yellow>KevinGranade</color>
+<color_white>원작자:</color>    <color_white>프로젝트 매니저:</color>      <color_white>CCB 프로젝트 매니저:</color>
+<color_yellow>Whales</color> (<color_dark_gray>은퇴</color>)    <color_yellow>KevinGranade</color>    <color_yellow>g1ytx</color>
 
 <color_white>도움을 주신 분들:</color>
 <color_yellow>Standing-Storm</color>- 대규모 모드인 '마인드 오버 매터' 의 제작자이자 유지 관리자이며 다른 모드(페어 포크들과 에스퍼와 마법사들!)에도 많은 기여를 했습니다.

--- a/data/credits/nb.credits
+++ b/data/credits/nb.credits
@@ -2,8 +2,8 @@
 # The following line is for reference
 ##############################################################################
 (<color_cyan>0.H</color>):</color>
-<color_white>Original forfatter:</color> <color_white>Prosjektsjef:</color>
-<color_yellow>Whales</color> (<color_dark_gray>pensjonert</color>) <color_yellow>KevinGranade</color>
+<color_white>Original forfatter:</color>    <color_white>Prosjektsjef:</color>    <color_white>CCB-prosjektsjef:</color>
+<color_yellow>Whales</color> (<color_dark_gray>pensjonert</color>)    <color_yellow>KevinGranade</color>     <color_yellow>g1ytx</color>
 
 <color_white>Nåværende hovedutviklere:</color>
 <color_yellow>anoobindisguise</color> - Relentless bugfixing and polish across most areas of the game.

--- a/data/credits/pl.credits
+++ b/data/credits/pl.credits
@@ -2,8 +2,8 @@
 # Poniższa linia jest dla przykładu
 ##############################################################################
 (<color_cyan>0.I</color>):</color>
-<color_white>Oryginalny autor:</color>         <color_white>Menedżer projektu:</color>
-<color_yellow>Whales</color> (<color_dark_gray>emerytowany</color>)    <color_yellow>KevinGranade</color>
+<color_white>Oryginalny autor:</color>    <color_white>Menedżer projektu:</color>    <color_white>Menedżer projektu CCB:</color>
+<color_yellow>Whales</color> (<color_dark_gray>emerytowany</color>)    <color_yellow>KevinGranade</color>       <color_yellow>g1ytx</color>
 
 <color_white>Specjalne podziękowania dla:</color>
 <color_yellow>Standing-Storm</color> - Twórca i konserwator ogromnego moda „Mind over Matter” i licznych kontrybucji do innych modów (fair folk i espers and wizards)

--- a/data/credits/pt_BR.credits
+++ b/data/credits/pt_BR.credits
@@ -2,8 +2,8 @@
 # A linha a seguir é para referência
 ##############################################################################
 (<color_cyan>0.I</color>):</color>
-<color_white>Autor original:</color>    <color_white>Gerente de Projeto:</color>
-<color_yellow>Whales</color> (<color_dark_gray>inativo</color>)   <color_yellow>KevinGranade</color>
+<color_white>Autor original:</color>    <color_white>Gerente de Projeto:</color>    <color_white>Gerente do Projeto CCB:</color>
+<color_yellow>Whales</color> (<color_dark_gray>inativo</color>)    <color_yellow>KevinGranade</color>          <color_yellow>g1ytx</color>
 
 <color_white>Agradecimentos especiais para:</color>
 <color_yellow>Standing-Storm</color> - Creator and maintainer of the enormous 'Mind over Matter' mod and numerous contributions to other mods (fair folk and espers and wizards, oh my!)

--- a/data/credits/ru.credits
+++ b/data/credits/ru.credits
@@ -2,8 +2,8 @@
 # Следующая строка для сравнения
 ##############################################################################
 (<color_cyan>0.I</color>):</color>
-<color_white>Автор оригинала:</color>                <color_white>Руководитель проекта:</color>
-<color_yellow>Whales</color> (<color_dark_gray>отошёл от разработки</color>)   <color_yellow>KevinGranade</color>
+<color_white>Автор оригинала:</color>    <color_white>Руководитель проекта:</color>    <color_white>Руководитель проекта CCB:</color>
+<color_yellow>Whales</color> (<color_dark_gray>отошёл от разработки</color>)    <color_yellow>KevinGranade</color><color_yellow>g1ytx</color>
 
 <color_white>Особая благодарность:</color>
 <color_yellow>Standing-Storm</color> — создатель и сопровождающий огромного мода «Mind over Matter», а также многочисленный вклад в другие мод (феи, эсперы и волшебники, вау!)

--- a/data/credits/tr.credits
+++ b/data/credits/tr.credits
@@ -2,8 +2,8 @@
 # Aşağıdaki satır referans içindir
 ##############################################################################
 (<color_cyan>0.I</color>):</color>
-<color_white>Original yapımcı:</color>    <color_white>Proje Müdürü:</color>
-<color_yellow>Whales</color> (<color_dark_gray>emekli</color>)    <color_yellow>KevinGranade</color>
+<color_white>Original yapımcı:</color>    <color_white>Proje Müdürü:</color>    <color_white>CCB Proje Müdürü:</color>
+<color_yellow>Whales</color> (<color_dark_gray>emekli</color>)    <color_yellow>KevinGranade</color>       <color_yellow>g1ytx</color>
 
 <color_white>Özel teşekkürler:</color>
 <color_yellow>Standing-Storm</color> - Creator and maintainer of the enormous 'Mind over Matter' mod and numerous contributions to other mods (fair folk and espers and wizards, oh my!)

--- a/data/credits/uk_UA.credits
+++ b/data/credits/uk_UA.credits
@@ -2,8 +2,8 @@
 # Наступний рядок для довідки
 ##############################################################################
 (<color_cyan>0.I</color>):</color>
-<color_white>Оригінальний автор:</color> <color_white>Проєкт менеджер:</color>
-<color_yellow>Whales</color>(<color_dark_gray>вже не розробляє</color>)     <color_yellow>KevinGranade</color>
+<color_white>Оригінальний автор:</color>    <color_white>Проєкт менеджер:</color>    <color_white>Менеджер проєкту CCB:</color>
+<color_yellow>Whales</color> (<color_dark_gray>вже не розробляє</color>)    <color_yellow>KevinGranade</color>  <color_yellow>g1ytx</color>
 
 <color_white>Спеціальна подяка:</color>
 <color_yellow>Standing-Storm</color> - Creator and maintainer of the enormous 'Mind over Matter' mod and numerous contributions to other mods (fair folk and espers and wizards, oh my!)

--- a/data/credits/zh_CN.credits
+++ b/data/credits/zh_CN.credits
@@ -3,7 +3,7 @@
 ##############################################################################
 (<color_cyan>0.Aa</color>):</color>
 <color_white>原作者：</color>           <color_white>原项目主管：           </color><color_white>项目主管：</color>
-<color_yellow>Whales</color>（<color_dark_gray>不再参与</color>） <color_yellow>KevinGranade</color>   <color_yellow>g1ytx</color>
+<color_yellow>Whales</color>（<color_dark_gray>不再参与</color>） <color_yellow>KevinGranade</color>           <color_yellow>g1ytx</color>
 
 <color_white>项目创始人：</color>
 <color_yellow>滑稽摸鱼Na--喵</color>（<color_cyan>lapp2333xhj</color>）

--- a/data/credits/zh_TW.credits
+++ b/data/credits/zh_TW.credits
@@ -2,8 +2,8 @@
 ＃以下僅供參考
 ##############################################################################
 (<color_cyan>0.I</color>):</color>
-<color_white> 原作者：</color>    <color_white> 專案管理員：</color>
-<color_yellow>Whales</color> (<color_dark_gray>退休</color>)    <color_yellow>KevinGranade</color>
+<color_white>原作者：</color>    <color_white>專案管理員：</color>          <color_white>CCB專案管理員：</color>
+<color_yellow>Whales</color>（<color_dark_gray>退休</color>）    <color_yellow>KevinGranade</color>    <color_yellow>g1ytx</color>
 
 <color_white>特別感謝：</color>
 <color_yellow>Standing-Storm</color> - 大型Mod 'Mind over Matter' 的创建者和维护者以及其他几个Mod的有力贡献者（平民、超能力者和巫师，哦我的天！）

--- a/data/motd/ar.motd
+++ b/data/motd/ar.motd
@@ -4,6 +4,7 @@
 <color_white>زورونا:</color>
 
 <color_light_gray>* الصفحة الرئيسية:</color>  <color_cyan> https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
 
 <color_white>البلاغ عن الأخطاء وإرسال الاقتراحات ومتابعة التطوير على:</color>
 

--- a/data/motd/cs.motd
+++ b/data/motd/cs.motd
@@ -4,6 +4,7 @@
 <color_white>Navštivte nás na:</color>
 
 <color_light_gray>*Domovská stránka:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
 
 <color_white>Hlaste případné chyby, sdělte své návrhy a sledujte vývoj hry na stránkách:</color>
 

--- a/data/motd/de.motd
+++ b/data/motd/de.motd
@@ -4,6 +4,7 @@
 <color_white>Besuche uns:</color>
 
 <color_light_gray>* Homepage:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
 
 <color_white>Melde Fehler, mache Vorschläge und folgen der Entwicklung unter:</color>
 

--- a/data/motd/el.motd
+++ b/data/motd/el.motd
@@ -4,6 +4,7 @@
 <color_white>Επισκεφθείτε μας:</color>
 
 <color_light_gray>*Αρχική σελίδα:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
 
 <color_white>* Αναφέρετε σφάλματα, προτάσεις και ακολουθήστε την ανάπτυξη στο:</color>
 

--- a/data/motd/en.motd
+++ b/data/motd/en.motd
@@ -4,6 +4,7 @@
 <color_white>Visit us:</color>
 
 <color_light_gray>* Homepage:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
 
 <color_white>Report bugs, suggestion and follow the development at:</color>
 

--- a/data/motd/es_AR.motd
+++ b/data/motd/es_AR.motd
@@ -4,6 +4,7 @@
 <color_white>Visitanos:</color>
 
 <color_light_gray>* Página web:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
 
 <color_white>Comentar bugs, sugerencias y ver el desarrollo del juego:</color>
 

--- a/data/motd/es_ES.motd
+++ b/data/motd/es_ES.motd
@@ -4,6 +4,7 @@
 <color_white>Visitanos:</color>
 
 <color_light_gray>* Pagina principal:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
 
 <color_white>Informar de errores, sugerencias y seguir el desarrollo en: </color>
 

--- a/data/motd/fil_PH.motd
+++ b/data/motd/fil_PH.motd
@@ -4,6 +4,7 @@
 <color_white>Bisitahin kami:</color>
 
 <color_light_gray>* Ang aming homepage:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
 
 <color_white>Mag-report ng bugs, suwestiyon at I-follow ang development sa:</color>
 

--- a/data/motd/fr.motd
+++ b/data/motd/fr.motd
@@ -4,6 +4,7 @@
 <color_white>Rendez-nous visite:</color>
 
 <color_light_gray>*Accueil:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
 
 <color_white> Signalez des bugs, faites des suggestions et suivez le développement du jeu sur : </color>
 

--- a/data/motd/ga_IE.motd
+++ b/data/motd/ga_IE.motd
@@ -4,6 +4,7 @@
 <color_white>Tar ar cuairt chugainn:</color>
 
 <color_light_gray>* Leathanach baile:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
 
 <color_white>Tuairiscigh fabhtanna, cuir moltaí isteach, agus lean forbairt ag:</color>
 

--- a/data/motd/hu.motd
+++ b/data/motd/hu.motd
@@ -4,6 +4,7 @@
 <color_white>Rólunk:</color>
 
 <color_light_gray>* Honlap:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
 
 <color_white>Programhibák bejelentése, új ötletek és folyamatos fejlesztés:</color>
 

--- a/data/motd/id.motd
+++ b/data/motd/id.motd
@@ -4,6 +4,7 @@
 <color_white>Kunjungi kami:</color>
 
 <color_light_gray>* Halaman depan:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
 
 <color_white>Laporkan bug, saran dan ikuti pengembangannya di:</color>
 

--- a/data/motd/it_IT.motd
+++ b/data/motd/it_IT.motd
@@ -4,6 +4,7 @@
 <color_white>Visitaci:</color>
 
 <color_light_gray>* Homepage:</color>  <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
 
 <color_white>Segnala bug, suggerimenti e segui lo sviluppo su:</color>
 

--- a/data/motd/ja.motd
+++ b/data/motd/ja.motd
@@ -4,6 +4,7 @@
 <color_white>関連リンク:</color>
 
 <color_light_gray>* 公式サイト:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
 
 <color_white>バグ報告、提案、開発状況の確認:</color>
 

--- a/data/motd/ko.motd
+++ b/data/motd/ko.motd
@@ -4,6 +4,7 @@
 <color_white>방문하기:</color>
 
 <color_light_gray>* 홈페이지:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
 
 <color_white>버그 보고, 기능 제안, 개발현황 확인:</color>
 

--- a/data/motd/nb.motd
+++ b/data/motd/nb.motd
@@ -4,6 +4,7 @@
 <color_white>Besøk oss:</color>
 
 <color_light_gray>*Hjemmeside:</color> <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
 
 <color_white>Rapporter feil, forslag og følg utviklingen ved:</color>
 

--- a/data/motd/pl.motd
+++ b/data/motd/pl.motd
@@ -4,6 +4,7 @@
 <color_white>Odwiedź nas:</color>
 
 <color_light_gray>* Strona domowa:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
 
 <color_white>Zgłaszaj błędy, sugestie i śledź rozwój gry na:</color>
 

--- a/data/motd/pt_BR.motd
+++ b/data/motd/pt_BR.motd
@@ -4,6 +4,7 @@
 <color_white>Nos visite:</color>
 
 <color_light_gray>* Homepage:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
 
 <color_white>Reporte bugs, sugestões e siga o desenvolvimento em: </color>
 

--- a/data/motd/ru.motd
+++ b/data/motd/ru.motd
@@ -4,6 +4,7 @@
 <color_white>Посетите нас:</color>
 
 <color_light_gray>* Официальный сайт:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
 
 <color_white>Сообщайте о багах, выдвигайте предложения и следите за разработкой:</color>
 

--- a/data/motd/tr.motd
+++ b/data/motd/tr.motd
@@ -4,6 +4,7 @@
 <color_white>Bizi ziyaret edin:</color>
 
 <color_light_gray>* Ana Sayfa:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
 
 <color_white>Hataları rapor etmek, öneride bulunmak ve gelişmeleri takip etmek için:</color>
 

--- a/data/motd/uk_UA.motd
+++ b/data/motd/uk_UA.motd
@@ -4,6 +4,7 @@
 <color_white>Відвідати нас:</color>
 
 <color_light_gray>* Домашня сторінка гри:</color>      <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
 
 <color_white>Повідомте про помилки, пропозиції та стежте за розробками на:</color>
 

--- a/data/motd/zh_CN.motd
+++ b/data/motd/zh_CN.motd
@@ -4,6 +4,7 @@
 <color_white>访问官网：</color>
 
 <color_light_gray>* 主页：</color><color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* CCB官网：</color><color_cyan>https://lyhglytx.github.io</color><color_light_gray>（等我中彩票换个域名）</color>
 
 <color_white>报告BUG，提交建议及跟进开发进度：</color>
 
@@ -12,9 +13,9 @@
 
 <color_white>加入论坛及讨论组：</color>
 
-<color_light_gray>* QQ群            ：</color><color_cyan>552610319</color>
-<color_light_gray>* Discord:                   </color><color_cyan>https://discord.gg/tUG9MFwCqf</color>
-<color_light_gray>* Reddit:                    </color><color_cyan>https://www.reddit.com/r/CataclysmCB/</color>
+<color_light_gray>* QQ群:</color><color_cyan>552610319</color>
+<color_light_gray>* Discord:</color><color_cyan>https://discord.gg/tUG9MFwCqf</color>
+<color_light_gray>* Reddit:</color><color_cyan>https://www.reddit.com/r/CataclysmCB/</color>
 
 <color_light_gray>官网主页上还提供了其他有用的链接。</color>
 

--- a/data/motd/zh_TW.motd
+++ b/data/motd/zh_TW.motd
@@ -4,6 +4,7 @@
 <color_white>造訪我們</color>
 
 <color_light_gray>* 官網：</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* CCB官網：</color><color_cyan>https://lyhglytx.github.io</color><color_light_gray>（等我中樂透再換個網域）</color>
 
 <color_white>回報bug，提供建議與關注開發進度：</color>
 


### PR DESCRIPTION
## Summary

- add the CCB website link to every localized main-menu MOTD
- identify `g1ytx` as the CCB project manager in every available credits locale
- align the project-manager heading and `g1ytx` using terminal display widths
- clean up spacing in the Simplified Chinese MOTD community links

## Why

The CCB website and current project-manager credit were only present in Simplified Chinese and English, leaving other game languages with stale or incomplete main-menu information.

## Localization notes

Simplified and Traditional Chinese include localized lottery/domain notes. Other MOTD files use one consistent English website note to avoid introducing unreliable machine translations. Credits preserve each locale's existing terminology and add a locale-specific CCB project-manager label.

## Validation

- confirmed all 23 MOTD files contain `https://lyhglytx.github.io`
- confirmed all 20 credits files contain `g1ytx`
- verified each credits heading and `g1ytx` start at the same terminal display column
- `git diff --check` passed