### PR TITLE
Fix map memory after movement

### DIFF
--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -1054,8 +1054,11 @@ void game::simulate_turn_suffix()
     // / crafting) — the same condition that triggers handle_progress_ui's
     // wait popup.  During those the player cannot see the world, so per-turn
     // memorisation is pure waste and the source of the stutter.
+    // Autodrive uses the progress UI too, but unlike reading/crafting it moves
+    // the avatar through a visible world and must keep recording map memory.
     const bool in_long_wait = u.has_effect( effect_sleep ) ||
-                              static_cast<bool>( u.activity.get_progress_message( u ) );
+                              ( u.activity.id() != ACT_AUTODRIVE &&
+                                static_cast<bool>( u.activity.get_progress_message( u ) ) );
     if( !in_long_wait ) {
         m.update_map_memory( u );
     }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -625,6 +625,16 @@ void map::update_map_memory( avatar &you )
 {
     ZoneScoped;
     map &here = *this;
+    const int z = you.posz();
+
+    // Map memory must use visibility from the avatar's current position.  The
+    // final step of ordinary movement and activity-driven vehicle movement can
+    // both happen without an intervening render, leaving this cache at the
+    // previous position.  Refresh it here so simulation-side memory never
+    // depends on whether a frame happened to be drawn.
+    here.build_map_cache( z );
+    here.update_visibility_cache( z );
+
     const visibility_variables &cache = here.get_visibility_variables_cache();
     const tripoint_bub_ms you_pos = you.pos_bub( here );
     // Limit the update area to the maximum view range, matching the render-path
@@ -632,7 +642,6 @@ void map::update_map_memory( avatar &you )
     const point min_visible( you_pos.x() % SEEX, you_pos.y() % SEEY );
     const point max_visible( ( you_pos.x() % SEEX ) + ( MAPSIZE - 1 ) * SEEX,
                              ( you_pos.y() % SEEY ) + ( MAPSIZE - 1 ) * SEEY );
-    const int z = you.posz();
     const level_cache &ch = here.access_cache( z );
 
     // Ensure the player's map-memory cache covers the window this pass is about

--- a/tests/map_memory_test.cpp
+++ b/tests/map_memory_test.cpp
@@ -3,13 +3,21 @@
 #include <sstream>
 #include <string>
 
+#include "avatar.h"
+#include "calendar.h"
 #include "cata_catch.h"
 #include "coordinates.h"
+#include "game.h"
 #include "lru_cache.h"
 #include "map.h"
+#include "map_helpers.h"
 #include "map_memory.h"
 #include "map_scale_constants.h"
+#include "options_helpers.h"
+#include "player_helpers.h"
 #include "point.h"
+#include "type_id.h"
+#include "weather_type.h"
 
 static constexpr tripoint_abs_ms p1{ -SEEX - 2, -SEEY - 3, -1 };
 static constexpr tripoint_abs_ms p2{ 5, 7, -1 };
@@ -120,6 +128,41 @@ TEST_CASE( "map_memory_forgets", "[map_memory]" )
     CHECK( mt.get_dec_id().empty() );
     CHECK( mt.get_dec_subtile() == 0 );
     CHECK( mt.get_dec_rotation() == 0 );
+}
+
+TEST_CASE( "map_memory_refreshes_visibility_after_avatar_moves", "[map_memory][vision]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+    calendar::turn = calendar::turn_zero;
+
+    map &here = get_map();
+    avatar &you = get_avatar();
+    const tripoint_bub_ms start( 50, 50, 0 );
+    const tripoint_bub_ms destination = start + tripoint::east * 20;
+    const tripoint_abs_ms destination_abs = here.get_abs( destination );
+    const ter_str_id floor( "t_floor" );
+
+    g->place_player( start );
+    you.clear_map_memory();
+    you.recalc_sight_limits();
+    REQUIRE( here.ter_set( destination, floor ) );
+
+    // Establish a valid visibility cache at the old position.  At midnight,
+    // the destination is beyond the avatar's unaided vision.
+    here.invalidate_map_cache( start.z() );
+    here.build_map_cache( start.z() );
+    here.invalidate_visibility_cache();
+    here.update_visibility_cache( start.z() );
+    CHECK_FALSE( you.has_memory_at( destination_abs ) );
+
+    // Vehicle movement and the last step of a turn can move the avatar without
+    // rendering a frame.  update_map_memory must refresh visibility itself.
+    you.setpos( here, destination, false );
+    here.update_map_memory( you );
+
+    CHECK( you.get_memorized_tile( destination_abs ).get_ter_id() == floor.str() );
 }
 
 // TODO: map memory save / load


### PR DESCRIPTION
## What changed

- Refresh the map and visibility caches before recording avatar map memory.
- Allow autodrive activities to update map memory each turn.
- Add a regression test for movement without an intervening rendered frame.

## Why

Movement in darkness could record tiles using visibility cached at the avatar's previous position, revealing an incorrect radius at the edge of vision. Autodrive was also treated like a stationary long-running activity, so nighttime vehicle travel did not record explored terrain.

## Validation

- `git diff --cached --check`
- Compiled `src/map.o`, `src/do_turn.o`, and `tests/map_memory_test.o` with warnings as errors.
- Built and linked the Linux SDL3 Tiles + Sound Release executable.