### PR TITLE
Fix: Restore the Eyebot summon robot attack time event after its erroneous deletion

### DIFF
--- a/src/timed_event.cpp
+++ b/src/timed_event.cpp
@@ -50,10 +50,8 @@ static const mtype_id mon_sewer_snake( "mon_sewer_snake" );
 static const mtype_id mon_spider_cellar_giant( "mon_spider_cellar_giant" );
 static const mtype_id mon_spider_widow_giant( "mon_spider_widow_giant" );
 
-static const mtype_id mon_afs_eyebot( "mon_afs_eyebot" );
 static const mtype_id mon_afs_copbot( "mon_afs_copbot" );
 static const mtype_id mon_afs_riotbot( "mon_afs_riotbot" );
-static const mtype_id mon_fcl_eyebot( "mon_fcl_eyebot" );
 static const mtype_id mon_fcl_copbot( "mon_fcl_copbot" );
 static const mtype_id mon_fcl_riotbot( "mon_fcl_riotbot" );
 

--- a/src/timed_event.cpp
+++ b/src/timed_event.cpp
@@ -34,6 +34,7 @@
 #include "translation.h"
 #include "translations.h"
 #include "type_id.h"
+#include "worldfactory.h"
 
 static const itype_id itype_petrified_eye( "petrified_eye" );
 
@@ -48,6 +49,13 @@ static const mtype_id mon_dsa_alien_dispatch( "mon_dsa_alien_dispatch" );
 static const mtype_id mon_sewer_snake( "mon_sewer_snake" );
 static const mtype_id mon_spider_cellar_giant( "mon_spider_cellar_giant" );
 static const mtype_id mon_spider_widow_giant( "mon_spider_widow_giant" );
+
+static const mtype_id mon_afs_eyebot( "mon_afs_eyebot" );
+static const mtype_id mon_afs_copbot( "mon_afs_copbot" );
+static const mtype_id mon_afs_riotbot( "mon_afs_riotbot" );
+static const mtype_id mon_fcl_eyebot( "mon_fcl_eyebot" );
+static const mtype_id mon_fcl_copbot( "mon_fcl_copbot" );
+static const mtype_id mon_fcl_riotbot( "mon_fcl_riotbot" );
 
 static const spell_id spell_dks_summon_alrp( "dks_summon_alrp" );
 
@@ -351,6 +359,34 @@ void timed_event::per_turn()
     Character &player_character = get_player_character();
     map &here = get_map();
     switch( type ) {
+
+        case timed_event_type::ROBOT_ATTACK: {
+            const tripoint_abs_sm u_pos = player_character.pos_abs_sm();
+            if( rl_dist( u_pos, map_point ) <= 4 ) {
+                mod_id afs_mod = mod_id("aftershock_exoplanet");
+                mod_id fcl_mod = mod_id("catalegacy_future");
+                int mod_load_type = 0;
+                for( const mod_id &mod : world_generator->active_world->active_mod_order ) {
+                    if( mod == afs_mod && mod_load_type == 0 ) {
+                        mod_load_type = 1;
+                    }
+                    if( mod == fcl_mod ) {
+                        mod_load_type = 2;
+                    }
+                }
+                if( mod_load_type > 0 ) {
+                    const mtype_id &robot_type = one_in( 2 ) ? ( mod_load_type == 1 ? mon_afs_copbot : mon_fcl_copbot ) : ( mod_load_type == 1 ? mon_afs_riotbot : mon_fcl_riotbot );
+
+                    get_event_bus().send<event_type::becomes_wanted>( player_character.getID() );
+                    point rob( u_pos.x() > map_point.x() ? 0 - SEEX * 2 : SEEX * 4,
+                               u_pos.y() > map_point.y() ? 0 - SEEY * 2 : SEEY * 4 );
+                    tripoint_bub_ms rob_final( tripoint( rob, u_pos.z() ) );
+                    g->place_critter_at( robot_type, rob_final );
+                }
+            }
+        }
+        break;
+
         case timed_event_type::SPAWN_WYRMS:
             if( here.get_abs_sub().z() >= 0 ) {
                 when -= 1_turns;


### PR DESCRIPTION
####  Summary

Fix a bug in both the `Aftershock: Exoplanet` and `Futurism Cataclysm: Legacy` mods where the eyebot's special attack `PHOTOGRAPH` only executes the photography logic while its accompanying chain-summon functionality was completely missing.

#### Purpose of change

When the upstream C:DDA branch moved the police robot out of the core module and into Aftershock in [PR66872](https://github.com/CleverRaven/Cataclysm-DDA/pull/66872), the time event `ROBOT_ATTACK`, which is chained to and triggered by the eyebot's special attack `PHOTOGRAPH`, was inadvertently purged. This code was originally the core mechanic of the eyebot's functionality: calling and summoning other robots. However, when that PR migrated the assets into the mod, it completely overlooked the fact that the event was still being invoked there. It stripped out all direct C++ hardcoding related to the police robot, leaving this broken indirect reference floating in the codebase since 2023. It has remained unfixed for over three years.

While working on my `Futurism Cataclysm: Legacy` mod, I re-introduced the previously removed eyebot and was trying to design scenarios requiring it to spawn corresponding reinforcement robots. However, multiple rounds of initial testing revealed that the drone was functioning abnormally. After digging through the commit history and checking implementations in other branches, I finally uncovered this root cause.

#### Describe the solution

Ported the legacy `ROBOT_ATTACK` event logic back from the 2023 codebase and added active mod checks to it. The summoning branch is now executed only when the active mod list includes either `aftershock_exoplanet` (marked as 1) or `catalegacy_future` (marked as 2). It will then spawn the appropriate police robot corresponding to whichever mod is currently loaded.

While my implementation might look a bit messy, since AFS and FCL are explicitly marked as incompatible, this straightforward conditional check should fully suffice for our current needs.

#### Additional context

Essentially, this is just copying back the deleted code, but due to the long time span, some related methods may have undergone multiple rewrites... Although VSC didn't throw any immediate errors, I must admit that with my current level of C++ proficiency, I cannot guarantee it is completely free of runtime bugs. If this code happens to introduce any new issues down the line, I would be incredibly grateful if a peer with stronger technical expertise could help clean it up. Thank you very much!