### PR TITLE
android: migrate CCB identity to CrimsonCrossBunker

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://docs.github.com/en/repositories/working-with-files/managing-files/editing-files#editing-files-in-another-users-repository
     about: 这类问题即使是初学者也能轻松修复。自己动手改比报告还快，而且你还能因修复获得贡献署名！
   - name: 翻译相关
-    url: https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/blob/master/doc/TRANSLATING.md
+    url: https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/blob/master/doc/TRANSLATING.md
     about: 翻译中的错别字或其他非技术性错误？请到这里。

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,9 +21,9 @@ PR 提交准则：
 2. Bugfixes "修复长矛无法锁定不同楼层敌人的问题"
 3. Interface "在制作界面显示制作失败几率"
 分类含义详见：
-https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/blob/master/doc/CHANGELOG_GUIDELINES.md
+https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/blob/master/doc/CHANGELOG_GUIDELINES.md
 合并后，你的概述会被加入项目更新日志：
-https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/blob/master/data/changelog.txt -->
+https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/blob/master/data/changelog.txt -->
 
 #### 改动目的 (Purpose of change)
 

--- a/.github/workflows/compose-tilesets.yml
+++ b/.github/workflows/compose-tilesets.yml
@@ -116,7 +116,7 @@ jobs:
             tileset_repo: pixel-32/CDDA-tileset
             tileset_src_checkout: ""
           - name: MSX++UndeadPeopleEdition
-            tileset_repo: LYHGLYTX/CCB_UNDEAD_PEOPLE
+            tileset_repo: CrimsonCrossBunker/CCB_UNDEAD_PEOPLE
             tileset_dir: .
             precomposed: true
             release_download: true

--- a/.github/workflows/greet-first-time-comment.yml
+++ b/.github/workflows/greet-first-time-comment.yml
@@ -24,8 +24,8 @@ jobs:
         run: |
           commenter="${GITHUB_EVENT_COMMENT_USER_LOGIN}"
           echo "Debug: Checking comment counts for... $commenter"
-          comment_count_all_PR=$(gh search prs --repo=LYHGLYTX/Cataclysm-Cleanwater-Bomb --commenter $commenter --json id | jq 'length')
-          num_PRs_authored=$(gh search prs --repo=LYHGLYTX/Cataclysm-Cleanwater-Bomb --author $commenter --json id | jq 'length')
+          comment_count_all_PR=$(gh search prs --repo=CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb --commenter $commenter --json id | jq 'length')
+          num_PRs_authored=$(gh search prs --repo=CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb --author $commenter --json id | jq 'length')
           
           num_times_commented=$(gh pr view $PR_NUMBER --json comments --jq "[.comments.[].author.login | match(\"$commenter\")] | length")
 
@@ -42,6 +42,6 @@ jobs:
           # I have no earthly idea how to pass the commenter on from the previous run (I have tried), so let's just re-acquire it.
           commenter_name="${GITHUB_EVENT_COMMENT_USER_LOGIN}"
           # We 'hardcode' the URLs here because doing a dynamic url points to OWNER/REPO/pull/code_of_conduct.md. Why is the 'pull' there? No idea.
-          gh pr comment $PR_NUMBER --body "Hi @$commenter_name, welcome to Cataclysm: Cleanwater Bomb! We see that this is your first time commenting here. Check out [how development works](https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/blob/master/doc/development_process.md) and be sure to follow the [code of conduct](https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/blob/master/CODE_OF_CONDUCT.md)! We hope to see you around!"
+          gh pr comment $PR_NUMBER --body "Hi @$commenter_name, welcome to Cataclysm: Cleanwater Bomb! We see that this is your first time commenting here. Check out [how development works](https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/blob/master/doc/development_process.md) and be sure to follow the [code of conduct](https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/blob/master/CODE_OF_CONDUCT.md)! We hope to see you around!"
         env:
           GITHUB_EVENT_COMMENT_USER_LOGIN: ${{ github.event.comment.user.login }}

--- a/.github/workflows/push-translation-template.yml
+++ b/.github/workflows/push-translation-template.yml
@@ -19,7 +19,7 @@ jobs:
       ${{ github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.conclusion == 'success' &&
       ( github.event.workflow_run.status == 'success' || github.event.workflow_run.status == 'completed' ) &&
-      github.repository == 'LYHGLYTX/Cataclysm-Cleanwater-Bomb' }}
+      github.repository == 'CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb' }}
     steps:
       - name: "Install gettext tools"
         run: sudo apt install gettext

--- a/.github/workflows/request-review.yml
+++ b/.github/workflows/request-review.yml
@@ -16,7 +16,7 @@ jobs:
   auto-request-review:
     # Do not spam reviewer with PRs in forks. If fork owners wish to alert
     # people of their changes they may change this line themselves.
-    if: github.repository == 'LYHGLYTX/Cataclysm-Cleanwater-Bomb'
+    if: github.repository == 'CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb'
     name: Auto request review
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## 下载
 
-**发布** 你可以在这里下载目前的测试版本：[Release](https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/releases)
+**发布** 你可以在这里下载目前的测试版本：[Release](https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/releases)
 
 ## 贡献方式
 
@@ -57,7 +57,7 @@ In this game, you will face a complex, procedurally generated environment filled
 Based on the `cdda/master` branch of [CleverRaven/Cataclysm-DDA](https://github.com/CleverRaven/Cataclysm-DDA), commit: **221c786e7d**
 
 ## Downloads
-**Releases** You can download the current test version here: [Releases](https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/releases)
+**Releases** You can download the current test version here: [Releases](https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/releases)
 
 ## How to Contribute
 Any developer interested in contributing to this branch is welcome to submit pull requests to this repository to support its development.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -282,7 +282,7 @@ preBuild.dependsOn createWindowsJunctionLinks
 createWindowsJunctionLinks.dependsOn makeLocalization
 
 android {
-    namespace "com.lyhglytx.cataclysmcb"
+    namespace "com.crimsoncrossbunker.cataclysmcb"
     compileSdkVersion override_compileSdkVersion
     ndkVersion override_ndkVersion
 
@@ -300,7 +300,7 @@ android {
         versionCode Integer.valueOf(override_versionCode)
         versionName new File("$version_header_path").text.split('\"')[1]
         if (buildAsApplication) {
-            applicationId "com.lyhglytx.cataclysmcb"
+            applicationId "com.crimsoncrossbunker.cataclysmcb"
         }
         resValue "string", "app_name", "Cataclysm: Cleanwater Bomb"
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -65,7 +65,7 @@
         <!-- Expose app's private data directory for backup without root -->
         <provider
             android:name=".CDDADocumentsProvider"
-            android:authorities="com.lyhglytx.cataclysmcb.documents"
+            android:authorities="${applicationId}.documents"
             android:exported="true"
             android:grantUriPermissions="true"
             android:permission="android.permission.MANAGE_DOCUMENTS">

--- a/android/app/src/main/java/com/crimsoncrossbunker/cataclysmcb/CDDADocumentsProvider.java
+++ b/android/app/src/main/java/com/crimsoncrossbunker/cataclysmcb/CDDADocumentsProvider.java
@@ -1,4 +1,4 @@
-package com.lyhglytx.cataclysmcb;
+package com.crimsoncrossbunker.cataclysmcb;
 
 import android.annotation.TargetApi;
 import android.content.Context;

--- a/android/app/src/main/java/com/crimsoncrossbunker/cataclysmcb/CataclysmDDA.java
+++ b/android/app/src/main/java/com/crimsoncrossbunker/cataclysmcb/CataclysmDDA.java
@@ -1,4 +1,4 @@
-package com.lyhglytx.cataclysmcb;
+package com.crimsoncrossbunker.cataclysmcb;
 
 import org.libsdl.app.SDLActivity;
 

--- a/android/app/src/main/java/com/crimsoncrossbunker/cataclysmcb/CataclysmDDA_Helpers.java
+++ b/android/app/src/main/java/com/crimsoncrossbunker/cataclysmcb/CataclysmDDA_Helpers.java
@@ -1,4 +1,4 @@
-package com.lyhglytx.cataclysmcb;
+package com.crimsoncrossbunker.cataclysmcb;
 
 import java.util.HashSet;
 import java.util.List;

--- a/android/app/src/main/java/com/crimsoncrossbunker/cataclysmcb/NativeUI.java
+++ b/android/app/src/main/java/com/crimsoncrossbunker/cataclysmcb/NativeUI.java
@@ -1,4 +1,4 @@
-package com.lyhglytx.cataclysmcb;
+package com.crimsoncrossbunker.cataclysmcb;
 
 import java.util.concurrent.Semaphore;
 

--- a/android/app/src/main/java/com/crimsoncrossbunker/cataclysmcb/SplashScreen.java
+++ b/android/app/src/main/java/com/crimsoncrossbunker/cataclysmcb/SplashScreen.java
@@ -1,4 +1,4 @@
-package com.lyhglytx.cataclysmcb;
+package com.crimsoncrossbunker.cataclysmcb;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -36,7 +36,7 @@ import android.widget.RadioGroup;
 import android.widget.ScrollView;
 import android.widget.TextView;
 
-import com.lyhglytx.cataclysmcb.CataclysmDDA_Helpers;
+import com.crimsoncrossbunker.cataclysmcb.CataclysmDDA_Helpers;
 
 public class SplashScreen extends Activity {
     private static final String TAG = "Splash";

--- a/data/credits/en.credits
+++ b/data/credits/en.credits
@@ -37,7 +37,7 @@
 <color_yellow>gettingusedto</color> - MSX+ heavyweight and all around nice guy. We've gotten used to (heh) seeing them around!
 
 <color_white>For a full list of contributors please see:</color>
-<color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
+<color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
 <color_cyan>https://github.com/CleverRaven/Cataclysm-DDA/contributors</color>
 <color_cyan>https://github.com/I-am-Erk/CDDA-Tilesets/graphs/contributors</color>
 <color_cyan>https://github.com/pixel-32/CDDA-tileset/graphs/contributors</color>

--- a/data/credits/zh_CN.credits
+++ b/data/credits/zh_CN.credits
@@ -37,7 +37,7 @@
 <color_yellow>gettingusedto</color> - MSX + 大量代码，到处都是好人。我们已经习惯了 (嘿嘿) 看到他们在周围！
 
 <color_white>完整贡献者列表请见：</color>
-<color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
+<color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
 <color_cyan>https://github.com/CleverRaven/Cataclysm-DDA/contributors</color>
 <color_cyan>https://github.com/I-am-Erk/CDDA-Tilesets/graphs/contributors</color>
 <color_cyan>https://github.com/pixel-32/CDDA-tileset/graphs/contributors</color>

--- a/data/motd/ar.motd
+++ b/data/motd/ar.motd
@@ -3,12 +3,12 @@
 ##############################################################################
 <color_white>زورونا:</color>
 
-<color_light_gray>* الصفحة الرئيسية:</color>  <color_cyan> https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
-<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
+<color_light_gray>* الصفحة الرئيسية:</color>  <color_cyan> https://crimsoncrossbunker.github.io</color>
+<color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>البلاغ عن الأخطاء وإرسال الاقتراحات ومتابعة التطوير على:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* البريد الاكتروني: </color> <color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>انضم إلى المناقشة في المنتديات والدردشات على:</color>

--- a/data/motd/cs.motd
+++ b/data/motd/cs.motd
@@ -3,12 +3,12 @@
 ##############################################################################
 <color_white>Navštivte nás na:</color>
 
-<color_light_gray>*Domovská stránka:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
-<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
+<color_light_gray>*Domovská stránka:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
+<color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Hlaste případné chyby, sdělte své návrhy a sledujte vývoj hry na stránkách:</color>
 
-<color_light_gray>* Github:</color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* Github:</color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail:</color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Připojte se k diskuzi na fórech a chatech:</color>

--- a/data/motd/de.motd
+++ b/data/motd/de.motd
@@ -3,12 +3,12 @@
 ##############################################################################
 <color_white>Besuche uns:</color>
 
-<color_light_gray>* Homepage:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
-<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
+<color_light_gray>* Homepage:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
+<color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Melde Fehler, mache Vorschläge und folgen der Entwicklung unter:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* E-Mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Nimm an den Diskussionen in Foren und Chats teil:</color>

--- a/data/motd/el.motd
+++ b/data/motd/el.motd
@@ -3,12 +3,12 @@
 ##############################################################################
 <color_white>Επισκεφθείτε μας:</color>
 
-<color_light_gray>*Αρχική σελίδα:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
-<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
+<color_light_gray>*Αρχική σελίδα:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
+<color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>* Αναφέρετε σφάλματα, προτάσεις και ακολουθήστε την ανάπτυξη στο:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Λάβετε μέρος στη συζήτηση στα φόρουμ και στα chats:</color>

--- a/data/motd/en.motd
+++ b/data/motd/en.motd
@@ -3,12 +3,12 @@
 ##############################################################################
 <color_white>Visit us:</color>
 
-<color_light_gray>* Homepage:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
-<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
+<color_light_gray>* Homepage:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
+<color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Report bugs, suggestion and follow the development at:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Join the discussion on forums and chats:</color>

--- a/data/motd/es_AR.motd
+++ b/data/motd/es_AR.motd
@@ -3,12 +3,12 @@
 ##############################################################################
 <color_white>Visitanos:</color>
 
-<color_light_gray>* Página web:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
-<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
+<color_light_gray>* Página web:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
+<color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Comentar bugs, sugerencias y ver el desarrollo del juego:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Vení a discutir en los foros y chats:</color>

--- a/data/motd/es_ES.motd
+++ b/data/motd/es_ES.motd
@@ -3,12 +3,12 @@
 ##############################################################################
 <color_white>Visitanos:</color>
 
-<color_light_gray>* Pagina principal:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
-<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
+<color_light_gray>* Pagina principal:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
+<color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Informar de errores, sugerencias y seguir el desarrollo en: </color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Comunícate y habla en los foros y chats: </color>

--- a/data/motd/fil_PH.motd
+++ b/data/motd/fil_PH.motd
@@ -3,12 +3,12 @@
 ##############################################################################
 <color_white>Bisitahin kami:</color>
 
-<color_light_gray>* Ang aming homepage:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
-<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
+<color_light_gray>* Ang aming homepage:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
+<color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Mag-report ng bugs, suwestiyon at I-follow ang development sa:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Sundin ang aming diskusyon sa aming forums at chats:</color>

--- a/data/motd/fr.motd
+++ b/data/motd/fr.motd
@@ -3,12 +3,12 @@
 ##############################################################################
 <color_white>Rendez-nous visite:</color>
 
-<color_light_gray>*Accueil:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
-<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
+<color_light_gray>*Accueil:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
+<color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white> Signalez des bugs, faites des suggestions et suivez le développement du jeu sur : </color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Rejoignez la discussion sur les forums et chats:</color>

--- a/data/motd/ga_IE.motd
+++ b/data/motd/ga_IE.motd
@@ -3,12 +3,12 @@
 ##############################################################################
 <color_white>Tar ar cuairt chugainn:</color>
 
-<color_light_gray>* Leathanach baile:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
-<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
+<color_light_gray>* Leathanach baile:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
+<color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Tuairiscigh fabhtanna, cuir moltaí isteach, agus lean forbairt ag:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* R-phoist:</color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Bí sa chomhrá ar fóraim agus comhráite grúpaí:</color>

--- a/data/motd/hu.motd
+++ b/data/motd/hu.motd
@@ -3,12 +3,12 @@
 ##############################################################################
 <color_white>Rólunk:</color>
 
-<color_light_gray>* Honlap:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
-<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
+<color_light_gray>* Honlap:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
+<color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Programhibák bejelentése, új ötletek és folyamatos fejlesztés:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Angol nyelvű fórumozás és chat:</color>

--- a/data/motd/id.motd
+++ b/data/motd/id.motd
@@ -3,12 +3,12 @@
 ##############################################################################
 <color_white>Kunjungi kami:</color>
 
-<color_light_gray>* Halaman depan:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
-<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
+<color_light_gray>* Halaman depan:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
+<color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Laporkan bug, saran dan ikuti pengembangannya di:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Ikuti diskusi di forum dan chat:</color>

--- a/data/motd/it_IT.motd
+++ b/data/motd/it_IT.motd
@@ -3,12 +3,12 @@
 ##############################################################################
 <color_white>Visitaci:</color>
 
-<color_light_gray>* Homepage:</color>  <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
-<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
+<color_light_gray>* Homepage:</color>  <color_cyan>https://crimsoncrossbunker.github.io</color>
+<color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Segnala bug, suggerimenti e segui lo sviluppo su:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Unisciti alla discussione nei forum e nelle chat:</color>

--- a/data/motd/ja.motd
+++ b/data/motd/ja.motd
@@ -3,12 +3,12 @@
 ##############################################################################
 <color_white>関連リンク:</color>
 
-<color_light_gray>* 公式サイト:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
-<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
+<color_light_gray>* 公式サイト:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
+<color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>バグ報告、提案、開発状況の確認:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>議論やチャットへの参加:</color>

--- a/data/motd/ko.motd
+++ b/data/motd/ko.motd
@@ -3,12 +3,12 @@
 ##############################################################################
 <color_white>방문하기:</color>
 
-<color_light_gray>* 홈페이지:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
-<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
+<color_light_gray>* 홈페이지:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
+<color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>버그 보고, 기능 제안, 개발현황 확인:</color>
 
-<color_light_gray>* 깃허브: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* 깃허브: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* 이메일: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>포럼과 챗에서 토론하기:</color>

--- a/data/motd/nb.motd
+++ b/data/motd/nb.motd
@@ -3,12 +3,12 @@
 ##############################################################################
 <color_white>Besøk oss:</color>
 
-<color_light_gray>*Hjemmeside:</color> <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
-<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
+<color_light_gray>*Hjemmeside:</color> <color_cyan>https://crimsoncrossbunker.github.io</color>
+<color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Rapporter feil, forslag og følg utviklingen ved:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Delta i diskusjonene på forum og chatter:</color>

--- a/data/motd/pl.motd
+++ b/data/motd/pl.motd
@@ -3,12 +3,12 @@
 ##############################################################################
 <color_white>Odwiedź nas:</color>
 
-<color_light_gray>* Strona domowa:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
-<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
+<color_light_gray>* Strona domowa:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
+<color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Zgłaszaj błędy, sugestie i śledź rozwój gry na:</color>
 
-<color_light_gray>* GitHub: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* GitHub: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Dołącz do dyskusji na forach i czatach:</color>

--- a/data/motd/pt_BR.motd
+++ b/data/motd/pt_BR.motd
@@ -3,12 +3,12 @@
 ##############################################################################
 <color_white>Nos visite:</color>
 
-<color_light_gray>* Homepage:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
-<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
+<color_light_gray>* Homepage:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
+<color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Reporte bugs, sugestões e siga o desenvolvimento em: </color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Entre na discussão em fóruns e chats:</color>

--- a/data/motd/ru.motd
+++ b/data/motd/ru.motd
@@ -3,12 +3,12 @@
 ##############################################################################
 <color_white>Посетите нас:</color>
 
-<color_light_gray>* Официальный сайт:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
-<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
+<color_light_gray>* Официальный сайт:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
+<color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Сообщайте о багах, выдвигайте предложения и следите за разработкой:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Присоединяйтесь к обсуждению на форумах и в чатах:</color>

--- a/data/motd/tr.motd
+++ b/data/motd/tr.motd
@@ -3,12 +3,12 @@
 ##############################################################################
 <color_white>Bizi ziyaret edin:</color>
 
-<color_light_gray>* Ana Sayfa:</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
-<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
+<color_light_gray>* Ana Sayfa:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
+<color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Hataları rapor etmek, öneride bulunmak ve gelişmeleri takip etmek için:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-posta: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Forumlara ve sohbetlere katılmak için:</color>

--- a/data/motd/uk_UA.motd
+++ b/data/motd/uk_UA.motd
@@ -3,12 +3,12 @@
 ##############################################################################
 <color_white>Відвідати нас:</color>
 
-<color_light_gray>* Домашня сторінка гри:</color>      <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
-<color_light_gray>* CCB website:</color> <color_cyan>https://lyhglytx.github.io</color> <color_light_gray>(We'll get a custom domain after winning the lottery.)</color>
+<color_light_gray>* Домашня сторінка гри:</color>      <color_cyan>https://crimsoncrossbunker.github.io</color>
+<color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>Повідомте про помилки, пропозиції та стежте за розробками на:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* е-мейл: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Приєднуйтесь до розмов на форумах і чатах:</color>

--- a/data/motd/zh_CN.motd
+++ b/data/motd/zh_CN.motd
@@ -3,12 +3,12 @@
 ##############################################################################
 <color_white>访问官网：</color>
 
-<color_light_gray>* 主页：</color><color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
-<color_light_gray>* CCB官网：</color><color_cyan>https://lyhglytx.github.io</color><color_light_gray>（等我中彩票换个域名）</color>
+<color_light_gray>* 主页：</color><color_cyan>https://crimsoncrossbunker.github.io</color>
+<color_light_gray>* GitHub 仓库：</color><color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>报告BUG，提交建议及跟进开发进度：</color>
 
-<color_light_gray>* GitHub：</color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* GitHub：</color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* E-mail：</color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>加入论坛及讨论组：</color>

--- a/data/motd/zh_TW.motd
+++ b/data/motd/zh_TW.motd
@@ -3,12 +3,12 @@
 ##############################################################################
 <color_white>造訪我們</color>
 
-<color_light_gray>* 官網：</color>    <color_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb</color>
-<color_light_gray>* CCB官網：</color><color_cyan>https://lyhglytx.github.io</color><color_light_gray>（等我中樂透再換個網域）</color>
+<color_light_gray>* 官網：</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
+<color_light_gray>* GitHub 倉庫：</color><color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
 
 <color_white>回報bug，提供建議與關注開發進度：</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/LYHGLYTX/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>在論壇或聊天室討論：</color>

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -848,7 +848,7 @@ bool query_yn( const std::string &text )
         jobject activity = ( jobject )GetAndroidActivity();
         jclass clazz( env->GetObjectClass( activity ) );
         jmethodID get_nativeui_method_id = env->GetMethodID( clazz, "getNativeUI",
-                                           "()Lcom/lyhglytx/cataclysmcb/NativeUI;" );
+                                           "()Lcom/crimsoncrossbunker/cataclysmcb/NativeUI;" );
         jobject native_ui_obj = env->CallObjectMethod( activity, get_nativeui_method_id );
         jclass native_ui_cls( env->GetObjectClass( native_ui_obj ) );
         jmethodID queryYN_method_id = env->GetMethodID( native_ui_cls, "queryYN", "(Ljava/lang/String;)Z" );
@@ -961,7 +961,7 @@ int popup( const std::string &text, PopupFlags flags )
         jobject activity = ( jobject )GetAndroidActivity();
         jclass clazz( env->GetObjectClass( activity ) );
         jmethodID get_nativeui_method_id = env->GetMethodID( clazz, "getNativeUI",
-                                           "()Lcom/lyhglytx/cataclysmcb/NativeUI;" );
+                                           "()Lcom/crimsoncrossbunker/cataclysmcb/NativeUI;" );
         jobject native_ui_obj = env->CallObjectMethod( activity, get_nativeui_method_id );
         jclass native_ui_cls( env->GetObjectClass( native_ui_obj ) );
         jmethodID queryYN_method_id = env->GetMethodID( native_ui_cls, "popup", "(Ljava/lang/String;)V" );

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -981,7 +981,7 @@ extern "C" {
         visible_frame_inbox.publish( left, top, right, bottom, visible == JNI_TRUE );
     }
 
-    JNIEXPORT void JNICALL Java_com_lyhglytx_cataclysmcb_CataclysmDDA_onNativeImeInsetsChanged(
+    JNIEXPORT void JNICALL Java_com_crimsoncrossbunker_cataclysmcb_CataclysmDDA_onNativeImeInsetsChanged(
         JNIEnv *env, jclass jcls, jint left, jint top, jint right, jint bottom, jboolean visible )
     {
         ( void )env;
@@ -997,7 +997,7 @@ extern "C" {
         on_native_ime_insets_changed( left, top, right, bottom, visible );
     }
 
-    JNIEXPORT void JNICALL Java_com_lyhglytx_cataclysmcb_CataclysmDDA_nativeButtonClick(
+    JNIEXPORT void JNICALL Java_com_crimsoncrossbunker_cataclysmcb_CataclysmDDA_nativeButtonClick(
         JNIEnv *env, jclass jcls, jstring text )
     {
         ( void )jcls;

--- a/src/uilist.cpp
+++ b/src/uilist.cpp
@@ -924,7 +924,7 @@ bool uilist::query_setup()
         jobject activity = ( jobject )GetAndroidActivity();
         jclass clazz( env->GetObjectClass( activity ) );
         jmethodID get_nativeui_method_id = env->GetMethodID( clazz, "getNativeUI",
-                                           "()Lcom/lyhglytx/cataclysmcb/NativeUI;" );
+                                           "()Lcom/crimsoncrossbunker/cataclysmcb/NativeUI;" );
         jobject native_ui_obj = env->CallObjectMethod( activity, get_nativeui_method_id );
         jclass native_ui_cls( env->GetObjectClass( native_ui_obj ) );
         jmethodID list_menu_method_id = env->GetMethodID( native_ui_cls, "singleChoiceList",


### PR DESCRIPTION
## Summary

- migrate the Android namespace, application ID, Java packages, JNI symbols, and NativeUI descriptors from `com.lyhglytx.cataclysmcb` to `com.crimsoncrossbunker.cataclysmcb`
- scope the Android DocumentsProvider authority to `${applicationId}.documents` so stable and experimental variants do not collide
- update the in-game MOTD and credits across all locales to use the CrimsonCrossBunker website, repository, and issue tracker
- update repository links in the README, GitHub templates, workflows, and tileset integration

## Android compatibility note

The new package ID makes this a separate Android application. It cannot upgrade an installation using the old package ID, and Android private app data/saves are not migrated automatically.

## Validation

- built `:app:assembleStableRelease` for arm64-v8a successfully
- verified APK application ID: `com.crimsoncrossbunker.cataclysmcb`
- verified provider authority: `com.crimsoncrossbunker.cataclysmcb.documents`
- verified the APK contains `lib/arm64-v8a/libmain.so`
- verified the embedded zh_CN MOTD uses the new website/repository/issues URLs
- passed `git diff --check`
- confirmed no old package, personal repository, or personal Pages references remain in the changed source scope