### PR TITLE
try fix ROBOT_ATTACK tripoint to tripoint_bub_ms data trans make

### DIFF
--- a/src/timed_event.cpp
+++ b/src/timed_event.cpp
@@ -375,10 +375,16 @@ void timed_event::per_turn()
                 if( mod_load_type > 0 ) {
                     const mtype_id &robot_type = one_in( 2 ) ? ( mod_load_type == 1 ? mon_afs_copbot : mon_fcl_copbot ) : ( mod_load_type == 1 ? mon_afs_riotbot : mon_fcl_riotbot );
 
+                    const tripoint_bub_ms u_pos_bub = player_character.pos_bub();
+
                     get_event_bus().send<event_type::becomes_wanted>( player_character.getID() );
-                    point rob( u_pos.x() > map_point.x() ? 0 - SEEX * 2 : SEEX * 4,
-                               u_pos.y() > map_point.y() ? 0 - SEEY * 2 : SEEY * 4 );
-                    tripoint_bub_ms rob_final( tripoint( rob, u_pos.z() ) );
+                    point rob(
+                        u_pos.x() > map_point.x() ? 0 - SEEX * 2 : SEEX * 4,
+                        u_pos.y() > map_point.y() ? 0 - SEEY * 2 : SEEY * 4
+                    );
+
+                    tripoint_bub_ms rob_final = tripoint_bub_ms( u_pos_bub.raw() + tripoint(rob, 0) );
+
                     g->place_critter_at( robot_type, rob_final );
                 }
             }


### PR DESCRIPTION
####  Summary

Attempt to fix the conversion between the old tripoint format parameter in timed_event_type::ROBOT_ATTACK and the new tripoint_bub_ms.

#### Purpose of change

I'm terrified! Although I had a premonition that simply porting back the `ROBOT_ATTACK` event code that was mistakenly deleted three years ago and fixing the compiler's red error message in PR #385 wouldn't solve all the problems. Essentially, this is just copying back the deleted code, but due to the long time span, some related methods may have undergone multiple rewrites...

But why is it that when I tested it in the game, running `place_critter_at` caused the corresponding mobs to spawn simultaneously across a large number of tiles? According to players' memory, the old code would only randomly spawn one point. The eyebot only summoned reinforcements three times, yet over forty police robots appeared!

This clearly severely impacts game balance and experience, disrupting normal gameplay and requiring immediate fixing.

#### Describe the solution

Instead of directly using offsets and the player's `tripoint_abs_sm` for input and calculation, I'm trying to obtain the `u_pos` version of `tripoint_bub_ms` and reconstruct the coordinate parameters along with the original offsets for input to `place_critter_at`. However, I'm unsure if this will work perfectly.