### PR TITLE
A few minor near-future structures (Futurism Cataclysm: Legacy Part.4)

### DIFF
--- a/data/mods/FuturismCataclysmLegacy/itemgroups/bionics.json
+++ b/data/mods/FuturismCataclysmLegacy/itemgroups/bionics.json
@@ -47,5 +47,10 @@
       [ "bio_fitnessband", 10 ],
       [ "bio_taser", 5 ]
     ]
+  },
+  {
+    "id": "fcl_bionics_power",
+    "type": "item_group",
+    "items": [ [ "bio_power_storage_mkII", 1 ], [ "bio_power_storage", 14 ], [ "bio_betavoltaic", 5 ] ]
   }
 ]

--- a/data/mods/FuturismCataclysmLegacy/itemgroups/bionics.json
+++ b/data/mods/FuturismCataclysmLegacy/itemgroups/bionics.json
@@ -5,8 +5,8 @@
     "copy-from": "bionics",
     "extend": { 
       "items": [
-        { "item": "fcl_bio_neurosoft_aeronautics", "prob": 10},
-        { "item": "fcl_bio_neurosoft_aircraft_mechanic", "prob": 10}
+        { "item": "fcl_bio_neurosoft_aeronautics", "prob": 10 },
+        { "item": "fcl_bio_neurosoft_aircraft_mechanic", "prob": 10 }
       ]
     }
   },
@@ -16,8 +16,8 @@
     "copy-from": "bionics_mil",
     "extend": { 
       "items": [
-        { "item": "fcl_bio_neurosoft_aeronautics", "prob": 10},
-        { "item": "fcl_bio_neurosoft_aircraft_mechanic", "prob": 10}
+        { "item": "fcl_bio_neurosoft_aeronautics", "prob": 10 },
+        { "item": "fcl_bio_neurosoft_aircraft_mechanic", "prob": 10 }
       ]
     }
   },

--- a/data/mods/FuturismCataclysmLegacy/itemgroups/bionics.json
+++ b/data/mods/FuturismCataclysmLegacy/itemgroups/bionics.json
@@ -20,5 +20,32 @@
         { "item": "fcl_bio_neurosoft_aircraft_mechanic", "prob": 10}
       ]
     }
+  },
+  {
+    "type": "item_group",
+    "id": "bionics_retail",
+    "subtype": "distribution",
+    "items": [
+      [ "bio_power_storage", 20 ],
+      [ "bio_tools", 10 ],
+      [ "bio_multimeter", 10 ],
+      [ "bio_electrokit", 10 ],
+      [ "bio_flashlight", 10 ],
+      [ "bio_tattoo_led", 10 ],
+      [ "bio_lighter", 10 ],
+      [ "bio_magnet", 10 ],
+      [ "bio_alarm", 10 ],
+      [ "bio_meteorologist", 10 ],
+      [ "bio_batteries", 10 ],
+      [ "bio_armor_eyes", 8 ],
+      [ "bio_metabolics", 8 ],
+      [ "bio_watch", 10 ],
+      [ "bio_radio", 5 ],
+      [ "bio_torsionratchet", 10 ],
+      [ "bio_cable", 10 ],
+      [ "bio_ears", 2 ],
+      [ "bio_fitnessband", 10 ],
+      [ "bio_taser", 5 ]
+    ]
   }
 ]

--- a/data/mods/FuturismCataclysmLegacy/itemgroups/bionics.json
+++ b/data/mods/FuturismCataclysmLegacy/itemgroups/bionics.json
@@ -51,6 +51,10 @@
   {
     "id": "fcl_bionics_power",
     "type": "item_group",
-    "items": [ [ "bio_power_storage_mkII", 1 ], [ "bio_power_storage", 14 ], [ "bio_betavoltaic", 5 ] ]
+    "items": [
+      [ "bio_power_storage_mkII", 1 ],
+      [ "bio_power_storage", 14 ],
+      [ "bio_betavoltaic", 5 ]
+    ]
   }
 ]

--- a/data/mods/FuturismCataclysmLegacy/itemgroups/vending_machines.json
+++ b/data/mods/FuturismCataclysmLegacy/itemgroups/vending_machines.json
@@ -1,0 +1,13 @@
+[
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "fcl_vending_medicine",
+    "entries": [
+      { "group": "drugs_pharmacy", "count": [ 5, 20 ] },
+      { "group": "drugs_soldier", "prob": 40, "count": [ 5, 25 ] },
+      { "group": "drugs_soldier", "prob": 40, "count": [ 5, 25 ] },
+      { "group": "hospital_medical_items", "prob": 50, "count": [ 5, 10 ] }
+    ]
+  }
+]

--- a/data/mods/FuturismCataclysmLegacy/itemgroups/vending_machines.json
+++ b/data/mods/FuturismCataclysmLegacy/itemgroups/vending_machines.json
@@ -7,7 +7,20 @@
       { "group": "drugs_pharmacy", "count": [ 5, 20 ] },
       { "group": "drugs_soldier", "prob": 40, "count": [ 5, 25 ] },
       { "group": "drugs_soldier", "prob": 40, "count": [ 5, 25 ] },
+      { "group": "drugs_morphine", "prob": 10, "count": [ 5, 10 ] },
       { "group": "hospital_medical_items", "prob": 50, "count": [ 5, 10 ] }
+    ]
+  },
+  {
+    "id": "drugs_morphine",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "morphine", "count": [ 1, 12 ], "container-item": "null", "prob": 10 },
+      { "item": "heroin", "entry-wrapper": "bag_zipper", "container-item": "null", "count": [ 20, 30 ], "prob": 10 },
+      { "group": "oxycodone_ad_group", "prob": 40 },
+      { "group": "codeine_ad_group", "prob": 60 },
+      { "group": "tramadol_ad_group", "prob": 60 }
     ]
   }
 ]

--- a/data/mods/FuturismCataclysmLegacy/mapgen/augmentation_clinic.json
+++ b/data/mods/FuturismCataclysmLegacy/mapgen/augmentation_clinic.json
@@ -1,0 +1,298 @@
+[
+  {
+    "type": "palette",
+    "id": "fcl_aug_clinic",
+    "terrain": {
+      " ": "t_region_groundcover_urban",
+      "!": "t_door_locked_interior",
+      "-": "t_wall_metal",
+      "|": "t_concrete_wall",
+      "+": "t_door_c",
+      "0": "t_vat",
+      "9": "t_window_domestic",
+      ":": "t_door_glass_c",
+      ";": "t_door_locked",
+      "=": "t_wall_glass",
+      "(": "t_reinforced_glass",
+      "X": "t_door_metal_locked",
+      "ó": "t_metal_ventilation_shutter",
+      "Y": "t_thconc_floor_olight",
+      "R": "t_railing",
+      "w": "t_window",
+      ">": "t_stairs_down",
+      "<": "t_stairs_up",
+      "~": "t_sidewalk"
+    },
+    "furniture": {
+      "$": "f_safe_l",
+      "A": "f_IV_pole",
+      "&": "f_toilet",
+      "%": "f_console_broken",
+      "5": "f_console",
+      "B": "f_bed",
+      "S": "f_sink",
+      "b": "f_bench",
+      "c": "f_counter",
+      "d": "f_desk",
+      "h": "f_chair",
+      "H": "f_utility_shelf",
+      "l": "f_locker",
+      "k": "f_bookcase",
+      "r": "f_trashcan",
+      "s": "f_sink",
+      "t": "f_metal_table",
+      "f": "f_filing_cabinet",
+      "^": "f_indoor_plant"
+    },
+    "items": { "&": { "item": "SUS_toilet", "chance": 50 } },
+    "toilets": { "&": {  } }
+  },
+  {
+    "type": "mapgen",
+    "om_terrain": [ "fcl_augmentation_clinic_n1" ],
+    "weight": 200,
+    "object": {
+      "fill_ter": "t_strconc_floor",
+      "rows": [
+        "                   ,,   ",
+        "                   ,,   ",
+        " -ó-----------    |,,|  ",
+        " -.--0.H%%H.0-     ,,   ",
+        " -.--0......0-     ,,   ",
+        " -.--0......0-     ,,   ",
+        " -.--0......0-     ,,   ",
+        " -.----...------  |,,|  ",
+        " -.--0......0-.-V,,,,,, ",
+        " -.--0......0ó.-V,,,Y,, ",
+        " ó.--0......0-.- |<,,|  ",
+        " ------(:(----.- |||||  ",
+        " -lb..:.Y.:..-.-        ",
+        " -lb.l|...(.0-.-        ",
+        " -llll|^.^(.A-.-        ",
+        " ----|||:||||-.-------- ",
+        "  -.!........-.óö....óó ",
+        "  -<-((('((((----.S-.-- ",
+        "  ---c.........-EEE-.óó ",
+        "    -c..tt..dh.-------- ",
+        "    -c..B...d.n-        ",
+        "    ------------        ",
+        "                        ",
+        "                        "
+      ],
+      "palettes": [ "fcl_aug_clinic" ],
+      "terrain": { "'": "t_door_glass_o", ".": "t_strconc_floor", ",": "t_sidewalk" },
+      "furniture": {
+        "?": "f_autodoc",
+        "/": "f_autodoc_couch",
+        "T": "f_table",
+        "n": "f_trashcan",
+        "E": "f_machinery_electronic",
+        "B": "f_xray"
+      },
+      "items": {
+        "c": { "item": "dissection", "chance": 80, "repeat": [ 1, 3 ] },
+        "d": { "item": "office", "chance": 60 },
+        "l": [
+          { "item": "dresser", "chance": 60, "repeat": [ 4, 9 ] },
+          { "item": "harddrugs", "chance": 30, "repeat": [ 1, 3 ] },
+          { "item": "drugs_analgesic", "chance": 20, "repeat": [ 1, 3 ] },
+          { "item": "gear_medical", "chance": 20 }
+        ],
+        "H": [
+          { "item": "harddrugs", "chance": 60 },
+          { "item": "gear_medical", "chance": 60, "repeat": [ 1, 3 ] },
+          { "item": "drugs_analgesic", "chance": 60, "repeat": [ 1, 3 ] },
+          { "item": "drugs_rare", "chance": 60 },
+          { "item": "surgery", "chance": 60 }
+        ],
+        "?": { "item": "autodoc_supplies", "chance": 100 }
+      },
+      "monster": { "ö": { "monster": "mon_skitterbot" } },
+      "vendingmachines": { "V": { "item_group": "fcl_vending_medicine", "reinforced": true } }
+    }
+  },
+  {
+    "type": "mapgen",
+    "om_terrain": [ "fcl_augmentation_clinic_n2" ],
+    "object": {
+      "fill_ter": "t_strconc_floor",
+      "rows": [
+        "                        ",
+        "                        ",
+        " |||||||((((((    |..|  ",
+        " |&s|^RÁ.ooot(          ",
+        " |r.|^......o(          ",
+        " ||+|^....t.o(          ",
+        " |^.........o(          ",
+        " ||+|^.....|||||RRRRRRR ",
+        " |&.|^hd......Y:......R ",
+        " |rs|^.d......Y:......R ",
+        " |||||||:||||||||R>..RR ",
+        " |Sccl|...|lccS| RRRRR  ",
+        " |....:.Y.:....|        ",
+        " |./?.=...=.?/.|        ",
+        " |....=^.^=....|        ",
+        " |||||||:|||||||---ó--- ",
+        "  |<!...........X....H- ",
+        "  |>||:|||:||||5-....H- ",
+        "  |||c..|Y.Y.c||-$ll$H- ",
+        "    |S..|.?/..c|------- ",
+        "    |S..|..A..c|        ",
+        "    ||||||||||||        ",
+        "                        ",
+        "                        "
+      ],
+      "palettes": [ "fcl_aug_clinic" ],
+      "terrain": { " ": "t_open_air" },
+      "furniture": { "?": "f_autodoc", "/": "f_autodoc_couch", "o": "f_sofa", "T": "f_metal_table", "Á": "f_armchair", "n": "f_trashcan" },
+      "computers": {
+        "5": {
+          "name": "Secure Bionic Storage Access",
+          "security": 2,
+          "options": [ { "name": "Unlock Door", "action": "unlock" } ],
+          "failures": [ { "action": "shutdown" }, { "action": "alarm" } ]
+        }
+      },
+      "items": {
+        "B": { "item": "hospital_bed", "chance": 60 },
+        "R": { "item": "SUS_trash_floor", "chance": 50 },
+        "o": { "item": "waitingroom", "chance": 60 },
+        "e": { "item": "SUS_fridge", "chance": 80 },
+        "C": { "item": "dresser", "chance": 75 },
+        "$": [
+          { "item": "bionics", "chance": 70, "repeat": [ 1, 2 ] },
+          { "item": "fcl_bionics_power", "repeat": [ 1, 2 ] }
+        ],
+        "f": { "item": "SUS_office_filing_cabinet", "chance": 90 },
+        "d": { "item": "SUS_office_desk", "chance": 60 },
+        "l": [
+          { "item": "harddrugs", "chance": 30, "repeat": [ 1, 3 ] },
+          { "item": "drugs_analgesic", "chance": 20, "repeat": [ 1, 3 ] },
+          { "item": "gear_medical", "chance": 20 }
+        ],
+        "c": [
+          { "item": "harddrugs", "chance": 30, "repeat": [ 1, 3 ] },
+          { "item": "drugs_analgesic", "chance": 20, "repeat": [ 1, 3 ] },
+          { "item": "surgery", "chance": 40 }
+        ],
+        "H": [
+          { "item": "harddrugs", "chance": 60 },
+          { "item": "gear_medical", "chance": 60, "repeat": [ 1, 3 ] },
+          { "item": "fcl_bionics_power", "repeat": [ 1, 2 ], "chance": 60 },
+          { "item": "drugs_analgesic", "chance": 60, "repeat": [ 1, 3 ] },
+          { "item": "drugs_rare", "chance": 60 },
+          { "item": "surgery", "chance": 60 }
+        ],
+        "?": { "item": "autodoc_supplies", "chance": 100 }
+      }
+    }
+  },
+  {
+    "type": "mapgen",
+    "om_terrain": "fcl_augmentation_clinic_n3",
+    "object": {
+      "fill_ter": "t_floor",
+      "rows": [
+        "                        ",
+        "                        ",
+        " ---------------------- ",
+        " -....................- ",
+        " -....................- ",
+        " -........o...........- ",
+        " -....................- ",
+        " -....................- ",
+        " -....................- ",
+        " -....................- ",
+        " -......#w##w##w##....- ",
+        " -.######bt#bt#bt#....- ",
+        " -.#f__f#__#__#__#....- ",
+        " -.#f__f#+##+##+##....- ",
+        " -.#f__f#________#....- ",
+        " -###+###_########A...- ",
+        "  #>____+_+_____L#A...- ",
+        "  ####w##_#y_/?_t#....- ",
+        "  ---..4##########....- ",
+        "    -.....&=...5------- ",
+        "    -..........-        ",
+        "    ------------        ",
+        "                        ",
+        "                        "
+      ],
+      "terrain": {
+        ".": "t_flat_roof",
+        "=": "t_flat_roof",
+        "&": "t_flat_roof",
+        "A": "t_flat_roof",
+        " ": "t_open_air",
+        "o": "t_glass_roof",
+        ">": "t_stairs_down",
+        "#": "t_wall_b",
+        "_": "t_floor",
+        "w": "t_wall_glass",
+        "+": "t_door_glass_frosted_lab_c",
+        "-": "t_gutter",
+        "4": "t_gutter_downspout",
+        "5": "t_gutter_drop"
+      },
+      "furniture": {
+        "&": "f_roof_turbine_vent",
+        "=": "f_vent_pipe",
+        "b": "f_bed",
+        "t": "f_metal_table",
+        "c": "f_armchair",
+        "f": "f_filing_cabinet",
+        "?": "f_autodoc",
+        "L": "f_locker",
+        "/": "f_autodoc_couch",
+        "y": [ "f_indoor_plant_y", "f_indoor_plant" ],
+        "A": "f_air_conditioner"
+      },
+      "items": {
+        "b": { "item": "hospital_bed", "chance": 60 },
+        "f": { "item": "SUS_office_filing_cabinet", "chance": 70 },
+        "L": [
+          { "item": "harddrugs", "chance": 60, "repeat": [ 1, 3 ] },
+          { "item": "gear_medical", "chance": 60, "repeat": [ 1, 3 ] },
+          { "item": "drugs_analgesic", "chance": 60, "repeat": [ 1, 3 ] },
+          { "item": "drugs_rare", "chance": 60 },
+          { "item": "surgery", "chance": 60 }
+        ],
+        "?": { "item": "autodoc_supplies", "chance": 100 }
+      }
+    }
+  },
+  {
+    "type": "mapgen",
+    "om_terrain": "fcl_augmentation_clinic_n4",
+    "object": {
+      "fill_ter": "t_flat_roof",
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "        ----------      ",
+        "   ------........-      ",
+        "   -..........:..-      ",
+        "   -.X...........-      ",
+        "   -.............-      ",
+        "  --.............-      ",
+        "  -........oooo..-      ",
+        "  ------5........-      ",
+        "        ----------      ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "palettes": [ "roof_palette" ]
+    }
+  }
+]

--- a/data/mods/FuturismCataclysmLegacy/mapgen/augmentation_clinic.json
+++ b/data/mods/FuturismCataclysmLegacy/mapgen/augmentation_clinic.json
@@ -54,7 +54,7 @@
     "object": {
       "fill_ter": "t_strconc_floor",
       "rows": [
-        "                   ,,   ",
+        "                 ∑ ,,   ",
         "                   ,,   ",
         " -ó-----------    |,,|  ",
         " -.--0.H%%H.0-     ,,   ",
@@ -107,7 +107,10 @@
         ],
         "?": { "item": "autodoc_supplies", "chance": 100 }
       },
-      "monster": { "ö": { "monster": "mon_skitterbot" } },
+      "monster": {
+        "ö": { "monster": "mon_skitterbot" },
+        "∑": { "monster": "mon_zombie_static" }
+      },
       "vendingmachines": { "V": { "item_group": "fcl_vending_medicine", "reinforced": true } }
     }
   },

--- a/data/mods/FuturismCataclysmLegacy/mapgen/basement/basement_bionic.json
+++ b/data/mods/FuturismCataclysmLegacy/mapgen/basement/basement_bionic.json
@@ -1,0 +1,63 @@
+[
+  {
+    "type": "mapgen",
+    "om_terrain": [ "basement_bionic" ],
+    "weight": 100,
+    "object": {
+      "fill_ter": "t_thconc_floor",
+      "rows": [
+        "                        ",
+        "           ############ ",
+        "           #...jjj....# ",
+        "           #..........# ",
+        "           #..~~~~~~..# ",
+        " ###########..~~~~~~..# ",
+        " #...jj..S#!..~~~~~~..# ",
+        " #?.......#...~~~~~~..# ",
+        " #/.......+!..........# ",
+        " #.CCC.CCC#!!...jjj...# ",
+        " #############+######## ",
+        " #bbbb#RRRRRR#...qqCCr# ",
+        " #....#H....R#FF......# ",
+        " #jj..#H.s..R#...CCCCC# ",
+        " #....#E....R#........# ",
+        " #c.u.............H..s# ",
+        " #................H..s# ",
+        " #X.Â.............H..s# ",
+        " #...............###### ",
+        " #.....#+##++#...#t..S# ",
+        " #.....#.w#..#...+...C# ",
+        " #.}...#.â#.<#...#.CC9# ",
+        " ###################### ",
+        "                        "
+      ],
+      "palettes": [ "domestic_general_and_variant_palette", "standard_and_variant_domestic_basement_palette" ],
+      "terrain": { "~": "t_water_pool" },
+      "furniture": { "}": "f_pinball_machine", "?": "f_autodoc", "/": "f_autodoc_couch" },
+      "place_loot": [
+        { "group": "alcohol", "x": [ 14, 15 ], "y": 12, "chance": 96, "repeat": [ 1, 2 ] },
+        { "group": "SUS_fridge_snacks", "x": [ 14, 15 ], "y": 12, "chance": 80, "repeat": [ 1, 2 ] },
+        { "group": "homebooks", "x": [ 7, 12 ], "y": 11, "chance": 70, "repeat": [ 1, 2 ] },
+        { "group": "homebooks", "x": 12, "y": [ 12, 14 ], "chance": 70, "repeat": [ 1, 2 ] },
+        { "group": "magazines", "x": 21, "y": [ 15, 17 ], "chance": 30 },
+        { "group": "magazines", "x": 9, "y": 12, "chance": 30 },
+        { "group": "snacks", "x": [ 16, 21 ], "y": 11, "chance": 40, "repeat": [ 1, 2 ] },
+        { "group": "snacks", "x": [ 16, 21 ], "y": 13, "chance": 40, "repeat": [ 1, 2 ] },
+        { "group": "softdrugs", "x": 21, "y": 20, "chance": 75, "repeat": [ 1, 2 ] },
+        { "group": "cleaning", "x": 11, "y": 6, "chance": 70, "repeat": [ 1, 2 ] },
+        { "group": "swimmer_set_any", "x": 11, "y": 8, "chance": 75, "repeat": [ 1, 4 ] },
+        { "group": "cleaning", "x": [ 11, 12 ], "y": 9, "chance": 70, "repeat": [ 1, 2 ] },
+        { "group": "surgery", "x": [ 8, 9 ], "y": 9, "chance": 70, "repeat": [ 1, 2 ] },
+        { "group": "bionics_retail", "x": [ 3, 5 ], "y": 9, "chance": 100 },
+        { "group": "bionics_retail", "x": [ 3, 5 ], "y": 9, "chance": 50 },
+        { "item": "television", "x": 21, "y": 16, "chance": 95 },
+        { "item": "soap", "x": 19, "y": 21, "chance": 80 },
+        { "item": "towel", "x": 20, "y": 21, "chance": 80 },
+        { "item": "towel", "x": 3, "y": 13, "chance": 60 },
+        { "item": "stereo", "x": 2, "y": 13, "chance": 50 }
+      ],
+      "items": { "?": { "item": "autodoc_supplies", "chance": 100 } },
+      "place_monster": [ { "monster": "mon_broken_cyborg", "x": 14, "y": 3, "chance": 100 } ]
+    }
+  }
+]

--- a/data/mods/FuturismCataclysmLegacy/mapgen/basement/basement_bionic.json
+++ b/data/mods/FuturismCataclysmLegacy/mapgen/basement/basement_bionic.json
@@ -48,6 +48,7 @@
         { "group": "swimmer_set_any", "x": 11, "y": 8, "chance": 75, "repeat": [ 1, 4 ] },
         { "group": "cleaning", "x": [ 11, 12 ], "y": 9, "chance": 70, "repeat": [ 1, 2 ] },
         { "group": "surgery", "x": [ 8, 9 ], "y": 9, "chance": 70, "repeat": [ 1, 2 ] },
+        { "group": "drugs_morphine", "x": [ 8, 9 ], "y": 9, "chance": 100, "repeat": [ 1, 2 ] },
         { "group": "bionics_retail", "x": [ 3, 5 ], "y": 9, "chance": 100 },
         { "group": "bionics_retail", "x": [ 3, 5 ], "y": 9, "chance": 50 },
         { "item": "television", "x": 21, "y": 16, "chance": 95 },

--- a/data/mods/FuturismCataclysmLegacy/modinfo.json
+++ b/data/mods/FuturismCataclysmLegacy/modinfo.json
@@ -2,7 +2,7 @@
   {
     "type": "MOD_INFO",
     "id": "catalegacy_future",
-    "name": "Futurism Cataclysm: Legacy (WIP)",
+    "name": "Futurism Cataclysm: Legacy",
     "authors": [ "LunaGlaze" ],
     "maintainers": [ "LunaGlaze" ],
     "description": "Brings back the nostalgic classic Cataclysm lore and deleted near-future elements, packed with even more content and enhancements. Atomic technology goes commercial, the US and China engage in an arms race over CBM technologies, and AI is fully deployed in police robotics... Plus, plenty of other ultra-cool, near-future sci-fi gear awaits you!",

--- a/data/mods/FuturismCataclysmLegacy/monstergroups/misc.json
+++ b/data/mods/FuturismCataclysmLegacy/monstergroups/misc.json
@@ -6,5 +6,14 @@
     "monsters": [
       { "monster": "mon_fcl_riotbot" }
     ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "FCL_GROUP_AUG_CLINIC",
+    "monsters": [
+      { "monster": "mon_broken_cyborg", "weight": 100 },
+      { "monster": "mon_prototype_cyborg", "weight": 100, "cost_multiplier": 2 },
+      { "group": "FCL_GROUP_ROBOT_CIVIL_SECURITY", "weight": 50, "cost_multiplier": 2, "pack_size": [ 1, 2 ] }
+    ]
   }
 ]

--- a/data/mods/FuturismCataclysmLegacy/monstergroups/robots.json
+++ b/data/mods/FuturismCataclysmLegacy/monstergroups/robots.json
@@ -6,5 +6,14 @@
       { "monster": "mon_fcl_copbot", "weight": 0, "cost_multiplier": 0 },
       { "monster": "mon_fcl_molebot", "weight": 40, "cost_multiplier": 0 }
     ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "FCL_GROUP_ROBOT_CIVIL_SECURITY",
+    "default": "mon_fcl_copbot",
+    "monsters": [
+      { "monster": "mon_fcl_copbot", "weight": 100, "cost_multiplier": 40 },
+      { "monster": "mon_fcl_riotbot", "weight": 100, "cost_multiplier": 100 }
+    ]
   }
 ]

--- a/data/mods/FuturismCataclysmLegacy/overmap/multitile_city_buildings.json
+++ b/data/mods/FuturismCataclysmLegacy/overmap/multitile_city_buildings.json
@@ -1,0 +1,12 @@
+[
+  {
+    "type": "city_building",
+    "id": "house_09b",
+    "locations": [ "land" ],
+    "overmaps": [
+      { "point": [ 0, 0, 0 ], "overmap": "house_09_north" },
+      { "point": [ 0, 0, 1 ], "overmap": "house_09_roof_north" },
+      { "point": [ 0, 0, -1 ], "overmap": "basement_bionic_north" }
+    ]
+  }
+]

--- a/data/mods/FuturismCataclysmLegacy/overmap/multitile_city_buildings.json
+++ b/data/mods/FuturismCataclysmLegacy/overmap/multitile_city_buildings.json
@@ -8,5 +8,16 @@
       { "point": [ 0, 0, 1 ], "overmap": "house_09_roof_north" },
       { "point": [ 0, 0, -1 ], "overmap": "basement_bionic_north" }
     ]
+  },
+  {
+    "type": "city_building",
+    "id": "fcl_augmentation_clinic_1",
+    "overmaps": [
+      { "point": [ 0, 0, 0 ], "overmap": "fcl_augmentation_clinic_n1_north" },
+      { "point": [ 0, 0, 1 ], "overmap": "fcl_augmentation_clinic_n2_north" },
+      { "point": [ 0, 0, 2 ], "overmap": "fcl_augmentation_clinic_n3_north" },
+      { "point": [ 0, 0, 3 ], "overmap": "fcl_augmentation_clinic_n4_north" }
+    ],
+    "locations": [ "land" ]
   }
 ]

--- a/data/mods/FuturismCataclysmLegacy/overmap/overmap_terrain/overmap_terrain_commercial.json
+++ b/data/mods/FuturismCataclysmLegacy/overmap/overmap_terrain/overmap_terrain_commercial.json
@@ -1,0 +1,17 @@
+[
+  {
+    "type": "overmap_terrain",
+    "id": [
+      "fcl_augmentation_clinic_n1",
+      "fcl_augmentation_clinic_n2",
+      "fcl_augmentation_clinic_n3",
+      "fcl_augmentation_clinic_n4"
+    ],
+    "name": "augmentation clinic",
+    "spawns": { "group": "FCL_GROUP_AUG_CLINIC", "population": [ 4, 10 ], "chance": 80 },
+    "sym": "P",
+    "color": "yellow",
+    "flags": [ "SIDEWALK" ],
+    "see_cost": "high"
+  }
+]

--- a/data/mods/FuturismCataclysmLegacy/overmap/overmap_terrain/overmap_terrain_residential.json
+++ b/data/mods/FuturismCataclysmLegacy/overmap/overmap_terrain/overmap_terrain_residential.json
@@ -1,0 +1,8 @@
+[
+  {
+    "type": "overmap_terrain",
+    "id": [ "basement_bionic" ],
+    "copy-from": "generic_city_house_basement",
+    "spawns": { "group": "GROUP_BASEMENT_HOUSE", "population": [ 1, 1 ], "chance": 80 }
+  }
+]

--- a/data/mods/FuturismCataclysmLegacy/overmap/overmap_terrain/overmap_terrain_residential.json
+++ b/data/mods/FuturismCataclysmLegacy/overmap/overmap_terrain/overmap_terrain_residential.json
@@ -4,20 +4,5 @@
     "id": [ "basement_bionic" ],
     "copy-from": "generic_city_house_basement",
     "spawns": { "group": "GROUP_BASEMENT_HOUSE", "population": [ 1, 1 ], "chance": 80 }
-  },
-  {
-    "type": "overmap_terrain",
-    "id": [
-      "fcl_augmentation_clinic_n1",
-      "fcl_augmentation_clinic_n2",
-      "fcl_augmentation_clinic_n3",
-      "fcl_augmentation_clinic_n4"
-    ],
-    "name": "augmentation clinic",
-    "spawns": { "group": "FCL_GROUP_AUG_CLINIC", "population": [ 4, 10 ], "chance": 80 },
-    "sym": "P",
-    "color": "yellow",
-    "flags": [ "SIDEWALK" ],
-    "see_cost": "high"
   }
 ]

--- a/data/mods/FuturismCataclysmLegacy/overmap/overmap_terrain/overmap_terrain_residential.json
+++ b/data/mods/FuturismCataclysmLegacy/overmap/overmap_terrain/overmap_terrain_residential.json
@@ -4,5 +4,20 @@
     "id": [ "basement_bionic" ],
     "copy-from": "generic_city_house_basement",
     "spawns": { "group": "GROUP_BASEMENT_HOUSE", "population": [ 1, 1 ], "chance": 80 }
+  },
+  {
+    "type": "overmap_terrain",
+    "id": [
+      "fcl_augmentation_clinic_n1",
+      "fcl_augmentation_clinic_n2",
+      "fcl_augmentation_clinic_n3",
+      "fcl_augmentation_clinic_n4"
+    ],
+    "name": "augmentation clinic",
+    "spawns": { "group": "FCL_GROUP_AUG_CLINIC", "population": [ 4, 10 ], "chance": 80 },
+    "sym": "P",
+    "color": "yellow",
+    "flags": [ "SIDEWALK" ],
+    "see_cost": "high"
   }
 ]

--- a/data/mods/FuturismCataclysmLegacy/region_settings/regional_map_settings.json
+++ b/data/mods/FuturismCataclysmLegacy/region_settings/regional_map_settings.json
@@ -8,7 +8,7 @@
         [ "house_09b", 20 ]
       ],
       "shops": [
-        [ "fcl_augmentation_clinic_1", 150 ]
+        [ "fcl_augmentation_clinic_1", 180 ]
       ]
     }
   }

--- a/data/mods/FuturismCataclysmLegacy/region_settings/regional_map_settings.json
+++ b/data/mods/FuturismCataclysmLegacy/region_settings/regional_map_settings.json
@@ -1,0 +1,12 @@
+[
+  {
+    "type": "region_settings_city",
+    "id": "default",
+    "copy-from": "default",
+    "extend": {
+      "houses": [
+        [ "house_09b", 20 ]
+      ]
+    }
+  }
+]

--- a/data/mods/FuturismCataclysmLegacy/region_settings/regional_map_settings.json
+++ b/data/mods/FuturismCataclysmLegacy/region_settings/regional_map_settings.json
@@ -6,6 +6,9 @@
     "extend": {
       "houses": [
         [ "house_09b", 20 ]
+      ],
+      "shops": [
+        [ "fcl_augmentation_clinic_1", 150 ]
       ]
     }
   }

--- a/data/mods/FuturismCataclysmLegacy/start_locations.json
+++ b/data/mods/FuturismCataclysmLegacy/start_locations.json
@@ -1,0 +1,13 @@
+[
+  {
+    "type": "start_location",
+    "id": "sloc_house",
+    "name": "House",
+    "copy-from": "sloc_house",
+    "extend": {
+      "terrains": [
+        "house_09b"
+      ]
+    }
+  }
+]

--- a/data/mods/FuturismCataclysmLegacy/start_locations.json
+++ b/data/mods/FuturismCataclysmLegacy/start_locations.json
@@ -9,5 +9,11 @@
         "house_09b"
       ]
     }
+  },
+  {
+    "type": "start_location",
+    "id": "sloc_fcl_augmentation_clinic_n3",
+    "name": "Augclinic",
+    "terrain": [ "fcl_augmentation_clinic_n3" ]
   }
 ]


### PR DESCRIPTION
####  Summary

Update the `Futurism Cataclysm: Legacy` mod to add two new structures related to the commercialization of CBM technology.

#### Purpose of change

As is widely known, Cataclysm was originally a realistic, hardcore post-apocalyptic roguelike survival game with sci-fi elements. However, the core module of the C:DDA branch has long been gutting its inherent sci-fi elements without providing a **sufficiently** suitable replacement. I have already discussed all of this back in PR #374 and PR #377. To recap the big picture: I am currently building a more lightweight, optional alternative for our new branch that won't completely overhaul the core module, ensuring these near-future elements aren't lost to history.

Per the previous plan, the final step to complete the initial draft of this mod is to add, at a bare minimum, some structures that correspond to its core theme. However, after doing some research, the number of such locations that were genuinely implemented in the past and are easy to restore but have since been deleted is actually quite small...

#### Describe the solution

 - Ported the "retail" CBM item groups from C:TLG.
 - Restored a rare basement variant featuring an autodoc capable of implanting CBMs, along with some extra morphine-type drugs, implying a form of illegal, underground modification practice.
 - Ported the augmentation clinic from AFS, replacing some mod-exclusive ultra-futuristic items with assets from the core module, with a lower spawn probability than in AFS, but added a variant where a nurse bot might appear.
 - Removed the WIP declaration.

#### Test

Downloaded the latest compiled experimental version, applied the mod's updated content, and loaded it into a world; the game runs perfectly fine with no startup errors.