### PR TITLE
Fix GitHub workflow automation

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,23 +3,23 @@ version: v1
 labels:
   - label: "<Enhancement / Feature>"
     matcher:
-      body: "(\\s|^)#### 概述 \(Summary\)\\s*Features +\".+\"\\s*(\n|$)"
+      body: "(\\s|^)#### Summary\\s*Features +\".+\"\\s*(\n|$)"
 
   - label: "Info / User Interface"
     matcher:
-      body: "(\\s|^)#### 概述 \(Summary\)\\s*Interface +\".+\"\\s*(\n|$)"
+      body: "(\\s|^)#### Summary\\s*Interface +\".+\"\\s*(\n|$)"
 
   - label: "Mods"
     matcher:
-      body: "(\\s|^)#### 概述 \(Summary\)\\s*Mods +\".+\"\\s*(\n|$)"
+      body: "(\\s|^)#### Summary\\s*Mods +\".+\"\\s*(\n|$)"
 
   - label: "Game: Balance"
     matcher:
-      body: "(\\s|^)#### 概述 \(Summary\)\\s*Balance +\".+\"\\s*(\n|$)"
+      body: "(\\s|^)#### Summary\\s*Balance +\".+\"\\s*(\n|$)"
 
   - label: "<Bugfix>"
     matcher:
-      body: "(\\s|^)#### 概述 \(Summary\)\\s*Bugfixes +\".+\"\\s*(\n|$)"
+      body: "(\\s|^)#### Summary\\s*Bugfixes +\".+\"\\s*(\n|$)"
 
   - label: "<Bugfix>"
     matcher:
@@ -27,19 +27,19 @@ labels:
 
   - label: "Code: Performance"
     matcher:
-      body: "(\\s|^)#### 概述 \(Summary\)\\s*Performance +\".+\"\\s*(\n|$)"
+      body: "(\\s|^)#### Summary\\s*Performance +\".+\"\\s*(\n|$)"
 
   - label: "Code: Infrastructure / Style / Static Analysis"
     matcher:
-      body: "(\\s|^)#### 概述 \(Summary\)\\s*Infrastructure +\".+\"\\s*(\n|$)"
+      body: "(\\s|^)#### Summary\\s*Infrastructure +\".+\"\\s*(\n|$)"
 
   - label: "Code: Build"
     matcher:
-      body: "(\\s|^)#### 概述 \(Summary\)\\s*Build +\".+\"\\s*(\n|$)"
+      body: "(\\s|^)#### Summary\\s*Build +\".+\"\\s*(\n|$)"
 
   - label: "Translation"
     matcher:
-      body: "(\\s|^)#### 概述 \(Summary\)\\s*I18N +\".+\"\\s*(\n|$)"
+      body: "(\\s|^)#### Summary\\s*I18N +\".+\"\\s*(\n|$)"
 
   - label: "[C++]"
     matcher:
@@ -452,6 +452,21 @@ labels:
     matcher:
       files:
         - data/mods/Isolation-Protocol/**/*
+
+  - label: "Mods: Futurism Cataclysm"
+    matcher:
+      files:
+        - data/mods/FuturismCataclysmLegacy/**/*
+
+  - label: "Mods: Cataclysm Delight"
+    matcher:
+      files:
+        - data/mods/cdda_Delight/**/*
+
+  - label: "Mods: Path of Immortals"
+    matcher:
+      files:
+        - data/mods/immortal_path/**/*
 
   - label: "Mods"
     matcher:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,8 @@ PR 提交准则：
 - 你可以另开 PR 来拆分一次较大的预期改动；如果不确定怎么拆，尽管问。我们很乐意与你协作，并建议合并你 PR 的最佳方式。
 -->
 
-#### 概述 (Summary)
+#### Summary
+<!-- #### 概述 -->
 分类 "简要描述"
 
 <!-- 这一节应当只有一行，请编辑上面那一行。
@@ -25,7 +26,8 @@ https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/blob/master/doc/
 合并后，你的概述会被加入项目更新日志：
 https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/blob/master/data/changelog.txt -->
 
-#### 改动目的 (Purpose of change)
+#### Purpose of change
+<!-- #### 变更目的 -->
 
 <!-- 用几句话描述你做这次改动的原因。
 如果它与某个已有 issue 相关，可以用「#」加 GitHub issue 编号来关联，例如 #1234。
@@ -41,19 +43,23 @@ https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/blob/master/data
 如果没有相关 issue，请在这里说明你要解决的问题、特性或其他关注点。如果这是一个 bug 修复，请附上复现原始 bug 的步骤，以便你的修复可以被验证。 -->
 
 
-#### 解决方案描述 (Describe the solution)
+#### Describe the solution
+<!-- #### 解决方案描述 -->
 
 <!-- 这个特性是如何工作的，或者这个 bug 是怎么被修复的？方案越易于理解，就越快能被合并。 -->
 
-#### 你考虑过的替代方案 (Describe alternatives you've considered)
+#### Describe alternatives you've considered
+<!-- #### 你考虑过的替代方案 -->
 
 <!-- 说明你为解决同一问题考虑过的其他方案、不同思路或可能性。 -->
 
-#### 测试 (Testing)
+#### Testing
+<!-- #### 测试 -->
 
 <!-- 描述你采取了哪些步骤来测试这个 PR 是否修复了 bug 或添加了特性，以及你做了哪些测试以确保没有引入回归问题。也请为审阅者和维护者提供测试建议。参见 TESTING_YOUR_CHANGES.md -->
 
-#### 补充说明 (Additional context)
+#### Additional context
+<!-- #### 补充说明 -->
 
 <!-- 在此添加关于这个特性或 bug 修复的其他背景信息（例如原型图、概念验证或截图）。 -->
 

--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -3,4 +3,5 @@ files:
     - ZihanZheng258
   'data/mods/immortal_path/**':
     - EliadOArias
-      
+  'data/mods/FuturismCataclysmLegacy/**':
+    - LunaGlaze


### PR DESCRIPTION
####  Summary

None

#### Purpose of change

Fix the issue where the github-actions Bot failed to function properly due to the incorrect changes in #363, and update the GitHub workflow automation.

#### Describe the solution

 - Request Review: Synchronize our branch-exclusive mod info (assigning me as the developer and contributor of `Futurism Cataclysm: Legacy`).
 - Labeler: The github-actions Bot does not recognize Chinese. The changes in #363, which modified its regex pattern to "gaishu(zh_cn) (Summary)", caused it to completely stop working. Reverted this change, and added label determination logic for three branch-exclusive mods: "Mods: Futurism Cataclysm", "Mods: Cataclysm Delight", and "Mods: Path of Immortals".
 - pull_request_template: Synchronized with the Labeler and changed the headings back to English only.