### PR TITLE
fix: 修复纯计数型工具作为原材料时的错误

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3982,7 +3982,12 @@ bool item::use_charges( const itype_id &what, int &qty, std::list<item> &used,
             return VisitResponse::NEXT;
         }
 
-        if( e->is_tool() || e->is_gun() ) {
+        // 纯计数型工具（subtypes:["TOOL"] 且 stackable:true，如 cotton_patchwork、
+        // glass_shard、nylon 等裁缝/碎片组件）应作为"按数量消耗的材料"走下文
+        // count_by_charges 的 split 路径，否则会落入 ammo_consume 就地扣减 charges
+        // 的 TOOL 路径，导致 used 记录剩余量而非消耗量、0-charge 残栈与回退多扣。
+        // 真·工具 / 枪（count_by_charges()==false）仍走 TOOL 路径，行为不变。
+        if( ( e->is_tool() || e->is_gun() ) && !e->count_by_charges() ) {
             if( e->typeId() == what || ( in_tools && e->ammo_current() == what ) ) {
                 int n = 0;
                 if( e->uses_firing_requirements() ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3982,11 +3982,14 @@ bool item::use_charges( const itype_id &what, int &qty, std::list<item> &used,
             return VisitResponse::NEXT;
         }
 
-        // 纯计数型工具（subtypes:["TOOL"] 且 stackable:true，如 cotton_patchwork、
-        // glass_shard、nylon 等裁缝/碎片组件）应作为"按数量消耗的材料"走下文
-        // count_by_charges 的 split 路径，否则会落入 ammo_consume 就地扣减 charges
-        // 的 TOOL 路径，导致 used 记录剩余量而非消耗量、0-charge 残栈与回退多扣。
-        // 真·工具 / 枪（count_by_charges()==false）仍走 TOOL 路径，行为不变。
+        // Items that are both tools (or guns) and count_by_charges (e.g. stackable
+        // TOOL components such as cotton_patchwork, glass_shard, nylon) are
+        // consumed by quantity as material and must take the count_by_charges
+        // split branch below. Otherwise they fall into the TOOL branch, where
+        // ammo_consume mutates e->charges in place, so the copy in `used` records
+        // the remaining charges instead of the amount consumed, leaves behind
+        // 0-charge stacks, and triggers spurious retry over-consumption. Items
+        // that are not count_by_charges continue to take the TOOL/gun path unchanged.
         if( ( e->is_tool() || e->is_gun() ) && !e->count_by_charges() ) {
             if( e->typeId() == what || ( in_tools && e->ammo_current() == what ) ) {
                 int n = 0;


### PR DESCRIPTION
# Bug：TOOL 类型物品在批量制造中消耗数量与记录不一致

#### 概述 (Summary)
Bugfixes "修复既为 TOOL 且 `stackable: true` 的物品在批量制造中消耗记录与实际扣减不一致的问题"

#### 改动目的 (Purpose of change)

当玩家使用 **`subtypes: ["TOOL"]` 且 `stackable: true`** 的物品作为制作材料进行批量制造时，会发生以下异常：

1. **物品实际被扣减**，但系统记录的数量与实际消耗量不一致。
2. **后续制造检查时报告原材料不足**，即使背包中仍然有足够的材料。
3. 触发 `DEBUG assert "Attempted a recipe with no available components!"`。
4. **物品栈可能残留 0-charge 的空物品**，干扰后续的库存计数。

##### 复现步骤

物品：`cotton_patchwork`（棉布片），定义见 `data/json/items/tool/toiletries.json`。
配方：打包 100 个棉布片 → 1 个打包棉布片。
背包：400 个 + 95 个 = 495 个。

配方和物品来源于我自己的 MOD(此处列出简要说明)
```json
[
    {
        "id": "pack_cotton_patchwork",
        "type": "ITEM",
        "category": "spare_parts",
        "name": {
            "str": "打包的棉布片(100)"
        },
        "description": "打包在一起的棉布片",
        "looks_like": "cotton_patchwork",
        "weight": "150 g",
        "volume": "180 ml",
        "price": "200 USD",
        "price_postapoc": "200 cent",
        "symbol": "=",
        "material": [
            "cotton"
        ]
    },
    {
        "type": "recipe",
        "activity_level": "LIGHT_EXERCISE",
        "result": "pack_cotton_patchwork",
        "category": "CC_打包",
        "subcategory": "CSC_打包_布料打包",
        "skill_used": "fabrication",
        "id_suffix": "打包", 
        "difficulty": 0,
        "charges": 1,
        "time": "1 s",
        "autolearn": true,
        "proficiencies": [],
        "qualities": [],
        "tools": [],
        "components": [
            [
                [
                    "cotton_patchwork",
                    100
                ]
            ]
        ]
    }
]
```

**场景 A（单次批量 4 个）**：
- 需要 400 个棉布片。
- 实际从 400 的栈中扣光了所有 495 个，两栈均变为 0 个。
- 系统记录为：消耗了 0 charges（空物品）。
- 报错：缺乏原材料。

**场景 B（逐个制作）**：
- 第一次制作：消耗了 100 个，记录为消耗了 300（剩余 300 + 95）。
- 第二次制作：在 300 上再消耗 100，记录为消耗了 200（剩余 200 + 95）。
- 第三次制作：在 200 上再消耗 100，记录为消耗了 100（剩余 100 + 95）。
- 第四次制作：库存显示 196，但 `charges_of` 返回异常，无法继续。

---

#### 解决方案描述 (Describe the solution)

##### 前置知识：`charges` 字段的双重语义

在 CDDA 中，`charges` 字段的语义取决于物品类型：

| 物品类型 | `charges` 含义 |
|----------|---------------|
| `count_by_charges()` 物品（含 `stackable: true`）| **堆叠数量**。400 个棉布片堆在一格 = 1 个 item 对象，`charges = 400`。 |
| 工具/武器（`is_tool()` / `is_gun()`）| **弹药/燃料剩余次数**。焊枪的电池电量、打火机的使用次数。 |

`cotton_patchwork` 同时满足两条判定：`stackable: true` 使 `count_by_charges()` 返回 `true`（`src/itype.h` 中 `count_by_charges()` 的实现为 `stackable_ || ammo || ( comestible && phase != phase_id::SOLID )`），`subtypes: ["TOOL"]` 使 `is_tool()` 返回 `true`。

##### 根因

`item::use_charges`（`src/item.cpp`）中 `is_tool() || is_gun()` 分支位于 `count_by_charges()` 分支之前：

```cpp
if( e->is_tool() || e->is_gun() ) {   // cotton_patchwork 走此路
    ...
    n = e->ammo_consume( qty, pos, carrier );   // 就地修改 e->charges
    if( n > 0 ) {
        item temp( *e );            // 复制的是扣减后的状态
        used.push_back( temp );     // charges 是剩余量，不是消耗量
        ...
        return VisitResponse::SKIP; // 不加入 del，整栈扣尽也不清理
    }
}
```

`ammo_consume`（`src/item_gun_tool_ammo.cpp`，对 `is_tool() && ammo_id.empty()` 的物品）直接修改 `e->charges`：

```cpp
if( is_tool() && type->tool->ammo_id.empty() ) {
    int charg_used = std::min( charges, qty );
    charges -= charg_used;     // 直接修改 item 的 charges 字段
    qty -= charg_used;
}
```

由此 `used` 中记录的是**剩余量**而非**消耗量**，且整栈扣尽时不进入 `del`，故产生 0-charge 残栈。下游 `consume_items`（`src/crafting.cpp`）以 `real_count -= it.charges` 抵扣，等于减了剩余量，导致回退逻辑误判与多扣（场景 A 全部 495 个被扣光即源于此）。

而语义正确的 `count_by_charges` 分支使用 `split`：扣减前复制一份记录消耗量，整栈扣尽时入 `del` 清理。但因为 `is_tool()` 判断在前，此类物品永远走不到 `split` 路径。

##### 修复

收紧 TOOL/GUN 分支入口条件，让 `count_by_charges()` 为真的物品 fall-through 到下方的 `count_by_charges` 分支，由既有 `split` / `del` 逻辑接管：

```cpp
// 修改前
if( e->is_tool() || e->is_gun() ) {

// 修改后
if( ( e->is_tool() || e->is_gun() ) && !e->count_by_charges() ) {
```

改动后这两类物品改走 `split` 路径：
- `qty < charges`：`split` 返回新 item，`charges = qty`（消耗量）入 `used`，原栈原地扣减，`real_count -= it.charges` 正确抵扣。
- `qty >= charges`：`split` 返回 null，整体消耗——`used.push_back(*e)`（扣减前状态，charges=整栈量），`del.push_back(e)` 使整栈被 `remove_item` 清理，0-charge 残栈自动消除。

上述 4 个症状一次性全部消除，无需额外的记录修正补丁，也无需单独写"清理耗尽栈"代码（`del` 机制本就处理）。

##### 行为不变性

`count_by_charges() == stackable_ || ammo || ( comestible && phase != SOLID )`。

- 常规工具（焊枪、打火机等）：`stackable_=false`、非 ammo、非液体食物 → `count_by_charges()` 为 `false`，条件不变，仍走 TOOL 路径。
- 枪 / 枪改件：必为非 stackable、非 ammo、非液体食物 → `count_by_charges()` 为 `false`，仍走 TOOL/GUN 路径。
- `uses_firing_requirements()` 工具：全数据交叉验证（核心 `data/json` 与全部 mod，含 `TEST_DATA`）共 11 个，均为 GUN 子类型，无一为 TOOL，无一写 `stackable`；`firing_requirements` 与 `stackable` 在现有数据中不会同时出现于同一物品，`consume_tool_uses` 的 `factor` 换算路径完全不受影响。
- 唯一行为变化的是既满足 `is_tool()` 又满足 `count_by_charges()` 的物品，全仓库共 **6 个**（`cotton_patchwork`、`glass_shard`、`nylon`、`sheet_kevlar_layered`、`rigid_kevlar_plate`、`gambeson_batting`），全部应是按数量消耗的裁缝/碎片组件，本就该走 `split`。

| 路径 | `qty < charges`（部分消耗） | `qty >= charges`（整栈消耗） |
|---|---|---|
| 修改前（TOOL 路径）| `ammo_consume` 扣 `e->charges`；`temp(*e)` 记剩余量 | 整栈扣成 0；`temp(*e).charges=0`；残栈保留 |
| 修改后（split 路径）| `split` 返新 item.charges=消耗量；原栈原地扣减 | `del.push_back(e)`；整栈入 `used` 并被清理 |

---

#### 你考虑过的替代方案 (Describe alternatives you've considered)

**治标方案**：在 TOOL 路径 `if( n > 0 )` 块内补 `temp.charges = n;`。这能把 `used` 中记录的 charges 修正为实际消耗量 `n`（`ammo_consume` 返回的 `wanted_qty - qty`），使下游 `real_count` 抵扣正确。

该方案的局限：
- 仅修正记录语义，**无法清理 0-charge 残栈**——TOOL 路径从不 `del.push_back(e)`，仍会产生空栈占位、干扰库存计数（即症状 4）。
- 仍把本应按数量消耗的材料塞进 `ammo_consume` 代码路径，分支语义未归位，后续维护易再引入同类问题。

相比之下，采用 fall-through 方案由既有的 `split`/`del` 路径统一处理记录、整栈消耗与残栈清理三类问题，改动更小且语义更一致。

---

#### 测试 (Testing)

属于 C++ 改动，需自行编译（见 [doc/c++/COMPILING.md](https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/blob/master/doc/c%2B%2B/COMPILING.md)），并按 [doc/TESTING_YOUR_CHANGES.md](https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/blob/master/doc/TESTING_YOUR_CHANGES.md) 在游戏内验证（可用调试菜单 `Spawning > Spawn item` 生成 `cotton_patchwork` 等）。

##### 建议验证场景

1. **单个制作 × 4 次**（batch_size=1）：
   - 背包：400 + 95 = 495。
   - 每次消耗 100，4 次均能成功，剩余 95。
   - 检查每次 `used` 中 item.charges = 100（而非 300/200/100）。
   - `real_count` 每次应精确归零。

2. **批量制作 4 个**（batch_size=4）：
   - 背包：400 + 95 = 495。
   - 一次消耗 400，顺利完成，剩余 95。
   - 检查 `used` 中 item.charges = 400（而非 0）。

3. **边界情况**：
   - 背包恰好等于所需数量（如 400 个 → 批量 4 个）。
   - 背包不足（如 399 个 → 批量 4 个，应拒绝）。
   - 多个不同来源的栈（背包 + 地面 + 容器内物品）。

4. **回归验证**：常规工具（焊枪、打火机等）按 charges 正常消耗、`uses_firing_requirements()` 工具的 `factor` 换算仍正确——这些物品 `count_by_charges()` 为 false，行为不变。

---

#### 补充说明 (Additional context)

##### 制作消耗调用链

```
make_craft_with_command()
  → craft_command::execute()          // 选择组件
    → select_item_component()         // 使用 charges_of() 检查库存
  → craft_command::create_in_progress_craft()
    → sane_consume_items()
      → Character::consume_items()
        → Character::use_charges()
          → item::use_charges()       // 问题发生处
            → item::ammo_consume()    // 实际扣减 charges
```

`used` 中 items 的 charges 记录混乱，会导致后续 `get_continue_reqs()` 与 `can_continue_craft()` 基于错误数据计算剩余需求。

##### 相关代码文件

| 文件 | 行号 | 内容 |
|------|------|------|
| `src/item.cpp` | 3973-4044 | `item::use_charges` — 消耗逻辑入口 |
| `src/item.cpp` | 3985-4020 | TOOL/GUN 路径（已收紧条件，纯计数型工具 fall-through） |
| `src/item.cpp` | 4022-4041 | count_by_charges 路径（split 路径，纯计数型工具改走此路） |
| `src/item_gun_tool_ammo.cpp` | 1832-1918 | `item::ammo_consume` — 实际扣减 charges |
| `src/character.cpp` | 5759-5813 | `Character::use_charges` — 遍历背包调用 item::use_charges |
| `src/crafting.cpp` | 3210-3326 | `Character::consume_items` — 消耗组件主体逻辑 |
| `src/craft_command.cpp` | 658 | `create_in_progress_craft` — 将 `used` 计入 `used.add(it)` |
| `src/visitable.cpp` | 904-937 | `scan_tool_charges` — 统计可用 charges 数量 |
| `src/item.cpp` | 497 | `item::split` — qty>=charges 时返回 null |

##### 其他发现

**`uses_firing_requirements()` 分支的结构相似性**：`item::use_charges` 中该分支由 `consume_tool_uses` 修改工具状态后 `item temp(*e)` 复制，模式与本次 bug 相似，但涉及 `legacy_charges_per_use_factor` 换算。数据交叉验证表明此类物品均为 GUN、非 stackable、`count_by_charges()` 为 false，不受本次改动影响，故未改动。

**`split` 边界条件**：`item::split`（`src/item.cpp:497`）在 `qty >= charges` 时返回 null，是设计正确的行为（需要等于或超过栈大小时应整体消耗而非拆分），结合 `visit_items` 的 `ABORT` 行为可保证遍历完整。

##### 影响物品清单（既 `is_tool()` 又 `count_by_charges()`）

| id | 文件 |
|----|------|
| `glass_shard` | `data/json/items/resources/glass.json` |
| `nylon` | `data/json/items/resources/plastic.json` |
| `sheet_kevlar_layered` | `data/json/items/resources/tailoring.json` |
| `rigid_kevlar_plate` | `data/json/items/resources/tailoring.json` |
| `gambeson_batting` | `data/json/items/resources/tailoring.json` |
| `cotton_patchwork` | `data/json/items/tool/toiletries.json` |

---

<!--README: Cataclysm: Cleanwater Bomb (CCB) 以 Creative Commons Attribution ShareAlike 3.0 许可证发布。
游戏的代码与内容可自由用于任何目的的使用、修改和再分发。
通过为本项目做贡献，你即同意该许可证的条款，并同意你所做的任何贡献也将受同一许可证覆盖。
详见 http://creativecommons.org/licenses/by-sa/3.0/ 。 -->