### PR TITLE
Fix map memory test CI diagnostics

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -135,6 +135,14 @@ static const ammotype ammo_battery( "battery" );
 
 static const furn_str_id furn_f_rope_up( "f_rope_up" );
 
+static void erase_cached_vehicle_ladders( std::map<tripoint_bub_ms, std::pair<vehicle *, int> > &cache,
+        const vehicle *veh )
+{
+    erase_if( cache, [veh]( const std::pair<const tripoint_bub_ms, std::pair<vehicle *, int>> &entry ) {
+        return entry.second.first == veh;
+    } );
+}
+
 static const bionic_id bio_shock_absorber( "bio_shock_absorber" );
 
 static const damage_type_id damage_bash( "bash" );
@@ -282,14 +290,6 @@ static const ter_str_id ter_t_window_no_curtains( "t_window_no_curtains" );
 
 static const trap_str_id tr_portal( "tr_portal" );
 static const trap_str_id tr_unfinished_construction( "tr_unfinished_construction" );
-
-static void erase_cached_vehicle_ladders( std::map<tripoint_bub_ms, std::pair<vehicle *, int> > &cache,
-        const vehicle *veh )
-{
-    erase_if( cache, [veh]( const std::pair<const tripoint_bub_ms, std::pair<vehicle *, int>> &entry ) {
-        return entry.second.first == veh;
-    } );
-}
 
 #define dbg(x) DebugLog((x),D_MAP) << __FILE__ << ":" << __LINE__ << ": "
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -135,14 +135,6 @@ static const ammotype ammo_battery( "battery" );
 
 static const furn_str_id furn_f_rope_up( "f_rope_up" );
 
-static void erase_cached_vehicle_ladders( std::map<tripoint_bub_ms, std::pair<vehicle *, int> > &cache,
-        const vehicle *veh )
-{
-    erase_if( cache, [veh]( const std::pair<const tripoint_bub_ms, std::pair<vehicle *, int>> &entry ) {
-        return entry.second.first == veh;
-    } );
-}
-
 static const bionic_id bio_shock_absorber( "bio_shock_absorber" );
 
 static const damage_type_id damage_bash( "bash" );
@@ -290,6 +282,14 @@ static const ter_str_id ter_t_window_no_curtains( "t_window_no_curtains" );
 
 static const trap_str_id tr_portal( "tr_portal" );
 static const trap_str_id tr_unfinished_construction( "tr_unfinished_construction" );
+
+static void erase_cached_vehicle_ladders( std::map<tripoint_bub_ms, std::pair<vehicle *, int> > &cache,
+        const vehicle *veh )
+{
+    erase_if( cache, [veh]( const std::pair<const tripoint_bub_ms, std::pair<vehicle *, int>> &entry ) {
+        return entry.second.first == veh;
+    } );
+}
 
 #define dbg(x) DebugLog((x),D_MAP) << __FILE__ << ":" << __LINE__ << ": "
 

--- a/tests/map_memory_test.cpp
+++ b/tests/map_memory_test.cpp
@@ -10,6 +10,7 @@
 #include "coordinates.h"
 #include "enums.h"
 #include "game.h"
+#include "level_cache.h"
 #include "lru_cache.h"
 #include "map.h"
 #include "map_helpers.h"

--- a/tests/map_memory_test.cpp
+++ b/tests/map_memory_test.cpp
@@ -1,5 +1,6 @@
 #include <bitset>
 #include <cstdio>
+#include <memory>
 #include <sstream>
 #include <string>
 
@@ -7,12 +8,14 @@
 #include "calendar.h"
 #include "cata_catch.h"
 #include "coordinates.h"
+#include "enums.h"
 #include "game.h"
 #include "lru_cache.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "map_memory.h"
 #include "map_scale_constants.h"
+#include "mdarray.h"
 #include "options_helpers.h"
 #include "player_helpers.h"
 #include "point.h"
@@ -23,6 +26,9 @@ static constexpr tripoint_abs_ms p1{ -SEEX - 2, -SEEY - 3, -1 };
 static constexpr tripoint_abs_ms p2{ 5, 7, -1 };
 static constexpr tripoint_abs_ms p3{ SEEX * 2 + 5, SEEY + 7, -1 };
 static constexpr tripoint_abs_ms p4{ SEEX * 3 + 2, SEEY * 7 + 1, -1 };
+
+static const ter_str_id ter_t_floor( "t_floor" );
+static const ter_str_id ter_t_wall( "t_wall" );
 
 TEST_CASE( "map_memory_keeps_region", "[map_memory]" )
 {
@@ -142,12 +148,11 @@ TEST_CASE( "map_memory_refreshes_visibility_after_avatar_moves", "[map_memory][v
     const tripoint_bub_ms start( 50, 50, 0 );
     const tripoint_bub_ms destination = start + tripoint::east * 20;
     const tripoint_abs_ms destination_abs = here.get_abs( destination );
-    const ter_str_id floor( "t_floor" );
 
     g->place_player( start );
     you.clear_map_memory();
     you.recalc_sight_limits();
-    REQUIRE( here.ter_set( destination, floor ) );
+    REQUIRE( here.ter_set( destination, ter_t_floor ) );
 
     // Establish a valid visibility cache at the old position.  At midnight,
     // the destination is beyond the avatar's unaided vision.
@@ -162,7 +167,7 @@ TEST_CASE( "map_memory_refreshes_visibility_after_avatar_moves", "[map_memory][v
     you.setpos( here, destination, false );
     here.update_map_memory( you );
 
-    CHECK( you.get_memorized_tile( destination_abs ).get_ter_id() == floor.str() );
+    CHECK( you.get_memorized_tile( destination_abs ).get_ter_id() == ter_t_floor.str() );
 }
 
 TEST_CASE( "map_memory_refreshes_visibility_after_transparency_changes", "[map_memory][vision]" )
@@ -175,8 +180,6 @@ TEST_CASE( "map_memory_refreshes_visibility_after_transparency_changes", "[map_m
     map &here = get_map();
     avatar &you = get_avatar();
     const tripoint_bub_ms requested_start( 50, 50, 0 );
-    const ter_str_id floor( "t_floor" );
-    const ter_str_id wall( "t_wall" );
 
     g->place_player( requested_start );
     const tripoint_bub_ms start = you.pos_bub( here );
@@ -186,8 +189,8 @@ TEST_CASE( "map_memory_refreshes_visibility_after_transparency_changes", "[map_m
     you.clear_map_memory();
     g->reset_light_level();
     you.recalc_sight_limits();
-    REQUIRE( here.ter_set( blocker, wall ) );
-    REQUIRE( here.ter_set( target, floor ) );
+    REQUIRE( here.ter_set( blocker, ter_t_wall ) );
+    REQUIRE( here.ter_set( target, ter_t_floor ) );
 
     here.invalidate_map_cache( start.z() );
     here.build_map_cache( start.z() );
@@ -206,11 +209,11 @@ TEST_CASE( "map_memory_refreshes_visibility_after_transparency_changes", "[map_m
     // Opening a door or curtains changes transparency without moving the
     // avatar.  The derived visibility cache must be refreshed before map
     // memory is recorded at the end of the action.
-    REQUIRE( here.ter_set( blocker, floor ) );
+    REQUIRE( here.ter_set( blocker, ter_t_floor ) );
     here.update_map_memory( you );
 
     CHECK( target_is_clear() );
-    CHECK( you.get_memorized_tile( target_abs ).get_ter_id() == floor.str() );
+    CHECK( you.get_memorized_tile( target_abs ).get_ter_id() == ter_t_floor.str() );
 }
 
 // TODO: map memory save / load


### PR DESCRIPTION
## Summary

Follow-up to #395, which merged before its CI cleanup commit was pushed.

- add the direct includes required by IWYU for the map-memory regression test
- promote fixed terrain IDs to file-scope constants for clang-tidy

No runtime behavior is changed by this follow-up. The PR now changes only `tests/map_memory_test.cpp`.

## Validation

- `make -j6 tests` — compiled and linked successfully
- targeted Catch2 test — **All tests passed (7 assertions in 1 test case)**
- `git diff --check origin/master...HEAD` — passed

The test process still reports initialization errors from existing JSON text-style violations on `master`; the Catch2 assertions pass.