### PR TITLE
That spark glittering on your fingertips bring unshakeable faith for life back.

### DIFF
--- a/data/mods/FuturismCataclysmLegacy/bionics.json
+++ b/data/mods/FuturismCataclysmLegacy/bionics.json
@@ -8,11 +8,23 @@
     "learned_proficiencies": [ "prof_helicopter_pilot" ]
   },
   {
-  "id": "fcl_bio_neurosoft_aircraft_mechanic",
-  "type": "bionic",
-  "name": { "str": "Neurosoft: Airframe and Powerplant Mechanic" },
-  "description": "A brain implant that grants instinctual knowledge about the repair of flying machines.",
-  "occupied_bodyparts": [ [ "head", 2 ] ],
-  "learned_proficiencies": [ "prof_aircraft_mechanic" ]
+    "id": "fcl_bio_neurosoft_aircraft_mechanic",
+    "type": "bionic",
+    "name": { "str": "Neurosoft: Airframe and Powerplant Mechanic" },
+    "description": "A brain implant that grants instinctual knowledge about the repair of flying machines.",
+    "occupied_bodyparts": [ [ "head", 2 ] ],
+    "learned_proficiencies": [ "prof_aircraft_mechanic" ]
+  },
+  {
+    "id": "fcl_bio_railgun",
+    "type": "bionic",
+    "name": { "str": "Railgun" },
+    "description": "EM field generators in the user's arms allow them to launch metallic objects in an unconventional way. This mechanism requires the projectile to hover briefly in the air in front of an outstretched arm, usually after being thrown up slightly. Then, at the precise moment, a massive magnetic pulse is released, causing the object to be launched by electrical currents emitted alongside the user's arms, requiring no actual throwing motion. It consumes a tremendous amount of energy and relies far more on the user's intelligence to control than on physical strength. In theory, it can even hit with the force of a sniper rifle using nothing more than a coin.",
+    "occupied_bodyparts": [ [ "head", 1 ], [ "torso", 2 ], [ "arm_r", 10 ], [ "hand_r", 2 ] ],
+    "flags": [ "BIONIC_TOGGLED" ],
+    "act_cost": "1 kJ",
+    "react_cost": "100 J",
+    "trigger_cost": "200 kJ",
+    "time": "1 s"
   }
 ]

--- a/data/mods/FuturismCataclysmLegacy/itemgroups/bionics.json
+++ b/data/mods/FuturismCataclysmLegacy/itemgroups/bionics.json
@@ -6,7 +6,8 @@
     "extend": { 
       "items": [
         { "item": "fcl_bio_neurosoft_aeronautics", "prob": 10 },
-        { "item": "fcl_bio_neurosoft_aircraft_mechanic", "prob": 10 }
+        { "item": "fcl_bio_neurosoft_aircraft_mechanic", "prob": 10 },
+        { "item": "fcl_bio_railgun", "prob": 10 }
       ]
     }
   },
@@ -17,7 +18,8 @@
     "extend": { 
       "items": [
         { "item": "fcl_bio_neurosoft_aeronautics", "prob": 10 },
-        { "item": "fcl_bio_neurosoft_aircraft_mechanic", "prob": 10 }
+        { "item": "fcl_bio_neurosoft_aircraft_mechanic", "prob": 10 },
+        { "item": "fcl_bio_railgun", "prob": 10 }
       ]
     }
   },

--- a/data/mods/FuturismCataclysmLegacy/itemgroups/harvest_cbm.json
+++ b/data/mods/FuturismCataclysmLegacy/itemgroups/harvest_cbm.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "Zomborg_CBM_harvest_ranged_weapons",
+    "type": "item_group",
+    "copy-from": "Zomborg_CBM_harvest_ranged_weapons",
+    "extend": { 
+      "items": [
+        [ "fcl_bio_railgun", 5 ]
+      ]
+    }
+  }
+]

--- a/data/mods/FuturismCataclysmLegacy/items/cbms.json
+++ b/data/mods/FuturismCataclysmLegacy/items/cbms.json
@@ -20,5 +20,16 @@
     "price": "10 kUSD",
     "price_postapoc": "1 kUSD",
     "difficulty": 8
+  },
+  {
+    "id": "fcl_bio_railgun",
+    "copy-from": "bionic_general",
+    "name": { "str": "Railgun CBM" },
+    "looks_like": "bio_int_enhancer",
+    "description": "EM field generators in the user's arms allow them to launch metallic objects in an unconventional way. This mechanism requires the projectile to hover briefly in the air in front of an outstretched arm, usually after being thrown up slightly. Then, at the precise moment, a massive magnetic pulse is released, causing the object to be launched by electrical currents emitted alongside the user's arms, requiring no actual throwing motion. It consumes a tremendous amount of energy and relies far more on the user's intelligence to control than on physical strength. In theory, it can even hit with the force of a sniper rifle using nothing more than a coin.",
+    "price": "2200 USD",
+    "price_postapoc": "950 USD",
+    "weight": "1000 g",
+    "difficulty": 5
   }
 ]

--- a/data/mods/FuturismCataclysmLegacy/items/cbms.json
+++ b/data/mods/FuturismCataclysmLegacy/items/cbms.json
@@ -24,6 +24,8 @@
   {
     "id": "fcl_bio_railgun",
     "copy-from": "bionic_general",
+    "type": "ITEM",
+    "subtypes": [ "BIONIC_ITEM" ],
     "name": { "str": "Railgun CBM" },
     "looks_like": "bio_int_enhancer",
     "description": "EM field generators in the user's arms allow them to launch metallic objects in an unconventional way. This mechanism requires the projectile to hover briefly in the air in front of an outstretched arm, usually after being thrown up slightly. Then, at the precise moment, a massive magnetic pulse is released, causing the object to be launched by electrical currents emitted alongside the user's arms, requiring no actual throwing motion. It consumes a tremendous amount of energy and relies far more on the user's intelligence to control than on physical strength. In theory, it can even hit with the force of a sniper rifle using nothing more than a coin.",

--- a/data/mods/FuturismCataclysmLegacy/npcs/exodii/exodii_merchant_itemlist.json
+++ b/data/mods/FuturismCataclysmLegacy/npcs/exodii/exodii_merchant_itemlist.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "EXODII_CBM_unlocks_weapons_heavy",
+    "type": "item_group",
+    "copy-from": "EXODII_CBM_unlocks_weapons_heavy",
+    "extend": { 
+      "items": [
+        [ "fcl_bio_railgun", 5 ]
+      ]
+    }
+  }
+]

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3757,7 +3757,7 @@ int Character::throw_range( const item &it ) const
     // When using bionic railgun, it is not considered a normal throw; a special algorithm is employed.
     if( do_railgun && !throw_assist ) {
         int ench_range = enchantment_cache->get_value_add( enchant_vals::mod::RANGE );
-        int ench_range_mult = enchantment_cache->get_value_multiply( enchant_vals::mod::RANGE );
+        float ench_range_mult = 1.0f + enchantment_cache->get_value_multiply( enchant_vals::mod::RANGE );
         const int railgun_range_cap_max = round( ( attr_int * 3 + get_skill_level( skill_throw ) + ench_range ) * ench_range_mult + 10 );
         if( tmp.weight() >= 150_gram ) {
             ret = ( ( attr_int * 20 ) / ( tmp.weight() / 113_gram ) + ench_range ) * ench_range_mult + 5;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3709,6 +3709,9 @@ int Character::throw_range( const item &it ) const
 
     int ench_bonus = enchantment_cache->get_value_add( enchant_vals::mod::THROW_STR );
     int str = get_arm_str() + ench_bonus;
+    int attr_int = get_int();
+
+    const bool do_railgun = has_active_bionic( bio_railgun ) && tmp.made_of_any( ferric );
 
     /** @ARM_STR determines maximum weight that can be thrown */
     if( ( tmp.weight() / 113_gram ) > str * 15 )  {
@@ -3716,9 +3719,13 @@ int Character::throw_range( const item &it ) const
     }
     // Increases as weight decreases until 150 g, then decreases again
     /** @ARM_STR increases throwing range, vs item weight (high or low) */
+    std::optional<int> throw_assist = std::nullopt;
     if( is_mounted() ) {
         auto *mons = mounted_creature.get();
-        str = mons->mech_str_addition() != 0 ? mons->mech_str_addition() : str;
+        if( mons->mech_str_addition() != 0 ) {
+            throw_assist = mons->mech_str_addition();
+        }
+        str = throw_assist ? *throw_assist : str;
     }
     // Skill and high dexterity reduce the range penalty for very light items.
     float light_item_coeff = 1.0f + 0.1f * get_skill_level( skill_throw );
@@ -3736,9 +3743,6 @@ int Character::throw_range( const item &it ) const
         ret = ( str * 10 ) / light_penalty;
     }
     ret -= tmp.volume() / 1_liter;
-    if( has_active_bionic( bio_railgun ) && tmp.made_of_any( ferric ) ) {
-        ret *= 2;
-    }
 
     if( ret < 1 ) {
         ret = 1;
@@ -3748,6 +3752,26 @@ int Character::throw_range( const item &it ) const
     const int range_cap = round( str * 3 + get_skill_level( skill_throw ) + ench_bonus );
     if( ret > range_cap ) {
         ret = range_cap;
+    }
+
+    // When using bionic railgun, it is not considered a normal throw; a special algorithm is employed.
+    if( do_railgun && !throw_assist ) {
+        int ench_range = enchantment_cache->get_value_add( enchant_vals::mod::RANGE );
+        int ench_range_mult = enchantment_cache->get_value_multiply( enchant_vals::mod::RANGE );
+        const int railgun_range_cap_max = round( ( attr_int * 3 + get_skill_level( skill_throw ) + ench_range ) * ench_range_mult + 10 );
+        if( tmp.weight() >= 150_gram ) {
+            ret = ( ( attr_int * 20 ) / ( tmp.weight() / 113_gram ) + ench_range ) * ench_range_mult + 5;
+        } else if( tmp.weight() >= 20_gram ) {
+            int light_penalty = 10 - static_cast<int>( tmp.weight() / 15_gram );
+            light_penalty = std::max( 1, static_cast<int>( light_penalty / light_item_coeff ) );
+            ret = ( ( attr_int * 20 ) / light_penalty + ench_range ) * ench_range_mult + 10;
+        } else {
+            ret = railgun_range_cap_max;
+        }
+        ret -= tmp.volume() / 1_liter;
+        if( ret > railgun_range_cap_max ) {
+            ret = railgun_range_cap_max;
+        }
     }
 
     ret = static_cast<int>( std::round( ret * throw_range_multiplier() ) );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3757,7 +3757,7 @@ int Character::throw_range( const item &it ) const
     // When using bionic railgun, it is not considered a normal throw; a special algorithm is employed.
     if( do_railgun && !throw_assist ) {
         int ench_range = enchantment_cache->get_value_add( enchant_vals::mod::RANGE );
-        float ench_range_mult = 1.0f + enchantment_cache->get_value_multiply( enchant_vals::mod::RANGE );
+        double ench_range_mult = 1.0 + enchantment_cache->get_value_multiply( enchant_vals::mod::RANGE );
         const int railgun_range_cap_max = round( ( attr_int * 3 + get_skill_level( skill_throw ) + ench_range ) * ench_range_mult + 10 );
         if( tmp.weight() >= 150_gram ) {
             ret = ( ( attr_int * 20 ) / ( tmp.weight() / 113_gram ) + ench_range ) * ench_range_mult + 5;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -143,7 +143,7 @@ static const addiction_id addiction_sleeping_pill( "sleeping pill" );
 static const anatomy_id anatomy_human_anatomy( "human_anatomy" );
 
 static const bionic_id bio_ods( "bio_ods" );
-static const bionic_id bio_railgun( "bio_railgun" );
+static const bionic_id fcl_bio_railgun( "fcl_bio_railgun" );
 static const bionic_id bio_shock_absorber( "bio_shock_absorber" );
 static const bionic_id bio_sleep_shutdown( "bio_sleep_shutdown" );
 static const bionic_id bio_soporific( "bio_soporific" );
@@ -3711,7 +3711,7 @@ int Character::throw_range( const item &it ) const
     int str = get_arm_str() + ench_bonus;
     int attr_int = get_int();
 
-    const bool do_railgun = has_active_bionic( bio_railgun ) && tmp.made_of_any( ferric );
+    const bool do_railgun = has_active_bionic( fcl_bio_railgun ) && tmp.made_of_any( ferric );
 
     /** @ARM_STR determines maximum weight that can be thrown */
     if( ( tmp.weight() / 113_gram ) > str * 15 )  {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1579,8 +1579,28 @@ static double thrown_item_weight_damage( const Character &thrower, const item &t
                                   + 0.5f * ( skill / static_cast<float>( MAX_SKILL ) )
                                   + 0.03f * std::max( 0, dex - 8 );
 
-    const double scaled_weight_dmg = weight_dmg * velocity_factor;
-    const double cap = thrower.thrown_item_adjusted_damage( thrown );
+    double scaled_weight_dmg = weight_dmg * velocity_factor;
+    double cap = thrower.thrown_item_adjusted_damage( thrown );
+
+    // When using bionic railgun, it is not considered a normal throw; a special algorithm is employed.
+    bool do_railgun = thrower.has_active_bionic( bio_railgun ) && thrown.made_of_any( ferric );
+    if( do_railgun && thrower.is_mounted() ) {
+        auto *mons = thrower.mounted_creature.get();
+        if( mons->mech_str_addition() != 0 ) {
+            do_railgun = false;
+        }
+    }
+    // RANGED_DAMAGE enchantment can used at railgun throwing
+    if( do_railgun ) {
+        int ench_range = thrower.enchantment_cache->get_value_add( enchant_vals::mod::RANGED_DAMAGE );
+        int ench_range_mult = thrower.enchantment_cache->get_value_multiply( enchant_vals::mod::RANGED_DAMAGE );
+        scaled_weight_dmg *= std::max( ( thrower.get_int() / 10.0 ), 1.0 );
+        scaled_weight_dmg += ench_range;
+        scaled_weight_dmg *= ench_range_mult;
+        cap += ench_range;
+        cap *= ench_range_mult;
+    }
+
     return std::min( scaled_weight_dmg, cap );
 }
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -142,6 +142,7 @@ character_modifier_melee_thrown_move_lift_mod( "melee_thrown_move_lift_mod" );
 static const character_modifier_id
 character_modifier_ranged_dispersion_manip_mod( "ranged_dispersion_manip_mod" );
 static const character_modifier_id character_modifier_thrown_dex_mod( "thrown_dex_mod" );
+static const character_modifier_id character_modifier_limb_str_mod( "limb_str_mod" );
 
 static const damage_type_id damage_bash( "bash" );
 static const damage_type_id damage_cut( "cut" );
@@ -1591,9 +1592,11 @@ int Character::thrown_item_adjusted_damage( const item &thrown ) const
 
     // The damage dealt due to item's weight, player's strength, and skill level
     // Up to str/2 or weight/100g (lower), so 10 str is 5 damage before multipliers
-    // Railgun doubles the effective strength
+    // Railgun uses intelligence and base kinetic energy boosts as a form of power 
+    // to simulate a character's ability to operate and calculate with high-tech equipment.
     ///\ARM_STR increases throwing damage
-    double stats_mod = do_railgun ? get_str() : ( get_arm_str() / 2.0 );
+    double modifier = std::max( 0.85f , get_modifier( character_modifier_limb_str_mod ) );
+    double stats_mod = do_railgun ? ( 10 + ( get_int() * modifier ) / 2.0 ) : ( get_arm_str() / 2.0 );
     stats_mod = throw_assist ? *throw_assist / 2.0 : stats_mod;
     // modify strength impact based on skill level, clamped to [0.15 - 1]
     // mod = mod * [ ( ( skill / max_skill ) * 0.85 ) + 0.15 ]

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1579,8 +1579,9 @@ static double thrown_item_weight_damage( const Character &thrower, const item &t
                                   + 0.5f * ( skill / static_cast<float>( MAX_SKILL ) )
                                   + 0.03f * std::max( 0, dex - 8 );
 
-    double scaled_weight_dmg = weight_dmg * velocity_factor;
-    double cap = thrower.thrown_item_adjusted_damage( thrown );
+    const double scaled_weight_dmg = weight_dmg * velocity_factor;
+    const double cap = thrower.thrown_item_adjusted_damage( thrown );
+    double thrown_dmg = std::min( scaled_weight_dmg, cap );
 
     // When using bionic railgun, it is not considered a normal throw; a special algorithm is employed.
     bool do_railgun = thrower.has_active_bionic( bio_railgun ) && thrown.made_of_any( ferric );
@@ -1592,16 +1593,13 @@ static double thrown_item_weight_damage( const Character &thrower, const item &t
     }
     // RANGED_DAMAGE enchantment can used at railgun throwing
     if( do_railgun ) {
-        int ench_range = thrower.enchantment_cache->get_value_add( enchant_vals::mod::RANGED_DAMAGE );
-        int ench_range_mult = thrower.enchantment_cache->get_value_multiply( enchant_vals::mod::RANGED_DAMAGE );
-        scaled_weight_dmg *= std::max( ( thrower.get_int() / 10.0 ), 1.0 );
-        scaled_weight_dmg += ench_range;
-        scaled_weight_dmg *= ench_range_mult;
-        cap += ench_range;
-        cap *= ench_range_mult;
+        int ench_range_dmg = thrower.enchantment_cache->get_value_add( enchant_vals::mod::RANGED_DAMAGE );
+        int ench_range_dmg_mult = thrower.enchantment_cache->get_value_multiply( enchant_vals::mod::RANGED_DAMAGE );
+        thrown_dmg += ench_range_dmg;
+        thrown_dmg *= ench_range_dmg_mult;
     }
 
-    return std::min( scaled_weight_dmg, cap );
+    return thrown_dmg;
 }
 
 int Character::thrown_item_adjusted_damage( const item &thrown ) const

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1575,13 +1575,9 @@ static double thrown_item_weight_damage( const Character &thrower, const item &t
 
     // Base 1.0; high skill and dexterity let the thrower get more damage out of
     // light items without changing the low-stat balance.
-    const float velocity_factor = 1.0f
+    float velocity_factor = 1.0f
                                   + 0.5f * ( skill / static_cast<float>( MAX_SKILL ) )
                                   + 0.03f * std::max( 0, dex - 8 );
-
-    const double scaled_weight_dmg = weight_dmg * velocity_factor;
-    const double cap = thrower.thrown_item_adjusted_damage( thrown );
-    double thrown_dmg = std::min( scaled_weight_dmg, cap );
 
     // When using bionic railgun, it is not considered a normal throw; a special algorithm is employed.
     bool do_railgun = thrower.has_active_bionic( bio_railgun ) && thrown.made_of_any( ferric );
@@ -1591,12 +1587,21 @@ static double thrown_item_weight_damage( const Character &thrower, const item &t
             do_railgun = false;
         }
     }
+    if( do_railgun ) {
+        velocity_factor += std::max( ( thrower.get_int() / 10.0 ), 1.0 );
+    }
+
+    const double scaled_weight_dmg = weight_dmg * velocity_factor;
+    const double cap = thrower.thrown_item_adjusted_damage( thrown );
+    double thrown_dmg = std::min( scaled_weight_dmg, cap );
+
     // RANGED_DAMAGE enchantment can used at railgun throwing
     if( do_railgun ) {
         int ench_range_dmg = thrower.enchantment_cache->get_value_add( enchant_vals::mod::RANGED_DAMAGE );
         int ench_range_dmg_mult = thrower.enchantment_cache->get_value_multiply( enchant_vals::mod::RANGED_DAMAGE );
         thrown_dmg += ench_range_dmg;
         thrown_dmg *= ench_range_dmg_mult;
+        thrown_dmg += 8;
     }
 
     return thrown_dmg;

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1598,7 +1598,7 @@ static double thrown_item_weight_damage( const Character &thrower, const item &t
     // RANGED_DAMAGE enchantment can used at railgun throwing
     if( do_railgun ) {
         int ench_range_dmg = thrower.enchantment_cache->get_value_add( enchant_vals::mod::RANGED_DAMAGE );
-        int ench_range_dmg_mult = thrower.enchantment_cache->get_value_multiply( enchant_vals::mod::RANGED_DAMAGE );
+        float ench_range_dmg_mult = 1.0f + thrower.enchantment_cache->get_value_multiply( enchant_vals::mod::RANGED_DAMAGE );
         thrown_dmg += ench_range_dmg;
         thrown_dmg *= ench_range_dmg_mult;
         thrown_dmg += 8;

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1598,7 +1598,7 @@ static double thrown_item_weight_damage( const Character &thrower, const item &t
     // RANGED_DAMAGE enchantment can used at railgun throwing
     if( do_railgun ) {
         int ench_range_dmg = thrower.enchantment_cache->get_value_add( enchant_vals::mod::RANGED_DAMAGE );
-        float ench_range_dmg_mult = 1.0f + thrower.enchantment_cache->get_value_multiply( enchant_vals::mod::RANGED_DAMAGE );
+        double ench_range_dmg_mult = 1.0 + thrower.enchantment_cache->get_value_multiply( enchant_vals::mod::RANGED_DAMAGE );
         thrown_dmg += ench_range_dmg;
         thrown_dmg *= ench_range_dmg_mult;
         thrown_dmg += 8;

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -133,7 +133,7 @@ static const ammotype ammo_m235( "m235" );
 static const ammotype ammo_metal_rail( "metal_rail" );
 static const ammotype ammo_strange_arrow( "strange_arrow" );
 
-static const bionic_id bio_railgun( "bio_railgun" );
+static const bionic_id fcl_bio_railgun( "fcl_bio_railgun" );
 
 static const character_modifier_id
 character_modifier_melee_thrown_move_balance_mod( "melee_thrown_move_balance_mod" );
@@ -1580,7 +1580,7 @@ static double thrown_item_weight_damage( const Character &thrower, const item &t
                                   + 0.03f * std::max( 0, dex - 8 );
 
     // When using bionic railgun, it is not considered a normal throw; a special algorithm is employed.
-    bool do_railgun = thrower.has_active_bionic( bio_railgun ) && thrown.made_of_any( ferric );
+    bool do_railgun = thrower.has_active_bionic( fcl_bio_railgun ) && thrown.made_of_any( ferric );
     if( do_railgun && thrower.is_mounted() ) {
         auto *mons = thrower.mounted_creature.get();
         if( mons->mech_str_addition() != 0 ) {
@@ -1610,7 +1610,7 @@ static double thrown_item_weight_damage( const Character &thrower, const item &t
 int Character::thrown_item_adjusted_damage( const item &thrown ) const
 {
     const std::optional<int> throw_assist = character_throw_assist( *this );
-    const bool do_railgun = has_active_bionic( bio_railgun ) && thrown.made_of_any( ferric ) &&
+    const bool do_railgun = has_active_bionic( fcl_bio_railgun ) && thrown.made_of_any( ferric ) &&
                             !throw_assist;
 
     // The damage dealt due to item's weight, player's strength, and skill level
@@ -1699,7 +1699,7 @@ dealt_projectile_attack Character::throw_item( const tripoint_bub_ms &target, co
         proj.critical_multiplier += 0.06f * std::min( dex, per );
     }
 
-    const bool do_railgun = has_active_bionic( bio_railgun ) && thrown.made_of_any( ferric ) &&
+    const bool do_railgun = has_active_bionic( fcl_bio_railgun ) && thrown.made_of_any( ferric ) &&
                             !throw_assist;
 
     impact.add_damage( damage_bash, thrown_item_weight_damage( *this, thrown ) );
@@ -1743,7 +1743,7 @@ dealt_projectile_attack Character::throw_item( const tripoint_bub_ms &target, co
     if( do_railgun ) {
         proj_effects.insert( ammo_effect_LIGHTNING );
 
-        const units::energy trigger_cost = bio_railgun->power_trigger;
+        const units::energy trigger_cost = fcl_bio_railgun->power_trigger;
         mod_power_level( -trigger_cost );
     }
 


### PR DESCRIPTION
####  Summary

Mods "Rationalize, upgrade, and bring back Railgun CBM in Futurism Cataclysm: Legacy"

#### Purpose of change

While researching items "migrated" in older versions, I discovered a removed CBM with the internal ID `bio_railgun`. The annotation noted: remove after 0.H stable https://github.com/CleverRaven/Cataclysm-DDA/pull/61176
However, I found that the C++ code for `bio_railgun` is still floating in the `src` directory, remaining undeleted despite not being referenced by the core module or migrated to Aftershock.

To salvage this "redundant" code, I read the corresponding C:DDA branch PR and discovered it was removed because it used a throwing algorithm logic, which was deemed inconsistent with the principles of a "railgun," leading it to be replaced by the pure `Throwing Assist CBM` as a more reasonable enhancement for throwing capabilities. 
However, I felt the concept was still quite cool, and if the logic and lore were rewritten, it could be seamlessly re-implemented into my `Futurism Cataclysm: Legacy` mod. Moreover, I saw the following reply in the comments section of that PR:

```
The "Railgun" in this context is clearly a reference to the well-known Toaru Majutsu no Index series and one of its main characters' abilities to launch a coin at high speeds utilising the character's electrical manipulation abilities.
```

This provided a clear direction, and I even found some hypothetical calculation data regarding this character's abilities on a Chinese subculture wiki that can serve as a reference.

#### Describe the solution

Completely reset the internal throwing logic for `bio_railgun` and renamed it to `fcl_bio_railgun`. The damage and range calculations are now set to scale primarily with the character's Intelligence stat, and it can benefit from ranged attack enchantments (typically those meant for firearms). At the same time, its specific performance has been significantly boosted.

Simultaneously, I rewrote the `bio_railgun` item removed in the DDA PR as `fcl_bio_railgun` and added it to the `Futurism Cataclysm: Legacy` mod and its spawn lists. I adjusted the CBM slot occupation data and increased the energy cost per throw by 20x (from 10kJ to 200kJ; according to calculations by Chinese ACG enthusiasts, the energy consumed by the prototype character per Railgun launch is approximately 218kJ, so I rounded this down assuming higher energy efficiency from near-future technology).

Completely rewrote the lore and mechanism description to:

```
EM field generators in the user's arms allow them to launch metallic objects in an unconventional way. This mechanism requires the projectile to hover briefly in the air in front of an outstretched arm, usually after being thrown up slightly. Then, at the precise moment, a massive magnetic pulse is released, causing the object to be launched by electrical currents emitted alongside the user's arms, requiring no actual throwing motion. It consumes a tremendous amount of energy and relies far more on the user's intelligence to control than on physical strength. In theory, it can even hit with the force of a sniper rifle using nothing more than a coin.
```