### PR TITLE
Fix pocket whitelist item selection crash

### DIFF
--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -406,12 +406,12 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
         if( selected >= 0 ) {
             size_t idx = selected;
             const std::vector<std::pair<itype_id, std::string>> *names = nullptr;
-            if( idx <= listed_names.size() ) {
+            if( idx < listed_names.size() ) {
                 names = &listed_names;
             } else {
                 idx -= listed_names.size();
             }
-            if( !names && idx <= nearby_names.size() ) {
+            if( !names && idx < nearby_names.size() ) {
                 names = &nearby_names;
             }
             if( names ) {


### PR DESCRIPTION
## Summary
- Fix out-of-bounds selection when adding nearby items to pocket whitelist/blacklist settings
- Keep listed and nearby item selector indices within their respective vectors

## Testing
- make -j6 obj/item_contents.o
- git diff --check
- tests/cata_test "pocket_favorites_allow_or_restrict_items"