### PR TITLE
修复 Experimental Release 启动失败

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,9 @@ jobs:
     uses: ./.github/workflows/compose-tilesets.yml
   build-translations:
     uses: ./.github/workflows/build-translations.yml
+    permissions:
+      actions: read
+      contents: read
     secrets:
       TX_TOKEN: ${{ secrets.TX_TOKEN }}
 


### PR DESCRIPTION
## 原因

PR #401 将 `build-translations.yml` 的可复用工作流权限收紧为 `actions: read` 和 `contents: read`，但 `release.yml` 的调用处没有授予这些权限，导致 Experimental Release 在创建 job 前以 `startup_failure` 结束。

## 修复

在 `release.yml` 的 `build-translations` 调用处补充：

- `actions: read`
- `contents: read`

该配置与已能正常启动的 `matrix.yml` 调用保持一致。

## 验证

- YAML 语法解析通过。
- `git diff --check` 通过。
- 仅修改 Actions 权限声明，不涉及游戏代码。
