### PR TITLE
CI：固定 AStyle 3.1 格式环境

### DIFF
--- a/.github/workflows/astyle.yml
+++ b/.github/workflows/astyle.yml
@@ -5,7 +5,7 @@ on: pull_request
 jobs:
   skip-duplicates:
     continue-on-error: true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # Map a step output to a job output
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -25,7 +25,7 @@ jobs:
     needs: skip-duplicates
     if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' }}
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -33,7 +33,10 @@ jobs:
         persist-credentials: false
 
     - name: install dependencies
-      run: sudo apt-get install astyle
+      run: |
+        sudo apt-get update
+        sudo apt-get install --no-install-recommends astyle
+        astyle --version | grep -F "Artistic Style Version 3.1"
 
     - name: astyle check
       run: make astyle-check

--- a/doc/c++/DEVELOPER_TOOLING.md
+++ b/doc/c++/DEVELOPER_TOOLING.md
@@ -47,6 +47,10 @@ More details below on how to make these work and other ways to invoke these tool
 
 Automatic formatting of source code is performed by [Artistic Style](http://astyle.sourceforge.net/).
 
+CI uses AStyle 3.1 from Ubuntu 24.04.  AStyle output changes between releases,
+so verify `astyle --version` before formatting; using a newer formatter can
+rewrite otherwise valid files and will not match CI.
+
 If you have both `make` and `astyle` installed then this can be done with:
 
 ```BASH


### PR DESCRIPTION
## 问题

AStyle 的格式化结果会随版本变化。目前 CI 依赖 `ubuntu-latest` 和未固定的软件包版本，开发者使用较新的 AStyle 时会看到数百个与 CI 不一致的格式改动。

## 解决方案

- 将 AStyle workflow 固定到 `ubuntu-24.04`
- 安装后明确校验 `Artistic Style Version 3.1`
- 在开发者工具文档中注明 CI 使用的准确版本，提醒不要用新版格式化器重写全仓

## 验证

- `.github/workflows/astyle.yml` YAML 解析通过
- 在 `ubuntu:24.04` 容器中验证安装结果为 AStyle 3.1
- `git diff --check` 通过

这不会让格式错误的 PR 被强行标绿；它保证本地和 CI 使用相同格式规则，减少无关的全仓格式震荡。