### PR TITLE
JSON：修复车辆老化模组描述的文本样式

### DIFF
--- a/data/mods/vehicle_degradation/modinfo.json
+++ b/data/mods/vehicle_degradation/modinfo.json
@@ -4,7 +4,7 @@
     "id": "vehicle_degradation",
     "name": "Disable vehicle degradation",
     "authors": [ "LunaGlaze" ],
-    "description": "This mod disables the vehicle degradation mechanism, preventing vehicle parts from losing maximum durability when damaged, thus allowing for full repair. This mod may affect balance and will not affect vehicle parts that have already experienced durability loss.",
+    "description": "This mod disables the vehicle degradation mechanism, preventing vehicle parts from losing maximum durability when damaged, thus allowing for full repair.  This mod may affect balance and will not affect vehicle parts that have already experienced durability loss.",
     "category": "rebalance",
     "dependencies": [ "dda" ]
   },


### PR DESCRIPTION
## 问题

`data/mods/vehicle_degradation/modinfo.json` 的英文描述在句号后只有一个空格。测试初始化的文本样式检查要求句子之间使用两个空格，因此所有运行完整测试的 PR 都会先记录初始化错误，并最终以失败退出。PR #366 的基础测试因此出现大量连锁失败。

## 解决方案

按照测试日志给出的修复建议，在 `full repair.` 后补一个空格。

## 验证

- `make style-all-json-parallel RELEASE=1` 通过
- `git diff --check` 通过
- 修改与测试日志的 `Suggested fix: insert " "` 完全一致

本 PR 不修改功能代码。合并后需要把 master 更新到 #366，再重新运行基础测试。