### PR TITLE
修复VEHICLE_DEGRADATION_WHEN_DAMAGE的注释描述错误

### DIFF
--- a/data/core/external_options.json
+++ b/data/core/external_options.json
@@ -331,7 +331,7 @@
   {
     "type": "EXTERNAL_OPTION",
     "name": "VEHICLE_DEGRADATION_WHEN_DAMAGE",
-    "//": "If true, it will disable the reduction in the maximum repairable damage capacity of vehicle parts when they are damaged.",
+    "//": "If true, it will able the reduction in the maximum repairable damage capacity of vehicle parts when they are damaged.",
     "stype": "bool",
     "value": true
   },

--- a/data/mods/vehicle_degradation/modinfo.json
+++ b/data/mods/vehicle_degradation/modinfo.json
@@ -11,7 +11,7 @@
   {
     "type": "EXTERNAL_OPTION",
     "name": "VEHICLE_DEGRADATION_WHEN_DAMAGE",
-    "//": "If true, it will disable the reduction in the maximum repairable damage capacity of vehicle parts when they are damaged.",
+    "//": "If true, it will able the reduction in the maximum repairable damage capacity of vehicle parts when they are damaged.",
     "stype": "bool",
     "value": false
   }

--- a/data/mods/vehicle_degradation/modinfo.json
+++ b/data/mods/vehicle_degradation/modinfo.json
@@ -11,7 +11,7 @@
   {
     "type": "EXTERNAL_OPTION",
     "name": "VEHICLE_DEGRADATION_WHEN_DAMAGE",
-    "//": "If true, it will able the reduction in the maximum repairable damage capacity of vehicle parts when they are damaged.",
+    "//": "If false, it will disable the reduction in the maximum repairable damage capacity of vehicle parts when they are damaged.",
     "stype": "bool",
     "value": false
   }


### PR DESCRIPTION
#### 问题
在 PR #405 中引入了扩展配置项`VEHICLE_DEGRADATION_WHEN_DAMAGE`，其实际效果是启用载具部件退化机制，但注释描述错误地描述成了当为真时禁用效果。

#### 解决方案
将`external_options.json`和`vehicle_degradation\modinfo.json`中的注释正确描述。即`If true, it will able ...`、`If false, it will disable ...`