### PR TITLE
修复无人值守制作 max_time 截止时间

### DIFF
--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1787,7 +1787,7 @@ void craft_stamp_passive_entry( item &craft, const Character &crafter, time_poin
                                        static_cast<double>( to_moves<int64_t>( raw_fail ) ), batch ) );
         const int64_t max_moves = static_cast<int64_t>( cur_step.batch_info.apply(
                                       static_cast<double>( to_moves<int64_t>( raw_max ) ), batch ) );
-        time_point fail_pt = craft.get_ready_at() + time_duration::from_moves( fail_moves );
+        time_point fail_pt = entry_time + time_duration::from_moves( fail_moves );
         // Keep ruin strictly after completion; grace window is the marginal
         // scaled difference, or a floor when there is no grace_period.
         const int64_t grace_moves = fail_moves - max_moves;

--- a/tests/craft_attention_test.cpp
+++ b/tests/craft_attention_test.cpp
@@ -1410,14 +1410,14 @@ TEST_CASE( "craft_stamp_passive_entry_batch_scales_fail_at",
         item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
         craft_stamp_passive_entry( on_map, u, calendar::turn, loc );
 
-        // Cure: time 10m -> ready; max_time 20m + grace 5m -> fail 35m.
+        // Cure: time 10m -> ready; max_time 20m + grace 5m -> fail 25m.
         CHECK( on_map.get_ready_at() == calendar::turn + 10_minutes );
-        CHECK( on_map.get_fail_at() == calendar::turn + 35_minutes );
+        CHECK( on_map.get_fail_at() == calendar::turn + 25_minutes );
     }
 
     // Batch of eight (no batch_time_factors -> none -> x8):
     //   ready_at = entry + 10m*8 = 80m
-    //   fail_at  = ready_at + (20m + 5m)*8 = 280m
+    //   fail_at  = entry + (20m + 5m)*8 = 200m
     SECTION( "batch of eight scales both deadlines, fail stays after ready" ) {
         const int batch = 8;
         item ingredient( itype_2x4, calendar::turn );
@@ -1433,7 +1433,7 @@ TEST_CASE( "craft_stamp_passive_entry_batch_scales_fail_at",
         craft_stamp_passive_entry( on_map, u, calendar::turn, loc );
 
         CHECK( on_map.get_ready_at() == calendar::turn + 80_minutes );
-        CHECK( on_map.get_fail_at() == calendar::turn + 280_minutes );
+        CHECK( on_map.get_fail_at() == calendar::turn + 200_minutes );
         // Ruin deadline must stay strictly after completion.
         CHECK( on_map.get_fail_at() > on_map.get_ready_at() );
     }
@@ -1703,7 +1703,7 @@ TEST_CASE( "craft_env_unpause_alarm_clears_when_already_due",
     CHECK( on_map.get_pause_started_at() == calendar::before_time_starts );
 }
 
-TEST_CASE( "craft_stamp_anchors_fail_at_to_ready_at_not_entry",
+TEST_CASE( "craft_stamp_keeps_max_time_as_entry_deadline",
            "[craft][attention][overdue][fail]" )
 {
     clear_avatar();
@@ -1725,11 +1725,10 @@ TEST_CASE( "craft_stamp_anchors_fail_at_to_ready_at_not_entry",
     item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
     craft_stamp_passive_entry( on_map, u, calendar::turn, loc );
 
-    // fail_at must be anchored to completion (ready_at + max_time + grace),
-    // NOT to entry_time.  Anchoring to entry made large batches hit a fixed
-    // deadline before ready_at could scale past it (boiling 4+ water vanished).
+    // max_time is a hard deadline measured from entry.  Batch scaling and the
+    // ready_at clamp prevent a large batch from expiring before completion.
     REQUIRE( on_map.get_passive_started_at() == calendar::turn );
-    CHECK( on_map.get_fail_at() == on_map.get_ready_at() + 20_minutes + 5_minutes );
+    CHECK( on_map.get_fail_at() == calendar::turn + 20_minutes + 5_minutes );
     CHECK( on_map.get_fail_at() > on_map.get_ready_at() );
 }
 


### PR DESCRIPTION
## 概要

修复 #411 合并后 Codex 审查指出的无人值守制作截止时间回归。

- 恢复 `max_time` 以无人值守步骤进入时间 `entry_time` 为基准的硬截止时间。
- 保留批量制作的时间缩放，以及 `ready_at + grace` 的下限钳制，避免大批量物品尚未完成便提前失败。
- 修正遗留测试名称和预期：单批为 25 分钟，批量 8 为 200 分钟。
- 不影响 #411 的其他功能与测试基线修复。

该逻辑与上游修复 `4863d326ed0` 一致。

## 测试

- `make -j4 tests`
- 4 个相关测试：17/17 断言通过
- `make astyle-check ASTYLE_BINARY=/tmp/astyle31/usr/bin/astyle`
- `git diff --check`