### PR TITLE
CI：重试被中断的 Transifex 翻译下载

### DIFF
--- a/.github/workflows/build-translations.yml
+++ b/.github/workflows/build-translations.yml
@@ -10,6 +10,7 @@ jobs:
   build-translations:
 
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
     permissions:
       actions: read
       contents: read
@@ -38,7 +39,47 @@ jobs:
 
       - name: Pull translations
         if: ${{ env.TX_TOKEN != '' }}
-        run: tx pull -a --force -w 2
+        shell: bash
+        run: |
+          log="$RUNNER_TEMP/tx-pull.log"
+          attempted="$RUNNER_TEMP/tx-attempted-languages"
+          completed="$RUNNER_TEMP/tx-completed-languages"
+          failed="$RUNNER_TEMP/tx-failed-languages"
+
+          # The Transifex HTTP/2 connection may be closed after roughly one
+          # hour. Use the CLI's default concurrency to finish sooner, let it
+          # continue past individual failures, then retry only the languages
+          # that started but did not finish using a fresh connection.
+          pull_status=0
+          tx pull -a --force --skip -w 5 2>&1 | tee "$log" || pull_status=$?
+
+          sed -nE 's/.*\[([^][]+)\] - .*/\1/p' "$log" |
+            sort -u > "$attempted"
+          sed -nE 's/.*\[([^][]+)\] - Done[[:space:]]*$/\1/p' "$log" |
+            sort -u > "$completed"
+          comm -23 "$attempted" "$completed" > "$failed"
+
+          if [ ! -s "$failed" ]; then
+            exit "$pull_status"
+          fi
+
+          retry_failed=0
+          while IFS= read -r language; do
+            recovered=false
+            for attempt in 1 2 3; do
+              echo "::warning::Retrying Transifex language $language (attempt $attempt/3)"
+              if timeout 5m tx pull -l "$language" --force -w 1; then
+                recovered=true
+                break
+              fi
+              sleep $((attempt * 10))
+            done
+            if [ "$recovered" != true ]; then
+              echo "::error::Failed to pull Transifex language $language after 3 retries"
+              retry_failed=1
+            fi
+          done < "$failed"
+          exit "$retry_failed"
 
       - name: Reuse translations from latest successful master build
         if: ${{ env.TX_TOKEN == '' }}

--- a/.github/workflows/build-translations.yml
+++ b/.github/workflows/build-translations.yml
@@ -10,7 +10,9 @@ jobs:
   build-translations:
 
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    # Leave enough time for a full pull followed by targeted retries. This is
+    # a safety cap only; the higher worker count keeps normal runs much shorter.
+    timeout-minutes: 120
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
     paths:
+      - '.github/workflows/build-translations.yml'
       - '.github/workflows/release.yml'
       - 'android/**'
       - 'build-data/**'


### PR DESCRIPTION
## 问题

[Experimental Release 运行 360](https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/actions/runs/29544723642) 与 [运行 361](https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/actions/runs/29568613300) 的翻译拉取均在约 64–65 分钟后收到 Transifex HTTP/2 `GOAWAY`：

- 运行 360：`uk_UA` 中断
- 运行 361：`th_TH` 中断

这属于长连接/外部服务瞬时中断，不是 PO 内容错误。当前 `tx pull -a --force -w 2` 在任意单语言失败时会终止整个 release。

## 修复

- 将 Transifex 并发从 2 恢复为 CLI 默认值 5，缩短全量拉取时间。
- 使用官方 `--skip` 继续处理其他语言。
- 找出已开始但没有 `Done` 的语言，并用新进程逐语言重试最多 3 次。
- 单次重试限制 5 分钟；job 总安全上限为 120 分钟，覆盖完整拉取及重试。
- 重试仍失败时保持失败，不会静默打包缺失的最新翻译。
- 将共享 `build-translations.yml` 加入 release 路径过滤，使合并后立即触发真实发布验证。

共享工作流同时修复 Experimental Release 与 General build matrix。

## 验证

- 两个 workflow 均通过 PyYAML 解析
- `git diff --check`
- 使用两次实际失败日志模拟，正确识别 `uk_UA`、`th_TH`，排除已完成的 `zh_TW`
- 已确认 Transifex CLI v1.6.17 仍为最新正式版