### PR TITLE
Isolate multiplayer work from solo turns

### DIFF
--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -655,19 +655,12 @@ bool game::do_turn()
 
     simulate_turn_prefix();
 
-    // Process multiplayer events from network thread.
-    cata_mp::process_mp_events();
-    // Apply server state updates received since the last turn (client mode).
-    cata_mp::client_process_incoming();
-    // Resolve any blocking UI deferred out of the recv path.
-    cata_mp::client_resolve_pending_ui();
-    // Lockstep: grant the client their turn at the start of each game turn.
-    if( cata_mp::is_hosting() ) {
-        cata_mp::grant_client_turn();
-    }
-    // Keep the MP debug HUD alive whenever multiplayer is active.
-    if( cata_mp::is_client_mode() || cata_mp::is_host_mode() ) {
-        cata_mp::ensure_mp_hud();
+    // Keep multiplayer entirely outside the single-player turn path.  The
+    // false branch is stable for the lifetime of a solo session, so it is
+    // cheap for the CPU to predict and no MP queue, cleanup, logging or UI
+    // synchronization function is entered.
+    if( cata_mp::is_session_active() ) {
+        cata_mp::process_session_turn();
     }
 
     if( do_avatar_action_loop() ) {

--- a/src/game_io.cpp
+++ b/src/game_io.cpp
@@ -65,6 +65,7 @@
 #include "memorial_logger.h"
 #include "messages.h"
 #include "mod_manager.h"
+#include "mp_gamestate.h"
 #include "options.h"
 #include "output.h"
 #include "overmapbuffer.h"
@@ -424,6 +425,7 @@ bool game::load( const save_t &name )
                         uistate.deserialize( jsin.get_object() );
                     } );
                     reload_npcs();
+                    cata_mp::mp_cleanup_stale_npcs_after_load();
                     validate_npc_followers();
                     validate_mounted_npcs();
                     validate_camps();

--- a/src/mp_gamestate.cpp
+++ b/src/mp_gamestate.cpp
@@ -397,6 +397,11 @@ bool is_mp_mode()
     return server_mode_ || host_mode_;
 }
 
+bool is_session_active()
+{
+    return is_client_mode() || is_mp_mode();
+}
+
 bool is_hosting()
 {
     return get_active_server() != nullptr;
@@ -1646,7 +1651,7 @@ static void mp_save_npc_ids()
 static void purge_npcs_by_name( const std::string &name );
 
 // Remove stale MP NPCs saved from a previous session.
-// Called once per process lifetime, early in the game loop.
+// Called once per world load while the loading screen is still active.
 static bool mp_cleanup_done = false;
 static void mp_cleanup_stale_npcs()
 {
@@ -1763,6 +1768,24 @@ static void mp_cleanup_stale_npcs()
         mp_log( "[cdda-mp] ORPHAN-SWEEP removed " + std::to_string( orphans )
                 + " loaded + " + std::to_string( overmap_orphans ) + " overmap proxy NPCs" );
     }
+}
+
+void mp_cleanup_stale_npcs_after_load()
+{
+    if( mp_cleanup_done || !world_generator || !world_generator->active_world ) {
+        return;
+    }
+
+    const std::string &worldname = world_generator->active_world->world_name;
+    if( worldname.empty() || !mp_world_has_history( worldname ) ) {
+        // A world with no co-op marker or legacy MP state cannot contain one of
+        // our saved proxy NPCs.  Latch the migration for this load without
+        // scanning the active NPC list or nearby overmaps.
+        mp_cleanup_done = true;
+        return;
+    }
+
+    mp_cleanup_stale_npcs();
 }
 
 // Client: remove NPCs spawned by the client's own divergent local world — the
@@ -6340,10 +6363,6 @@ void process_mp_events()
     // nothing is pending). Keeps the ~32k-cell apply off the single-frame hot path.
     mp_drain_pending_omsync();
 
-    // On the very first tick, purge any MP NPCs that leaked into the world save
-    // from a previous session (server and client share the same world directory).
-    mp_cleanup_stale_npcs();
-
     // Stamp this world as MP-touched so the world pickers can badge it.
     mp_world_marker_update();
 
@@ -6392,6 +6411,24 @@ void process_mp_events()
                 }
                 break;
         }
+    }
+}
+
+void process_session_turn()
+{
+    process_mp_events();
+
+    if( is_client_mode() ) {
+        client_process_incoming();
+        client_resolve_pending_ui();
+    }
+
+    if( is_hosting() ) {
+        grant_client_turn();
+    }
+
+    if( is_client_mode() || is_host_mode() ) {
+        ensure_mp_hud();
     }
 }
 
@@ -7785,7 +7822,6 @@ void client_process_incoming()
         return;
     }
 
-    mp_cleanup_stale_npcs();
     mp_cull_local_npcs();   // drop client-local phantom NPCs (keep only host proxy)
 
     // Send the join message on the first tick — the save is loaded by now.

--- a/src/mp_gamestate.h
+++ b/src/mp_gamestate.h
@@ -26,6 +26,16 @@ namespace cata_mp
 // processes connect/disconnect/action events from remote players.
 void process_mp_events();
 
+// Cheap outer gate for the game loop.  Single-player code should test this
+// before calling any per-turn multiplayer work so queues, cleanup, logging and
+// UI synchronization are not entered at all in a solo session.
+bool is_session_active();
+
+// Run all multiplayer work associated with the start of a game turn.  The
+// caller must first check is_session_active(); keeping the gate at the call
+// site makes the single-player hot path one predictable mode check.
+void process_session_turn();
+
 // Returns a JSON string describing the remote player's current position,
 // HP, and nearby visible tiles. Sent to the client after each action.
 std::string serialize_remote_player_state();
@@ -209,12 +219,17 @@ void set_host_mode( bool enabled );
 // whether it is also a headless dedicated server.
 bool is_hosting();
 
-// Called from the main loop when a world is unloaded (quit-to-menu). Resets
-// per-world MP state — currently the stale-NPC sweep guard — so re-entering any
+// Called when a world is unloaded (quit-to-menu). Resets per-world MP state —
+// currently the stale-NPC sweep guard — so re-entering any
 // world in the same process re-runs the orphan-proxy cleanup instead of
 // skipping it (the one-shot guard otherwise leaves phantom proxies from a prior
 // load-in; reproduced 2026-06-03).
 void mp_on_world_exit();
+
+// Load-time migration for worlds with co-op history.  Removes proxy NPCs left
+// by an interrupted multiplayer session while the loading screen is active,
+// rather than discovering and scanning for them from the per-turn hot path.
+void mp_cleanup_stale_npcs_after_load();
 
 // Host: the world's overmap seed (g->get_seed()), captured on the game thread.
 // Sent to the client in the join 'welcome' so it can match the host's terrain.


### PR DESCRIPTION
## Summary

- gate all per-turn multiplayer processing behind one stable session-active check
- centralize the multiplayer turn queue, client UI, host grant, and HUD work
- move stale multiplayer NPC cleanup from the turn hot path to world load
- skip the cleanup scan entirely for worlds with no co-op marker or legacy multiplayer state

This keeps single-player and multiplayer in the same executable while preventing solo turns from entering multiplayer queues, cleanup, logging, or UI synchronization.

## Verification

- `make -j4 tests` compiled all sources successfully
- `make -j1 tests` completed the final `cata_test` link successfully
- `git diff --check`
