### PR TITLE
消息日志增加导出筛选结果功能

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -762,6 +762,12 @@
   },
   {
     "type": "keybinding",
+    "id": "EXPORT",
+    "name": "Export",
+    "bindings": [ { "input_method": "keyboard_char", "key": "E" }, { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] } ]
+  },
+  {
+    "type": "keybinding",
     "id": "SCROLL_RECIPE_INFO_UP",
     "category": "CRAFTING",
     "name": "Scroll recipe info up",

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -13,6 +13,7 @@
 #include "cached_options.h"
 #include "calendar.h"
 #include "catacharset.h"
+#include "cata_utility.h"
 #include "character.h"
 #include "color.h"
 #include "cursesdef.h"
@@ -535,6 +536,7 @@ class dialog
         void input();
         void do_filter( const std::string &filter_str );
         static std::vector<std::string> filter_help_text( int width );
+        void export_filtered_log() const;
 
         const nc_color border_color;
         const nc_color filter_color;
@@ -623,6 +625,7 @@ void Messages::dialog::init( ui_adaptor &ui )
         ctxt.register_action( "PAGE_DOWN" );
         ctxt.register_action( "FILTER" );
         ctxt.register_action( "RESET_FILTER" );
+        ctxt.register_action( "EXPORT", to_translation( "Export filtered log" ) );
         ctxt.register_action( "QUIT" );
         ctxt.register_action( "HELP_KEYBINDINGS" );
         ctxt.register_action( "SCROLL_UP" );
@@ -767,8 +770,9 @@ void Messages::dialog::show()
     } else {
         if( filter_str.empty() ) {
             mvwprintz( w, point( border_width, w_height - 1 ), border_color,
-                       _( "< Press %s to filter, %s to reset >" ),
-                       ctxt.get_desc( "FILTER" ), ctxt.get_desc( "RESET_FILTER" ) );
+                       _( "< Press %s to filter, %s to export, %s to reset >" ),
+                       ctxt.get_desc( "FILTER" ), ctxt.get_desc( "EXPORT" ),
+                       ctxt.get_desc( "RESET_FILTER" ) );
         } else {
             mvwprintz( w, point( border_width, w_height - 1 ), border_color, "< %s >", filter_str );
             mvwprintz( w, point( border_width + 2, w_height - 1 ), filter_color, "%s", filter_str );
@@ -812,6 +816,40 @@ void Messages::dialog::do_filter( const std::string &filter_str )
         offset = 0;
     } else {
         offset = folded_filtered.size() - max_lines;
+    }
+}
+
+void Messages::dialog::export_filtered_log() const
+{
+    if( folded_filtered.empty() ) {
+        popup( _( "No messages to export." ) );
+        return;
+    }
+
+    std::unordered_set<size_t> seen;
+    for( size_t folded_ind : folded_filtered ) {
+        seen.insert( folded_all[folded_ind].first );
+    }
+    const size_t exported_count = seen.size();
+
+    const bool success = write_to_file( "message_log_export.txt", [this]( std::ostream & fout ) {
+        std::unordered_set<size_t> written;
+        for( size_t folded_ind : folded_filtered ) {
+            const size_t msg_ind = folded_all[folded_ind].first;
+            if( !written.insert( msg_ind ).second ) {
+                continue;
+            }
+            const game_message &msg = player_messages.history( msg_ind );
+            const std::string time_str = to_string_clipped( calendar::turn - msg.timestamp_in_turns,
+                                          clipped_align::right );
+            fout << "[" << time_str << "] " << remove_color_tags( msg.get_with_count() ) << "\n";
+        }
+    }, "message_log_export" );
+
+    if( success ) {
+        popup( _( "Exported %zu messages to message_log_export.txt." ), exported_count );
+    } else {
+        popup( _( "Failed to export message log." ) );
     }
 }
 
@@ -860,6 +898,8 @@ void Messages::dialog::input()
             filter_str.clear();
             filter.text( filter_str );
             do_filter( filter_str );
+        } else if( action == "EXPORT" ) {
+            export_filtered_log();
         } else if( action == "QUIT" ) {
             canceled = true;
         }

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -4,8 +4,10 @@
 #include <array>
 #include <cmath>
 #include <deque>
+#include <functional>
 #include <iterator>
 #include <memory>
+#include <ostream>
 #include <string>
 #include <type_traits>
 #include <unordered_set>


### PR DESCRIPTION
在消息查看界面新增 EXPORT 按键，默认大写E,可将当前筛选后的消息导出到 message_log_export.txt,便于根据日志排查

<!-- 使用说明：在下面每个「#### 标题」下填写与你的 PR 相关的信息。


#### Purpose of change
便于玩家和开发者打开调试信息后，导出日志排查问题

<!-- 用几句话描述你做这次改动的原因。
便于玩家和开发者打开调试信息后，导出日志排查问题


#### Describe the solution
P按键打开的日志页面，可以绑定快捷键以导出日志

#### Describe alternatives you've considered
无

#### Testing
在游戏中尝试导出日志

#### Additional context
无