### PR TITLE
修复 tiles 渲染中的除零与空指针崩溃

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1,6 +1,7 @@
 #if defined(TILES)
 #include "cata_tiles.h"
 #include "tileset_loader.h"
+#include "uistate.h"
 
 #include <algorithm>
 #include <array>
@@ -539,6 +540,10 @@ void cata_tiles::reinit()
 void cata_tiles::set_draw_scale( int scale )
 {
     cata_assert( tileset_ptr );
+    if( scale <= 0 ) {
+        debugmsg( "Invalid tileset draw scale %d, using default %d", scale, DEFAULT_TILESET_ZOOM );
+        scale = DEFAULT_TILESET_ZOOM;
+    }
     const int mult = tileset_ptr->get_tile_pixelscale() * scale;
     const int div = 16;
     tile_width = tileset_ptr->get_tile_width() * mult / div;
@@ -585,13 +590,10 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
         return;
     }
 
-#if defined(__ANDROID__)
-    // Attempted bugfix for Google Play crash - prevent divide-by-zero if no tile
-    // width/height specified
+    // Prevent divide-by-zero if no tile width/height specified
     if( tile_width == 0 || tile_height == 0 ) {
         return;
     }
-#endif
 
     has_animated_tiles_ = false;
 
@@ -2420,6 +2422,11 @@ point_bub_ms cata_tiles::screen_to_player(
     const point &win_size, const point_bub_ms &center,
     const bool iso )
 {
+    if( tile_size.x == 0 || tile_size.y == 0 ) {
+        debugmsg( "tile_size is 0 in screen_to_player" );
+        return center;
+    }
+
     // `scr_pos` is the offset from the window origin
     const point base_tile = get_window_base_tile_counts( win_size, tile_size, iso );
     if( iso ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6651,8 +6651,9 @@ void game::reset_zoom()
 void game::set_zoom( const int level )
 {
 #if defined(TILES)
-    if( uistate.tileset_zoom != level ) {
-        uistate.tileset_zoom = level;
+    const int safe_level = level > 0 ? level : DEFAULT_TILESET_ZOOM;
+    if( uistate.tileset_zoom != safe_level ) {
+        uistate.tileset_zoom = safe_level;
         rescale_tileset( uistate.tileset_zoom );
     }
 #else
@@ -6663,8 +6664,9 @@ void game::set_zoom( const int level )
 void game::set_overmap_zoom( const int level )
 {
 #if defined(TILES)
-    if( uistate.overmap_tileset_zoom != level ) {
-        uistate.overmap_tileset_zoom = level;
+    const int safe_level = level > 0 ? level : DEFAULT_TILESET_ZOOM;
+    if( uistate.overmap_tileset_zoom != safe_level ) {
+        uistate.overmap_tileset_zoom = safe_level;
         overmap_tilecontext->set_draw_scale( uistate.overmap_tileset_zoom );
     }
 #else

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -506,6 +506,12 @@ void uistatedata::deserialize( const JsonObject &jo )
     jo.read( "overmap_fast_scroll", overmap_fast_scroll );
     jo.read( "tileset_zoom", tileset_zoom );
     jo.read( "overmap_tileset_zoom", overmap_tileset_zoom );
+    if( tileset_zoom <= 0 ) {
+        tileset_zoom = DEFAULT_TILESET_ZOOM;
+    }
+    if( overmap_tileset_zoom <= 0 ) {
+        overmap_tileset_zoom = DEFAULT_TILESET_ZOOM;
+    }
     jo.read( "overmap_sidebar_uistate", overmap_sidebar_state );
     jo.read( "editmap_uistate", editmap_state );
     jo.read( "distraction_noise", distraction_noise );

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -7073,7 +7073,12 @@ static int map_font_width()
     if( use_tiles && tilecontext ) {
         return tilecontext->get_tile_width();
     }
-    return ( map_font ? map_font.get() : font.get() )->width;
+    const Font *f = map_font ? map_font.get() : font.get();
+    if( !f ) {
+        debugmsg( "map_font and font are both null in map_font_width" );
+        return 1;
+    }
+    return f->width;
 }
 
 static int map_font_height()
@@ -7081,7 +7086,12 @@ static int map_font_height()
     if( use_tiles && tilecontext ) {
         return tilecontext->get_tile_height();
     }
-    return ( map_font ? map_font.get() : font.get() )->height;
+    const Font *f = map_font ? map_font.get() : font.get();
+    if( !f ) {
+        debugmsg( "map_font and font are both null in map_font_height" );
+        return 1;
+    }
+    return f->height;
 }
 
 static int overmap_font_width()
@@ -7089,7 +7099,12 @@ static int overmap_font_width()
     if( use_tiles && overmap_tilecontext && use_tiles_overmap ) {
         return overmap_tilecontext->get_tile_width();
     }
-    return ( overmap_font ? overmap_font.get() : font.get() )->width;
+    const Font *f = overmap_font ? overmap_font.get() : font.get();
+    if( !f ) {
+        debugmsg( "overmap_font and font are both null in overmap_font_width" );
+        return 1;
+    }
+    return f->width;
 }
 
 static int overmap_font_height()
@@ -7097,17 +7112,32 @@ static int overmap_font_height()
     if( use_tiles && overmap_tilecontext && use_tiles_overmap ) {
         return overmap_tilecontext->get_tile_height();
     }
-    return ( overmap_font ? overmap_font.get() : font.get() )->height;
+    const Font *f = overmap_font ? overmap_font.get() : font.get();
+    if( !f ) {
+        debugmsg( "overmap_font and font are both null in overmap_font_height" );
+        return 1;
+    }
+    return f->height;
 }
 
 void to_map_font_dim_width( int &w )
 {
-    w = ( w * fontwidth ) / map_font_width();
+    const int divisor = map_font_width();
+    if( divisor == 0 ) {
+        debugmsg( "map_font_width is 0 in to_map_font_dim_width" );
+        return;
+    }
+    w = ( w * fontwidth ) / divisor;
 }
 
 void to_map_font_dim_height( int &h )
 {
-    h = ( h * fontheight ) / map_font_height();
+    const int divisor = map_font_height();
+    if( divisor == 0 ) {
+        debugmsg( "map_font_height is 0 in to_map_font_dim_height" );
+        return;
+    }
+    h = ( h * fontheight ) / divisor;
 }
 
 void to_map_font_dimension( int &w, int &h )
@@ -7118,14 +7148,32 @@ void to_map_font_dimension( int &w, int &h )
 
 void from_map_font_dimension( int &w, int &h )
 {
+    if( fontwidth == 0 ) {
+        debugmsg( "fontwidth is 0 in from_map_font_dimension" );
+        return;
+    }
+    if( fontheight == 0 ) {
+        debugmsg( "fontheight is 0 in from_map_font_dimension" );
+        return;
+    }
     w = ( w * map_font_width() + fontwidth - 1 ) / fontwidth;
     h = ( h * map_font_height() + fontheight - 1 ) / fontheight;
 }
 
 void to_overmap_font_dimension( int &w, int &h )
 {
-    w = ( w * fontwidth ) / overmap_font_width();
-    h = ( h * fontheight ) / overmap_font_height();
+    const int divisor_w = overmap_font_width();
+    if( divisor_w == 0 ) {
+        debugmsg( "overmap_font_width is 0 in to_overmap_font_dimension" );
+        return;
+    }
+    const int divisor_h = overmap_font_height();
+    if( divisor_h == 0 ) {
+        debugmsg( "overmap_font_height is 0 in to_overmap_font_dimension" );
+        return;
+    }
+    w = ( w * fontwidth ) / divisor_w;
+    h = ( h * fontheight ) / divisor_h;
 }
 
 bool is_draw_tiles_mode()


### PR DESCRIPTION
set_draw_scale 拒绝非正缩放并回退默认值；draw 的 tile 宽高除零防护
从 Android 扩展到全平台；screen_to_player 增加 tile_size 为零防护； 字体尺寸函数在字体为空或宽度为零时不再解引用或除零；反序列化时修正非法的 tileset zoom 值。

<!-- 使用说明：在下面每个「#### 标题」下填写与你的 PR 相关的信息。
先前我的存档似乎出现了坏数据，导致进入游戏后tile的宽高出现了除0问题，故此加上除零防御，并在需要的时候按照默认的缩放显示
-->

#### Summary
<!-- #### 概述 -->
先前我的存档似乎出现了坏数据，导致进入游戏后tile的宽高出现了除0问题，故此加上除零防御，并在需要的时候按照默认的缩放显示

#### Purpose of change
<!-- #### 变更目的 -->

加固代码，以免旧的存档内的错误数据导致游戏崩溃和显示异常


#### Describe the solution
检查tile长宽比例的异常数据，并将其改为原本默认的样子

#### Describe alternatives you've considered
无

#### Testing
进入我的那个坏掉的存档，可以正常显示，但是坏掉的存档我没有留下坏掉时的快照，不过只是加固代码而已。