### PR TITLE
优化 NPC 活动加载与执行的调试输出

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3539,7 +3539,9 @@ void npc::on_load( map *here )
     // TODO: Sleeping, healing etc.
     last_updated = calendar::turn;
     time_point cur = calendar::turn - dt;
-    add_msg_debug( debugmode::DF_NPC, "on_load() by %s, %d turns", get_name(), to_turns<int>( dt ) );
+    add_msg_debug( debugmode::DF_NPC, "on_load() by %s, dt=%d turns, activity=%s, has_dest=%s",
+                   get_name(), to_turns<int>( dt ), activity ? "yes" : "no",
+                   has_destination() ? "yes" : "no" );
     // First update with 30 minute granularity, then 5 minutes, then turns
     for( ; cur < calendar::turn - 30_minutes; cur += 30_minutes + 1_turns ) {
         update_body( cur, cur + 30_minutes );
@@ -3570,7 +3572,13 @@ void npc::on_load( map *here )
         process_items( here );
         // give NPCs that are doing activities a pile of moves
         if( has_destination() || activity ) {
+            add_msg_debug( debugmode::DF_NPC, "on_load: adding %d moves to %s (cur=%d)",
+                           to_moves<int>( dt ), get_name(), get_moves() );
             mod_moves( to_moves<int>( dt ) );
+            add_msg_debug( debugmode::DF_NPC, "on_load: %s now has %d moves", get_name(), get_moves() );
+        } else {
+            add_msg_debug( debugmode::DF_NPC, "on_load: %s no activity/destination, no moves added",
+                           get_name() );
         }
     }
 

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1962,8 +1962,12 @@ void npc::move()
     if( action == npc_undecided && attitude == NPCATT_ACTIVITY && !has_flag( json_flag_CANNOT_MOVE ) ) {
         if( has_stashed_activity() ) {
             if( !check_outbounds_activity( get_stashed_activity(), true ) ) {
+                add_msg_debug( debugmode::DF_NPC, "npc %s restored stashed activity, moves=%d",
+                               get_name(), get_moves() );
                 assign_stashed_activity();
             } else {
+                add_msg_debug( debugmode::DF_NPC, "npc %s stashed activity still out of bounds",
+                               get_name() );
                 // wait a turn, because next turn, the object of our activity
                 // may have been loaded in.
                 set_moves( 0 );
@@ -4789,6 +4793,9 @@ bool npc::can_do_pulp()
 bool npc::do_player_activity()
 {
     int old_moves = moves;
+    add_msg_debug( debugmode::DF_NPC, "do_player_activity: %s id=%s moves=%d multi=%s",
+                   get_name(), activity ? activity.id().c_str() : "null", moves,
+                   activity && activity.is_multi_type() ? "yes" : "no" );
     // the multi-activity types can sometimes cancel the activity, and return without using up any moves.
     // ( when they are setting a destination etc. )
     // normally this isn't a problem, but in the main game loop, if the NPC has a huge backlog of moves;

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -249,7 +249,11 @@ void player_activity::do_turn( Character &you )
         const int progress = base_progress + npc_bonus;
         if( moves_left >= progress ) {
             moves_left -= progress * activity_mult;
-            you.mod_moves( -progress );
+            if( you.is_npc() ) {
+                you.mod_moves( -progress );
+            } else {
+                you.set_moves( 0 );
+            }
         } else {
             you.mod_moves( -you.get_moves() * moves_left / progress );
             moves_left = 0;

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -242,11 +242,16 @@ void player_activity::do_turn( Character &you )
     }
     const float activity_mult = you.exertion_adjusted_move_multiplier( exertion_level() );
     if( type->based_on() == based_on_type::TIME ) {
-        if( moves_left >= 100 ) {
-            moves_left -= 100 * activity_mult;
-            you.set_moves( 0 );
+        // NPCs that re-enter the reality bubble may have a large backlog of moves.
+        // Allow them to fast-forward time-based activities proportionally.
+        const int base_progress = 100;
+        const int npc_bonus = you.is_npc() ? std::max( 0, you.get_moves() - base_progress ) : 0;
+        const int progress = base_progress + npc_bonus;
+        if( moves_left >= progress ) {
+            moves_left -= progress * activity_mult;
+            you.mod_moves( -progress );
         } else {
-            you.mod_moves( -you.get_moves() * moves_left / 100 );
+            you.mod_moves( -you.get_moves() * moves_left / progress );
             moves_left = 0;
         }
     } else if( type->based_on() == based_on_type::SPEED ) {


### PR DESCRIPTION
在 npc::on_load、npc::move 与 do_player_activity 中添加调试日志，便于追踪 NPC 活动恢复与移动分配。

允许 NPC 在重新进入现实气泡时快进到时间型活动的进度，减少活动积压。

#### Summary
<!-- #### 概述 -->
npc在进行区域任务时，任务一般会分段为小任务由npc依次执行，但是这些分段小任务，如种植，不受进入现实气泡时时间追赶的影响，只是默认100 行动点，故此更改，顺便加点方便调试的信息

#### Purpose of change
修复npc进行区域分段任务时，进入现实气泡时间不追赶的问题

#### Describe the solution
当进行分段任务时，给足npc没有在现实气泡时，那段时间的行动点

#### Describe alternatives you've considered
无

#### Testing
在游戏中让npc种一大块地，离开，几个小时后让npc重新进入现实气泡，地种好了