### PR TITLE
调整 NO_NPC_FOOD 以同时禁用 NPC 睡眠与疲劳

### DIFF
--- a/data/core/external_options.json
+++ b/data/core/external_options.json
@@ -114,7 +114,7 @@
   {
     "type": "EXTERNAL_OPTION",
     "name": "NO_NPC_FOOD",
-    "//": "Disables tracking food, thirst and ( partially ) fatigue for NPCs.  If true, NPCs won't need to eat or drink and will only get tired enough to sleep, not to get penalties.",
+    "//": "Disables tracking food, thirst and fatigue/sleep for NPCs.  If true, NPCs won't need to eat, drink, or sleep and will stay perpetually rested.",
     "stype": "bool",
     "value": false
   },

--- a/src/character.h
+++ b/src/character.h
@@ -946,7 +946,7 @@ class Character : public Creature, public visitable
         void apply_wound( bodypart_id bp, wound_type_id wd );
         /** Updates the status of wounds character has */
         void update_wounds( time_duration time_passed );
-        /** Returns true if character needs food, false if character is an NPC with NO_NPC_FOOD set */
+        /** Returns true if character needs food/sleep, false if character is an NPC with NO_NPC_FOOD set */
         bool needs_food() const;
         /** Increases hunger, thirst, sleepiness and stimulants wearing off. `rate_multiplier` is for retroactive updates. */
         void update_needs( int rate_multiplier );

--- a/src/character.h
+++ b/src/character.h
@@ -946,7 +946,7 @@ class Character : public Creature, public visitable
         void apply_wound( bodypart_id bp, wound_type_id wd );
         /** Updates the status of wounds character has */
         void update_wounds( time_duration time_passed );
-        /** Returns true if character needs food/sleep, false if character is an NPC with NO_NPC_FOOD set */
+        /** Returns true if character needs food, false if character is an NPC with NO_NPC_FOOD set */
         bool needs_food() const;
         /** Increases hunger, thirst, sleepiness and stimulants wearing off. `rate_multiplier` is for retroactive updates. */
         void update_needs( int rate_multiplier );

--- a/src/character_health.cpp
+++ b/src/character_health.cpp
@@ -142,6 +142,7 @@ static const efftype_id effect_melatonin( "melatonin" );
 static const efftype_id effect_mending( "mending" );
 static const efftype_id effect_narcosis( "narcosis" );
 static const efftype_id effect_nausea( "nausea" );
+static const efftype_id effect_npc_suspend( "npc_suspend" );
 static const efftype_id effect_pkill1_acetaminophen( "pkill1_acetaminophen" );
 static const efftype_id effect_pkill1_generic( "pkill1_generic" );
 static const efftype_id effect_pkill1_nsaid( "pkill1_nsaid" );
@@ -1008,6 +1009,9 @@ void Character::set_thirst( int nthirst )
 
 void Character::mod_sleepiness( int nsleepiness )
 {
+    if( is_npc() && !needs_food() ) {
+        return;
+    }
     set_sleepiness( sleepiness + nsleepiness );
 }
 
@@ -1454,8 +1458,19 @@ void Character::update_needs( int rate_multiplier )
     needs_rates rates = calc_needs_rates();
 
     const bool wasnt_sleepinessd = get_sleepiness() <= sleepiness_levels::DEAD_TIRED;
-    // Don't increase sleepiness if sleeping or trying to sleep or if we're at the cap.
-    if( get_sleepiness() < 1050 && !asleep && !debug_ls ) {
+    // NO_NPC_FOOD disables hunger, thirst, and sleep/fatigue for NPCs.
+    if( !needs_food() ) {
+        set_sleepiness( 0 );
+        set_sleep_deprivation( 0 );
+        if( asleep ) {
+            sleep.set_duration( 1_turns );
+        }
+        remove_effect( effect_lying_down );
+        remove_effect( effect_npc_suspend );
+        if( activity.id() == ACT_TRY_SLEEP ) {
+            activity.set_to_null();
+        }
+    } else if( get_sleepiness() < 1050 && !asleep && !debug_ls ) {
         if( rates.sleepiness > 0.0f ) {
             int sleepiness_roll = roll_remainder( rates.sleepiness * rate_multiplier );
             mod_sleepiness( sleepiness_roll );
@@ -1468,11 +1483,6 @@ void Character::update_needs( int rate_multiplier )
                 // Note: Since needs are updated in 5-minute increments, we have to multiply the roll again by
                 // 5. If rate_multiplier is > 1, sleepiness_roll will be higher and this will work out.
                 mod_sleep_deprivation( sleepiness_roll * 5 );
-            }
-
-            if( !needs_food() && get_sleepiness() > sleepiness_levels::TIRED ) {
-                set_sleepiness( sleepiness_levels::TIRED );
-                set_sleep_deprivation( 0 );
             }
         }
     } else if( asleep ) {

--- a/src/character_health.cpp
+++ b/src/character_health.cpp
@@ -142,7 +142,6 @@ static const efftype_id effect_melatonin( "melatonin" );
 static const efftype_id effect_mending( "mending" );
 static const efftype_id effect_narcosis( "narcosis" );
 static const efftype_id effect_nausea( "nausea" );
-static const efftype_id effect_npc_suspend( "npc_suspend" );
 static const efftype_id effect_pkill1_acetaminophen( "pkill1_acetaminophen" );
 static const efftype_id effect_pkill1_generic( "pkill1_generic" );
 static const efftype_id effect_pkill1_nsaid( "pkill1_nsaid" );
@@ -1463,10 +1462,9 @@ void Character::update_needs( int rate_multiplier )
         set_sleepiness( 0 );
         set_sleep_deprivation( 0 );
         if( asleep ) {
-            sleep.set_duration( 1_turns );
+            remove_effect( effect_sleep );
         }
         remove_effect( effect_lying_down );
-        remove_effect( effect_npc_suspend );
         if( activity.id() == ACT_TRY_SLEEP ) {
             activity.set_to_null();
         }

--- a/src/character_oracle.cpp
+++ b/src/character_oracle.cpp
@@ -225,6 +225,10 @@ status_t character_oracle_t::can_obtain_warmth( std::string_view ) const
 
 status_t character_oracle_t::needs_sleep_badly( std::string_view ) const
 {
+    // NO_NPC_FOOD disables sleep for NPCs.
+    if( !subject->needs_food() ) {
+        return status_t::success;
+    }
     // TIRED (191): low enough that off-shift NPCs go to bed early.
     // On-shift duty (0.45) easily beats sleep urgency at this level (0.191).
     if( subject->get_sleepiness() >= static_cast<int>( sleepiness_levels::TIRED ) ) {
@@ -277,6 +281,10 @@ float character_oracle_t::warmth_urgency( std::string_view ) const
 
 status_t character_oracle_t::can_sleep( std::string_view ) const
 {
+    // NO_NPC_FOOD disables sleep for NPCs.
+    if( !subject->needs_food() ) {
+        return status_t::failure;
+    }
     // Meth is the only hard blocker in Character::can_sleep().
     // Stim, comfort, insomnia, and rng are soft score modifiers whose
     // net effect depends on location and luck -- the oracle can't
@@ -292,6 +300,10 @@ status_t character_oracle_t::can_sleep( std::string_view ) const
 
 float character_oracle_t::sleepiness_urgency( std::string_view ) const
 {
+    // NO_NPC_FOOD disables sleep for NPCs.
+    if( !subject->needs_food() ) {
+        return 0.0f;
+    }
     // 0 = rested, 1 = forced unconsciousness (MASSIVE_SLEEPINESS = 1000).
     static constexpr float cap = 1000.0f;
     return std::clamp( subject->get_sleepiness() / cap, 0.0f, 1.0f );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2444,9 +2444,8 @@ void npc::reconcile_schedule()
         }
         clear_committed_goal();
     } else if( !on_shift && !in_sleep_state() && !needs_food() ) {
-        if( get_sleepiness() < static_cast<int>( sleepiness_levels::TIRED ) ) {
-            set_sleepiness( sleepiness_levels::TIRED );
-        }
+        // NO_NPC_FOOD keeps NPCs perpetually rested; do not raise sleepiness to TIRED.
+        set_sleepiness( 0 );
     }
 }
 
@@ -2473,11 +2472,8 @@ void npc::reconcile_schedule_on_load()
                           : ( end_mins - start_mins );
 
     if( on_shift && shift_len > 0 ) {
-        int mins_in = wraps && now_mins < start_mins
-                      ? ( 24 * 60 - start_mins + now_mins )
-                      : ( now_mins - start_mins );
-        int expected = mins_in * static_cast<int>( sleepiness_levels::TIRED ) / shift_len;
-        set_sleepiness( expected );
+        // NO_NPC_FOOD keeps NPCs perpetually rested regardless of shift progress.
+        set_sleepiness( 0 );
     }
 }
 

--- a/tests/behavior_test.cpp
+++ b/tests/behavior_test.cpp
@@ -252,7 +252,7 @@ TEST_CASE( "check_npc_behavior_tree", "[npc][behavior]" )
         food.remove_item();
         CHECK( npc_needs.tick( &oracle ) == "idle" );
     }
-    SECTION( "NO_NPC_FOOD suppresses hunger and thirst" ) {
+    SECTION( "NO_NPC_FOOD suppresses hunger, thirst and sleep" ) {
         override_option no_food( "NO_NPC_FOOD", "true" );
         REQUIRE_FALSE( test_npc.needs_food() );
 
@@ -260,10 +260,14 @@ TEST_CASE( "check_npc_behavior_tree", "[npc][behavior]" )
         test_npc.set_hunger( 500 );
         test_npc.set_stored_kcal( 1000 );
         test_npc.set_thirst( 700 );
+        test_npc.set_sleepiness( sleepiness_levels::EXHAUSTED );
         CHECK( oracle.needs_food_badly( "" ) == behavior::status_t::success );
         CHECK( oracle.needs_water_badly( "" ) == behavior::status_t::success );
+        CHECK( oracle.needs_sleep_badly( "" ) == behavior::status_t::success );
+        CHECK( oracle.can_sleep( "" ) == behavior::status_t::failure );
         CHECK( oracle.hunger_urgency( "" ) == 0.0f );
         CHECK( oracle.thirst_urgency( "" ) == 0.0f );
+        CHECK( oracle.sleepiness_urgency( "" ) == 0.0f );
 
         // Even with food and water in inventory, BT returns idle.
         test_npc.i_add( item( itype_sandwich_cheese_grilled ) );

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -3105,7 +3105,7 @@ TEST_CASE( "npc_shopkeeper_sleep_wake_return", "[npc][needs]" )
         CHECK( guy.get_sleepiness() == 0 );
     }
 
-    SECTION( "NO_NPC_FOOD wakes sleeping NPC and keeps sleepiness at zero" ) {
+    SECTION( "NO_NPC_FOOD removes sleep while preserving NPC suspension" ) {
         override_option no_food( "NO_NPC_FOOD", "true" );
         npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
         clear_character( guy, true );
@@ -3119,7 +3119,7 @@ TEST_CASE( "npc_shopkeeper_sleep_wake_return", "[npc][needs]" )
         guy.update_needs( 1 );
 
         CHECK( guy.get_sleepiness() == 0 );
-        CHECK_FALSE( guy.in_sleep_state() );
+        CHECK_FALSE( guy.has_effect( effect_sleep ) );
         CHECK( guy.has_effect( effect_npc_suspend ) );
     }
 

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -3095,14 +3095,29 @@ TEST_CASE( "npc_shopkeeper_sleep_wake_return", "[npc][needs]" )
         CHECK( guy.pos_abs() == post );
     }
 
-    SECTION( "NO_NPC_FOOD caps unscheduled NPC at TIRED" ) {
+    SECTION( "NO_NPC_FOOD keeps unscheduled NPC at zero sleepiness" ) {
         override_option no_food( "NO_NPC_FOOD", "true" );
         npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
         clear_character( guy, true );
-        guy.set_sleepiness( sleepiness_levels::TIRED );
+        guy.set_sleepiness( sleepiness_levels::EXHAUSTED );
         REQUIRE_FALSE( guy.needs_food() );
         guy.update_needs( 1 );
-        CHECK( guy.get_sleepiness() <= static_cast<int>( sleepiness_levels::TIRED ) );
+        CHECK( guy.get_sleepiness() == 0 );
+    }
+
+    SECTION( "NO_NPC_FOOD wakes sleeping NPC and keeps sleepiness at zero" ) {
+        override_option no_food( "NO_NPC_FOOD", "true" );
+        npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+        clear_character( guy, true );
+        guy.set_sleepiness( sleepiness_levels::EXHAUSTED );
+        guy.add_effect( effect_sleep, 1_hours );
+        REQUIRE( guy.in_sleep_state() );
+        REQUIRE_FALSE( guy.needs_food() );
+
+        guy.update_needs( 1 );
+
+        CHECK( guy.get_sleepiness() == 0 );
+        CHECK_FALSE( guy.in_sleep_state() );
     }
 
     SECTION( "DEAD_TIRED shopkeeper commits to sleep, no oscillation" ) {
@@ -3306,7 +3321,7 @@ TEST_CASE( "schedule_reconciliation_no_npc_food", "[npc][schedule]" )
         CHECK( guy.get_sleepiness() == 0 );
     }
 
-    SECTION( "floors sleepiness at off-shift transition" ) {
+    SECTION( "keeps sleepiness zero off-shift" ) {
         calendar::turn = calendar::turn_zero + 20_hours;
         npc &guy = spawn_scheduled_npc( { 50, 50 }, NC_ROBOFAC_INTERCOM_DAY );
         guy.set_sleepiness( 100 );
@@ -3314,12 +3329,10 @@ TEST_CASE( "schedule_reconciliation_no_npc_food", "[npc][schedule]" )
 
         guy.reconcile_schedule();
 
-        CHECK( guy.get_sleepiness() >= static_cast<int>( sleepiness_levels::TIRED ) );
+        CHECK( guy.get_sleepiness() == 0 );
     }
 
-    SECTION( "on_load sets sleepiness proportional to shift" ) {
-        // 12:00 is 6 hours into a [6,18] shift (12h total).
-        // Expected: TIRED * 6/12 = TIRED/2
+    SECTION( "on_load keeps sleepiness zero" ) {
         calendar::turn = calendar::turn_zero + 12_hours;
         npc &guy = spawn_scheduled_npc( { 50, 50 }, NC_ROBOFAC_INTERCOM_DAY );
         guy.set_sleepiness( 0 );
@@ -3327,12 +3340,10 @@ TEST_CASE( "schedule_reconciliation_no_npc_food", "[npc][schedule]" )
 
         guy.reconcile_schedule_on_load();
 
-        int expected = static_cast<int>( sleepiness_levels::TIRED ) / 2;
-        CHECK( guy.get_sleepiness() >= expected - 5 );
-        CHECK( guy.get_sleepiness() <= expected + 5 );
+        CHECK( guy.get_sleepiness() == 0 );
     }
 
-    SECTION( "loaded NPC covers full shift then sleeps" ) {
+    SECTION( "loaded NPC covers full shift and stays awake" ) {
         // Start just before shift end so we don't need a massive time jump.
         calendar::turn = calendar::turn_zero + 17_hours + 59_minutes;
         map &here = get_map();
@@ -3344,7 +3355,7 @@ TEST_CASE( "schedule_reconciliation_no_npc_food", "[npc][schedule]" )
         const tripoint_abs_ms post = guy.pos_abs();
         REQUIRE( guy.guard_pos == post );
 
-        // Place a bed 3 tiles away for sleep target.
+        // Place a bed 3 tiles away; with NO_NPC_FOOD it should not be used.
         const tripoint_bub_ms bed_pos = guy.pos_bub() + tripoint( 3, 0, 0 );
         here.ter_set( bed_pos, ter_t_floor );
         here.furn_set( bed_pos, furn_f_bed );
@@ -3362,9 +3373,9 @@ TEST_CASE( "schedule_reconciliation_no_npc_food", "[npc][schedule]" )
         guy.update_body( calendar::turn - 10_seconds, calendar::turn );
         guy.npc_update_body();
 
-        CHECK( guy.get_sleepiness() >= static_cast<int>( sleepiness_levels::TIRED ) );
+        CHECK( guy.get_sleepiness() == 0 );
 
-        // BT should now send NPC to sleep.
+        // BT should NOT send NPC to sleep while NO_NPC_FOOD is active.
         bool reached_sleep = false;
         for( int i = 0; i < 20; ++i ) {
             guy.set_moves( 100 );
@@ -3375,7 +3386,7 @@ TEST_CASE( "schedule_reconciliation_no_npc_food", "[npc][schedule]" )
                 break;
             }
         }
-        CHECK( reached_sleep );
+        CHECK_FALSE( reached_sleep );
     }
 }
 
@@ -3448,6 +3459,7 @@ TEST_CASE( "npc_update_body_calls_reconcile_schedule", "[npc][schedule]" )
     guy.npc_update_body();
 
     CHECK_FALSE( guy.in_sleep_state() );
+    CHECK( guy.get_sleepiness() == 0 );
 }
 
 // --- Trade delegate tests ---

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -3111,13 +3111,16 @@ TEST_CASE( "npc_shopkeeper_sleep_wake_return", "[npc][needs]" )
         clear_character( guy, true );
         guy.set_sleepiness( sleepiness_levels::EXHAUSTED );
         guy.add_effect( effect_sleep, 1_hours );
+        guy.add_effect( effect_npc_suspend, 1_hours );
         REQUIRE( guy.in_sleep_state() );
+        REQUIRE( guy.has_effect( effect_npc_suspend ) );
         REQUIRE_FALSE( guy.needs_food() );
 
         guy.update_needs( 1 );
 
         CHECK( guy.get_sleepiness() == 0 );
         CHECK_FALSE( guy.in_sleep_state() );
+        CHECK( guy.has_effect( effect_npc_suspend ) );
     }
 
     SECTION( "DEAD_TIRED shopkeeper commits to sleep, no oscillation" ) {


### PR DESCRIPTION
当 NO_NPC_FOOD 开启时，NPC 不再积累困倦值，也不会进入睡眠状态。

相关逻辑覆盖 update_needs、行为树 oracle、schedule reconciliation 以及对应测试。


#### Summary
<!-- #### 概述 -->
虽然关闭了npc的需求，但是npc还是会困，虽然不会困到某个程度，但还是会进入强制睡眠的阈值，我觉得这个也是可以由这个mod关闭的，并保持npc精神
#### Purpose of change
看到npc在蜂后行为树强制进入睡眠绷不住了


#### Describe the solution
如果这个mod的选项开启，npc不会变困并会刷新原本的疲劳状态

#### Describe alternatives you've considered
无

#### Testing
在游戏中，npc的困度不变化