### PR TITLE
修复 #423 合并后的代码格式

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -14811,13 +14811,15 @@ bool zone_sort_activity_actor::find_dropoff_destination( Character &you,
     auto dest_free_volume = [this, &here, &mgr, fac_id]( const tripoint_bub_ms & dest_bub )
     -> units::volume {
         const bool dest_vehicle_only = current_dropoff_zt_id != zone_type_id::NULL_ID() &&
-                                       mgr.has_vehicle( current_dropoff_zt_id, here.get_abs( dest_bub ), fac_id ) &&
-                                       !mgr.has_terrain( current_dropoff_zt_id, here.get_abs( dest_bub ), fac_id );
+        mgr.has_vehicle( current_dropoff_zt_id, here.get_abs( dest_bub ), fac_id ) &&
+        !mgr.has_terrain( current_dropoff_zt_id, here.get_abs( dest_bub ), fac_id );
         units::volume avail = 0_ml;
-        for( const vpart_reference &vp_dest : zone_sorting::cargo_parts_at( dest_bub ) ) {
+        for( const vpart_reference &vp_dest : zone_sorting::cargo_parts_at( dest_bub ) )
+        {
             avail += vp_dest.items().free_volume();
         }
-        if( !dest_vehicle_only ) {
+        if( !dest_vehicle_only )
+        {
             avail += here.free_volume( dest_bub );
         }
         return avail;

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1042,7 +1042,8 @@ std::optional<vpart_reference> cargo_part_from_index( const tripoint_bub_ms &pos
         return std::nullopt;
     }
     vehicle &veh = ovp->vehicle();
-    if( part_index < 0 || static_cast<size_t>( part_index ) >= static_cast<size_t>( veh.part_count() ) ) {
+    if( part_index < 0 ||
+        static_cast<size_t>( part_index ) >= static_cast<size_t>( veh.part_count() ) ) {
         return std::nullopt;
     }
     return vpart_reference( veh, static_cast<size_t>( part_index ) );


### PR DESCRIPTION
#423 在代码风格检查完成前已合并；该检查随后报告了两处 AStyle 3.1 格式差异。本 PR 原样应用 CI 生成的格式补丁，不改变逻辑。

验证：相关 `activity_actor.cpp` 与 `activity_item_handling.cpp` 已使用项目编译参数通过 `-Werror` 编译。