### PR TITLE
Fix cached MacPorts setup on macOS runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -523,6 +523,11 @@ jobs:
       - name: install macports (mac, SDL2)
         if: runner.os == 'macOS' && matrix.tiles == 1 && matrix.sdl3 != 1
         uses: melusina-org/setup-macports@c7eb59386def259a274627092566a7f7b8d219b1 # v1
+        with:
+          # The action only caches /opt/local, not the macports system user
+          # created by the installer.  Restoring that incomplete cache on a
+          # fresh runner breaks package installation and archive validation.
+          cache: disable
       - name: install macports packages (mac, SDL2)
         if: runner.os == 'macOS' && matrix.tiles == 1 && matrix.sdl3 != 1
         run: |
@@ -530,6 +535,9 @@ jobs:
       - name: install macports (mac, SDL3)
         if: runner.os == 'macOS' && matrix.tiles == 1 && matrix.sdl3 == 1
         uses: melusina-org/setup-macports@c7eb59386def259a274627092566a7f7b8d219b1 # v1
+        with:
+          # See the SDL2 setup above: /opt/local is not a self-contained cache.
+          cache: disable
       - name: install macports packages (mac, SDL3)
         if: runner.os == 'macOS' && matrix.tiles == 1 && matrix.sdl3 == 1
         run: |


### PR DESCRIPTION
## What changed

- Disable setup-macports caching for both SDL2 and SDL3 macOS release jobs.
- Keep the existing SDL3 library build cache unchanged.

## Why

The setup action caches only /opt/local. It does not preserve the macports system user and group created by the installer. Restoring that cache on a fresh runner caused Unknown user given and then failed MacPorts archive signature verification while installing gettext-runtime.

Installing MacPorts on each fresh runner restores a complete, internally consistent environment.

## Validation

- release.yml parses successfully as YAML.
- git diff --check passes.
- The fix must be confirmed by the macOS release job after merge because that workflow only runs on master or manual dispatch.