### PR TITLE
Treat canceled mod loading as normal control flow

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -678,7 +678,7 @@ void game::reenter_fullscreen()
 /*
  * Initialize more stuff after mapbuffer is loaded.
  */
-void game::setup()
+bool game::setup()
 {
     new_game = true;
     {
@@ -696,7 +696,9 @@ void game::setup()
     // must be called before load_world_modfiles() #81904
     calendar::set_season_length( ::get_option<int>( "SEASON_LENGTH" ) );
 
-    world_generator->get_mod_manager().check_mods_list( world_generator->active_world );
+    if( !world_generator->get_mod_manager().check_mods_list( world_generator->active_world ) ) {
+        return false;
+    }
     load_world_modfiles();
     // Panel manager needs JSON data to be loaded before init
     panel_manager::get_manager().init();
@@ -705,6 +707,7 @@ void game::setup()
 
     reset_game_state();
     // back to menu for save loading, new game etc
+    return true;
 }
 
 // Reset all per-game runtime state to a clean slate, so a fresh load can

--- a/src/game.h
+++ b/src/game.h
@@ -262,7 +262,11 @@ class game
         /** Loads dynamic data from the folder if it is part of a subdirectory that is named after a currently loaded mod_id.  May throw. */
         void load_mod_interaction_data_from_dir( const cata_path &path, const std::string &src );
     public:
-        void setup();
+        /**
+         * Load the active world's core and mod data.
+         * @return false if the player cancels while resolving missing mods.
+         */
+        bool setup();
         /**
          * Reset all per-game runtime state (ID counters, weather, trackers,
          * EOC queues, global variables, etc.) to a clean slate. Called by

--- a/src/game_io.cpp
+++ b/src/game_io.cpp
@@ -309,7 +309,9 @@ bool game::load( const std::string &world )
 
     try {
         world_generator->set_active_world( wptr );
-        g->setup();
+        if( !g->setup() ) {
+            return false;
+        }
         g->load( wptr->world_saves.front() );
     } catch( const std::exception &err ) {
         debugmsg( "cannot load world '%s': %s", world, err.what() );

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -939,7 +939,9 @@ bool main_menu::opening_screen()
                         world->active_mod_order.emplace_back( MOD_INFORMATION_dda_tutorial );
                         world_generator->set_active_world( world );
                         try {
-                            g->setup();
+                            if( !g->setup() ) {
+                                break;
+                            }
                         } catch( const std::exception &err ) {
                             debugmsg( "Error: %s", err.what() );
                             break;
@@ -1313,7 +1315,9 @@ bool main_menu::new_character_tab()
 
                 world_generator->set_active_world( world );
                 try {
-                    g->setup();
+                    if( !g->setup() ) {
+                        continue;
+                    }
                 } catch( const std::exception &err ) {
                     debugmsg( "Error: %s", err.what() );
                     continue;
@@ -1359,7 +1363,9 @@ bool main_menu::new_character_tab()
         }
         world_generator->set_active_world( world );
         try {
-            g->setup();
+            if( !g->setup() ) {
+                return false;
+            }
         } catch( const std::exception &err ) {
             debugmsg( "Error: %s", err.what() );
             return false;
@@ -1411,7 +1417,9 @@ bool main_menu::load_game( std::string const &worldname, save_t const &savegame 
     world_generator->set_active_world( world );
 
     try {
-        g->setup();
+        if( !g->setup() ) {
+            return false;
+        }
     } catch( const std::exception &err ) {
         debugmsg( "Error: %s", err.what() );
         return false;

--- a/src/mod_manager.cpp
+++ b/src/mod_manager.cpp
@@ -459,10 +459,10 @@ void mod_manager::load_mods_list( WORLD *world ) const
     } );
 }
 
-void mod_manager::check_mods_list( WORLD *world ) const
+bool mod_manager::check_mods_list( WORLD *world ) const
 {
     if( world == nullptr ) {
-        return;
+        return true;
     }
     std::vector<mod_id> &amo = world->active_mod_order;
     bool changed = false;
@@ -489,7 +489,7 @@ void mod_manager::check_mods_list( WORLD *world ) const
                 }
                 switch( res ) {
                     case query_ynq_result::quit:
-                        throw std::runtime_error( _( "Player aborted load." ) );
+                        return false;
                     case query_ynq_result::no:
                         break;
                     case query_ynq_result::yes:
@@ -504,6 +504,7 @@ void mod_manager::check_mods_list( WORLD *world ) const
     if( changed ) {
         save_mods_list( world );
     }
+    return true;
 }
 
 const mod_manager::t_mod_list &mod_manager::get_default_mods() const

--- a/src/mod_manager.cpp
+++ b/src/mod_manager.cpp
@@ -7,7 +7,6 @@
 #include <memory>
 #include <ostream>
 #include <queue>
-#include <stdexcept>
 
 #include "cata_utility.h"
 #include "debug.h"

--- a/src/mod_manager.h
+++ b/src/mod_manager.h
@@ -139,10 +139,10 @@ class mod_manager
          */
         void load_mods_list( WORLD *world ) const;
         /**
-        * Handle mod migrations/removals
-        * Returns false if player decided to back out of loading after encountering missing mod
+        * Handle mod migrations/removals.
+        * Returns false if the player decided to back out of loading after encountering a missing mod.
         */
-        void check_mods_list( WORLD *world ) const;
+        bool check_mods_list( WORLD *world ) const;
         const t_mod_list &get_default_mods() const;
         bool set_default_mods( const t_mod_list &mods );
         const std::vector<mod_id> &get_usable_mods() const {


### PR DESCRIPTION
## Summary

- return an explicit cancellation status when the player backs out of resolving a missing mod
- propagate that status through `game::setup()` and every world-loading entry point
- return cleanly to the menu without showing the generic error dialog
- keep real loading exceptions on the existing error-reporting path

## Root cause

`mod_manager::check_mods_list()` was documented as returning false when the player canceled, but its signature was still `void`. Cancellation was implemented by throwing `std::runtime_error("Player aborted load.")`. Main-menu loaders catch all `std::exception` values as genuine failures, so a normal user choice was displayed as “the game has encountered an error.”

## User impact

Choosing Cancel on the missing-mod prompt now stops loading and returns to the menu normally. It does not modify the world's mod list and does not display a false crash/error report.

## Validation

- `git diff --check`
- confirmed all five `game::setup()` call sites handle the returned cancellation status
- confirmed the `Player aborted load.` exception path no longer exists
- compiled `game.cpp`, `game_io.cpp`, `main_menu.cpp`, and `mod_manager.cpp` with GCC, `-Werror`, and `-j10` on Arch Linux