### PR TITLE
Preserve the radiation mutation world default

### DIFF
--- a/data/core/external_options.json
+++ b/data/core/external_options.json
@@ -430,6 +430,7 @@
     "type": "EXTERNAL_OPTION",
     "name": "RAD_MUTATION",
     "//": "If true, radiation causes the player to mutate.",
+    "stub": true,
     "stype": "bool",
     "value": false
   },

--- a/tests/options_test.cpp
+++ b/tests/options_test.cpp
@@ -11,6 +11,11 @@
 
 static const option_slider_id option_slider_test_world_difficulty( "test_world_difficulty" );
 
+TEST_CASE( "core data preserves the radiation mutation world default", "[option]" )
+{
+    CHECK( get_option<bool>( "RAD_MUTATION" ) );
+}
+
 TEST_CASE( "option_slider_test", "[option]" )
 {
     options_manager::options_container opts = get_options().get_world_defaults();


### PR DESCRIPTION
## Summary

- mark the core `RAD_MUTATION` external-option entry as a compatibility stub
- add a regression test confirming core data loading preserves the registered world default

## Root cause

`RAD_MUTATION` is a visible world-default option, but its duplicate entry in `data/core/external_options.json` was not marked as a stub. Startup loaded the saved option first and then core data forced it to `false`, so changing the default-world setting never appeared to persist.

## User impact

The “Mutations by radiation” default-world setting now retains the player’s saved choice, and newly created worlds inherit that choice correctly.

## Validation

- `git diff --check`
- parsed `data/core/external_options.json`
- targeted Catch2 test: `core data preserves the radiation mutation world default`
- result: 1 assertion in 1 test case passed
