### PR TITLE
Add configurable progression and reproduction rates

### DIFF
--- a/data/core/external_options.json
+++ b/data/core/external_options.json
@@ -463,13 +463,6 @@
   },
   {
     "type": "EXTERNAL_OPTION",
-    "name": "SKILL_TRAINING_SPEED",
-    "//": "Scales experience gained from practicing skills and reading books.  0.5 is half as fast as default, 2.0 is twice as fast, 0.0 disables skill training except for NPC training.",
-    "stype": "float",
-    "value": 1.0
-  },
-  {
-    "type": "EXTERNAL_OPTION",
     "name": "PROFICIENCY_TRAINING_SPEED",
     "//": "Scales experience gained from practicing proficiencies.  0.5 is half as fast as default, 2.0 is twice as fast, 0.0 disables proficiency training except for NPC training.",
     "stype": "float",

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -247,6 +247,26 @@ static int compute_kill_xp( const mtype_id &mon_type )
     return mon_type->get_total_difficulty() + mon_type->get_difficulty_adjustment();
 }
 
+static bool lays_eggs( const mtype &type )
+{
+    return !type.baby_type.baby_egg.is_null() || !type.baby_type.baby_egg_group.is_null();
+}
+
+static float reproduction_speed( const mtype &type )
+{
+    return get_option<float>( lays_eggs( type ) ? "EGG_LAYING_SPEED" : "LIVE_BIRTH_SPEED" );
+}
+
+static time_duration reproduction_interval( const mtype &type )
+{
+    const time_duration base_interval = *type.baby_timer;
+    const float speed = reproduction_speed( type );
+    if( speed <= 0.0f ) {
+        return base_interval;
+    }
+    return std::max( 1_turns, base_interval / speed );
+}
+
 monster::monster()
 {
     unset_dest();
@@ -276,7 +296,7 @@ monster::monster( const mtype_id &id ) : monster()
     upgrades = type->upgrades && ( type->half_life || type->age_grow );
     reproduces = type->reproduces && type->baby_timer && !monster::has_flag( mon_flag_NO_BREED );
     if( reproduces && type->baby_timer ) {
-        baby_timer.emplace( calendar::turn + *type->baby_timer );
+        baby_timer.emplace( calendar::turn + reproduction_interval( *type ) );
     }
     biosignatures = type->biosignatures;
     if( monster::has_flag( mon_flag_AQUATIC ) ) {
@@ -559,6 +579,11 @@ void monster::set_baby_timer( const time_point &time )
     baby_timer.emplace( time );
 }
 
+const std::optional<time_point> &monster::get_baby_timer() const
+{
+    return baby_timer;
+}
+
 void monster::try_reproduce()
 {
     if( !reproduces ) {
@@ -566,6 +591,10 @@ void monster::try_reproduce()
     }
     // This can happen if the monster type has changed (from reproducing to non-reproducing monster)
     if( !type->baby_timer ) {
+        return;
+    }
+    if( reproduction_speed( *type ) <= 0.0f ) {
+        baby_timer.emplace( calendar::turn + *type->baby_timer );
         return;
     }
 
@@ -624,7 +653,7 @@ void monster::try_reproduce()
                 here.spawn_items( pos_bub(), item_group::items_from( type->baby_type.baby_egg_group ) );
             }
         }
-        *baby_timer += *type->baby_timer;
+        *baby_timer += reproduction_interval( *type );
     }
 }
 

--- a/src/monster.h
+++ b/src/monster.h
@@ -113,6 +113,7 @@ class monster : public Creature
         void allow_upgrade();
         void try_upgrade( bool pin_time );
         void set_baby_timer( const time_point &time );
+        const std::optional<time_point> &get_baby_timer() const;
         void try_reproduce();
         void try_biosignature();
         void refill_udders();

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3110,6 +3110,16 @@ void options_manager::add_options_world_default()
              to_translation( "Determines how much damage monsters can take.  A higher value makes monsters more resilient and a lower makes them more flimsy.  Requires world reset." ),
              1, 1000, 100, COPT_NO_HIDE, "%i%%"
            );
+
+        add( "EGG_LAYING_SPEED", page_id, to_translation( "Egg-laying speed" ),
+             to_translation( "Multiplier for the rate at which creatures lay eggs.  0.5 is half as fast as default, 2.0 is twice as fast, and 0.0 disables egg laying.  This does not affect creatures that give birth to live young." ),
+             0.0f, 100.0f, 1.0f, 0.1f
+           );
+
+        add( "LIVE_BIRTH_SPEED", page_id, to_translation( "Live-birth speed" ),
+             to_translation( "Multiplier for the rate at which creatures give birth to live young.  0.5 is half as fast as default, 2.0 is twice as fast, and 0.0 disables live births.  This does not affect creatures that lay eggs." ),
+             0.0f, 100.0f, 1.0f, 0.1f
+           );
     } );
 
     add_empty_line();

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3085,6 +3085,18 @@ void options_manager::add_options_world_default()
     } );
     add_empty_line();
 
+    add_option_group( "world_default", Group( "character_progression_opts",
+                      to_translation( "Character progression options" ),
+                      to_translation( "Options regarding character skill progression." ) ),
+    [&]( const std::string & page_id ) {
+        add( "SKILL_TRAINING_SPEED", page_id, to_translation( "Skill training speed" ),
+             to_translation( "Scales experience gained from practicing skills and reading books.  0.5 is half as fast as default, 2.0 is twice as fast, 0.0 disables skill training except for NPC training." ),
+             0.0, 100.0, 1.0, 0.1
+           );
+    } );
+
+    add_empty_line();
+
     add_option_group( "world_default", Group( "monster_props_opts",
                       to_translation( "Monster properties options" ),
                       to_translation( "Options regarding monster properties." ) ),
@@ -4422,7 +4434,7 @@ void options_manager::deserialize( const JsonArray &ja )
         // yay hardcoded list! remove after 0.J
         std::vector<std::string> removed_options = { "DISTANCE_INITIAL_VISIBILITY", "FOV_3D_Z_RANGE", "SAFEMODE",
                                                      "INITIAL_STAT_POINTS", "INITIAL_TRAIT_POINTS", "INITIAL_SKILL_POINTS", "MAX_TRAIT_POINTS",
-                                                     "SKILL_TRAINING_SPEED", "PROFICIENCY_TRAINING_SPEED"
+                                                     "PROFICIENCY_TRAINING_SPEED"
                                                    };
 
         const std::string name = migrateOptionName( joOptions.get_string( "name" ) );

--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -685,6 +685,66 @@ TEST_CASE( "monsters_spawn_eggs", "[monster][reproduction]" )
     CHECK( test_monster_spawns_eggs );
 }
 
+TEST_CASE( "egg_laying_speed_scales_reproduction_timers", "[monster][reproduction]" )
+{
+    clear_map_without_vision();
+    g->place_player( { 66, 66, 0 } );
+    const tripoint_bub_ms egg_loc = get_avatar().pos_bub() + tripoint::east;
+    const tripoint_bub_ms live_birth_loc = egg_loc + tripoint::east;
+    override_option egg_laying_speed( "EGG_LAYING_SPEED", "2.0" );
+    override_option live_birth_speed( "LIVE_BIRTH_SPEED", "4.0" );
+
+    monster &egg_layer = spawn_test_monster( "mon_dummy_reproducer_eggs", egg_loc );
+    monster &live_birth = spawn_test_monster( "mon_dummy_reproducer_mon", live_birth_loc );
+
+    REQUIRE( egg_layer.get_baby_timer().has_value() );
+    REQUIRE( live_birth.get_baby_timer().has_value() );
+    CHECK( *egg_layer.get_baby_timer() == calendar::turn + 12_hours );
+    CHECK( *live_birth.get_baby_timer() == calendar::turn + 6_hours );
+}
+
+TEST_CASE( "zero_egg_laying_speed_disables_egg_production", "[monster][reproduction]" )
+{
+    clear_map_without_vision();
+    map &here = get_map();
+    g->place_player( { 66, 66, 0 } );
+    const tripoint_bub_ms loc = get_avatar().pos_bub() + tripoint::east;
+    override_option egg_laying_speed( "EGG_LAYING_SPEED", "0.0" );
+    monster &egg_layer = spawn_test_monster( "mon_dummy_reproducer_eggs", loc );
+
+    egg_layer.set_baby_timer( calendar::turn - 2_days );
+    for( int i = 0; i < 100; ++i ) {
+        egg_layer.try_reproduce();
+    }
+
+    CHECK_FALSE( here.has_items( loc ) );
+    REQUIRE( egg_layer.get_baby_timer().has_value() );
+    CHECK( *egg_layer.get_baby_timer() == calendar::turn + 1_days );
+}
+
+TEST_CASE( "zero_live_birth_speed_disables_live_births", "[monster][reproduction]" )
+{
+    clear_map_without_vision();
+    creature_tracker &creatures = get_creature_tracker();
+    g->place_player( { 66, 66, 0 } );
+    const tripoint_bub_ms loc = get_avatar().pos_bub() + tripoint::east;
+    override_option live_birth_speed( "LIVE_BIRTH_SPEED", "0.0" );
+    monster &parent = spawn_test_monster( "mon_dummy_reproducer_mon", loc );
+
+    get_map().spawn_monsters( true );
+    const std::size_t creature_count_before_birth = creatures.get_monsters_list().size();
+
+    parent.set_baby_timer( calendar::turn - 2_days );
+    for( int i = 0; i < 100; ++i ) {
+        parent.try_reproduce();
+    }
+    get_map().spawn_monsters( true );
+
+    CHECK( creatures.get_monsters_list().size() == creature_count_before_birth );
+    REQUIRE( parent.get_baby_timer().has_value() );
+    CHECK( *parent.get_baby_timer() == calendar::turn + 1_days );
+}
+
 TEST_CASE( "monsters_spawn_egg_itemgroups", "[monster][reproduction]" )
 {
     clear_map_without_vision();


### PR DESCRIPTION
## Summary

- restore `SKILL_TRAINING_SPEED` as a world option available during world creation and in-game world settings
- add independent `EGG_LAYING_SPEED` and `LIVE_BIRTH_SPEED` world options
- scale egg-laying and live-birth reproduction periods separately, with 0 disabling that reproduction type
- add monster reproduction coverage for default, faster, slower, and disabled rates

All three multipliers default to 1.0 and accept values from 0 to 100.

## Background

Cataclysm-DDA PR [#80640](https://github.com/CleverRaven/Cataclysm-DDA/pull/80640) moved `SKILL_TRAINING_SPEED` out of the settings UI into an external option. The underlying training-speed behavior remained, so this restores it as a per-world setting in CCB.

## Validation

- reproduction tests: 7 test cases, 54 assertions passed
- affected core C++ sources compiled successfully
- `git diff --check` passed

The repository's strict full test build currently stops on the pre-existing unused-variable warning in `tests/clzones_test.cpp:3500`; linking with `WARNINGS='-Wall -Wextra'` was used to run the focused reproduction tests.
