### PR TITLE
Make unit-sensitive tests platform independent

### DIFF
--- a/tests/item_tname_test.cpp
+++ b/tests/item_tname_test.cpp
@@ -682,6 +682,7 @@ TEST_CASE( "molle_vest_additional_pockets", "[item][tname]" )
 
 TEST_CASE( "nested_items_tname", "[item][tname]" )
 {
+    override_option metric_weight( "USE_METRIC_WEIGHTS", "kg" );
     item backpack_hiking( itype_backpack_hiking );
     item purse( itype_purse );
     item rock( itype_test_rock );

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -2730,6 +2730,8 @@ TEST_CASE( "repairable_and_with_what_tools", "[iteminfo][repair]" )
 TEST_CASE( "disassembly_time_and_yield", "[iteminfo][disassembly]" )
 {
     clear_avatar();
+    override_option metric_weight( "USE_METRIC_WEIGHTS", "kg" );
+    override_option metric_distance( "DISTANCE_UNITS", "metric" );
 
     std::vector<iteminfo_parts> disassemble = { iteminfo_parts::DESCRIPTION_COMPONENTS_DISASSEMBLE };
 

--- a/tests/options_test.cpp
+++ b/tests/options_test.cpp
@@ -11,7 +11,7 @@
 
 static const option_slider_id option_slider_test_world_difficulty( "test_world_difficulty" );
 
-TEST_CASE( "core data preserves the radiation mutation world default", "[option]" )
+TEST_CASE( "core_data_preserves_the_radiation_mutation_world_default", "[option]" )
 {
     CHECK( get_option<bool>( "RAD_MUTATION" ) );
 }


### PR DESCRIPTION
## Summary

- use normalized characters in the radiation world-default test name
- explicitly select metric mass and distance units in disassembly output tests
- explicitly select metric mass units in nested item-name tests

## Root cause

The Windows runner selected imperial units from its system locale, while two tests asserted metric output without overriding the relevant options. A separate test introduced in #432 also used spaces in its test-case name, which violates the normalized test-name check.

## Validation

- `git diff --check`
- changes use the existing RAII `override_option` helper so global options are restored after each test