### PR TITLE
POWER_TRICKLE's settlement order

### DIFF
--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1706,14 +1706,14 @@ void Character::suffer()
         }
     }
 
-    for( bionic &bio : *my_bionics ) {
-        process_bionic( bio );
-    }
-
     units::energy trickle = enchantment_cache->modify_value( enchant_vals::mod::POWER_TRICKLE,
                             0_J );
     if( trickle != 0_J ) {
         mod_power_level( trickle );
+    }
+
+    for( bionic &bio : *my_bionics ) {
+        process_bionic( bio );
     }
 
     for( const trait_id &mut_id : get_functioning_mutations() ) {


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

The developer discussion group raised objections to the implementation order of POWER_TRICKLE in fix #438. They believe it might cause active bionics to shut down prematurely due to insufficient energy when a player's bionic power is depleted but passive functions provide enough power.

In reality, most game scenarios where power and production are at critical limits result in intermittent shutdowns, but changing the order so that passive production from enchantments is processed first does improve the player experience. This is because while production overflows when bionic power is full and is then consumed by bionics, and not all POWER_TRICKLE enchantments are unconditional, the maximum penalty for a bionic being briefly shut down in the game is currently greater than the loss from overflow.

#### Describe the solution

Moved the bionic power modification logic of the POWER_TRICKLE enchantment from Character::suffer() in suffer.cpp, positioning it before the for( bionic &bio : *my_bionics ) loop. This reverses the initial plan for the settlement order.