### PR TITLE
Fix null explosion field sources

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -925,10 +925,12 @@ std::optional<int> explosion_iuse::use( Character *p, item &it, map *here,
         explosion_handler::flashbang( pos, flashbang_player_immune );
     }
     if( fields_radius >= 0 && fields_type.id() ) {
+        const effect_source field_source = source != nullptr
+                                           ? effect_source( source ) : effect_source::empty();
         std::vector<tripoint_bub_ms> gas_sources = points_for_gas_cloud( here, pos, fields_radius );
         for( tripoint_bub_ms &gas_source : gas_sources ) {
             const int field_intensity = rng( fields_min_intensity, fields_max_intensity );
-            here->add_field( gas_source, fields_type, field_intensity, 1_turns, true, effect_source( source ) );
+            here->add_field( gas_source, fields_type, field_intensity, 1_turns, true, field_source );
         }
     }
     if( scrambler_blast_radius >= 0 ) {

--- a/tests/item_countdown_test.cpp
+++ b/tests/item_countdown_test.cpp
@@ -1,10 +1,13 @@
 #include <string>
 
+#include "avatar.h"
 #include "calendar.h"
 #include "cata_catch.h"
 #include "coordinates.h"
+#include "debug.h"
 #include "item.h"
 #include "map.h"
+#include "map_helpers.h"
 #include "type_id.h"
 
 static const itype_id itype_arrow_field_point_fletched( "arrow_field_point_fletched" );
@@ -13,6 +16,7 @@ static const itype_id itype_cheese_hard( "cheese_hard" );
 static const itype_id itype_grenade_act( "grenade_act" );
 static const itype_id itype_migo_plate( "migo_plate" );
 static const itype_id itype_migo_plate_undergrown( "migo_plate_undergrown" );
+static const itype_id itype_tear_gas_payload_act( "tear_gas_payload_act" );
 static const itype_id itype_test_rock_cheese( "test_rock_cheese" );
 
 TEST_CASE( "countdown_action_triggering", "[item]" )
@@ -37,6 +41,23 @@ TEST_CASE( "countdown_action_triggering", "[item]" )
         // Grenade explodes and is to be removed
         CHECK( grenade.process( get_map(), nullptr, tripoint_bub_ms::zero ) == true );
     }
+}
+
+TEST_CASE( "countdown_explosion_fields_without_character_source", "[item][explosion]" )
+{
+    clear_map();
+    map &here = get_map();
+    const tripoint_bub_ms origin = get_avatar().pos_bub( here );
+    item tear_gas_payload( itype_tear_gas_payload_act );
+    tear_gas_payload.active = true;
+    tear_gas_payload.countdown_point = calendar::turn;
+
+    const std::string dmsg = capture_debugmsg_during( [&]() {
+        CHECK( tear_gas_payload.process( here, nullptr, origin ) );
+    } );
+
+    CHECK( dmsg.empty() );
+    CHECK( here.has_field_at( origin, fd_tear_gas ) );
 }
 
 TEST_CASE( "countdown_action_revert_to", "[item]" )


### PR DESCRIPTION
## Summary

- use an explicit empty `effect_source` when an explosion creates fields without a character source
- reuse the resolved source for every generated field
- add a regression test covering an uncarried tear-gas payload countdown explosion

## Root cause

Kamikaze monsters process their active payload with a null `Character *`. Field-producing explosion actions constructed `effect_source` directly from that pointer for every generated field, which emitted repeated `effect_source constructor called with nullptr character` debug errors.

## Impact

Kamikaze tear-gas and EMP payloads continue to generate their fields normally, but unowned or monster-triggered payloads no longer display repeated debug popups. Character-attributed explosions retain their existing source attribution.

## Validation

- `make -j10 tests`
- `./tests/cata_test '[item][explosion]'` — 3 assertions passed
- `./tests/cata_test 'countdown*'` — 18 assertions passed
- AStyle dry-run on changed files
- `git diff --check`