### PR TITLE
data: update localized MOTD links

### DIFF
--- a/data/motd/ar.motd
+++ b/data/motd/ar.motd
@@ -5,10 +5,11 @@
 
 <color_light_gray>* الصفحة الرئيسية:</color>  <color_cyan> https://crimsoncrossbunker.github.io</color>
 <color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* ويكي العناصر:</color> <color_cyan>https://crimsoncrossbunker.github.io/CCB-GUIDE</color>
 
 <color_white>البلاغ عن الأخطاء وإرسال الاقتراحات ومتابعة التطوير على:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* URL: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* البريد الاكتروني: </color> <color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>انضم إلى المناقشة في المنتديات والدردشات على:</color>

--- a/data/motd/cs.motd
+++ b/data/motd/cs.motd
@@ -9,7 +9,7 @@
 
 <color_white>Hlaste případné chyby, sdělte své návrhy a sledujte vývoj hry na stránkách:</color>
 
-<color_light_gray>* URL:</color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* URL: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail:</color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Připojte se k diskuzi na fórech a chatech:</color>

--- a/data/motd/cs.motd
+++ b/data/motd/cs.motd
@@ -5,10 +5,11 @@
 
 <color_light_gray>*Domovská stránka:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
 <color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* Wiki předmětů:</color> <color_cyan>https://crimsoncrossbunker.github.io/CCB-GUIDE</color>
 
 <color_white>Hlaste případné chyby, sdělte své návrhy a sledujte vývoj hry na stránkách:</color>
 
-<color_light_gray>* Github:</color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* URL:</color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail:</color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Připojte se k diskuzi na fórech a chatech:</color>

--- a/data/motd/de.motd
+++ b/data/motd/de.motd
@@ -5,10 +5,11 @@
 
 <color_light_gray>* Homepage:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
 <color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* Gegenstands-Wiki:</color> <color_cyan>https://crimsoncrossbunker.github.io/CCB-GUIDE</color>
 
 <color_white>Melde Fehler, mache Vorschläge und folgen der Entwicklung unter:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* URL: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* E-Mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Nimm an den Diskussionen in Foren und Chats teil:</color>

--- a/data/motd/el.motd
+++ b/data/motd/el.motd
@@ -5,10 +5,11 @@
 
 <color_light_gray>*Αρχική σελίδα:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
 <color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* Βίκι αντικειμένων:</color> <color_cyan>https://crimsoncrossbunker.github.io/CCB-GUIDE</color>
 
 <color_white>* Αναφέρετε σφάλματα, προτάσεις και ακολουθήστε την ανάπτυξη στο:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* URL: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Λάβετε μέρος στη συζήτηση στα φόρουμ και στα chats:</color>

--- a/data/motd/en.motd
+++ b/data/motd/en.motd
@@ -5,10 +5,11 @@
 
 <color_light_gray>* Homepage:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
 <color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* Item wiki:</color> <color_cyan>https://crimsoncrossbunker.github.io/CCB-GUIDE</color>
 
 <color_white>Report bugs, suggestion and follow the development at:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* URL: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Join the discussion on forums and chats:</color>

--- a/data/motd/es_AR.motd
+++ b/data/motd/es_AR.motd
@@ -5,10 +5,11 @@
 
 <color_light_gray>* Página web:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
 <color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* Wiki de objetos:</color> <color_cyan>https://crimsoncrossbunker.github.io/CCB-GUIDE</color>
 
 <color_white>Comentar bugs, sugerencias y ver el desarrollo del juego:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* URL: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Vení a discutir en los foros y chats:</color>

--- a/data/motd/es_ES.motd
+++ b/data/motd/es_ES.motd
@@ -5,10 +5,11 @@
 
 <color_light_gray>* Pagina principal:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
 <color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* Wiki de objetos:</color> <color_cyan>https://crimsoncrossbunker.github.io/CCB-GUIDE</color>
 
 <color_white>Informar de errores, sugerencias y seguir el desarrollo en: </color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* URL: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Comunícate y habla en los foros y chats: </color>

--- a/data/motd/fil_PH.motd
+++ b/data/motd/fil_PH.motd
@@ -5,10 +5,11 @@
 
 <color_light_gray>* Ang aming homepage:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
 <color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* Wiki ng mga item:</color> <color_cyan>https://crimsoncrossbunker.github.io/CCB-GUIDE</color>
 
 <color_white>Mag-report ng bugs, suwestiyon at I-follow ang development sa:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* URL: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Sundin ang aming diskusyon sa aming forums at chats:</color>

--- a/data/motd/fr.motd
+++ b/data/motd/fr.motd
@@ -5,10 +5,11 @@
 
 <color_light_gray>*Accueil:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
 <color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* Wiki des objets:</color> <color_cyan>https://crimsoncrossbunker.github.io/CCB-GUIDE</color>
 
 <color_white> Signalez des bugs, faites des suggestions et suivez le développement du jeu sur : </color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* URL: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Rejoignez la discussion sur les forums et chats:</color>

--- a/data/motd/ga_IE.motd
+++ b/data/motd/ga_IE.motd
@@ -5,10 +5,11 @@
 
 <color_light_gray>* Leathanach baile:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
 <color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* Vicí na míreanna:</color> <color_cyan>https://crimsoncrossbunker.github.io/CCB-GUIDE</color>
 
 <color_white>Tuairiscigh fabhtanna, cuir moltaí isteach, agus lean forbairt ag:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* URL: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* R-phoist:</color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Bí sa chomhrá ar fóraim agus comhráite grúpaí:</color>

--- a/data/motd/hu.motd
+++ b/data/motd/hu.motd
@@ -5,10 +5,11 @@
 
 <color_light_gray>* Honlap:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
 <color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* Tárgywiki:</color> <color_cyan>https://crimsoncrossbunker.github.io/CCB-GUIDE</color>
 
 <color_white>Programhibák bejelentése, új ötletek és folyamatos fejlesztés:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* URL: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Angol nyelvű fórumozás és chat:</color>

--- a/data/motd/id.motd
+++ b/data/motd/id.motd
@@ -5,10 +5,11 @@
 
 <color_light_gray>* Halaman depan:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
 <color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* Wiki item:</color> <color_cyan>https://crimsoncrossbunker.github.io/CCB-GUIDE</color>
 
 <color_white>Laporkan bug, saran dan ikuti pengembangannya di:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* URL: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Ikuti diskusi di forum dan chat:</color>

--- a/data/motd/it_IT.motd
+++ b/data/motd/it_IT.motd
@@ -5,10 +5,11 @@
 
 <color_light_gray>* Homepage:</color>  <color_cyan>https://crimsoncrossbunker.github.io</color>
 <color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* Wiki degli oggetti:</color> <color_cyan>https://crimsoncrossbunker.github.io/CCB-GUIDE</color>
 
 <color_white>Segnala bug, suggerimenti e segui lo sviluppo su:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* URL: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Unisciti alla discussione nei forum e nelle chat:</color>

--- a/data/motd/ja.motd
+++ b/data/motd/ja.motd
@@ -5,10 +5,11 @@
 
 <color_light_gray>* 公式サイト:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
 <color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* アイテムWiki:</color> <color_cyan>https://crimsoncrossbunker.github.io/CCB-GUIDE</color>
 
 <color_white>バグ報告、提案、開発状況の確認:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* URL: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>議論やチャットへの参加:</color>

--- a/data/motd/ko.motd
+++ b/data/motd/ko.motd
@@ -5,10 +5,11 @@
 
 <color_light_gray>* 홈페이지:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
 <color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* 아이템 위키:</color> <color_cyan>https://crimsoncrossbunker.github.io/CCB-GUIDE</color>
 
 <color_white>버그 보고, 기능 제안, 개발현황 확인:</color>
 
-<color_light_gray>* 깃허브: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* URL: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* 이메일: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>포럼과 챗에서 토론하기:</color>

--- a/data/motd/nb.motd
+++ b/data/motd/nb.motd
@@ -5,10 +5,11 @@
 
 <color_light_gray>*Hjemmeside:</color> <color_cyan>https://crimsoncrossbunker.github.io</color>
 <color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* Gjenstandswiki:</color> <color_cyan>https://crimsoncrossbunker.github.io/CCB-GUIDE</color>
 
 <color_white>Rapporter feil, forslag og følg utviklingen ved:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* URL: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Delta i diskusjonene på forum og chatter:</color>

--- a/data/motd/pl.motd
+++ b/data/motd/pl.motd
@@ -5,10 +5,11 @@
 
 <color_light_gray>* Strona domowa:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
 <color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* Wiki przedmiotów:</color> <color_cyan>https://crimsoncrossbunker.github.io/CCB-GUIDE</color>
 
 <color_white>Zgłaszaj błędy, sugestie i śledź rozwój gry na:</color>
 
-<color_light_gray>* GitHub: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* URL: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Dołącz do dyskusji na forach i czatach:</color>

--- a/data/motd/pt_BR.motd
+++ b/data/motd/pt_BR.motd
@@ -5,10 +5,11 @@
 
 <color_light_gray>* Homepage:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
 <color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* Wiki de itens:</color> <color_cyan>https://crimsoncrossbunker.github.io/CCB-GUIDE</color>
 
 <color_white>Reporte bugs, sugestões e siga o desenvolvimento em: </color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* URL: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Entre na discussão em fóruns e chats:</color>

--- a/data/motd/ru.motd
+++ b/data/motd/ru.motd
@@ -5,10 +5,11 @@
 
 <color_light_gray>* Официальный сайт:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
 <color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* Вики предметов:</color> <color_cyan>https://crimsoncrossbunker.github.io/CCB-GUIDE</color>
 
 <color_white>Сообщайте о багах, выдвигайте предложения и следите за разработкой:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* URL: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Присоединяйтесь к обсуждению на форумах и в чатах:</color>

--- a/data/motd/tr.motd
+++ b/data/motd/tr.motd
@@ -5,10 +5,11 @@
 
 <color_light_gray>* Ana Sayfa:</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
 <color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* Eşya vikisi:</color> <color_cyan>https://crimsoncrossbunker.github.io/CCB-GUIDE</color>
 
 <color_white>Hataları rapor etmek, öneride bulunmak ve gelişmeleri takip etmek için:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* URL: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-posta: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Forumlara ve sohbetlere katılmak için:</color>

--- a/data/motd/uk_UA.motd
+++ b/data/motd/uk_UA.motd
@@ -5,10 +5,11 @@
 
 <color_light_gray>* Домашня сторінка гри:</color>      <color_cyan>https://crimsoncrossbunker.github.io</color>
 <color_light_gray>* GitHub repository:</color> <color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* Вікі предметів:</color> <color_cyan>https://crimsoncrossbunker.github.io/CCB-GUIDE</color>
 
 <color_white>Повідомте про помилки, пропозиції та стежте за розробками на:</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* URL: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* е-мейл: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>Приєднуйтесь до розмов на форумах і чатах:</color>

--- a/data/motd/zh_CN.motd
+++ b/data/motd/zh_CN.motd
@@ -9,7 +9,7 @@
 
 <color_white>报告BUG，提交建议及跟进开发进度：</color>
 
-<color_light_gray>* </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* URL：</color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* E-mail：</color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>加入论坛及讨论组：</color>

--- a/data/motd/zh_CN.motd
+++ b/data/motd/zh_CN.motd
@@ -9,7 +9,7 @@
 
 <color_white>报告BUG，提交建议及跟进开发进度：</color>
 
-<color_light_gray>* URL：</color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* URL: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* E-mail：</color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>加入论坛及讨论组：</color>

--- a/data/motd/zh_CN.motd
+++ b/data/motd/zh_CN.motd
@@ -5,10 +5,11 @@
 
 <color_light_gray>* 主页：</color><color_cyan>https://crimsoncrossbunker.github.io</color>
 <color_light_gray>* GitHub 仓库：</color><color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* 物品维基：</color><color_cyan>https://crimsoncrossbunker.github.io/CCB-GUIDE</color>
 
 <color_white>报告BUG，提交建议及跟进开发进度：</color>
 
-<color_light_gray>* GitHub：</color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* E-mail：</color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>加入论坛及讨论组：</color>

--- a/data/motd/zh_TW.motd
+++ b/data/motd/zh_TW.motd
@@ -5,10 +5,11 @@
 
 <color_light_gray>* 官網：</color>    <color_cyan>https://crimsoncrossbunker.github.io</color>
 <color_light_gray>* GitHub 倉庫：</color><color_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb</color>
+<color_light_gray>* 物品維基：</color><color_cyan>https://crimsoncrossbunker.github.io/CCB-GUIDE</color>
 
 <color_white>回報bug，提供建議與關注開發進度：</color>
 
-<color_light_gray>* Github: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* URL：</color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>在論壇或聊天室討論：</color>

--- a/data/motd/zh_TW.motd
+++ b/data/motd/zh_TW.motd
@@ -9,7 +9,7 @@
 
 <color_white>回報bug，提供建議與關注開發進度：</color>
 
-<color_light_gray>* URL：</color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
+<color_light_gray>* URL: </color><color_light_cyan>https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/issues</color>
 <color_light_gray>* e-mail: </color><color_light_cyan>lyhxit@gmail.com</color>
 
 <color_white>在論壇或聊天室討論：</color>


### PR DESCRIPTION
## Summary

- add a localized CCB item wiki link to every in-game MOTD language
- keep each full GitHub Issues URL and label it with the short `URL:` prefix
- keep each Issues entry on one rendered line

## Why

The item wiki was missing from the MOTD languages. The previous Issues labels made the already-long GitHub URL exceed the documented 78-character line limit in the rendered MOTD.

## User impact

Players using any of the 23 available MOTD languages can find the item wiki from the main menu. The GitHub Issues links remain intact and now render cleanly.

## Validation

- `git diff --check`
- confirmed all 23 MOTD files contain the item wiki URL
- confirmed all 23 Issues entries use `URL:` and retain the full GitHub URL
- verified the changed URL lines are at most 77 display columns