### PR TITLE
Fix EOCs targeting removed unique NPCs

### DIFF
--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -868,5 +868,13 @@
         ]
       }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_test_run_unique_npc",
+    "effect": {
+      "u_run_npc_eocs": [ { "id": "EOC_test_mark_unique_npc", "effect": { "u_add_var": "unique_npc_eoc_ran", "value": "yes" } } ],
+      "unique_ids": [ "EOC_TEST_UNIQUE_NPC" ]
+    }
   }
 ]

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -7023,16 +7023,20 @@ talk_effect_fun_t::func f_run_npc_eocs( const JsonObject &jo,
     } else {
         return [eocs, unique_ids]( dialogue const & d ) {
             for( const str_or_var &target : unique_ids ) {
-                if( g->unique_npc_exists( target.evaluate( d ) ) ) {
-                    for( const effect_on_condition_id &eoc : eocs ) {
-                        npc *npc = g->find_npc_by_unique_id( target.evaluate( d ) );
-                        if( npc ) {
-                            dialogue newDialog( get_talker_for( npc ), nullptr, d.get_conditionals(), d.get_context() );
-                            eoc->activate( newDialog );
-                        } else {
-                            debugmsg( "Tried to use invalid npc: %s. %s", target.evaluate( d ), d.get_callstack() );
-                        }
-                    }
+                const std::string target_id = target.evaluate( d );
+                if( !g->unique_npc_exists( target_id ) ) {
+                    continue;
+                }
+                // The unique NPC registry also prevents mapgen from respawning an NPC, so an
+                // entry can legitimately outlive an NPC that was killed or otherwise removed.
+                npc *target_npc = g->find_npc_by_unique_id( target_id );
+                if( target_npc == nullptr ) {
+                    continue;
+                }
+                for( const effect_on_condition_id &eoc : eocs ) {
+                    dialogue newDialog( get_talker_for( target_npc ), nullptr, d.get_conditionals(),
+                                        d.get_context() );
+                    eoc->activate( newDialog );
                 }
             }
         };
@@ -9682,4 +9686,3 @@ std::vector<std::string> get_all_talk_topic_ids()
     }
     return dialogue_ids;
 }
-

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -168,6 +168,8 @@ effect_on_condition_EOC_string_var_var( "EOC_string_var_var" );
 static const effect_on_condition_id effect_on_condition_EOC_teleport_test( "EOC_teleport_test" );
 static const effect_on_condition_id
 effect_on_condition_EOC_test_weapon_damage( "EOC_test_weapon_damage" );
+static const effect_on_condition_id
+effect_on_condition_EOC_test_run_unique_npc( "EOC_test_run_unique_npc" );
 static const effect_on_condition_id effect_on_condition_EOC_try_kill( "EOC_try_kill" );
 static const effect_on_condition_id effect_on_condition_run_eocs_1( "run_eocs_1" );
 static const effect_on_condition_id effect_on_condition_run_eocs_2( "run_eocs_2" );
@@ -276,6 +278,31 @@ TEST_CASE( "EOC_beta_elevate", "[eoc]" )
     effect_on_condition_EOC_try_kill->activate( newDialog );
 
     CHECK( n.hp_percentage() == 0 );
+}
+
+TEST_CASE( "EOC_run_unique_npc_skips_removed_target", "[eoc][npc]" )
+{
+    clear_avatar();
+    clear_map_without_vision();
+
+    npc &target = spawn_npc( get_avatar().pos_bub().xy() + point::south, "thug" );
+    target.set_unique_id( "EOC_TEST_UNIQUE_NPC" );
+    const character_id target_id = target.getID();
+    dialogue d( get_talker_for( get_avatar() ), nullptr );
+
+    REQUIRE( effect_on_condition_EOC_test_run_unique_npc->activate( d ) );
+    CHECK( target.get_value( "unique_npc_eoc_ran" ) == "yes" );
+
+    overmap_buffer.remove_npc( target_id );
+    g->remove_npc( target_id );
+    REQUIRE( g->unique_npc_exists( "EOC_TEST_UNIQUE_NPC" ) );
+
+    const std::string debug_message = capture_debugmsg_during( [&]() {
+        effect_on_condition_EOC_test_run_unique_npc->activate( d );
+    } );
+    CHECK( debug_message.empty() );
+
+    g->unique_npc_despawn( "EOC_TEST_UNIQUE_NPC" );
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity): false positive


### PR DESCRIPTION
#### Summary
Bugfixes "避免 EOC 操作已死亡或移除的唯一 NPC 时反复弹出 Debug"

#### Purpose of change
难民中心守卫可能在任务或战斗中死亡，但唯一 NPC 登记会继续保留其 ID，以阻止地图生成再次生成同一 NPC。全局守卫轮班 EOC 随后仍会查找该 NPC，并每隔数小时弹出 `Tried to use invalid npc`。

该问题与上游报告 https://github.com/CleverRaven/Cataclysm-DDA/issues/75048 相同。

复现方式：
1. 生成难民中心并让一个带唯一 ID 的守卫死亡。
2. 等待全局守卫轮班 EOC 运行。
3. EOC 找不到实际 NPC，但登记仍存在，于是弹出 Debug。

#### Describe the solution
在非本地 `u_run_npc_eocs` 路径中只计算一次目标 ID，并在唯一 NPC 登记存在、但实际 NPC 已被删除时静默跳过。仍存在的远程 NPC 会照常运行 EOC。

新增回归测试，同时验证：
- 存在的唯一 NPC 能正常运行目标 EOC；
- 删除 NPC 并保留唯一 ID 后，再次运行不会产生 Debug。

#### Describe alternatives you've considered
没有从难民中心 EOC 中硬编码删除特定守卫 ID，因为死亡的可能是任意守卫，也会影响正常存档的轮班。没有在 NPC 死亡时清除唯一 ID，因为该登记还承担阻止唯一 NPC 被地图生成重复创建的职责。

#### Testing
- `make -j10 tests`
- `tests/cata_test 'EOC_run_unique_npc_skips_removed_target' --rng-seed time`
- 结果：1 个测试用例、6 个断言全部通过。
- `git diff --check`

#### Additional context
该修复保留跨现实泡远程运行 NPC EOC 的现有行为，仅将已经登记但不再存在的 NPC 视为正常缺席。