### PR TITLE
[FCL] Implementing the power consumption function of the FTK-93 fusion rifle, which was temporarily suspended due to a bug.

### DIFF
--- a/data/mods/FuturismCataclysmLegacy/itemgroups/main.json
+++ b/data/mods/FuturismCataclysmLegacy/itemgroups/main.json
@@ -10,6 +10,7 @@
         [ "fcl_plasma_rifle", 10 ],
         [ "fcl_heavy_rail_rifle", 10 ],
         [ "fcl_ftk93", 10 ],
+        [ "fcl_fusion_pack", 10 ],
         [ "fcl_fusion_pellet", 10 ],
         [ "fcl_bio_neurosoft_aeronautics", 10 ],
         [ "fcl_bio_neurosoft_aircraft_mechanic", 10 ]

--- a/data/mods/FuturismCataclysmLegacy/items/ranged/energy.json
+++ b/data/mods/FuturismCataclysmLegacy/items/ranged/energy.json
@@ -115,7 +115,8 @@
       }
     ],
     "firing_requirements": { "DEFAULT": [ { "pocket": "ammo", "qty": 1 }, { "pocket": "fusion pellet", "qty": 1 } ] },
-    "flags": [ "NEVER_JAMS", "NON_FOULING" ],
+    "energy_drain": "5 kJ",
+    "flags": [ "NEVER_JAMS", "NON_FOULING", "USE_UPS", "FIRING_EXT_POWER" ],
     "valid_mod_locations": [
       [ "accessories", 4 ],
       [ "grip", 1 ],


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

I added the FTK-93 fusion rifle in #449, but this experimental weapon, which requires high-voltage electricity to activate the fusion pellet, is not properly powered. I've already explained the specific problem in #455. I initially put the implementation of the power consumption part on hold, but #455 fixed the bug where firearms with firing_requirements cannot correctly consume external UPS or bionic power.

#### Describe the solution

Implementing the power consumption function of the FTK-93 fusion rifle, which was temporarily suspended due to a bug.

Furthermore, since it was discovered that firearms manufactured using nanoprinters cannot produce bullets or magazines, fusion packs have also been added to the list of weapons that can be manufactured.