### PR TITLE
[FCL] FTK Series: Add microfusion laser guns

### DIFF
--- a/data/mods/FuturismCataclysmLegacy/itemgroups/Weapons_Mods_Ammo/guns.json
+++ b/data/mods/FuturismCataclysmLegacy/itemgroups/Weapons_Mods_Ammo/guns.json
@@ -7,7 +7,9 @@
       "items": [
         { "item": "fcl_plasma_gun", "prob": 10, "charges": [ 0, 25 ] },
         { "item": "fcl_plasma_rifle", "prob": 5, "charges": [ 0, 25 ] },
-        { "item": "fcl_ftk93", "prob": 2, "charges": [ 0, 25 ], "contents-group": "fcl_fusion_pack" }
+        { "item": "fcl_ftk93", "prob": 2, "charges": [ 0, 25 ], "contents-group": "fcl_fusion_pack" },
+        { "item": "fcl_ftk29", "prob": 4, "contents-group": "fcl_fusion_ftk29_mag" },
+        { "item": "fcl_ftk07", "prob": 3, "contents-group": "fcl_fusion_ftk07_mag" }
       ]
     }
   },
@@ -26,6 +28,24 @@
     "subtype": "collection",
     "items": [
       { "item": "fcl_fusion_pack", "charges": [ 0, 3 ] }
+    ]
+  },
+  {
+    "id": "fcl_fusion_ftk29_mag",
+    "type": "item_group",
+    "subtype": "collection",
+    "items": [
+      { "item": "medium_battery_cell", "charges": [ 0, 56 ] },
+      { "item": "fcl_fusion_10_mag", "charges": [ 0, 10 ] }
+    ]
+  },
+  {
+    "id": "fcl_fusion_ftk07_mag",
+    "type": "item_group",
+    "subtype": "collection",
+    "items": [
+      { "item": "heavy_battery_cell", "charges": [ 0, 259 ] },
+      { "item": "fcl_fusion_20_mag", "charges": [ 0, 20 ] }
     ]
   },
   {

--- a/data/mods/FuturismCataclysmLegacy/itemgroups/Weapons_Mods_Ammo/guns.json
+++ b/data/mods/FuturismCataclysmLegacy/itemgroups/Weapons_Mods_Ammo/guns.json
@@ -35,8 +35,8 @@
     "type": "item_group",
     "subtype": "collection",
     "items": [
-      { "item": "medium_battery_cell", "charges": [ 0, 56 ] },
-      { "item": "fcl_fusion_10_mag", "charges": [ 0, 10 ] }
+      { "item": "fcl_fusion_10_mag", "charges": [ 0, 10 ] },
+      { "item": "medium_battery_cell", "charges": [ 0, 56 ] }
     ]
   },
   {
@@ -44,8 +44,8 @@
     "type": "item_group",
     "subtype": "collection",
     "items": [
-      { "item": "heavy_battery_cell", "charges": [ 0, 259 ] },
-      { "item": "fcl_fusion_20_mag", "charges": [ 0, 20 ] }
+      { "item": "fcl_fusion_20_mag", "charges": [ 0, 20 ] },
+      { "item": "heavy_battery_cell", "charges": [ 0, 259 ] }
     ]
   },
   {

--- a/data/mods/FuturismCataclysmLegacy/itemgroups/main.json
+++ b/data/mods/FuturismCataclysmLegacy/itemgroups/main.json
@@ -12,6 +12,8 @@
         [ "fcl_ftk93", 10 ],
         [ "fcl_fusion_pack", 10 ],
         [ "fcl_fusion_pellet", 10 ],
+        [ "fcl_ftk29", 10 ],
+        [ "fcl_ftk07", 10 ],
         [ "fcl_bio_neurosoft_aeronautics", 10 ],
         [ "fcl_bio_neurosoft_aircraft_mechanic", 10 ]
       ]

--- a/data/mods/FuturismCataclysmLegacy/items/ammo.json
+++ b/data/mods/FuturismCataclysmLegacy/items/ammo.json
@@ -24,7 +24,7 @@
     "price_postapoc": "50 USD",
     "ammo_type": "fcl_fusion_pellet",
     "range": 0,
-    "count": 50,
+    "count": 25,
     "effects": [ "NEVER_MISFIRES" ],
     "flags": [ "LEAK_DAM", "RADIOACTIVE", "UNRECOVERABLE" ]
   },

--- a/data/mods/FuturismCataclysmLegacy/items/ammo.json
+++ b/data/mods/FuturismCataclysmLegacy/items/ammo.json
@@ -47,5 +47,39 @@
     "capacity": 3,
     "reload_time": 600,
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "fcl_fusion_pellet": 3 } } ]
+  },
+  {
+    "id": "fcl_fusion_10_mag",
+    "looks_like": "stanag30",
+    "type": "ITEM",
+    "subtypes": [ "MAGAZINE" ],
+    "name": { "str": "fusion 10-round extended magazine" },
+    "description": "A modified high-density magazine designed to hold and align micro-fusion target pellets. Its original capacitive contacts and magnetic shielding have been weakened and expanded using nanomaterials, making it unstable and unsafe for use in propellant-reaction microfusion firearms. However, it's perfect for energy laser-type microfusion firearms.",
+    "copy-from": "fcl_fusion_pack",
+    "weight": "168 g",
+    "volume": "250 ml",
+    "price": "500 USD",
+    "price_postapoc": "10 USD",
+    "flags": [ "MAG_COMPACT" ],
+    "capacity": 10,
+    "reload_time": 600,
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "fcl_fusion_pellet": 10 } } ]
+  },
+  {
+    "id": "fcl_fusion_20_mag",
+    "looks_like": "stanag30",
+    "type": "ITEM",
+    "subtypes": [ "MAGAZINE" ],
+    "name": { "str": "fusion 20-round extended magazine" },
+    "description": "A modified high-density magazine designed to hold and align micro-fusion target pellets. Its original capacitive contacts and magnetic shielding have been weakened and expanded using nanomaterials, making it unstable and unsafe for use in propellant-reaction microfusion firearms. However, it's perfect for energy laser-type microfusion firearms.",
+    "copy-from": "fcl_fusion_pack",
+    "weight": "198 g",
+    "volume": "300 ml",
+    "price": "500 USD",
+    "price_postapoc": "10 USD",
+    "flags": [ "MAG_COMPACT" ],
+    "capacity": 20,
+    "reload_time": 600,
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "fcl_fusion_pellet": 20 } } ]
   }
 ]

--- a/data/mods/FuturismCataclysmLegacy/items/ammo.json
+++ b/data/mods/FuturismCataclysmLegacy/items/ammo.json
@@ -24,7 +24,7 @@
     "price_postapoc": "50 USD",
     "ammo_type": "fcl_fusion_pellet",
     "range": 0,
-    "count": 25,
+    "count": 50,
     "effects": [ "NEVER_MISFIRES" ],
     "flags": [ "LEAK_DAM", "RADIOACTIVE", "UNRECOVERABLE" ]
   },

--- a/data/mods/FuturismCataclysmLegacy/items/ranged/energy.json
+++ b/data/mods/FuturismCataclysmLegacy/items/ranged/energy.json
@@ -167,18 +167,18 @@
     ],
     "pocket_data": [
       {
-        "id": "power",
-        "pocket_type": "MAGAZINE_WELL",
-        "rigid": true,
-        "flag_restriction": [ "BATTERY_MEDIUM" ],
-        "default_magazine": "medium_battery_cell"
-      },
-      {
         "id": "fusion pellet",
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
         "item_restriction": [ "fcl_fusion_pack", "fcl_fusion_10_mag", "fcl_fusion_20_mag" ],
         "default_magazine": "fcl_fusion_10_mag"
+      },
+      {
+        "id": "power",
+        "pocket_type": "MAGAZINE_WELL",
+        "rigid": true,
+        "flag_restriction": [ "BATTERY_MEDIUM" ],
+        "default_magazine": "medium_battery_cell"
       }
     ],
     "firing_requirements": { "DEFAULT": [ { "pocket": "power", "qty": 5 }, { "pocket": "fusion pellet", "qty": 1 } ] },
@@ -218,18 +218,18 @@
     "ammo": [ "fcl_fusion_pellet", "battery" ],
     "pocket_data": [
       {
-        "id": "power",
-        "pocket_type": "MAGAZINE_WELL",
-        "rigid": true,
-        "flag_restriction": [ "BATTERY_HEAVY" ],
-        "default_magazine": "heavy_battery_cell"
-      },
-      {
         "id": "fusion pellet",
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
         "item_restriction": [ "fcl_fusion_pack", "fcl_fusion_10_mag", "fcl_fusion_20_mag" ],
         "default_magazine": "fcl_fusion_20_mag"
+      },
+      {
+        "id": "power",
+        "pocket_type": "MAGAZINE_WELL",
+        "rigid": true,
+        "flag_restriction": [ "BATTERY_HEAVY" ],
+        "default_magazine": "heavy_battery_cell"
       }
     ],
     "firing_requirements": {

--- a/data/mods/FuturismCataclysmLegacy/items/ranged/energy.json
+++ b/data/mods/FuturismCataclysmLegacy/items/ranged/energy.json
@@ -100,7 +100,7 @@
     "ammo_effects": [ "PLASMA", "EXPLOSIVE", "FLAME", "IGNITE" ],
     "ammo": [ "plasma" ],
     "to_hit": -1,
-    "clip_size": 2,
+    "clip_size": 25,
     "reload": 200,
     "pocket_data": [
       { "id": "ammo", "pocket_type": "MAGAZINE", "ammo_restriction": { "plasma": 25 } },
@@ -126,5 +126,130 @@
       [ "underbarrel", 1 ]
     ],
     "melee_damage": { "bash": 18 }
+  },
+  {
+    "type": "ITEM",
+    "subtypes": [ "GUN" ],
+    "id": "fcl_ftk29",
+    "looks_like": "glock_17",
+    "reload_noise_volume": 10,
+    "name": { "str": "FTK-29 microfusion laser pistol" },
+    "description": "An experimental energy laser-type microfusion firearm. Its design incorporates some ideas from the V29 and the MagLIF technology used in the prototype, but abandons the highly destructive and unstable propellant reaction jet route, instead miniaturizing it to create a composite energy weapon that fires a small amount of plasma along with a laser beam. Because it converts fusion energy release into its primary attack energy source, this model has reduced the number of internal energy interfaces and cannot natively support UPS, but it features a simple battery compartment compatible with medium batteries.",
+    "weight": "1020 g",
+    "volume": "1500 ml",
+    "longest_side": "233 mm",
+    "price": "87 kUSD 250 USD",
+    "price_postapoc": "95 USD",
+    "material": [ "steel", "superalloy", "plastic" ],
+    "symbol": "(",
+    "color": "magenta",
+    "skill": "pistol",
+    "range": 30,
+    "ranged_damage": { "damage_type": "fcl_laser", "amount": 25, "armor_penetration": 8 },
+    "dispersion": 180,
+    "durability": 8,
+    "loudness": 7,
+    "reload": 200,
+    "overheat_threshold": 60,
+    "cooling_value": 2,
+    "heat_per_shot": 6,
+    "ammo_effects": [ "PLASMA", "LASER", "INCENDIARY" ],
+    "ammo": [ "fcl_fusion_pellet", "battery" ],
+    "valid_mod_locations": [
+      [ "accessories", 2 ],
+      [ "emitter", 1 ],
+      [ "grip", 1 ],
+      [ "lens", 1 ],
+      [ "rail", 1 ],
+      [ "sights", 1 ],
+      [ "stock", 1 ],
+      [ "underbarrel", 1 ]
+    ],
+    "pocket_data": [
+      {
+        "id": "power",
+        "pocket_type": "MAGAZINE_WELL",
+        "rigid": true,
+        "flag_restriction": [ "BATTERY_MEDIUM" ],
+        "default_magazine": "medium_battery_cell"
+      },
+      {
+        "id": "fusion pellet",
+        "pocket_type": "MAGAZINE_WELL",
+        "rigid": true,
+        "item_restriction": [ "fcl_fusion_pack", "fcl_fusion_10_mag", "fcl_fusion_20_mag" ],
+        "default_magazine": "fcl_fusion_pack"
+      }
+    ],
+    "firing_requirements": { "DEFAULT": [ { "pocket": "power", "qty": 5 }, { "pocket": "fusion pellet", "qty": 1 } ] },
+    "flags": [ "NEVER_JAMS", "NON_FOULING", "NEEDS_NO_LUBE", "OVERHEATS" ],
+    "faults": [ { "fault": "fault_overheat_melting" }, { "fault": "fault_overheat_safety" } ],
+    "melee_damage": { "bash": 5 }
+  },
+  {
+    "type": "ITEM",
+    "subtypes": [ "GUN" ],
+    "id": "fcl_ftk07",
+    "looks_like": "modular_ar15",
+    "reload_noise_volume": 10,
+    "name": { "str": "FTK-07 microfusion laser rifle" },
+    "description": "An experimental energy laser-type microfusion firearm. Its design incorporates some ideas from the A7 and the MagLIF technology used in the prototype, but abandons the highly destructive and unstable propellant reaction jet route, instead miniaturizing it to create a composite energy weapon that fires a small amount of plasma along with a laser beam. Because it converts fusion energy release into its primary attack energy source, this model has reduced the number of internal energy interfaces and cannot natively support UPS, but it features a simple battery compartment compatible with tool batteries.",
+    "weight": "4425 g",
+    "volume": "4500 ml",
+    "longest_side": "900 mm",
+    "price": "102 kUSD",
+    "price_postapoc": "125 USD",
+    "to_hit": -1,
+    "material": [ "steel", "superalloy", "plastic" ],
+    "symbol": "(",
+    "color": "yellow",
+    "skill": "rifle",
+    "range": 30,
+    "ranged_damage": { "damage_type": "fcl_laser", "amount": 50, "armor_penetration": 8 },
+    "dispersion": 10,
+    "durability": 8,
+    "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "AUTO", "auto", 4 ] ],
+    "overheat_threshold": 100,
+    "cooling_value": 2,
+    "heat_per_shot": 5,
+    "loudness": 12,
+    "reload": 200,
+    "ammo_effects": [ "PLASMA", "LASER", "IGNITE" ],
+    "ammo": [ "fcl_fusion_pellet", "battery" ],
+    "pocket_data": [
+      {
+        "id": "power",
+        "pocket_type": "MAGAZINE_WELL",
+        "rigid": true,
+        "flag_restriction": [ "BATTERY_HEAVY" ],
+        "default_magazine": "heavy_battery_cell"
+      },
+      {
+        "id": "fusion pellet",
+        "pocket_type": "MAGAZINE_WELL",
+        "rigid": true,
+        "item_restriction": [ "fcl_fusion_pack", "fcl_fusion_10_mag", "fcl_fusion_20_mag" ],
+        "default_magazine": "fcl_fusion_pack"
+      }
+    ],
+    "firing_requirements": {
+      "DEFAULT": [ { "pocket": "power", "qty": 20 }, { "pocket": "fusion pellet", "qty": 1 } ],
+      "AUTO": [ { "pocket": "power", "qty": 80 }, { "pocket": "fusion pellet", "qty": 4 } ]
+    },
+    "valid_mod_locations": [
+      [ "accessories", 2 ],
+      [ "emitter", 1 ],
+      [ "grip", 1 ],
+      [ "lens", 1 ],
+      [ "rail", 1 ],
+      [ "sights", 1 ],
+      [ "sling", 1 ],
+      [ "stock", 1 ],
+      [ "stock accessory", 1 ],
+      [ "underbarrel", 1 ]
+    ],
+    "flags": [ "NEVER_JAMS", "NON_FOULING", "NEEDS_NO_LUBE", "OVERHEATS" ],
+    "faults": [ { "fault": "fault_overheat_melting" }, { "fault": "fault_overheat_safety" } ],
+    "melee_damage": { "bash": 12 }
   }
 ]

--- a/data/mods/FuturismCataclysmLegacy/items/ranged/energy.json
+++ b/data/mods/FuturismCataclysmLegacy/items/ranged/energy.json
@@ -178,7 +178,7 @@
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
         "item_restriction": [ "fcl_fusion_pack", "fcl_fusion_10_mag", "fcl_fusion_20_mag" ],
-        "default_magazine": "fcl_fusion_pack"
+        "default_magazine": "fcl_fusion_10_mag"
       }
     ],
     "firing_requirements": { "DEFAULT": [ { "pocket": "power", "qty": 5 }, { "pocket": "fusion pellet", "qty": 1 } ] },
@@ -229,7 +229,7 @@
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
         "item_restriction": [ "fcl_fusion_pack", "fcl_fusion_10_mag", "fcl_fusion_20_mag" ],
-        "default_magazine": "fcl_fusion_pack"
+        "default_magazine": "fcl_fusion_20_mag"
       }
     ],
     "firing_requirements": {

--- a/data/mods/FuturismCataclysmLegacy/items/ranged/energy.json
+++ b/data/mods/FuturismCataclysmLegacy/items/ranged/energy.json
@@ -234,7 +234,7 @@
     ],
     "firing_requirements": {
       "DEFAULT": [ { "pocket": "power", "qty": 20 }, { "pocket": "fusion pellet", "qty": 1 } ],
-      "AUTO": [ { "pocket": "power", "qty": 80 }, { "pocket": "fusion pellet", "qty": 4 } ]
+      "AUTO": [ { "pocket": "power", "qty": 20 }, { "pocket": "fusion pellet", "qty": 1 } ]
     },
     "valid_mod_locations": [
       [ "accessories", 2 ],

--- a/data/mods/FuturismCataclysmLegacy/items/ranged/energy.json
+++ b/data/mods/FuturismCataclysmLegacy/items/ranged/energy.json
@@ -205,7 +205,7 @@
     "color": "yellow",
     "skill": "rifle",
     "range": 30,
-    "ranged_damage": { "damage_type": "fcl_laser", "amount": 50, "armor_penetration": 8 },
+    "ranged_damage": { "damage_type": "fcl_laser", "amount": 50, "armor_penetration": 16 },
     "dispersion": 10,
     "durability": 8,
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "AUTO", "auto", 4 ] ],

--- a/data/mods/FuturismCataclysmLegacy/recipes/weapon/magazines.json
+++ b/data/mods/FuturismCataclysmLegacy/recipes/weapon/magazines.json
@@ -1,0 +1,48 @@
+[
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "fcl_fusion_10_mag",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_MAGAZINES",
+    "skill_used": "electronics",
+    "skills_required": [ [ "mechanics", 4 ], [ "fabrication", 4 ] ],
+    "difficulty": 6,
+    "time": "1 h",
+    "book_learn": [ [ "advanced_electronics", 7 ], [ "textbook_electronics", 8 ] ],
+    "using": [ [ "soldering_standard", 20 ] ],
+    "qualities": [ { "id": "SCREW_FINE", "level": 1 }, { "id": "WRENCH_FINE", "level": 1 } ],
+    "proficiencies": [ { "proficiency": "prof_elec_soldering" }, { "proficiency": "prof_electromagnetics" } ],
+    "components": [
+      [ [ "fcl_fusion_pack", 1 ] ],
+      [ [ "nanomaterial", 3 ] ],
+      [ [ "circuit", 2 ] ],
+      [ [ "cable", 4 ] ],
+      [ [ "e_scrap", 8 ] ]
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "fcl_fusion_20_mag",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_MAGAZINES",
+    "skill_used": "electronics",
+    "skills_required": [ [ "mechanics", 5 ], [ "fabrication", 5 ] ],
+    "difficulty": 8,
+    "time": "2 h",
+    "book_learn": [ [ "advanced_electronics", 8 ], [ "textbook_electronics", 9 ] ],
+    "using": [ [ "soldering_standard", 35 ] ],
+    "qualities": [ { "id": "SCREW_FINE", "level": 1 }, { "id": "WRENCH_FINE", "level": 1 } ],
+    "proficiencies": [ { "proficiency": "prof_elec_soldering" }, { "proficiency": "prof_electromagnetics" } ],
+    "components": [
+      [ [ "fcl_fusion_pack", 2 ] ],
+      [ [ "nanomaterial", 5 ] ],
+      [ [ "amplifier", 1 ] ],
+      [ [ "processor", 1 ] ],
+      [ [ "circuit", 4 ] ],
+      [ [ "cable", 8 ] ],
+      [ [ "e_scrap", 16 ] ]
+    ]
+  }
+]


### PR DESCRIPTION
####  Summary

Adds two microfusion laser guns that consume electricity instead of plasma to the FTK series in Futurism Cataclysm: Legacy.

#### Purpose of change

Futurism Cataclysm: Legacy is a mod dedicated to bringing back legacy near-future settings and elements into Cataclysm. I am currently expanding its content.

Starting from #449, I ported the legacy 0.D weapon FTK-93 fusion rifle and restructured it into a more scientifically plausible "fusion ion weapon" based on Magnetized Liner Inertial Fusion technology. In subsequent PRs, I refined several minor issues with it. However, a single weapon setup currently occupies three slots in the nanofabricator templates (the weapon itself, fusion pellet, and fusion pack), which significantly dilutes the generation probabilities for other items. This is suboptimal because the entire fusion pellet magazine-and-ammo system is only utilized by a single firearm, yet its components take up excessive spawn weight. Furthermore, I felt it would be a waste for such a cool concept to remain limited to just one weapon, so I decided to expand the lineup.

#### Describe the solution

Added four items: FTK-29 microfusion laser pistol (based on the V29 prototype), FTK-07 microfusion laser rifle (based on the A7 prototype), fusion 10-round extended magazine, and fusion 20-round extended magazine. The firearms have been added to nanofabricator template spawn lists and energy weapon spawn groups, while the extended fusion magazines can be crafted using a fusion pack and nanomaterial. Their descriptions are as follows:

Gun: An experimental energy laser-type microfusion firearm. Its design incorporates some ideas from the V29/A7 and the MagLIF technology used in the prototype, but abandons the highly destructive and unstable propellant reaction jet route, instead miniaturizing it to create a composite energy weapon that fires a small amount of plasma along with a laser beam. Because it converts fusion energy release into its primary attack energy source, this model has reduced the number of internal energy interfaces and cannot natively support UPS, but it features a simple battery compartment compatible with medium/tool batteries.

Magazine: A modified high-density magazine designed to hold and align micro-fusion target pellets. Its original capacitive contacts and magnetic shielding have been weakened and expanded using nanomaterials, making it unstable and unsafe for use in propellant-reaction microfusion firearms. However, it's perfect for energy laser-type microfusion firearms.

Both firearms require a battery and any fusion target pellet magazine to fire. They consume only 25% of the power required by their prototype baselines while delivering slightly more than double the damage performance (with correspondingly rarer spawn rates).

#### Test

Downloaded the latest compiled experimental version, applied the mod's updated content, and loaded it into a world; the game runs perfectly fine with no startup errors.