### PR TITLE
Misc tweaker: Copy several miscellaneous core module tweaks from C:TLG

### DIFF
--- a/data/json/harvest.json
+++ b/data/json/harvest.json
@@ -2219,6 +2219,7 @@
       { "drop": "veggy", "type": "flesh", "mass_ratio": 0.2 },
       { "drop": "veggy", "type": "offal", "mass_ratio": 0.05 },
       { "drop": "stick", "type": "bone", "mass_ratio": 0.05 },
+      { "drop": "latex", "type": "blood", "mass_ratio": 0.1 },
       { "drop": "venom_paralytic", "type": "offal", "mass_ratio": 0.0075 }
     ]
   },
@@ -2256,6 +2257,7 @@
       { "drop": "stick_fiber", "type": "bone", "mass_ratio": 0.15 },
       { "drop": "veggy", "type": "flesh", "mass_ratio": 0.2 },
       { "drop": "veggy", "type": "offal", "mass_ratio": 0.05 },
+      { "drop": "latex", "type": "blood", "mass_ratio": 0.1 },
       { "drop": "venom_paralytic", "type": "offal", "mass_ratio": 0.02 }
     ]
   },

--- a/data/json/items/gun/9mm.json
+++ b/data/json/items/gun/9mm.json
@@ -219,6 +219,17 @@
     "barrel_length": "146 mm",
     "price": "30 kUSD",
     "price_postapoc": "140 USD",
+    "valid_mod_locations": [
+      [ "barrel", 1 ],
+      [ "brass catcher", 1 ],
+      [ "mechanism", 2 ],
+      [ "rail mount", 1 ],
+      [ "sights mount", 1 ],
+      [ "sling", 1 ],
+      [ "stock accessory", 1 ],
+      [ "stock", 1 ],
+      [ "underbarrel mount", 1 ]
+    ],
     "built_in_mods": [ "mp5sd_suppressor" ]
   },
   {

--- a/data/json/items/resources/misc.json
+++ b/data/json/items/resources/misc.json
@@ -55,19 +55,20 @@
   {
     "type": "ITEM",
     "id": "fighter_sting",
-    "name": { "str": "fungal fighter stinger" },
-    "description": "A short dart from a fungal fighter.  Makes a poor melee weapon.",
+    "name": { "str": "triffid stinger" },
+    "description": "A short wooden dart grown from a mutated plant.",
     "weight": "270 g",
-    "to_hit": { "grip": "bad", "length": "hand", "surface": "point", "balance": "neutral" },
+    "to_hit": { "grip": "solid", "length": "hand", "surface": "point", "balance": "neutral" },
     "color": "green",
     "symbol": ",",
-    "material": [ "veggy" ],
+    "material": [ "wood" ],
     "volume": "250 ml",
-    "flags": [ "SHEATH_KNIFE", "ALLOWS_BODY_BLOCK" ],
+    "flags": [ "NPC_THROWN" ],
     "weapon_category": [ "SHIVS" ],
-    "price": "5 USD",
+    "price": "0 USD",
     "price_postapoc": "0 cent",
-    "melee_damage": { "stab": 8 }
+    "thrown_damage": [ { "damage_type": "stab", "amount": 6 } ],
+    "melee_damage": { "stab": 7 }
   },
   {
     "id": "incendiary",

--- a/data/json/items/resources/misc.json
+++ b/data/json/items/resources/misc.json
@@ -56,19 +56,19 @@
     "type": "ITEM",
     "id": "fighter_sting",
     "name": { "str": "triffid stinger" },
-    "description": "A short wooden dart grown from a mutated plant.",
+    "description": "A short wooden dart grown from a mutated plant.  Makes a poor melee weapon.",
     "weight": "270 g",
     "to_hit": { "grip": "solid", "length": "hand", "surface": "point", "balance": "neutral" },
     "color": "green",
     "symbol": ",",
     "material": [ "wood" ],
     "volume": "250 ml",
-    "flags": [ "NPC_THROWN" ],
+    "flags": [ "SHEATH_KNIFE", "ALLOWS_BODY_BLOCK", "NPC_THROWN" ],
     "weapon_category": [ "SHIVS" ],
     "price": "0 USD",
     "price_postapoc": "0 cent",
     "thrown_damage": [ { "damage_type": "stab", "amount": 6 } ],
-    "melee_damage": { "stab": 7 }
+    "melee_damage": { "stab": 8 }
   },
   {
     "id": "incendiary",

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3023,7 +3023,7 @@ void move_items_activity_actor::do_turn( player_activity &act, Character &who )
         // This is for hauling across zlevels, remove when going up and down stairs
         // is no longer teleportation
         const tripoint_bub_ms src = target.pos_bub( here );
-        const float distance = src.z() == dest.z() ? std::max( trig_dist( src, dest ), 1.0f ) : 1.0f;
+        const int distance = src.z() == dest.z() ? std::max( static_cast<int>( trig_dist( src, dest ) ), 1 ) : 1;
         // Yuck, I'm sticking weariness scaling based on activity level here
         const float weary_mult = who.exertion_adjusted_move_multiplier( exertion_level() );
         who.mod_moves( -Pickup::cost_to_move_item( who, newit ) * distance / weary_mult );

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3023,7 +3023,7 @@ void move_items_activity_actor::do_turn( player_activity &act, Character &who )
         // This is for hauling across zlevels, remove when going up and down stairs
         // is no longer teleportation
         const tripoint_bub_ms src = target.pos_bub( here );
-        const int distance = src.z() == dest.z() ? std::max( rl_dist( src, dest ), 1 ) : 1;
+        const float distance = src.z() == dest.z() ? std::max( trig_dist( src, dest ), 1.0f ) : 1.0f;
         // Yuck, I'm sticking weariness scaling based on activity level here
         const float weary_mult = who.exertion_adjusted_move_multiplier( exertion_level() );
         who.mod_moves( -Pickup::cost_to_move_item( who, newit ) * distance / weary_mult );

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -26,8 +26,8 @@ template<typename Point, typename Container>
 std::vector<Point> get_sorted_tiles_by_distance( const Point &center, const Container &tiles )
 {
     const auto cmp = [center]( const Point & a, const Point & b ) {
-        const int da = trig_dist( center, a );
-        const int db = trig_dist( center, b );
+        const float da = trig_dist( center, a );
+        const float db = trig_dist( center, b );
 
         return da < db;
     };

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -26,8 +26,8 @@ template<typename Point, typename Container>
 std::vector<Point> get_sorted_tiles_by_distance( const Point &center, const Container &tiles )
 {
     const auto cmp = [center]( const Point & a, const Point & b ) {
-        const int da = rl_dist( center, a );
-        const int db = rl_dist( center, b );
+        const int da = trig_dist( center, a );
+        const int db = trig_dist( center, b );
 
         return da < db;
     };

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -329,13 +329,15 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
     creature_tracker &creatures = get_creature_tracker();
     Creature *target_critter = creatures.creature_at( target_arg );
     double target_size;
+    bool hard_to_hit_bypass = false;
 
     if( target_critter != nullptr ) {
         const monster *mon = target_critter->as_monster();
         if( ( mon && mon->has_flag( mon_flag_HARDTOSHOOT ) ) || ( !mon &&
                 target_critter->as_character()->has_flag( json_flag_HARDTOHIT ) ) ) {
-            if( proj_arg.proj_effects.count( ammo_effect_WIDE ) ||
-                x_in_y( proj_arg.count + proj_arg.shot_spread * 2, 1000 ) ) {
+            hard_to_hit_bypass = proj_arg.proj_effects.count( ammo_effect_WIDE ) ||
+                                 x_in_y( proj_arg.count + proj_arg.shot_spread * 2, 1000 );
+            if( hard_to_hit_bypass ) {
                 /* Ammo with ammo_effect_WIDE ignores mon_flag_HARDTOSHOOT.
                 Multishots have a chance to do this as well. At the time
                 of this writing, birshot is 350 pellets and 350 dispersion,
@@ -360,6 +362,15 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
     }
 
     projectile_attack_aim aim = projectile_attack_roll( dispersion, range, target_size );
+
+    if( target_critter && target_critter->as_character() &&
+        target_critter->as_character()->has_flag( json_flag_HARDTOHIT ) && !hard_to_hit_bypass ) {
+        projectile_attack_aim lucky_aim = projectile_attack_roll( dispersion, range, target_size );
+        // If the target is lucky, choose the result that misses by more.
+        if( lucky_aim.missed_by > aim.missed_by ) {
+            aim = lucky_aim;
+        }
+    }
 
     attack.proj = proj_arg;
     attack.last_hit_critter = nullptr;

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -29,6 +29,7 @@
 #include "mapdata.h"
 #include "messages.h"
 #include "monster.h"
+#include "mtype.h"
 #include "npc.h"
 #include "options.h"
 #include "point.h"
@@ -108,11 +109,7 @@ static void drop_or_embed_projectile( map *here, const dealt_projectile_attack &
 
         const units::mass shard_mass = itype_glass_shard->weight;
         const int max_nb_of_shards = floor( to_gram( drop_item.type->weight ) / to_gram( shard_mass ) );
-        //between half and max_nb_of_shards-1 will be usable
         const int nb_of_dropped_shard = std::max( 0, rng( max_nb_of_shards / 2, max_nb_of_shards - 1 ) );
-        //feel free to remove this msg_debug
-        /*add_msg_debug( "Shattered %s dropped %i shards out of a max of %i, based on mass %i g",
-                       drop_item.tname(), nb_of_dropped_shard, max_nb_of_shards - 1, to_gram( drop_item.type->weight ) );*/
 
         for( int i = 0; i < nb_of_dropped_shard; ++i ) {
             item shard( itype_glass_shard );
@@ -124,7 +121,7 @@ static void drop_or_embed_projectile( map *here, const dealt_projectile_attack &
     }
 
     if( effects.count( ammo_effect_BURST ) ) {
-        // Drop the contents, not the thrown item
+        // Drop the contents, not the thrown item.
         add_msg_if_player_sees( reality_bubble().get_bub( here->get_abs( pt ) ), _( "The %s bursts!" ),
                                 drop_item.tname() );
 
@@ -227,12 +224,11 @@ projectile_attack_aim projectile_attack_roll( const dispersion_sources &dispersi
     // the error angle between where the shot was aimed and where this one actually went
     // NB: some cases pass dispersion == 0 for a "never misses" shot e.g. bio_magnet,
     aim.dispersion = dispersion.roll();
-    add_msg_debug( debugmode::DF_BALLISTIC, "Dispersion rolled / max : %f / %f; %f / %f degrees",
+    add_msg_debug( debugmode::DF_RANGED, "Dispersion rolled / max possible : %f / %f; %f / %f degrees",
                    aim.dispersion, dispersion.max(), aim.dispersion / 60.0, dispersion.max() / 60.0 );
 
     // an isosceles triangle is formed by the intended and actual target tiles
     aim.missed_by_tiles = iso_tangent( range, units::from_arcmin( aim.dispersion ) );
-
     // fraction we missed a monster target by (0.0 = perfect hit, 1.0 = miss)
     if( target_size > 0.0 ) {
         aim.missed_by = std::min( 1.0, aim.missed_by_tiles / target_size );
@@ -336,28 +332,34 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
 
     if( target_critter != nullptr ) {
         const monster *mon = target_critter->as_monster();
-        if( mon && proj_arg.proj_effects.count( ammo_effect_WIDE ) ) {
-            // ammo with ammo_effect_WIDE ignores mon_flag_HARDTOSHOOT
-            target_size = occupied_tile_fraction( mon->get_size() );
+        if( ( mon && mon->has_flag( mon_flag_HARDTOSHOOT ) ) || ( !mon &&
+                target_critter->as_character()->has_flag( json_flag_HARDTOHIT ) ) ) {
+            if( proj_arg.proj_effects.count( ammo_effect_WIDE ) ||
+                x_in_y( proj_arg.count + proj_arg.shot_spread * 2, 1000 ) ) {
+                /* Ammo with ammo_effect_WIDE ignores mon_flag_HARDTOSHOOT.
+                Multishots have a chance to do this as well. At the time
+                of this writing, birshot is 350 pellets and 350 dispersion,
+                so it's basically guaranteed unless there's a choke or
+                something, and buckshot comes out to around 61%.
+                */
+                target_size = occupied_tile_fraction( target_critter->get_size() );
+                add_msg_debug( debugmode::DF_RANGED,
+                               "Shot spread or WIDE ammo effect negates HARDTOSHOOT/HARDTOHIT.  Target size %s", target_size );
+            } else {
+                target_size = target_critter->ranged_target_size();
+                add_msg_debug( debugmode::DF_RANGED,
+                               "HARDTOSHOOT/HARDTOHIT targets are harder to hit.  Target size: %s", target_size );
+            }
         } else {
             target_size = target_critter->ranged_target_size();
+            add_msg_debug( debugmode::DF_RANGED, "Target creature size: %s", target_size );
         }
     } else {
         target_size = here->ranged_target_size( target_arg );
+        add_msg_debug( debugmode::DF_RANGED, "Target size for tile: %s", target_size );
     }
+
     projectile_attack_aim aim = projectile_attack_roll( dispersion, range, target_size );
-
-    if( target_critter && target_critter->as_character() &&
-        target_critter->as_character()->has_flag( json_flag_HARDTOHIT ) ) {
-
-        projectile_attack_aim lucky_aim = projectile_attack_roll( dispersion, range, target_size );
-        // if the target's lucky they're more likely to be missed
-        if( lucky_aim.missed_by > aim.missed_by ) {
-            aim = lucky_aim;
-        }
-    }
-
-    // TODO: move to-hit roll back in here
 
     attack.proj = proj_arg;
     attack.last_hit_critter = nullptr;
@@ -465,7 +467,7 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
         }
 
         // Don't extend range further, miss here can mean hitting the ground near the target
-        range = rl_dist( source, target );
+        range = trig_dist( source, target );
         extend_to_range = range;
 
         if( reality_bubble().inbounds( here->get_abs( target ) ) ) {
@@ -479,7 +481,7 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
     //Use find clear path to draw the trajectory with optimal initial tile offsets.
     trajectory = here->find_clear_path( source, target );
 
-    add_msg_debug( debugmode::DF_BALLISTIC,
+    add_msg_debug( debugmode::DF_RANGED,
                    "missed_by_tiles: %.2f; missed_by: %.2f; target (orig/hit): %s/%s",
                    aim.missed_by_tiles, aim.missed_by, target_arg.to_string_writable(),
                    target.to_string_writable() );
@@ -548,14 +550,14 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
                     t_copy.insert( t_copy.end(), extension.begin(), extension.end() );
                 }
             }
-            add_msg_debug( debugmode::DF_BALLISTIC,
+            add_msg_debug( debugmode::DF_RANGED,
                            "shot_spread: %d; spread roll/max_spread: %.2f/%.2f; target (orig/hit): %s/%s",
                            proj.shot_spread, spread, max_spread,
                            target_arg.to_string_writable(), target_c.to_string_writable() );
         }
         // Range can be 0
         size_t traj_len = t_copy.size();
-        while( traj_len > 0 && rl_dist( source, t_copy[traj_len - 1] ) > proj_arg.range ) {
+        while( traj_len > 0 && trig_dist( source, t_copy[traj_len - 1] ) > proj_arg.range ) {
             --traj_len;
         }
 

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -346,19 +346,19 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
                 */
                 target_size = occupied_tile_fraction( target_critter->get_size() );
                 add_msg_debug( debugmode::DF_RANGED,
-                               "Shot spread or WIDE ammo effect negates HARDTOSHOOT/HARDTOHIT.  Target size %s", target_size );
+                               "Shot spread or WIDE ammo effect negates HARDTOSHOOT/HARDTOHIT.  Target size %.2f", target_size );
             } else {
                 target_size = target_critter->ranged_target_size();
                 add_msg_debug( debugmode::DF_RANGED,
-                               "HARDTOSHOOT/HARDTOHIT targets are harder to hit.  Target size: %s", target_size );
+                               "HARDTOSHOOT/HARDTOHIT targets are harder to hit.  Target size: %.2f", target_size );
             }
         } else {
             target_size = target_critter->ranged_target_size();
-            add_msg_debug( debugmode::DF_RANGED, "Target creature size: %s", target_size );
+            add_msg_debug( debugmode::DF_RANGED, "Target creature size: %.2f", target_size );
         }
     } else {
         target_size = here->ranged_target_size( target_arg );
-        add_msg_debug( debugmode::DF_RANGED, "Target size for tile: %s", target_size );
+        add_msg_debug( debugmode::DF_RANGED, "Target size for tile: %.2f", target_size );
     }
 
     projectile_attack_aim aim = projectile_attack_roll( dispersion, range, target_size );
@@ -568,7 +568,7 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
         }
         // Range can be 0
         size_t traj_len = t_copy.size();
-        while( traj_len > 0 && trig_dist( source, t_copy[traj_len - 1] ) > proj_arg.range ) {
+        while( traj_len > 0 && rl_dist( source, t_copy[traj_len - 1] ) > proj_arg.range ) {
             --traj_len;
         }
 

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -344,7 +344,8 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
                 so it's basically guaranteed unless there's a choke or
                 something, and buckshot comes out to around 61%.
                 */
-                target_size = occupied_tile_fraction( target_critter->get_size() );
+                target_size = target_critter->as_character() ? target_critter->ranged_target_size() :
+                              occupied_tile_fraction( target_critter->get_size() );
                 add_msg_debug( debugmode::DF_RANGED,
                                "Shot spread or WIDE ammo effect negates HARDTOSHOOT/HARDTOHIT.  Target size %.2f", target_size );
             } else {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -862,6 +862,24 @@ int Character::effective_dispersion( int dispersion, bool zoom ) const
     return get_character_parallax( zoom ) + dispersion;
 }
 
+double Character::dispersion_variance() const
+{
+    double ability = static_cast<double>( get_per() ) *
+                     ( ( get_limb_score( limb_score_manip ) +
+                         get_limb_score( limb_score_vision ) ) / 2.0 );
+    ability = std::clamp( ability, 0.01, 20.0 );
+    double low;
+    if( ability <= 10.0 ) {
+        low = -20.0 + ability;
+    } else {
+        low = -10.0 + ( ability - 10.0 ) * 0.5;
+    }
+    const double high = 5.0 + ability * 0.5;
+    const double variance = rng_float( low, high );
+    add_msg_debug( debugmode::DF_RANGED, "Semi-random variance adds %1f dispersion.", variance );
+    return variance;
+}
+
 int Character::get_character_parallax( bool zoom ) const
 {
     /** @EFFECT_PER penalizes sight dispersion when low. */

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -874,7 +874,7 @@ double Character::dispersion_variance() const
     } else {
         low = -10.0 + ( ability - 10.0 ) * 0.5;
     }
-    const double high = 5.0 + ability * 0.5;
+    const double high = 5.0 + 5 * std::log( 1.0 + 0.1 * ability );
     const double variance = rng_float( low, high );
     add_msg_debug( debugmode::DF_RANGED, "Semi-random variance adds %1f dispersion.", variance );
     return variance;

--- a/src/character.h
+++ b/src/character.h
@@ -775,6 +775,7 @@ class Character : public Creature, public visitable
 
         /* Adjusts provided sight dispersion to account for player stats */
         int effective_dispersion( int dispersion, bool zoom = false ) const;
+        double dispersion_variance() const;
 
         dispersion_sources total_gun_dispersion( const item &gun, double recoil, int spread ) const;
 

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -239,7 +239,6 @@ std::string filter_name( debug_filter value )
         case DF_ACTIVITY: return "DF_ACTIVITY";
         case DF_ANATOMY_BP: return "DF_ANATOMY_BP";
         case DF_AVATAR: return "DF_AVATAR";
-        case DF_BALLISTIC: return "DF_BALLISTIC";
         case DF_CAMPS: return "DF_CAMPS";
         case DF_CHARACTER: return "DF_CHARACTER";
         case DF_CHAR_CALORIES: return "DF_CHAR_CALORIES";

--- a/src/debug.h
+++ b/src/debug.h
@@ -255,7 +255,6 @@ enum debug_filter : int {
     DF_ACTIVITY, // activity actor generic
     DF_ANATOMY_BP, // anatomy::select_body_part()
     DF_AVATAR, // avatar generic
-    DF_BALLISTIC, // ballistic generic
     DF_CAMPS, // Everything to do with camps, player-owned or otherwise
     DF_CHARACTER, // character generic
     DF_CHAR_CALORIES, // character stomach and calories

--- a/src/dispersion.cpp
+++ b/src/dispersion.cpp
@@ -16,13 +16,14 @@ double dispersion_sources::roll() const
     for( const double &source : multipliers ) {
         this_roll *= source;
     }
+
     return std::min( this_roll, 3600.0 );
 }
 
 double dispersion_sources::max() const
 {
     double sum = 0.0;
-    for( const double &source : linear_sources ) {
+    for( const auto &source : linear_sources ) {
         sum += source;
     }
     for( const double &source : normal_sources ) {

--- a/src/dispersion.cpp
+++ b/src/dispersion.cpp
@@ -17,7 +17,7 @@ double dispersion_sources::roll() const
         this_roll *= source;
     }
 
-    return std::min( this_roll, 3600.0 );
+    return std::clamp( this_roll, 0.0, 3600.0 );
 }
 
 double dispersion_sources::max() const

--- a/src/dispersion.h
+++ b/src/dispersion.h
@@ -12,6 +12,7 @@ class dispersion_sources
         std::vector<double> linear_sources;
         std::vector<double> multipliers;
         double spread_sources = 0.0;
+
     public:
         explicit dispersion_sources( double normal_source = 0.0 ) {
             if( normal_source != 0.0 ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2636,7 +2636,8 @@ bool item::can_revive() const
            damage() < max_damage() &&
            !( has_flag( flag_FIELD_DRESS ) || has_flag( flag_FIELD_DRESS_FAILED ) ||
               has_flag( flag_QUARTERED ) ||
-              has_flag( flag_SKINNED ) || has_flag( flag_PULPED ) );
+              has_flag( flag_SKINNED ) || has_flag( flag_PULPED ) ||
+              ( has_flag( flag_FROZEN ) && !corpse->has_flag( mon_flag_DORMANT ) ) );
 }
 
 bool item::ready_to_revive( map &here, const tripoint_bub_ms &pos ) const

--- a/src/line.h
+++ b/src/line.h
@@ -205,7 +205,7 @@ inline int rl_dist( const tripoint &loc1, const tripoint &loc2 )
 }
 inline int rl_dist( const point &a, const point &b )
 {
-    return trig_dist( tripoint( a, 0 ), tripoint( b, 0 ) );
+    return rl_dist( tripoint( a, 0 ), tripoint( b, 0 ) );
 }
 
 template< class Point >

--- a/src/line.h
+++ b/src/line.h
@@ -196,7 +196,6 @@ inline int square_dist( const point &loc1, const point &loc2 )
     return std::max( d.x, d.y );
 }
 
-// Choose between the above two according to the "circular distances" option
 inline int rl_dist( const tripoint &loc1, const tripoint &loc2 )
 {
     if( trigdist ) {
@@ -206,7 +205,7 @@ inline int rl_dist( const tripoint &loc1, const tripoint &loc2 )
 }
 inline int rl_dist( const point &a, const point &b )
 {
-    return rl_dist( tripoint( a, 0 ), tripoint( b, 0 ) );
+    return trig_dist( tripoint( a, 0 ), tripoint( b, 0 ) );
 }
 
 template< class Point >

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3574,7 +3574,7 @@ double map::ranged_target_size( const tripoint_bub_ms &p ) const
         return 0.0;
     }
 
-    // TODO: Handle cases like shrubs, trees, furniture, sandbags...
+    // 0.1 strikes the floor. All other cases are handled by cover.
     return 0.1;
 }
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1233,6 +1233,7 @@ int Character::fire_gun( map &here, const tripoint_bub_ms &target, int shots, it
         }
 
         dispersion_sources dispersion = total_gun_dispersion( gun, recoil_total(), proj.shot_spread );
+        dispersion.add_range( dispersion_variance() );
 
         dealt_projectile_attack shot;
         projectile_attack( shot, proj, &here, pos_bub( here ), aim, dispersion, this, in_veh, wp_attack );
@@ -2768,7 +2769,7 @@ static double dispersion_from_skill( double skill, double weapon_dispersion )
         return 0.0;
     }
     double skill_shortfall = static_cast<double>( MAX_SKILL ) - skill;
-    double dispersion_penalty = 6 * skill_shortfall;
+    double dispersion_penalty = skill_shortfall;
     double skill_threshold = 5;
     if( skill >= skill_threshold ) {
         double post_threshold_skill_shortfall = static_cast<double>( MAX_SKILL ) - skill;
@@ -2779,7 +2780,7 @@ static double dispersion_from_skill( double skill, double weapon_dispersion )
     // Unskilled shooters suffer greater penalties, still scaling with weapon penalties.
     double pre_threshold_skill_shortfall = skill_threshold - skill;
     dispersion_penalty += weapon_dispersion *
-                          ( 1.25 + pre_threshold_skill_shortfall * 6.0 / skill_threshold );
+                          ( 1.25 + pre_threshold_skill_shortfall / skill_threshold );
 
     return dispersion_penalty;
 }
@@ -4096,7 +4097,7 @@ bool target_ui::action_aim()
     for( int i = 0; i < 10; ++i ) {
         do_aim( *you, *relevant, target, min_recoil );
     }
-    add_msg_debug( debugmode::debug_filter::DF_BALLISTIC,
+    add_msg_debug( debugmode::debug_filter::DF_RANGED,
                    "you reduced recoil from %f to %f in 10 moves",
                    hold_recoil, you->recoil );
     // We've changed pc.recoil, update penalty


### PR DESCRIPTION
#### Summary
Synchronize several plausible changes and bug fix-type modifications from the C:TLG fork

#### Purpose of change
As far as I know, C:TLG is a Cataclysm fork aiming for realistic and hardcore survival challenges, which once actively synchronized excellent changes from C:DDA just like us. Although C:TLG has currently stopped syncing with C:DDA due to various issues and code compatibility problems, the differences between its repository and our fork remain relatively low among all Cataclysm forks. Furthermore, I strongly agree with some of worm-girl's modifications.

This PR serves as a test run to synchronize some recent plausible changes and bug fix-type modifications from C:TLG.

#### Describe the solution

 - Synchronized CTLG [PR2775](https://github.com/Cataclysm-TLG/Cataclysm-TLG/pull/2775)
   + Added latex as blood-type harvest for Triffids
   + Partially modified fungal fighter stinger by removing "fungal" from its description (as it does not originate solely from fungal fighters) and adding thrown object properties; removal-type changes from C:TLG were not fully retained
 - Synchronized CTLG [PR2771](https://github.com/Cataclysm-TLG/Cataclysm-TLG/pull/2771) ranged dispersion fix
   + Previously, we also made adjustments to the relevant data, but we assumed that the `* 10` multiplier here was a deliberate design by C:DDA to increase shooting difficulty, so we only reduced the multiplier. However, C:TLG confirmed that this was completely a bug (hence synchronizing their change)
   + Concurrently synchronized C:TLG's random dispersion value implementation in the `dispersion_variance()` function to simulate shooting mistake (this actually further increases the mathematical expectation of hits for beginners while introducing a slight nerf at high skill levels, though removing the extra ranged dispersion multiplier bug compensates for this)
 - Synchronized CTLG [PR2751](https://github.com/Cataclysm-TLG/Cataclysm-TLG/pull/2751) Dormant zombies revive when "Frozen"
 - Synchronized CTLG [PR2743](https://github.com/Cataclysm-TLG/Cataclysm-TLG/pull/2743) Fix mp5sd mod slots

Not all changes were copied wholesale; I modified certain parts of the content. All changes originating from worm-girl retain the original author's attribution.