### PR TITLE
修复FTK系列枪械的口袋顺序

### DIFF
--- a/data/mods/FuturismCataclysmLegacy/itemgroups/Weapons_Mods_Ammo/guns.json
+++ b/data/mods/FuturismCataclysmLegacy/itemgroups/Weapons_Mods_Ammo/guns.json
@@ -35,8 +35,8 @@
     "type": "item_group",
     "subtype": "collection",
     "items": [
-      { "item": "fcl_fusion_10_mag", "charges": [ 0, 10 ] },
-      { "item": "medium_battery_cell", "charges": [ 0, 56 ] }
+      { "item": "medium_battery_cell", "charges": [ 0, 56 ] },
+      { "item": "fcl_fusion_10_mag", "charges": [ 0, 10 ] }
     ]
   },
   {
@@ -44,8 +44,8 @@
     "type": "item_group",
     "subtype": "collection",
     "items": [
-      { "item": "fcl_fusion_20_mag", "charges": [ 0, 20 ] },
-      { "item": "heavy_battery_cell", "charges": [ 0, 259 ] }
+      { "item": "heavy_battery_cell", "charges": [ 0, 259 ] },
+      { "item": "fcl_fusion_20_mag", "charges": [ 0, 20 ] }
     ]
   },
   {

--- a/data/mods/FuturismCataclysmLegacy/items/ranged/energy.json
+++ b/data/mods/FuturismCataclysmLegacy/items/ranged/energy.json
@@ -167,21 +167,21 @@
     ],
     "pocket_data": [
       {
-        "id": "fusion pellet",
-        "pocket_type": "MAGAZINE_WELL",
-        "rigid": true,
-        "item_restriction": [ "fcl_fusion_pack", "fcl_fusion_10_mag", "fcl_fusion_20_mag" ],
-        "default_magazine": "fcl_fusion_10_mag"
-      },
-      {
         "id": "power",
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
         "flag_restriction": [ "BATTERY_MEDIUM" ],
         "default_magazine": "medium_battery_cell"
+      },
+      {
+        "id": "ammo",
+        "pocket_type": "MAGAZINE_WELL",
+        "rigid": true,
+        "item_restriction": [ "fcl_fusion_pack", "fcl_fusion_10_mag", "fcl_fusion_20_mag" ],
+        "default_magazine": "fcl_fusion_10_mag"
       }
     ],
-    "firing_requirements": { "DEFAULT": [ { "pocket": "power", "qty": 5 }, { "pocket": "fusion pellet", "qty": 1 } ] },
+    "firing_requirements": { "DEFAULT": [ { "pocket": "ammo", "qty": 1 }, { "pocket": "power", "qty": 5 } ] },
     "flags": [ "NEVER_JAMS", "NON_FOULING", "NEEDS_NO_LUBE", "OVERHEATS" ],
     "faults": [ { "fault": "fault_overheat_melting" }, { "fault": "fault_overheat_safety" } ],
     "melee_damage": { "bash": 5 }
@@ -218,23 +218,23 @@
     "ammo": [ "fcl_fusion_pellet", "battery" ],
     "pocket_data": [
       {
-        "id": "fusion pellet",
-        "pocket_type": "MAGAZINE_WELL",
-        "rigid": true,
-        "item_restriction": [ "fcl_fusion_pack", "fcl_fusion_10_mag", "fcl_fusion_20_mag" ],
-        "default_magazine": "fcl_fusion_20_mag"
-      },
-      {
         "id": "power",
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
         "flag_restriction": [ "BATTERY_HEAVY" ],
         "default_magazine": "heavy_battery_cell"
+      },
+      {
+        "id": "ammo",
+        "pocket_type": "MAGAZINE_WELL",
+        "rigid": true,
+        "item_restriction": [ "fcl_fusion_pack", "fcl_fusion_10_mag", "fcl_fusion_20_mag" ],
+        "default_magazine": "fcl_fusion_20_mag"
       }
     ],
     "firing_requirements": {
-      "DEFAULT": [ { "pocket": "power", "qty": 20 }, { "pocket": "fusion pellet", "qty": 1 } ],
-      "AUTO": [ { "pocket": "power", "qty": 20 }, { "pocket": "fusion pellet", "qty": 1 } ]
+      "DEFAULT": [ { "pocket": "ammo", "qty": 1 }, { "pocket": "power", "qty": 20 } ],
+      "AUTO": [ { "pocket": "ammo", "qty": 1 }, { "pocket": "power", "qty": 20 } ]
     },
     "valid_mod_locations": [
       [ "accessories", 2 ],


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
之前错误地听信了GitHub Codex Bot的自动代码审查找出的所谓“[bug](https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/pull/463#discussion_r3622449418)”在#463合并前更换了电池和聚变靶丸的口袋顺序，导致了 DEBUG : Cannot find magazine fitting fcl_ftk29 with any capacity for ammo battery (ammotype battery).  Magazines considered were fcl_fusion_pack（使用fcl_fusion_pellet），fcl_fusion_10_mag（使用fcl_fusion_pellet） 和 fcl_fusion_20_mag（使用fcl_fusion_pellet）错误


#### Describe the solution
回退改动