### PR TITLE
增加更多堆叠并调整少量数据

### DIFF
--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -564,7 +564,9 @@
     "material": [ "powder" ],
     "volume": "33 ml",
     "category": "chems",
-    "fun": -15
+    "fun": -15,
+    "display_type": "BY_WEIGHT",
+    "stackable": true
   },
   {
     "type": "ITEM",

--- a/data/json/items/comestibles/bread.json
+++ b/data/json/items/comestibles/bread.json
@@ -184,7 +184,8 @@
     "volume": "60 ml",
     "flags": [ "EATEN_HOT" ],
     "fun": 3,
-    "vitamins": [ [ "calcium", 2 ], [ "iron", 14 ], [ "wheat_allergen", 1 ] ]
+    "vitamins": [ [ "calcium", 2 ], [ "iron", 14 ], [ "wheat_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -270,7 +271,8 @@
     "volume": "60 ml",
     "flags": [ "EATEN_HOT" ],
     "fun": 2,
-    "vitamins": [ [ "calcium", 8 ], [ "iron", 6 ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "calcium", 8 ], [ "iron", 6 ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -311,7 +313,8 @@
     "volume": "20 ml",
     "flags": [ "EATEN_HOT", "EDIBLE_FROZEN" ],
     "fun": 1,
-    "vitamins": [ [ "calcium", 1 ], [ "iron", 1 ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "calcium", 1 ], [ "iron", 1 ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -332,7 +335,8 @@
     "volume": "20 ml",
     "flags": [ "EATEN_HOT", "EDIBLE_FROZEN" ],
     "fun": 1,
-    "vitamins": [ [ "calcium", 1 ], [ "iron", 1 ], [ "wheat_allergen", 1 ] ]
+    "vitamins": [ [ "calcium", 1 ], [ "iron", 1 ], [ "wheat_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -374,7 +378,8 @@
     "volume": "70 ml",
     "flags": [ "INEDIBLE" ],
     "vitamins": [ [ "calcium", 2 ], [ "iron", 15 ], [ "wheat_allergen", 1 ] ],
-    "fun": -4
+    "fun": -4,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -394,7 +399,8 @@
     "volume": "70 ml",
     "flags": [ "EDIBLE_FROZEN" ],
     "vitamins": [ [ "calcium", 2 ], [ "iron", 15 ], [ "wheat_allergen", 1 ] ],
-    "fun": -1
+    "fun": -1,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -415,7 +421,8 @@
     "volume": "25 ml",
     "flags": [ "EATEN_HOT", "EDIBLE_FROZEN" ],
     "fun": 3,
-    "vitamins": [ [ "calcium", 11 ], [ "iron", 9 ], [ "wheat_allergen", 1 ] ]
+    "vitamins": [ [ "calcium", 11 ], [ "iron", 9 ], [ "wheat_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -438,7 +445,8 @@
     "flags": [ "EATEN_HOT" ],
     "fun": -1,
     "vitamins": [ [ "calcium", 12 ], [ "wheat_allergen", 1 ], [ "junk_allergen", 1 ] ],
-    "//": "this item will generally inherit its values, so it is essentially a copy of bread"
+    "//": "this item will generally inherit its values, so it is essentially a copy of bread",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -458,7 +466,8 @@
     "volume": "48 ml",
     "flags": [ "EATEN_HOT", "EATEN_COLD" ],
     "fun": 3,
-    "vitamins": [ [ "calcium", 4 ], [ "iron", 4 ], [ "wheat_allergen", 1 ] ]
+    "vitamins": [ [ "calcium", 4 ], [ "iron", 4 ], [ "wheat_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -479,6 +488,7 @@
     "volume": "48 ml",
     "flags": [ "EATEN_HOT", "EATEN_COLD" ],
     "fun": 4,
-    "vitamins": [ [ "calcium", 2 ], [ "iron", 6 ], [ "wheat_allergen", 1 ] ]
+    "vitamins": [ [ "calcium", 2 ], [ "iron", 6 ], [ "wheat_allergen", 1 ] ],
+    "stackable": true
   }
 ]

--- a/data/json/items/comestibles/bread.json
+++ b/data/json/items/comestibles/bread.json
@@ -162,7 +162,8 @@
     "calories": 77,
     "flags": [ "EATEN_HOT" ],
     "fun": 1,
-    "vitamins": [ [ "calcium", 3 ], [ "iron", 6 ], [ "wheat_allergen", 1 ] ]
+    "vitamins": [ [ "calcium", 3 ], [ "iron", 6 ], [ "wheat_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -292,7 +293,8 @@
     "volume": "41 ml",
     "flags": [ "EATEN_HOT" ],
     "fun": 2,
-    "vitamins": [ [ "calcium", 4 ], [ "iron", 7 ], [ "wheat_allergen", 1 ], [ "junk_allergen", 1 ] ]
+    "vitamins": [ [ "calcium", 4 ], [ "iron", 7 ], [ "wheat_allergen", 1 ], [ "junk_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -357,7 +359,8 @@
     "volume": "420 ml",
     "flags": [ "INEDIBLE" ],
     "vitamins": [ [ "calcium", 12 ], [ "iron", 90 ], [ "wheat_allergen", 1 ] ],
-    "fun": -4
+    "fun": -4,
+    "stackable": true
   },
   {
     "type": "ITEM",

--- a/data/json/items/comestibles/dairy.json
+++ b/data/json/items/comestibles/dairy.json
@@ -259,7 +259,8 @@
     "price_postapoc": "1 USD 50 cent",
     "vitamins": [ [ "calcium", 32 ], [ "iron", 2 ], [ "milk_allergen", 0 ] ],
     "fun": 5,
-    "flags": [ "NUTRIENT_OVERRIDE" ]
+    "flags": [ "NUTRIENT_OVERRIDE" ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -280,7 +281,8 @@
     "material": [ { "type": "cheese" } ],
     "volume": "31 ml",
     "fun": 7,
-    "vitamins": [ [ "calcium", 16 ], [ "milk_allergen", 1 ] ]
+    "vitamins": [ [ "calcium", 16 ], [ "milk_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -350,7 +352,8 @@
     "volume": "250 ml",
     "fun": 1,
     "smoking_result": "mozzarella_cheese_smoked",
-    "vitamins": [ [ "calcium", 13 ], [ "milk_allergen", 1 ] ]
+    "vitamins": [ [ "calcium", 13 ], [ "milk_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -410,7 +413,8 @@
     "flags": [ "EDIBLE_FROZEN" ],
     "vitamins": [ [ "calcium", 16 ], [ "milk_allergen", 1 ] ],
     "fun": -1,
-    "freezing_point": -459
+    "freezing_point": -459,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -432,7 +436,8 @@
     "material": [ "milk" ],
     "volume": "62 ml",
     "vitamins": [ [ "calcium", 16 ], [ "milk_allergen", 1 ] ],
-    "fun": 4
+    "fun": 4,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -475,7 +480,8 @@
     "flags": [ "EDIBLE_FROZEN" ],
     "vitamins": [ [ "vitC", 1 ], [ "calcium", 7 ], [ "milk_allergen", 1 ] ],
     "fun": -5,
-    "freezing_point": -459
+    "freezing_point": -459,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -599,12 +605,14 @@
     "symbol": "%",
     "calories": 135,
     "description": "A slice of pecorino, famous Italian hard cheese used in pasta carbonara.",
+    "display_type": "BY_WEIGHT",
     "price": "45 cent",
     "price_postapoc": "62 cent",
     "material": [ { "type": "cheese" } ],
     "volume": "62 ml",
     "flags": [ "EDIBLE_FROZEN" ],
     "fun": 2,
-    "vitamins": [ [ "calcium", 19 ], [ "iron", 5 ] ]
+    "vitamins": [ [ "calcium", 19 ], [ "iron", 5 ] ],
+    "stackable": true
   }
 ]

--- a/data/json/items/comestibles/junkfood.json
+++ b/data/json/items/comestibles/junkfood.json
@@ -1351,6 +1351,7 @@
     "symbol": "%",
     "calories": 89,
     "description": "Processed cheese spread.",
+    "display_type": "BY_WEIGHT",
     "price": "20 cent",
     "price_postapoc": "37 cent",
     "material": [ { "type": "cheese", "portion": 10 }, { "type": "milk", "portion": 1 }, { "type": "junk", "portion": 1 } ],

--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -20,6 +20,7 @@
     "comestible_type": "FOOD",
     "name": { "str_sp": "chewing gum" },
     "description": "Sugar-free chewing gum.",
+    "stackable": true,
     "category": "food",
     "weight": "3 g",
     "volume": "2 ml",
@@ -158,7 +159,8 @@
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "volume": "250 ml",
-    "fun": -10
+    "fun": -10,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -177,7 +179,8 @@
     "price_postapoc": "3 USD",
     "material": [ "honey" ],
     "volume": "250 ml",
-    "fun": 9
+    "fun": 9,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -192,7 +195,8 @@
     "price": "13 USD",
     "price_postapoc": "10 cent",
     "volume": "250 ml",
-    "flags": [ "UNRECOVERABLE" ]
+    "flags": [ "UNRECOVERABLE" ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -210,7 +214,8 @@
     "price_postapoc": "4 USD",
     "volume": "250 ml",
     "flags": [ "EDIBLE_FROZEN", "NUTRIENT_OVERRIDE" ],
-    "fun": -5
+    "fun": -5,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -229,7 +234,8 @@
     "flags": [ "NUTRIENT_OVERRIDE" ],
     "vitamins": [ [ "mutant_toxin", 6 ] ],
     "//": "It takes about 30 portions of honeydew to feed an adult (~2000 kkal). 2000 kkal is about 10 raw chunks of mutant meat, which is 250% toxins. Honeydew probably isn't as toxic as meat, so 30 portions of it would give you 180% of toxins.",
-    "volume": "16 ml"
+    "volume": "16 ml",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -253,7 +259,8 @@
     "volume": "62 ml",
     "flags": [ "MYCUS_OK" ],
     "fun": 30,
-    "vitamins": [ [ "fruit_allergen", 1 ] ]
+    "vitamins": [ [ "fruit_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -277,7 +284,8 @@
     "material": [ "fruit" ],
     "volume": "10 ml",
     "fun": 30,
-    "vitamins": [ [ "fruit_allergen", 1 ] ]
+    "vitamins": [ [ "fruit_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -298,7 +306,8 @@
     "volume": "62 ml",
     "flags": [ "MYCUS_OK" ],
     "vitamins": [ [ "vitC", 25 ], [ "calcium", 25 ], [ "iron", 25 ], [ "fruit_allergen", 1 ] ],
-    "fun": 30
+    "fun": 30,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -413,7 +422,8 @@
     "material": [ "flesh" ],
     "volume": "250 ml",
     "vitamins": [ [ "vitC", 15 ], [ "calcium", 2 ], [ "iron", 8 ], [ "meat_allergen", 1 ] ],
-    "flags": [ "EATEN_COLD", "FREEZERBURN" ]
+    "flags": [ "EATEN_COLD", "FREEZERBURN" ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -451,7 +461,8 @@
     "material": [ "paper" ],
     "volume": "3 ml",
     "flags": [ "TINDER" ],
-    "//2": "Based on https://www.sizes.com/home/napkins.htm"
+    "//2": "Based on https://www.sizes.com/home/napkins.htm",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -466,7 +477,8 @@
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "material": [ "cardboard" ],
-    "volume": "25 ml"
+    "volume": "25 ml",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -488,7 +500,8 @@
     "material": [ "bean" ],
     "volume": "250 ml",
     "flags": [ "EATEN_HOT" ],
-    "vitamins": [ [ "calcium", 9 ], [ "iron", 24 ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "calcium", 9 ], [ "iron", 24 ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -545,7 +558,8 @@
     "volume": "250 ml",
     "flags": [ "EATEN_HOT", "NUTRIENT_OVERRIDE" ],
     "fun": 1,
-    "vitamins": [ [ "calcium", 8 ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "calcium", 8 ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -567,7 +581,8 @@
     "volume": "85 ml",
     "flags": [ "EATEN_HOT", "NUTRIENT_OVERRIDE" ],
     "smoking_result": "dry_tofu",
-    "vitamins": [ [ "calcium", 20 ], [ "iron", 4 ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "calcium", 20 ], [ "iron", 4 ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -588,7 +603,8 @@
     "material": [ "veggy" ],
     "volume": "85 ml",
     "flags": [ "EATEN_HOT", "NUTRIENT_OVERRIDE" ],
-    "vitamins": [ [ "calcium", 16 ], [ "iron", 4 ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "calcium", 16 ], [ "iron", 4 ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -607,7 +623,8 @@
     "price_postapoc": "75 cent",
     "material": [ "veggy" ],
     "volume": "85 ml",
-    "vitamins": [ [ "calcium", 16 ], [ "iron", 4 ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "calcium", 16 ], [ "iron", 4 ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -644,7 +661,8 @@
       { "GROWTH_OVERGROWN": "1 hour" }
     ],
     "into": "paste_nut",
-    "recipe": "paste_nut_mill_5_1"
+    "recipe": "paste_nut_mill_5_1",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -746,7 +764,8 @@
     "volume": "125 ml",
     "flags": [ "EDIBLE_FROZEN", "IRREPLACEABLE_CONSUMABLE" ],
     "addiction_potential": 1,
-    "fun": 2
+    "fun": 2,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -766,7 +785,8 @@
     "volume": "12 ml",
     "flags": [ "EDIBLE_FROZEN", "IRREPLACEABLE_CONSUMABLE" ],
     "addiction_potential": 1,
-    "fun": 1
+    "fun": 1,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -783,7 +803,8 @@
     "price": "1 cent",
     "price_postapoc": "50 cent",
     "volume": "125 ml",
-    "flags": [ "EATEN_HOT", "FREEZERBURN" ]
+    "flags": [ "EATEN_HOT", "FREEZERBURN" ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -838,7 +859,8 @@
     "sealed": false,
     "quench": 1,
     "calories": 201,
-    "fun": 2
+    "fun": 2,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -860,7 +882,8 @@
     "material": [ "tomato" ],
     "volume": "125 ml",
     "vitamins": [ [ "vitC", "11 mg" ], [ "iron", "1600 μg" ], [ "calcium", "40800 μg" ], [ "veggy_allergen", 1 ] ],
-    "flags": [ "RAW" ]
+    "flags": [ "RAW" ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -882,7 +905,8 @@
     "material": [ "hflesh" ],
     "flags": [ "TRADER_AVOID" ],
     "volume": "250 ml",
-    "fun": -30
+    "fun": -30,
+    "stackable": true
   },
   {
     "id": "cattlefodder",
@@ -975,7 +999,8 @@
     "color": "brown",
     "flags": [ "INEDIBLE", "BIRD", "NUTRIENT_OVERRIDE" ],
     "use_action": [ "PETFOOD" ],
-    "petfood": [ "BIRDFOOD" ]
+    "petfood": [ "BIRDFOOD" ],
+    "stackable": true
   },
   {
     "id": "dogfood_raw",
@@ -999,7 +1024,8 @@
     "color": "red",
     "flags": [ "LUPINE" ],
     "use_action": [ "PETFOOD" ],
-    "petfood": [ "DOGFOOD" ]
+    "petfood": [ "DOGFOOD" ],
+    "stackable": true
   },
   {
     "id": "dogfood",
@@ -1023,7 +1049,8 @@
     "color": "brown",
     "flags": [ "LUPINE" ],
     "use_action": [ "PETFOOD" ],
-    "petfood": [ "DOGFOOD" ]
+    "petfood": [ "DOGFOOD" ],
+    "stackable": true
   },
   {
     "id": "dogfood_dry",
@@ -1048,7 +1075,8 @@
     "color": "brown",
     "flags": [ "LUPINE" ],
     "use_action": [ "PETFOOD" ],
-    "petfood": [ "DOGFOOD" ]
+    "petfood": [ "DOGFOOD" ],
+    "stackable": true
   },
   {
     "id": "catfood_raw",
@@ -1072,7 +1100,8 @@
     "color": "red",
     "flags": [ "FELINE" ],
     "use_action": [ "PETFOOD" ],
-    "petfood": [ "CATFOOD" ]
+    "petfood": [ "CATFOOD" ],
+    "stackable": true
   },
   {
     "id": "catfood",
@@ -1096,7 +1125,8 @@
     "color": "brown",
     "flags": [ "FELINE" ],
     "use_action": [ "PETFOOD" ],
-    "petfood": [ "CATFOOD" ]
+    "petfood": [ "CATFOOD" ],
+    "stackable": true
   },
   {
     "id": "catfood_dry",
@@ -1122,7 +1152,8 @@
     "color": "brown",
     "flags": [ "FELINE" ],
     "use_action": [ "PETFOOD" ],
-    "petfood": [ "CATFOOD" ]
+    "petfood": [ "CATFOOD" ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1140,7 +1171,8 @@
     "price_postapoc": "0 cent",
     "material": [ "veggy" ],
     "flags": [ "TRADER_AVOID" ],
-    "volume": "250 ml"
+    "volume": "250 ml",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1161,7 +1193,8 @@
     "price_postapoc": "0 cent",
     "material": [ "veggy" ],
     "flags": [ "TRADER_AVOID" ],
-    "volume": "250 ml"
+    "volume": "250 ml",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1179,7 +1212,8 @@
     "price_postapoc": "0 cent",
     "material": [ "veggy" ],
     "flags": [ "TRADER_AVOID" ],
-    "volume": "250 ml"
+    "volume": "250 ml",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1196,7 +1230,8 @@
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "flags": [ "TRADER_AVOID" ],
-    "volume": "250 ml"
+    "volume": "250 ml",
+    "stackable": true
   },
   {
     "id": "tea_bag",
@@ -1215,7 +1250,8 @@
     "price": "50 cent",
     "price_postapoc": "2 USD",
     "freezing_point": -274,
-    "description": "A paper sachet with tea leaves inside.  Put it into boiling water to make a cup of black tea."
+    "description": "A paper sachet with tea leaves inside.  Put it into boiling water to make a cup of black tea.",
+    "stackable": true
   },
   {
     "id": "tea_green_bag",
@@ -1296,7 +1332,7 @@
     "material": [ "powder" ],
     "price": "30 cent",
     "price_postapoc": "1 USD",
-    "description": "A сocoa powder.  No milk or sweetener added.  Bitter, used on baking.",
+    "description": "A cocoa powder.  No milk or sweetener added.  Bitter, used on baking.",
     "display_type": "BY_WEIGHT",
     "stackable": true
   },
@@ -1319,7 +1355,7 @@
     "material": [ "powder" ],
     "price": "40 cent",
     "price_postapoc": "1 USD",
-    "description": "A сocoa powder, with some milk powder and sugar added.  Sweet with a bitter aftertaste, water or milk will made it very tasty.",
+    "description": "A cocoa powder, with some milk powder and sugar added.  Sweet with a bitter aftertaste, water or milk will made it very tasty.",
     "display_type": "BY_WEIGHT",
     "stackable": true
   },
@@ -1449,7 +1485,8 @@
     "parasites": 20,
     "flags": [ "FREEZERBURN", "RAW", "NO_AUTO_CONSUME", "BIRD", "NUTRIENT_OVERRIDE" ],
     "//1": "1 earthworm has such a small amount of vitamins, i'm not sure it's possible to model them.",
-    "vitamins": [ [ "calcium", 1 ], [ "iron", 1 ], [ "meat_allergen", 1 ] ]
+    "vitamins": [ [ "calcium", 1 ], [ "iron", 1 ], [ "meat_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1464,7 +1501,8 @@
     "fun": -20,
     "calories": 13,
     "parasites": 10,
-    "vitamins": [ [ "calcium", 3 ], [ "iron", 8 ] ]
+    "vitamins": [ [ "calcium", 3 ], [ "iron", 8 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1480,7 +1518,8 @@
     "flags": [ "SMOKED", "NUTRIENT_OVERRIDE" ],
     "//": "Dried weight is about 15% of normal",
     "weight": "3 g",
-    "volume": "3 ml"
+    "volume": "3 ml",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1526,7 +1565,8 @@
     "price_postapoc": "0 cent",
     "volume": "15 ml",
     "fun": -20,
-    "vitamins": [ [ "meat_allergen", 1 ] ]
+    "vitamins": [ [ "meat_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",

--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -319,7 +319,8 @@
     "material": [ "yeast" ],
     "volume": "10 ml",
     "flags": [ "EDIBLE_FROZEN" ],
-    "fun": -10
+    "fun": -10,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -340,7 +341,8 @@
     "material": [ "powder" ],
     "volume": "62 ml",
     "flags": [ "EDIBLE_FROZEN" ],
-    "fun": -10
+    "fun": -10,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -362,7 +364,8 @@
     "material": [ "powder" ],
     "volume": "10 ml",
     "flags": [ "EDIBLE_FROZEN" ],
-    "fun": -10
+    "fun": -10,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -384,7 +387,8 @@
     "volume": "10 ml",
     "flags": [ "EDIBLE_FROZEN" ],
     "fun": -10,
-    "vitamins": [ [ "iron", "100 μg" ], [ "calcium", "6 mg" ], [ "meat_allergen", 1 ] ]
+    "vitamins": [ [ "iron", "100 μg" ], [ "calcium", "6 mg" ], [ "meat_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -429,7 +433,8 @@
     "material": [ "powder" ],
     "volume": "112 ml",
     "flags": [ "EDIBLE_FROZEN", "NUTRIENT_OVERRIDE" ],
-    "fun": -10
+    "fun": -10,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -517,7 +522,8 @@
       { "GROWTH_MATURE": "23 days" },
       { "GROWTH_HARVEST": "22 days" },
       { "GROWTH_OVERGROWN": "1 hour" }
-    ]
+    ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -674,7 +680,8 @@
       { "GROWTH_OVERGROWN": "1 hour" }
     ],
     "into": "flour_wheat_free",
-    "recipe": "flour_wheat_free_mill_1_1"
+    "recipe": "flour_wheat_free_mill_1_1",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -697,7 +704,8 @@
     "vitamins": [ [ "iron", 26 ], [ "vitC", 16 ], [ "calcium", 6 ], [ "veggy_allergen", 1 ] ],
     "petfood": [ "CATTLEFOOD" ],
     "flags": [ "NUTRIENT_OVERRIDE", "RAW", "INEDIBLE", "CATTLE" ],
-    "smoking_result": "edamame_roasted"
+    "smoking_result": "edamame_roasted",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -717,7 +725,8 @@
     "material": [ "veggy", "blood" ],
     "volume": "83 ml",
     "flags": [ "EATEN_HOT" ],
-    "vitamins": [ [ "meat_allergen", 1 ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "meat_allergen", 1 ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -798,7 +807,8 @@
     "flags": [ "EDIBLE_FROZEN", "RAW", "IRREPLACEABLE_CONSUMABLE", "NUTRIENT_OVERRIDE" ],
     "calories": 2,
     "fun": -5,
-    "freezing_point": -274
+    "freezing_point": -274,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1264,7 +1274,8 @@
     "price_postapoc": "2 USD",
     "freezing_point": -274,
     "description": "A small packet of commercial instant coffee powder.  No creamer or sweetener added.",
-    "display_type": "BY_WEIGHT"
+    "display_type": "BY_WEIGHT",
+    "stackable": true
   },
   {
     "id": "cocoa_powder",
@@ -1286,7 +1297,8 @@
     "price": "30 cent",
     "price_postapoc": "1 USD",
     "description": "A сocoa powder.  No milk or sweetener added.  Bitter, used on baking.",
-    "display_type": "BY_WEIGHT"
+    "display_type": "BY_WEIGHT",
+    "stackable": true
   },
   {
     "id": "cocoa_powder_milk",
@@ -1308,7 +1320,8 @@
     "price": "40 cent",
     "price_postapoc": "1 USD",
     "description": "A сocoa powder, with some milk powder and sugar added.  Sweet with a bitter aftertaste, water or milk will made it very tasty.",
-    "display_type": "BY_WEIGHT"
+    "display_type": "BY_WEIGHT",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1595,7 +1608,8 @@
     "material": [ "powder" ],
     "volume": "5 ml",
     "vitamins": [ [ "meat_allergen", 1 ] ],
-    "fun": -10
+    "fun": -10,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1617,7 +1631,8 @@
     "material": [ "powder" ],
     "volume": "5 ml",
     "vitamins": [ [ "veggy_allergen", 1 ] ],
-    "fun": -10
+    "fun": -10,
+    "stackable": true
   },
   {
     "type": "ITEM",

--- a/data/json/items/comestibles/raw_fruit.json
+++ b/data/json/items/comestibles/raw_fruit.json
@@ -733,8 +733,7 @@
     "material": [ "fruit" ],
     "spoils_in": "360 days",
     "melee_damage": { "bash": 2 },
-    "flags": [ "INEDIBLE" ],
-    "stackable": true
+    "flags": [ "INEDIBLE" ]
   },
   {
     "type": "ITEM",
@@ -788,7 +787,7 @@
     "name": { "str": "watermelon" },
     "weight": "4518 g",
     "color": "green",
-    "spoils_in": "21 days",
+    "spoils_in": "10 days",
     "comestible_type": "FOOD",
     "symbol": "%",
     "quench": 826,
@@ -801,8 +800,7 @@
     "volume": "7150 ml",
     "flags": [ "EATEN_COLD", "FREEZERBURN", "INEDIBLE" ],
     "vitamins": [ [ "vitC", "366 mg" ], [ "iron", "10800 μg" ], [ "calcium", "316300 μg" ], [ "fruit_allergen", 1 ] ],
-    "melee_damage": { "bash": 2 },
-    "stackable": true
+    "melee_damage": { "bash": 2 }
   },
   {
     "type": "ITEM",
@@ -811,7 +809,7 @@
     "name": { "str": "watermelon wedge" },
     "weight": "286 g",
     "color": "green",
-    "spoils_in": "7 days 12 hours",
+    "spoils_in": "8 hours",
     "comestible_type": "FOOD",
     "symbol": "%",
     "quench": 52,
@@ -847,8 +845,7 @@
     "flags": [ "EATEN_COLD", "INEDIBLE" ],
     "fun": 4,
     "vitamins": [ [ "vitC", "202600 μg" ], [ "iron", "1200 μg" ], [ "calcium", "49700 μg" ], [ "fruit_allergen", 1 ] ],
-    "melee_damage": { "bash": 1 },
-    "stackable": true
+    "melee_damage": { "bash": 1 }
   },
   {
     "type": "ITEM",
@@ -857,7 +854,7 @@
     "name": { "str": "handful of cantaloupe melon chunks", "str_pl": "handfuls of cantaloupe melon chunks" },
     "weight": "138 g",
     "color": "light_red",
-    "spoils_in": "3 days",
+    "spoils_in": "2 days",
     "comestible_type": "FOOD",
     "symbol": "%",
     "quench": 25,

--- a/data/json/items/comestibles/raw_grain.json
+++ b/data/json/items/comestibles/raw_grain.json
@@ -275,7 +275,8 @@
     "price": "25 cent",
     "price_postapoc": "20 cent",
     "volume": "252 ml",
-    "vitamins": [ [ "wheat_allergen", 1 ] ]
+    "vitamins": [ [ "wheat_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -308,7 +309,8 @@
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "volume": "2 ml",
-    "vitamins": [ [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -353,7 +355,8 @@
       { "GROWTH_OVERGROWN": "1 hour" }
     ],
     "into": "flour",
-    "recipe": "flour_mill_1_15"
+    "recipe": "flour_mill_1_15",
+    "stackable": true
   },
   {
     "type": "ITEM",

--- a/data/json/items/comestibles/raw_veggy.json
+++ b/data/json/items/comestibles/raw_veggy.json
@@ -17,7 +17,8 @@
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "flags": [ "RABBIT", "CATTLE" ],
-    "vitamins": [ [ "veggy_allergen", 1 ], [ "vitC", "136 μg" ] ]
+    "vitamins": [ [ "veggy_allergen", 1 ], [ "vitC", "136 μg" ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -39,7 +40,8 @@
     "looks_like": "potato",
     "flags": [ "RAW", "RAT", "MOUSE" ],
     "vitamins": [ [ "calcium", 14 ], [ "iron", 1 ], [ "veggy_allergen", 1 ] ],
-    "fun": -3
+    "fun": -3,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -60,7 +62,8 @@
     "symbol": ",",
     "flags": [ "RAW", "RAT" ],
     "vitamins": [ [ "calcium", 10 ], [ "iron", 8 ], [ "veggy_allergen", 1 ] ],
-    "fun": -3
+    "fun": -3,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -82,7 +85,8 @@
     "flags": [ "RAW", "RAT" ],
     "material": [ "veggy" ],
     "vitamins": [ [ "calcium", 1 ], [ "iron", 8 ], [ "vitC", 2 ], [ "veggy_allergen", 1 ] ],
-    "fun": -2
+    "fun": -2,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -103,7 +107,8 @@
     "flags": [ "RAW" ],
     "material": [ "veggy" ],
     "vitamins": [ [ "vitC", 10 ], [ "iron", 2 ], [ "veggy_allergen", 1 ] ],
-    "fun": -2
+    "fun": -2,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -167,7 +172,8 @@
     "fun": -2,
     "flags": [ "RAW", "CATTLE", "RABBIT", "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
-    "vitamins": [ [ "vitC", "25600 μg" ], [ "iron", "300 μg" ], [ "calcium", "28 mg" ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "vitC", "25600 μg" ], [ "iron", "300 μg" ], [ "calcium", "28 mg" ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -187,7 +193,8 @@
     "volume": "250 ml",
     "flags": [ "FREEZERBURN", "RAW", "CATTLE", "RABBIT", "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
-    "vitamins": [ [ "vitC", 2 ], [ "calcium", 4 ], [ "iron", 2 ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "vitC", 2 ], [ "calcium", 4 ], [ "iron", 2 ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -208,7 +215,8 @@
     "volume": "325 ml",
     "flags": [ "RAW" ],
     "smoking_result": "dry_veggy",
-    "vitamins": [ [ "veggy_allergen", 1 ], [ "vitC", "15 mg" ], [ "iron", "3 mg" ], [ "calcium", "25 mg" ] ]
+    "vitamins": [ [ "veggy_allergen", 1 ], [ "vitC", "15 mg" ], [ "iron", "3 mg" ], [ "calcium", "25 mg" ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -230,7 +238,8 @@
     "fun": -2,
     "flags": [ "RAW", "CATTLE", "RABBIT", "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
-    "vitamins": [ [ "vitC", "8400 μg" ], [ "iron", "800 μg" ], [ "calcium", "29700 μg" ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "vitC", "8400 μg" ], [ "iron", "800 μg" ], [ "calcium", "29700 μg" ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -345,7 +354,8 @@
     "//": "It appears that celery is energy-negative for rodents",
     "flags": [ "FREEZERBURN", "RAW", "CATTLE", "RABBIT" ],
     "smoking_result": "dry_veggy",
-    "vitamins": [ [ "vitC", "8400 μg" ], [ "iron", "800 μg" ], [ "calcium", "29700 μg" ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "vitC", "8400 μg" ], [ "iron", "800 μg" ], [ "calcium", "29700 μg" ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -365,7 +375,8 @@
     "material": [ "veggy", "cotton" ],
     "volume": "62 ml",
     "fun": -10,
-    "vitamins": [ [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -422,7 +433,8 @@
     "//": "No data on cows finding cucumbers super tasty",
     "flags": [ "FREEZERBURN", "RAW", "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
-    "vitamins": [ [ "vitC", "8400 μg" ], [ "iron", "800 μg" ], [ "calcium", "48200 μg" ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "vitC", "8400 μg" ], [ "iron", "800 μg" ], [ "calcium", "48200 μg" ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -436,7 +448,8 @@
     "spoils_in": "2 days",
     "description": "A chopped-up salad cucumber.",
     "price": "30 cent",
-    "price_postapoc": "10 cent"
+    "price_postapoc": "10 cent",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -458,7 +471,8 @@
     "longest_side": "10 cm",
     "flags": [ "FREEZERBURN", "RAW", "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
-    "vitamins": [ [ "vitC", "700 μg" ], [ "iron", "300 μg" ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "vitC", "700 μg" ], [ "iron", "300 μg" ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -491,7 +505,8 @@
     "fun": -4,
     "flags": [ "RAW", "RAT", "MOUSE" ],
     "//": "Dahlia roots contain an incredible amount of vitamin B6. This isn't a vitamin tracked in Cataclysm, but be careful of vitamin overdose when eating dahlia in real life.",
-    "vitamins": [ [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -513,7 +528,8 @@
     "fun": -2,
     "smoking_result": "dry_veggy",
     "flags": [ "RAW", "RAT", "MOUSE" ],
-    "vitamins": [ [ "vitC", "10600 μg" ], [ "iron", "900 μg" ], [ "calcium", "79800 μg" ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "vitC", "10600 μg" ], [ "iron", "900 μg" ], [ "calcium", "79800 μg" ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -533,7 +549,8 @@
     "volume": "135 ml",
     "fun": -8,
     "flags": [ "RAW" ],
-    "vitamins": [ [ "vitC", "3 mg" ], [ "iron", "500 μg" ], [ "calcium", "24600 μg" ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "vitC", "3 mg" ], [ "iron", "500 μg" ], [ "calcium", "24600 μg" ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -568,7 +585,8 @@
     "volume": "250 ml",
     "price": "0 cent",
     "price_postapoc": "0 cent",
-    "vitamins": [ [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -590,7 +608,8 @@
     "fun": -18,
     "flags": [ "RAW", "PLANTABLE_SEED" ],
     "vitamins": [ [ "vitC", "5400 μg" ], [ "iron", "600 μg" ], [ "calcium", "32400 μg" ], [ "veggy_allergen", 1 ] ],
-    "//": "Who in their right mind would eat an entire garlic bulb raw?"
+    "//": "Who in their right mind would eat an entire garlic bulb raw?",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -621,7 +640,8 @@
       { "GROWTH_MATURE": "16 days" },
       { "GROWTH_HARVEST": "16 days" },
       { "GROWTH_OVERGROWN": "1 hour" }
-    ]
+    ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -641,7 +661,8 @@
     "volume": "62 ml",
     "flags": [ "EDIBLE_FROZEN", "RAW" ],
     "fun": -15,
-    "vitamins": [ [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -661,7 +682,8 @@
     "volume": "400 ml",
     "fun": -12,
     "flags": [ "FREEZERBURN", "RAW" ],
-    "vitamins": [ [ "vitC", "62300 μg" ], [ "iron", "1100 μg" ], [ "calcium", "140 mg" ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "vitC", "62300 μg" ], [ "iron", "1100 μg" ], [ "calcium", "140 mg" ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -702,7 +724,8 @@
     "volume": "250 ml",
     "flags": [ "FREEZERBURN", "RAW", "CATTLE", "RABBIT", "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
-    "vitamins": [ [ "vitC", "2 mg" ], [ "iron", "300 μg" ], [ "calcium", "13 mg" ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "vitC", "2 mg" ], [ "iron", "300 μg" ], [ "calcium", "13 mg" ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -722,7 +745,8 @@
     "flags": [ "CATTLE", "RABBIT" ],
     "price": "0 cent",
     "price_postapoc": "10 cent",
-    "vitamins": [ [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -744,7 +768,8 @@
     "flags": [ "FREEZERBURN", "RAW" ],
     "smoking_result": "dry_veggy",
     "//": "Raw onions probably aren't all that tasty to most people.",
-    "vitamins": [ [ "vitC", "8100 μg" ], [ "iron", "200 μg" ], [ "calcium", "25300 μg" ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "vitC", "8100 μg" ], [ "iron", "200 μg" ], [ "calcium", "25300 μg" ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -872,7 +897,8 @@
     "//": "Lots of negative results for cattle, apparently very much not good for them",
     "flags": [ "FREEZERBURN", "RAW", "RABBIT" ],
     "smoking_result": "dry_veggy",
-    "vitamins": [ [ "vitC", 30 ], [ "calcium", 2 ], [ "iron", 3 ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "vitC", 30 ], [ "calcium", 2 ], [ "iron", 3 ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -893,7 +919,8 @@
     "fun": -12,
     "flags": [ "FREEZERBURN", "RAW", "RABBIT", "CATTLE" ],
     "smoking_result": "dry_veggy",
-    "vitamins": [ [ "vitC", 23 ], [ "calcium", 11 ], [ "iron", 10 ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "vitC", 23 ], [ "calcium", 11 ], [ "iron", 10 ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -915,7 +942,8 @@
     "//": "Apparently toxic to rabbits",
     "flags": [ "FREEZERBURN", "RAW", "CATTLE" ],
     "smoking_result": "dry_veggy",
-    "vitamins": [ [ "vitC", 1 ], [ "calcium", 23 ], [ "iron", 10 ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "vitC", 1 ], [ "calcium", 23 ], [ "iron", 10 ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -937,7 +965,8 @@
     "fun": -12,
     "flags": [ "FREEZERBURN", "RAW" ],
     "smoking_result": "dry_veggy",
-    "vitamins": [ [ "vitC", "6 mg" ], [ "iron", "1 mg" ], [ "calcium", "20 mg" ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "vitC", "6 mg" ], [ "iron", "1 mg" ], [ "calcium", "20 mg" ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -959,7 +988,8 @@
     "longest_side": "19 cm",
     "flags": [ "RAW" ],
     "smoking_result": "dry_veggy",
-    "vitamins": [ [ "vitC", "4100 μg" ], [ "iron", "100 μg" ], [ "calcium", "43900 μg" ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "vitC", "4100 μg" ], [ "iron", "100 μg" ], [ "calcium", "43900 μg" ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -980,7 +1010,8 @@
     "fun": -10,
     "flags": [ "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
-    "vitamins": [ [ "vitC", "4 mg" ], [ "iron", "1 mg" ], [ "calcium", "13 mg" ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "vitC", "4 mg" ], [ "iron", "1 mg" ], [ "calcium", "13 mg" ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1061,7 +1092,8 @@
     "volume": "150 ml",
     "flags": [ "RABBIT", "CATTLE", "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
-    "vitamins": [ [ "vitC", "16900 μg" ], [ "iron", "300 μg" ], [ "calcium", "12300 μg" ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "vitC", "16900 μg" ], [ "iron", "300 μg" ], [ "calcium", "12300 μg" ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1093,7 +1125,8 @@
     "smoking_result": "dry_veggy",
     "volume": "250 ml",
     "//": "average of broccoli, cabbage, carrot, cattail_stalk, celery, chili_pepper, cucumber, lettuce, onion, pumpkin, raw_dandelion, rhubarb, sugar_beet, tomato, zucchini",
-    "vitamins": [ [ "vitC", 36 ], [ "calcium", 4 ], [ "iron", 4 ], [ "veggy_allergen", 1 ], [ "triffid_fiber", 2 ] ]
+    "vitamins": [ [ "vitC", 36 ], [ "calcium", 4 ], [ "iron", 4 ], [ "veggy_allergen", 1 ], [ "triffid_fiber", 2 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1187,7 +1220,8 @@
       { "GROWTH_MATURE": "23 days" },
       { "GROWTH_HARVEST": "22 days" },
       { "GROWTH_OVERGROWN": "1 hour" }
-    ]
+    ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1290,7 +1324,8 @@
     "flags": [ "RAW", "CATTLE", "RABBIT", "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
     "fun": -5,
-    "vitamins": [ [ "vitC", "95700 μg" ], [ "iron", "400 μg" ], [ "calcium", "11900 μg" ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "vitC", "95700 μg" ], [ "iron", "400 μg" ], [ "calcium", "11900 μg" ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1368,7 +1403,8 @@
     "flags": [ "RAW", "CATTLE", "RABBIT", "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", "12100 μg" ], [ "iron", "1300 μg" ], [ "calcium", "49300 μg" ], [ "veggy_allergen", 1 ] ],
-    "fun": -8
+    "fun": -8,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1390,7 +1426,8 @@
     "flags": [ "RAW" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", "60500 μg" ], [ "iron", "650 μg" ], [ "calcium", "24650 μg" ], [ "veggy_allergen", 1 ] ],
-    "fun": -5
+    "fun": -5,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1407,7 +1444,8 @@
     "volume": "30 ml",
     "flags": [ "INEDIBLE" ],
     "smoking_result": "dry_seaweed",
-    "vitamins": [ [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1424,7 +1462,8 @@
     "volume": "600 ml",
     "flags": [ "INEDIBLE" ],
     "smoking_result": "dry_seaweed_pile",
-    "vitamins": [ [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1444,7 +1483,8 @@
     "volume": "250 ml",
     "flags": [ "FREEZERBURN", "CATTLE", "RABBIT" ],
     "smoking_result": "dry_veggy",
-    "vitamins": [ [ "calcium", 3 ], [ "iron", 3 ], [ "vitC", 1 ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "calcium", 3 ], [ "iron", 3 ], [ "vitC", 1 ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1464,7 +1504,8 @@
     "volume": "250 ml",
     "flags": [ "FREEZERBURN", "CATTLE", "RABBIT" ],
     "smoking_result": "kombu",
-    "vitamins": [ [ "calcium", 3 ], [ "iron", 3 ], [ "vitC", 1 ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "calcium", 3 ], [ "iron", 3 ], [ "vitC", 1 ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1484,7 +1525,8 @@
     "volume": "250 ml",
     "flags": [ "FREEZERBURN", "CATTLE", "RABBIT" ],
     "smoking_result": "dry_veggy",
-    "vitamins": [ [ "calcium", 2 ], [ "iron", 4 ], [ "vitC", 1 ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "calcium", 2 ], [ "iron", 4 ], [ "vitC", 1 ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1506,7 +1548,8 @@
     "flags": [ "RAW", "CATTLE", "RABBIT", "RAT", "MOUSE", "FREEZERBURN" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", 4 ], [ "iron", 2 ], [ "calcium", 2 ], [ "veggy_allergen", 1 ] ],
-    "fun": -5
+    "fun": -5,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1528,7 +1571,8 @@
     "flags": [ "RAW" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", 4 ], [ "iron", 1 ], [ "calcium", 1 ], [ "veggy_allergen", 1 ] ],
-    "fun": -5
+    "fun": -5,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1550,7 +1594,8 @@
     "flags": [ "RAW", "CATTLE", "RABBIT", "RAT", "MOUSE", "FREEZERBURN" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", 4 ], [ "iron", 2 ], [ "calcium", 2 ], [ "veggy_allergen", 1 ] ],
-    "fun": -5
+    "fun": -5,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1572,7 +1617,8 @@
     "flags": [ "RAW", "CATTLE", "RABBIT", "RAT", "MOUSE", "FREEZERBURN" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", 4 ], [ "iron", 2 ], [ "calcium", 2 ], [ "veggy_allergen", 1 ] ],
-    "fun": -5
+    "fun": -5,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1594,7 +1640,8 @@
     "flags": [ "RAW" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "vitC", 4 ], [ "iron", 2 ], [ "calcium", 2 ], [ "veggy_allergen", 1 ] ],
-    "fun": -5
+    "fun": -5,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1615,7 +1662,8 @@
     "flags": [ "FREEZERBURN", "CATTLE", "RABBIT", "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "calcium", 2 ], [ "iron", 4 ], [ "vitC", 3 ], [ "veggy_allergen", 1 ] ],
-    "fun": -5
+    "fun": -5,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1636,7 +1684,8 @@
     "flags": [ "FREEZERBURN", "CATTLE", "RABBIT", "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "calcium", 2 ], [ "iron", 4 ], [ "vitC", 3 ], [ "veggy_allergen", 1 ] ],
-    "fun": -3
+    "fun": -3,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1657,7 +1706,8 @@
     "flags": [ "FREEZERBURN", "CATTLE", "RABBIT", "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "calcium", 4 ], [ "iron", 4 ], [ "vitC", 5 ], [ "veggy_allergen", 1 ] ],
-    "fun": -5
+    "fun": -5,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1678,7 +1728,8 @@
     "flags": [ "FREEZERBURN", "CATTLE", "RABBIT", "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "calcium", 4 ], [ "iron", 4 ], [ "vitC", 5 ], [ "veggy_allergen", 1 ] ],
-    "fun": -5
+    "fun": -5,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1700,7 +1751,8 @@
     "flags": [ "FREEZERBURN", "CATTLE", "RABBIT", "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "calcium", 2 ], [ "iron", 2 ], [ "vitC", 3 ], [ "veggy_allergen", 1 ] ],
-    "fun": -5
+    "fun": -5,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1721,6 +1773,7 @@
     "flags": [ "FREEZERBURN", "CATTLE", "RABBIT", "RAT", "MOUSE" ],
     "smoking_result": "dry_veggy",
     "vitamins": [ [ "calcium", 2 ], [ "iron", 2 ], [ "vitC", 3 ], [ "veggy_allergen", 1 ] ],
-    "fun": -5
+    "fun": -5,
+    "stackable": true
   }
 ]

--- a/data/json/items/comestibles/raw_veggy.json
+++ b/data/json/items/comestibles/raw_veggy.json
@@ -1003,7 +1003,8 @@
     "flags": [ "EDIBLE_FROZEN", "RAW", "IRREPLACEABLE_CONSUMABLE" ],
     "//": "Tea is sold by weight not by volume. 1 kg of tea has a volume of 3,4 liters. We use smaller packs of at least 100 mg. Such a tea has a volume of 340 ml minus package makes it around 320 ml. 3 g per serving makes 33 charges.",
     "fun": -1,
-    "vitamins": [ [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1030,7 +1031,8 @@
     "volume": "50 ml",
     "flags": [ "EDIBLE_FROZEN", "RAW" ],
     "fun": -10,
-    "vitamins": [ [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1207,7 +1209,8 @@
     "fun": -10,
     "use_action": [ "POISON" ],
     "//": "Fiddleheads that haven't been boiled can make you sick.  As they are poisonous here, they will get no CATTLE or RABBIT flag as the poison should not get nullified.",
-    "vitamins": [ [ "vitC", 6 ], [ "calcium", 4 ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "vitC", 6 ], [ "calcium", 4 ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1227,7 +1230,8 @@
     "material": [ "veggy" ],
     "volume": "45 ml",
     "fun": -2,
-    "vitamins": [ [ "vitC", 1 ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "vitC", 1 ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1241,7 +1245,8 @@
     "volume": "250 ml",
     "fun": -8,
     "calories": 6,
-    "vitamins": [ [ "vitC", "7 mg" ], [ "iron", "300 μg" ], [ "calcium", "29 mg" ] ]
+    "vitamins": [ [ "vitC", "7 mg" ], [ "iron", "300 μg" ], [ "calcium", "29 mg" ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1262,7 +1267,8 @@
     "material": [ "veggy" ],
     "volume": "62 ml",
     "longest_side": "20 cm",
-    "vitamins": [ [ "vitC", 6 ], [ "veggy_allergen", 1 ] ]
+    "vitamins": [ [ "vitC", 6 ], [ "veggy_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -1319,7 +1325,8 @@
     "flags": [ "EDIBLE_FROZEN", "RAW", "NO_AUTO_CONSUME" ],
     "use_action": [ "BLECH" ],
     "vitamins": [ [ "iron", "500 μg" ], [ "calcium", "5 mg" ], [ "veggy_allergen", 1 ] ],
-    "fun": -5
+    "fun": -5,
+    "stackable": true
   },
   {
     "type": "ITEM",

--- a/data/json/items/comestibles/veggy_dishes.json
+++ b/data/json/items/comestibles/veggy_dishes.json
@@ -431,7 +431,8 @@
     "vitamins": [ [ "iron", 3 ], [ "veggy_allergen", 1 ] ],
     "fun": -15,
     "into": "flour_wheat_free",
-    "recipe": "flour_wheat_free_mill_1_4"
+    "recipe": "flour_wheat_free_mill_1_4",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -457,7 +458,8 @@
     "vitamins": [ [ "iron", 3 ], [ "veggy_allergen", 1 ] ],
     "fun": -15,
     "into": "flour_wheat_free",
-    "recipe": "flour_wheat_free_mill_1_4"
+    "recipe": "flour_wheat_free_mill_1_4",
+    "stackable": true
   },
   {
     "type": "ITEM",

--- a/data/json/items/comestibles/wheat.json
+++ b/data/json/items/comestibles/wheat.json
@@ -39,7 +39,8 @@
     "volume": "62 ml",
     "flags": [ "EDIBLE_FROZEN", "RAW" ],
     "vitamins": [ [ "calcium", 1 ], [ "iron", 10 ], [ "wheat_allergen", 1 ] ],
-    "fun": -8
+    "fun": -8,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -60,7 +61,8 @@
     "volume": "130 ml",
     "flags": [ "EDIBLE_FROZEN", "RAW" ],
     "vitamins": [ [ "calcium", 1 ], [ "iron", 10 ], [ "wheat_allergen", 1 ] ],
-    "fun": -8
+    "fun": -8,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -197,7 +199,8 @@
     "cooks_like": "oatmeal_cooked",
     "flags": [ "EDIBLE_FROZEN", "NUTRIENT_OVERRIDE", "RAW" ],
     "vitamins": [ [ "calcium", 1 ], [ "iron", 10 ], [ "wheat_allergen", 1 ] ],
-    "fun": -8
+    "fun": -8,
+    "stackable": true
   },
   {
     "type": "ITEM",

--- a/data/json/items/comestibles/wheat.json
+++ b/data/json/items/comestibles/wheat.json
@@ -83,7 +83,8 @@
     "material": [ "wheat" ],
     "volume": "250 ml",
     "flags": [ "EATEN_HOT", "TRADER_AVOID" ],
-    "vitamins": [ [ "calcium", 1 ], [ "iron", 10 ], [ "wheat_allergen", 1 ] ]
+    "vitamins": [ [ "calcium", 1 ], [ "iron", 10 ], [ "wheat_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -104,7 +105,8 @@
     "flags": [ "EDIBLE_FROZEN", "RAW" ],
     "volume": "62 ml",
     "vitamins": [ [ "calcium", 1 ], [ "iron", 10 ], [ "wheat_allergen", 1 ] ],
-    "fun": -6
+    "fun": -6,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -126,7 +128,8 @@
     "volume": "250 ml",
     "flags": [ "EATEN_HOT", "TRADER_AVOID", "FREEZERBURN" ],
     "fun": 5,
-    "vitamins": [ [ "calcium", 10 ], [ "iron", 11 ], [ "wheat_allergen", 1 ], [ "milk_allergen", 1 ] ]
+    "vitamins": [ [ "calcium", 10 ], [ "iron", 11 ], [ "wheat_allergen", 1 ], [ "milk_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -151,7 +154,8 @@
     "use_action": [ "BLECH" ],
     "flags": [ "EDIBLE_FROZEN", "RAW", "NO_AUTO_CONSUME" ],
     "vitamins": [ [ "iron", 3 ], [ "wheat_allergen", 1 ] ],
-    "fun": -5
+    "fun": -5,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -175,7 +179,8 @@
     "flags": [ "EDIBLE_FROZEN", "RAW", "NO_AUTO_CONSUME" ],
     "use_action": [ "BLECH" ],
     "vitamins": [ [ "iron", 4 ], [ "wheat_allergen", 1 ] ],
-    "fun": -5
+    "fun": -5,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -222,7 +227,8 @@
     "volume": "250 ml",
     "flags": [ "EATEN_HOT", "NUTRIENT_OVERRIDE" ],
     "fun": 2,
-    "vitamins": [ [ "calcium", 1 ], [ "iron", 10 ], [ "wheat_allergen", 1 ] ]
+    "vitamins": [ [ "calcium", 1 ], [ "iron", 10 ], [ "wheat_allergen", 1 ] ],
+    "stackable": true
   },
   {
     "type": "ITEM",

--- a/data/json/items/resources/bone.json
+++ b/data/json/items/resources/bone.json
@@ -23,7 +23,8 @@
     "to_hit": { "grip": "none", "length": "short", "surface": "any", "balance": "uneven" },
     "flags": [ "RAW", "INEDIBLE", "LUPINE", "NO_TEMP", "PUNCTURE_VEHICLE_WHEELS" ],
     "into": "meal_bone",
-    "recipe": "meal_bone_mill_1_4"
+    "recipe": "meal_bone_mill_1_4",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -101,7 +102,8 @@
     "material": [ "powder" ],
     "volume": "125 ml",
     "flags": [ "NO_TEMP" ],
-    "fun": -10
+    "fun": -10,
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -130,7 +132,8 @@
     "qualities": [ [ "COOK", 1 ] ],
     "use_action": [ "HEAT_SOLID_ITEMS" ],
     "into": "meal_bone_tainted",
-    "recipe": "meal_bone_tainted_mill_6_1"
+    "recipe": "meal_bone_tainted_mill_6_1",
+    "stackable": true
   },
   {
     "type": "ITEM",

--- a/data/json/items/resources/chemicals.json
+++ b/data/json/items/resources/chemicals.json
@@ -12,7 +12,8 @@
     "price_postapoc": "1 USD",
     "material": [ "dense_powder_nonflam" ],
     "symbol": "=",
-    "color": "dark_gray"
+    "color": "dark_gray",
+    "stackable": true
   },
   {
     "id": "dye_powder",
@@ -27,7 +28,8 @@
     "price_postapoc": "50 cent",
     "material": [ "dense_powder_nonflam" ],
     "symbol": "=",
-    "color": "dark_gray"
+    "color": "dark_gray",
+    "stackable": true
   },
   {
     "type": "ITEM",
@@ -42,7 +44,8 @@
     "container": "bag_canvas",
     "material": [ "dense_powder_nonflam" ],
     "volume": "1 ml",
-    "weight": "2150 mg"
+    "weight": "2150 mg",
+    "stackable": true
   },
   {
     "type": "ITEM",

--- a/data/json/items/resources/fasteners.json
+++ b/data/json/items/resources/fasteners.json
@@ -11,7 +11,8 @@
     "price_postapoc": "10 cent",
     "material": [ "steel" ],
     "symbol": "=",
-    "color": "dark_gray"
+    "color": "dark_gray",
+    "stackable": true
   },
   {
     "id": "button_plastic",
@@ -55,7 +56,8 @@
     "price_postapoc": "10 cent",
     "material": [ "cotton" ],
     "symbol": "=",
-    "color": "dark_gray"
+    "color": "dark_gray",
+    "stackable": true
   },
   {
     "id": "zipper_long_plastic",
@@ -77,6 +79,7 @@
     "price_postapoc": "10 cent",
     "material": [ "plastic", "cotton" ],
     "symbol": "=",
-    "color": "dark_gray"
+    "color": "dark_gray",
+    "stackable": true
   }
 ]

--- a/data/json/items/resources/plastic.json
+++ b/data/json/items/resources/plastic.json
@@ -45,7 +45,8 @@
     "material": [ "hard_plastic_transp" ],
     "symbol": ",",
     "color": "light_blue",
-    "flags": [ "NO_SALVAGE" ]
+    "flags": [ "NO_SALVAGE" ],
+    "stackable": true
   },
   {
     "id": "10l_plastic",
@@ -90,7 +91,8 @@
     "material": [ "plastic" ],
     "symbol": ",",
     "color": "light_blue",
-    "flags": [ "NO_SALVAGE" ]
+    "flags": [ "NO_SALVAGE" ],
+    "stackable": true
   },
   {
     "id": "nylon",
@@ -125,7 +127,8 @@
     "material": [ "lycra" ],
     "symbol": ",",
     "color": "light_blue",
-    "flags": [ "NO_SALVAGE" ]
+    "flags": [ "NO_SALVAGE" ],
+    "stackable": true
   },
   {
     "id": "plastic_sheet",
@@ -143,7 +146,8 @@
     "symbol": ")",
     "color": "light_blue",
     "use_action": { "type": "deploy_furn", "furn_type": "f_plastic_groundsheet" },
-    "flags": [ "NO_SALVAGE" ]
+    "flags": [ "NO_SALVAGE" ],
+    "stackable": true
   },
   {
     "id": "plastic_sheet_small",
@@ -157,7 +161,8 @@
     "price_postapoc": "2 cent",
     "material": [ "plastic" ],
     "symbol": ",",
-    "flags": [ "NO_SALVAGE" ]
+    "flags": [ "NO_SALVAGE" ],
+    "stackable": true
   },
   {
     "id": "polycarbonate_sheet",
@@ -209,7 +214,8 @@
     "material": [ "hard_plastic_transp" ],
     "symbol": ",",
     "color": "light_blue",
-    "flags": [ "NO_SALVAGE" ]
+    "flags": [ "NO_SALVAGE" ],
+    "stackable": true
   },
   {
     "id": "inhalation_valve",
@@ -225,7 +231,8 @@
     "material": [ "plastic", "rubber" ],
     "symbol": ",",
     "color": "light_blue",
-    "flags": [ "NO_SALVAGE" ]
+    "flags": [ "NO_SALVAGE" ],
+    "stackable": true
   },
   {
     "id": "filter_port_40mm",
@@ -242,6 +249,7 @@
     "material": [ "hard_plastic_transp" ],
     "symbol": ",",
     "color": "light_blue",
-    "flags": [ "NO_SALVAGE" ]
+    "flags": [ "NO_SALVAGE" ],
+    "stackable": true
   }
 ]

--- a/data/json/items/tool/med.json
+++ b/data/json/items/tool/med.json
@@ -13,7 +13,8 @@
     "symbol": "!",
     "color": "white",
     "flags": [ "SINGLE_USE" ],
-    "use_action": { "type": "heal", "bandages_power": 1, "bleed": 4, "move_cost": 750 }
+    "use_action": { "type": "heal", "bandages_power": 1, "bleed": 4, "move_cost": 750 },
+    "stackable": true
   },
   {
     "id": "alcohol_wipes",
@@ -29,7 +30,8 @@
     "symbol": ",",
     "color": "white",
     "flags": [ "SINGLE_USE", "IRREPLACEABLE_CONSUMABLE" ],
-    "use_action": { "type": "heal", "disinfectant_power": 2, "bite": 0.3, "move_cost": 500 }
+    "use_action": { "type": "heal", "disinfectant_power": 2, "bite": 0.3, "move_cost": 500 },
+    "stackable": true
   },
   {
     "id": "anesthetic_kit",

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1468,7 +1468,11 @@ std::optional<int> deploy_furn_actor::use( Character *p, item &it,
 
     here->furn_set( suitable.value(), furn_type, false, false, true );
     it.spill_contents( suitable.value() );
-    form_loc( *p, here, pos, it ).remove_item();
+    if( it.count_by_charges() && it.count() > 1 ) {
+        it.split( 1 );
+    } else {
+        form_loc( *p, here, pos, it ).remove_item();
+    }
     p->mod_moves( -to_moves<int>( 2_seconds ) );
     return 0;
 }


### PR DESCRIPTION
<!-- 使用说明：在下面每个「#### 标题」下填写与你的 PR 相关的信息。
请保留这些标题。像这样的注释可以安全删除。

如果你是在 GitHub 网页界面发起这个 PR，可以用「preview（预览）」按钮查看 PR 对他人显示的样子。

PR 提交准则：
- 让你的改动只聚焦于一个具体的问题或变更，外加为实现它所必需的最小相关改动。
- 一个经验法则：大多数 PR 的改动应少于 500 行。
- 你可以另开 PR 来拆分一次较大的预期改动；如果不确定怎么拆，尽管问。我们很乐意与你协作，并建议合并你 PR 的最佳方式。
-->

#### Summary
Balance "增加堆叠并调整少量数据"

#### Purpose of change
主要是为了修复大量食物可能造成的卡顿/超过单格数量上限的问题。

#### Describe the solution
- 为更多物品添加堆叠，主要是食物相关，但也包括其他物品。
- 添加了几个display_type。
- 移除了西瓜、哈密瓜和椰子的堆叠，目前堆叠的物品会瞬间拾取/转移，不适合对大体积物品使用。
- 缩短了西瓜和哈密瓜的保质期，使用网络搜索的数据，并保守估计（由于是小改动所以放进来了）
- 更新：修改了 deploy_furn_actor::use 函数以解决放置会使用整个物品堆的问题。

#### Describe alternatives you've considered

使全部物品都能堆叠，但行为与未堆叠的一致，纯粹作为优化措施。

#### Testing

能够正常编译/运行。

#### Additional context

已知问题：增加堆叠会使旧存档里的物品在UI里散开。

<!--README: Cataclysm: Cleanwater Bomb (CCB) 以 Creative Commons Attribution ShareAlike 3.0 许可证发布。
游戏的代码与内容可自由用于任何目的的使用、修改和再分发。
通过为本项目做贡献，你即同意该许可证的条款，并同意你所做的任何贡献也将受同一许可证覆盖。
详见 http://creativecommons.org/licenses/by-sa/3.0/ 。 -->