### PR TITLE
Vehicle passenger parts' spatial capacity is a mess

### DIFF
--- a/data/json/vehicleparts/airship.json
+++ b/data/json/vehicleparts/airship.json
@@ -16,6 +16,7 @@
     "type": "vehicle_part",
     "name": "airship balloon",
     "item": "airship_balloon_item",
+    "categories": [ "movement" ],
     "height": 30,
     "requirements": {
       "install": { "skills": [ [ "mechanics", 2 ] ], "time": "60 m", "using": [ [ "rope_natural_short", 1 ] ] },
@@ -36,6 +37,7 @@
     "type": "vehicle_part",
     "name": "external airship balloon",
     "location": "structure",
+    "categories": [ "movement" ],
     "//": "Overhead canopy acting as its own structural frame, so it can stand alone over empty tiles without a frame beneath.  Overhead flags keep it from being boarded or blocking movement.",
     "extend": { "flags": [ "EXTENDABLE", "AISLE", "ROOF", "NOCOLLIDE", "NOCOLLIDEBELOW" ] }
   },
@@ -58,6 +60,7 @@
     "type": "vehicle_part",
     "name": "aircraft propeller",
     "item": "metal_propeller_item",
+    "categories": [ "movement" ],
     "propeller_diameter": 3,
     "requirements": {
       "install": { "skills": [ [ "mechanics", 6 ] ], "time": "2 h", "using": [ [ "welding_standard", 20 ] ] },
@@ -75,6 +78,7 @@
     "type": "vehicle_part",
     "name": "wooden aircraft propeller",
     "item": "wood_propeller_item",
+    "categories": [ "movement" ],
     "propeller_diameter": 2,
     "requirements": {
       "install": { "skills": [ [ "mechanics", 5 ] ], "time": "2 h", "using": [ [ "vehicle_nail_install", 20 ] ] },

--- a/data/json/vehicleparts/ladders.json
+++ b/data/json/vehicleparts/ladders.json
@@ -16,6 +16,7 @@
     "type": "vehicle_part",
     "name": "3-story rope ladder",
     "item": "rope_30",
+    "categories": [ "utility" ],
     "length": 3,
     "requirements": { "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "60 m", "using": [  ] } },
     "durability": 60,

--- a/data/json/vehicleparts/seats.json
+++ b/data/json/vehicleparts/seats.json
@@ -48,7 +48,7 @@
         "using": [ [ "repair_welding_standard", 1 ], [ "sewing_standard", 8 ] ]
       }
     },
-    "size": "25 L",
+    "size": "40 L",
     "type": "vehicle_part",
     "variants_bases": [ { "id": "windshield", "label": "Windshield" }, { "id": "swivel_chair", "label": "Swivel Chair" } ],
     "variants": [
@@ -76,7 +76,7 @@
     "comfort": 3,
     "description": "A soft seat with an adjustable backrest, making it a reasonably comfortable place to sleep.",
     "durability": 100,
-    "size": "6250 ml",
+    "size": "50 L",
     "floor_bedding_warmth": 350,
     "name": { "str": "reclining bucket seat" },
     "extend": { "flags": [ "BED" ] },
@@ -100,6 +100,7 @@
     "description": "A wide, flat seat like you'd find in the back of a sedan, upholstered with soft nylon.",
     "floor_bedding_warmth": 500,
     "item": "seat_bench",
+    "size": "50 L",
     "extend": { "flags": [ "BED" ] },
     "type": "vehicle_part"
   },

--- a/data/json/vehicleparts/skyfarer_parts.json
+++ b/data/json/vehicleparts/skyfarer_parts.json
@@ -5,6 +5,7 @@
     "copy-from": "sail",
     "name": { "str": "large sail" },
     "description": "Sails and rigging fit for a yacht or sloop, about as large as a single person can reasonably crew.",
+    "categories": [ "movement", "operations" ],
     "durability": 150,
     "power": "4000 W",
     "item": "sail_large_item",

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -204,7 +204,7 @@
     "damage_modifier": 60,
     "durability": 95,
     "description": "A small but comfortable bed.",
-    "size": "50 L",
+    "size": "65 L",
     "item": "mattress",
     "comfort": 4,
     "floor_bedding_warmth": 700,
@@ -2516,7 +2516,7 @@
     "comfort": 1,
     "item": "frame_wood",
     "location": "center",
-    "size": "85 L",
+    "size": "40 L",
     "requirements": {
       "install": { "skills": [ [ "mechanics", 1 ] ], "time": "30 m", "using": [ [ "vehicle_nail_install", 1 ] ] },
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },
@@ -2533,7 +2533,7 @@
     "name": { "str": "wooden bench" },
     "copy-from": "seat_wood",
     "durability": 150,
-    "size": "95 L",
+    "size": "65 L",
     "description": "A benchlike place to sit."
   },
   {


### PR DESCRIPTION
#### Summary

Fix several vehicle component issues, primarily focusing on the `size` field for the `passengers` category

#### Purpose of change

C:DDA's [PR #81191](https://github.com/CleverRaven/Cataclysm-DDA/pull/81191) claimed to `Revert vehicle cargo sizes to sane values`, but some changes appear overly aggressive. Furthermore, I noticed that items like wooden seats clearly still retain their legacy `size` attributes. This has left the spatial capacity of vehicle passenger components in a cluttered state. Additionally, that PR failed to explain the specific meaning behind the modified numbers, leaving me no choice but to treat them as magic numbers.

Generally speaking, while having someone sitting in a seat certainly makes it harder for others to pass through, an adult holding a child can still fit in a seat rather than "overflowing" into surrounding tiles... or to put it less pleasantly in an apocalyptic context, a seat ought to fit a character and their unfortunate child, while a bed might accommodate an unfortunate partner. Overall, however, these passenger components should not have capacities that glaringly exceed dedicated cargo parts. In-game testing shows that a child zombie corpse is slightly over 30 L but under 40 L, while a standard zombie corpse is a bit over 60 L (rarely exceeding that by much). Given that a box made with a steel frame holds 68.75 L, unifying these values within a 40–65 L range seems reasonable.

Additionally, some players persistently claim that vehicle components ported from CBN's airship fail to display in their corresponding categories. Although I believe the JSON inheritance mechanism works properly, I am taking extra fallback measures just to be safe and prevent further nagging.

#### Describe the solution

Referenced pre-modification data to fix inconsistent spatial capacity (`size`) specifications for `passengers` vehicle components:

- `seat` / `seat_leather`: 25 L -> 40 L
- `reclining_seat` / `reclining_seat_leather`: 6.25 L -> 50 L
- `seat_back` / `seat_back_leather`: 25 L -> 50 L
- `seat_wood` / `seat_wood_light`: 85 L -> 40 L
- `seat_wood_bench`: 95 L -> 65 L
- `bed`: 50 L -> 65 L

Additionally added the `categories` field to certain airship vehicle components as a fallback measure.

#### Describe alternatives you've considered

Someone suggested completely reverting the change? However, I don't feel the author of the original PR, RenechCDDA, is someone enjoys to make moves that are utterly unreasonable from rationale to execution. It's just that due to differing development philosophies, some of his changes are indeed quite aggressive. As he once put it, `Nothing happens "for no reason"`... emm, and besides, I also agree that a seat with over 90 L of capacity is indeed quite ridiculous (when compared to dedicated cargo bays, but 50± may).