### PR TITLE
[FCL] High-tech Hydroponics Technology from Helixwirl Biotechnologies

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -3124,6 +3124,7 @@
   {
     "id": "NO_CROP_OVERGROWTH",
     "type": "json_flag",
-    "//": "Furniture with this flag prevents plants growing on it from becoming overgrown."
+    "//": "Furniture with this flag prevents plants growing on it from becoming overgrown.",
+    "info": "This planting facility can prevent crops from over-ripening and wilting."
   }
 ]

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -3120,5 +3120,10 @@
     "id": "GENDER_INVARIANCE",
     "type": "json_flag",
     "//": "Preventing a character from changing their gender will override GENDER_FLUIDITY."
+  },
+  {
+    "id": "NO_CROP_OVERGROWTH",
+    "type": "json_flag",
+    "//": "Furniture with this flag prevents plants growing on it from becoming overgrown."
   }
 ]

--- a/data/mods/FuturismCataclysmLegacy/construction/hydroponics.json
+++ b/data/mods/FuturismCataclysmLegacy/construction/hydroponics.json
@@ -1,0 +1,46 @@
+[
+  {
+    "type": "construction",
+    "id": "fcl_constr_hydroponics",
+    "group": "fcl_build_hydroponics",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "fabrication", 4 ], [ "survival", 2 ], [ "electronics", 2 ] ],
+    "time": "3 h",
+    "qualities": [ [ { "id": "SAW_M", "level": 1 } ], [ { "id": "SCREW", "level": 1 } ], [ { "id": "WRENCH", "level": 2 } ] ],
+    "components": [
+      [ [ "fcl_hydroponics_core", 1 ] ],
+      [ [ "pipe", 6 ], [ "xlframe", 1 ] ],
+      [ [ "plastic_chunk", 10 ] ],
+      [ [ "metal_tank_little", 2 ] ],
+      [ [ "cu_pipe", 4 ] ],
+      [ [ "small_storage_battery", 1 ] ],
+      [ [ "plut_cell", 1 ] ],
+      [ [ "e_scrap", 2 ] ],
+      [ [ "lightstrip_inactive", 2 ] ],
+      [ [ "circuit", 1 ] ],
+      [ [ "fertilizer_commercial", 1 ] ],
+      [ [ "water", 100 ] ]
+    ],
+    "pre_special": "check_empty",
+    "post_terrain": "f_fcl_hydroponics"
+  },
+  {
+    "type": "construction",
+    "id": "fcl_constr_hydroponics_heater",
+    "group": "fcl_build_hydroponics_heater",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "fabrication", 4 ], [ "electronics", 3 ] ],
+    "time": "45 m",
+    "qualities": [ [ { "id": "SAW_M", "level": 1 } ], [ { "id": "SCREW", "level": 1 } ], [ { "id": "WRENCH", "level": 2 } ] ],
+    "components": [
+      [ [ "plut_cell", 1 ] ],
+      [ [ "small_storage_battery", 1 ] ],
+      [ [ "element", 12 ] ],
+      [ [ "cable", 6 ] ],
+      [ [ "sheet_metal", 4 ] ],
+      [ [ "power_supply", 1 ] ]
+    ],
+    "pre_special": "check_empty",
+    "post_terrain": "f_fcl_hydroponics_heater"
+  }
+]

--- a/data/mods/FuturismCataclysmLegacy/construction_group.json
+++ b/data/mods/FuturismCataclysmLegacy/construction_group.json
@@ -18,5 +18,15 @@
     "type": "construction_group",
     "id": "place_reinforced_ground_solar_panel_v3",
     "name": "Place Reinforced Quantum Solar Panel Array"
+  },
+  {
+    "type": "construction_group",
+    "id": "fcl_build_hydroponics",
+    "name": "Build hydroponics unit"
+  },
+  {
+    "type": "construction_group",
+    "id": "fcl_build_hydroponics_heater",
+    "name": "Build hydroponics heater"
   }
 ]

--- a/data/mods/FuturismCataclysmLegacy/furniture_and_terrain/hydroponics.json
+++ b/data/mods/FuturismCataclysmLegacy/furniture_and_terrain/hydroponics.json
@@ -1,0 +1,125 @@
+[
+  {
+    "type": "furniture",
+    "id": "f_fcl_hydroponics",
+    "name": "hydroponics unit",
+    "description": "A self-contained hydroponics unit for growing crops indoors.  This technology was originally patented by Helixwirl Biotechnologies, with the patent and surviving units recovered by Trans-Coast Logistics during the company's bankruptcy liquidation.  It relies on a specialized energy field that keeps plants at maturity instead of allowing them to overgrow and wither.  In theory, unauthorized individuals and organizations are not permitted to use it.  In the aftermath of the apocalypse, however, no one seems to care about your patent infringement.",
+    "symbol": "^",
+    "color": "light_blue",
+    "move_cost_mod": 1,
+    "light_emitted": 10,
+    "required_str": 12,
+    "looks_like": "f_planter",
+    "flags": [ "TRANSPARENT", "PLANTABLE", "SHALLOW_WATER", "FLAT", "MOUNTABLE", "NO_CROP_OVERGROWTH" ],
+    "deconstruct": { "items": [ { "group": "fcl_hydrop_deconstruct_results" } ] },
+    "bash": {
+      "str_min": 6,
+      "str_max": 14,
+      "sound": "crunch.",
+      "sound_fail": "whish.",
+      "items": [ { "group": "fcl_hydrop_bash_results" } ]
+    },
+    "plant_data": {
+      "transform": "f_fcl_hydroponics_seed",
+      "max_water_storage": 200,
+      "water_consumption_multiplier": 0.5
+    },
+    "examine_action": "dirtmound"
+  },
+  {
+    "type": "furniture",
+    "id": "f_fcl_hydroponics_seed",
+    "name": "hydroponics unit with seeds",
+    "description": "A self-contained hydroponics unit for growing crops indoors.  It contains planted seeds.  This technology was originally patented by Helixwirl Biotechnologies, with the patent and surviving units recovered by Trans-Coast Logistics during the company's bankruptcy liquidation.  It relies on a specialized energy field that keeps plants at maturity instead of allowing them to overgrow and wither.  In theory, unauthorized individuals and organizations are not permitted to use it.  In the aftermath of the apocalypse, however, no one seems to care about your patent infringement.",
+    "symbol": "^",
+    "color": "brown",
+    "looks_like": "f_planter",
+    "required_str": -1,
+    "flags": [ "PLANT", "SEALED", "TRANSPARENT", "CONTAINER", "NOITEM", "TINY", "DONT_REMOVE_ROTTEN", "GROWTH_SEED", "NO_CROP_OVERGROWTH" ],
+    "examine_action": "aggie_plant",
+    "copy-from": "f_fcl_hydroponics",
+    "plant_data": { "transform": "f_fcl_hydroponics_seedling", "base": "f_fcl_hydroponics" }
+  },
+  {
+    "type": "furniture",
+    "id": "f_fcl_hydroponics_seedling",
+    "name": "hydroponics unit with seedlings",
+    "description": "A self-contained hydroponics unit for growing crops indoors.  It contains young seedlings.  This technology was originally patented by Helixwirl Biotechnologies, with the patent and surviving units recovered by Trans-Coast Logistics during the company's bankruptcy liquidation.  It relies on a specialized energy field that keeps plants at maturity instead of allowing them to overgrow and wither.  In theory, unauthorized individuals and organizations are not permitted to use it.  In the aftermath of the apocalypse, however, no one seems to care about your patent infringement.",
+    "symbol": "^",
+    "color": "green",
+    "looks_like": "f_planter_seedling",
+    "required_str": -1,
+    "flags": [ "PLANT", "SEALED", "TRANSPARENT", "CONTAINER", "NOITEM", "TINY", "DONT_REMOVE_ROTTEN", "GROWTH_SEEDLING", "NO_CROP_OVERGROWTH" ],
+    "examine_action": "aggie_plant",
+    "copy-from": "f_fcl_hydroponics_seed",
+    "plant_data": { "transform": "f_fcl_hydroponics_mature", "base": "f_fcl_hydroponics" }
+  },
+  {
+    "type": "furniture",
+    "id": "f_fcl_hydroponics_mature",
+    "name": "hydroponics unit with mature plants",
+    "description": "A self-contained hydroponics unit for growing crops indoors.  The plants have matured.  This technology was originally patented by Helixwirl Biotechnologies, with the patent and surviving units recovered by Trans-Coast Logistics during the company's bankruptcy liquidation.  It relies on a specialized energy field that keeps plants at maturity instead of allowing them to overgrow and wither.  In theory, unauthorized individuals and organizations are not permitted to use it.  In the aftermath of the apocalypse, however, no one seems to care about your patent infringement.",
+    "symbol": "#",
+    "color": "green",
+    "looks_like": "f_planter_mature",
+    "move_cost_mod": 0,
+    "required_str": -1,
+    "flags": [ "PLANT", "SEALED", "TRANSPARENT", "CONTAINER", "NOITEM", "TINY", "DONT_REMOVE_ROTTEN", "GROWTH_MATURE", "SMALL_HIDE", "NO_CROP_OVERGROWTH" ],
+    "examine_action": "aggie_plant",
+    "copy-from": "f_fcl_hydroponics_seed",
+    "plant_data": { "transform": "f_fcl_hydroponics_harvest", "base": "f_fcl_hydroponics" }
+  },
+  {
+    "type": "furniture",
+    "id": "f_fcl_hydroponics_harvest",
+    "name": "hydroponics unit ready for harvest",
+    "description": "A self-contained hydroponics unit for growing crops indoors.  The plants are ready for harvest.  This technology was originally patented by Helixwirl Biotechnologies, with the patent and surviving units recovered by Trans-Coast Logistics during the company's bankruptcy liquidation.  It relies on a specialized energy field that keeps plants at maturity instead of allowing them to overgrow and wither.  In theory, unauthorized individuals and organizations are not permitted to use it.  In the aftermath of the apocalypse, however, no one seems to care about your patent infringement.",
+    "symbol": "#",
+    "color": "light_green",
+    "looks_like": "f_planter_harvest",
+    "required_str": -1,
+    "flags": [ "PLANT", "SEALED", "TRANSPARENT", "CONTAINER", "NOITEM", "TINY", "DONT_REMOVE_ROTTEN", "GROWTH_HARVEST", "SMALL_HIDE", "NO_CROP_OVERGROWTH" ],
+    "examine_action": "harvest_plant_ex",
+    "copy-from": "f_fcl_hydroponics_mature",
+    "plant_data": {
+      "base": "f_fcl_hydroponics",
+      "harvest_multiplier": 2.5
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "f_fcl_hydroponics_heater",
+    "name": "hydroponics heater",
+    "description": "A dedicated heater for warming hydroponics units.",
+    "symbol": "#",
+    "color": "light_blue",
+    "move_cost_mod": 1,
+    "required_str": 12,
+    "looks_like": "mountable_heater",
+    "flags": [ "TRANSPARENT", "FLAT", "MOUNTABLE" ],
+    "emissions": [ "emit_hot_air2_blast" ],
+    "deconstruct": {
+      "items": [
+        { "item": "small_storage_battery" },
+        { "item": "element", "count": [ 10, 12 ] },
+        { "item": "cable", "count": [ 4, 6 ] },
+        { "item": "sheet_metal", "count": [ 2, 4 ] },
+        { "item": "power_supply", "count": [ 0, 1 ] }
+      ]
+    },
+    "bash": {
+      "str_min": 6,
+      "str_max": 14,
+      "sound": "crunch.",
+      "sound_fail": "whish.",
+      "items": [
+        { "item": "small_storage_battery", "count": [ 0, 1 ] },
+        { "item": "element", "count": [ 4, 12 ] },
+        { "item": "cable", "count": [ 2, 6 ] },
+        { "item": "sheet_metal", "count": [ 1, 3 ] },
+        { "item": "scrap", "count": [ 3, 12 ] },
+        { "item": "power_supply", "count": [ 0, 1 ] }
+      ]
+    }
+  }
+]

--- a/data/mods/FuturismCataclysmLegacy/itemgroups/hydroponics.json
+++ b/data/mods/FuturismCataclysmLegacy/itemgroups/hydroponics.json
@@ -1,0 +1,46 @@
+[
+  {
+    "type": "item_group",
+    "id": "fcl_hydroponics_lab_documents",
+    "subtype": "collection",
+    "entries": [
+      { "item": "fcl_helixwirl_hydroponics_manual" }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "fcl_hydrop_deconstruct_results",
+    "subtype": "collection",
+    "entries": [
+      { "item": "fcl_hydroponics_core", "count": 1 },
+      { "item": "pipe", "count": [ 5, 6 ] },
+      { "item": "plastic_chunk", "count": 10 },
+      { "item": "metal_tank_little", "count": 2 },
+      { "item": "cu_pipe", "count": 4 },
+      { "item": "e_scrap", "count": 2 },
+      { "item": "lightstrip_inactive", "count": 2 },
+      { "item": "circuit", "count": 1 },
+      { "item": "small_storage_battery" },
+      { "item": "scrap", "count": [ 1, 2 ] },
+      { "item": "fertilizer_commercial", "count": [ 0, 1 ] }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "fcl_hydrop_bash_results",
+    "subtype": "collection",
+    "entries": [
+      { "item": "fcl_hydroponics_core", "count": [ 0, 1 ] },
+      { "item": "pipe", "count": [ 2, 4 ] },
+      { "item": "plastic_chunk", "count": [ 8, 10 ] },
+      { "item": "metal_tank_little", "count": [ 0, 2 ], "damage": [ 1, 3 ] },
+      { "item": "cu_pipe", "count": [ 0, 2 ] },
+      { "item": "e_scrap", "count": 2 },
+      { "item": "lightstrip_inactive", "count": 2 },
+      { "item": "circuit", "count": [ 0, 1 ] },
+      { "item": "small_storage_battery", "count": [ 0, 1 ], "damage": [ 1, 3 ] },
+      { "item": "scrap", "count": [ 3, 6 ] },
+      { "item": "fertilizer_commercial", "count": [ 0, 1 ] }
+    ]
+  }
+]

--- a/data/mods/FuturismCataclysmLegacy/items/book/hydroponics.json
+++ b/data/mods/FuturismCataclysmLegacy/items/book/hydroponics.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "fcl_helixwirl_hydroponics_manual",
+    "type": "ITEM",
+    "subtypes": [ "BOOK" ],
+    "category": "manuals",
+    "name": { "str": "Helixwirl Biotechnologies internal hydroponics memorandum" },
+    "description": "An internal Helixwirl Biotechnologies memorandum detailing the hydroponics core's field-control architecture.  The documentation is dry and technical, except for one bizarre structure whose function cannot be identified.  A warning in huge, bright-red lettering reads: DO NOT ALTER, IF PRODUCTION REVEALS ANY DEVIATION FROM THE REFERENCE, DISCARD THE UNIT IMMEDIATELY.",
+    "weight": "700 g",
+    "volume": "750 ml",
+    "price": "100 USD",
+    "price_postapoc": "10 USD",
+    "looks_like": "file",
+    "material": [ "paper" ],
+    "symbol": "?",
+    "color": "light_blue",
+    "intelligence": 12,
+    "required_level": 0,
+    "max_level": 8,
+    "time": "90 m",
+    "read_skill": "electronics",
+    "read_fun": -30
+  }
+]

--- a/data/mods/FuturismCataclysmLegacy/items/electronics/hydroponics.json
+++ b/data/mods/FuturismCataclysmLegacy/items/electronics/hydroponics.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "fcl_hydroponics_core",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "hydroponics core" },
+    "description": "A compact Helixwirl control core that projects the energy field used to keep hydroponic crops at their mature state.",
+    "weight": "800 g",
+    "volume": "500 ml",
+    "price": "2 kUSD",
+    "price_postapoc": "20 USD",
+    "material": [ "steel", "plastic" ],
+    "symbol": "o",
+    "color": "light_blue",
+    "category": "tools"
+  }
+]

--- a/data/mods/FuturismCataclysmLegacy/items/electronics/hydroponics.json
+++ b/data/mods/FuturismCataclysmLegacy/items/electronics/hydroponics.json
@@ -4,7 +4,7 @@
     "type": "ITEM",
     "subtypes": [ "TOOL" ],
     "name": { "str": "hydroponics core" },
-    "description": "A compact Helixwirl control core that projects the energy field used to keep hydroponic crops at their mature state.",
+    "description": "A compact Helixwirl control core that projects the energy field used to keep hydroponic crops at their mature state.  You can't understand its principles at all.  Its technology definitely uses some undisclosed research results from other technical routes, but if you get the blueprints and follow the tutorial to manufacture it, it may not be as difficult as you imagine.",
     "weight": "800 g",
     "volume": "500 ml",
     "price": "2 kUSD",

--- a/data/mods/FuturismCataclysmLegacy/mapgen/lab/lab_modular/lab_hydroponics_rooms.json
+++ b/data/mods/FuturismCataclysmLegacy/mapgen/lab/lab_modular/lab_hydroponics_rooms.json
@@ -1,0 +1,63 @@
+[
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "lab_common_6x6",
+    "weight": 50,
+    "object": {
+      "mapgensize": [ 6, 6 ],
+      "rotation": [ 0, 3 ],
+      "rows": [
+        "HH..HH",
+        "......",
+        ".HHHH.",
+        ".HHHH.",
+        "......",
+        "HH..HH"
+      ],
+      "palettes": [ "lab_common_palette", "fcl_hydroponics_lab_palette" ],
+      "place_loot": [ { "group": "fcl_hydroponics_lab_documents", "x": 2, "y": 1, "chance": 20 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "lab_common_9x9_E",
+    "weight": 50,
+    "object": {
+      "mapgensize": [ 9, 9 ],
+      "rows": [
+        "HH.HH|   ",
+        ".....|   ",
+        "HHHHH|   ",
+        ".....|   ",
+        "H...H+   ",
+        ".....|   ",
+        "HHHHH|   ",
+        ".....|   ",
+        "HH.HH|   "
+      ],
+      "palettes": [ "lab_common_palette", "fcl_hydroponics_lab_palette" ],
+      "place_loot": [ { "group": "fcl_hydroponics_lab_documents", "x": 0, "y": 1, "chance": 20 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "lab_common_9x9_W",
+    "weight": 50,
+    "object": {
+      "mapgensize": [ 9, 9 ],
+      "rows": [
+        "   |HH.HH",
+        "   |.....",
+        "   |HHHHH",
+        "   |.....",
+        "   +H...H",
+        "   |.....",
+        "   |HHHHH",
+        "   |.....",
+        "   |HH.HH"
+      ],
+      "palettes": [ "lab_common_palette", "fcl_hydroponics_lab_palette" ],
+      "place_loot": [ { "group": "fcl_hydroponics_lab_documents", "x": 8, "y": 1, "chance": 20 } ]
+    }
+  }
+]

--- a/data/mods/FuturismCataclysmLegacy/mapgen_palettes/fcl_hydroponics.json
+++ b/data/mods/FuturismCataclysmLegacy/mapgen_palettes/fcl_hydroponics.json
@@ -1,0 +1,13 @@
+[
+  {
+    "type": "palette",
+    "id": "fcl_hydroponics_lab_palette",
+    "terrain": { "H": "t_thconc_floor" },
+    "sealed_item": {
+      "H": {
+        "items": { "item": "farming_seeds", "chance": 100 },
+        "furniture": "f_fcl_hydroponics_harvest"
+      }
+    }
+  }
+]

--- a/data/mods/FuturismCataclysmLegacy/recipes/electronics/hydroponics.json
+++ b/data/mods/FuturismCataclysmLegacy/recipes/electronics/hydroponics.json
@@ -1,0 +1,34 @@
+[
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "fcl_hydroponics_core",
+    "category": "CC_ELECTRONIC",
+    "subcategory": "CSC_ELECTRONIC_PARTS",
+    "skill_used": "electronics",
+    "difficulty": 8,
+    "time": "4 h",
+    "book_learn": [ [ "fcl_helixwirl_hydroponics_manual", 1 ] ],
+    "skills_required": [ [ "fabrication", 4 ], [ "mechanics", 4 ] ],
+    "proficiencies": [
+      { "proficiency": "prof_carving" },
+      { "proficiency": "prof_elec_integrated_circuits" }
+    ],
+    "qualities": [
+      { "id": "SCREW", "level": 1 },
+      { "id": "SAW_M", "level": 1 }
+    ],
+    "components": [
+      [ [ "power_supply", 1 ] ],
+      [ [ "processor", 1 ] ],
+      [ [ "circuit", 2 ] ],
+      [ [ "small_storage_battery", 1 ] ],
+      [ [ "plut_cell", 1 ] ],
+      [ [ "lightstrip_inactive", 1 ] ],
+      [ [ "plastic_chunk", 5 ] ],
+      [ [ "cable", 4 ] ],
+      [ [ "diamond", 1 ] ],
+      [ [ "gold_small", 1 ] ]
+    ]
+  }
+]

--- a/data/mods/TEST_DATA/plant_eoc_test.json
+++ b/data/mods/TEST_DATA/plant_eoc_test.json
@@ -155,6 +155,77 @@
     }
   },
   {
+    "type": "furniture",
+    "id": "test_f_planter_no_overgrowth",
+    "copy-from": "f_planter",
+    "name": "test planter without crop overgrowth",
+    "extend": { "flags": [ "NO_CROP_OVERGROWTH" ] },
+    "plant_data": {
+      "transform": "test_f_planter_no_overgrowth_seed",
+      "max_water_storage": 0
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "test_f_planter_no_overgrowth_seed",
+    "copy-from": "test_f_plant_seed",
+    "name": "test planter seed without crop overgrowth",
+    "extend": { "flags": [ "NO_CROP_OVERGROWTH" ] },
+    "plant_data": {
+      "transform": "test_f_planter_no_overgrowth_seedling",
+      "base": "test_f_planter_no_overgrowth",
+      "max_water_storage": 0
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "test_f_planter_no_overgrowth_seedling",
+    "copy-from": "test_f_plant_seedling",
+    "name": "test planter seedling without crop overgrowth",
+    "extend": { "flags": [ "NO_CROP_OVERGROWTH" ] },
+    "plant_data": {
+      "transform": "test_f_planter_no_overgrowth_mature",
+      "base": "test_f_planter_no_overgrowth",
+      "max_water_storage": 0
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "test_f_planter_no_overgrowth_mature",
+    "copy-from": "test_f_plant_mature",
+    "name": "test planter mature without crop overgrowth",
+    "extend": { "flags": [ "NO_CROP_OVERGROWTH" ] },
+    "plant_data": {
+      "transform": "test_f_planter_no_overgrowth_harvest",
+      "base": "test_f_planter_no_overgrowth",
+      "max_water_storage": 0
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "test_f_planter_no_overgrowth_harvest",
+    "copy-from": "test_f_plant_harvest",
+    "name": "test planter harvest without crop overgrowth",
+    "extend": { "flags": [ "NO_CROP_OVERGROWTH" ] },
+    "plant_data": {
+      "transform": "test_f_planter_no_overgrowth_overgrown",
+      "base": "test_f_planter_no_overgrowth",
+      "max_water_storage": 0
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "test_f_planter_no_overgrowth_overgrown",
+    "copy-from": "test_f_plant_overgrown",
+    "name": "test planter overgrown without crop overgrowth",
+    "extend": { "flags": [ "NO_CROP_OVERGROWTH" ] },
+    "plant_data": {
+      "transform": "test_f_planter_no_overgrowth_overgrown",
+      "base": "test_f_planter_no_overgrowth",
+      "max_water_storage": 0
+    }
+  },
+  {
     "type": "ITEM",
     "subtypes": [ "SEED", "COMESTIBLE" ],
     "id": "test_seed_eoc",

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -723,6 +723,7 @@ Can also be used as `pre_flags` for `construction`.
 - ```PLACE_ITEM``` Valid terrain for `place_item()` to put items on.
 - ```PLANTABLE``` This terrain or furniture can have seeds planted in it.
 - ```PLANT``` A 'furniture' that grows and fruits.
+- ```NO_CROP_OVERGROWTH``` Furniture with this flag prevents plants growing on it from becoming overgrown. Crops can still reach and remain at the harvest stage.
 - ```PLOWABLE``` Terrain can be plowed.
 - ```RAIL``` This is a railroad, railroad vehicles can use it to move.
 - ```RAMP_DOWN``` The end of a ramp that leads down, walking into this moves you one z-level down.  Overrides `WALL`, while still displaying the tile as Impassable.

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -10461,7 +10461,8 @@ void map::grow_plant( const tripoint_bub_ms &p )
     const int mature_stage_idx = iexamine::get_plant_mature_stage_idx( *seed->type->seed );
     const int overgrown_stage_idx = iexamine::get_plant_overgrown_stage_idx( *seed->type->seed );
 
-    const bool overgrown_enabled = crop_overgrown_enabled;
+    const bool overgrown_enabled = crop_overgrown_enabled &&
+                                   !initial_furn.has_flag( "NO_CROP_OVERGROWTH" );
     // When overgrowth is disabled, clamp growth at the stage just before
     // overgrown (usually harvest), not at mature.  Mature is too early and
     // would prevent harvesting entirely.

--- a/tests/plant_test.cpp
+++ b/tests/plant_test.cpp
@@ -46,6 +46,10 @@ static const furn_str_id furn_test_f_plant_mature( "test_f_plant_mature" );
 static const furn_str_id furn_test_f_plant_overgrown( "test_f_plant_overgrown" );
 static const furn_str_id furn_test_f_plant_seed( "test_f_plant_seed" );
 static const furn_str_id furn_test_f_plant_seedling( "test_f_plant_seedling" );
+static const furn_str_id furn_test_f_planter_no_overgrowth_seed( "test_f_planter_no_overgrowth_seed" );
+static const furn_str_id furn_test_f_planter_no_overgrowth_seedling( "test_f_planter_no_overgrowth_seedling" );
+static const furn_str_id furn_test_f_planter_no_overgrowth_mature( "test_f_planter_no_overgrowth_mature" );
+static const furn_str_id furn_test_f_planter_no_overgrowth_harvest( "test_f_planter_no_overgrowth_harvest" );
 static const furn_str_id
 furn_test_f_planter_high_water_mature( "test_f_planter_high_water_mature" );
 static const furn_str_id furn_test_f_planter_high_water_seed( "test_f_planter_high_water_seed" );
@@ -809,6 +813,42 @@ TEST_CASE( "crop_overgrown_enabled_world_option", "[plant][world_option]" )
     CHECK( here.furn( plot ) != furn_test_f_plant_overgrown );
     // But the plant must be allowed to reach harvest, not be stuck at mature.
     CHECK( here.furn( plot ) == furn_test_f_plant_harvest );
+    CHECK( iexamine::is_plant_harvestable( here, plot ) );
+}
+
+TEST_CASE( "planter_flag_prevents_crop_overgrowth", "[plant][furniture][flag]" )
+{
+    map &here = get_map();
+    avatar &u = get_avatar();
+    clear_avatar();
+    clear_map_without_vision();
+    reset_test_globals();
+
+    options_manager::options_container world_opts = get_options().get_world_defaults();
+    world_opts["CROP_OVERGROWN_ENABLED"].setValue( "true" );
+    get_options().set_world_options( &world_opts );
+    on_out_of_scope cleanup( [&]() {
+        get_options().set_world_options( nullptr );
+    } );
+
+    const tripoint_bub_ms plot = u.pos_bub() + tripoint::east;
+    here.add_item( plot, item( itype_test_seed_eoc ) );
+    here.furn_set( plot, furn_test_f_planter_no_overgrowth_seed );
+
+    for( const furn_str_id &expected : { furn_test_f_planter_no_overgrowth_seedling,
+                                         furn_test_f_planter_no_overgrowth_mature,
+                                         furn_test_f_planter_no_overgrowth_harvest } ) {
+        calendar::turn += 1_hours;
+        here.grow_plant( plot );
+        CHECK( here.furn( plot ) == expected );
+        CHECK( here.furn( plot ).obj().has_flag( "NO_CROP_OVERGROWTH" ) );
+    }
+
+    calendar::turn += 1_hours;
+    here.grow_plant( plot );
+
+    CHECK( here.furn( plot ) == furn_test_f_planter_no_overgrowth_harvest );
+    CHECK( !iexamine::is_plant_overgrown( here, plot ) );
     CHECK( iexamine::is_plant_harvestable( here, plot ) );
 }
 


### PR DESCRIPTION
#### Summary

[FCL] Add hydroponics unit and related systems

#### Purpose of change

Futurism Cataclysm: Legacy is a mod dedicated to bringing back legacy near-future settings and elements into Cataclysm. I am currently expanding its content.

Since we already have mealgrub aquaculture, why not expand on the lore of Helixwirl Biotechnologies—a company newly introduced in this mod—and add some common industrial hydroponics? As is well known, our game has long possessed furniture capable of growing crops.

#### Describe the solution

Added a brand-new flag and its functionality: `NO_CROP_OVERGROWTH`, which allows planter-type furniture to prevent plants from overgrowing to withering even when the global setting `CROP_OVERGROWN_ENABLED = false` is not enabled.

Added the hydroponics unit system to Futurism Cataclysm, designed as a patented new technology from Helixwirl Biotechnologies, and enabled it to spawn in laboratory environments (which includes Trans-Coast Logistics). The hydroponic unit has a maximum water capacity of 200, a water consumption rate of 0.5, and a yield 2.5 times higher, which should make planting more cost-effective. Furthermore, it employs the `NO_CROP_OVERGROWTH` system.

Part of the lore is as follows:

- **hydroponics unit**: A self-contained hydroponics unit for growing crops indoors. This technology was originally patented by Helixwirl Biotechnologies, with the patent and surviving units recovered by Trans-Coast Logistics during the company's bankruptcy liquidation. It relies on a specialized energy field that keeps plants at maturity instead of allowing them to overgrow and wither. In theory, unauthorized individuals and organizations are not permitted to use it. In the aftermath of the apocalypse, however, no one seems to care about your patent infringement.
- **Helixwirl Biotechnologies internal hydroponics memorandum**: An internal Helixwirl Biotechnologies memorandum detailing the hydroponics core's field-control architecture. The documentation is dry and technical, except for one bizarre structure whose function cannot be identified. A warning in huge, bright-red lettering reads: DO NOT ALTER, IF PRODUCTION REVEALS ANY DEVIATION FROM THE REFERENCE, DISCARD THE UNIT IMMEDIATELY.
- **hydroponics core**: A compact Helixwirl control core that projects the energy field used to keep hydroponic crops at their mature state. You can't understand its principles at all. Its technology definitely uses some undisclosed research results from other technical routes, but if you get the blueprints and follow the tutorial to manufacture it, it may not be as difficult as you imagine.

#### Describe alternatives you've considered

I believe the current lore setting makes it unsuitable for spawning in residential houses or basements, though restricting it solely to laboratories feels a bit sparse. Perhaps I should create a legacy Helixwirl Biotechnologies location in the future to house them properly?

#### Testing

- Incremental MSVC `RelWithDebInfo` build of `cata_test` completed successfully, without errors.
- Ran `cata_test.exe "[plant]" --rng-seed 1 --abort`.
- All 34 plant test cases passed, with 208 assertions.
- Validated all affected JSON files with `ConvertFrom-Json`.
- `git diff --check` passed.