### PR TITLE
Fix SHOCK_** flags on vehicle parts being completely non-functional

### DIFF
--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -1795,6 +1795,8 @@ Note: Vehicle parts requiring other parts is defined by setting a `requires_flag
 - ```SECURITY``` If installed, will emit a loud noise when the vehicle is smashed.
 - ```SHARP``` Striking a monster with this part does cutting damage instead of bashing damage, and prevents stunning the monster.
 - ```SHOCK_ABSORBER``` This part protects non-frame parts on the same tile from shock damage from collisions.  It doesn't provide protect against direct impacts or other attacks.
+- ```SHOCK_RESISTANT``` This part protects self from shock damage from collisions.  It works like `SHOCK_ABSORBER`, also doesn't provide protect against direct impacts or other attacks.
+- ```SHOCK_IMMUNE``` This part is immune to shock damage from collisions. When the impact damage is transmitted to the component, it will return to 0.
 - ```SIMPLE_PART``` This part can be installed or removed from that otherwise prevent modification.
 - ```SMASH_REMOVE``` When you remove this part, instead of getting the item back, you will get the bash results.
 - ```SOLAR_PANEL``` Recharges vehicle batteries when exposed to sunlight.  Has a 1/4 chance of being broken on car generation.

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -7956,7 +7956,14 @@ void vehicle::damage_all( map &here, int dmg1, int dmg2, const damage_type_id &t
         const int distance = 1 + square_dist( vp.mount, impact );
         if( distance > 1 ) {
             int net_dmg = rng( dmg1, dmg2 ) / ( distance * distance );
-            if( vpi.location != vpart_location_structure || !vpi.has_flag( "PROTRUSION" ) ) {
+            if( vpi.location != vpart_location_structure || !vpi.has_flag( "PROTRUSION" ) || vpi.has_flag( "SHOCK_IMMUNE" ) || vpi.has_flag( "SHOCK_RESISTANT" ) ) {
+                if( vpi.has_flag( "SHOCK_IMMUNE" ) ) {
+                    net_dmg = 0;
+                    continue;
+                }
+                if( vpi.has_flag( "SHOCK_RESISTANT" ) ) {
+                    net_dmg = std::max( 0, net_dmg - ( vpi.bonus > 0 ? vpi.bonus : 10 ) );
+                }
                 const int shock_absorber = part_with_feature( vp.mount, "SHOCK_ABSORBER", true );
                 if( shock_absorber >= 0 ) {
                     const vehicle_part &vp_shock_absorber = part( shock_absorber );


### PR DESCRIPTION

#### Summary
﻿
Bugfixes "Fix SHOCK_** flags on vehicle parts being completely non-functional"
﻿
#### Purpose of change
﻿
While reviewing the codebase, I noticed that there are three vehicle part flags related to shock damage: `SHOCK_ABSORBER`, `SHOCK_RESISTANT`, and `SHOCK_IMMUNE`. All three have corresponding in-game descriptions explaining their intended behavior to players, but... in reality, only `SHOCK_ABSORBER` actually works. The other two exist entirely in the JSON data, yet the C++ code responsible for vehicle damage handling never references either of them at all.
﻿
I traced the history and it appears that @LYHGLYTX imported these flags together with the airship port from CBN about a month ago, but never implemented the corresponding code. Since he is currently busy working on Android controls and the custom UI based on Lua, I decided to implement this missing functionality myself.
﻿
By the way, the "shock damage" here refers to the propagated damage transmitted from the point of impact to other vehicle parts after a collision. It is obviously unrelated to electric shocks or stunning.
﻿
#### Describe the solution
﻿
Extended `vehicle::damage_all()` by implementing support for `SHOCK_RESISTANT` and `SHOCK_IMMUNE`. The priority order is `SHOCK_IMMUNE` first, `SHOCK_RESISTANT` second, and `SHOCK_ABSORBER` last.
﻿
`SHOCK_IMMUNE` completely negates shock damage by setting the damage to 0 and returning immediately.
﻿
`SHOCK_RESISTANT` provides additional shock damage absorption. It works similarly to `SHOCK_ABSORBER`, but only reduces the damage dealt to the part itself. Like `SHOCK_ABSORBER`, the amount of reduction is determined by the vehicle part's `bonus` field (if not, default 10).
﻿
Also updated the corresponding documentation.