### PR TITLE
Further upgrade superalloy vehicle parts

### DIFF
--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -248,6 +248,24 @@
     ]
   },
   {
+    "id": "repair_welding_superalloy",
+    "type": "requirement",
+    "qualities": [ { "id": "GLARE", "level": 1 }, { "id": "HAMMER", "level": 2 } ],
+    "tools": [
+      [
+        [ "welder", 200 ],
+        [ "welding_kit", 200 ],
+        [ "welder_crude", 400 ],
+        [ "integrated_welder", 300 ],
+        [ "oxy_torch", 10 ]
+      ]
+    ],
+    "components": [
+      [ [ "welding_rod_alloy", 10 ], [ "welding_wire_alloy", 10 ], [ "brazing_rod_alloy", 10 ] ],
+      [ [ "alloy_sheet", 1 ] ]
+    ]
+  },
+  {
     "id": "repair_welding_alloys",
     "type": "requirement",
     "//": "Repair of aluminum items - per 10 cm of weld (100 seconds each), done this way to use 1 chunk of steel per 10 cm",

--- a/data/json/uncraft/recipe_deconstruction.json
+++ b/data/json/uncraft/recipe_deconstruction.json
@@ -8059,5 +8059,15 @@
     "time": "4 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "meat_tainted", 6 ] ], [ [ "bone_tainted", 3 ] ], [ [ "sinew", 2 ] ] ]
+  },
+  {
+    "type": "uncraft",
+    "activity_level": "ACTIVE_EXERCISE",
+    "result": "alloy_plate",
+    "skill_used": "fabrication",
+    "difficulty": 6,
+    "time": "2 h",
+    "qualities": [ { "id": "SAW_M", "level": 3 }, { "id": "SAW_M_FINE", "level": 2 }, { "id": "HAMMER", "level": 3 } ],
+    "components": [ [ [ "alloy_sheet", 12 ] ] ]
   }
 ]

--- a/data/json/vehicleparts/armor.json
+++ b/data/json/vehicleparts/armor.json
@@ -25,7 +25,7 @@
     "type": "vehicle_part",
     "item": "spring_plate",
     "description": "A makeshift combination of springs and scrap that protects a particular section of a vehicle from the shock of impacts.  The springs can absorb a surprising amount of damage.",
-    "location": "armor",
+    "location": "damping",
     "categories": [ "warfare" ],
     "color": "dark_gray",
     "broken_color": "dark_gray",

--- a/data/json/vehicleparts/rams.json
+++ b/data/json/vehicleparts/rams.json
@@ -36,11 +36,11 @@
     "item": "alloy_plate",
     "color": "dark_gray",
     "broken_color": "dark_gray",
-    "durability": 750,
+    "durability": 860,
+    "bonus": 50,
     "breaks_into": [
-      { "item": "mc_steel_lump", "count": [ 4, 6 ] },
-      { "item": "mc_steel_chunk", "count": [ 4, 6 ] },
-      { "item": "scrap", "count": [ 4, 6 ] }
+      { "item": "scrap", "count": [ 6, 18 ] },
+      { "item": "alloy_sheet", "count": [ 4, 8 ] }
     ],
     "requirements": {
       "install": {
@@ -53,9 +53,14 @@
         "time": "15 m",
         "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
       },
-      "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 5 ] ] }
+      "repair": {
+        "skills": [ [ "mechanics", 5 ] ],
+        "time": "10 m",
+        "using": [ [ "repair_welding_superalloy", 1 ], [ "repair_welding_standard", 5 ] ]
+      }
     },
-    "damage_reduction": { "all": 70 }
+    "damage_reduction": { "all": 87 },
+    "extend": { "flags": [ "SHOCK_RESISTANT" ] }
   },
   {
     "id": "ram_hardsteel",

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -1995,10 +1995,11 @@
     "categories": [ "warfare" ],
     "color": "dark_gray",
     "broken_color": "dark_gray",
-    "durability": 660,
+    "durability": 780,
+    "bonus": 50,
     "item": "alloy_plate",
     "location": "armor",
-    "//": "240 cm weld to install, 60 cm weld per damage quadrant",
+    "//": "240 cm weld to install, 50 cm weld and 1 superalloy sheet per damage quadrant",
     "requirements": {
       "install": {
         "skills": [ [ "mechanics", 4 ] ],
@@ -2010,15 +2011,18 @@
         "time": "30 m",
         "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
       },
-      "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 6 ] ] }
+      "repair": {
+        "skills": [ [ "mechanics", 5 ] ],
+        "time": "10 m",
+        "using": [ [ "repair_welding_superalloy", 1 ], [ "repair_welding_standard", 5 ] ]
+      }
     },
     "flags": [ "ARMOR", "SHOCK_RESISTANT" ],
     "breaks_into": [
-      { "item": "ch_steel_lump", "count": [ 4, 6 ] },
-      { "item": "ch_steel_chunk", "count": [ 4, 6 ] },
-      { "item": "scrap", "count": [ 4, 6 ] }
+      { "item": "scrap", "count": [ 6, 18 ] },
+      { "item": "alloy_sheet", "count": [ 4, 8 ] }
     ],
-    "damage_reduction": { "all": 56 },
+    "damage_reduction": { "all": 70 },
     "variants": [ { "symbols": ")", "symbols_broken": ")" } ]
   },
   {


### PR DESCRIPTION
#### Summary

Further improve and rebalance superalloy vehicle parts.

#### Purpose of change

The first time I raised the issue that superalloy items did not live up to their name was in PR #327. Later, in #489, I strengthened the base properties of the superalloy material itself and added a relatively stable way to obtain it. I think it makes sense to further improve the related superalloy vehicle parts as well so that they better match the changes introduced in #489.

#### Describe the solution

Increased the durability and armor of the superalloy ram and superalloy plating. They now have the same base defensive performance as parts made from hard plating (which uses Tempered Carbon Steel, previously the strongest steel material in the game). In addition, they now have the `SHOCK_RESISTANT` flag with a `bonus` of 50, allowing them to reduce propagated (non-direct) shock damage from vehicle collisions by an additional 50 points, significantly improving their practical durability. (However, this functionality is currently inactive and will only take effect after the bugfix PR #490 is merged.)

As compensation for the upgrade, repairing superalloy rams and superalloy plating now requires superalloy sheets instead of just welding rods. At the same time, destroyed superalloy rams and superalloy plating no longer drop steel chunks. Instead, they now yield some scrap while recovering part of the superalloy sheets used to make them, albeit with noticeable material loss. Additionally, intact superalloy plating items (the installation materials for these two vehicle parts) can now be disassembled into an equivalent weight of superalloy sheets.