### PR TITLE
CI：暂停桌面 SDL3 构建并保留 Android SDL3

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -108,7 +108,7 @@ jobs:
         CATA_CLANG_TIDY_SUBSET: ${{ matrix.subset }}
         TILES: 1
         SOUND: 1
-        SDL3: 1
+        SDL3: 0
         LOCALIZE: 1
     if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
     steps:
@@ -118,15 +118,11 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh 22
           sudo apt-get install -y clang-tidy-22 cmake ccache jq gettext
+          sudo apt-get install -y libflac-dev libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev libpulse-dev
     - name: checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-    - name: setup SDL3 stack
-      uses: ./.github/actions/setup-sdl3-stack
-      with:
-        cache-key: sdl3-stack-strict-sdl-3.4.10-image-3.4.4-ttf-3.2.2-mixer-3.2.4-ubuntu-24.04-v2
-        prefix: ${{ runner.workspace }}/sdl3_prefix
     - name: download plugin from the previous job in this workflow run
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -140,16 +140,16 @@ jobs:
             pch: 0
             tiles: 1
             sound: 1
-            sdl3: 1
+            sdl3: 0
             localize: 1
-            title: macOS 15, Apple Clang 17, Tiles, Sound, SDL3
+            title: macOS 15, Apple Clang 17, Tiles, Sound, SDL2
             ccache_limit: 12G
-            ccache_key: macos-llvm-17-sdl3
+            ccache_key: macos-llvm-17-sdl2
 
           - title: Android x64 (build only)
             os: ubuntu-latest
             android: arm64
-            sdl3: 1
+            sdl3: 1 # Android remains on SDL3.
 
           - compiler: g++-9
             os: ubuntu-24.04
@@ -173,7 +173,7 @@ jobs:
             cmake: 0
             tiles: 1
             sound: 0
-            sdl3: 1
+            sdl3: 0
             localize: 1
             native: linux64
             pch: 1
@@ -200,7 +200,7 @@ jobs:
             cmake: 1
             tiles: 1
             sound: 1
-            sdl3: 1
+            sdl3: 0
             localize: 0
             native: linux64
             sanitize: undefined
@@ -280,6 +280,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install libncursesw5-dev ccache gettext parallel ${{ matrix.extra_package }}
           sudo locale-gen en_US.UTF-8 de_DE.UTF-8
+    - name: install SDL2 dependencies (ubuntu)
+      if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && matrix.tiles == 1 && matrix.sdl3 != 1 && matrix.android == '' }}
+      run: |
+          sudo apt-get install libflac-dev libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev libpulse-dev
     - name: setup SDL3 stack (ubuntu)
       if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && matrix.tiles == 1 && matrix.sdl3 == 1 }}
       uses: ./.github/actions/setup-sdl3-stack
@@ -297,6 +301,21 @@ jobs:
       if: ${{ env.SKIP == 'false' && runner.os == 'macOS' }}
       run: |
           HOMEBREW_NO_AUTO_UPDATE=yes HOMEBREW_NO_INSTALL_CLEANUP=yes brew install gettext ccache parallel
+    - name: install SDL2 frameworks (mac)
+      if: ${{ env.SKIP == 'false' && runner.os == 'macOS' && matrix.tiles == 1 && matrix.sdl3 != 1 }}
+      uses: BrettDong/setup-sdl2-frameworks@8ec523df88d65b2af0e1ae520695badd88851497 # v1
+      with:
+        sdl2: 2.30.11
+        sdl2-ttf: 2.24.0
+        sdl2-image: 2.8.4
+        sdl2-mixer: 2.8.0
+    - name: install macports (mac, SDL2)
+      if: ${{ env.SKIP == 'false' && runner.os == 'macOS' && matrix.tiles == 1 && matrix.sdl3 != 1 }}
+      uses: melusina-org/setup-macports@c7eb59386def259a274627092566a7f7b8d219b1 # v1
+    - name: install macports packages (mac, SDL2)
+      if: ${{ env.SKIP == 'false' && runner.os == 'macOS' && matrix.tiles == 1 && matrix.sdl3 != 1 }}
+      run: |
+        sudo port install freetype +universal pkgconfig +universal
     - name: install SDL3 dependencies (mac)
       if: ${{ env.SKIP == 'false' && runner.os == 'macOS' && matrix.tiles == 1 && matrix.sdl3 == 1 }}
       run: |

--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -102,7 +102,7 @@ jobs:
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: msvc-full-features/vcpkg_installed
-        key: vcpkg-installed-sdl3-${{ hashFiles('msvc-full-features/vcpkg.json', '.github/vcpkg_triplets/x64-windows-static.cmake') }}-f6672d8e480ccdecddfad3fd1b838ba369ffe6cd
+        key: vcpkg-installed-sdl2-${{ hashFiles('msvc-full-features/vcpkg.json', '.github/vcpkg_triplets/x64-windows-static.cmake') }}-f6672d8e480ccdecddfad3fd1b838ba369ffe6cd
 
     - name: Download ccache
       uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1.13
@@ -149,7 +149,7 @@ jobs:
 
     - name: Build
       run: |
-          msbuild -m -p:Configuration=Release -p:Platform=x64 -p:UseSDL3=true "-target:Cataclysm-vcpkg-static;Cataclysm-test-vcpkg-static;JsonFormatter-vcpkg-static;zzip" msvc-full-features/Cataclysm-vcpkg-static.sln
+          msbuild -m -p:Configuration=Release -p:Platform=x64 -p:UseSDL3=false "-target:Cataclysm-vcpkg-static;Cataclysm-test-vcpkg-static;JsonFormatter-vcpkg-static;zzip" msvc-full-features/Cataclysm-vcpkg-static.sln
 
     - name: Get ccache cache age cutoff
       id: get-cache-age

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,15 +182,17 @@ jobs:
             content: application/zip
             tiles: 1
             sound: 1
-          - name: Windows Tiles Sounds x64 MSVC (SDL3)
-            artifact: windows-with-graphics-and-sounds-sdl3-x64
-            arch: x64
-            os: windows-2022
-            ext: zip
-            content: application/zip
-            tiles: 1
-            sound: 1
-            sdl3: 1
+          # Desktop SDL3 release artifacts are temporarily disabled. Keep the
+          # definitions here so they can be restored after the migration pause.
+          # - name: Windows Tiles Sounds x64 MSVC (SDL3)
+          #   artifact: windows-with-graphics-and-sounds-sdl3-x64
+          #   arch: x64
+          #   os: windows-2022
+          #   ext: zip
+          #   content: application/zip
+          #   tiles: 1
+          #   sound: 1
+          #   sdl3: 1
           - name: Linux Tiles x64
             os: ubuntu-24.04
             android: none
@@ -209,16 +211,16 @@ jobs:
             artifact: linux-with-graphics-and-sounds-x64
             ext: tar.gz
             content: application/gzip
-          - name: Linux Tiles Sounds x64 (SDL3)
-            os: ubuntu-22.04
-            android: none
-            libbacktrace: 1
-            tiles: 1
-            sound: 1
-            sdl3: 1
-            artifact: linux-with-graphics-and-sounds-sdl3-x64
-            ext: tar.gz
-            content: application/gzip
+          # - name: Linux Tiles Sounds x64 (SDL3)
+          #   os: ubuntu-22.04
+          #   android: none
+          #   libbacktrace: 1
+          #   tiles: 1
+          #   sound: 1
+          #   sdl3: 1
+          #   artifact: linux-with-graphics-and-sounds-sdl3-x64
+          #   ext: tar.gz
+          #   content: application/gzip
           - name: Linux Curses x64
             os: ubuntu-24.04
             android: none
@@ -242,14 +244,14 @@ jobs:
             artifact: osx-with-graphics-universal
             ext: dmg
             content: application/x-apple-diskimage
-          - name: macOS Tiles Universal Binary (SDL3)
-            os: macos-15
-            tiles: 1
-            sound: 1
-            sdl3: 1
-            artifact: osx-with-graphics-sdl3-universal
-            ext: dmg
-            content: application/x-apple-diskimage
+          # - name: macOS Tiles Universal Binary (SDL3)
+          #   os: macos-15
+          #   tiles: 1
+          #   sound: 1
+          #   sdl3: 1
+          #   artifact: osx-with-graphics-sdl3-universal
+          #   ext: dmg
+          #   content: application/x-apple-diskimage
           - name: Android x64
             os: ubuntu-latest
             tiles: 1

--- a/.github/workflows/sdl3-matrix.yml
+++ b/.github/workflows/sdl3-matrix.yml
@@ -30,7 +30,10 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Desktop SDL3 is temporarily paused. Set the repository variable
+  # CCB_DESKTOP_SDL3_ENABLED=true to restore this workflow without reverting it.
   skip-duplicates-code:
+    if: ${{ vars.CCB_DESKTOP_SDL3_ENABLED == 'true' }}
     continue-on-error: true
     runs-on: ubuntu-latest
     outputs:
@@ -47,7 +50,7 @@ jobs:
   # picks the format matching its GPU backend (Vulkan/D3D12/Metal).
   compile-shaders:
     needs: [ skip-duplicates-code ]
-    if: ${{ needs.skip-duplicates-code.outputs.should_skip_code != 'true' && github.event.pull_request.draft == false }}
+    if: ${{ vars.CCB_DESKTOP_SDL3_ENABLED == 'true' && needs.skip-duplicates-code.outputs.should_skip_code != 'true' && github.event.pull_request.draft == false }}
     name: Compile shaders
     runs-on: ubuntu-24.04
     steps:
@@ -129,7 +132,7 @@ jobs:
 
   build:
     needs: [ skip-duplicates-code, compile-shaders ]
-    if: ${{ needs.skip-duplicates-code.outputs.should_skip_code != 'true' && github.event.pull_request.draft == false }}
+    if: ${{ vars.CCB_DESKTOP_SDL3_ENABLED == 'true' && needs.skip-duplicates-code.outputs.should_skip_code != 'true' && github.event.pull_request.draft == false }}
     strategy:
       fail-fast: true
       max-parallel: 1


### PR DESCRIPTION
## 概述

暂时停止 Linux、macOS 与 Windows 的 SDL3 CI/发布构建，同时保留全部 SDL3 源码和恢复入口。Android 继续使用 SDL3。

## 改动

- 普通 Linux/macOS CI Tiles 项改回 SDL2，并补齐 SDL2 依赖
- clang-tidy 与 MSVC full-features 改用 SDL2
- 专用桌面 SDL3 matrix 默认跳过；设置仓库变量 `CCB_DESKTOP_SDL3_ENABLED=true` 可恢复
- 暂停 Windows、Linux、macOS 三个 SDL3 release artifact，定义以注释形式保留
- Android CI 与 release 的 SDL3 项及 shader artifact 流程保持启用

## 影响

桌面平台继续获得 SDL2 构建和检查覆盖，不再消耗桌面 SDL3 构建资源；Android 构建策略不变。

## 验证

- `git diff --check`
- Ruby YAML 解析通过全部 5 个修改后的 workflow
- 解析 release matrix：仅 Android x64/x32 仍为 SDL3
- 解析普通 matrix：仅 Android x64 仍为 SDL3
