### PR TITLE
Allow vehicle parts to have default tint rendering.

### DIFF
--- a/src/cata_tiles_color.cpp
+++ b/src/cata_tiles_color.cpp
@@ -112,10 +112,10 @@ std::optional<RGBColor> cata_tiles::get_vpart_tint( const vehicle &veh,
         return std::nullopt;
     }
     const vehicle_part &vp = veh.part( part_idx );
-    if( !vp.has_custom_color() ) {
-        return std::nullopt;
+    if( vp.has_custom_color() ) {
+        return vp.get_color( true ).fg;
     }
-    return vp.get_color().fg;
+    return vp.info().default_tint_color;
 }
 
 #endif // TILES

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -281,6 +281,13 @@ void vpart_info::load( const JsonObject &jo, const std::string_view src )
     optional( jo, was_loaded, "description", description );
     optional( jo, was_loaded, "color", color, nc_color_reader{}, c_light_gray );
     optional( jo, was_loaded, "broken_color", color_broken, nc_color_reader{}, c_light_gray );
+    if( jo.has_member( "default_tint_color" ) ) {
+        const std::string tint = jo.get_string( "default_tint_color" );
+        default_tint_color = RGBColor::try_parse( tint );
+        if( !default_tint_color ) {
+            debugmsg( "Invalid default_tint_color '%s' on vehicle part '%s'", tint, id.str() );
+        }
+    }
     optional( jo, was_loaded, "comfort", comfort, 0 );
     optional( jo, was_loaded, "floor_bedding_warmth", floor_bedding_warmth, 0_C_delta );
     optional( jo, was_loaded, "bonus_fire_warmth_feet", bonus_fire_warmth_feet, 0.6_C_delta );

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -16,6 +16,7 @@
 
 #include "calendar.h"
 #include "color.h"
+#include "hsv_color.h"
 #include "lightmap.h"
 #include "coordinates.h"
 #include "memory_fast.h"
@@ -451,6 +452,8 @@ class vpart_info
         /** Color of part for different states */
         nc_color color = c_light_gray;
         nc_color color_broken = c_light_gray;
+        /** Optional default tiles tint for this vehicle part. */
+        std::optional<RGBColor> default_tint_color;
 
         /** Fuel type of engine or tank */
         itype_id fuel_type = itype_id::NULL_ID();


### PR DESCRIPTION
#### Summary

Allow vehicle parts to have default tint rendering.

#### Purpose of change

PR #123 and #126 introduced a vehicle part tinting system to C:CB, but it only applies when vehicles are generated. It is not possible to define a default tint for different vehicle parts that reference the same tiles.

#### Describe the solution

Implemented the `default_tint_color` JSON field for the `vehicle_part` type. Its data type is the same as the `color` field in `vehicle_color_palette`, allowing vehicle part tiles to have a default tint.

Example:
```
{
  "id": "my_colored_board",
  "type": "vehicle_part",
  "copy-from": "board",
  "default_tint_color": "Traffic white"
}
```