### PR TITLE
CI：独立发布 Android x64 New UI APK

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,6 +260,15 @@ jobs:
             artifact: android-x64
             ext: apk
             content: application/apk
+          - name: Android x64 New UI
+            os: ubuntu-latest
+            tiles: 1
+            sdl3: 1
+            android: arm64
+            new_ui: 1
+            artifact: android-x64-new-ui
+            ext: apk
+            content: application/apk
           - name: Android x32
             os: ubuntu-latest
             tiles: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -805,7 +805,11 @@ jobs:
           gpg -d --passphrase "${{ secrets.KEYSTORE_PASSWORD }}" --batch keystore.properties.asc > keystore.properties
           export UPSTREAM_BUILD_NUMBER="$((11581 + ${{ github.run_number }}))"
           chmod +x gradlew
-          if [ ${{ matrix.android }} = arm64 ]
+          if [ "${{ matrix.new_ui }}" = 1 ]
+          then
+               ./gradlew -Pj=$((`nproc`+0)) -Pabi_arm_32=false -Pprebuilt_shaders=true assembleNewUiRelease
+               mv ./app/build/outputs/apk/newUi/release/*.apk ../ccb-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.apk
+          elif [ ${{ matrix.android }} = arm64 ]
           then
                ./gradlew -Pj=$((`nproc`+0)) -Pabi_arm_32=false -Pprebuilt_shaders=true assembleExperimentalRelease
                mv ./app/build/outputs/apk/experimental/release/*.apk ../ccb-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.apk


### PR DESCRIPTION
## 内容

- 在 Experimental Release 矩阵中新增独立的 Android x64 New UI 构建
- 新产物命名为 `ccb-android-x64-new-ui-<timestamp>.apk`
- 仅该矩阵项调用 `assembleNewUiRelease`
- 原 Android x32/x64 继续调用原有的 `assembleExperimentalRelease`
- 桌面和现有 Android 发布配置均不改变

## 发布结果

- 原有 9 个构建产物保持不变
- GitHub 自动附带的 source zip/tar 保持不变
- 总资产数从 11 增加到 12
- 第 12 个资产为带原生可定制 HUD 和 Lua Mod API v4 的 Android arm64 New UI APK

## 验证

- Release YAML 解析通过
- `git diff --check` 通过
- 结构化比较确认原 9 个矩阵项逐项未变，只新增 1 项
- 本地 `assembleNewUiRelease` arm64 Release 已完成 C++、Lua 链接和 APK 打包
