### PR TITLE
孤独者在醉酒和睡眠下检测范围为1

### DIFF
--- a/data/json/effects_on_condition/mutation_eocs/mutation_effect_eocs.json
+++ b/data/json/effects_on_condition/mutation_eocs/mutation_effect_eocs.json
@@ -805,9 +805,23 @@
         { "not": { "u_has_effect": "took_prozac" } },
         { "not": { "u_has_effect": "valium" } },
         { "not": { "u_has_effect": "took_xanax" } },
-        { "not": { "u_has_effect": "drunk" } },
-        { "math": [ "u_characters_nearby('radius': 30) > 0" ] },
-        { "not": { "u_has_effect": "narcosis" } }
+        { "not": { "u_has_effect": "narcosis" } },
+        {
+          "or": [
+            {
+              "and": [
+                { "or": [ { "u_has_effect": "sleep" }, { "u_has_effect": "drunk" } ] },
+                { "math": [ "u_characters_nearby('radius': 1) > 0" ] }
+              ]
+            },
+            {
+              "and": [
+                { "not": { "or": [ { "u_has_effect": "sleep" }, { "u_has_effect": "drunk" } ] } },
+                { "math": [ "u_characters_nearby('radius': 30) > 0" ] }
+              ]
+            }
+          ]
+        }
       ]
     },
     "effect": [

--- a/data/json/effects_on_condition/mutation_eocs/mutation_effect_eocs.json
+++ b/data/json/effects_on_condition/mutation_eocs/mutation_effect_eocs.json
@@ -797,7 +797,7 @@
         { "math": [ "u_characters_nearby('radius': 30) == 0" ] }
       ]
     },
-    "effect": [ { "u_add_effect": "asocial_satisfied", "duration": "6 hours" } ]
+    "effect": [ { "u_lose_effect": "asocial_dissatisfied" }, { "u_add_effect": "asocial_satisfied", "duration": "6 hours" } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/json/effects_on_condition/mutation_eocs/mutation_effect_eocs.json
+++ b/data/json/effects_on_condition/mutation_eocs/mutation_effect_eocs.json
@@ -788,12 +788,47 @@
     "condition": {
       "and": [
         { "u_has_flag": "ASOCIAL2" },
-        { "math": [ "u_characters_nearby('radius': 30) == 0" ] },
+        { "not": { "u_has_effect": "valium" } },
+        { "not": { "u_has_effect": "took_xanax" } },
         { "not": { "u_has_effect": "took_prozac" } },
-        { "not": { "u_has_effect": "narcosis" } }
+        { "not": { "u_has_effect": "narcosis" } },
+        { "not": { "u_has_effect": "sleep" } },
+        { "not": { "u_has_effect": "drunk" } },
+        { "math": [ "u_characters_nearby('radius': 30) == 0" ] }
       ]
     },
-    "effect": [ { "u_lose_effect": "asocial_dissatisfied" }, { "u_add_effect": "asocial_satisfied", "duration": "6 hours" } ]
+    "effect": [ { "u_add_effect": "asocial_satisfied", "duration": "6 hours" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_asocial2_penalty_reset",
+    "recurrence": [ "10 minutes", "30 minutes" ],
+    "condition": {
+      "and": [
+        { "u_has_flag": "ASOCIAL2" },
+        {
+          "or": [
+            { "u_has_effect": "took_prozac" },
+            { "u_has_effect": "valium" },
+            { "u_has_effect": "took_xanax" },
+            { "u_has_effect": "narcosis" },
+            {
+              "and": [
+                { "or": [ { "u_has_effect": "sleep" }, { "u_has_effect": "drunk" } ] },
+                { "math": [ "u_characters_nearby('radius': 1) == 0" ] }
+              ]
+            },
+            {
+              "and": [
+                { "not": { "or": [ { "u_has_effect": "sleep" }, { "u_has_effect": "drunk" } ] } },
+                { "math": [ "u_characters_nearby('radius': 30) == 0" ] }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "effect": [ { "u_lose_effect": "asocial_dissatisfied" } ]
   },
   {
     "type": "effect_on_condition",


### PR DESCRIPTION

#### Summary
Balance "孤独者在醉酒和睡眠下检测范围为1"

<!-- 这一节应当只有一行，请编辑上面那一行。
1. 把「分类」替换为下列具体分类之一：Features、Content、Interface、Mods、Balance、Bugfixes、Performance、Infrastructure、Build、I18N。
2. 把引号内的文字替换为对你改动的简要描述。
如果你不希望生成更新日志条目，把整行替换为单独一个词「None」（不带引号）。
示例：
1. None
2. Bugfixes "修复长矛无法锁定不同楼层敌人的问题"
3. Interface "在制作界面显示制作失败几率"
分类含义详见：
https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/blob/master/doc/CHANGELOG_GUIDELINES.md
合并后，你的概述会被加入项目更新日志：
https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/blob/master/data/changelog.txt -->

#### Purpose of change
孤独者在睡觉时仍能感觉到隔壁的人。

#### Describe the solution

将孤独者在醉酒和睡眠效果下检测距离调整为1（此前分别为不检测和30）。
- 依据：人在睡觉时显然没法感知太远的距离，但其实仍会受到极近距离的人活动的影响。醉酒下也不会无视极近距离的人。

#### Describe alternatives you've considered
<!-- #### 你考虑过的替代方案 -->
在醉酒/睡眠下不检测，简化条件。
<!-- 说明你为解决同一问题考虑过的其他方案、不同思路或可能性。 -->

#### Testing
进入游戏测试，与预期效果一致。

#### Additional context
<!-- #### 补充说明 -->

<!-- 在此添加关于这个特性或 bug 修复的其他背景信息（例如原型图、概念验证或截图）。 -->


<!--README: Cataclysm: Cleanwater Bomb (CCB) 以 Creative Commons Attribution ShareAlike 3.0 许可证发布。
游戏的代码与内容可自由用于任何目的的使用、修改和再分发。
通过为本项目做贡献，你即同意该许可证的条款，并同意你所做的任何贡献也将受同一许可证覆盖。
详见 http://creativecommons.org/licenses/by-sa/3.0/ 。 -->