### PR TITLE
安卓：修复普通 x64 主菜单布局与单击确认

### DIFF
--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -479,6 +479,40 @@ static nc_color submenu_option_color( const nc_color base, const bool selected )
     return selected ? hilite( base ) : base;
 }
 
+static std::string aligned_submenu_shortcut_text( const nc_color shortcut_color,
+        const std::string &text )
+{
+#if !defined(__ANDROID__)
+    return shortcut_text( shortcut_color, text );
+#else
+    if( android_ui_mode::is_new_ui_build() ) {
+        return shortcut_text( shortcut_color, text );
+    }
+
+    const size_t shortcut_begin = text.find( '<' );
+    const size_t shortcut_end = text.find( '>', shortcut_begin );
+    if( shortcut_begin == std::string::npos || shortcut_end == std::string::npos ) {
+        return text;
+    }
+
+    const size_t separator = std::min( text.find( '|', shortcut_begin ), shortcut_end );
+    const std::string shortcut = text.substr( shortcut_begin + 1,
+                                 separator - shortcut_begin - 1 );
+    if( shortcut.empty() ) {
+        return text;
+    }
+
+    const std::string prefix = text.substr( 0, shortcut_begin );
+    const std::string suffix = text.substr( shortcut_end + 1 );
+    const bool shortcut_starts_word = shortcut_begin == 0 && !suffix.empty() &&
+                                      ( ( suffix.front() >= 'A' && suffix.front() <= 'Z' ) ||
+                                        ( suffix.front() >= 'a' && suffix.front() <= 'z' ) );
+    const std::string label = trim( shortcut_begin == 0 && !shortcut_starts_word ?
+                                    suffix : prefix + shortcut + suffix );
+    return colorize( shortcut, shortcut_color ) + "  " + label;
+#endif
+}
+
 void main_menu::on_move() const
 {
     sfx::play_variant_sound( "menu_move", "default", 100 );
@@ -623,8 +657,8 @@ void main_menu::display_sub_menu( int sel, const point &bottom_left, int sel_lin
         case main_menu_opts::NEWCHAR:
             for( int i = 0; static_cast<size_t>( i ) < vNewGameSubItems.size(); i++ ) {
                 nc_color clr = submenu_option_color( c_yellow, i == sel2 );
-                sub_opts.push_back( shortcut_text( clr, vNewGameSubItems[i] ) );
-                int len = utf8_width( shortcut_text( clr, vNewGameSubItems[i] ), true );
+                sub_opts.push_back( aligned_submenu_shortcut_text( clr, vNewGameSubItems[i] ) );
+                int len = utf8_width( sub_opts.back(), true );
                 if( len > xlen ) {
                     xlen = len;
                 }
@@ -805,7 +839,7 @@ void main_menu::print_menu( const catacurses::window &w_open, int iSel, const po
     if( !android_ui_mode::is_new_ui_build() ) {
         int menu_length = 0;
         for( size_t i = 0; i < vMenuItems.size(); ++i ) {
-            menu_length += utf8_width_notags( vMenuItems[i].c_str() ) + 2;
+            menu_length += utf8_width_notags( vMenuItems[i].c_str() ) + 4;
             if( !vMenuHotkeys[i].empty() ) {
                 menu_length += utf8_width( vMenuHotkeys[i][0] );
             }

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -6109,16 +6109,18 @@ static void CheckMessages()
             last_tap_time > 0 &&
             ticks - last_tap_time >= static_cast<uint32_t>
             ( get_option<int>( "ANDROID_INITIAL_DELAY" ) ) ) {
-            // Gameplay keeps its configurable tap key.  Menus use the pointer
-            // coordinates emitted on finger-up and must not receive a second,
-            // delayed Enter/confirm for the same physical tap.
+            // New UI menus use pointer coordinates emitted on finger-up and
+            // must not receive a second, delayed confirmation.  Legacy Android
+            // menus still use the original single-tap Enter interaction.
             if( is_default_mode ) {
                 last_input = input_event( get_key_event_from_string(
                                               get_option<std::string>( "ANDROID_TAP_KEY" ) ),
                                           input_event_t::keyboard_char );
+            } else if( !android_ui_mode::is_new_ui_build() ) {
+                last_input = input_event( '\n', input_event_t::keyboard_char );
             }
             last_tap_time = 0;
-            if( is_default_mode ) {
+            if( is_default_mode || !android_ui_mode::is_new_ui_build() ) {
                 return;
             }
         }


### PR DESCRIPTION
## 变更内容

- 恢复传统 Android 主菜单的准确宽度计算，避免 `Q 退出` 折到下一行。
- 在传统 Android 的“新游戏”子菜单中将快捷键与标签分列显示，使 `U  教程` 与其余条目对齐。
- 恢复传统 Android 菜单的单击确认事件。
- 保持桌面端原版菜单排版以及 New UI 的 ImGui 坐标点击行为不变。

## 根因

主菜单合并时将每个菜单项边框占用宽度从 4 格误改成 2 格，累计低估后导致末项换行。触控坐标点击改造移除了菜单的延迟 Enter，随后坐标路径仅保留给 New UI，导致传统 Android 没有任何单击确认事件。新游戏条目还继续依赖翻译字符串中的快捷键位置，无法稳定形成快捷键列。

## 用户影响

普通 Android arm64 APK 恢复原有的单击确认，并正确显示主菜单与新游戏子菜单。New UI APK 不会收到额外 Enter，也不会改变其 ImGui 菜单。

## 验证

- `:app:assembleExperimentalRelease`（arm64-v8a，New UI OFF、Lua UI OFF）
- `:app:assembleNewUiRelease`（arm64-v8a，New UI ON、Lua UI ON）
- `astyle --options=.astylerc --dry-run -X -Q --ascii src/main_menu.cpp src/sdltiles.cpp`
- `git diff --check`