### PR TITLE
安卓：为 ImGui 页面添加原生式惯性滚动

### DIFF
--- a/src/android_imgui_touch.cpp
+++ b/src/android_imgui_touch.cpp
@@ -1,0 +1,188 @@
+#include "android_imgui_touch.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace android_imgui_touch
+{
+
+namespace
+{
+
+constexpr float direction_change_ratio = 1.25F;
+constexpr float velocity_blend = 0.35F;
+constexpr float maximum_velocity = 8000.0F;
+constexpr float minimum_fling_velocity = 80.0F;
+constexpr float stop_velocity = 24.0F;
+constexpr float fling_friction = 5.5F;
+constexpr std::uint32_t maximum_animation_step_ms = 32;
+constexpr std::uint32_t maximum_velocity_sample_gap_ms = 100;
+
+} // namespace
+
+void gesture::press( const float x, const float y, const std::uint32_t now )
+{
+    mode_ = gesture_mode::pending;
+    start_x_ = last_x_ = x;
+    start_y_ = last_y_ = y;
+    velocity_y_ = 0.0F;
+    last_sample_time_ = now;
+    animation_time_ = now;
+}
+
+motion_result gesture::move( const float x, const float y, const std::uint32_t now,
+                             const float touch_slop, const bool can_scroll_vertically )
+{
+    motion_result result;
+    if( !touching() ) {
+        return result;
+    }
+
+    const float total_x = x - start_x_;
+    const float total_y = y - start_y_;
+    const float delta_y = y - last_y_;
+    const float threshold = std::max( 1.0F, touch_slop );
+    const bool passed_slop = std::hypot( total_x, total_y ) > threshold;
+    const bool vertical_intent = std::abs( total_y ) > std::abs( total_x );
+
+    if( mode_ == gesture_mode::pending && passed_slop ) {
+        if( can_scroll_vertically && vertical_intent ) {
+            mode_ = gesture_mode::vertical_scroll;
+            result.begin_vertical_scroll = true;
+        } else {
+            mode_ = gesture_mode::pointer_drag;
+            result.begin_pointer_drag = true;
+        }
+    } else if( mode_ == gesture_mode::pointer_drag && can_scroll_vertically &&
+               std::abs( total_y ) > std::abs( total_x ) * direction_change_ratio ) {
+        mode_ = gesture_mode::vertical_scroll;
+        result.cancel_pointer_drag = true;
+        result.begin_vertical_scroll = true;
+        velocity_y_ = 0.0F;
+    }
+
+    if( mode_ == gesture_mode::vertical_scroll ) {
+        result.scroll_delta_y = delta_y;
+        update_velocity( delta_y, now );
+    }
+
+    last_x_ = x;
+    last_y_ = y;
+    if( mode_ != gesture_mode::vertical_scroll ) {
+        last_sample_time_ = now;
+    }
+    return result;
+}
+
+release_result gesture::release( const float x, const float y, const std::uint32_t now,
+                                 const float touch_slop, const bool can_scroll_vertically )
+{
+    release_result result;
+    result.motion = move( x, y, now, touch_slop, can_scroll_vertically );
+
+    switch( mode_ ) {
+        case gesture_mode::pending:
+            result.tap = true;
+            mode_ = gesture_mode::idle;
+            break;
+        case gesture_mode::pointer_drag:
+            result.release_pointer = true;
+            mode_ = gesture_mode::idle;
+            break;
+        case gesture_mode::vertical_scroll: {
+            if( std::abs( velocity_y_ ) >= minimum_fling_velocity ) {
+                mode_ = gesture_mode::inertia;
+                animation_time_ = now;
+            } else {
+                mode_ = gesture_mode::idle;
+                velocity_y_ = 0.0F;
+            }
+            break;
+        }
+        case gesture_mode::idle:
+        case gesture_mode::inertia:
+            break;
+    }
+
+    return result;
+}
+
+animation_result gesture::animate( const std::uint32_t now )
+{
+    animation_result result;
+    if( mode_ != gesture_mode::inertia ) {
+        return result;
+    }
+
+    const std::uint32_t elapsed_ms = std::min( now - animation_time_,
+                                     maximum_animation_step_ms );
+    if( elapsed_ms == 0 ) {
+        result.active = true;
+        return result;
+    }
+
+    const float elapsed = static_cast<float>( elapsed_ms ) / 1000.0F;
+    result.scroll_delta_y = velocity_y_ * elapsed;
+    velocity_y_ *= std::exp( -fling_friction * elapsed );
+    animation_time_ = now;
+
+    if( std::abs( velocity_y_ ) < stop_velocity ) {
+        mode_ = gesture_mode::idle;
+        velocity_y_ = 0.0F;
+    } else {
+        result.active = true;
+    }
+    return result;
+}
+
+void gesture::cancel()
+{
+    mode_ = gesture_mode::idle;
+    velocity_y_ = 0.0F;
+}
+
+void gesture::stop_inertia()
+{
+    if( mode_ == gesture_mode::inertia ) {
+        cancel();
+    }
+}
+
+gesture_mode gesture::mode() const
+{
+    return mode_;
+}
+
+bool gesture::touching() const
+{
+    return mode_ == gesture_mode::pending ||
+           mode_ == gesture_mode::pointer_drag ||
+           mode_ == gesture_mode::vertical_scroll;
+}
+
+bool gesture::pointer_is_down() const
+{
+    return mode_ == gesture_mode::pointer_drag;
+}
+
+bool gesture::animating() const
+{
+    return mode_ == gesture_mode::inertia;
+}
+
+void gesture::update_velocity( const float delta_y, const std::uint32_t now )
+{
+    const std::uint32_t elapsed_ms = now - last_sample_time_;
+    if( elapsed_ms > 0 ) {
+        const float sample = std::clamp(
+                                 delta_y * 1000.0F / static_cast<float>( elapsed_ms ),
+                                 -maximum_velocity, maximum_velocity );
+        velocity_y_ = velocity_y_ == 0.0F ||
+                      elapsed_ms > maximum_velocity_sample_gap_ms ? sample :
+                      velocity_y_ * ( 1.0F - velocity_blend ) +
+                      sample * velocity_blend;
+    }
+    last_sample_time_ = now;
+}
+
+} // namespace android_imgui_touch

--- a/src/android_imgui_touch.h
+++ b/src/android_imgui_touch.h
@@ -1,0 +1,67 @@
+#ifndef CATA_SRC_ANDROID_IMGUI_TOUCH_H
+#define CATA_SRC_ANDROID_IMGUI_TOUCH_H
+
+#include <cstdint>
+
+namespace android_imgui_touch
+{
+
+enum class gesture_mode : int {
+    idle = 0,
+    pending,
+    pointer_drag,
+    vertical_scroll,
+    inertia
+};
+
+struct motion_result {
+    bool begin_pointer_drag = false;
+    bool cancel_pointer_drag = false;
+    bool begin_vertical_scroll = false;
+    float scroll_delta_y = 0.0F;
+};
+
+struct release_result {
+    motion_result motion;
+    bool tap = false;
+    bool release_pointer = false;
+};
+
+struct animation_result {
+    float scroll_delta_y = 0.0F;
+    bool active = false;
+};
+
+class gesture
+{
+    public:
+        void press( float x, float y, std::uint32_t now );
+        motion_result move( float x, float y, std::uint32_t now,
+                            float touch_slop, bool can_scroll_vertically );
+        release_result release( float x, float y, std::uint32_t now,
+                                float touch_slop, bool can_scroll_vertically );
+        animation_result animate( std::uint32_t now );
+        void cancel();
+        void stop_inertia();
+
+        gesture_mode mode() const;
+        bool touching() const;
+        bool pointer_is_down() const;
+        bool animating() const;
+
+    private:
+        gesture_mode mode_ = gesture_mode::idle;
+        float start_x_ = 0.0F;
+        float start_y_ = 0.0F;
+        float last_x_ = 0.0F;
+        float last_y_ = 0.0F;
+        float velocity_y_ = 0.0F;
+        std::uint32_t last_sample_time_ = 0;
+        std::uint32_t animation_time_ = 0;
+
+        void update_velocity( float delta_y, std::uint32_t now );
+};
+
+} // namespace android_imgui_touch
+
+#endif // CATA_SRC_ANDROID_IMGUI_TOUCH_H

--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -1,6 +1,7 @@
 #include "cata_imgui.h"
 
 #include <algorithm>
+#include <cfloat>
 #include <cmath>
 
 #define IMGUI_DEFINE_MATH_OPERATORS
@@ -798,11 +799,60 @@ bool cataimgui::client::want_text_input()
     return ImGui::GetCurrentContext() != nullptr && ImGui::GetIO().WantTextInput;
 }
 
-void cataimgui::client::clear_text_focus()
+ImGuiID cataimgui::client::vertical_scroll_window_at( const float x, const float y )
+{
+    ImGuiContext *context = ImGui::GetCurrentContext();
+    if( context == nullptr ) {
+        return 0;
+    }
+
+    ImGuiWindow *hovered_window = nullptr;
+    ImGui::FindHoveredWindowEx( ImVec2( x, y ), false, &hovered_window, nullptr );
+    for( ImGuiWindow *window = hovered_window; window != nullptr;
+         window = window->ParentWindow ) {
+        const bool accepts_scroll = !( window->Flags & ImGuiWindowFlags_NoMouseInputs ) &&
+                                    !( window->Flags & ImGuiWindowFlags_NoScrollWithMouse );
+        if( accepts_scroll && window->ScrollMax.y > 0.0F ) {
+            return window->ID;
+        }
+    }
+    return 0;
+}
+
+bool cataimgui::client::scroll_window_y( const ImGuiID window_id, const float finger_delta_y )
+{
+    if( window_id == 0 || finger_delta_y == 0.0F ||
+        ImGui::GetCurrentContext() == nullptr ) {
+        return false;
+    }
+
+    ImGuiWindow *window = ImGui::FindWindowByID( window_id );
+    if( window == nullptr || window->ScrollMax.y <= 0.0F ) {
+        return false;
+    }
+
+    const float current_target = window->ScrollTarget.y < FLT_MAX ?
+                                 window->ScrollTarget.y : window->Scroll.y;
+    const float next_target = std::clamp(
+                                  current_target - finger_delta_y,
+                                  0.0F, window->ScrollMax.y );
+    if( next_target == current_target ) {
+        return false;
+    }
+    ImGui::SetScrollY( window, next_target );
+    return true;
+}
+
+void cataimgui::client::clear_active_item()
 {
     if( ImGui::GetCurrentContext() != nullptr ) {
         ImGui::ClearActiveID();
     }
+}
+
+void cataimgui::client::clear_text_focus()
+{
+    clear_active_item();
 }
 
 static ImGuiKey cata_key_to_imgui( int cata_key )

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -130,6 +130,12 @@ class client
         static bool want_capture_keyboard();
         // True if an ImGui text-entry widget is focused and wants character input.
         static bool want_text_input();
+        // Return the nearest vertically scrollable ImGui window at a display-buffer position.
+        static ImGuiID vertical_scroll_window_at( float x, float y );
+        // Move a captured scroll window by a finger-space delta.
+        static bool scroll_window_y( ImGuiID window_id, float finger_delta_y );
+        // Cancel the active widget without changing the hovered window.
+        static void clear_active_item();
         // Drop the active ImGui item so a focused text widget releases input.
         static void clear_text_focus();
 };

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -112,6 +112,7 @@ std::unique_ptr<cataimgui::client> imclient;
 
     #include "action.h"
     #include "android_hud.h"
+    #include "android_imgui_touch.h"
     #include "input_context_actions.h"
     #include "inventory.h"
     #include "map.h"
@@ -902,7 +903,40 @@ void draw_quick_shortcuts();
 void draw_virtual_joystick();
 
 static bool quick_shortcuts_enabled = true;
-static bool android_imgui_touch_active = false;
+
+enum class android_imgui_tap_phase : int {
+    idle = 0,
+    press,
+    release
+};
+
+struct android_imgui_touch_runtime {
+    android_imgui_touch::gesture gesture;
+    bool captures_touch = false;
+    ImGuiID scroll_window = 0;
+    float pending_scroll_y = 0.0F;
+    float pointer_x = 0.0F;
+    float pointer_y = 0.0F;
+    float touch_slop = 12.0F;
+    std::uint32_t tap_time = 0;
+    std::uint32_t last_frame_time = 0;
+    android_imgui_tap_phase tap_phase = android_imgui_tap_phase::idle;
+    bool frame_pending = false;
+    bool wake_owner_after_frame = false;
+    bool completed_tap_after_frame = false;
+};
+
+static android_imgui_touch_runtime android_imgui_touch_state;
+static constexpr std::uint32_t android_imgui_frame_interval = 16;
+
+static bool android_imgui_fast_frames_requested()
+{
+    return android_ui_mode::is_new_ui_build() &&
+           ( android_imgui_touch_state.captures_touch ||
+             android_imgui_touch_state.frame_pending ||
+             android_imgui_touch_state.gesture.animating() ||
+             android_imgui_touch_state.tap_phase != android_imgui_tap_phase::idle );
+}
 
 static bool android_legacy_shortcuts_enabled()
 {
@@ -1489,7 +1523,13 @@ void refresh_display()
 static void try_sdl_update()
 {
     uint32_t now = GetTicks();
-    if( now - lastupdate >= interval ) {
+    uint32_t effective_interval = interval;
+#if defined(__ANDROID__)
+    if( android_imgui_fast_frames_requested() ) {
+        effective_interval = std::min( effective_interval, android_imgui_frame_interval );
+    }
+#endif
+    if( now - lastupdate >= effective_interval ) {
         refresh_display();
     } else {
         needupdate = true;
@@ -4817,6 +4857,17 @@ static int finger_slot_for( SDL_FingerID id, bool create_if_missing )
     return -1;
 }
 
+static std::uint32_t android_touch_event_time( const SDL_Event &event )
+{
+#if SDL_MAJOR_VERSION >= 3
+    const std::uint64_t timestamp_ms = event.tfinger.timestamp / 1000000ULL;
+#else
+    const std::uint64_t timestamp_ms = event.tfinger.timestamp;
+#endif
+    return timestamp_ms > 0 ? static_cast<std::uint32_t>( timestamp_ms ) :
+           GetTicks();
+}
+
 static void finger_slot_clear( SDL_FingerID id )
 {
     for( int i = 0; i < CATA_MAX_FINGERS; ++i ) {
@@ -4827,35 +4878,209 @@ static void finger_slot_clear( SDL_FingerID id )
     }
 }
 
-static void android_process_imgui_touch( const Uint32 event_type, const float raw_x,
-        const float raw_y )
+static ImVec2 android_imgui_touch_position( const float raw_x, const float raw_y )
+{
+    const SDL_Point position = window_to_display_buffer_coords( SDL_Point{
+        static_cast<int>( std::lround( raw_x ) ), static_cast<int>( std::lround( raw_y ) )
+    } );
+    return ImVec2( static_cast<float>( position.x ), static_cast<float>( position.y ) );
+}
+
+static void android_process_imgui_pointer( const Uint32 event_type, const float x,
+        const float y )
 {
     if( !android_ui_mode::is_new_ui_build() ||
         !imclient || !imclient->any_window_shown() ) {
         return;
     }
-    const SDL_Point position = window_to_display_buffer_coords( SDL_Point{
-        static_cast<int>( std::lround( raw_x ) ), static_cast<int>( std::lround( raw_y ) )
-    } );
     SDL_Event mouse_event{};
     mouse_event.type = event_type;
     if( event_type == CATA_MOUSEMOTION ) {
         mouse_event.motion.windowID = SDL_GetWindowID( ::window.get() );
         mouse_event.motion.which = SDL_TOUCH_MOUSEID;
-        mouse_event.motion.x = position.x;
-        mouse_event.motion.y = position.y;
+        mouse_event.motion.x = x;
+        mouse_event.motion.y = y;
     } else {
         mouse_event.button.windowID = SDL_GetWindowID( ::window.get() );
         mouse_event.button.which = SDL_TOUCH_MOUSEID;
         mouse_event.button.button = SDL_BUTTON_LEFT;
         mouse_event.button.clicks = 1;
-        mouse_event.button.x = position.x;
-        mouse_event.button.y = position.y;
+        mouse_event.button.x = x;
+        mouse_event.button.y = y;
     }
     int buffer_width = 0;
     int buffer_height = 0;
     get_display_buffer_dims( &buffer_width, &buffer_height );
     imclient->process_input( &mouse_event, buffer_width, buffer_height );
+}
+
+static float android_imgui_touch_slop()
+{
+    const float native_touch_slop = 8.0F *
+                                    std::max( 1.0F, android_get_display_density() );
+    if( ImGui::GetCurrentContext() == nullptr ) {
+        return native_touch_slop;
+    }
+    return std::max( native_touch_slop,
+                     ImGui::GetIO().MouseDragThreshold * 2.0F );
+}
+
+static void android_request_imgui_touch_frame()
+{
+    android_imgui_touch_state.frame_pending = true;
+    needupdate = true;
+}
+
+static void android_cancel_imgui_touch()
+{
+    const bool pointer_is_down = android_imgui_touch_state.gesture.pointer_is_down() ||
+                                 android_imgui_touch_state.tap_phase ==
+                                 android_imgui_tap_phase::release;
+    if( pointer_is_down ) {
+        cataimgui::client::clear_active_item();
+        android_process_imgui_pointer( CATA_MOUSEMOTION,
+                                       android_imgui_touch_state.pointer_x,
+                                       android_imgui_touch_state.pointer_y );
+        android_process_imgui_pointer( CATA_MOUSEBUTTONUP,
+                                       android_imgui_touch_state.pointer_x,
+                                       android_imgui_touch_state.pointer_y );
+        android_request_imgui_touch_frame();
+    }
+
+    android_imgui_touch_state.gesture.cancel();
+    android_imgui_touch_state.captures_touch = false;
+    android_imgui_touch_state.scroll_window = 0;
+    android_imgui_touch_state.pending_scroll_y = 0.0F;
+    android_imgui_touch_state.tap_phase = android_imgui_tap_phase::idle;
+    android_imgui_touch_state.frame_pending = pointer_is_down;
+    android_imgui_touch_state.wake_owner_after_frame = false;
+    android_imgui_touch_state.completed_tap_after_frame = false;
+}
+
+static void android_service_imgui_touch( const std::uint32_t now )
+{
+    if( !android_ui_mode::is_new_ui_build() || !imclient ||
+        !imclient->any_window_shown() ) {
+        android_imgui_touch_state.gesture.cancel();
+        android_imgui_touch_state.captures_touch = false;
+        android_imgui_touch_state.scroll_window = 0;
+        android_imgui_touch_state.pending_scroll_y = 0.0F;
+        android_imgui_touch_state.tap_phase = android_imgui_tap_phase::idle;
+        android_imgui_touch_state.frame_pending = false;
+        android_imgui_touch_state.wake_owner_after_frame = false;
+        android_imgui_touch_state.completed_tap_after_frame = false;
+        return;
+    }
+
+    const bool animation_pending = android_imgui_touch_state.gesture.animating();
+    const bool tap_pending = android_imgui_touch_state.tap_phase !=
+                             android_imgui_tap_phase::idle;
+    if( !android_imgui_touch_state.frame_pending && !animation_pending && !tap_pending ) {
+        return;
+    }
+    if( now - android_imgui_touch_state.last_frame_time <
+        android_imgui_frame_interval ) {
+        needupdate = true;
+        return;
+    }
+
+    android_imgui_touch_state.last_frame_time = now;
+    bool keep_animating = false;
+    if( animation_pending ) {
+        const android_imgui_touch::animation_result animation =
+            android_imgui_touch_state.gesture.animate( now );
+        android_imgui_touch_state.pending_scroll_y += animation.scroll_delta_y;
+        keep_animating = animation.active;
+    }
+
+    if( android_imgui_touch_state.pending_scroll_y != 0.0F ) {
+        const bool moved = cataimgui::client::scroll_window_y(
+                               android_imgui_touch_state.scroll_window,
+                               android_imgui_touch_state.pending_scroll_y );
+        android_imgui_touch_state.pending_scroll_y = 0.0F;
+        if( !moved && android_imgui_touch_state.gesture.animating() ) {
+            android_imgui_touch_state.gesture.stop_inertia();
+            keep_animating = false;
+        }
+    }
+
+    const android_imgui_tap_phase tap_phase = android_imgui_touch_state.tap_phase;
+    android_imgui_touch_state.frame_pending = false;
+    if( tap_phase == android_imgui_tap_phase::press ) {
+        android_process_imgui_pointer( CATA_MOUSEMOTION,
+                                       android_imgui_touch_state.pointer_x,
+                                       android_imgui_touch_state.pointer_y );
+        android_process_imgui_pointer( CATA_MOUSEBUTTONDOWN,
+                                       android_imgui_touch_state.pointer_x,
+                                       android_imgui_touch_state.pointer_y );
+        android_imgui_touch_state.tap_phase = android_imgui_tap_phase::release;
+        android_imgui_touch_state.frame_pending = true;
+    } else if( tap_phase == android_imgui_tap_phase::release ) {
+        android_process_imgui_pointer( CATA_MOUSEBUTTONUP,
+                                       android_imgui_touch_state.pointer_x,
+                                       android_imgui_touch_state.pointer_y );
+        android_imgui_touch_state.tap_phase = android_imgui_tap_phase::idle;
+        android_imgui_touch_state.wake_owner_after_frame = true;
+        android_imgui_touch_state.completed_tap_after_frame = true;
+    }
+
+    ui_manager::redraw_invalidated();
+    needupdate = true;
+    android_imgui_touch_state.frame_pending |= keep_animating;
+
+    if( android_imgui_touch_state.wake_owner_after_frame &&
+        last_input.type == input_event_t::error ) {
+        android_imgui_touch_state.wake_owner_after_frame = false;
+        if( android_imgui_touch_state.completed_tap_after_frame &&
+            last_tap_time > 0 &&
+            android_imgui_touch_state.tap_time - last_tap_time <
+            static_cast<std::uint32_t>( get_option<int>( "ANDROID_INITIAL_DELAY" ) ) ) {
+            last_input = input_event( KEY_ESCAPE, input_event_t::keyboard_char );
+            last_tap_time = 0;
+        } else {
+            last_input.type = input_event_t::timeout;
+            if( android_imgui_touch_state.completed_tap_after_frame ) {
+                last_tap_time = android_imgui_touch_state.tap_time;
+            }
+        }
+        android_imgui_touch_state.completed_tap_after_frame = false;
+    }
+}
+
+static void android_apply_imgui_motion(
+    const android_imgui_touch::motion_result &motion )
+{
+    bool pointer_event = false;
+    if( motion.cancel_pointer_drag ) {
+        cataimgui::client::clear_active_item();
+        android_process_imgui_pointer( CATA_MOUSEMOTION,
+                                       android_imgui_touch_state.pointer_x,
+                                       android_imgui_touch_state.pointer_y );
+        android_process_imgui_pointer( CATA_MOUSEBUTTONUP,
+                                       android_imgui_touch_state.pointer_x,
+                                       android_imgui_touch_state.pointer_y );
+        pointer_event = true;
+    } else if( motion.begin_pointer_drag ) {
+        android_process_imgui_pointer( CATA_MOUSEMOTION,
+                                       android_imgui_touch_state.pointer_x,
+                                       android_imgui_touch_state.pointer_y );
+        android_process_imgui_pointer( CATA_MOUSEBUTTONDOWN,
+                                       android_imgui_touch_state.pointer_x,
+                                       android_imgui_touch_state.pointer_y );
+        pointer_event = true;
+    } else if( android_imgui_touch_state.gesture.mode() ==
+               android_imgui_touch::gesture_mode::pointer_drag ) {
+        android_process_imgui_pointer( CATA_MOUSEMOTION,
+                                       android_imgui_touch_state.pointer_x,
+                                       android_imgui_touch_state.pointer_y );
+        pointer_event = true;
+    }
+
+    android_imgui_touch_state.pending_scroll_y += motion.scroll_delta_y;
+    if( pointer_event || motion.begin_vertical_scroll ||
+        motion.scroll_delta_y != 0.0F ) {
+        android_request_imgui_touch_frame();
+    }
 }
 
 // Quick shortcuts container: maps the touch input context category (std::string) to a std::list of input_events.
@@ -5845,6 +6070,9 @@ static void CheckMessages()
         touch_input_context = *new_input_context;
         touch_input_context_owner = new_input_context;
         if( owner_changed || category_changed ) {
+            if( android_ui_mode::is_new_ui_build() ) {
+                android_cancel_imgui_touch();
+            }
             // A tap that opened a new screen must not become the first half of a
             // double-tap gesture inside that new input context.
             last_tap_time = 0;
@@ -6069,7 +6297,7 @@ static void CheckMessages()
         }
 
         // Handle repeating inputs from touch + holds
-        if( !android_imgui_touch_active && !is_quick_shortcut_touch &&
+        if( !android_imgui_touch_state.captures_touch && !is_quick_shortcut_touch &&
             !is_two_finger_touch && !is_three_finger_touch &&
             finger_down_time > 0 &&
             ticks - finger_down_time > static_cast<uint32_t>
@@ -6137,6 +6365,10 @@ static void CheckMessages()
     last_input = input_event();
 #if defined(__ANDROID__)
     last_input_has_explicit_mouse_pos = false;
+    android_service_imgui_touch( ticks );
+    if( last_input.type != input_event_t::error ) {
+        return;
+    }
     if( android_legacy_shortcuts_enabled() && pop_extra_button_input( last_input ) ) {
         text_refresh = true;
         return;
@@ -6537,18 +6769,32 @@ static void CheckMessages()
                 case CATA_FINGERMOTION: {
                     const int slot = finger_slot_for( GetFingerID( ev ), false );
                     if( slot == 0 ) {
-                        if( !is_quick_shortcut_touch ) {
-                            update_finger_repeat_delay();
-                        }
-                        needupdate = true; // ensure virtual joystick and quick shortcuts redraw as we interact
-                        ui_manager::redraw_invalidated();
                         finger_curr_x = GetFingerX( ev, WindowWidth );
                         finger_curr_y = GetFingerY( ev, WindowHeight );
-                        if( android_imgui_touch_active ) {
-                            android_process_imgui_touch( CATA_MOUSEMOTION, finger_curr_x, finger_curr_y );
+                        if( android_imgui_touch_state.captures_touch ) {
+                            const ImVec2 position = android_imgui_touch_position(
+                                                        finger_curr_x, finger_curr_y );
+                            android_imgui_touch_state.pointer_x = position.x;
+                            android_imgui_touch_state.pointer_y = position.y;
+                            const android_imgui_touch::motion_result motion =
+                                android_imgui_touch_state.gesture.move(
+                                    position.x, position.y,
+                                    android_touch_event_time( ev ),
+                                    android_imgui_touch_state.touch_slop,
+                                    android_imgui_touch_state.scroll_window != 0 );
+                            android_apply_imgui_motion( motion );
+                        } else {
+                            if( !is_quick_shortcut_touch ) {
+                                update_finger_repeat_delay();
+                            }
+                            // Legacy joystick and shortcut overlays still redraw while
+                            // moving. New UI ImGui touches are coalesced below instead.
+                            needupdate = true;
+                            ui_manager::redraw_invalidated();
                         }
 
-                        if( get_option<bool>( "ANDROID_VIRTUAL_JOYSTICK_FOLLOW" ) && !is_two_finger_touch &&
+                        if( !android_imgui_touch_state.captures_touch &&
+                            get_option<bool>( "ANDROID_VIRTUAL_JOYSTICK_FOLLOW" ) && !is_two_finger_touch &&
                             !is_three_finger_touch ) {
                             // If we've moved too far from joystick center, offset joystick center automatically
                             float delta_x = finger_curr_x - finger_down_x;
@@ -6579,8 +6825,9 @@ static void CheckMessages()
                     }
                     break;
                 }
-                case CATA_FINGERDOWN:
-                    if( finger_slot_for( GetFingerID( ev ), true ) == 0 ) {
+                case CATA_FINGERDOWN: {
+                    const int slot = finger_slot_for( GetFingerID( ev ), true );
+                    if( slot == 0 ) {
                         finger_down_x = finger_curr_x = GetFingerX( ev, WindowWidth );
                         finger_down_y = finger_curr_y = GetFingerY( ev, WindowHeight );
                         finger_down_time = ticks;
@@ -6590,20 +6837,35 @@ static void CheckMessages()
                         if( !is_quick_shortcut_touch ) {
                             update_finger_repeat_delay();
                         }
-                        android_imgui_touch_active = android_ui_mode::is_new_ui_build() &&
-                                                     imclient && imclient->any_window_shown();
-                        if( android_imgui_touch_active ) {
-                            android_process_imgui_touch( CATA_MOUSEMOTION, finger_curr_x, finger_curr_y );
-                            android_process_imgui_touch( CATA_MOUSEBUTTONDOWN, finger_curr_x, finger_curr_y );
+                        const bool capture_imgui = android_ui_mode::is_new_ui_build() &&
+                                                   imclient && imclient->any_window_shown();
+                        if( capture_imgui ) {
+                            android_cancel_imgui_touch();
+                            const ImVec2 position = android_imgui_touch_position(
+                                                        finger_curr_x, finger_curr_y );
+                            android_imgui_touch_state.captures_touch = true;
+                            android_imgui_touch_state.pointer_x = position.x;
+                            android_imgui_touch_state.pointer_y = position.y;
+                            android_imgui_touch_state.touch_slop =
+                                android_imgui_touch_slop();
+                            android_imgui_touch_state.scroll_window =
+                                cataimgui::client::vertical_scroll_window_at(
+                                    position.x, position.y );
+                            android_imgui_touch_state.gesture.press(
+                                position.x, position.y,
+                                android_touch_event_time( ev ) );
+                            // Hit testing used the explicit touch position above.
+                            // Do not hover or press a widget until this gesture is
+                            // known to be a tap or a control drag.
+                        } else {
+                            ui_manager::redraw_invalidated();
+                            // Ensure virtual joystick and quick shortcuts redraw.
+                            needupdate = true;
                         }
-                        ui_manager::redraw_invalidated();
-                        needupdate = true; // ensure virtual joystick and quick shortcuts redraw as we interact
-                    } else if( finger_slot_for( GetFingerID( ev ), true ) == 1 ) {
+                    } else if( slot == 1 ) {
                         if( !is_quick_shortcut_touch ) {
-                            if( android_imgui_touch_active ) {
-                                android_process_imgui_touch( CATA_MOUSEBUTTONUP, finger_curr_x,
-                                                             finger_curr_y );
-                                android_imgui_touch_active = false;
+                            if( android_imgui_touch_state.captures_touch ) {
+                                android_cancel_imgui_touch();
                             }
                             second_finger_down_x = second_finger_curr_x = GetFingerX( ev, WindowWidth );
                             second_finger_down_y = second_finger_curr_y = GetFingerY( ev, WindowHeight );
@@ -6612,7 +6874,7 @@ static void CheckMessages()
                                 android_begin_pinch_zoom();
                             }
                         }
-                    } else if( finger_slot_for( GetFingerID( ev ), true ) == 2 ) {
+                    } else if( slot == 2 ) {
                         if( !is_quick_shortcut_touch ) {
                             third_finger_down_x = third_finger_curr_x = GetFingerX( ev, WindowWidth );
                             third_finger_down_y = third_finger_curr_y = GetFingerY( ev, WindowHeight );
@@ -6624,28 +6886,51 @@ static void CheckMessages()
                         }
                     }
                     break;
+                }
                 case CATA_FINGERUP: {
                     const int slot = finger_slot_for( GetFingerID( ev ), false );
                     if( slot == 0 ) {
                         finger_curr_x = GetFingerX( ev, WindowWidth );
                         finger_curr_y = GetFingerY( ev, WindowHeight );
-                        if( android_imgui_touch_active ) {
-                            android_process_imgui_touch( CATA_MOUSEMOTION, finger_curr_x, finger_curr_y );
-                            android_process_imgui_touch( CATA_MOUSEBUTTONUP, finger_curr_x, finger_curr_y );
-                            if( last_tap_time > 0 &&
-                                ticks - last_tap_time < static_cast<uint32_t>(
-                                    get_option<int>( "ANDROID_INITIAL_DELAY" ) ) ) {
-                                // ImGui windows consume touch as synthetic mouse events and
-                                // bypass the regular menu gesture branch below.  Preserve the
-                                // same double-tap Back gesture for dialogs such as keybindings.
-                                last_input = input_event( KEY_ESCAPE,
-                                                          input_event_t::keyboard_char );
-                                last_tap_time = 0;
-                            } else {
-                                // Wake the owning ImGui loop so it can draw the click result.
-                                last_input.type = input_event_t::timeout;
-                                last_tap_time = ticks;
+                        const bool imgui_touch = android_imgui_touch_state.captures_touch;
+                        if( imgui_touch ) {
+                            const ImVec2 position = android_imgui_touch_position(
+                                                        finger_curr_x, finger_curr_y );
+                            android_imgui_touch_state.pointer_x = position.x;
+                            android_imgui_touch_state.pointer_y = position.y;
+                            const android_imgui_touch::release_result released =
+                                android_imgui_touch_state.gesture.release(
+                                    position.x, position.y,
+                                    android_touch_event_time( ev ),
+                                    android_imgui_touch_state.touch_slop,
+                                    android_imgui_touch_state.scroll_window != 0 );
+
+                            // A drag first detected by the release event has no
+                            // useful down frame and must not turn into a click.
+                            android_imgui_touch::motion_result final_motion =
+                                released.motion;
+                            const bool pointer_started_on_release =
+                                final_motion.begin_pointer_drag;
+                            final_motion.begin_pointer_drag = false;
+                            android_apply_imgui_motion( final_motion );
+
+                            if( released.tap ) {
+                                android_imgui_touch_state.tap_time = ticks;
+                                android_imgui_touch_state.tap_phase =
+                                    android_imgui_tap_phase::press;
+                                android_imgui_touch_state.completed_tap_after_frame = false;
+                                android_request_imgui_touch_frame();
+                            } else if( released.release_pointer &&
+                                       !pointer_started_on_release ) {
+                                android_process_imgui_pointer( CATA_MOUSEMOTION,
+                                                               position.x, position.y );
+                                android_process_imgui_pointer( CATA_MOUSEBUTTONUP,
+                                                               position.x, position.y );
+                                android_imgui_touch_state.wake_owner_after_frame = true;
+                                android_imgui_touch_state.completed_tap_after_frame = false;
+                                android_request_imgui_touch_frame();
                             }
+                            android_imgui_touch_state.captures_touch = false;
                         } else if( is_quick_shortcut_touch ) {
                             input_event *quick_shortcut = get_quick_shortcut_under_finger();
                             if( quick_shortcut ) {
@@ -6856,10 +7141,14 @@ static void CheckMessages()
                         pinch_zoom_handled = false;
                         finger_down_time = 0;
                         finger_repeat_time = 0;
-                        android_imgui_touch_active = false;
-                        // ensure virtual joystick and quick shortcuts are updated properly
-                        android_request_repaint();
-                        refresh_display(); // as above, but actually redraw it now as well
+                        if( imgui_touch ) {
+                            android_request_imgui_touch_frame();
+                        } else {
+                            // Ensure legacy virtual joystick and shortcuts are
+                            // updated and presented immediately.
+                            android_request_repaint();
+                            refresh_display();
+                        }
                     } else if( slot == 1 ) {
                         if( is_two_finger_touch ) {
                             // on second finger release, just remember the x/y position so we can calculate delta once first finger is done
@@ -6898,6 +7187,9 @@ static void CheckMessages()
             break;
         }
     }
+#if defined(__ANDROID__)
+    android_service_imgui_touch( GetTicks() );
+#endif
     if( needupdate ) {
         try_sdl_update();
     }

--- a/tests/android_imgui_touch_test.cpp
+++ b/tests/android_imgui_touch_test.cpp
@@ -1,0 +1,127 @@
+#include "catch/catch.hpp"
+
+#include "android_imgui_touch.h"
+
+#include <cmath>
+
+using android_imgui_touch::gesture;
+using android_imgui_touch::gesture_mode;
+
+TEST_CASE( "android_imgui_touch_tap_waits_for_release", "[android][imgui][touch]" )
+{
+    gesture input;
+    input.press( 100.0F, 200.0F, 0 );
+
+    CHECK( input.mode() == gesture_mode::pending );
+    CHECK( input.touching() );
+
+    const android_imgui_touch::release_result released =
+        input.release( 104.0F, 203.0F, 40, 12.0F, true );
+    CHECK( released.tap );
+    CHECK_FALSE( released.release_pointer );
+    CHECK( input.mode() == gesture_mode::idle );
+}
+
+TEST_CASE( "android_imgui_touch_vertical_drag_becomes_scroll", "[android][imgui][touch]" )
+{
+    gesture input;
+    input.press( 100.0F, 200.0F, 0 );
+
+    const android_imgui_touch::motion_result below_slop =
+        input.move( 103.0F, 207.0F, 8, 12.0F, true );
+    CHECK_FALSE( below_slop.begin_vertical_scroll );
+    CHECK( below_slop.scroll_delta_y == 0.0F );
+
+    const android_imgui_touch::motion_result scrolling =
+        input.move( 104.0F, 220.0F, 16, 12.0F, true );
+    CHECK( scrolling.begin_vertical_scroll );
+    CHECK( scrolling.scroll_delta_y == 13.0F );
+    CHECK( input.mode() == gesture_mode::vertical_scroll );
+
+    const android_imgui_touch::release_result released =
+        input.release( 104.0F, 228.0F, 24, 12.0F, true );
+    CHECK_FALSE( released.tap );
+    CHECK( input.animating() );
+}
+
+TEST_CASE( "android_imgui_touch_preserves_pointer_drags", "[android][imgui][touch]" )
+{
+    gesture input;
+    input.press( 100.0F, 200.0F, 0 );
+
+    const android_imgui_touch::motion_result horizontal =
+        input.move( 120.0F, 203.0F, 16, 12.0F, true );
+    CHECK( horizontal.begin_pointer_drag );
+    CHECK( input.pointer_is_down() );
+
+    const android_imgui_touch::release_result released =
+        input.release( 126.0F, 204.0F, 32, 12.0F, true );
+    CHECK( released.release_pointer );
+    CHECK_FALSE( released.tap );
+}
+
+TEST_CASE( "android_imgui_touch_does_not_scroll_non_scrollable_window",
+           "[android][imgui][touch]" )
+{
+    gesture input;
+    input.press( 100.0F, 200.0F, 0 );
+
+    const android_imgui_touch::motion_result motion =
+        input.move( 102.0F, 224.0F, 16, 12.0F, false );
+    CHECK( motion.begin_pointer_drag );
+    CHECK_FALSE( motion.begin_vertical_scroll );
+}
+
+TEST_CASE( "android_imgui_touch_inertia_decelerates", "[android][imgui][touch]" )
+{
+    gesture input;
+    input.press( 100.0F, 200.0F, 0 );
+    input.move( 100.0F, 220.0F, 16, 12.0F, true );
+    input.move( 100.0F, 240.0F, 32, 12.0F, true );
+    input.release( 100.0F, 248.0F, 40, 12.0F, true );
+    REQUIRE( input.animating() );
+
+    const android_imgui_touch::animation_result first = input.animate( 56 );
+    const android_imgui_touch::animation_result second = input.animate( 72 );
+    CHECK( first.active );
+    CHECK( second.active );
+    CHECK( std::abs( second.scroll_delta_y ) < std::abs( first.scroll_delta_y ) );
+
+    std::uint32_t now = 72;
+    for( int frame = 0; frame < 180 && input.animating(); ++frame ) {
+        now += 16;
+        input.animate( now );
+    }
+    CHECK_FALSE( input.animating() );
+}
+
+TEST_CASE( "android_imgui_touch_does_not_fling_after_a_pause",
+           "[android][imgui][touch]" )
+{
+    gesture input;
+    input.press( 100.0F, 200.0F, 0 );
+    input.move( 100.0F, 220.0F, 16, 12.0F, true );
+    input.move( 100.0F, 240.0F, 32, 12.0F, true );
+
+    const android_imgui_touch::release_result released =
+        input.release( 100.0F, 240.0F, 200, 12.0F, true );
+    CHECK_FALSE( released.tap );
+    CHECK_FALSE( input.animating() );
+}
+
+TEST_CASE( "android_imgui_touch_can_change_from_control_drag_to_scroll",
+           "[android][imgui][touch]" )
+{
+    gesture input;
+    input.press( 100.0F, 200.0F, 0 );
+
+    const android_imgui_touch::motion_result horizontal =
+        input.move( 120.0F, 204.0F, 16, 12.0F, true );
+    REQUIRE( horizontal.begin_pointer_drag );
+
+    const android_imgui_touch::motion_result vertical =
+        input.move( 122.0F, 232.0F, 32, 12.0F, true );
+    CHECK( vertical.cancel_pointer_drag );
+    CHECK( vertical.begin_vertical_scroll );
+    CHECK( input.mode() == gesture_mode::vertical_scroll );
+}


### PR DESCRIPTION
## 概要

- 新增独立、可测试的 Android ImGui 触控手势状态机，区分点击、控件拖动、纵向滚动和惯性阶段。
- 触点按下时不再立即激活按钮；只有抬手确认点击，超过 Android 风格触控阈值后才进入拖动或滚动。
- 捕获落指位置的 ImGui 滚动窗口，并按窗口 ID 定向更新滚动，避免滑动过程中串到其他子窗口。
- 将连续手指移动事件合并到约 16 ms 一帧，并加入速度采样、指数衰减和边界停止，改善 Android New UI 页面卡顿。
- 保留滑块、调色盘和横向交互需要的 pointer drag；普通 Android flavor 的旧触控逻辑保持不变。

## 根因

此前每个 `FINGERMOTION` 都会立即重建一次完整 ImGui 帧，但同一事件批次中的大部分帧不会呈现；同时显示刷新使用 25 ms 间隔，最高约 40 FPS。`FINGERDOWN` 还会立刻注入 mouse-down，导致玩家本想滚动时按钮已经进入激活状态。各页面自行实现的拖动逻辑也没有统一的惯性和点击取消机制。

## 实现与隔离

本 PR 在底层统一处理 New UI 触控：

1. 纯 C++ 手势状态机负责方向判定、触控阈值、速度和惯性。
2. ImGui 宿主提供按坐标捕获滚动窗口、按 ID 滚动和取消活动控件的最小接口。
3. SDL Android 输入层负责事件合帧、两帧派发抬手点击和 60 FPS 呈现。

入口均受 `android_ui_mode::is_new_ui_build()` 限制；普通 Android x64/x32 构建继续使用现有行为。

## 验证

- Android ImGui 触控测试：7 个用例、29 个断言全部通过。
- `astyle`：相关文件均无需重新格式化。
- `git diff --check`：通过。
- `assembleNewUiRelease`：Android arm64-v8a Release 构建成功。
- APK 架构检查：只包含 `lib/arm64-v8a/libmain.so`。
- 已在 arm64 真机 `PLC110` 上完成 New UI APK 安装验证。