### PR TITLE
Airships: show maximum lift and block cross-z pulls

### DIFF
--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -521,6 +521,18 @@ void melee_actor::load_internal( const JsonObject &obj, const std::string & )
     }
 }
 
+static bool target_is_on_airborne_vehicle_or_ladder( const map &here,
+        const tripoint_bub_ms &target_pos )
+{
+    if( const optional_vpart_position vp = here.veh_at( target_pos ) ) {
+        return vp->vehicle().is_flying_in_air();
+    }
+    if( const std::optional<vpart_reference> ladder = here.vehicle_ladder_at( target_pos ) ) {
+        return ladder->vehicle().is_flying_in_air();
+    }
+    return false;
+}
+
 Creature *melee_actor::find_target( monster &z ) const
 {
     const map &here = get_map();
@@ -532,6 +544,17 @@ Creature *melee_actor::find_target( monster &z ) const
     Creature *target = z.attack_target();
 
     if( target == nullptr || ( no_adjacent && z.is_adjacent( target, false ) ) ) {
+        return nullptr;
+    }
+
+    // Pulling a target laterally from another z-level can move them off an
+    // airborne deck or its hanging ladder, after which gravity drops them to
+    // the attacker.  Ground creatures must not be able to pull occupants or
+    // climbers out of a flying vehicle this way.
+    const bool repositions_target = is_grab &&
+                                    ( grab_data.pull_chance > -1 || grab_data.drag_distance > 0 );
+    if( repositions_target && z.posz() != target->posz() &&
+        target_is_on_airborne_vehicle_or_ladder( here, target->pos_bub( here ) ) ) {
         return nullptr;
     }
 

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -2832,6 +2832,16 @@ void veh_interact::display_stats( map &here ) const
                     _( "Mass: <color_light_blue>%5.0f</color> %s" ),
                     convert_weight( veh->total_mass( here ) ), weight_units() );
     i += 1;
+    if( !veh->balloons.empty() ) {
+        // total_balloon_lift() is expressed in newtons.  Convert it back to the
+        // equivalent supported mass so it can use the player's weight units.
+        const units::mass maximum_lift =
+            units::from_kilogram( veh->total_balloon_lift() / 9.8 );
+        fold_and_print( *win[i], point( 0, row[i] ), getmaxx( *win[i] ), c_light_gray,
+                        _( "Maximum Lift: <color_light_blue>%5.0f</color> %s" ),
+                        convert_weight( maximum_lift ), weight_units() );
+        i += 1;
+    }
     fold_and_print( *win[i], point( 0, row[i] ), getmaxx( *win[i] ), c_light_gray,
                     disp_w > 35 ? _( "Cargo volume: <color_light_blue>%s</color> / <color_light_blue>%s</color> %s" ) :
                     _( "Cargo: <color_light_blue>%s</color> / <color_light_blue>%s</color> %s" ),

--- a/tests/monster_attack_test.cpp
+++ b/tests/monster_attack_test.cpp
@@ -29,6 +29,8 @@
 #include "test_statistics.h"
 #include "type_id.h"
 #include "units.h"
+#include "veh_type.h"
+#include "vehicle.h"
 #include "weather.h"
 #include "weather_type.h"
 
@@ -42,6 +44,10 @@ static const json_character_flag json_flag_TOUGH_FEET( "TOUGH_FEET" );
 static const matype_id style_brawling( "style_brawling" );
 static const skill_id skill_unarmed( "unarmed" );
 static const trait_id trait_TOUGH_FEET( "TOUGH_FEET" );
+
+static const vpart_id vpart_aisle( "aisle" );
+static const vpart_id vpart_ladder_3( "ladder_3" );
+static const vproto_id vehicle_prototype_test_turret_rig( "test_turret_rig" );
 
 static constexpr tripoint_bub_ms attacker_location{ 65, 65, 0 };
 
@@ -409,6 +415,62 @@ TEST_CASE( "Ranged_pull_tests", "[mattack][grab]" )
         }
         REQUIRE( counter < 100 );
     }
+}
+
+TEST_CASE( "ranged_pull_cannot_drag_targets_from_airborne_vehicle_ladders",
+           "[mattack][grab][vehicle][zlevel]" )
+{
+    clear_map_without_vision();
+    clear_creatures();
+    clear_avatar();
+    map &here = get_map();
+    build_test_map( ter_id( "t_pavement" ) );
+    for( const tripoint_bub_ms &p : here.points_on_zlevel( 1 ) ) {
+        here.ter_set( p, ter_id( "t_open_air" ) );
+    }
+    here.invalidate_map_cache( 1 );
+    here.build_map_cache( 1, true );
+
+    const tripoint_bub_ms vehicle_pos( 60, 60, 1 );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_test_turret_rig, vehicle_pos,
+                                     0_degrees, 0, veh_spawn_status::PRISTINE,
+                                     false, true );
+    REQUIRE( veh != nullptr );
+    REQUIRE( veh->install_part( here, point_rel_ms::zero, vpart_aisle ) >= 0 );
+    REQUIRE( veh->install_part( here, point_rel_ms::zero, vpart_ladder_3 ) >= 0 );
+    veh->refresh();
+    veh->set_flying( true );
+
+    Character &you = get_player_character();
+    // board_vehicle() keeps the avatar on the map's current z-level.  Make the
+    // airborne level current so the fixture cannot silently move the target
+    // back to ground level while boarding.
+    here.vertical_shift( vehicle_pos.z() );
+    you.setpos( here, vehicle_pos );
+    here.board_vehicle( vehicle_pos, &you );
+    REQUIRE( you.in_vehicle );
+    REQUIRE( you.pos_bub() == vehicle_pos );
+
+    const tripoint_bub_ms puller_pos = vehicle_pos + tripoint( -1, 0, -1 );
+    monster &puller = spawn_test_monster( "mon_debug_puller_strong", puller_pos );
+    puller.set_dest( you.pos_abs() );
+    reset_caches( puller_pos.z(), vehicle_pos.z() );
+    REQUIRE( you.pos_bub() == vehicle_pos );
+    REQUIRE( here.veh_at( you.pos_bub() ) );
+    REQUIRE( &here.veh_at( you.pos_bub() )->vehicle() == veh );
+    REQUIRE( veh->is_flying_in_air() );
+    REQUIRE( puller.sees( here, you ) );
+
+    const mattack_actor &attack =
+        *puller.type->special_attacks.at( "ranged_pull" );
+    CHECK_FALSE( attack.call( puller ) );
+    CHECK( you.pos_bub() == vehicle_pos );
+    CHECK( you.in_vehicle );
+
+    here.unboard_vehicle( you.pos_bub() );
+    here.destroy_vehicle( veh );
+    here.vertical_shift( 0 );
+    you.setpos( here, tripoint_bub_ms( 60, 60, 0 ) );
 }
 
 TEST_CASE( "Grab_drag_tests", "[mattack][grab][drag]" )


### PR DESCRIPTION
## What changed

- Show **Maximum Lift** in the vehicle interaction stats for vehicles with balloons, using the player's configured weight units.
- Prevent grab attacks that reposition a target across Z-levels from pulling occupants off a flying vehicle or its hanging ladder.

## Why

Airship load capacity was not visible in the vehicle UI, and ground-level pull attacks could drag occupants or climbers off an airborne airship.

## Validation

- `make -j12 tests`
- `ranged_pull_cannot_drag_targets_from_airborne_vehicle_ladders` passed
- Modified C++ files pass the project's astyle dry run
- `git diff --check`

The targeted test runner still reports the two pre-existing `t_nanoforge(_body)` / `cable` data errors from current `master`; the selected tests themselves pass.