### PR TITLE
Fix automatic vehicle turret targeting across Z-levels

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -803,27 +803,29 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
             // can't see nor sense it
             if( is_fake() && in_veh ) {
                 // If turret in the vehicle then
-                // Hack: trying yo avoid turret LOS blocking by frames bug by trying to see target from vehicle boundary
-                // Or turret wallhack for turret's car
-                // TODO: to visibility checking another way, probably using 3D FOV
-                std::vector<tripoint_bub_ms> path_to_target = line_to( pos_bub( here ), m->pos_bub( here ) );
-                path_to_target.insert( path_to_target.begin(), pos_bub( here ) );
+                // Hack: avoid the turret's own deck and frames blocking its
+                // targeting NPC by checking visibility from the vehicle edge.
+                // TODO: replace this workaround with 3D FOV.
+                const tripoint_bub_ms turret_pos = pos_bub( here );
+                std::vector<tripoint_bub_ms> path_to_target =
+                    line_to( turret_pos, m->pos_bub( here ) );
+                path_to_target.insert( path_to_target.begin(), turret_pos );
 
-                // Getting point on vehicle boundaries and on line between target and turret
-                bool continueFlag = true;
-                do {
+                while( !path_to_target.empty() ) {
                     const optional_vpart_position vp = here.veh_at( path_to_target.back() );
                     vehicle *const veh = vp ? &vp->vehicle() : nullptr;
                     if( in_veh == veh ) {
-                        continueFlag = false;
-                    } else {
-                        path_to_target.pop_back();
+                        break;
                     }
-                } while( continueFlag );
+                    path_to_target.pop_back();
+                }
+                if( path_to_target.empty() ) {
+                    continue;
+                }
 
-                tripoint_bub_ms oldPos = pos_bub( here );
+                const tripoint_bub_ms oldPos = turret_pos;
                 setpos( here, path_to_target.back() ); //Temporary moving targeting npc on vehicle boundary position
-                bool seesFromVehBound = sees( here, *m ); // And look from there
+                const bool seesFromVehBound = sees( here, *m ); // And look from there
                 setpos( here, oldPos );
                 if( !seesFromVehBound ) {
                     continue;

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -805,10 +805,14 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
                 // If turret in the vehicle then
                 // Hack: avoid the turret's own deck and frames blocking its
                 // targeting NPC by checking visibility from the vehicle edge.
-                // TODO: replace this workaround with 3D FOV.
+                // Find that edge in the turret's horizontal plane.  A 3D ray
+                // can change z before leaving a wide vehicle, causing it to
+                // mistake an interior tile for the boundary when targeting
+                // creatures above or below the turret.
                 const tripoint_bub_ms turret_pos = pos_bub( here );
+                const tripoint_bub_ms projected_target( m->pos_bub( here ).xy(), turret_pos.z() );
                 std::vector<tripoint_bub_ms> path_to_target =
-                    line_to( turret_pos, m->pos_bub( here ) );
+                    line_to( turret_pos, projected_target );
                 path_to_target.insert( path_to_target.begin(), turret_pos );
 
                 while( !path_to_target.empty() ) {

--- a/tests/vehicle_turrets_test.cpp
+++ b/tests/vehicle_turrets_test.cpp
@@ -9,12 +9,16 @@
 #include "character.h"
 #include "character_attire.h"
 #include "coordinates.h"
+#include "creature.h"
 #include "enums.h"
 #include "explosion.h"
+#include "game.h"
 #include "item.h"
 #include "itype.h"
 #include "map.h"
 #include "map_helpers.h"
+#include "map_helpers_tests.h"
+#include "monster.h"
 #include "player_helpers.h"
 #include "pocket_type.h"
 #include "point.h"
@@ -37,6 +41,7 @@ static const itype_id itype_backpack( "backpack" );
 static const itype_id itype_gasoline( "gasoline" );
 static const itype_id itype_glockmag( "glockmag" );
 
+static const vpart_id vpart_aisle( "aisle" );
 static const vpart_id vpart_frame( "frame" );
 static const vpart_id vpart_tank( "tank" );
 static const vpart_id vpart_turret_test_multimag_gun_consume( "turret_test_multimag_gun_consume" );
@@ -475,4 +480,67 @@ TEST_CASE( "vehicle_turret_multimag", "[vehicle][turret][multimag]" )
         explosion_handler::process_explosions();
         clear_avatar();
     }
+}
+
+TEST_CASE( "automatic_vehicle_turret_targets_across_z_levels",
+           "[vehicle][turret][zlevel]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+    build_test_map( ter_id( "t_pavement" ) );
+    set_time_to_day();
+
+    for( const tripoint_bub_ms &p : here.points_on_zlevel( 1 ) ) {
+        here.ter_set( p, ter_id( "t_open_air" ) );
+    }
+    here.invalidate_map_cache( 1 );
+    here.build_map_cache( 1, true );
+
+    Character &player_character = get_player_character();
+    player_character.setpos( here, tripoint_bub_ms( 10, 10, 0 ) );
+
+    const tripoint_bub_ms veh_pos( 65, 65, 1 );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_test_turret_rig, veh_pos,
+                                     0_degrees, 0, veh_spawn_status::PRISTINE,
+                                     false, true );
+    REQUIRE( veh != nullptr );
+
+    // Model a turret near the middle of a wide airship deck.  A 3D line from
+    // the turret to the ground drops below the deck before reaching its edge,
+    // which is the case that the old same-Z boundary workaround missed.
+    REQUIRE( veh->install_part( here, point_rel_ms::zero, vpart_aisle ) >= 0 );
+    for( int x = 1; x <= 8; ++x ) {
+        const point_rel_ms mount( -x, 0 );
+        REQUIRE( veh->install_part( here, mount, vpart_frame ) >= 0 );
+        REQUIRE( veh->install_part( here, mount, vpart_aisle ) >= 0 );
+    }
+    veh->refresh();
+
+    const int turret_index = veh->install_part( here, point_rel_ms::zero,
+                             vpart_turret_test_multimag_turret_gun );
+    REQUIRE( turret_index >= 0 );
+    vehicle_part &turret = veh->part( turret_index );
+
+    const auto &[battery_current, battery_capacity] = veh->battery_power_level();
+    REQUIRE( battery_capacity > 0 );
+    veh->charge_battery( here, battery_capacity, /* apply_loss = */ false );
+
+    item magazine( itype_glockmag );
+    magazine.put_in( item( itype_9mm, calendar::turn, 15 ), pocket_type::MAGAZINE );
+    item gun( turret.get_base() );
+    REQUIRE( gun.put_in( magazine, pocket_type::MAGAZINE_WELL ).success() );
+    turret.set_base( std::move( gun ) );
+    turret.enabled = true;
+    turret.reset_target( veh->abs_part_pos( turret ) );
+
+    const tripoint_bub_ms target_pos( veh_pos.x() - 12, veh_pos.y(), 0 );
+    monster &target = spawn_test_monster( "mon_zombie", target_pos, false );
+    REQUIRE( target.attitude_to( player_character ) == Creature::Attitude::HOSTILE );
+
+    CHECK( veh->automatic_fire_turret( turret ) > 0 );
+
+    here.destroy_vehicle( veh );
+    explosion_handler::process_explosions();
+    clear_avatar();
 }


### PR DESCRIPTION
## What changed

Automatic vehicle turrets now find the edge of their own vehicle in the turret's horizontal plane, then perform the real three-dimensional line-of-sight check from that edge.

A regression test models a turret near the middle of a wide airship deck firing at a hostile target on the ground.

## Root cause

The existing workaround traced a 3D line while searching for the vehicle boundary. Against targets above or below a wide vehicle, that line could change Z-level before leaving the deck and select an interior tile as the boundary. The turret's own deck then blocked most target acquisition attempts.

## Impact

Automatic turrets can acquire valid targets on other Z-levels with the same targeting cycle as same-level enemies, while the final 3D line-of-sight and range checks still apply.

## Validation

- `make -j12 tests`
- `automatic_vehicle_turret_targets_across_z_levels` passed
- Modified C++ files pass the project's astyle dry run
- `git diff --check`

The targeted test runner still reports the two pre-existing `t_nanoforge(_body)` / `cable` data errors from current `master`; the selected tests themselves pass.