### PR TITLE
Stabilize vehicle autodriving speed and damage handling

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -8205,9 +8205,11 @@ int vehicle::damage_direct( map &here, vehicle_part &vp, int dmg, const damage_t
     }
     const vpart_info &vpi = vp.info();
     const tripoint_bub_ms vppos = bub_part_pos( here, vp );
-    // If auto-driving and damage happens, bail out
+    // Damage invalidates the current automated route, but a projectile impact
+    // should not apply the brakes and instantly stop a moving vehicle.
+    // Physical collisions still stop autodriving through the collision path.
     if( is_autodriving ) {
-        stop_autodriving();
+        stop_autodriving( false );
     }
     here.memory_cache_dec_set_dirty( vppos, true );
     if( vp.is_broken() ) {

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -1327,17 +1327,17 @@ std::optional<navigation_step> vehicle::autodrive_controller::compute_next_step(
     precompute_data( here );
     const tripoint_abs_ms veh_pos = driven_veh.pos_abs();
     const bool had_cached_path = !data.path.empty();
-    const bool two_steps = data.path.size() > 2;
-    const navigation_step first_step = two_steps ? data.path.back() : navigation_step();
-    const navigation_step second_step = two_steps ? data.path.at( data.path.size() - 2 ) :
-                                        navigation_step();
+    const bool has_next_step = data.path.size() >= 2;
+    const navigation_step first_step = has_next_step ? data.path.back() : navigation_step();
+    const navigation_step second_step = has_next_step ?
+                                        data.path.at( data.path.size() - 2 ) : navigation_step();
     bool maintain_speed = false;
     // If vehicle did not move as far as planned and direction is the same
     // then it is still accelerating. If the vehicle moved more than expected
     // then we likely underestimated the acceleration when planning the path.
     // If either of these happen, we should maintain speed but compute a new path.
     if( !in_greedy_mode ) {
-        if( two_steps &&
+        if( has_next_step &&
             square_dist( first_step.pos.xy().raw(), second_step.pos.xy().raw() ) !=
             square_dist( first_step.pos.xy().raw(), veh_pos.xy().raw() ) &&
             first_step.steering_dir == second_step.steering_dir ) {
@@ -1564,11 +1564,14 @@ autodrive_result vehicle::do_autodrive( map &here, Character &driver )
 
 void vehicle::stop_autodriving( bool apply_brakes )
 {
-    if( !is_autodriving && !is_patrolling && !is_following ) {
-        return;
-    }
+    // Braking is an explicit safety request and must still take effect if a
+    // preceding event (such as collision damage) already cleared the
+    // autodriving state.
     if( apply_brakes ) {
         cruise_velocity = 0;
+    }
+    if( !is_autodriving && !is_patrolling && !is_following ) {
+        return;
     }
     is_autodriving = false;
     is_patrolling = false;

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -21,6 +21,7 @@
 #include "itype.h"
 #include "map.h"
 #include "map_helpers.h"
+#include "map_helpers_tests.h"
 #include "map_scale_constants.h"
 #include "player_activity.h"
 #include "player_helpers.h"
@@ -833,6 +834,108 @@ TEST_CASE( "autopilot_tests", "[vehicle][autopilot]" )
     // checks if it moves, most of the test is a cutout from vehicle_efficiency_test.cpp
     CHECK( test_autopilot_moving( vehicle_prototype_car, vpart_id::NULL_ID() ) == 0 );
     CHECK( test_autopilot_moving( vehicle_prototype_car, vpart_programmable_autopilot ) == 9 );
+}
+
+TEST_CASE( "vehicle_damage_cancels_autodrive_without_braking", "[vehicle][autodrive][damage]" )
+{
+    clear_map_without_vision();
+    map &here = get_map();
+    const tripoint_bub_ms vehicle_origin( 60, 60, 0 );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_car, vehicle_origin, 0_degrees, 0,
+                                     veh_spawn_status::UNDAMAGED );
+    REQUIRE( veh != nullptr );
+    REQUIRE( veh->part_count() > 0 );
+
+    constexpr int cruising_speed = 7000;
+    veh->cruise_velocity = cruising_speed;
+    veh->is_autodriving = true;
+
+    veh->damage_direct( here, veh->part( 0 ), 1, damage_pure );
+
+    CHECK_FALSE( veh->is_autodriving );
+    CHECK( veh->cruise_velocity == cruising_speed );
+
+    // Collision handling can run after damage handling.  Its explicit stop
+    // request must still apply the brakes even though damage already cleared
+    // the autodriving flag.
+    veh->stop_autodriving();
+    CHECK( veh->cruise_velocity == 0 );
+}
+
+TEST_CASE( "autodrive_replanning_a_two_step_path_maintains_speed",
+           "[vehicle][autodrive]" )
+{
+    clear_avatar();
+    clear_map_without_vision();
+    build_test_map( ter_id( "t_pavement" ) );
+    map &here = get_map();
+
+    constexpr int omt_size = coords::map_squares_per( coords::omt );
+    const tripoint_bub_ms probe( 60, 60, 0 );
+    const tripoint_abs_omt current_omt =
+        project_to<coords::omt>( here.get_abs( probe ) );
+    const tripoint_abs_ms omt_origin = project_to<coords::ms>( current_omt );
+    // At the cautious road speed of three tiles per turn, starting twelve
+    // tiles from the next OMT produces four straight cached steps.  Following
+    // two of them leaves exactly the current and next nodes in the cache.
+    const tripoint_abs_ms start_abs =
+        omt_origin + tripoint( omt_size - 12, omt_size / 2, 0 );
+    const tripoint_bub_ms start = here.get_bub( start_abs );
+    REQUIRE( here.inbounds( start ) );
+
+    avatar &driver = get_avatar();
+    driver.clear_map_memory();
+    const tripoint_abs_ms omt_end =
+        omt_origin + tripoint( omt_size - 1, omt_size - 1, 0 );
+    driver.prepare_map_memory_region( omt_origin, omt_end );
+    for( int x = 0; x < omt_size; ++x ) {
+        for( int y = 0; y < omt_size; ++y ) {
+            driver.memorize_terrain( omt_origin + tripoint( x, y, 0 ),
+                                     "t_pavement", 0, 0 );
+        }
+    }
+    REQUIRE( driver.is_map_memory_valid() );
+
+    vehicle *veh = here.add_vehicle( vehicle_prototype_car, start, 0_degrees, 100,
+                                     veh_spawn_status::UNDAMAGED );
+    REQUIRE( veh != nullptr );
+    veh->add_tag( "IN_CONTROL_OVERRIDE" );
+    driver.setpos( here, start + tripoint::south * 8 );
+    set_time_to_day();
+
+    constexpr int cautious_speed =
+        3 * static_cast<int>( vehicles::vmiph_per_tile );
+    veh->engine_on = true;
+    REQUIRE( veh->safe_velocity( here ) >= cautious_speed );
+    veh->velocity = cautious_speed;
+    veh->cruise_velocity = cautious_speed;
+    veh->is_autodriving = true;
+    driver.omt_path = { current_omt + tripoint::east };
+    driver.set_moves( 1000 );
+
+    REQUIRE( veh->do_autodrive( here, driver ) == autodrive_result::ok );
+    const int planned_speed = veh->cruise_velocity;
+    REQUIRE( planned_speed > static_cast<int>( vehicles::vmiph_per_tile ) );
+
+    // Follow two complete cached steps, leaving exactly two nodes.
+    for( int step = 0; step < 2; ++step ) {
+        REQUIRE( here.displace_vehicle( *veh, tripoint_rel_ms( 3, 0, 0 ) ) );
+        veh->skidding = false;
+        driver.set_moves( 1000 );
+        REQUIRE( veh->do_autodrive( here, driver ) == autodrive_result::ok );
+    }
+
+    // Move less than the final cached step predicted.  This is normal while a
+    // vehicle is accelerating and must trigger a same-speed replan even with
+    // only the current and next cached nodes remaining.
+    REQUIRE( here.displace_vehicle( *veh, tripoint_rel_ms::east ) );
+    veh->skidding = false;
+    driver.set_moves( 1000 );
+    REQUIRE( veh->do_autodrive( here, driver ) == autodrive_result::ok );
+    CHECK( veh->cruise_velocity == planned_speed );
+
+    driver.omt_path.clear();
+    here.destroy_vehicle( veh );
 }
 
 TEST_CASE( "vehicle_enchantments", "[vehicle][enchantments]" )


### PR DESCRIPTION
## What changed

- Preserve the planned speed when an accelerating vehicle replans with exactly two cached path nodes remaining.
- Cancel an invalidated automated route on ordinary part damage without instantly setting cruise speed to zero.
- Keep explicit safety stops effective even if damage handling already cleared the autodriving state.

## Root cause

The speed-maintenance path required more than two cached nodes, so the common two-node replan case dropped back to a very low target speed and repeatedly accelerated again. Separately, all vehicle damage used the braking form of `stop_autodriving()`, making a projectile hit stop an airship immediately. Collision processing can run after damage processing, so explicit braking also has to work after the route flag has already been cleared.

## Impact

Autodrive no longer oscillates between roughly 70 and 6, ordinary incoming fire does not instantly brake the vehicle, and actual collision/safety stops still brake correctly.

## Validation

- `make -j12 tests`
- `vehicle_damage_cancels_autodrive_without_braking` passed
- `autodrive_replanning_a_two_step_path_maintains_speed` passed
- Modified C++ files pass the project's astyle dry run
- `git diff --check`

The targeted test runner still reports the two pre-existing `t_nanoforge(_body)` / `cable` data errors from current `master`; the selected tests themselves pass.