### PR TITLE
Allow remote controls to change aircraft altitude

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -3463,6 +3463,15 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                     }
                 }
 
+                // Remote controls take priority over whatever the operator is
+                // standing on.  pldrive() already selects the remote vehicle
+                // first, so mirror that behavior for vertical movement.
+                if( vehicle *remote_veh = g->remoteveh();
+                    remote_veh && remote_veh->is_rotorcraft( here ) ) {
+                    pldrive( tripoint_rel_ms::below );
+                    break;
+                }
+
                 const tripoint_bub_ms pos = player_character.pos_bub();
                 const bool has_vehicle_ladder = here.has_vehicle_ladder_at( pos );
                 if( const std::optional<tripoint_bub_ms> ladder_dest =

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -3551,6 +3551,13 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                     break;
                 }
             }
+            // As with horizontal remote driving, route vertical input to the
+            // remote aircraft before considering movement by the operator.
+            if( vehicle *remote_veh = g->remoteveh();
+                remote_veh && remote_veh->is_rotorcraft( here ) ) {
+                pldrive( tripoint_rel_ms::above );
+                break;
+            }
             if( !player_character.in_vehicle ) {
                 if( const std::optional<tripoint_bub_ms> ladder_dest =
                         here.vehicle_ladder_destination( player_character.pos_bub(), 1 ) ) {

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -3482,7 +3482,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
 
                 if( has_vehicle_control( player_character ) ) {
                     const optional_vpart_position vp = here.veh_at( player_character.pos_bub() );
-                    if( vp->vehicle().is_rotorcraft( here ) ) {
+                    if( vp && vp->vehicle().is_rotorcraft( here ) ) {
                         pldrive( tripoint_rel_ms::below );
                         break;
                     }
@@ -3555,7 +3555,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                 vertical_move( 1, u.has_flag( json_flag_PHASE_MOVEMENT ) );
             } else if( has_vehicle_control( player_character ) ) {
                 const optional_vpart_position vp = here.veh_at( player_character.pos_bub() );
-                if( vp->vehicle().is_rotorcraft( here ) ) {
+                if( vp && vp->vehicle().is_rotorcraft( here ) ) {
                     pldrive( tripoint_rel_ms::above );
                 }
             }


### PR DESCRIPTION
## What changed

The move-up and move-down action handlers now route vertical input to a remotely controlled aircraft before considering stairs, climbing, or the vehicle under the operator.

The local-control checks also guard the optional vehicle lookup before dereferencing it.

## Root cause

Horizontal movement already passed through the remote-aware `pldrive()` path, but vertical actions only attempted aircraft control when the player was physically aboard a locally controlled vehicle.

## Impact

While using remote vehicle controls, players can take off, climb, descend, and land an airworthy remote aircraft with the normal vertical movement keys.

## Validation

- `make -j12 tests`
- Modified C++ file passes the project's astyle dry run
- `git diff --check`

This action-routing path currently has no practical unit-test seam; the implementation reuses the same remote vehicle selection and flight checks already used by `pldrive()`. The targeted test runner also reports the two pre-existing `t_nanoforge(_body)` / `cable` data errors from current `master`.