### PR TITLE
CVD machine restored

### DIFF
--- a/data/json/furniture_and_terrain/terrain-manufactured.json
+++ b/data/json/furniture_and_terrain/terrain-manufactured.json
@@ -572,6 +572,63 @@
   },
   {
     "type": "terrain",
+    "id": "t_cvdbody",
+    "name": "CVD machine",
+    "description": "The bulk of a highly technical-looking apparatus controlled by a nearby console.",
+    "symbol": "%",
+    "color": "dark_gray",
+    "move_cost": 0,
+    "coverage": 65,
+    "connect_groups": "WALL",
+    "connects_to": "WALL",
+    "flags": [ "NOITEM", "WALL", "PERMEABLE" ],
+    "bash": {
+      "str_min": 6,
+      "str_max": 150,
+      "sound": "crunch!",
+      "sound_fail": "whack!",
+      "ter_set": "t_floor",
+      "items": [
+        { "item": "e_scrap", "count": [ 1, 4 ], "prob": 50 },
+        { "item": "circuit", "count": [ 1, 6 ], "prob": 50 },
+        { "item": "scrap", "count": [ 2, 8 ], "prob": 50 }
+      ]
+    }
+  },
+  {
+    "type": "terrain",
+    "id": "t_cvdmachine",
+    "name": "CVD control panel",
+    "description": "A VERY expensive-looking apparatus that's labeled 'Chemical Vapor Deposition Machine'.  With the input of certain exceptionally rare chemicals and elements, one could conceivably coat one's weapon with diamond.  While the process is extremely complicated, a previous user has helpfully sketched: Hydrogen + charcoal = smiley face.",
+    "symbol": "&",
+    "color": "cyan",
+    "looks_like": "f_console",
+    "move_cost": 0,
+    "coverage": 50,
+    "flags": [ "TRANSPARENT", "NOITEM", "PERMEABLE" ],
+    "examine_action": "cvdmachine",
+    "bash": {
+      "str_min": 8,
+      "str_max": 150,
+      "sound": "crunch!",
+      "sound_fail": "whack!",
+      "ter_set": "t_metal_floor",
+      "items": [
+        { "item": "processor", "prob": 25 },
+        { "item": "RAM", "count": [ 0, 2 ], "prob": 50 },
+        { "item": "cable", "count": [ 1, 2 ], "prob": 50 },
+        { "item": "small_lcd_screen", "prob": 25 },
+        { "item": "e_scrap", "count": [ 1, 4 ], "prob": 50 },
+        { "item": "circuit", "count": [ 0, 2 ], "prob": 50 },
+        { "item": "power_supply", "prob": 25 },
+        { "item": "amplifier", "prob": 25 },
+        { "item": "plastic_chunk", "count": [ 4, 10 ], "prob": 50 },
+        { "item": "scrap", "count": [ 2, 6 ], "prob": 50 }
+      ]
+    }
+  },
+  {
+    "type": "terrain",
     "id": "t_nanofab_body",
     "name": "nanofabricator",
     "symbol": "%",

--- a/data/json/obsoletion_and_migration_0.J/terrain.json
+++ b/data/json/obsoletion_and_migration_0.J/terrain.json
@@ -21,16 +21,6 @@
   },
   {
     "type": "ter_furn_migration",
-    "from_ter": "t_cvdbody",
-    "to_ter": "t_thconc_floor"
-  },
-  {
-    "type": "ter_furn_migration",
-    "from_ter": "t_cvdmachine",
-    "to_ter": "t_thconc_floor"
-  },
-  {
-    "type": "ter_furn_migration",
     "from_ter": "t_nl_metal_wall_edge",
     "to_ter": "t_nl_metal_wall_border"
   },

--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -273,6 +273,12 @@
     "components": [ [ [ "any_sheet_metal_small", 4, "LIST" ] ], [ [ "nanomaterial", 5 ] ] ]
   },
   {
+    "id": "cvd_diamond",
+    "type": "requirement",
+    "//": "Materials required to apply diamond coating (per 250ml volume)",
+    "components": [ [ [ "plasma", 5 ] ], [ [ "charcoal", 25 ], [ "coal_lump", 25 ] ] ]
+  },
+  {
     "id": "autoclave",
     "type": "requirement",
     "//": "Materials required to run one cycle of the furniture autoclave",

--- a/data/mods/FuturismCataclysmLegacy/mapgen/microlab/microlab_special_tiles.json
+++ b/data/mods/FuturismCataclysmLegacy/mapgen/microlab/microlab_special_tiles.json
@@ -39,5 +39,46 @@
       "place_monsters": [ { "monster": "GROUP_LAB", "chance": 2, "x": [ 2, 21 ], "y": [ 2, 21 ], "repeat": [ 1, 5 ] } ],
       "place_monster": [ { "monster": "mon_mech_lifter", "x": 17, "y": 13, "chance": 75 } ]
     }
+  },
+  {
+    "//": "cvdmachin room",
+    "type": "mapgen",
+    "nested_mapgen_id": "microlab_generic_tile",
+    "object": {
+      "mapgensize": [ 24, 24 ],
+      "rows": [
+        "   hdh  dd|  |||||||||||",
+        "   hdh    2  2     hddh|",
+        "    Y     |  |cccc     |",
+        "cccccc  |||22||||||||22|",
+        "||||||  ||-  -------|  |",
+        " +  @|  ||-  --K rr-|  |",
+        " | D@|  ||-  -- Y  -|  |",
+        " |||||  ||-  --K rr-|  |",
+        " +  @|  ||-55G--2---|  |",
+        " | D@|  ||-       C-|  |",
+        "||||||  ||-  Y  Y C-|22|",
+        "   Y    c|-  T  T C-|YY2",
+        "   Y   cc|-(((22(((-|YY2",
+        "|||2||||||-   YY  A-|22|",
+        "|dh    cc|- hh    A-|  |",
+        "|dh     c|- dd   AA-|  |",
+        "|||||   c|- dd   //-|  |",
+        "|cc    cc|- hh  `//-|  |",
+        "|c   |||||-   YY //-|  |",
+        "|c   Y hd|----------|  |",
+        "|cc    hd||||||||||||22|",
+        "||||||2||||            |",
+        " dd    ccc|  |ccc   ccc|",
+        " hh      c|  |||||||||||"
+      ],
+      "palettes": [ "microlab" ],
+      "furniture": { "K": "f_rack", "C": "f_machinery_electronic", "A": "f_machinery_heavy" },
+      "terrain": { "G": "t_card_science", "`": "t_cvdmachine", "/": "t_cvdbody" },
+      "item": { "r": { "item": "standard_template_construct" }, "K": { "item": "nanomaterial", "repeat": [ 25, 75 ] } },
+      "monster": { "T": { "monster": "mon_turret_rifle", "spawn_data": { "ammo": [ { "ammo_id": "556", "qty": [ 30, 90 ] } ] } } },
+      "place_monsters": [ { "monster": "GROUP_LAB", "chance": 2, "x": [ 2, 21 ], "y": [ 2, 21 ], "repeat": [ 1, 5 ] } ],
+      "place_monster": [ { "monster": "mon_mech_lifter", "x": 17, "y": 13, "chance": 75 } ]
+    }
   }
 ]

--- a/data/mods/FuturismCataclysmLegacy/mapgen/microlab/microlab_special_tiles.json
+++ b/data/mods/FuturismCataclysmLegacy/mapgen/microlab/microlab_special_tiles.json
@@ -75,7 +75,7 @@
       "palettes": [ "microlab" ],
       "furniture": { "K": "f_rack", "C": "f_machinery_electronic", "A": "f_machinery_heavy" },
       "terrain": { "G": "t_card_science", "`": "t_cvdmachine", "/": "t_cvdbody" },
-      "item": { "r": { "item": "standard_template_construct" }, "K": { "item": "nanomaterial", "repeat": [ 25, 75 ] } },
+      "item": { "r": { "item": "standard_template_construct" }, "K": { "item": "plasma", "repeat": [ 25, 75 ] } },
       "monster": { "T": { "monster": "mon_turret_rifle", "spawn_data": { "ammo": [ { "ammo_id": "556", "qty": [ 30, 90 ] } ] } } },
       "place_monsters": [ { "monster": "GROUP_LAB", "chance": 2, "x": [ 2, 21 ], "y": [ 2, 21 ], "repeat": [ 1, 5 ] } ],
       "place_monster": [ { "monster": "mon_mech_lifter", "x": 17, "y": 13, "chance": 75 } ]

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -229,6 +229,13 @@ static const json_character_flag json_flag_WING_GLIDE( "WING_GLIDE" );
 
 static const material_id material_bone( "bone" );
 static const material_id material_cac2powder( "cac2powder" );
+static const material_id material_ch_steel( "ch_steel" );
+static const material_id material_hc_steel( "hc_steel" );
+static const material_id material_iron( "iron" );
+static const material_id material_lc_steel( "lc_steel" );
+static const material_id material_mc_steel( "mc_steel" );
+static const material_id material_qt_steel( "qt_steel" );
+static const material_id material_steel( "steel" );
 static const material_id material_wood( "wood" );
 
 static const mtype_id mon_broken_cyborg( "mon_broken_cyborg" );
@@ -259,6 +266,7 @@ static const quality_id qual_TREE_TAP( "TREE_TAP" );
 
 static const requirement_id requirement_data_anesthetic( "anesthetic" );
 static const requirement_id requirement_data_autoclave( "autoclave" );
+static const requirement_id requirement_data_cvd_diamond( "cvd_diamond" );
 static const requirement_id requirement_data_superalloy_forge( "superalloy_forge" );
 
 static const skill_id skill_chemistry( "chemistry" );
@@ -360,6 +368,50 @@ bool iexamine::harvestable_now( const tripoint_bub_ms &examp )
 {
     const harvest_id hid = get_map().get_harvest( examp );
     return !hid->is_null() && !hid->empty();
+}
+
+/**
+ * Pick an appropriate item and apply diamond coating if possible.
+ */
+void iexamine::cvdmachine( Character &you, const tripoint_bub_ms & )
+{
+    // Select an item to which it is possible to apply a diamond coating
+    item_location loc = g->inv_map_splice( []( const item & e ) {
+        return e.has_edged_damage() &&
+               !e.has_flag( flag_DIAMOND ) && !e.has_flag( flag_NO_CVD ) &&
+               ( e.made_of( material_steel ) || e.made_of( material_ch_steel ) ||
+                 e.made_of( material_hc_steel ) || e.made_of( material_lc_steel ) ||
+                 e.made_of( material_mc_steel ) || e.made_of( material_qt_steel ) ||
+                 e.made_of( material_iron ) );
+    }, _( "Apply diamond coating" ), 1, _( "You don't have a suitable item to coat with diamond" ) );
+
+    if( !loc ) {
+        return;
+    }
+
+    // Require materials proportional to selected item volume
+    auto qty = loc->volume() / 250_ml;
+    qty = std::max( 1, qty );
+    requirement_data reqs = *requirement_data_cvd_diamond * qty;
+
+    if( !reqs.can_make_with_inventory( you.crafting_inventory(), is_crafting_component ) ) {
+        popup( "%s", reqs.list_missing() );
+        return;
+    }
+
+    // Consume materials
+    for( const auto &e : reqs.get_components() ) {
+        you.consume_items( e, 1, is_crafting_component );
+    }
+    for( const auto &e : reqs.get_tools() ) {
+        you.consume_tools( e );
+    }
+    you.invalidate_crafting_inventory();
+
+    // Apply flag to item
+    loc->set_flag( flag_DIAMOND );
+    add_msg( m_good, _( "You apply a diamond coating to your %s" ), loc->type_name() );
+    you.mod_moves( -to_moves<int>( 10_seconds ) );
 }
 
 /**
@@ -8124,6 +8176,7 @@ iexamine_functions iexamine_functions_from_string( const std::string &function_n
     static const std::map<std::string, function_data> function_map = {{
             { "none", { no_translation( "none" ), &iexamine::none } },
             { "deployed_furniture", { to_translation( "Take down or deploy furniture" ), &iexamine::deployed_furniture } },
+            { "cvdmachine", { to_translation( "Use CVD machine" ), &iexamine::cvdmachine } },
             { "change_appearance", { to_translation( "Change your appearance" ), &iexamine::change_appearance } },
             { "genemill", { to_translation( "Use genemill" ), &iexamine::genemill } },
             { "nanofab", { to_translation( "Use nanofab" ), &iexamine::nanofab } },

--- a/src/iexamine.h
+++ b/src/iexamine.h
@@ -85,6 +85,7 @@ void cardreader_robofac( Character &you, const tripoint_bub_ms &examp );
 void cardreader_foodplace( Character &you, const tripoint_bub_ms &examp );
 void intercom( Character &you, const tripoint_bub_ms &examp );
 void intercom_balthazar( Character &you, const tripoint_bub_ms &examp );
+void cvdmachine( Character &you, const tripoint_bub_ms &examp );
 void change_appearance( Character &you, const tripoint_bub_ms &examp );
 void rubble( Character &you, const tripoint_bub_ms &examp );
 void chainfence( Character &you, const tripoint_bub_ms &examp );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

CVD was completely removed by the upstream branch, with the reason being: `It's ability to make weapons deadlier by coating them in diamond is not really how this works so it's getting ripped out instead of rehomed.` However, it still has room for improvement, and there are still mods using it. Moreover, while its working principle is somewhat sci-fi, it is actually still relatively reasonable.

The only part that seems likely to be genuinely inaccurate is the actual effect that was not removed: real-world CVD diamond coating technology does not directly increase weapon damage like it does in the game. It primarily improves wear resistance and service life. However, this is also something that can be tolerated temporarily for gameplay reasons. I think we can gradually improve it rather than completely destroying an old gameplay mechanic.

#### Describe the solution

Reverted https://github.com/CleverRaven/Cataclysm-DDA/pull/85285

Nothing else has been changed yet. I have not decided on the specific improvements to make.

Same as #500, because our upstream branch removed a large amount of laboratory content before the fork, I found that there is currently no suitable mapgen location for this facility. For now, it has been placed in the generic microlab spawns added by the Futurism Cataclysm: Legacy mod, as a variant of the existing `nano_fabricator room`.