### PR TITLE
Preserve nested item identity while loading saves

### DIFF
--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <tuple>
 #include <type_traits>
+#include <utility>
 
 #include "avatar.h"
 #include "cata_imgui.h"
@@ -912,6 +913,31 @@ ret_val<item *> item_contents::insert_item( const item &it,
     }
 
     ret_val<item *> inserted = pocket.value()->insert_item( it, false, true, ignore_contents );
+    if( inserted.success() ) {
+        if( unseal_pockets ) {
+            pocket.value()->unseal();
+        }
+        return inserted;
+    }
+    return ret_val<item *>::make_failure( nullptr, inserted.str() );
+}
+
+ret_val<item *> item_contents::insert_item( item &&it,
+        pocket_type pk_type, bool ignore_contents, const bool unseal_pockets,
+        bool restack_charges )
+{
+    if( pk_type == pocket_type::LAST ) {
+        // LAST is invalid, so we assume it will be a regular container
+        pk_type = pocket_type::CONTAINER;
+    }
+
+    ret_val<item_pocket *> pocket = find_pocket_for( it, pk_type );
+    if( !pocket.success() ) {
+        return ret_val<item *>::make_failure( nullptr, pocket.str() );
+    }
+
+    ret_val<item *> inserted = pocket.value()->insert_item( std::move( it ), false, restack_charges,
+                               ignore_contents );
     if( inserted.success() ) {
         if( unseal_pockets ) {
             pocket.value()->unseal();
@@ -2412,6 +2438,12 @@ std::vector<item *> item_contents::get_added_pockets_mutable()
 
 void item_contents::add_pocket( const item &pocket_item )
 {
+    item copied_pocket( pocket_item );
+    add_pocket( std::move( copied_pocket ) );
+}
+
+void item_contents::add_pocket( item &&pocket_item )
+{
     units::volume total_nonrigid_volume = 0_ml;
     units::volume effective_nonrigid_volume = 0_ml;
     for( const item_pocket *i_pocket : pocket_item.get_container_pockets() ) {
@@ -2428,7 +2460,7 @@ void item_contents::add_pocket( const item &pocket_item )
     additional_pockets_volume += total_nonrigid_volume;
     additional_pockets_effective_volume += effective_nonrigid_volume;
     additional_pockets_space_used += pocket_item.get_pocket_size();
-    additional_pockets.push_back( pocket_item );
+    additional_pockets.push_back( std::move( pocket_item ) );
     additional_pockets.back().clear_items();
 
 }

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -704,18 +704,19 @@ size_t item_contents::size() const
     return contents.size();
 }
 
-void item_contents::read_mods( const item_contents &read_input )
+void item_contents::read_mods( item_contents &read_input )
 {
-    for( const item_pocket &pocket : read_input.contents ) {
+    for( item_pocket &pocket : read_input.contents ) {
         if( pocket.saved_type() == pocket_type::MOD ) {
-            for( const item *it : pocket.all_items_top() ) {
-                if( it->is_gunmod() || it->is_toolmod() ) {
-                    insert_item( *it, pocket_type::MOD );
+            for( item &it : pocket.edit_contents() ) {
+                if( it.is_gunmod() || it.is_toolmod() ) {
+                    insert_item( std::move( it ), pocket_type::MOD );
                 } else {
-                    debugmsg( "Non-mod %s in MOD pocket!", it->tname() );
-                    insert_item( *it, pocket_type::MIGRATION );
+                    debugmsg( "Non-mod %s in MOD pocket!", it.tname() );
+                    insert_item( std::move( it ), pocket_type::MIGRATION );
                 }
             }
+            pocket.clear_items();
         }
     }
 }
@@ -723,15 +724,22 @@ void item_contents::read_mods( const item_contents &read_input )
 void item_contents::combine( const item_contents &read_input, const bool convert,
                              const bool into_bottom, bool restack_charges, bool ignore_contents )
 {
-    std::list<item_pocket> mismatched_pockets;
+    item_contents copied_input( read_input );
+    combine( std::move( copied_input ), convert, into_bottom, restack_charges, ignore_contents );
+}
+
+void item_contents::combine( item_contents &&read_input, const bool convert,
+                             const bool into_bottom, bool restack_charges, bool ignore_contents )
+{
+    std::vector<item_pocket *> mismatched_pockets;
     std::vector<item> uninserted_items;
     size_t pocket_index = 0;
 
-    for( const item &pocket : read_input.additional_pockets ) {
-        add_pocket( pocket );
+    for( item &pocket : read_input.additional_pockets ) {
+        add_pocket( std::move( pocket ) );
     }
 
-    for( const item_pocket &pocket : read_input.contents ) {
+    for( item_pocket &pocket : read_input.contents ) {
         if( convert ) {
             if( pocket.is_type( pocket_type::MIGRATION ) ||
                 pocket.is_type( pocket_type::CORPSE ) ||
@@ -739,9 +747,11 @@ void item_contents::combine( const item_contents &read_input, const bool convert
                 pocket.is_type( pocket_type::MAGAZINE_WELL ) ||
                 pocket.is_type( pocket_type::E_FILE_STORAGE ) ) {
                 ++pocket_index;
-                for( const item *it : pocket.all_items_top() ) {
-                    insert_item( *it, pocket.get_pocket_data()->type, ignore_contents );
+                for( item &it : pocket.edit_contents() ) {
+                    insert_item( std::move( it ), pocket.get_pocket_data()->type, ignore_contents,
+                                 false, restack_charges );
                 }
+                pocket.clear_items();
                 continue;
             } else if( pocket.is_type( pocket_type::MOD ) ) {
                 // skipping mod type pocket because using combine this way requires mods to come first
@@ -755,9 +765,11 @@ void item_contents::combine( const item_contents &read_input, const bool convert
             continue;
         } else if( pocket.saved_type() == pocket_type::MIGRATION ||
                    pocket.saved_type() == pocket_type::CORPSE ) {
-            for( const item *it : pocket.all_items_top() ) {
-                insert_item( *it, pocket.saved_type(), ignore_contents );
+            for( item &it : pocket.edit_contents() ) {
+                insert_item( std::move( it ), pocket.saved_type(), ignore_contents, false,
+                             restack_charges );
             }
+            pocket.clear_items();
             ++pocket_index;
             continue;
         }
@@ -768,46 +780,53 @@ void item_contents::combine( const item_contents &read_input, const bool convert
 
             if( !current_pocket_iter->is_type( convert ? pocket.get_pocket_data()->type :
                                                pocket.saved_type() ) ) {
-                mismatched_pockets.push_back( pocket );
+                mismatched_pockets.push_back( &pocket );
                 continue;
             }
 
-            for( const item *it : pocket.all_items_top() ) {
-                const ret_val<item *> inserted = current_pocket_iter->insert_item( *it,
+            for( item &it : pocket.edit_contents() ) {
+                const ret_val<item *> inserted = current_pocket_iter->insert_item( std::move( it ),
                                                  into_bottom, restack_charges, ignore_contents );
                 if( !inserted.success() ) {
-                    uninserted_items.push_back( *it );
+                    uninserted_items.push_back( std::move( it ) );
                     DebugLog( DebugLevel::D_WARNING, DebugClass::D_GAME ) <<
-                            "error: item " << it->typeId().str() << "cannot fit into pocket while loading: " << inserted.str();
+                            "error: item " << uninserted_items.back().typeId().str() <<
+                            "cannot fit into pocket while loading: " << inserted.str();
                 }
             }
+            pocket.clear_items();
 
             if( pocket.saved_sealed() ) {
                 current_pocket_iter->seal();
             }
             current_pocket_iter->settings = pocket.settings;
         } else {
-            for( const item *it : pocket.all_items_top() ) {
-                uninserted_items.push_back( *it );
+            for( item &it : pocket.edit_contents() ) {
+                uninserted_items.push_back( std::move( it ) );
             }
+            pocket.clear_items();
         }
         ++pocket_index;
     }
 
-    for( const item_pocket &pocket : mismatched_pockets ) {
-        const pocket_type mismatched_type = convert ? pocket.get_pocket_data()->type : pocket.saved_type();
-        for( const item *it : pocket.all_items_top() ) {
-            const ret_val<item *> inserted = insert_item( *it, mismatched_type, ignore_contents );
+    for( item_pocket *pocket : mismatched_pockets ) {
+        const pocket_type mismatched_type = convert ? pocket->get_pocket_data()->type :
+                                            pocket->saved_type();
+        for( item &it : pocket->edit_contents() ) {
+            const ret_val<item *> inserted = insert_item( std::move( it ), mismatched_type,
+                                             ignore_contents, false, restack_charges );
             if( !inserted.success() ) {
-                uninserted_items.push_back( *it );
+                uninserted_items.push_back( std::move( it ) );
                 debugmsg( "error: item %s cannot fit into any pocket while loading: %s",
-                          it->typeId().str(), inserted.str() );
+                          uninserted_items.back().typeId().str(), inserted.str() );
             }
         }
+        pocket->clear_items();
     }
 
-    for( const item &uninserted_item : uninserted_items ) {
-        insert_item( uninserted_item, pocket_type::MIGRATION, ignore_contents );
+    for( item &uninserted_item : uninserted_items ) {
+        insert_item( std::move( uninserted_item ), pocket_type::MIGRATION, ignore_contents, false,
+                     restack_charges );
     }
 }
 

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -275,6 +275,8 @@ class item_contents
          * Called when adding an item as pockets to a molle item.
          */
         void add_pocket( const item &pocket );
+        /** Loading-only counterpart which preserves the incorporated item's serialized UID. */
+        void add_pocket( item &&pocket );
 
         /*
          * Called when removing a molle pocket.
@@ -340,6 +342,12 @@ class item_contents
          */
         ret_val<item *> insert_item( const item &it, pocket_type pk_type,
                                      bool ignore_contents = false, bool unseal_pockets = false );
+        /**
+         * Loading-only counterpart which transfers an existing item and preserves its UID.
+         */
+        ret_val<item *> insert_item( item &&it, pocket_type pk_type,
+                                     bool ignore_contents = false, bool unseal_pockets = false,
+                                     bool restack_charges = true );
         void force_insert_item( const item &it, pocket_type pk_type );
         bool can_unload_liquid() const;
 

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -462,9 +462,17 @@ class item_contents
 
         void info( std::vector<iteminfo> &info, const iteminfo_query *parts ) const;
 
-        /** Read the items in the MOD pocket only. */
-        void read_mods( const item_contents &read_input );
+        /**
+         * Read and remove the items in the MOD pocket.  This is destructive so loaded item
+         * identities can be transferred without generating new UIDs.
+         */
+        void read_mods( item_contents &read_input );
         void combine( const item_contents &read_input, bool convert = false, bool into_bottom = false,
+                      bool restack_charges = true, bool ignore_contents = false );
+        /**
+         * Loading-only counterpart which consumes read_input and preserves serialized UIDs.
+         */
+        void combine( item_contents &&read_input, bool convert = false, bool into_bottom = false,
                       bool restack_charges = true, bool ignore_contents = false );
 
         void serialize( JsonOut &json ) const;

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -799,6 +799,8 @@ class item_location::impl::item_in_container : public item_location::impl
 
         item_in_container( const item_location &container, item *which ) :
             impl( which ), container( container ) {}
+        item_in_container( const item_location &container, int idx, int64_t uid ) :
+            impl( idx, uid ), container( container ) {}
 
         void serialize( JsonOut &js ) const override {
             if( !target() ) {
@@ -821,17 +823,31 @@ class item_location::impl::item_in_container : public item_location::impl
         }
 
         item *unpack( int idx ) const override {
-            if( idx < 0 || static_cast<size_t>( idx ) >= target()->num_item_stacks() ) {
+            if( !container ) {
                 return nullptr;
             }
-            std::list<const item *> all_items = container->all_items_ptr();
+            std::list<const item *> all_items = container->all_items_container_top();
+            if( idx < 0 || static_cast<size_t>( idx ) >= all_items.size() ) {
+                return nullptr;
+            }
             auto iter = all_items.begin();
             std::advance( iter, idx );
             if( iter != all_items.end() ) {
                 return const_cast<item *>( *iter );
-            } else {
+            }
+            return nullptr;
+        }
+
+        item *unpack_by_uid( int64_t uid ) const override {
+            if( !container || uid <= 0 ) {
                 return nullptr;
             }
+            for( const item *it : container->all_items_container_top() ) {
+                if( it->uid().get_value() == uid ) {
+                    return const_cast<item *>( it );
+                }
+            }
+            return nullptr;
         }
 
         Character *carrier() const override {
@@ -1073,44 +1089,9 @@ void item_location::deserialize( const JsonObject &obj )
     } else if( type == "in_container" ) {
         item_location parent;
         obj.read( "parent", parent );
-        if( !parent.ptr->valid() ) {
-            if( parent == nowhere ) {
-                debugmsg( "parent location doesn't exist.  Item_location has lost its target over a save/load cycle." );
-                ptr = std::make_shared<impl::nowhere>();
-                return;
-            }
-            debugmsg( "parent location does not point to valid item" );
-            ptr = std::make_shared<impl::item_on_map>( map_cursor( parent.pos_abs() ), idx ); // drop on ground
-            return;
-        }
-        const std::list<item *> parent_contents = parent->all_items_container_top();
-
-        item *found = nullptr;
-        if( uid > 0 ) {
-            for( item *it : parent_contents ) {
-                if( it->uid().get_value() == uid ) {
-                    found = it;
-                    break;
-                }
-            }
-            if( !found ) {
-                debugmsg( "item_location UID not found in container contents" );
-                ptr = std::make_shared<impl::nowhere>();
-                return;
-            }
-        } else if( idx > -1 && idx < static_cast<int>( parent_contents.size() ) ) {
-            // Legacy save: no UID, use index
-            auto iter = parent_contents.begin();
-            std::advance( iter, idx );
-            found = *iter;
-        }
-
-        if( found ) {
-            ptr = std::make_shared<impl::item_in_container>( parent, found );
-        } else {
-            debugmsg( "contents index greater than contents size" );
-            ptr = std::make_shared<impl::nowhere>();
-        }
+        // The parent can belong to an NPC which has not yet been registered with the game
+        // while its activities are being deserialized.  Resolve both parent and child lazily.
+        ptr = std::make_shared<impl::item_in_container>( parent, idx, uid );
     }
 }
 

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -2309,6 +2309,41 @@ ret_val<item *> item_pocket::insert_item( const item &it,
     return ret_val<item *>::make_success( inserted );
 }
 
+ret_val<item *> item_pocket::insert_item( item &&it,
+        const bool into_bottom, bool restack_charges, bool ignore_contents )
+{
+    if( is_invalid_stackable_container_payload( it ) ) {
+        return ret_val<item *>::make_failure( nullptr,
+                                              _( "can't put a stackable container stack with contents in a pocket" ) );
+    }
+    ret_val<item_pocket::contain_code> containable = can_contain( it, ignore_contents );
+
+    if( !containable.success() ) {
+        return ret_val<item *>::make_failure( nullptr, containable.str() );
+    }
+
+    const units::volume inserted_volume = it.volume();
+    const units::mass inserted_weight = it.weight();
+    item *inserted = nullptr;
+    if( !into_bottom ) {
+        contents.push_front( std::move( it ) );
+        inserted = &contents.front();
+    } else {
+        contents.push_back( std::move( it ) );
+        inserted = &contents.back();
+    }
+    if( restack_charges && inserted->count_by_charges() ) {
+        inserted = restack( inserted );
+    }
+    if( bulk_fill_volume ) {
+        // restack conserves total volume/weight, so the inserted item's own
+        // contribution is the delta regardless of any merge.
+        *bulk_fill_volume += inserted_volume;
+        *bulk_fill_weight += inserted_weight;
+    }
+    return ret_val<item *>::make_success( inserted );
+}
+
 std::pair<item_location, item_pocket *> item_pocket::best_pocket_in_contents(
     item_location &this_loc, const item &it, const item *avoid,
     const bool allow_sealed, const bool ignore_settings )

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -345,6 +345,12 @@ class item_pocket
         ret_val<item *> insert_item( const item &it, bool into_bottom = false,
                                      bool restack_charges = true, bool ignore_contents = false );
         /**
+         * Loading-only counterpart to insert_item( const item & ).  Moving preserves the
+         * serialized item UID instead of creating the fresh UID required for a game-world copy.
+         */
+        ret_val<item *> insert_item( item &&it, bool into_bottom = false,
+                                     bool restack_charges = true, bool ignore_contents = false );
+        /**
           * adds an item to the pocket with no checks
           * may create a new pocket
           */

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3650,7 +3650,7 @@ void item::deserialize( const JsonObject &data )
         data.read( "contents", read_contents );
         contents.read_mods( read_contents );
         update_modified_pockets();
-        contents.combine( read_contents, false, true, false, true );
+        contents.combine( std::move( read_contents ), false, true, false, true );
 
         //migrate SOFTWARE pocket
         auto pockets_e_legacy = []( item_pocket const & pocket ) {

--- a/tests/item_location_test.cpp
+++ b/tests/item_location_test.cpp
@@ -225,6 +225,39 @@ TEST_CASE( "nested_item_uid_survives_parent_serialization", "[item][item_uid][sa
     CHECK( loaded_children.front()->uid().get_value() == original_child_uid );
 }
 
+TEST_CASE( "item_location_in_container_waits_for_parent_to_load",
+           "[item][item_location][item_uid][save]" )
+{
+    clear_map_without_vision();
+    map &m = get_map();
+    const tripoint_bub_ms pos( 60, 60, 0 );
+    m.i_clear( pos );
+
+    // Hand-craft an old-format location so the test is independent of map::add_item making
+    // game-world copies with fresh UIDs.  Both parent and child are deliberately absent here.
+    std::ostringstream os;
+    JsonOut jsout( os );
+    jsout.start_object();
+    jsout.member( "idx", 0 );
+    jsout.member( "type", "in_container" );
+    jsout.member( "parent" );
+    jsout.start_object();
+    jsout.member( "type", "map" );
+    jsout.member( "position", m.get_abs( pos ) );
+    jsout.member( "idx", 0 );
+    jsout.end_object();
+    jsout.end_object();
+    item_location loaded_location = deserialize_item_location( os.str() );
+
+    // Activities can be read before their owning NPC or map item is installed in the game.
+    item backpack( itype_backpack );
+    backpack.put_in( item( itype_tshirt ), pocket_type::CONTAINER );
+    m.add_item( pos, std::move( backpack ) );
+
+    REQUIRE( loaded_location );
+    CHECK( loaded_location->typeId() == itype_tshirt );
+}
+
 TEST_CASE( "item_location_in_container_survives_restack", "[item][item_location][item_uid]" )
 {
     clear_map_without_vision();
@@ -362,6 +395,8 @@ TEST_CASE( "item_location_in_container_uid_miss_becomes_nowhere",
     item_location loaded;
     std::string dmsg = capture_debugmsg_during( [&]() {
         loaded = deserialize_item_location( json_str );
+        // Resolution is lazy, so force it while the debug capture is active.
+        static_cast<void>( loaded.get_item() );
     } );
     CHECK_FALSE( loaded );
     CHECK_FALSE( dmsg.empty() );

--- a/tests/item_location_test.cpp
+++ b/tests/item_location_test.cpp
@@ -203,6 +203,28 @@ TEST_CASE( "item_uid_survives_serialization", "[item][item_uid]" )
     CHECK( loaded.uid().get_value() == original_uid );
 }
 
+TEST_CASE( "nested_item_uid_survives_parent_serialization", "[item][item_uid][save]" )
+{
+    item original( itype_backpack );
+    original.put_in( item( itype_tshirt ), pocket_type::CONTAINER );
+    const item *original_child = original.all_items_container_top().front();
+    REQUIRE( original_child != nullptr );
+    const int64_t original_child_uid = original_child->uid().get_value();
+
+    std::ostringstream os;
+    JsonOut jsout( os );
+    original.serialize( jsout );
+
+    item loaded;
+    JsonValue jv = json_loader::from_string( os.str() );
+    JsonObject jo = jv;
+    loaded.deserialize( jo );
+
+    const std::list<item *> loaded_children = loaded.all_items_container_top();
+    REQUIRE( loaded_children.size() == 1 );
+    CHECK( loaded_children.front()->uid().get_value() == original_child_uid );
+}
+
 TEST_CASE( "item_location_in_container_survives_restack", "[item][item_location][item_uid]" )
 {
     clear_map_without_vision();


### PR DESCRIPTION
## Summary

- transfer deserialized pocket items instead of copying them, preserving serialized item UIDs
- resolve `in_container` item locations lazily when their parent has not been registered yet
- add regression coverage for nested item UIDs and deferred parent loading

## Root cause

Loading rebuilt nested pocket contents through copy-based insertion. Those copies received new UIDs, so saved `item_location` references could no longer find their targets. In addition, contained locations were resolved immediately even when NPC or map parents were still being loaded.

## Player impact

Save files containing activities or references to nested items can load without losing the referenced target merely because the owning NPC, map item, or child UID is not available at the instant of deserialization.

## Validation

- `make -j10 tests`
- `./tests/cata_test "[item_uid][save]"` (2 cases, 5 assertions)
- `./tests/cata_test "item_location_in_container_uid_miss_becomes_nowhere"` (1 case, 3 assertions)
- `make astyle-diff`
- `git diff --check origin/master...HEAD`

This branch contains 7 commits and is based directly on `master`.