### PR TITLE
Preserve contents when removing gunmod pockets

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1025,9 +1025,40 @@ void gunmod_remove_activity_actor::gunmod_remove( Character &who, item &gun, ite
 
     gun.gun_set_mode( gun_mode_DEFAULT );
     const itype *modtype = mod.type;
+    std::set<const item *> mod_pocket_items;
+    if( modtype->mod ) {
+        const auto supplied_by_removed_mod = [modtype]( const item_pocket & pocket ) {
+            return std::any_of( modtype->mod->add_pockets.begin(), modtype->mod->add_pockets.end(),
+            [&pocket]( const pocket_data & data ) {
+                return pocket.get_pocket_data() == &data;
+            } );
+        };
+        for( item_pocket *pocket : gun.get_pockets( supplied_by_removed_mod ) ) {
+            for( item *it : pocket->all_items_top() ) {
+                mod_pocket_items.insert( it );
+            }
+        }
+    }
 
     who.i_add_or_drop( mod );
     gun.remove_item( mod );
+
+    // update_modified_pockets moves contents only from pockets which actually disappeared into
+    // MIGRATION.  Return those items to the character; identical pockets supplied by another
+    // installed copy of the mod remain untouched.
+    std::set<const item *> displaced_items;
+    for( item *it : gun.all_items_top( pocket_type::MIGRATION ) ) {
+        if( mod_pocket_items.count( it ) > 0 ) {
+            displaced_items.insert( it );
+        }
+    }
+    std::list<item> recovered_items = gun.remove_items_with(
+    [&displaced_items]( const item & it ) {
+        return displaced_items.count( &it ) > 0;
+    }, static_cast<int>( displaced_items.size() ) );
+    for( item &it : recovered_items ) {
+        who.i_add_or_drop( it );
+    }
 
     //~ %1$s - gunmod, %2$s - gun.
     who.add_msg_if_player( _( "You remove your %1$s from your %2$s." ), modtype->nname( 1 ),

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -2238,7 +2238,11 @@ void item_contents::update_modified_pockets(
                 ++pocket_iter;
             } else {
                 if( !pocket.empty() ) {
-                    debugmsg( "Oops!  deleted some items when updating pockets that were added via toolmods" );
+                    if( migration_pocket == contents.end() ) {
+                        ++pocket_iter;
+                        continue;
+                    }
+                    pocket.move_contents_to( *migration_pocket );
                 }
                 pocket_iter = contents.erase( pocket_iter );
             }

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -2182,6 +2182,11 @@ void item_contents::update_modified_pockets(
     std::vector<const pocket_data *> mag_or_mag_wells,
     std::vector<const pocket_data *> container_pockets )
 {
+    const auto migration_pocket = std::find_if( contents.begin(), contents.end(),
+    []( const item_pocket & pocket ) {
+        return pocket.is_type( pocket_type::MIGRATION );
+    } );
+
     for( auto pocket_iter = contents.begin(); pocket_iter != contents.end(); ) {
         item_pocket &pocket = *pocket_iter;
         if( pocket.is_type( pocket_type::CONTAINER ) ) {
@@ -2205,8 +2210,13 @@ void item_contents::update_modified_pockets(
 
             if( !found ) {
                 if( !pocket.empty() ) {
-                    // in case the debugmsg wasn't clear, this should never happen
-                    debugmsg( "Oops!  deleted some items when updating pockets that were added via toolmods" );
+                    // A removed mod can legitimately take away a non-empty pocket.  Preserve the
+                    // item nodes until the caller can unload or spill them.
+                    if( migration_pocket == contents.end() ) {
+                        ++pocket_iter;
+                        continue;
+                    }
+                    pocket.move_contents_to( *migration_pocket );
                 }
                 pocket_iter = contents.erase( pocket_iter );
             } else {

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -1978,6 +1978,11 @@ void item_pocket::clear_items()
     contents.clear();
 }
 
+void item_pocket::move_contents_to( item_pocket &destination )
+{
+    destination.contents.splice( destination.contents.end(), contents );
+}
+
 bool item_pocket::has_item( const item &it ) const
 {
     return contents.end() !=

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -311,6 +311,8 @@ class item_pocket
         void on_contents_changed();
         void handle_liquid_or_spill( Character &guy, const item *avoid = nullptr );
         void clear_items();
+        /** Transfer all contained item nodes without copying them or changing their UIDs. */
+        void move_contents_to( item_pocket &destination );
         bool has_item( const item &it ) const;
         item *get_item_with( const std::function<bool( const item & )> &filter );
         const item *get_item_with( const std::function<bool( const item & )> &filter ) const;

--- a/tests/item_pocket_test.cpp
+++ b/tests/item_pocket_test.cpp
@@ -77,6 +77,9 @@ static const itype_id itype_bag_plastic( "bag_plastic" ); //Purposefully nonsens
 static const itype_id itype_barrel_small( "barrel_small" );
 static const itype_id itype_bottle_plastic( "bottle_plastic" );
 static const itype_id itype_debug_modular_m4_carbine( "debug_modular_m4_carbine" );
+static const itype_id itype_debug_gun_no_mag_well( "debug_gun_no_mag_well" );
+static const itype_id itype_debug_retool_mag_well( "debug_retool_mag_well" );
+static const itype_id itype_stanag30( "stanag30" );
 static const itype_id itype_ketchup( "ketchup" );
 static const itype_id itype_mustard( "mustard" );
 static const itype_id itype_paper( "paper" );
@@ -3029,6 +3032,26 @@ TEST_CASE( "pocket_mods", "[pocket][toolmod][gunmod]" )
     }
 }
 
+TEST_CASE( "removing_mod_preserves_contents_of_removed_pocket",
+           "[item][pocket][gunmod][item_uid]" )
+{
+    item gun( itype_debug_gun_no_mag_well );
+    REQUIRE( gun.put_in( item( itype_debug_retool_mag_well ), pocket_type::MOD ).success() );
+    REQUIRE( gun.put_in( item( itype_stanag30 ), pocket_type::MAGAZINE_WELL ).success() );
+
+    item *magazine = gun.all_items_top( pocket_type::MAGAZINE_WELL ).front();
+    REQUIRE( magazine != nullptr );
+    const int64_t magazine_uid = magazine->uid().get_value();
+
+    item *mod = gun.gunmods().front();
+    gun.remove_item( *mod );
+
+    const std::list<item *> preserved = gun.all_items_top( pocket_type::MIGRATION );
+    REQUIRE( preserved.size() == 1 );
+    CHECK( preserved.front()->typeId() == itype_stanag30 );
+    CHECK( preserved.front()->uid().get_value() == magazine_uid );
+}
+
 // Reproduce previous segfault from https://github.com/CleverRaven/Cataclysm-DDA/issues/75156
 TEST_CASE( "unload_from_spillable_container", "[item][pocket]" )
 {
@@ -3081,4 +3104,3 @@ TEST_CASE( "unload_from_spillable_container", "[item][pocket]" )
         }
     }
 }
-


### PR DESCRIPTION
## Summary

- move items from disappearing mod-provided pockets into the migration pocket without copying
- return only the items displaced by the removed gunmod to the character
- preserve equivalent pockets that are still supplied by another installed mod
- add regression coverage for removing a mag-well mod while a magazine remains installed

## Root cause

Removing a gunmod recalculates dynamic pockets. When a non-empty pocket disappeared, `update_modified_pockets` erased the pocket and its contents, then emitted the blocking error reported while disassembling the receiver.

## Player impact

Removing a receiver or gunmod no longer deletes magazines, slings, or other items held by a pocket supplied by that mod. Displaced items are handed back to the player.

## Validation

- `make -j10 tests`
- `./tests/cata_test "removing_mod_preserves_contents_of_removed_pocket"` (1 case, 6 assertions)
- `./tests/cata_test "pocket_mods"` (1 case, 16 assertions)
- `make astyle-diff`
- `git diff --check origin/master...HEAD`

This branch contains 5 commits and is based directly on `master`.