### PR TITLE
Exclude data/lua/manifest.schema.json from translation extraction

### DIFF
--- a/lang/update_pot.sh
+++ b/lang/update_pot.sh
@@ -70,6 +70,7 @@ if ! lang/extract_json_strings.py \
         -X data/mods/aftershock_exoplanet/npcs/Backgrounds/BG_traits_afs.json \
         -X data/mods/aftershock_exoplanet/npcs/cyborg_npcs/backgrounds/bg_traits_cyborg.json \
         -X data/mods/Magiclysm/Spells/debug.json \
+        -X data/lua/manifest.schema.json \
         -n "$package $version" \
         -r lang/po/base.pot
 then


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

The current GitHub Action for pushing translation templates seems to have an issue and can never complete successfully.

The core error is:
```
Error in JSON object
from file: data/lua/manifest.schema.json
Exception: Unrecognized JSON data type 'object'
```

After investigation, I found that `lang/update_pot.sh` recursively scans the entire `data` directory, while `extract_json_strings.py` parses all `.json` files. `parse.py` directly throws an exception when encountering an unknown type, causing the entire workflow to fail.

These steps are interconnected. However, since the Lua update, the repository now contains a new `data/lua` directory, which includes `data/lua/manifest.schema.json`. This file does not follow the game's data format, but is instead a JSON Schema file. Because its top-level `"type": "object"` field exists, it is incorrectly interpreted as a game JSON type.

#### Describe the solution

Added:
`-X data/lua/manifest.schema.json \`
to exclude it. That's it.

#### Additional context

A bit..... hummm.... Although I don't know whether future Lua updates will introduce more files that could cause similar "incorrect identification" issues, I hope that if such files appear, people will remember to add them to this blacklist when pushing changes.