### PR TITLE
Handle transient activity state without blocking errors

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5894,8 +5894,11 @@ void consume_activity_actor::start( player_activity &act, Character &guy )
     } else if( !consume_item.is_null() ) {
         player_will_eat( consume_item );
     } else {
-        debugmsg( "Item/location to be consumed should not be null." );
+        add_msg_debug( debugmode::DF_ACTIVITY,
+                       "consume activity target is no longer available at start" );
         was_canceled = true;
+        reprompt_consume_menu = false;
+        uistate.consume_uistate.clear();
     }
 
     act.moves_total = moves;
@@ -5918,7 +5921,11 @@ void consume_activity_actor::finish( player_activity &act, Character & )
         } else if( !consume_item.is_null() ) {
             player_character.consume( consume_item, /*force=*/true );
         } else {
-            debugmsg( "Item location/name to be consumed should not be null." );
+            add_msg_debug( debugmode::DF_ACTIVITY,
+                           "consume activity target is no longer available at finish" );
+            was_canceled = true;
+            reprompt_consume_menu = false;
+            uistate.consume_uistate.clear();
         }
     }
 

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -3771,8 +3771,11 @@ void basecamp::finish_return( npc &comp, const bool fixed_time, const std::strin
     g->reload_npcs();
     validate_assignees();
 
-    // Missions that are not fixed_time can try to draw more food than is in the food supply
-    feed_workers( comp, camp_food_supply( -need_food ) );
+    // Missions that are not fixed_time can try to draw more food than is in the food supply.
+    // Fixed-time missions paid up front and have no food to deduct here.
+    if( need_food > 0 ) {
+        feed_workers( comp, camp_food_supply( -need_food ) );
+    }
     if( has_water() ) {
         comp.set_thirst( 0 );
     }

--- a/src/item_container.cpp
+++ b/src/item_container.cpp
@@ -40,6 +40,7 @@
 #include "itype.h"
 #include "iuse.h"
 #include "iuse_actor.h"
+#include "messages.h"
 #include "pocket_type.h"
 #include "ret_val.h"
 #include "string_formatter.h"
@@ -905,8 +906,10 @@ int item::fill_with( const item &contained, const int amount,
         }
     }
     if( num_contained == 0 ) {
-        debugmsg( "tried to put an item (%s, amount %d) in a container (%s) that cannot contain it",
-                  contained_item.typeId().str(), contained_item.charges, typeId().str() );
+        // Capacity can change between scheduling and executing an insert activity.
+        add_msg_debug( debugmode::DF_ACTIVITY,
+                       "could not put item %s (amount %d) in container %s",
+                       contained_item.typeId().str(), contained_item.charges, typeId().str() );
     }
     on_contents_changed();
     return num_contained;

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -418,7 +418,8 @@ bool Pickup::do_pickup( std::vector<item_location> &targets, std::vector<int> &q
         quantities.pop_back();
 
         if( !target ) {
-            debugmsg( "lost target item of ACT_PICKUP" );
+            // The item may legitimately burn up or otherwise disappear while pickup is queued.
+            add_msg_debug( debugmode::DF_ACTIVITY, "lost target item of ACT_PICKUP" );
             continue;
         }
         problem = !pick_one_up( target, quantity, got_water, got_gas, mapPickup, autopickup,

--- a/src/save_snapshot.cpp
+++ b/src/save_snapshot.cpp
@@ -92,11 +92,21 @@ bool copy_tree( const std::filesystem::path &src_dir,
                 return false;
             }
         } else if( iter->is_regular_file() ) {
+            // Atomic save writes use short-lived *.temp files which can be renamed between
+            // directory traversal and copy.  They are never part of a completed save.
+            if( entry.extension() == ".temp" ) {
+                continue;
+            }
             if( !assure_dir_exist( dst.parent_path() ) ) {
                 debugmsg( "snapshot: failed to create directory '%s'", dst.parent_path().u8string() );
                 return false;
             }
             if( !copy_file( entry.u8string(), dst.u8string() ) ) {
+                std::error_code exists_ec;
+                if( !std::filesystem::exists( entry, exists_ec ) && !exists_ec ) {
+                    // A temporary/atomic source can disappear after is_regular_file().
+                    continue;
+                }
                 debugmsg( "snapshot: failed to copy '%s'", entry.u8string() );
                 return false;
             }


### PR DESCRIPTION
## Summary

- treat pickup targets that vanish while queued as normal activity cancellation
- avoid a zero-food deduction when fixed-time camp missions return
- skip short-lived atomic-save files while creating snapshots
- safely cancel consume activities whose target disappeared
- downgrade container fill races from blocking debug popups to activity diagnostics

## Root cause

The affected paths assumed that queued targets, container capacity, temporary save files, and mission accounting could not change between scheduling and execution. Normal gameplay races therefore surfaced as blocking errors even though recovery was possible.

## Player impact

Burned pickup targets (including liquid bags thrown into fire), stale consume targets, snapshot races, fixed-time camp returns, and late container-capacity changes no longer interrupt play with false error dialogs.

## Validation

- `make -j10 tests`
- `./tests/cata_test "[pickup]"` (4 cases, 69 assertions)
- `./tests/cata_test "camp_calorie_counting"` (1 case, 37 assertions)
- `make astyle-diff`
- `git diff --check origin/master...HEAD`

This branch contains 5 commits and is based directly on `master`.