### PR TITLE
Fix empty gun and Geiger sound hooks

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -55,6 +55,7 @@
 #include "ranged.h"
 #include "ret_val.h"
 #include "rng.h"
+#include "sounds.h"
 #include "translations.h"
 #include "type_id.h"
 #include "ui_manager.h"
@@ -802,16 +803,26 @@ bool avatar_action::can_fire_weapon( avatar &you, const map &m, const item &weap
     }
 
     std::vector<std::string> messages;
+    bool selected_mode_is_empty = false;
 
     for( const std::pair<const gun_mode_id, gun_mode> &mode_map : weapon.gun_all_modes() ) {
         bool check_common = gunmode_checks_common( you, m, messages, mode_map.second );
         bool check_weapon = gunmode_checks_weapon( you, m, messages, mode_map.second );
+        if( mode_map.first == weapon.gun_get_mode_id() ) {
+            selected_mode_is_empty = check_common &&
+                                     !mode_map.second->ammo_sufficient( &you ) &&
+                                     !mode_map.second->has_flag( flag_RELOAD_AND_SHOOT ) &&
+                                     !mode_map.second->ammo_remaining();
+        }
         bool can_use_mode = check_common && check_weapon;
         if( can_use_mode ) {
             return true;
         }
     }
 
+    if( selected_mode_is_empty ) {
+        sfx::play_variant_sound( "fire_gun", "empty", sfx::get_heard_volume( you.pos_bub() ) );
+    }
     for( const std::string &message : messages ) {
         add_msg( m_info, message );
     }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -3238,8 +3238,9 @@ std::optional<int> iuse::geiger_active( Character *, item *it, const tripoint_bu
     std::string description = rads > 50 ? _( "buzzing" ) :
                               rads > 25 ? _( "rapid clicking" ) : _( "clicking" );
 
-    std::string sound_var = rads > 50 ? _( "geiger_high" ) :
-                            rads > 25 ? _( "geiger_medium" ) : _( "geiger_low" );
+    // Soundpack variants are stable internal identifiers and must not be translated.
+    const std::string sound_var = rads > 50 ? "geiger_high" :
+                                  rads > 25 ? "geiger_medium" : "geiger_low";
 
     if( !activation_success ) {
         sounds::sound( pos, 6, sounds::sound_t::alarm, _( "distorted buzz-clicking" ), true, "tool",

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3188,6 +3188,19 @@ target_handler::trajectory target_ui::run()
             action = ctxt.handle_input( timeout );
         }
 
+        const bool attempted_shot = action == "FIRE" || action == "AIMED_SHOT" ||
+                                    action == "CAREFUL_SHOT" || action == "PRECISE_SHOT";
+        if( mode == TargetMode::Fire && status == Status::OutOfAmmo && attempted_shot ) {
+            const gun_mode gun = relevant->gun_current_mode();
+            if( !gun->ammo_sufficient( you ) &&
+                !gun->has_flag( flag_RELOAD_AND_SHOOT ) &&
+                !gun->ammo_remaining() ) {
+                sfx::play_variant_sound( "fire_gun", "empty",
+                                         sfx::get_heard_volume( you->pos_bub() ) );
+            }
+            continue;
+        }
+
         // If an aiming mode is selected, use "*_SHOT" instead of "FIRE"
         if( mode == TargetMode::Fire && action == "FIRE" && aim_mode->has_threshold ) {
             action = aim_mode->action;


### PR DESCRIPTION
## Summary

- Play the documented `fire_gun` / `empty` soundpack variant when the avatar actually attempts to fire a selected gun mode that has no ammunition.
- Handle both the initial fire command and shot inputs made from the targeting UI, while keeping passive weapon/status checks free of sound side effects.
- Keep `geiger_low`, `geiger_medium`, and `geiger_high` as stable internal soundpack variants instead of translating them at runtime.

## Root cause

The documented empty-gun sound resource no longer had a player-side call site, so soundpacks could define it without it ever playing for the avatar. The Geiger counter passed internal variant names through gettext; for example, Simplified Chinese translated them to `辐射-低`, `辐射-中`, and `辐射-高`, which no longer matched the English identifiers defined by soundpacks.

The empty-gun hook is restricted to genuine empty-ammo attempts and excludes reload-and-shoot modes. It is not added to the generic `gun_actor`, because that actor also represents non-gun attacks such as thrown projectiles and breath attacks.

## Validation

- `astyle --options=.astylerc -n src/avatar_action.cpp src/iuse.cpp src/ranged.cpp`
- `git diff --check`
- Full Linux SDL2 tiles + sound release build linked successfully with:
  `CCACHE_DIR=/tmp/cataclysm-ccache make -j10 RELEASE=1 TILES=1 SOUND=1 SDL3=0 TESTS=0 CCACHE=1 LINTJSON=0`
- The same build with the default JSON lint enabled reached the repository's pre-existing style failure in `data/json/requirements/materials.json`; no file from that unrelated formatter result is included in this PR.