### PR TITLE
修复旧版界面的手柄按键绑定捕获

### DIFF
--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -23,6 +23,7 @@
 #endif
 #include "android_ui_mode.h"
 #include "cata_imgui.h"
+#include "cata_scope_helpers.h"
 #include "cata_utility.h"
 #include "catacharset.h"
 #include "catalua_ui.h"
@@ -1281,12 +1282,21 @@ bool input_context::action_remove( const std::string &name, const std::string &a
 bool input_context::action_add( const std::string &name, const std::string &action_id,
                                 bool is_local, kb_menu_status status )
 {
-    const input_event new_event = query_popup()
-                                  .preferred_keyboard_mode( preferred_keyboard_mode )
-                                  .message( _( "New key for %s" ), name )
-                                  .allow_anykey( true )
-                                  .query()
-                                  .evt;
+    const input_event new_event = [&]() {
+#if defined(TILES)
+        gamepad::set_raw_input_mode( true );
+        on_out_of_scope restore_gamepad_input_mode( []() {
+            gamepad::set_raw_input_mode( false );
+        } );
+#endif
+        return query_popup()
+               .preferred_keyboard_mode( preferred_keyboard_mode )
+               .message( _( "New key for %s" ), name )
+               .allow_anykey( true )
+               .query()
+               .evt;
+    }
+    ();
 
     if( action_uses_input( action_id, new_event )
         // Allow adding keys already used globally to local bindings

--- a/src/sdl_gamepad.cpp
+++ b/src/sdl_gamepad.cpp
@@ -134,6 +134,7 @@ static direction radial_right_last_dir = direction::NONE;
 static bool radial_left_open = false;
 static bool radial_right_open = false;
 static bool alt_modifier_held = false;
+static bool raw_input_mode = false;
 
 // SDL3: callback signature changes to (void *userdata, SDL_TimerID timerID, Uint32 interval)
 #if SDL_MAJOR_VERSION >= 3
@@ -450,6 +451,16 @@ static bool handle_axis_event( SDL_Event &event )
         bool trigger_pressed = value > triggers_threshold + error_margin;
         bool trigger_released = value < triggers_threshold - error_margin;
 
+        if( raw_input_mode ) {
+            if( !state && trigger_pressed ) {
+                triggers_state[idx] = 1;
+                send_input( idx == 0 ? JOY_LT : JOY_RT );
+            } else if( state && trigger_released ) {
+                triggers_state[idx] = 0;
+            }
+            return false;
+        }
+
         if( idx == 1 ) {
             // Right trigger (RT)
             if( !state && trigger_pressed ) {
@@ -536,6 +547,15 @@ static bool handle_axis_event( SDL_Event &event )
                 left_stick_dir = dir;
             } else {
                 right_stick_dir = dir;
+            }
+
+            if( raw_input_mode && i == 0 ) {
+                if( dir == direction::NONE ) {
+                    cancel_task( stick_task );
+                } else if( dir != old_dir ) {
+                    send_direction_movement();
+                }
+                continue;
             }
 
             if( alt_modifier_held ) {
@@ -856,12 +876,17 @@ bool is_in_menu()
 {
     // If the UI stack has more than 1 element, it usually means a menu is open
     // on top of the main game UI.
-    return ui_adaptor::ui_stack_size() > 1;
+    return !raw_input_mode && ui_adaptor::ui_stack_size() > 1;
 }
 
 bool is_active()
 {
     return controller != nullptr;
+}
+
+void set_raw_input_mode( bool enabled )
+{
+    raw_input_mode = enabled;
 }
 
 tripoint direction_to_offset( direction dir )

--- a/src/sdl_gamepad.h
+++ b/src/sdl_gamepad.h
@@ -50,6 +50,7 @@ bool is_radial_right_open();
 bool is_alt_held();
 bool is_in_menu();
 bool is_active();
+void set_raw_input_mode( bool enabled );
 
 // Convert direction enum to movement offset
 tripoint direction_to_offset( direction dir );


### PR DESCRIPTION
## 修改内容

- 仅在“新按键”捕获弹窗打开期间启用原始手柄输入模式。
- 让左扳机在绑定时返回 `JOY_LT`，避免只被当作 `ALT` 修饰键处理。
- 让十字键、ABXY 按键和左摇杆方向在绑定时返回真实的 `JOY_*` 输入。
- 捕获结束后自动恢复正常菜单映射，保留游戏中的左扳机径向菜单与修饰键行为。

## 问题原因

旧版界面的按键捕获弹窗仍沿用了普通菜单输入转换。左扳机因此被内部修饰键逻辑吞掉，十字键、摇杆和部分手柄按键也会被转换成菜单操作，无法记录用户实际按下的手柄输入。

## 用户影响

Android x64 旧版界面现在可以正常绑定左扳机、十字键、ABXY 按键和左摇杆方向；正常游玩时的菜单与径向菜单操作不受影响。

## 验证

- 已通过项目 AStyle 格式检查。
- 已通过 `git diff --check`。
- 按提交要求未执行完整编译，本 PR 先以草稿形式提交。

合并后将自动关闭对应问题：

Fixes #504
