### PR TITLE
修复大地图兴趣点无法删除

### DIFF
--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -496,8 +496,8 @@ namespace overmap_ui
 static bool create_note( const tripoint_abs_omt &curs,
                          std::optional<std::string> context = std::nullopt );
 
-// returns true if a point of interest was created, false otherwise
-static bool create_point_of_interest( const tripoint_abs_omt &curs );
+// returns true if a point of interest was created or deleted, false otherwise
+static bool toggle_point_of_interest( const tripoint_abs_omt &curs );
 
 // {note symbol, note color, offset to text}
 std::tuple<char, nc_color, size_t> get_note_display_info( std::string_view note )
@@ -1432,8 +1432,19 @@ static bool create_note( const tripoint_abs_omt &curs, std::optional<std::string
     return false;
 }
 
-static bool create_point_of_interest( const tripoint_abs_omt &curs )
+static bool toggle_point_of_interest( const tripoint_abs_omt &curs )
 {
+    avatar &player_character = get_avatar();
+    for( const point_of_interest &point : player_character.get_points_of_interest() ) {
+        if( point.pos == curs ) {
+            if( query_yn( _( "Really delete point of interest \"%s\"?" ), point.text ) ) {
+                player_character.delete_point_of_interest( curs );
+                return true;
+            }
+            return false;
+        }
+    }
+
     std::string context = _( "Add a Point of Interest entry to the Mission UI" );
     std::string title = _( "Description:" );
     std::string new_note;
@@ -1483,7 +1494,7 @@ static bool create_point_of_interest( const tripoint_abs_omt &curs )
     } while( true );
 
     if( !esc_pressed && !new_note.empty() ) {
-        get_avatar().add_point_of_interest( {curs, new_note} );
+        player_character.add_point_of_interest( {curs, new_note} );
         return true;
     }
     return false;
@@ -2293,7 +2304,7 @@ static tripoint_abs_omt display()
                 curs.y() = p.y();
             }
         } else if( action == "CREATE_POINT_OF_INTEREST" ) {
-            create_point_of_interest( curs );
+            toggle_point_of_interest( curs );
         } else if( action == "GO_TO_DESTINATION" ) {
             avatar &player_character = get_avatar();
             if( !player_character.omt_path.empty() ) {


### PR DESCRIPTION
## 修改内容

- 将大地图的兴趣点操作改为添加与删除切换。
- 光标位于现有兴趣点时，按 `P` 会显示删除确认框。
- 确认后调用现有的兴趣点删除接口；取消时不做修改。
- 当前坐标没有兴趣点时，继续使用原有的添加流程。

## 问题原因

大地图的 `CREATE_POINT_OF_INTEREST` 操作此前始终进入创建流程，没有检查当前坐标是否已经存在兴趣点，因此界面没有提供删除入口。

## 用户影响

玩家现在可以在已有兴趣点的位置按 `P` 删除该兴趣点，同时保留原来的添加方式和确认保护。

## 验证

- 已通过项目 AStyle 格式检查。
- 已通过 `git diff --check`。
- 按提交要求未执行完整编译，本 PR 先以草稿形式提交。

合并后将自动关闭对应问题：

Fixes #305
