### PR TITLE
Warn the player before crafting if the resulting food is likely to spoil

### DIFF
--- a/src/character.h
+++ b/src/character.h
@@ -3847,6 +3847,9 @@ class Character : public Creature, public visitable
                                        const std::function<bool( const item & )> &filter = return_true<item>,
                                        const std::vector<tripoint_bub_ms> &reachable_pts = {}, bool select_ind = false,
                                        bool disable_preference = false );
+        std::optional<item_components> preview_crafting_components(
+            const std::vector<comp_selection<item_comp>> &selections, int batch,
+            const std::function<bool( const item & )> &filter );
         // Selects one entry in components using select_item_component and consumes those items.
         std::list<item> consume_items( const std::vector<item_comp> &components, int batch = 1,
                                        const std::function<bool( const item & )> &filter = return_true<item>,

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -708,19 +708,17 @@ item craft_command::create_in_progress_craft()
     if( preview.goes_bad() ) {
         const time_duration predicted_remaining = preview.get_shelf_life() -
                 preview.get_shelf_life() * predicted_rot;
-        if( predicted_rot >= 1.0 && crafter->is_avatar() ) {
-            const bool continue_craft = crafter->query_yn(
-                                            _( "The selected ingredients may be rotten before this craft finishes.\n"
-                                               "Start crafting anyway?" ) );
-            if( !continue_craft ) {
+        if( ( predicted_rot >= 1.0 || predicted_remaining <= 1_hours ) &&
+            crafter->is_avatar() ) {
+            const char *warning = predicted_rot >= 1.0
+                                  ? _( "The selected ingredients may be rotten before this craft finishes.\n"
+                                       "Start crafting anyway?" )
+                                  : _( "The finished item may have less than an hour of shelf life left.\n"
+                                       "Start crafting anyway?" );
+            if( !crafter->query_yn( warning ) ) {
                 restore_crafting_components( *crafter, used );
                 return item();
             }
-        } else if( predicted_rot < 1.0 && predicted_remaining <= 1_hours &&
-                   crafter->is_avatar() ) {
-            crafter->add_msg_if_player( m_warning,
-                                        _( "The finished %s will have very little shelf life left." ),
-                                        rec->result_name() );
         }
     }
 

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -665,7 +665,7 @@ item craft_command::create_in_progress_craft()
             const char *warning = predicted_rot >= 1.0
                                   ? _( "The selected ingredients may be rotten before this craft "
                                        "finishes.\nStart crafting anyway?" )
-                                  : _( "The finished item may have one hour or less of shelf life "
+                                  : _( "The finished item may only have one to three hour or less of shelf life "
                                        "left.\nStart crafting anyway?" );
             if( !crafter->query_yn( warning ) ) {
                 return item();

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -60,7 +60,7 @@ struct craft_material_source {
 
 struct craft_material_plan {
     std::vector<craft_material_source> sources;
-    item_components preview_components;
+    std::vector<item_comp> preview_components;
 };
 
 std::vector<item_location> craft_source_locations( Character &crafter,
@@ -726,7 +726,8 @@ item craft_command::create_in_progress_craft()
     // consumed, so cancelling leaves every source unchanged.
     item_components preview_used;
     for( const craft_material_source &source : material_plan.sources ) {
-        preview_used.add( source.snapshot );
+        item preview_component = source.snapshot;
+        preview_used.add( preview_component );
     }
     item preview( rec, batch_size, preview_used, material_plan.preview_components, false );
     const time_duration expected_duration = time_duration::from_moves(

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -606,6 +606,7 @@ bool craft_command::query_continue( const std::vector<comp_selection<item_comp>>
 bool craft_command::continue_prompt_liquids( const std::function<bool( const item & )> &filter,
         bool no_prompt )
 {
+    map &m = get_map();
     for( const auto &it : item_selections ) {
         const std::vector<pocket_data> it_pkt = it.comp.type->pockets;
         if( ( item::count_by_charges( it.comp.type ) && it.comp.count > 0 ) ||
@@ -615,39 +616,127 @@ bool craft_command::continue_prompt_liquids( const std::function<bool( const ite
             continue;
         }
 
+        // Everything below only occurs for item components that are liquid containers
+        std::function<bool( const item & )> empty_filter = [&filter]( const item & it ) {
+            return it.empty_container() && filter( it );
+        };
+
+        const char *liq_cont_msg = _( "%1$s is not empty.  Continue anyway?" );
+        std::vector<std::pair<const tripoint_bub_ms, item>> map_items;
+        std::vector<std::pair<const vpart_reference, item>> veh_items;
+        std::vector<item> inv_items;
+
+        auto reset_items = [&]() {
+            for( auto &mit : map_items ) {
+                m.add_item_or_charges( mit.first, mit.second );
+            }
+            for( item &iit : inv_items ) {
+                crafter->i_add_or_drop( iit );
+            }
+            for( auto &vit : veh_items ) {
+                vit.first.vehicle().add_item( m, vit.first.part(), vit.second );
+            }
+        };
+
         int real_count = ( it.comp.count > 0 ) ? it.comp.count * batch_size : std::abs( it.comp.count );
-        std::vector<item_location> candidates;
-        for( bool preferred : { true, false } ) {
-            for( usage_from source : { usage_from::map, usage_from::player } ) {
-                if( ( it.use_from & source ) == usage_from::none ) {
-                    continue;
-                }
-                comp_selection<item_comp> source_selection = it;
-                source_selection.use_from = source;
-                const std::vector<item_location> pass_candidates = craft_source_locations(
-                            *crafter, source_selection, filter, preferred );
-                for( const item_location &candidate : pass_candidates ) {
-                    if( std::find( candidates.begin(), candidates.end(),
-                                  candidate ) == candidates.end() ) {
-                        candidates.push_back( candidate );
+        for( int i = 0; i < 2 && real_count > 0; i++ ) {
+            if( it.use_from & usage_from::map ) {
+                const tripoint_bub_ms &loc = crafter->pos_bub();
+                for( int radius = 0; radius <= PICKUP_RANGE && real_count > 0; radius++ ) {
+                    for( const tripoint_bub_ms &p : m.points_in_radius( loc, radius ) ) {
+                        if( rl_dist( loc, p ) >= radius ) {
+                            // "Simulate" consuming items and put them back
+                            // not very efficient but should be rare enough not to matter
+                            std::list<item> tmp = m.use_amount_square( p, it.comp.type, real_count,
+                                                  i == 0 ? empty_filter : filter );
+                            bool cont_not_empty = false;
+                            std::string iname;
+                            for( item &tmp_i : tmp ) {
+                                if( !tmp_i.empty_container() ) {
+                                    cont_not_empty = true;
+                                    iname = tmp_i.tname( 1U, true );
+                                }
+                                if( const std::optional<vpart_reference> vp = m.veh_at( p ).cargo() ) {
+                                    veh_items.emplace_back( vp.value(), tmp_i );
+                                } else {
+                                    map_items.emplace_back( p, tmp_i );
+                                }
+                            }
+                            if( cont_not_empty && ( no_prompt || !query_yn( liq_cont_msg, iname ) ) ) {
+                                reset_items();
+                                return false;
+                            }
+                        }
                     }
                 }
             }
-        }
-        for( const item_location &candidate : candidates ) {
-            if( real_count <= 0 ) {
-                break;
-            }
-            --real_count;
-            if( !candidate->empty_container() ) {
-                if( no_prompt || !query_yn( _( "%s is not empty.  Continue anyway?" ),
-                                             candidate->tname( 1U, true ) ) ) {
+            if( it.use_from & usage_from::player && real_count > 0 ) {
+                // "Simulate" consuming items and put them back
+                // not very efficient but should be rare enough not to matter
+                std::list<item> tmp = crafter->use_amount( it.comp.type, real_count,
+                                      i == 0 ? empty_filter : filter );
+                real_count -= tmp.size();
+                bool cont_not_empty = false;
+                std::string iname;
+                for( item &tmp_i : tmp ) {
+                    if( !tmp_i.empty_container() ) {
+                        cont_not_empty = true;
+                        iname = tmp_i.tname( 1U, true );
+                    }
+                    inv_items.emplace_back( tmp_i );
+                }
+                if( cont_not_empty && ( no_prompt || !query_yn( liq_cont_msg, iname ) ) ) {
+                    reset_items();
                     return false;
                 }
             }
         }
+        reset_items();
     }
     return true;
+}
+
+static std::list<item> sane_consume_items( const comp_selection<item_comp> &it, Character *crafter,
+        int batch, const std::function<bool( const item & )> &filter )
+{
+    map &m = get_map();
+    const std::vector<pocket_data> it_pkt = it.comp.type->pockets;
+    if( ( item::count_by_charges( it.comp.type ) && it.comp.count > 0 ) ||
+    !std::any_of( it_pkt.begin(), it_pkt.end(), []( const pocket_data & p ) {
+    return p.type == pocket_type::CONTAINER && p.watertight;
+} ) ) {
+        std::list<item> consumed = crafter->consume_items( it, batch, filter );
+        return consumed;
+    }
+
+    // Everything below only occurs for item components that are liquid containers
+    std::function<bool( const item & )> empty_filter = [&filter]( const item & it ) {
+        return it.empty_container() && filter( it );
+    };
+
+    int real_count = ( it.comp.count > 0 ) ? it.comp.count * batch : std::abs( it.comp.count );
+    std::list<item> ret;
+    for( int i = 0; i < 2 && real_count > 0; i++ ) {
+        if( it.use_from & usage_from::map ) {
+            const tripoint_bub_ms &loc = crafter->pos_bub();
+            for( int radius = 0; radius <= PICKUP_RANGE && real_count > 0; radius++ ) {
+                for( const tripoint_bub_ms &p : m.points_in_radius( loc, radius ) ) {
+                    if( rl_dist( loc, p ) >= radius ) {
+                        std::list<item> tmp = m.use_amount_square( p, it.comp.type, real_count,
+                                              i == 0 ? empty_filter : filter );
+                        ret.insert( ret.end(), tmp.begin(), tmp.end() );
+                    }
+                }
+            }
+        }
+        if( it.use_from & usage_from::player && real_count > 0 ) {
+            std::list<item> tmp = crafter->use_amount( it.comp.type, real_count,
+                                  i == 0 ? empty_filter : filter );
+            real_count -= tmp.size();
+            ret.insert( ret.end(), tmp.begin(), tmp.end() );
+        }
+    }
+    return ret;
 }
 
 bool craft_command::safe_to_unload_comp( const item &it )

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -119,7 +119,7 @@ bool build_craft_material_plan( Character &crafter,
         int remaining = selection.comp.count > 0 ? selection.comp.count * batch :
                         std::abs( selection.comp.count );
         if( by_charges && ( selection.use_from & usage_from::map ) ) {
-            const std::optional<item> infinite_source = infinite_map_charge_source(
+            std::optional<item> infinite_source = infinite_map_charge_source(
                     crafter, selection.comp.type );
             if( infinite_source ) {
                 infinite_source->charges = remaining;

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -708,7 +708,7 @@ item craft_command::create_in_progress_craft()
     if( preview.goes_bad() ) {
         const time_duration predicted_remaining = preview.get_shelf_life() -
                 preview.get_shelf_life() * predicted_rot;
-        if( ( predicted_rot >= 1.0 || predicted_remaining <= 1_hours ) &&
+        if( ( predicted_rot >= 1.0 || predicted_remaining <= 3_hours ) &&
             crafter->is_avatar() ) {
             const char *warning = predicted_rot >= 1.0
                                   ? _( "The selected ingredients may be rotten before this craft finishes.\n"

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -652,19 +652,6 @@ item craft_command::create_in_progress_craft()
         start_allocs = { step0 };
     }
 
-    // Run the start (bucket-0) tool debit on a probe before consuming components
-    // so a charge shortfall aborts without losing them; the debited allocations
-    // carry over to the real craft.
-    {
-        item probe( rec, batch_size, item_components{}, std::vector<item_comp> {} );
-        probe.set_step_tool_allocs( start_allocs );
-        if( !crafter->craft_consume_step_tools( probe ) ) {
-            debugmsg( "start tool debit failed for craft %s", rec->ident().str() );
-            return item();
-        }
-        start_allocs = probe.get_step_tool_allocs();
-    }
-
     for( const auto &it : item_selections ) {
         std::list<item> tmp = sane_consume_items( it, crafter, batch_size, filter );
         for( item &tmp_it : tmp ) {
@@ -720,6 +707,19 @@ item craft_command::create_in_progress_craft()
                 return item();
             }
         }
+    }
+
+    // Run the start (bucket-0) tool debit on a probe before consuming components
+    // so a charge shortfall aborts without losing them; the debited allocations
+    // carry over to the real craft.
+    {
+        item probe( rec, batch_size, item_components{}, std::vector<item_comp> {} );
+        probe.set_step_tool_allocs( start_allocs );
+        if( !crafter->craft_consume_step_tools( probe ) ) {
+            debugmsg( "start tool debit failed for craft %s", rec->ident().str() );
+            return item();
+        }
+        start_allocs = probe.get_step_tool_allocs();
     }
 
     item new_craft( rec, batch_size, used, comps_used, should_add_crafting_faults( crafter, rec ) );

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -46,306 +46,8 @@
 #include "weather.h"
 
 static const itype_id itype_candle( "candle" );
-static const itype_id itype_water_faucet( "water_faucet" );
 
 static const trait_id trait_DEBUG_HS( "DEBUG_HS" );
-
-namespace {
-
-struct craft_material_source {
-    item_location location;
-    item snapshot;
-    int64_t source_uid = 0;
-    int quantity = 0;
-    bool by_charges = false;
-    bool infinite_map_source = false;
-    vehicle *vehicle_source = nullptr;
-    itype_id vehicle_fuel_type;
-};
-
-struct craft_material_plan {
-    std::vector<craft_material_source> sources;
-    std::vector<item_comp> preview_components;
-};
-
-void append_craft_source_locations( item_location location,
-                                    const std::function<bool( const item & )> &filter,
-                                    std::vector<item_location> &locations )
-{
-    if( filter( *location ) ) {
-        locations.push_back( location );
-    }
-    for( item *contained : location->all_items_top( pocket_type::CONTAINER ) ) {
-        append_craft_source_locations( item_location( location, contained ), filter, locations );
-    }
-}
-
-std::vector<item_location> craft_source_locations( Character &crafter,
-        const comp_selection<item_comp> &selection,
-        const std::function<bool( const item & )> &filter, bool preferred )
-{
-    const itype_id type = selection.comp.type;
-    const std::function<bool( const item & )> source_filter =
-        [&filter, &type, preferred]( const item &candidate ) {
-            return candidate.typeId() == type && filter( candidate ) &&
-                   ( !preferred || is_preferred_component( candidate ) );
-        };
-    std::vector<item_location> locations;
-    map &here = get_map();
-
-    if( selection.use_from & usage_from::map ) {
-        const std::vector<tripoint_bub_ms> reachable = here.reachable_item_points(
-                    crafter.pos_bub(), PICKUP_RANGE, 1, 100 );
-        for( const tripoint_bub_ms &point : reachable ) {
-            if( !here.accessible_items( point ) ) {
-                continue;
-            }
-            std::list<item_location> at_point = here.items_with( point, []( const item & ) {
-                return true;
-            } );
-            for( item_location &location : at_point ) {
-                append_craft_source_locations( location, source_filter, locations );
-            }
-        }
-    }
-    if( selection.use_from & usage_from::player ) {
-        for( item *candidate : crafter.items_with( source_filter ) ) {
-            locations.emplace_back( crafter, candidate );
-        }
-    }
-    return locations;
-}
-
-std::optional<item> infinite_map_charge_source( Character &crafter, const itype_id &type )
-{
-    map &here = get_map();
-    const std::vector<tripoint_bub_ms> reachable = here.reachable_item_points(
-                crafter.pos_bub(), PICKUP_RANGE, 1, 100 );
-    for( const tripoint_bub_ms &point : reachable ) {
-        item source = here.liquid_from( point );
-        if( source.typeId() == type && source.charges == item::INFINITE_CHARGES ) {
-            return source;
-        }
-    }
-    return std::nullopt;
-}
-
-void add_vehicle_charge_sources( Character &crafter, const itype_id &type, int &remaining,
-                                 craft_material_plan &plan )
-{
-    map &here = get_map();
-    const itype_id vehicle_tool_type = type.obj().phase > phase_id::SOLID ?
-                                       itype_water_faucet : type;
-    const std::vector<tripoint_bub_ms> reachable = here.reachable_item_points(
-                crafter.pos_bub(), PICKUP_RANGE, 1, 100 );
-    for( const tripoint_bub_ms &point : reachable ) {
-        if( remaining <= 0 ) {
-            break;
-        }
-        const optional_vpart_position vehicle_position = here.veh_at( point );
-        if( !vehicle_position ) {
-            continue;
-        }
-        const std::optional<vpart_reference> tool_part = vehicle_position->part_with_tool( here,
-                vehicle_tool_type );
-        if( !tool_part ) {
-            continue;
-        }
-        const itype_id &tool_fuel_type = type->tool_slot_first_ammo();
-        const itype_id &fuel_type = tool_fuel_type.is_null() ? type : tool_fuel_type;
-        vehicle &source_vehicle = tool_part->vehicle();
-        int already_planned = 0;
-        for( const craft_material_source &source : plan.sources ) {
-            if( source.vehicle_source == &source_vehicle &&
-                source.vehicle_fuel_type == fuel_type ) {
-                already_planned += source.quantity;
-            }
-        }
-        const int available = static_cast<int>( source_vehicle.fuel_left( here, fuel_type ) ) -
-                              already_planned;
-        const int quantity = std::min( remaining, available );
-        if( quantity <= 0 ) {
-            continue;
-        }
-        item snapshot( type, calendar::turn_zero );
-        snapshot.charges = quantity;
-        plan.sources.push_back( { item_location::nowhere, snapshot, 0, quantity, true, false,
-                                  &source_vehicle, fuel_type } );
-        remaining -= quantity;
-    }
-}
-
-bool build_craft_material_plan( Character &crafter,
-                                const std::vector<comp_selection<item_comp>> &selections,
-                                int batch, const std::function<bool( const item & )> &filter,
-                                craft_material_plan &plan )
-{
-    for( const comp_selection<item_comp> &selection : selections ) {
-        const bool by_charges = item::count_by_charges( selection.comp.type ) &&
-                                selection.comp.count > 0;
-        int remaining = selection.comp.count > 0 ? selection.comp.count * batch :
-                        std::abs( selection.comp.count );
-        if( by_charges && ( selection.use_from & usage_from::map ) ) {
-            std::optional<item> infinite_source = infinite_map_charge_source(
-                    crafter, selection.comp.type );
-            if( infinite_source ) {
-                infinite_source->charges = remaining;
-                plan.sources.push_back( { item_location::nowhere, *infinite_source, 0, remaining,
-                                          true, true } );
-                remaining = 0;
-            }
-        }
-        std::vector<item_location> candidates;
-        for( int pass = 0; pass < 2 && remaining > 0; ++pass ) {
-            const bool preferred = pass == 0;
-            for( usage_from source : { usage_from::map, usage_from::player } ) {
-                if( ( selection.use_from & source ) == usage_from::none ) {
-                    continue;
-                }
-                comp_selection<item_comp> source_selection = selection;
-                source_selection.use_from = source;
-                const std::vector<item_location> pass_candidates = craft_source_locations(
-                            crafter, source_selection, filter, preferred );
-                for( const item_location &candidate : pass_candidates ) {
-                    if( std::find( candidates.begin(), candidates.end(),
-                                  candidate ) == candidates.end() ) {
-                        candidates.push_back( candidate );
-                    }
-                }
-            }
-        }
-
-        for( item_location &location : candidates ) {
-            if( remaining <= 0 ) {
-                break;
-            }
-            if( !location ) {
-                continue;
-            }
-            int already_planned = 0;
-            for( const craft_material_source &planned : plan.sources ) {
-                if( planned.location == location ) {
-                    already_planned += planned.quantity;
-                }
-            }
-            const int available = by_charges ? location->charges - already_planned :
-                              ( already_planned == 0 ? 1 : 0 );
-            const int quantity = by_charges ? std::min( remaining, available ) : 1;
-            if( quantity <= 0 ) {
-                continue;
-            }
-            item snapshot = *location;
-            if( by_charges && quantity < snapshot.charges ) {
-                snapshot.mod_charges( quantity - snapshot.charges );
-            }
-            plan.sources.push_back( { location, snapshot, location->uid().get_value(), quantity,
-                                      by_charges } );
-            remaining -= quantity;
-        }
-        if( by_charges && remaining > 0 && ( selection.use_from & usage_from::map ) ) {
-            add_vehicle_charge_sources( crafter, selection.comp.type, remaining, plan );
-        }
-        if( remaining > 0 ) {
-            return false;
-        }
-    }
-
-    for( const comp_selection<item_comp> &selection : selections ) {
-        item_comp used = selection.comp;
-        used.count *= batch;
-        std::vector<item_comp>::iterator found = std::find_if( plan.preview_components.begin(),
-                plan.preview_components.end(), [&used]( const item_comp &existing ) {
-            return existing.type == used.type;
-        } );
-        if( found == plan.preview_components.end() ) {
-            plan.preview_components.push_back( used );
-        } else {
-            found->count += used.count;
-        }
-    }
-    return true;
-}
-
-bool validate_craft_material_plan( const craft_material_plan &plan )
-{
-    for( const craft_material_source &source : plan.sources ) {
-        if( source.infinite_map_source ) {
-            continue;
-        }
-        if( source.vehicle_source != nullptr ) {
-            if( source.vehicle_source->fuel_left( get_map(), source.vehicle_fuel_type ) <
-                source.quantity ) {
-                return false;
-            }
-            continue;
-        }
-        if( !source.location || source.location->uid().get_value() != source.source_uid ||
-            source.location->typeId() != source.snapshot.typeId() ) {
-            return false;
-        }
-        if( source.by_charges && source.location->charges < source.quantity ) {
-            return false;
-        }
-    }
-    return true;
-}
-
-bool consume_craft_material_plan( Character &crafter, craft_material_plan &plan,
-                                  item_components &used )
-{
-    if( !validate_craft_material_plan( plan ) ) {
-        return false;
-    }
-
-    map &here = get_map();
-    for( craft_material_source &source : plan.sources ) {
-        item consumed = source.infinite_map_source || source.vehicle_source != nullptr ?
-                        source.snapshot : *source.location;
-        if( source.infinite_map_source ) {
-            used.add( consumed );
-            continue;
-        }
-        if( source.vehicle_source != nullptr ) {
-            if( source.vehicle_source->drain( here, source.vehicle_fuel_type,
-                                              source.quantity ) != source.quantity ) {
-                return false;
-            }
-            used.add( consumed );
-            continue;
-        }
-        if( source.location.has_parent() ) {
-            item_pocket *parent_pocket = source.location.parent_pocket();
-            if( parent_pocket != nullptr ) {
-                parent_pocket->unseal();
-            }
-        }
-        if( source.by_charges ) {
-            consumed.mod_charges( source.quantity - consumed.charges );
-            if( source.location->charges == source.quantity ) {
-                source.location.remove_item();
-            } else {
-                source.location->mod_charges( -source.quantity );
-                source.location.on_contents_changed();
-            }
-        } else {
-            source.location.remove_item();
-            remove_ammo( consumed, crafter );
-        }
-        if( !consumed.contains_no_solids() ) {
-            consumed.spill_contents( crafter );
-        }
-        consumed.overflow( here, crafter.pos_bub( here ) );
-        if( !source.by_charges && craft_command::safe_to_unload_comp( consumed ) ) {
-            item_location consumed_location( crafter, &consumed );
-            unload_activity_actor::unload( crafter, consumed_location );
-        }
-        used.add( consumed );
-    }
-    empty_buckets( crafter );
-    return true;
-}
-
-} // namespace
 
 template<typename CompType>
 std::string comp_selection<CompType>::nname() const
@@ -942,22 +644,16 @@ item craft_command::create_in_progress_craft()
         start_allocs = { step0 };
     }
 
-    craft_material_plan material_plan;
-    if( !build_craft_material_plan( *crafter, item_selections, batch_size, filter,
-                                     material_plan ) ) {
-        debugmsg( "Aborting crafting: couldn't build a non-destructive material plan" );
+    std::optional<item_components> preview_used = crafter->preview_crafting_components(
+                item_selections, batch_size, filter );
+    if( !preview_used ) {
+        debugmsg( "Aborting crafting: couldn't preview selected components" );
         return item();
     }
 
-    // Build the same temporary craft used by the real craft path from the planned
-    // snapshots.  This warning must happen before either materials or tools are
-    // consumed, so cancelling leaves every source unchanged.
-    item_components preview_used;
-    for( const craft_material_source &source : material_plan.sources ) {
-        item preview_component = source.snapshot;
-        preview_used.add( preview_component );
-    }
-    item preview( rec, batch_size, preview_used, material_plan.preview_components, false );
+    // The preview uses copies of the selected components and follows the same
+    // inheritance path as the craft that will be created below.
+    item preview( rec, batch_size, *preview_used, std::vector<item_comp> {}, false );
     const time_duration expected_duration = time_duration::from_moves(
                 crafter->expected_time_to_craft( *rec, batch_size ) );
     const double predicted_rot = preview.get_relative_rot_after(
@@ -978,11 +674,6 @@ item craft_command::create_in_progress_craft()
         }
     }
 
-    if( !validate_craft_material_plan( material_plan ) ) {
-        debugmsg( "Aborting crafting: planned material sources changed before tool validation" );
-        return item();
-    }
-
     // Run the start (bucket-0) tool debit on a probe before consuming components
     // so a charge shortfall aborts without losing them; the debited allocations
     // carry over to the real craft.
@@ -996,9 +687,17 @@ item craft_command::create_in_progress_craft()
         start_allocs = probe.get_step_tool_allocs();
     }
 
-    if( !consume_craft_material_plan( *crafter, material_plan, used ) ) {
-        debugmsg( "Aborting crafting: planned material sources changed before consumption" );
-        return item();
+    for( const auto &it : item_selections ) {
+        std::list<item> tmp = sane_consume_items( it, crafter, batch_size, filter );
+        for( item &tmp_it : tmp ) {
+            if( safe_to_unload_comp( tmp_it ) ) {
+                item_location tmp_loc( *crafter, &tmp_it );
+                unload_activity_actor::unload( *crafter, tmp_loc );
+            }
+        }
+        for( item &it : tmp ) {
+            used.add( it );
+        }
     }
 
     for( const comp_selection<item_comp> &selection : item_selections ) {

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -225,8 +225,12 @@ bool consume_craft_material_plan( Character &crafter, craft_material_plan &plan,
         }
         if( source.by_charges ) {
             consumed.mod_charges( source.quantity - consumed.charges );
-            source.location->mod_charges( -source.quantity );
-            source.location.on_contents_changed();
+            if( source.location->charges == source.quantity ) {
+                source.location.remove_item();
+            } else {
+                source.location->mod_charges( -source.quantity );
+                source.location.on_contents_changed();
+            }
         } else {
             source.location.remove_item();
             remove_ammo( consumed, crafter );

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -246,6 +246,12 @@ bool consume_craft_material_plan( Character &crafter, craft_material_plan &plan,
             used.add( consumed );
             continue;
         }
+        if( source.location.has_parent() ) {
+            item_pocket *parent_pocket = source.location.parent_pocket();
+            if( parent_pocket != nullptr ) {
+                parent_pocket->unseal();
+            }
+        }
         if( source.by_charges ) {
             consumed.mod_charges( source.quantity - consumed.charges );
             if( source.location->charges == source.quantity ) {
@@ -268,6 +274,7 @@ bool consume_craft_material_plan( Character &crafter, craft_material_plan &plan,
         }
         used.add( consumed );
     }
+    empty_buckets( crafter );
     return true;
 }
 

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -41,6 +41,7 @@
 #include "vehicle.h"
 #include "visitable.h"
 #include "vpart_position.h"
+#include "weather.h"
 
 static const itype_id itype_candle( "candle" );
 
@@ -478,6 +479,15 @@ static bool should_add_crafting_faults( Character *who, const recipe *rec )
     return false;
 }
 
+static void restore_crafting_components( Character &crafter, item_components &components )
+{
+    for( item_components::type_vector_pair &tvp : components ) {
+        for( item &component : tvp.second ) {
+            crafter.i_add_or_drop( component );
+        }
+    }
+}
+
 
 std::vector<std::vector<step_tool_alloc>> select_step_tool_allocs(
         Character &crafter, const recipe &rec, int batch, read_only_visitable &map_inv,
@@ -642,19 +652,6 @@ item craft_command::create_in_progress_craft()
         start_allocs = { step0 };
     }
 
-    // Run the start (bucket-0) tool debit on a probe before consuming components
-    // so a charge shortfall aborts without losing them; the debited allocations
-    // carry over to the real craft.
-    {
-        item probe( rec, batch_size, item_components{}, std::vector<item_comp> {} );
-        probe.set_step_tool_allocs( start_allocs );
-        if( !crafter->craft_consume_step_tools( probe ) ) {
-            debugmsg( "start tool debit failed for craft %s", rec->ident().str() );
-            return item();
-        }
-        start_allocs = probe.get_step_tool_allocs();
-    }
-
     for( const auto &it : item_selections ) {
         std::list<item> tmp = sane_consume_items( it, crafter, batch_size, filter );
         for( item &tmp_it : tmp ) {
@@ -683,6 +680,49 @@ item craft_command::create_in_progress_craft()
         } else {
             comps_used.emplace_back( comp_used );
         }
+    }
+
+    // Build the same temporary craft used by the real craft path, but without
+    // consuming the components from `used`.  This makes the warning follow the
+    // actual component inheritance logic instead of maintaining a second model.
+    std::vector<item_comp> preview_comps = comps_used;
+    item preview( rec, batch_size, used, preview_comps, false );
+    const time_duration expected_duration = time_duration::from_moves(
+                crafter->expected_time_to_craft( *rec, batch_size ) );
+    const double predicted_rot = preview.get_relative_rot_after(
+                                     get_weather().get_temperature( crafter->pos_bub() ), 1.0f,
+                                     expected_duration );
+    if( preview.goes_bad() ) {
+        const time_duration predicted_remaining = preview.get_shelf_life() -
+                preview.get_shelf_life() * predicted_rot;
+        if( predicted_rot >= 1.0 && crafter->is_avatar() ) {
+            const bool continue_craft = crafter->query_yn(
+                                            _( "The selected ingredients may be rotten before this craft finishes.\n"
+                                               "Start crafting anyway?" ) );
+            if( !continue_craft ) {
+                restore_crafting_components( *crafter, used );
+                return item();
+            }
+        } else if( predicted_rot < 1.0 && predicted_remaining <= 1_hours &&
+                   crafter->is_avatar() ) {
+            crafter->add_msg( m_warning,
+                              _( "The finished %s will have very little shelf life left." ),
+                              rec->result_name() );
+        }
+    }
+
+    // Run the start (bucket-0) tool debit on a probe after the rot warning so a
+    // cancelled warning does not consume tool charges; the debited allocations
+    // carry over to the real craft.
+    {
+        item probe( rec, batch_size, item_components{}, std::vector<item_comp> {} );
+        probe.set_step_tool_allocs( start_allocs );
+        if( !crafter->craft_consume_step_tools( probe ) ) {
+            debugmsg( "start tool debit failed for craft %s", rec->ident().str() );
+            restore_crafting_components( *crafter, used );
+            return item();
+        }
+        start_allocs = probe.get_step_tool_allocs();
     }
 
     item new_craft( rec, batch_size, used, comps_used, should_add_crafting_faults( crafter, rec ) );

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -65,6 +65,18 @@ struct craft_material_plan {
     std::vector<item_comp> preview_components;
 };
 
+void append_craft_source_locations( item_location location,
+                                    const std::function<bool( const item & )> &filter,
+                                    std::vector<item_location> &locations )
+{
+    if( filter( *location ) ) {
+        locations.push_back( location );
+    }
+    for( item *contained : location->all_items_top( pocket_type::CONTAINER ) ) {
+        append_craft_source_locations( item_location( location, contained ), filter, locations );
+    }
+}
+
 std::vector<item_location> craft_source_locations( Character &crafter,
         const comp_selection<item_comp> &selection,
         const std::function<bool( const item & )> &filter, bool preferred )
@@ -82,8 +94,15 @@ std::vector<item_location> craft_source_locations( Character &crafter,
         const std::vector<tripoint_bub_ms> reachable = here.reachable_item_points(
                     crafter.pos_bub(), PICKUP_RANGE, 1, 100 );
         for( const tripoint_bub_ms &point : reachable ) {
-            std::list<item_location> at_point = here.items_with( point, source_filter );
-            locations.insert( locations.end(), at_point.begin(), at_point.end() );
+            if( !here.accessible_items( point ) ) {
+                continue;
+            }
+            std::list<item_location> at_point = here.items_with( point, []( const item & ) {
+                return true;
+            } );
+            for( item_location &location : at_point ) {
+                append_craft_source_locations( location, source_filter, locations );
+            }
         }
     }
     if( selection.use_from & usage_from::player ) {

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -46,6 +46,7 @@
 #include "weather.h"
 
 static const itype_id itype_candle( "candle" );
+static const itype_id itype_water_faucet( "water_faucet" );
 
 static const trait_id trait_DEBUG_HS( "DEBUG_HS" );
 
@@ -58,6 +59,8 @@ struct craft_material_source {
     int quantity = 0;
     bool by_charges = false;
     bool infinite_map_source = false;
+    vehicle *vehicle_source = nullptr;
+    itype_id vehicle_fuel_type;
 };
 
 struct craft_material_plan {
@@ -127,6 +130,51 @@ std::optional<item> infinite_map_charge_source( Character &crafter, const itype_
     return std::nullopt;
 }
 
+void add_vehicle_charge_sources( Character &crafter, const itype_id &type, int &remaining,
+                                 craft_material_plan &plan )
+{
+    map &here = get_map();
+    const itype_id vehicle_tool_type = type.obj().phase > phase_id::SOLID ?
+                                       itype_water_faucet : type;
+    const std::vector<tripoint_bub_ms> reachable = here.reachable_item_points(
+                crafter.pos_bub(), PICKUP_RANGE, 1, 100 );
+    for( const tripoint_bub_ms &point : reachable ) {
+        if( remaining <= 0 ) {
+            break;
+        }
+        const optional_vpart_position vehicle_position = here.veh_at( point );
+        if( !vehicle_position ) {
+            continue;
+        }
+        const std::optional<vpart_reference> tool_part = vehicle_position->part_with_tool( here,
+                vehicle_tool_type );
+        if( !tool_part ) {
+            continue;
+        }
+        const itype_id &tool_fuel_type = type->tool_slot_first_ammo();
+        const itype_id &fuel_type = tool_fuel_type.is_null() ? type : tool_fuel_type;
+        vehicle &source_vehicle = tool_part->vehicle();
+        int already_planned = 0;
+        for( const craft_material_source &source : plan.sources ) {
+            if( source.vehicle_source == &source_vehicle &&
+                source.vehicle_fuel_type == fuel_type ) {
+                already_planned += source.quantity;
+            }
+        }
+        const int available = static_cast<int>( source_vehicle.fuel_left( here, fuel_type ) ) -
+                              already_planned;
+        const int quantity = std::min( remaining, available );
+        if( quantity <= 0 ) {
+            continue;
+        }
+        item snapshot( type, calendar::turn_zero );
+        snapshot.charges = quantity;
+        plan.sources.push_back( { item_location::nowhere, snapshot, 0, quantity, true, false,
+                                  &source_vehicle, fuel_type } );
+        remaining -= quantity;
+    }
+}
+
 bool build_craft_material_plan( Character &crafter,
                                 const std::vector<comp_selection<item_comp>> &selections,
                                 int batch, const std::function<bool( const item & )> &filter,
@@ -194,6 +242,9 @@ bool build_craft_material_plan( Character &crafter,
                                       by_charges } );
             remaining -= quantity;
         }
+        if( by_charges && remaining > 0 && ( selection.use_from & usage_from::map ) ) {
+            add_vehicle_charge_sources( crafter, selection.comp.type, remaining, plan );
+        }
         if( remaining > 0 ) {
             return false;
         }
@@ -221,6 +272,13 @@ bool validate_craft_material_plan( const craft_material_plan &plan )
         if( source.infinite_map_source ) {
             continue;
         }
+        if( source.vehicle_source != nullptr ) {
+            if( source.vehicle_source->fuel_left( get_map(), source.vehicle_fuel_type ) <
+                source.quantity ) {
+                return false;
+            }
+            continue;
+        }
         if( !source.location || source.location->uid().get_value() != source.source_uid ||
             source.location->typeId() != source.snapshot.typeId() ) {
             return false;
@@ -241,8 +299,17 @@ bool consume_craft_material_plan( Character &crafter, craft_material_plan &plan,
 
     map &here = get_map();
     for( craft_material_source &source : plan.sources ) {
-        item consumed = source.infinite_map_source ? source.snapshot : *source.location;
+        item consumed = source.infinite_map_source || source.vehicle_source != nullptr ?
+                        source.snapshot : *source.location;
         if( source.infinite_map_source ) {
+            used.add( consumed );
+            continue;
+        }
+        if( source.vehicle_source != nullptr ) {
+            if( source.vehicle_source->drain( here, source.vehicle_fuel_type,
+                                              source.quantity ) != source.quantity ) {
+                return false;
+            }
             used.add( consumed );
             continue;
         }

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -125,7 +125,14 @@ bool build_craft_material_plan( Character &crafter,
             if( !location ) {
                 continue;
             }
-            const int available = by_charges ? location->charges : 1;
+            int already_planned = 0;
+            for( const craft_material_source &planned : plan.sources ) {
+                if( planned.location == location ) {
+                    already_planned += planned.quantity;
+                }
+            }
+            const int available = by_charges ? location->charges - already_planned :
+                              ( already_planned == 0 ? 1 : 0 );
             const int quantity = by_charges ? std::min( remaining, available ) : 1;
             if( quantity <= 0 ) {
                 continue;
@@ -727,11 +734,24 @@ item craft_command::create_in_progress_craft()
     const double predicted_rot = preview.get_relative_rot_after(
                                      get_weather().get_temperature( crafter->pos_bub() ), 1.0f,
                                      expected_duration );
-    if( preview.goes_bad() && predicted_rot >= 1.0 && crafter->is_avatar() ) {
-        if( !crafter->query_yn( _( "The selected ingredients may be rotten before this craft finishes.\n"
-                                   "Start crafting anyway?" ) ) ) {
-            return item();
+    if( preview.goes_bad() && crafter->is_avatar() ) {
+        const time_duration predicted_remaining = preview.get_shelf_life() -
+                preview.get_shelf_life() * predicted_rot;
+        if( predicted_rot >= 1.0 || predicted_remaining <= 3_hours ) {
+            const char *warning = predicted_rot >= 1.0
+                                  ? _( "The selected ingredients may be rotten before this craft finishes.\n"
+                                       "Start crafting anyway?" )
+                                  : _( "The finished item may have one hour or less of shelf life left.\n"
+                                       "Start crafting anyway?" );
+            if( !crafter->query_yn( warning ) ) {
+                return item();
+            }
         }
+    }
+
+    if( !validate_craft_material_plan( material_plan ) ) {
+        debugmsg( "Aborting crafting: planned material sources changed before tool validation" );
+        return item();
     }
 
     // Run the start (bucket-0) tool debit on a probe before consuming components

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -718,9 +718,9 @@ item craft_command::create_in_progress_craft()
             }
         } else if( predicted_rot < 1.0 && predicted_remaining <= 1_hours &&
                    crafter->is_avatar() ) {
-            crafter->add_msg( m_warning,
-                              _( "The finished %s will have very little shelf life left." ),
-                              rec->result_name() );
+            crafter->add_msg_if_player( m_warning,
+                                        _( "The finished %s will have very little shelf life left." ),
+                                        rec->result_name() );
         }
     }
 

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -119,10 +119,12 @@ bool build_craft_material_plan( Character &crafter,
         int remaining = selection.comp.count > 0 ? selection.comp.count * batch :
                         std::abs( selection.comp.count );
         if( by_charges && ( selection.use_from & usage_from::map ) ) {
-            std::optional<item> infinite_source = infinite_map_charge_source( crafter, selection.comp.type );
+            const std::optional<item> infinite_source = infinite_map_charge_source(
+                    crafter, selection.comp.type );
             if( infinite_source ) {
                 infinite_source->charges = remaining;
-                plan.sources.push_back( { item_location::nowhere, *infinite_source, 0, remaining, true, true } );
+                plan.sources.push_back( { item_location::nowhere, *infinite_source, 0, remaining,
+                                          true, true } );
                 remaining = 0;
             }
         }
@@ -138,7 +140,8 @@ bool build_craft_material_plan( Character &crafter,
                 const std::vector<item_location> pass_candidates = craft_source_locations(
                             crafter, source_selection, filter, preferred );
                 for( const item_location &candidate : pass_candidates ) {
-                    if( std::find( candidates.begin(), candidates.end(), candidate ) == candidates.end() ) {
+                    if( std::find( candidates.begin(), candidates.end(),
+                                  candidate ) == candidates.end() ) {
                         candidates.push_back( candidate );
                     }
                 }
@@ -168,7 +171,8 @@ bool build_craft_material_plan( Character &crafter,
             if( by_charges && quantity < snapshot.charges ) {
                 snapshot.mod_charges( quantity - snapshot.charges );
             }
-            plan.sources.push_back( { location, snapshot, location->uid().get_value(), quantity, by_charges } );
+            plan.sources.push_back( { location, snapshot, location->uid().get_value(), quantity,
+                                      by_charges } );
             remaining -= quantity;
         }
         if( remaining > 0 ) {
@@ -179,8 +183,8 @@ bool build_craft_material_plan( Character &crafter,
     for( const comp_selection<item_comp> &selection : selections ) {
         item_comp used = selection.comp;
         used.count *= batch;
-        auto found = std::find_if( plan.preview_components.begin(), plan.preview_components.end(),
-        [&used]( const item_comp &existing ) {
+        std::vector<item_comp>::iterator found = std::find_if( plan.preview_components.begin(),
+                plan.preview_components.end(), [&used]( const item_comp &existing ) {
             return existing.type == used.type;
         } );
         if( found == plan.preview_components.end() ) {
@@ -530,7 +534,8 @@ bool craft_command::continue_prompt_liquids( const std::function<bool( const ite
                 const std::vector<item_location> pass_candidates = craft_source_locations(
                             *crafter, source_selection, filter, preferred );
                 for( const item_location &candidate : pass_candidates ) {
-                    if( std::find( candidates.begin(), candidates.end(), candidate ) == candidates.end() ) {
+                    if( std::find( candidates.begin(), candidates.end(),
+                                  candidate ) == candidates.end() ) {
                         candidates.push_back( candidate );
                     }
                 }
@@ -781,10 +786,10 @@ item craft_command::create_in_progress_craft()
                 preview.get_shelf_life() * predicted_rot;
         if( predicted_rot >= 1.0 || predicted_remaining <= 3_hours ) {
             const char *warning = predicted_rot >= 1.0
-                                  ? _( "The selected ingredients may be rotten before this craft finishes.\n"
-                                       "Start crafting anyway?" )
-                                  : _( "The finished item may have one hour or less of shelf life left.\n"
-                                       "Start crafting anyway?" );
+                                  ? _( "The selected ingredients may be rotten before this craft "
+                                       "finishes.\nStart crafting anyway?" )
+                                  : _( "The finished item may have one hour or less of shelf life "
+                                       "left.\nStart crafting anyway?" );
             if( !crafter->query_yn( warning ) ) {
                 return item();
             }

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -480,7 +480,6 @@ static bool should_add_crafting_faults( Character *who, const recipe *rec )
     }
     return false;
 }
-
 std::vector<std::vector<step_tool_alloc>> select_step_tool_allocs(
         Character &crafter, const recipe &rec, int batch, read_only_visitable &map_inv,
         bool &cancelled, int reselect_step )

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -53,7 +53,7 @@ namespace {
 struct craft_material_source {
     item_location location;
     item snapshot;
-    item_uid source_uid;
+    int64_t source_uid = 0;
     int quantity = 0;
     bool by_charges = false;
 };
@@ -141,7 +141,7 @@ bool build_craft_material_plan( Character &crafter,
             if( by_charges && quantity < snapshot.charges ) {
                 snapshot.mod_charges( quantity - snapshot.charges );
             }
-            plan.sources.push_back( { location, snapshot, location->uid(), quantity, by_charges } );
+            plan.sources.push_back( { location, snapshot, location->uid().get_value(), quantity, by_charges } );
             remaining -= quantity;
         }
         if( remaining > 0 ) {
@@ -168,7 +168,7 @@ bool build_craft_material_plan( Character &crafter,
 bool validate_craft_material_plan( const craft_material_plan &plan )
 {
     for( const craft_material_source &source : plan.sources ) {
-        if( !source.location || source.location->uid() != source.source_uid ||
+        if( !source.location || source.location->uid().get_value() != source.source_uid ||
             source.location->typeId() != source.snapshot.typeId() ) {
             return false;
         }

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -7,6 +7,7 @@
 #include <functional>
 #include <limits>
 #include <list>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -56,6 +57,7 @@ struct craft_material_source {
     int64_t source_uid = 0;
     int quantity = 0;
     bool by_charges = false;
+    bool infinite_map_source = false;
 };
 
 struct craft_material_plan {
@@ -92,6 +94,20 @@ std::vector<item_location> craft_source_locations( Character &crafter,
     return locations;
 }
 
+std::optional<item> infinite_map_charge_source( Character &crafter, const itype_id &type )
+{
+    map &here = get_map();
+    const std::vector<tripoint_bub_ms> reachable = here.reachable_item_points(
+                crafter.pos_bub(), PICKUP_RANGE, 1, 100 );
+    for( const tripoint_bub_ms &point : reachable ) {
+        item source = here.liquid_from( point );
+        if( source.typeId() == type && source.charges == item::INFINITE_CHARGES ) {
+            return source;
+        }
+    }
+    return std::nullopt;
+}
+
 bool build_craft_material_plan( Character &crafter,
                                 const std::vector<comp_selection<item_comp>> &selections,
                                 int batch, const std::function<bool( const item & )> &filter,
@@ -102,6 +118,14 @@ bool build_craft_material_plan( Character &crafter,
                                 selection.comp.count > 0;
         int remaining = selection.comp.count > 0 ? selection.comp.count * batch :
                         std::abs( selection.comp.count );
+        if( by_charges && ( selection.use_from & usage_from::map ) ) {
+            std::optional<item> infinite_source = infinite_map_charge_source( crafter, selection.comp.type );
+            if( infinite_source ) {
+                infinite_source->charges = remaining;
+                plan.sources.push_back( { item_location::nowhere, *infinite_source, 0, remaining, true, true } );
+                remaining = 0;
+            }
+        }
         std::vector<item_location> candidates;
         for( int pass = 0; pass < 2 && remaining > 0; ++pass ) {
             const bool preferred = pass == 0;
@@ -171,6 +195,9 @@ bool build_craft_material_plan( Character &crafter,
 bool validate_craft_material_plan( const craft_material_plan &plan )
 {
     for( const craft_material_source &source : plan.sources ) {
+        if( source.infinite_map_source ) {
+            continue;
+        }
         if( !source.location || source.location->uid().get_value() != source.source_uid ||
             source.location->typeId() != source.snapshot.typeId() ) {
             return false;
@@ -191,7 +218,11 @@ bool consume_craft_material_plan( Character &crafter, craft_material_plan &plan,
 
     map &here = get_map();
     for( craft_material_source &source : plan.sources ) {
-        item consumed = *source.location;
+        item consumed = source.infinite_map_source ? source.snapshot : *source.location;
+        if( source.infinite_map_source ) {
+            used.add( consumed );
+            continue;
+        }
         if( source.by_charges ) {
             consumed.mod_charges( source.quantity - consumed.charges );
             source.location->mod_charges( -source.quantity );

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -106,6 +106,9 @@ bool build_craft_material_plan( Character &crafter,
         for( int pass = 0; pass < 2 && remaining > 0; ++pass ) {
             const bool preferred = pass == 0;
             for( usage_from source : { usage_from::map, usage_from::player } ) {
+                if( ( selection.use_from & source ) == usage_from::none ) {
+                    continue;
+                }
                 comp_selection<item_comp> source_selection = selection;
                 source_selection.use_from = source;
                 const std::vector<item_location> pass_candidates = craft_source_locations(
@@ -484,6 +487,9 @@ bool craft_command::continue_prompt_liquids( const std::function<bool( const ite
         std::vector<item_location> candidates;
         for( bool preferred : { true, false } ) {
             for( usage_from source : { usage_from::map, usage_from::player } ) {
+                if( ( it.use_from & source ) == usage_from::none ) {
+                    continue;
+                }
                 comp_selection<item_comp> source_selection = it;
                 source_selection.use_from = source;
                 const std::vector<item_location> pass_candidates = craft_source_locations(

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -9,6 +9,7 @@
 #include <list>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "activity_actor_definitions.h"
 #include "character.h"
@@ -46,6 +47,163 @@
 static const itype_id itype_candle( "candle" );
 
 static const trait_id trait_DEBUG_HS( "DEBUG_HS" );
+
+namespace {
+
+struct craft_material_source {
+    item_location location;
+    item snapshot;
+    item_uid source_uid;
+    int quantity = 0;
+    bool by_charges = false;
+};
+
+struct craft_material_plan {
+    std::vector<craft_material_source> sources;
+    item_components preview_components;
+};
+
+std::vector<item_location> craft_source_locations( Character &crafter,
+        const comp_selection<item_comp> &selection,
+        const std::function<bool( const item & )> &filter, bool preferred )
+{
+    const itype_id type = selection.comp.type;
+    const std::function<bool( const item & )> source_filter =
+        [&filter, &type, preferred]( const item &candidate ) {
+            return candidate.typeId() == type && filter( candidate ) &&
+                   ( !preferred || is_preferred_component( candidate ) );
+        };
+    std::vector<item_location> locations;
+    map &here = get_map();
+
+    if( selection.use_from & usage_from::map ) {
+        const std::vector<tripoint_bub_ms> reachable = here.reachable_item_points(
+                    crafter.pos_bub(), PICKUP_RANGE, 1, 100 );
+        for( const tripoint_bub_ms &point : reachable ) {
+            std::list<item_location> at_point = here.items_with( point, source_filter );
+            locations.insert( locations.end(), at_point.begin(), at_point.end() );
+        }
+    }
+    if( selection.use_from & usage_from::player ) {
+        for( item *candidate : crafter.items_with( source_filter ) ) {
+            locations.emplace_back( crafter, candidate );
+        }
+    }
+    return locations;
+}
+
+bool build_craft_material_plan( Character &crafter,
+                                const std::vector<comp_selection<item_comp>> &selections,
+                                int batch, const std::function<bool( const item & )> &filter,
+                                craft_material_plan &plan )
+{
+    for( const comp_selection<item_comp> &selection : selections ) {
+        const bool by_charges = item::count_by_charges( selection.comp.type ) &&
+                                selection.comp.count > 0;
+        int remaining = selection.comp.count > 0 ? selection.comp.count * batch :
+                        std::abs( selection.comp.count );
+        std::vector<item_location> candidates;
+        for( int pass = 0; pass < 2 && remaining > 0; ++pass ) {
+            const bool preferred = pass == 0;
+            for( usage_from source : { usage_from::map, usage_from::player } ) {
+                comp_selection<item_comp> source_selection = selection;
+                source_selection.use_from = source;
+                const std::vector<item_location> pass_candidates = craft_source_locations(
+                            crafter, source_selection, filter, preferred );
+                for( const item_location &candidate : pass_candidates ) {
+                    if( std::find( candidates.begin(), candidates.end(), candidate ) == candidates.end() ) {
+                        candidates.push_back( candidate );
+                    }
+                }
+            }
+        }
+
+        for( item_location &location : candidates ) {
+            if( remaining <= 0 ) {
+                break;
+            }
+            if( !location ) {
+                continue;
+            }
+            const int available = by_charges ? location->charges : 1;
+            const int quantity = by_charges ? std::min( remaining, available ) : 1;
+            if( quantity <= 0 ) {
+                continue;
+            }
+            item snapshot = *location;
+            if( by_charges && quantity < snapshot.charges ) {
+                snapshot.mod_charges( quantity - snapshot.charges );
+            }
+            plan.sources.push_back( { location, snapshot, location->uid(), quantity, by_charges } );
+            remaining -= quantity;
+        }
+        if( remaining > 0 ) {
+            return false;
+        }
+    }
+
+    for( const comp_selection<item_comp> &selection : selections ) {
+        item_comp used = selection.comp;
+        used.count *= batch;
+        auto found = std::find_if( plan.preview_components.begin(), plan.preview_components.end(),
+        [&used]( const item_comp &existing ) {
+            return existing.type == used.type;
+        } );
+        if( found == plan.preview_components.end() ) {
+            plan.preview_components.push_back( used );
+        } else {
+            found->count += used.count;
+        }
+    }
+    return true;
+}
+
+bool validate_craft_material_plan( const craft_material_plan &plan )
+{
+    for( const craft_material_source &source : plan.sources ) {
+        if( !source.location || source.location->uid() != source.source_uid ||
+            source.location->typeId() != source.snapshot.typeId() ) {
+            return false;
+        }
+        if( source.by_charges && source.location->charges < source.quantity ) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool consume_craft_material_plan( Character &crafter, craft_material_plan &plan,
+                                  item_components &used )
+{
+    if( !validate_craft_material_plan( plan ) ) {
+        return false;
+    }
+
+    map &here = get_map();
+    for( craft_material_source &source : plan.sources ) {
+        item consumed = *source.location;
+        if( source.by_charges ) {
+            consumed.mod_charges( source.quantity - consumed.charges );
+            source.location->mod_charges( -source.quantity );
+            source.location.on_contents_changed();
+        } else {
+            source.location.remove_item();
+            remove_ammo( consumed, crafter );
+        }
+        if( !consumed.contains_no_solids() ) {
+            consumed.spill_contents( crafter );
+        }
+        consumed.overflow( here, crafter.pos_bub( here ) );
+        if( !source.by_charges && craft_command::safe_to_unload_comp( consumed ) ) {
+            item_location consumed_location( crafter, &consumed );
+            unload_activity_actor::unload( crafter, consumed_location );
+        }
+        used.add( consumed );
+    }
+    return true;
+}
+
+} // namespace
 
 template<typename CompType>
 std::string comp_selection<CompType>::nname() const
@@ -306,7 +464,6 @@ bool craft_command::query_continue( const std::vector<comp_selection<item_comp>>
 bool craft_command::continue_prompt_liquids( const std::function<bool( const item & )> &filter,
         bool no_prompt )
 {
-    map &m = get_map();
     for( const auto &it : item_selections ) {
         const std::vector<pocket_data> it_pkt = it.comp.type->pockets;
         if( ( item::count_by_charges( it.comp.type ) && it.comp.count > 0 ) ||
@@ -316,127 +473,35 @@ bool craft_command::continue_prompt_liquids( const std::function<bool( const ite
             continue;
         }
 
-        // Everything below only occurs for item components that are liquid containers
-        std::function<bool( const item & )> empty_filter = [&filter]( const item & it ) {
-            return it.empty_container() && filter( it );
-        };
-
-        const char *liq_cont_msg = _( "%1$s is not empty.  Continue anyway?" );
-        std::vector<std::pair<const tripoint_bub_ms, item>> map_items;
-        std::vector<std::pair<const vpart_reference, item>> veh_items;
-        std::vector<item> inv_items;
-
-        auto reset_items = [&]() {
-            for( auto &mit : map_items ) {
-                m.add_item_or_charges( mit.first, mit.second );
-            }
-            for( item &iit : inv_items ) {
-                crafter->i_add_or_drop( iit );
-            }
-            for( auto &vit : veh_items ) {
-                vit.first.vehicle().add_item( m, vit.first.part(), vit.second );
-            }
-        };
-
         int real_count = ( it.comp.count > 0 ) ? it.comp.count * batch_size : std::abs( it.comp.count );
-        for( int i = 0; i < 2 && real_count > 0; i++ ) {
-            if( it.use_from & usage_from::map ) {
-                const tripoint_bub_ms &loc = crafter->pos_bub();
-                for( int radius = 0; radius <= PICKUP_RANGE && real_count > 0; radius++ ) {
-                    for( const tripoint_bub_ms &p : m.points_in_radius( loc, radius ) ) {
-                        if( rl_dist( loc, p ) >= radius ) {
-                            // "Simulate" consuming items and put them back
-                            // not very efficient but should be rare enough not to matter
-                            std::list<item> tmp = m.use_amount_square( p, it.comp.type, real_count,
-                                                  i == 0 ? empty_filter : filter );
-                            bool cont_not_empty = false;
-                            std::string iname;
-                            for( item &tmp_i : tmp ) {
-                                if( !tmp_i.empty_container() ) {
-                                    cont_not_empty = true;
-                                    iname = tmp_i.tname( 1U, true );
-                                }
-                                if( const std::optional<vpart_reference> vp = m.veh_at( p ).cargo() ) {
-                                    veh_items.emplace_back( vp.value(), tmp_i );
-                                } else {
-                                    map_items.emplace_back( p, tmp_i );
-                                }
-                            }
-                            if( cont_not_empty && ( no_prompt || !query_yn( liq_cont_msg, iname ) ) ) {
-                                reset_items();
-                                return false;
-                            }
-                        }
+        std::vector<item_location> candidates;
+        for( bool preferred : { true, false } ) {
+            for( usage_from source : { usage_from::map, usage_from::player } ) {
+                comp_selection<item_comp> source_selection = it;
+                source_selection.use_from = source;
+                const std::vector<item_location> pass_candidates = craft_source_locations(
+                            *crafter, source_selection, filter, preferred );
+                for( const item_location &candidate : pass_candidates ) {
+                    if( std::find( candidates.begin(), candidates.end(), candidate ) == candidates.end() ) {
+                        candidates.push_back( candidate );
                     }
                 }
             }
-            if( it.use_from & usage_from::player && real_count > 0 ) {
-                // "Simulate" consuming items and put them back
-                // not very efficient but should be rare enough not to matter
-                std::list<item> tmp = crafter->use_amount( it.comp.type, real_count,
-                                      i == 0 ? empty_filter : filter );
-                real_count -= tmp.size();
-                bool cont_not_empty = false;
-                std::string iname;
-                for( item &tmp_i : tmp ) {
-                    if( !tmp_i.empty_container() ) {
-                        cont_not_empty = true;
-                        iname = tmp_i.tname( 1U, true );
-                    }
-                    inv_items.emplace_back( tmp_i );
-                }
-                if( cont_not_empty && ( no_prompt || !query_yn( liq_cont_msg, iname ) ) ) {
-                    reset_items();
+        }
+        for( const item_location &candidate : candidates ) {
+            if( real_count <= 0 ) {
+                break;
+            }
+            --real_count;
+            if( !candidate->empty_container() ) {
+                if( no_prompt || !query_yn( _( "%s is not empty.  Continue anyway?" ),
+                                             candidate->tname( 1U, true ) ) ) {
                     return false;
                 }
             }
         }
-        reset_items();
     }
     return true;
-}
-
-static std::list<item> sane_consume_items( const comp_selection<item_comp> &it, Character *crafter,
-        int batch, const std::function<bool( const item & )> &filter )
-{
-    map &m = get_map();
-    const std::vector<pocket_data> it_pkt = it.comp.type->pockets;
-    if( ( item::count_by_charges( it.comp.type ) && it.comp.count > 0 ) ||
-    !std::any_of( it_pkt.begin(), it_pkt.end(), []( const pocket_data & p ) {
-    return p.type == pocket_type::CONTAINER && p.watertight;
-} ) ) {
-        std::list<item> consumed = crafter->consume_items( it, batch, filter );
-        return consumed;
-    }
-
-    // Everything below only occurs for item components that are liquid containers
-    std::function<bool( const item & )> empty_filter = [&filter]( const item & it ) {
-        return it.empty_container() && filter( it );
-    };
-
-    int real_count = ( it.comp.count > 0 ) ? it.comp.count * batch : std::abs( it.comp.count );
-    std::list<item> ret;
-    for( int i = 0; i < 2 && real_count > 0; i++ ) {
-        if( it.use_from & usage_from::map ) {
-            const tripoint_bub_ms &loc = crafter->pos_bub();
-            for( int radius = 0; radius <= PICKUP_RANGE && real_count > 0; radius++ ) {
-                for( const tripoint_bub_ms &p : m.points_in_radius( loc, radius ) ) {
-                    if( rl_dist( loc, p ) >= radius ) {
-                        std::list<item> tmp = m.use_amount_square( p, it.comp.type, real_count,
-                                              i == 0 ? empty_filter : filter );
-                        ret.insert( ret.end(), tmp.begin(), tmp.end() );
-                    }
-                }
-            }
-        }
-        if( it.use_from & usage_from::player && real_count > 0 ) {
-            std::list<item> tmp = crafter->use_amount( it.comp.type, real_count,
-                                  i == 0 ? empty_filter : filter );
-            real_count -= tmp.size();
-            ret.insert( ret.end(), tmp.begin(), tmp.end() );
-        }
-    }
-    return ret;
 }
 
 bool craft_command::safe_to_unload_comp( const item &it )
@@ -478,16 +543,6 @@ static bool should_add_crafting_faults( Character *who, const recipe *rec )
     }
     return false;
 }
-
-static void restore_crafting_components( Character &crafter, item_components &components )
-{
-    for( item_components::type_vector_pair &tvp : components ) {
-        for( item &component : tvp.second ) {
-            crafter.i_add_or_drop( component );
-        }
-    }
-}
-
 
 std::vector<std::vector<step_tool_alloc>> select_step_tool_allocs(
         Character &crafter, const recipe &rec, int batch, read_only_visitable &map_inv,
@@ -652,6 +707,33 @@ item craft_command::create_in_progress_craft()
         start_allocs = { step0 };
     }
 
+    craft_material_plan material_plan;
+    if( !build_craft_material_plan( *crafter, item_selections, batch_size, filter,
+                                     material_plan ) ) {
+        debugmsg( "Aborting crafting: couldn't build a non-destructive material plan" );
+        return item();
+    }
+
+    // Build the same temporary craft used by the real craft path from the planned
+    // snapshots.  This warning must happen before either materials or tools are
+    // consumed, so cancelling leaves every source unchanged.
+    item_components preview_used;
+    for( const craft_material_source &source : material_plan.sources ) {
+        preview_used.add( source.snapshot );
+    }
+    item preview( rec, batch_size, preview_used, material_plan.preview_components, false );
+    const time_duration expected_duration = time_duration::from_moves(
+                crafter->expected_time_to_craft( *rec, batch_size ) );
+    const double predicted_rot = preview.get_relative_rot_after(
+                                     get_weather().get_temperature( crafter->pos_bub() ), 1.0f,
+                                     expected_duration );
+    if( preview.goes_bad() && predicted_rot >= 1.0 && crafter->is_avatar() ) {
+        if( !crafter->query_yn( _( "The selected ingredients may be rotten before this craft finishes.\n"
+                                   "Start crafting anyway?" ) ) ) {
+            return item();
+        }
+    }
+
     // Run the start (bucket-0) tool debit on a probe before consuming components
     // so a charge shortfall aborts without losing them; the debited allocations
     // carry over to the real craft.
@@ -665,17 +747,9 @@ item craft_command::create_in_progress_craft()
         start_allocs = probe.get_step_tool_allocs();
     }
 
-    for( const auto &it : item_selections ) {
-        std::list<item> tmp = sane_consume_items( it, crafter, batch_size, filter );
-        for( item &tmp_it : tmp ) {
-            if( safe_to_unload_comp( tmp_it ) ) {
-                item_location tmp_loc( *crafter, &tmp_it );
-                unload_activity_actor::unload( *crafter, tmp_loc );
-            }
-        }
-        for( item &it : tmp ) {
-            used.add( it );
-        }
+    if( !consume_craft_material_plan( *crafter, material_plan, used ) ) {
+        debugmsg( "Aborting crafting: planned material sources changed before consumption" );
+        return item();
     }
 
     for( const comp_selection<item_comp> &selection : item_selections ) {
@@ -692,33 +766,6 @@ item craft_command::create_in_progress_craft()
             found_comp.count += comp_used.count;
         } else {
             comps_used.emplace_back( comp_used );
-        }
-    }
-
-    // Build the same temporary craft used by the real craft path, but without
-    // consuming the components from `used`.  This makes the warning follow the
-    // actual component inheritance logic instead of maintaining a second model.
-    std::vector<item_comp> preview_comps = comps_used;
-    item preview( rec, batch_size, used, preview_comps, false );
-    const time_duration expected_duration = time_duration::from_moves(
-                crafter->expected_time_to_craft( *rec, batch_size ) );
-    const double predicted_rot = preview.get_relative_rot_after(
-                                     get_weather().get_temperature( crafter->pos_bub() ), 1.0f,
-                                     expected_duration );
-    if( preview.goes_bad() ) {
-        const time_duration predicted_remaining = preview.get_shelf_life() -
-                preview.get_shelf_life() * predicted_rot;
-        if( ( predicted_rot >= 1.0 || predicted_remaining <= 3_hours ) &&
-            crafter->is_avatar() ) {
-            const char *warning = predicted_rot >= 1.0
-                                  ? _( "The selected ingredients may be rotten before this craft finishes.\n"
-                                       "Start crafting anyway?" )
-                                  : _( "The finished item may have less than an hour of shelf life left.\n"
-                                       "Start crafting anyway?" );
-            if( !crafter->query_yn( warning ) ) {
-                restore_crafting_components( *crafter, used );
-                return item();
-            }
         }
     }
 

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -652,6 +652,19 @@ item craft_command::create_in_progress_craft()
         start_allocs = { step0 };
     }
 
+    // Run the start (bucket-0) tool debit on a probe before consuming components
+    // so a charge shortfall aborts without losing them; the debited allocations
+    // carry over to the real craft.
+    {
+        item probe( rec, batch_size, item_components{}, std::vector<item_comp> {} );
+        probe.set_step_tool_allocs( start_allocs );
+        if( !crafter->craft_consume_step_tools( probe ) ) {
+            debugmsg( "start tool debit failed for craft %s", rec->ident().str() );
+            return item();
+        }
+        start_allocs = probe.get_step_tool_allocs();
+    }
+
     for( const auto &it : item_selections ) {
         std::list<item> tmp = sane_consume_items( it, crafter, batch_size, filter );
         for( item &tmp_it : tmp ) {
@@ -707,19 +720,6 @@ item craft_command::create_in_progress_craft()
                 return item();
             }
         }
-    }
-
-    // Run the start (bucket-0) tool debit on a probe before consuming components
-    // so a charge shortfall aborts without losing them; the debited allocations
-    // carry over to the real craft.
-    {
-        item probe( rec, batch_size, item_components{}, std::vector<item_comp> {} );
-        probe.set_step_tool_allocs( start_allocs );
-        if( !crafter->craft_consume_step_tools( probe ) ) {
-            debugmsg( "start tool debit failed for craft %s", rec->ident().str() );
-            return item();
-        }
-        start_allocs = probe.get_step_tool_allocs();
     }
 
     item new_craft( rec, batch_size, used, comps_used, should_add_crafting_faults( crafter, rec ) );

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -652,6 +652,19 @@ item craft_command::create_in_progress_craft()
         start_allocs = { step0 };
     }
 
+    // Run the start (bucket-0) tool debit on a probe before consuming components
+    // so a charge shortfall aborts without losing them; the debited allocations
+    // carry over to the real craft.
+    {
+        item probe( rec, batch_size, item_components{}, std::vector<item_comp> {} );
+        probe.set_step_tool_allocs( start_allocs );
+        if( !crafter->craft_consume_step_tools( probe ) ) {
+            debugmsg( "start tool debit failed for craft %s", rec->ident().str() );
+            return item();
+        }
+        start_allocs = probe.get_step_tool_allocs();
+    }
+
     for( const auto &it : item_selections ) {
         std::list<item> tmp = sane_consume_items( it, crafter, batch_size, filter );
         for( item &tmp_it : tmp ) {
@@ -709,20 +722,6 @@ item craft_command::create_in_progress_craft()
                               _( "The finished %s will have very little shelf life left." ),
                               rec->result_name() );
         }
-    }
-
-    // Run the start (bucket-0) tool debit on a probe after the rot warning so a
-    // cancelled warning does not consume tool charges; the debited allocations
-    // carry over to the real craft.
-    {
-        item probe( rec, batch_size, item_components{}, std::vector<item_comp> {} );
-        probe.set_step_tool_allocs( start_allocs );
-        if( !crafter->craft_consume_step_tools( probe ) ) {
-            debugmsg( "start tool debit failed for craft %s", rec->ident().str() );
-            restore_crafting_components( *crafter, used );
-            return item();
-        }
-        start_allocs = probe.get_step_tool_allocs();
     }
 
     item new_craft( rec, batch_size, used, comps_used, should_add_crafting_faults( crafter, rec ) );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -3283,49 +3283,41 @@ std::optional<item> preview_infinite_map_charge_source( Character &crafter, cons
     return std::nullopt;
 }
 
-void add_vehicle_preview_sources( Character &crafter, const itype_id &type, int &remaining,
-                                  std::vector<crafting_component_preview> &sources )
+void add_vehicle_preview_source( const tripoint_bub_ms &point, const itype_id &type,
+                                 int &remaining, std::vector<crafting_component_preview> &sources )
 {
     map &here = get_map();
     const itype_id vehicle_tool_type = type.obj().phase > phase_id::SOLID ?
                                        itype_water_faucet : type;
-    const std::vector<tripoint_bub_ms> reachable = here.reachable_item_points(
-                crafter.pos_bub(), PICKUP_RANGE, 1, 100 );
-    for( const tripoint_bub_ms &point : reachable ) {
-        if( remaining <= 0 ) {
-            break;
-        }
-        const optional_vpart_position vehicle_position = here.veh_at( point );
-        if( !vehicle_position ) {
-            continue;
-        }
-        const std::optional<vpart_reference> tool_part = vehicle_position->part_with_tool( here,
-                vehicle_tool_type );
-        if( !tool_part ) {
-            continue;
-        }
-        const itype_id &tool_fuel_type = type->tool_slot_first_ammo();
-        const itype_id &fuel_type = tool_fuel_type.is_null() ? type : tool_fuel_type;
-        vehicle &source_vehicle = tool_part->vehicle();
-        int already_planned = 0;
-        for( const crafting_component_preview &source : sources ) {
-            if( source.vehicle_source == &source_vehicle &&
-                source.vehicle_fuel_type == fuel_type ) {
-                already_planned += source.quantity;
-            }
-        }
-        const int available = static_cast<int>( source_vehicle.fuel_left( here, fuel_type ) ) -
-                              already_planned;
-        const int quantity = std::min( remaining, available );
-        if( quantity <= 0 ) {
-            continue;
-        }
-        item snapshot( type, calendar::turn_zero );
-        snapshot.charges = quantity;
-        sources.push_back( { item_location::nowhere, snapshot, quantity, true, false,
-                             &source_vehicle, fuel_type } );
-        remaining -= quantity;
+    const optional_vpart_position vehicle_position = here.veh_at( point );
+    if( !vehicle_position ) {
+        return;
     }
+    const std::optional<vpart_reference> tool_part = vehicle_position->part_with_tool( here,
+            vehicle_tool_type );
+    if( !tool_part ) {
+        return;
+    }
+    const itype_id &tool_fuel_type = type->tool_slot_first_ammo();
+    const itype_id &fuel_type = tool_fuel_type.is_null() ? type : tool_fuel_type;
+    vehicle &source_vehicle = tool_part->vehicle();
+    int already_planned = 0;
+    for( const crafting_component_preview &source : sources ) {
+        if( source.vehicle_source == &source_vehicle && source.vehicle_fuel_type == fuel_type ) {
+            already_planned += source.quantity;
+        }
+    }
+    const int available = static_cast<int>( source_vehicle.fuel_left( here, fuel_type ) ) -
+                          already_planned;
+    const int quantity = std::min( remaining, available );
+    if( quantity <= 0 ) {
+        return;
+    }
+    item snapshot( type, calendar::turn_zero );
+    snapshot.charges = quantity;
+    sources.push_back( { item_location::nowhere, snapshot, quantity, true, false,
+                         &source_vehicle, fuel_type } );
+    remaining -= quantity;
 }
 
 } // namespace
@@ -3350,28 +3342,12 @@ std::optional<item_components> Character::preview_crafting_components(
                 remaining = 0;
             }
         }
-        std::vector<item_location> candidates;
-        for( int pass = 0; pass < 2 && remaining > 0; ++pass ) {
-            const bool preferred = pass == 0;
-            for( usage_from source : { usage_from::map, usage_from::player } ) {
-                if( ( selection.use_from & source ) == usage_from::none ) {
-                    continue;
-                }
-                comp_selection<item_comp> source_selection = selection;
-                source_selection.use_from = source;
-                const std::vector<item_location> pass_candidates = preview_source_locations(
-                            *this, source_selection, filter, preferred );
-                for( const item_location &candidate : pass_candidates ) {
-                    if( std::find( candidates.begin(), candidates.end(), candidate ) ==
-                        candidates.end() ) {
-                        candidates.push_back( candidate );
-                    }
-                }
-            }
-        }
-        for( item_location &location : candidates ) {
-            if( remaining <= 0 ) {
-                break;
+        std::vector<item_location> planned_locations;
+        const auto add_candidate = [&sources, &planned_locations, &remaining, by_charges](
+        item_location &location ) {
+            if( remaining <= 0 || std::find( planned_locations.begin(), planned_locations.end(),
+                                             location ) != planned_locations.end() ) {
+                return;
             }
             int already_planned = 0;
             for( const crafting_component_preview &source : sources ) {
@@ -3383,17 +3359,54 @@ std::optional<item_components> Character::preview_crafting_components(
                                   ( already_planned == 0 ? 1 : 0 );
             const int quantity = by_charges ? std::min( remaining, available ) : 1;
             if( quantity <= 0 ) {
-                continue;
+                return;
             }
             item snapshot = *location;
             if( by_charges && quantity < snapshot.charges ) {
                 snapshot.mod_charges( quantity - snapshot.charges );
             }
             sources.push_back( { location, snapshot, quantity, by_charges } );
+            planned_locations.push_back( location );
             remaining -= quantity;
-        }
-        if( by_charges && remaining > 0 && ( selection.use_from & usage_from::map ) ) {
-            add_vehicle_preview_sources( *this, selection.comp.type, remaining, sources );
+        };
+        for( int pass = 0; pass < 2 && remaining > 0; ++pass ) {
+            const bool preferred = pass == 0;
+            if( selection.use_from & usage_from::map ) {
+                comp_selection<item_comp> map_selection = selection;
+                map_selection.use_from = usage_from::map;
+                std::vector<item_location> map_candidates = preview_source_locations(
+                            *this, map_selection, filter, preferred );
+                map &here = get_map();
+                const std::vector<tripoint_bub_ms> reachable = here.reachable_item_points(
+                            pos_bub(), PICKUP_RANGE, 1, 100 );
+                for( const tripoint_bub_ms &point : reachable ) {
+                    for( item_location &location : map_candidates ) {
+                        if( location.pos_bub( here ) == point &&
+                            location.where_recursive() != item_location::type::vehicle ) {
+                            add_candidate( location );
+                        }
+                    }
+                    if( by_charges && remaining > 0 ) {
+                        add_vehicle_preview_source( point, selection.comp.type, remaining,
+                                                    sources );
+                    }
+                    for( item_location &location : map_candidates ) {
+                        if( location.pos_bub( here ) == point &&
+                            location.where_recursive() == item_location::type::vehicle ) {
+                            add_candidate( location );
+                        }
+                    }
+                }
+            }
+            if( selection.use_from & usage_from::player && remaining > 0 ) {
+                comp_selection<item_comp> player_selection = selection;
+                player_selection.use_from = usage_from::player;
+                std::vector<item_location> player_candidates = preview_source_locations(
+                            *this, player_selection, filter, preferred );
+                for( item_location &location : player_candidates ) {
+                    add_candidate( location );
+                }
+            }
         }
         if( remaining > 0 ) {
             return std::nullopt;

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -3191,7 +3191,7 @@ comp_selection<item_comp> Character::select_item_component( const std::vector<it
 
 // Prompts player to empty all newly-unsealed containers in inventory
 // Called after something that might have opened containers (making them buckets) but not emptied them
-static void empty_buckets( Character &p )
+void empty_buckets( Character &p )
 {
     // First grab (remove) all items that are non-empty buckets and not wielded
     auto buckets = p.remove_items_with( [&p]( const item & it ) {

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -3379,10 +3379,13 @@ std::optional<item_components> Character::preview_crafting_components(
                 map &here = get_map();
                 const std::vector<tripoint_bub_ms> reachable = here.reachable_item_points(
                             pos_bub(), PICKUP_RANGE, 1, 100 );
+                const bool vehicle_first = !by_charges;
                 for( const tripoint_bub_ms &point : reachable ) {
                     for( item_location &location : map_candidates ) {
+                        const bool vehicle_location = location.where_recursive() ==
+                                                      item_location::type::vehicle;
                         if( location.pos_bub( here ) == point &&
-                            location.where_recursive() != item_location::type::vehicle ) {
+                            vehicle_location == vehicle_first ) {
                             add_candidate( location );
                         }
                     }
@@ -3391,8 +3394,10 @@ std::optional<item_components> Character::preview_crafting_components(
                                                     sources );
                     }
                     for( item_location &location : map_candidates ) {
+                        const bool vehicle_location = location.where_recursive() ==
+                                                      item_location::type::vehicle;
                         if( location.pos_bub( here ) == point &&
-                            location.where_recursive() == item_location::type::vehicle ) {
+                            vehicle_location != vehicle_first ) {
                             add_candidate( location );
                         }
                     }

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -3191,7 +3191,7 @@ comp_selection<item_comp> Character::select_item_component( const std::vector<it
 
 // Prompts player to empty all newly-unsealed containers in inventory
 // Called after something that might have opened containers (making them buckets) but not emptied them
-void empty_buckets( Character &p )
+static void empty_buckets( Character &p )
 {
     // First grab (remove) all items that are non-empty buckets and not wielded
     auto buckets = p.remove_items_with( [&p]( const item & it ) {

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -3401,7 +3401,7 @@ std::optional<item_components> Character::preview_crafting_components(
     }
 
     item_components preview;
-    for( const crafting_component_preview &source : sources ) {
+    for( crafting_component_preview &source : sources ) {
         preview.add( source.snapshot );
     }
     return preview;

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -99,6 +99,8 @@ static const activity_id ACT_CRAFT( "ACT_CRAFT" );
 static const activity_id ACT_CRAFT_WAIT( "ACT_CRAFT_WAIT" );
 static const activity_id ACT_DISASSEMBLE( "ACT_DISASSEMBLE" );
 
+static const itype_id itype_water_faucet( "water_faucet" );
+
 static const efftype_id effect_contacts( "contacts" );
 static const efftype_id effect_transition_contacts( "transition_contacts" );
 
@@ -3209,8 +3211,6 @@ static void empty_buckets( Character &p )
 
 namespace
 {
-
-static const itype_id itype_water_faucet( "water_faucet" );
 
 struct crafting_component_preview {
     item_location location;

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -3338,7 +3338,7 @@ std::optional<item_components> Character::preview_crafting_components(
             if( infinite_source ) {
                 infinite_source->charges = remaining;
                 sources.push_back( { item_location::nowhere, *infinite_source, remaining, true,
-                                     true } );
+                                     true, nullptr, itype_id() } );
                 remaining = 0;
             }
         }
@@ -3365,7 +3365,8 @@ std::optional<item_components> Character::preview_crafting_components(
             if( by_charges && quantity < snapshot.charges ) {
                 snapshot.mod_charges( quantity - snapshot.charges );
             }
-            sources.push_back( { location, snapshot, quantity, by_charges } );
+            sources.push_back( { location, snapshot, quantity, by_charges, false, nullptr,
+                                 itype_id() } );
             planned_locations.push_back( location );
             remaining -= quantity;
         };

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -3207,6 +3207,206 @@ void empty_buckets( Character &p )
     }
 }
 
+namespace
+{
+
+static const itype_id itype_water_faucet( "water_faucet" );
+
+struct crafting_component_preview {
+    item_location location;
+    item snapshot;
+    int quantity = 0;
+    bool by_charges = false;
+    bool infinite_map_source = false;
+    vehicle *vehicle_source = nullptr;
+    itype_id vehicle_fuel_type;
+};
+
+void append_preview_source_locations( item_location location,
+                                      const std::function<bool( const item & )> &filter,
+                                      std::vector<item_location> &locations )
+{
+    if( filter( *location ) ) {
+        locations.push_back( location );
+    }
+    for( item *contained : location->all_items_top( pocket_type::CONTAINER ) ) {
+        append_preview_source_locations( item_location( location, contained ), filter, locations );
+    }
+}
+
+std::vector<item_location> preview_source_locations( Character &crafter,
+        const comp_selection<item_comp> &selection,
+        const std::function<bool( const item & )> &filter, bool preferred )
+{
+    const itype_id type = selection.comp.type;
+    const std::function<bool( const item & )> source_filter =
+        [&filter, &type, preferred]( const item &candidate ) {
+            return candidate.typeId() == type && filter( candidate ) &&
+                   ( !preferred || is_preferred_component( candidate ) );
+        };
+    std::vector<item_location> locations;
+    map &here = get_map();
+    if( selection.use_from & usage_from::map ) {
+        const std::vector<tripoint_bub_ms> reachable = here.reachable_item_points(
+                    crafter.pos_bub(), PICKUP_RANGE, 1, 100 );
+        for( const tripoint_bub_ms &point : reachable ) {
+            if( !here.accessible_items( point ) ) {
+                continue;
+            }
+            std::list<item_location> at_point = here.items_with( point, []( const item & ) {
+                return true;
+            } );
+            for( item_location &location : at_point ) {
+                append_preview_source_locations( location, source_filter, locations );
+            }
+        }
+    }
+    if( selection.use_from & usage_from::player ) {
+        for( item *candidate : crafter.items_with( source_filter ) ) {
+            locations.emplace_back( crafter, candidate );
+        }
+    }
+    return locations;
+}
+
+std::optional<item> preview_infinite_map_charge_source( Character &crafter, const itype_id &type )
+{
+    map &here = get_map();
+    const std::vector<tripoint_bub_ms> reachable = here.reachable_item_points(
+                crafter.pos_bub(), PICKUP_RANGE, 1, 100 );
+    for( const tripoint_bub_ms &point : reachable ) {
+        item source = here.liquid_from( point );
+        if( source.typeId() == type && source.charges == item::INFINITE_CHARGES ) {
+            return source;
+        }
+    }
+    return std::nullopt;
+}
+
+void add_vehicle_preview_sources( Character &crafter, const itype_id &type, int &remaining,
+                                  std::vector<crafting_component_preview> &sources )
+{
+    map &here = get_map();
+    const itype_id vehicle_tool_type = type.obj().phase > phase_id::SOLID ?
+                                       itype_water_faucet : type;
+    const std::vector<tripoint_bub_ms> reachable = here.reachable_item_points(
+                crafter.pos_bub(), PICKUP_RANGE, 1, 100 );
+    for( const tripoint_bub_ms &point : reachable ) {
+        if( remaining <= 0 ) {
+            break;
+        }
+        const optional_vpart_position vehicle_position = here.veh_at( point );
+        if( !vehicle_position ) {
+            continue;
+        }
+        const std::optional<vpart_reference> tool_part = vehicle_position->part_with_tool( here,
+                vehicle_tool_type );
+        if( !tool_part ) {
+            continue;
+        }
+        const itype_id &tool_fuel_type = type->tool_slot_first_ammo();
+        const itype_id &fuel_type = tool_fuel_type.is_null() ? type : tool_fuel_type;
+        vehicle &source_vehicle = tool_part->vehicle();
+        int already_planned = 0;
+        for( const crafting_component_preview &source : sources ) {
+            if( source.vehicle_source == &source_vehicle &&
+                source.vehicle_fuel_type == fuel_type ) {
+                already_planned += source.quantity;
+            }
+        }
+        const int available = static_cast<int>( source_vehicle.fuel_left( here, fuel_type ) ) -
+                              already_planned;
+        const int quantity = std::min( remaining, available );
+        if( quantity <= 0 ) {
+            continue;
+        }
+        item snapshot( type, calendar::turn_zero );
+        snapshot.charges = quantity;
+        sources.push_back( { item_location::nowhere, snapshot, quantity, true, false,
+                             &source_vehicle, fuel_type } );
+        remaining -= quantity;
+    }
+}
+
+} // namespace
+
+std::optional<item_components> Character::preview_crafting_components(
+    const std::vector<comp_selection<item_comp>> &selections, int batch,
+    const std::function<bool( const item & )> &filter )
+{
+    std::vector<crafting_component_preview> sources;
+    for( const comp_selection<item_comp> &selection : selections ) {
+        const bool by_charges = item::count_by_charges( selection.comp.type ) &&
+                                selection.comp.count > 0;
+        int remaining = selection.comp.count > 0 ? selection.comp.count * batch :
+                        std::abs( selection.comp.count );
+        if( by_charges && ( selection.use_from & usage_from::map ) ) {
+            std::optional<item> infinite_source = preview_infinite_map_charge_source( *this,
+                    selection.comp.type );
+            if( infinite_source ) {
+                infinite_source->charges = remaining;
+                sources.push_back( { item_location::nowhere, *infinite_source, remaining, true,
+                                     true } );
+                remaining = 0;
+            }
+        }
+        std::vector<item_location> candidates;
+        for( int pass = 0; pass < 2 && remaining > 0; ++pass ) {
+            const bool preferred = pass == 0;
+            for( usage_from source : { usage_from::map, usage_from::player } ) {
+                if( ( selection.use_from & source ) == usage_from::none ) {
+                    continue;
+                }
+                comp_selection<item_comp> source_selection = selection;
+                source_selection.use_from = source;
+                const std::vector<item_location> pass_candidates = preview_source_locations(
+                            *this, source_selection, filter, preferred );
+                for( const item_location &candidate : pass_candidates ) {
+                    if( std::find( candidates.begin(), candidates.end(), candidate ) ==
+                        candidates.end() ) {
+                        candidates.push_back( candidate );
+                    }
+                }
+            }
+        }
+        for( item_location &location : candidates ) {
+            if( remaining <= 0 ) {
+                break;
+            }
+            int already_planned = 0;
+            for( const crafting_component_preview &source : sources ) {
+                if( source.location == location ) {
+                    already_planned += source.quantity;
+                }
+            }
+            const int available = by_charges ? location->charges - already_planned :
+                                  ( already_planned == 0 ? 1 : 0 );
+            const int quantity = by_charges ? std::min( remaining, available ) : 1;
+            if( quantity <= 0 ) {
+                continue;
+            }
+            item snapshot = *location;
+            if( by_charges && quantity < snapshot.charges ) {
+                snapshot.mod_charges( quantity - snapshot.charges );
+            }
+            sources.push_back( { location, snapshot, quantity, by_charges } );
+            remaining -= quantity;
+        }
+        if( by_charges && remaining > 0 && ( selection.use_from & usage_from::map ) ) {
+            add_vehicle_preview_sources( *this, selection.comp.type, remaining, sources );
+        }
+        if( remaining > 0 ) {
+            return std::nullopt;
+        }
+    }
+
+    item_components preview;
+    for( const crafting_component_preview &source : sources ) {
+        preview.add( source.snapshot );
+    }
+    return preview;
+}
+
 std::list<item> Character::consume_items( const comp_selection<item_comp> &is, int batch,
         const std::function<bool( const item & )> &filter, bool select_ind, bool disable_preference )
 {

--- a/src/crafting.h
+++ b/src/crafting.h
@@ -35,9 +35,6 @@ void remove_ammo( std::list<item> &dis_items, Character &p );
 
 void drop_or_handle( const item &newit, Character &p );
 
-// Prompts the player to empty any newly-unsealed containers in their inventory.
-void empty_buckets( Character &p );
-
 // Per-choice data for the timer sub-menu when the modal is shown on an
 // in-flight unattended step.  All offsets are step-start anchored
 // (`alarm_at = passive_started_at + offset`), so the resulting

--- a/src/crafting.h
+++ b/src/crafting.h
@@ -35,6 +35,9 @@ void remove_ammo( std::list<item> &dis_items, Character &p );
 
 void drop_or_handle( const item &newit, Character &p );
 
+// Prompts the player to empty any newly-unsealed containers in their inventory.
+void empty_buckets( Character &p );
+
 // Per-choice data for the timer sub-menu when the modal is shown on an
 // in-flight unattended step.  All offsets are step-start anchored
 // (`alarm_at = passive_started_at + offset`), so the resulting

--- a/src/item.h
+++ b/src/item.h
@@ -1164,6 +1164,10 @@ class item : public visitable
          */
         void calc_rot( units::temperature temp, float spoil_modifier, const time_duration &time_delta );
 
+        /** Return relative rot after a hypothetical, non-mutating rot period. */
+        double get_relative_rot_after( units::temperature temp, float spoil_modifier,
+                                       const time_duration &time_delta ) const;
+
         /**
          * This is part of a workaround so that items don't rot away to nothing if the smoking rack
          * is outside the reality bubble.

--- a/src/item_degrade.cpp
+++ b/src/item_degrade.cpp
@@ -630,6 +630,15 @@ void item::calc_rot( units::temperature temp, const float spoil_modifier,
            ( 1_hours / 1_seconds );
 }
 
+double item::get_relative_rot_after( const units::temperature temp,
+                                     const float spoil_modifier,
+                                     const time_duration &time_delta ) const
+{
+    item simulated = *this;
+    simulated.calc_rot( temp, spoil_modifier, time_delta );
+    return simulated.get_relative_rot();
+}
+
 void item::calc_rot_while_processing( time_duration processing_duration )
 {
     if( !has_own_flag( flag_PROCESSING ) ) {

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -1280,6 +1280,19 @@ TEST_CASE( "item_rotten_contents", "[item]" )
     CHECK( wrapper.get_category_of_contents().id == item_category_food );
 }
 
+TEST_CASE( "item_relative_rot_after_is_non_mutating", "[item][rot]" )
+{
+    item butter( itype_butter );
+    butter.set_relative_rot( 0.5 );
+    const double initial_rot = butter.get_relative_rot();
+
+    const double simulated_rot = butter.get_relative_rot_after( temperatures::normal, 1.0f,
+                                  1_hours );
+
+    CHECK( butter.get_relative_rot() == initial_rot );
+    CHECK( simulated_rot > initial_rot );
+}
+
 static bool uncraft_need_to_be_checked( const item &it )
 {
     // skip items that do not have uncraft


### PR DESCRIPTION
#### Summary
Features "Warn and require confirmation if the crafted food is likely to spoil immediately"

#### Purpose of change

Some players have reported that the current rot inheritance mechanism for crafting feels unreasonable, as it often causes food made from unspoiled ingredients to spoil immediately upon completion. In reality, this is a side effect of an upstream fix for an older bug where items in progress could be preserved indefinitely. Now, in-progress crafting items also rot, and the entire crafting duration is counted toward their spoilage progress.

Items in progress now spoil as well, and the crafting time is directly counted toward their spoilage progress. When crafting begins, the temporary `craft` object calculates its initial spoilage based on its components, while `get_comestible()` returns the food data of the recipe result, treating it as the finished food item with the finished product's shelf life. As a result, if the player lacks sufficient skill or uses ingredients that are already close to spoiling, the game may create an in-progress food item that is already near its spoilage threshold, allowing it to spoil before crafting is even finished.

This is admittedly not ideal, but making in-progress food magically become an eternal object that cannot spoil until the end of the universe would probably be even more absurd. While the spoilage inheritance system may indeed need further improvements, I think players should at least be informed when their food is likely to spoil before the crafting process finishes.

#### Describe the solution

Modified `create_in_progress_craft` so that, before crafting actually begins, it constructs a temporary in-progress craft from the copies of the ingredients selected by the player. It then estimates the crafting duration based on the current character, recipe batch size, and crafting speed, and uses the existing spoilage simulation interface to predict the relative spoilage when crafting completes.

A confirmation dialog is shown if either of the following conditions is met:

- The predicted relative spoilage upon completion is at least 100%.
- The predicted remaining shelf life after completion is no more than 3 hours.

If the player cancels the confirmation, the consumed ingredients are restored.

Since the temporary craft is constructed using the existing `inherit_rot_from_components()` logic to determine its initial spoilage, and the prediction uses the existing spoilage calculation system, this implementation should automatically stay in sync with future changes to either spoilage inheritance or spoilage rate mechanics.