### PR TITLE
SCP-500 in Futurism Cataclysm: Legacy

### DIFF
--- a/data/mods/FuturismCataclysmLegacy/construction/comestibles.json
+++ b/data/mods/FuturismCataclysmLegacy/construction/comestibles.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "panacea",
+    "type": "ITEM",
+    "subtypes": [ "COMESTIBLE" ],
+    "comestible_type": "MED",
+    "name": { "str": "Panaceus", "str_pl": "Panaceii" },
+    "symbol": "!",
+    "color": "red",
+    "copy-from": "panacea",
+    "use_action": {
+      "type": "consume_drug",
+      "activation_message": "You feel AMAZING!",
+      "effects": [ { "id": "panacea", "duration": "1 m" }, { "id": "cureall" }, { "id": "fcl_cureall", "duration": "1 m" } ],
+      "damage_over_time": [
+        {
+          "damage_type": "pure",
+          "duration": "1 m",
+          "amount": -10,
+          "bodyparts": [ "torso", "head", "arm_l", "leg_l", "arm_r", "leg_r" ]
+        }
+      ]
+    },
+    "flags": [ "NPC_SAFE", "IRREPLACEABLE_CONSUMABLE" ]
+  }
+]

--- a/data/mods/FuturismCataclysmLegacy/effects.json
+++ b/data/mods/FuturismCataclysmLegacy/effects.json
@@ -1,0 +1,28 @@
+[
+  {
+    "type": "effect_type",
+    "id": "fcl_cureall",
+    "max_duration": "10 s",
+    "removes_effects": [
+        "bite",
+        "bleed",
+        "redcells_anemia",
+        "hypovolemia",
+        "shakes",
+        "stunned",
+        "winded",
+        "winded_leg_l",
+        "winded_leg_r",
+        "winded_arm_l",
+        "winded_arm_r",
+        "hypocalcemia",
+        "anemia",
+        "scurvy"
+    ],
+    "base_mods": {
+      "hurt_amount": [ -10 ],
+      "h_mod_min": [ 25 ],
+      "health_min": [ 100 ]
+    }
+  }
+]

--- a/data/mods/FuturismCataclysmLegacy/effects.json
+++ b/data/mods/FuturismCataclysmLegacy/effects.json
@@ -11,10 +11,8 @@
         "shakes",
         "stunned",
         "winded",
-        "winded_leg_l",
-        "winded_leg_r",
-        "winded_arm_l",
-        "winded_arm_r",
+        "winded_leg",
+        "winded_arm",
         "hypocalcemia",
         "anemia",
         "scurvy"

--- a/data/mods/FuturismCataclysmLegacy/effects_on_condition/effects_eocs.json
+++ b/data/mods/FuturismCataclysmLegacy/effects_on_condition/effects_eocs.json
@@ -1,0 +1,16 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_EFFECT_GAINS_FCL_CUREALL",
+    "eoc_type": "EVENT",
+    "required_event": "character_gains_effect",
+    "condition": { "compare_string": [ "fcl_cureall", { "context_val": "effect" } ] },
+    "effect": [
+      { "math": [ "u_vitamin('calcium') = max(0,u_vitamin('calcium'))" ] },
+      { "math": [ "u_vitamin('iron') = max(0,u_vitamin('iron'))" ] },
+      { "math": [ "u_vitamin('vitC') = max(0,u_vitamin('vitC'))" ] },
+      { "math": [ "u_vitamin('redcells') = max(-5000,u_vitamin('redcells')+1000)" ] },
+      { "math": [ "u_vitamin('blood') = max(-2500,u_vitamin('blood')+1000)" ] }
+    ]
+  }
+]


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Panaceus/Panaceii appears to be largely inspired by, or influenced by, SCP-500. However, it has apparently been nerfed several times in the core game over the years, to the point that some players now consider it less useful than the clones produced by 038.

Since Aftershock also gives panacea a slight buff, I wanted to strengthen it in the near-future mod I maintain, Futurism Cataclysm: Legacy. My approach is admittedly much more aggressive than Aftershock's, but considering how exceptionally rare this item is, and that I currently have no intention of introducing any more efficient way to obtain it in FCL, I don't think this will cause significant balance issues.

#### Describe the solution

Added a new `fcl_cureall` effect that cures bites, bleeding, negative effects caused by low red blood cell count or blood volume, vitamin deficiencies, and several other related conditions. It also provides health regeneration for a short period.

A corresponding EOC has also been added to restore the affected vitamin counters—`calcium`, `iron`, `vitC`, `redcells`, and `blood`—back to normal levels whenever their deficiencies would otherwise cause the above negative effects.

Finally, this effect has been added to the use action of panacea.