### PR TITLE
Porting Buff teaching form C:TLG

### DIFF
--- a/data/json/obsoletion_and_migration_0.J/player_activities.json
+++ b/data/json/obsoletion_and_migration_0.J/player_activities.json
@@ -48,7 +48,7 @@
   {
     "id": "ACT_TRAIN_TEACHER",
     "type": "activity_type",
-    "activity_level": "ACTIVE_EXERCISE",
+    "activity_level": "BRISK_EXERCISE",
     "verb": "teaching",
     "based_on": "speed",
     "can_resume": false

--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -413,7 +413,7 @@
   {
     "id": "ACT_TRAIN",
     "type": "activity_type",
-    "activity_level": "ACTIVE_EXERCISE",
+    "activity_level": "BRISK_EXERCISE",
     "verb": "training",
     "based_on": "speed"
   },

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -418,7 +418,7 @@ static const skill_id skill_computer( "computer" );
 static const skill_id skill_electronics( "electronics" );
 static const skill_id skill_fabrication( "fabrication" );
 static const skill_id skill_firstaid( "firstaid" );
-static const skill_id skill_social( "social" );
+static const skill_id skill_speech( "speech" );
 static const skill_id skill_gun( "gun" );
 static const skill_id skill_mechanics( "mechanics" );
 static const skill_id skill_survival( "survival" );
@@ -13043,11 +13043,11 @@ void training_activity_actor::train_skill( Character &who, skill_id trained_skil
     if( teacher_valid ) {
         // Teacher intelligence, subject matter knowledge, and social skill matters most.
         teacher_quality = ( teacher_valid->get_int() +
-                            ( teacher_valid->get_skill_level( skill_social ) +
+                            ( teacher_valid->get_skill_level( skill_speech ) +
                               teacher_valid->get_knowledge_level( trained_skill ) ) ) * 4;
     }
     // Student intelligence and social skill is secondary.
-    int student_quality = ( who.get_int() + ( who.get_skill_level( skill_social ) * 2 ) ) * 4;
+    int student_quality = ( who.get_int() + ( who.get_skill_level( skill_speech ) * 2 ) ) * 4;
     int teaching_effectiveness = std::min( 200, std::max( 10,
                                      ( teacher_quality * 2 + student_quality ) / 2 ) );
     who.practice( trained_skill, teaching_effectiveness, old_skill_level + 2 );

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -418,6 +418,7 @@ static const skill_id skill_computer( "computer" );
 static const skill_id skill_electronics( "electronics" );
 static const skill_id skill_fabrication( "fabrication" );
 static const skill_id skill_firstaid( "firstaid" );
+static const skill_id skill_social( "social" );
 static const skill_id skill_gun( "gun" );
 static const skill_id skill_mechanics( "mechanics" );
 static const skill_id skill_survival( "survival" );
@@ -13037,7 +13038,19 @@ void training_activity_actor::train_skill( Character &who, skill_id trained_skil
     const Skill &skill = trained_skill.obj();
     std::string skill_name = skill.name();
     int old_skill_level = who.get_knowledge_level( trained_skill );
-    who.practice( trained_skill, 100, old_skill_level + 2 );
+    Character *teacher_valid = g->critter_by_id<Character>( teacher );
+    int teacher_quality = 0;
+    if( teacher_valid ) {
+        // Teacher intelligence, subject matter knowledge, and social skill matters most.
+        teacher_quality = ( teacher_valid->get_int() +
+                            ( teacher_valid->get_skill_level( skill_social ) +
+                              teacher_valid->get_knowledge_level( trained_skill ) ) ) * 4;
+    }
+    // Student intelligence and social skill is secondary.
+    int student_quality = ( who.get_int() + ( who.get_skill_level( skill_social ) * 2 ) ) * 4;
+    int teaching_effectiveness = std::min( 200, std::max( 10,
+                                     ( teacher_quality * 2 + student_quality ) / 2 ) );
+    who.practice( trained_skill, teaching_effectiveness, old_skill_level + 2 );
     int new_skill_level = who.get_knowledge_level( trained_skill );
     if( old_skill_level != new_skill_level ) {
         if( who.is_avatar() ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Porting https://github.com/Cataclysm-TLG/Cataclysm-TLG/pull/2826

#### Describe the solution

Original PR Information:
```
#### Summary
Buff teaching

#### Purpose of change
- Teaching was almost never worth doing, as it was active exercise and raised skill very little for the investment.

#### Describe the solution
- Teaching now benefits from the social skill and intelligence of teacher and student, as well as the teacher's knowledge (not rank!) of the subject skill. A session can teach up to 2x what it did before, but teachers and students who lack the skills and stats may have some trouble.
- Teaching is now brisk exercise, instead of active. This means it takes fewer kcal and causes less weariness.

#### Describe alternatives you've considered

#### Testing

#### Additional context
```

The original author's (worm-girl) attribution has been retained. I am only responsible for the adaptation.