### PR TITLE
Control vehicle reactors individually

### DIFF
--- a/data/raw/keybindings/vehicle.json
+++ b/data/raw/keybindings/vehicle.json
@@ -339,7 +339,7 @@
     "id": "TOGGLE_REACTOR",
     "type": "keybinding",
     "category": "VEHICLE",
-    "name": "Toggle reactor",
+    "name": "Control reactors",
     "bindings": [ { "input_method": "keyboard_any", "key": "k" } ]
   },
   {

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -2268,6 +2268,8 @@ class vehicle
         // for destroying any terrain around vehicle part. Automated mining tool.
         void crash_terrain_around( map &here );
         void transform_terrain( map &here );
+        // Main method for the control of individual reactors.
+        void control_reactors( map &here );
         //main method for the control of individual engines
         void control_engines( map &here );
         //returns whether the engine is enabled or not, and has fueltype

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -338,8 +338,13 @@ void vehicle::build_electronics_menu( map &here, veh_menu &menu )
     const std::string & flag ) {
         add_electronic_toggle( here, *this, menu, name, action, flag );
     };
-    add_toggle( pgettext( "electronics menu option", "reactor" ),
-                "TOGGLE_REACTOR", "REACTOR" );
+    if( !reactors.empty() ) {
+        menu.add( _( "Control reactors" ) )
+        .hotkey( "TOGGLE_REACTOR" )
+        .on_submit( [this, &here] {
+            control_reactors( here );
+        } );
+    }
     add_toggle( pgettext( "electronics menu option", "headlights" ),
                 "TOGGLE_HEADLIGHT", "CONE_LIGHT" );
     add_toggle( pgettext( "electronics menu option", "wide angle headlights" ),
@@ -400,6 +405,24 @@ void vehicle::build_electronics_menu( map &here, veh_menu &menu )
             break;
         }
     }
+}
+
+void vehicle::control_reactors( map &here )
+{
+    veh_menu menu( this, _( "Toggle which?" ) );
+    do {
+        menu.reset();
+        for( const int reactor_idx : reactors ) {
+            const vehicle_part &vp = parts[reactor_idx];
+            menu.add( string_format( "[%s] %s", vp.enabled ? "x" : " ", vp.name() ) )
+            .enable( vp.enabled || can_enable( here, vp ) )
+            .keep_menu_open()
+            .on_submit( [this, reactor_idx] {
+                vehicle_part &vp = parts[reactor_idx];
+                vp.enabled = !vp.enabled;
+            } );
+        }
+    } while( menu.query() );
 }
 
 void vehicle::control_engines( map &here )


### PR DESCRIPTION
## Summary

- replace the bulk reactor toggle in the vehicle electronics menu with **Control reactors**
- add a persistent submenu that lists each reactor with its enabled state and toggles reactors independently
- preserve the existing `TOGGLE_REACTOR` action and `k` binding
- retain the normal reactor enable checks before allowing activation

## Why

Vehicles with multiple reactors previously turned every reactor on or off together. This made it impossible to select only the reactors needed for the current power demand.

## Player impact

Selecting **Control reactors** now opens a menu similar to individual engine control. Players can switch any installed reactor independently without leaving the submenu after each change.

## Validation

- `git diff --check`
- AStyle dry-run on `src/vehicle.h` and `src/vehicle_use.cpp`
- JSON parse validation for `data/raw/keybindings/vehicle.json`
- compiled `src/vehicle_use.cpp` with the SDL2 Release configuration and `-Werror`
- SDL2 Release tiles binary smoke test with `./cataclysm-tiles --version`