### PR TITLE
Attempt to fix several issues with the minireactor

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6258,6 +6258,7 @@ void unload_activity_actor::unload( Character &who, item_location &target )
 
             for( item *contained : it.all_items_top( ptype, true ) ) {
                 int old_charges = contained->charges;
+                contained->normalize_plutonium_fuel( true );
                 const bool consumed = who.add_or_drop_with_msg( *contained, true, &it, contained );
                 if( consumed || contained->charges != old_charges ) {
                     changed = true;
@@ -6286,9 +6287,7 @@ void unload_activity_actor::unload( Character &who, item_location &target )
 
     std::vector<item *> remove_contained;
     for( item *contained : it.all_items_top() ) {
-        if( contained->ammo_type() == ammo_plutonium ) {
-            contained->charges /= PLUTONIUM_CHARGES;
-        }
+        contained->normalize_plutonium_fuel( true );
         if( who.add_or_drop_with_msg( *contained, true, &it, contained ) ) {
             qty += contained->charges;
             remove_contained.push_back( contained );

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6245,6 +6245,8 @@ void unload_activity_actor::unload( Character &who, item_location &target )
     int qty = 0;
     item &it = *target.get_item();
     bool actually_unloaded = false;
+    const bool can_hold_legacy_plutonium = ( it.is_tool() || it.is_gun() || it.is_magazine() ) &&
+            it.ammo_capacity( ammo_plutonium ) > 0;
 
     if( it.is_container() ) {
         contents_change_handler handler;
@@ -6258,7 +6260,7 @@ void unload_activity_actor::unload( Character &who, item_location &target )
 
             for( item *contained : it.all_items_top( ptype, true ) ) {
                 int old_charges = contained->charges;
-                contained->normalize_plutonium_fuel( true );
+                contained->normalize_plutonium_fuel( can_hold_legacy_plutonium );
                 const bool consumed = who.add_or_drop_with_msg( *contained, true, &it, contained );
                 if( consumed || contained->charges != old_charges ) {
                     changed = true;
@@ -6287,7 +6289,7 @@ void unload_activity_actor::unload( Character &who, item_location &target )
 
     std::vector<item *> remove_contained;
     for( item *contained : it.all_items_top() ) {
-        contained->normalize_plutonium_fuel( true );
+        contained->normalize_plutonium_fuel( can_hold_legacy_plutonium );
         if( who.add_or_drop_with_msg( *contained, true, &it, contained ) ) {
             qty += contained->charges;
             remove_contained.push_back( contained );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2118,8 +2118,11 @@ void item::mark_internal_plutonium_fuel()
 
 bool item::normalize_plutonium_fuel( const bool allow_legacy_representation )
 {
+    // A running legacy reactor can leave fewer than one cell's worth of
+    // internal charges behind, so any positive charge in a compatible host
+    // must be treated as an incomplete internal cell.
     const bool legacy_representation = allow_legacy_representation &&
-                                       ammo_type() == ammo_plutonium && charges >= PLUTONIUM_CHARGES;
+                                       ammo_type() == ammo_plutonium && charges > 0;
     if( !is_internal_plutonium_fuel() && !legacy_representation ) {
         return false;
     }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -92,6 +92,11 @@
 #include "weather_type.h"
 #include "weighted_list.h"
 
+namespace
+{
+constexpr std::string_view internal_plutonium_fuel_var = "internal_plutonium_fuel";
+}
+
 static const ammotype ammo_battery( "battery" );
 static const ammotype ammo_money( "money" );
 
@@ -2024,7 +2029,15 @@ units::mass item::weight( bool include_contents, bool integral ) const
     }
 
     if( count_by_charges() ) {
-        ret_mul *= charges;
+        if( is_internal_plutonium_fuel() ) {
+            // Internally, one plutonium cell is represented by
+            // PLUTONIUM_CHARGES energy charges.  Keep the physical item's
+            // mass proportional to the number of cells, not the raw charge
+            // count.
+            ret_mul *= static_cast<double>( charges ) / PLUTONIUM_CHARGES;
+        } else {
+            ret_mul *= charges;
+        }
 
     } else if( ( hot & static_cast<uint64_t>( hot_flag_bit::CORPSE ) ) && corpse != nullptr ) {
         ret = corpse->weight;
@@ -2091,6 +2104,29 @@ units::mass item::weight( bool include_contents, bool integral ) const
     }
 
     return ret;
+}
+
+bool item::is_internal_plutonium_fuel() const
+{
+    return ammo_type() == ammo_plutonium && has_var( internal_plutonium_fuel_var );
+}
+
+void item::mark_internal_plutonium_fuel()
+{
+    set_var( std::string( internal_plutonium_fuel_var ), true );
+}
+
+bool item::normalize_plutonium_fuel( const bool allow_legacy_representation )
+{
+    const bool legacy_representation = allow_legacy_representation &&
+                                       ammo_type() == ammo_plutonium && charges >= PLUTONIUM_CHARGES;
+    if( !is_internal_plutonium_fuel() && !legacy_representation ) {
+        return false;
+    }
+
+    charges /= PLUTONIUM_CHARGES;
+    erase_var( std::string( internal_plutonium_fuel_var ) );
+    return true;
 }
 
 units::length item::length() const

--- a/src/item.h
+++ b/src/item.h
@@ -729,6 +729,12 @@ class item : public visitable
          */
         units::mass weight( bool include_contents = true, bool integral = false ) const;
 
+        // Plutonium fuel is stored in vehicle/tool magazines as an energy
+        // charge count, rather than as the physical item's normal charges.
+        bool is_internal_plutonium_fuel() const;
+        void mark_internal_plutonium_fuel();
+        bool normalize_plutonium_fuel( bool allow_legacy_representation = false );
+
         /**
          * Total volume of an item accounting for all contained/integrated items
          * NOTE: Result is rounded up to next nearest milliliter when working with stackable (@ref count_by_charges) items that have fractional volume per charge.

--- a/src/item_gun_tool_ammo.cpp
+++ b/src/item_gun_tool_ammo.cpp
@@ -3649,6 +3649,7 @@ bool item::reload( Character &u, item_location ammo, int qty, int pocket_index )
         if( ammo->ammo_type() == ammo_plutonium ) {
             // any excess is wasted rather than overfilling the item
             item_copy.charges = std::min( qty * PLUTONIUM_CHARGES, ammo_capacity( ammo_plutonium ) );
+            item_copy.mark_internal_plutonium_fuel();
         } else {
             item_copy.charges = qty;
         }

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -29,6 +29,7 @@
 #include "weather.h"
 
 static const ammotype ammo_battery( "battery" );
+static const ammotype ammo_plutonium( "plutonium" );
 
 static const itype_id fuel_type_battery( "battery" );
 static const itype_id fuel_type_none( "null" );

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -412,6 +412,13 @@ int vehicle_part::ammo_set( const itype_id &ammo, int qty )
         const itype *ammo_itype = item::find_type( ammo );
         if( ammo_itype && ammo_itype->ammo ) {
             base.ammo_set( ammo, qty >= 0 ? qty : ammo_capacity( ammo_itype->ammo->type ) );
+            if( ammo_itype->ammo->type == ammo_plutonium ) {
+                for( item *fuel : base.all_items_top() ) {
+                    if( fuel->ammo_type() == ammo_plutonium ) {
+                        fuel->mark_internal_plutonium_fuel();
+                    }
+                }
+            }
             return base.ammo_remaining( );
         }
     }


### PR DESCRIPTION
#### Summary

Bugfixes "Fix incorrect plut_cell fuel weight and unloading quantity for vehicle minireactors"

#### Purpose of change

Players reported that after loading fuel into the minireactors from AFS and FCL, their weight becomes several times higher than expected. In addition, after installing the battery into a vehicle and then removing it as an item, it is possible to unload far more `plut_cell` fuel cells than were originally inserted.

After reviewing the code, I found that the C++ fuel and magazine loading logic uses the `PLUTONIUM_CHARGES = 500` constant to scale the amount of fuel provided by each count of `plut_cell`. However, this conversion appears to be applied only during loading, while weight calculation and unloading logic do not perform the corresponding conversion.

#### Describe the solution

- Added a persistent marker for items that internally represent one `plut_cell` as 500 charges.
- Changed internal fuel weight calculations to use the actual number of plutonium fuel cells instead of scaling linearly by the raw charge count.
- Updated the calculations used by player loading, vehicle initialization, and programmatic loading to use the new conversion logic.
- Fixed the minireactor, when treated as a container item, skipping the `PLUTONIUM_CHARGES` conversion during unloading.
- Added compatibility normalization for legacy saves containing internal fuel without the new marker.