### PR TITLE
修复磨坊对可堆叠原料的数量计算

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -6863,6 +6863,50 @@ static bool is_non_rotten_crafting_component( const item &it )
     return is_crafting_component( it ) && !it.rotten();
 }
 
+static std::vector<item> extract_mill_items( map_stack &items, const itype_id &type,
+        int quantity )
+{
+    std::vector<item> extracted;
+
+    for( map_stack::iterator iter = items.begin(); iter != items.end() && quantity > 0; ) {
+        if( iter->typeId() != type ) {
+            ++iter;
+            continue;
+        }
+
+        const int item_count = iter->count();
+        if( iter->count_by_charges() && item_count > quantity ) {
+            item split = iter->split( quantity );
+            if( split.is_null() ) {
+                debugmsg( "Failed to split %d %s from a stack of %d while milling.",
+                          quantity, type.str(), item_count );
+                break;
+            }
+            extracted.emplace_back( std::move( split ) );
+            quantity = 0;
+        } else {
+            quantity -= item_count;
+            extracted.emplace_back( *iter );
+            iter = items.erase( iter );
+        }
+    }
+
+    if( quantity > 0 ) {
+        debugmsg( "Failed to extract %d %s from a mill.", quantity, type.str() );
+    }
+
+    return extracted;
+}
+
+static void move_mill_items_to_player( Character &you, map &here, map_stack &items,
+                                       const itype_id &type, int quantity )
+{
+    for( const item &it : extract_mill_items( items, type, quantity ) ) {
+        here.add_item_or_charges( you.pos_bub(), it );
+        you.mod_moves( -you.item_handling_cost( it ) );
+    }
+}
+
 static void mill_activate( Character &you, const tripoint_bub_ms &examp )
 {
     map &here = get_map();
@@ -6885,11 +6929,7 @@ static void mill_activate( Character &you, const tripoint_bub_ms &examp )
 
     for( const item &iter : items ) {
         if( iter.type->milling_data && !iter.type->milling_data->into_.is_null() ) {
-            if( millable_counts.find( iter.typeId() ) == millable_counts.end() ) {
-                millable_counts.emplace( iter.typeId(), 1 );
-            } else {
-                millable_counts[iter.typeId()]++;
-            }
+            millable_counts[iter.typeId()] += iter.count();
         }
     }
 
@@ -6904,16 +6944,8 @@ static void mill_activate( Character &you, const tripoint_bub_ms &examp )
             add_msg( m_bad, _( "This mill contains %s, which can't be milled!" ), source.tname( 1, false ) );
             add_msg( _( "You remove the %s from the mill." ), source.tname() );
 
-            for( int i = 0; i < mill_type_count.second; i++ ) {
-                here.add_item_or_charges( you.pos_bub(), source );
-                you.mod_moves( -you.item_handling_cost( source ) );
-                for( item &iter : items ) {
-                    if( iter.typeId() == source.typeId() ) {
-                        here.i_rem( examp, &iter );
-                        break;
-                    }
-                }
-            }
+            move_mill_items_to_player( you, here, items, source.typeId(),
+                                       mill_type_count.second );
 
         } else {
             const requirement_data::alter_item_comp_vector &components =
@@ -6941,16 +6973,8 @@ static void mill_activate( Character &you, const tripoint_bub_ms &examp )
                 add_msg( m_bad, _( "This mill contains %s, which can't be milled!" ), source.tname( 1, false ) );
                 add_msg( _( "You remove the %s from the mill." ), source.tname() );
 
-                for( int i = 0; i < mill_type_count.second; i++ ) {
-                    here.add_item_or_charges( you.pos_bub(), source );
-                    you.mod_moves( -you.item_handling_cost( source ) );
-                    for( item &iter : items ) {
-                        if( iter.typeId() == source.typeId() ) {
-                            here.i_rem( examp, &iter );
-                            break;
-                        }
-                    }
-                }
+                move_mill_items_to_player( you, here, items, source.typeId(),
+                                           mill_type_count.second );
             } else {
                 const int batches = mill_type_count.second / lot_size;
                 const int process_count = batches * lot_size;
@@ -6959,31 +6983,15 @@ static void mill_activate( Character &you, const tripoint_bub_ms &examp )
                     add_msg( m_bad, _( "This mill contains too little of %s, which requires a batch size of %d." ),
                              source.tname( 1, false ), lot_size );
                     add_msg( _( "You remove the %s from the mill." ), source.tname() );
-                    for( int i = 0; i < mill_type_count.second; i++ ) {
-                        here.add_item_or_charges( you.pos_bub(), source );
-                        you.mod_moves( -you.item_handling_cost( source ) );
-                        for( item &iter : items ) {
-                            if( iter.typeId() == source.typeId() ) {
-                                here.i_rem( examp, &iter );
-                                break;
-                            }
-                        }
-                    }
+                    move_mill_items_to_player( you, here, items, source.typeId(),
+                                               mill_type_count.second );
                 } else if( process_count != mill_type_count.second ) {
                     add_msg( m_bad,
                              _( "This mill doesn't contain a full last batch of %s, which requires a batch size of %d." ),
                              source.tname( 1, false ), lot_size );
                     add_msg( _( "You remove the excess %s from the mill." ), source.tname() );
-                    for( int i = 0; i < mill_type_count.second - process_count; i++ ) {
-                        here.add_item_or_charges( you.pos_bub(), source );
-                        you.mod_moves( -you.item_handling_cost( source ) );
-                        for( item &iter : items ) {
-                            if( iter.typeId() == source.typeId() ) {
-                                here.i_rem( examp, &iter );
-                                break;
-                            }
-                        }
-                    }
+                    move_mill_items_to_player( you, here, items, source.typeId(),
+                                               mill_type_count.second - process_count );
                 }
             }
         }
@@ -7202,11 +7210,7 @@ void iexamine::mill_finalize( Character &, map &here, const tripoint_bub_ms &exa
 
     for( const item &iter : items ) {
         if( iter.type->milling_data && !iter.type->milling_data->into_.is_null() ) {
-            if( millable_counts.find( iter.typeId() ) == millable_counts.end() ) {
-                millable_counts.emplace( iter.typeId(), 1 );
-            } else {
-                millable_counts[iter.typeId()]++;
-            }
+            millable_counts[iter.typeId()] += iter.count();
         }
     }
 
@@ -7255,36 +7259,17 @@ void iexamine::mill_finalize( Character &, map &here, const tripoint_bub_ms &exa
                              source.tname(), lot_size, mill_type_count.second - batches * lot_size );
                 }
 
-                mill_type_count.second = process_count;
-
                 item_components item_component_lot;
-                int count = 0;
-
-                for( item &iter : items ) {
-                    if( iter.typeId() == mill_type_count.first ) {
-                        item_component_lot.add( iter );
-                        count++;
-                        if( count == mill_type_count.second ) {
-                            break;
-                        }
-                    }
+                std::vector<item> used_items = extract_mill_items(
+                                                   items, mill_type_count.first, process_count );
+                for( item &used_item : used_items ) {
+                    item_component_lot.add( used_item );
                 }
 
                 std::vector<item> results = rec.create_results( batches, &item_component_lot );
 
                 for( const item &result : results ) {
                     here.add_item( examp, result );
-                }
-
-                for( map_stack::iterator iter = items.begin(); iter != items.end(); ) {
-                    item &it = *iter;
-
-                    if( it.typeId() == mill_type_count.first && mill_type_count.second > 0 ) {
-                        iter = items.erase( iter );
-                        mill_type_count.second--;
-                    } else {
-                        ++iter;
-                    }
                 }
             }
         }

--- a/tests/iexamine_test.cpp
+++ b/tests/iexamine_test.cpp
@@ -2,8 +2,10 @@
 
 #include "calendar.h"
 #include "cata_catch.h"
+#include "character.h"
 #include "coordinates.h"
 #include "iexamine.h"
+#include "item.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "mapdata.h"
@@ -49,4 +51,73 @@ TEST_CASE( "examine_bush" )
     calendar::turn = calendar::turn_zero + calendar::season_length() * 2 + 1_days;
     CHECK( m.ter( pine_loc )->can_examine( pine_loc ) );
     CHECK_FALSE( m.ter( elderberry_loc )->can_examine( elderberry_loc ) );
+}
+
+TEST_CASE( "mill_finalize_counts_stackable_food_by_charges", "[iexamine][mill][stackable]" )
+{
+    clear_map_without_vision();
+    map &here = get_map();
+    Character &you = get_player_character();
+    const tripoint_bub_ms mill_pos = tripoint_bub_ms::zero;
+    const furn_id wind_mill( "f_wind_mill" );
+    const furn_id wind_mill_active( "f_wind_mill_active" );
+    const itype_id dried_rice( "dry_rice" );
+    const itype_id wheat_free_flour( "flour_wheat_free" );
+
+    here.furn_set( mill_pos, wind_mill_active );
+    item rice( dried_rice, calendar::turn_zero );
+    REQUIRE( rice.count_by_charges() );
+    rice.charges = 240;
+    here.add_item( mill_pos, rice );
+
+    iexamine::mill_finalize( you, here, mill_pos );
+
+    int rice_count = 0;
+    int flour_count = 0;
+    for( const item &it : here.i_at( mill_pos ) ) {
+        if( it.typeId() == dried_rice ) {
+            rice_count += it.count();
+        } else if( it.typeId() == wheat_free_flour ) {
+            flour_count += it.count();
+            CHECK( you.compute_effective_nutrients( it ).kcal() == 65 );
+        }
+    }
+
+    CHECK( here.furn( mill_pos ) == wind_mill );
+    CHECK( rice_count == 0 );
+    CHECK( flour_count == 960 );
+}
+
+TEST_CASE( "mill_finalize_leaves_incomplete_charge_batch", "[iexamine][mill][stackable]" )
+{
+    clear_map_without_vision();
+    map &here = get_map();
+    Character &you = get_player_character();
+    const tripoint_bub_ms mill_pos = tripoint_bub_ms::zero;
+    const furn_id wind_mill( "f_wind_mill" );
+    const furn_id wind_mill_active( "f_wind_mill_active" );
+    const itype_id cooked_acorns( "acorns_cooked" );
+    const itype_id wheat_free_flour( "flour_wheat_free" );
+
+    here.furn_set( mill_pos, wind_mill_active );
+    item acorns( cooked_acorns, calendar::turn_zero );
+    REQUIRE( acorns.count_by_charges() );
+    acorns.charges = 3;
+    here.add_item( mill_pos, acorns );
+
+    iexamine::mill_finalize( you, here, mill_pos );
+
+    int acorn_count = 0;
+    int flour_count = 0;
+    for( const item &it : here.i_at( mill_pos ) ) {
+        if( it.typeId() == cooked_acorns ) {
+            acorn_count += it.count();
+        } else if( it.typeId() == wheat_free_flour ) {
+            flour_count += it.count();
+        }
+    }
+
+    CHECK( here.furn( mill_pos ) == wind_mill );
+    CHECK( acorn_count == 1 );
+    CHECK( flour_count == 3 );
 }

--- a/tests/iexamine_test.cpp
+++ b/tests/iexamine_test.cpp
@@ -10,6 +10,7 @@
 #include "map_helpers.h"
 #include "mapdata.h"
 #include "point.h"
+#include "stomach.h"
 #include "translation.h"
 #include "type_id.h"
 


### PR DESCRIPTION
## 问题

可按 charges 堆叠的磨制原料会被风力/水力磨坊按“地图上的物品对象数”计算，而不是按实际数量计算。

例如，将 240 份干米作为一个堆叠放入磨坊，完成后只会得到 4 份无麸质面粉；这 4 份面粉却继承了全部 240 份干米的营养，因此单份热量异常高。按现有配方，正确结果应为 960 份无麸质面粉，每份 65 kcal。

## 根因

干米等磨制原料改为可堆叠物品后，磨坊逻辑仍使用 `millable_counts[type]++` 统计每个地图物品对象。一个包含 240 charges 的堆叠因此被当成 1 份原料，但在生成产物时又把整个堆叠作为配方组件传入。

原有移除逻辑同样按对象删除，无法从 charges 堆叠中精确取出完整批次或退还余量。

## 修改

- 在磨坊启动和完成阶段使用 `item::count()` 统计实际物品/charges 数量。
- 增加按指定数量拆分和移除磨制原料的共用逻辑。
- 只把本批实际消耗的原料作为产物组件，避免营养被集中到少量产物中。
- 无效原料、数量不足和不完整批次现在会按实际 charges 数量移出或保留。
- 增加回归测试，覆盖：
  - 240 份干米生成 960 份无麸质面粉，单份 65 kcal；
  - 3 份熟橡子按每批 2 份处理时，生成 3 份面粉并保留 1 份余料。

风力磨坊和水力磨坊共用这套处理逻辑，因此两者都会修复。

## 验证

- `tests/lua-disabled-cata_test '[mill][stackable]' --rng-seed 0`
  - 2 个测试用例、9 个断言全部通过。
- 在最新 `origin/master` 基线上单独编译 `src/iexamine.cpp` 和 `tests/iexamine_test.cpp`，均通过。
- `git diff --check` 通过。
- AStyle dry-run 通过。