### PR TITLE
Fix manual vehicle collision cruise speed

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1555,6 +1555,11 @@ float map::vehicle_vehicle_collision( vehicle &veh, vehicle &veh2,
     vehicle_part &vp1 = veh.part( c.part );
     vehicle_part &vp2 = veh2.part( c.target_part );
 
+    // Cancel automated driving before collision damage does so without braking.
+    // Manual drivers must retain their requested cruise velocity after a crash.
+    veh.stop_autodriving();
+    veh2.stop_autodriving();
+
     // Check whether avatar sees the collision, and log a message if so
     const avatar &you = get_avatar();
     const tripoint_bub_ms part1_pos = veh.bub_part_pos( *this, vp1 );

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -1564,14 +1564,11 @@ autodrive_result vehicle::do_autodrive( map &here, Character &driver )
 
 void vehicle::stop_autodriving( bool apply_brakes )
 {
-    // Braking is an explicit safety request and must still take effect if a
-    // preceding event (such as collision damage) already cleared the
-    // autodriving state.
-    if( apply_brakes ) {
-        cruise_velocity = 0;
-    }
     if( !is_autodriving && !is_patrolling && !is_following ) {
         return;
+    }
+    if( apply_brakes ) {
+        cruise_velocity = 0;
     }
     is_autodriving = false;
     is_patrolling = false;

--- a/tests/vehicle_fake_part_test.cpp
+++ b/tests/vehicle_fake_part_test.cpp
@@ -282,6 +282,8 @@ TEST_CASE( "vehicle_to_vehicle_collision", "[vehicle] [vehicle_fake]" )
                                          veh_spawn_status::UNDAMAGED );
         REQUIRE( trg != nullptr );
         trg->name = "crash bus";
+        trg->cruise_velocity = target_velocity;
+        trg->is_autodriving = true;
         WHEN( "A vehicle is placed in the vehicle's path such that it will hit a true part" ) {
             // we're travelling south east, so place another vehicle in the way.
 
@@ -297,6 +299,9 @@ TEST_CASE( "vehicle_to_vehicle_collision", "[vehicle] [vehicle_fake]" )
 
                 // hitting the bus should have slowed the vehicle down
                 REQUIRE( veh->velocity < target_velocity );
+                CHECK( veh->cruise_velocity == target_velocity );
+                CHECK_FALSE( trg->is_autodriving );
+                CHECK( trg->cruise_velocity == 0 );
 
                 for( const vpart_reference &vp : veh->get_all_parts() ) {
                     if( vp.info().durability > vp.part().hp() ) {

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -854,12 +854,44 @@ TEST_CASE( "vehicle_damage_cancels_autodrive_without_braking", "[vehicle][autodr
 
     CHECK_FALSE( veh->is_autodriving );
     CHECK( veh->cruise_velocity == cruising_speed );
+}
 
-    // Collision handling can run after damage handling.  Its explicit stop
-    // request must still apply the brakes even though damage already cleared
-    // the autodriving flag.
-    veh->stop_autodriving();
-    CHECK( veh->cruise_velocity == 0 );
+TEST_CASE( "vehicle_collision_brakes_only_during_autodrive",
+           "[vehicle][autodrive][collision]" )
+{
+    clear_avatar();
+    clear_map_without_vision();
+    map &here = get_map();
+    const tripoint_bub_ms vehicle_origin( 60, 60, 0 );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_car, vehicle_origin, 0_degrees, 0,
+                                     veh_spawn_status::UNDAMAGED );
+    REQUIRE( veh != nullptr );
+    REQUIRE( veh->part_count() > 0 );
+
+    const tripoint_bub_ms target_pos = vehicle_origin + tripoint::east * 10;
+    spawn_test_monster( "mon_zombie", target_pos, false );
+    constexpr int cruising_speed = 7000;
+    veh->velocity = cruising_speed;
+    veh->cruise_velocity = cruising_speed;
+
+    SECTION( "manual driving keeps the requested speed" ) {
+        const veh_collision collision = veh->part_collision(
+                                            here, 0, here.get_abs( target_pos ), false, false );
+
+        REQUIRE( collision.type == veh_coll_body );
+        CHECK( veh->cruise_velocity == cruising_speed );
+    }
+
+    SECTION( "autodrive cancels and requests braking" ) {
+        veh->is_autodriving = true;
+
+        const veh_collision collision = veh->part_collision(
+                                            here, 0, here.get_abs( target_pos ), false, false );
+
+        REQUIRE( collision.type == veh_coll_body );
+        CHECK_FALSE( veh->is_autodriving );
+        CHECK( veh->cruise_velocity == 0 );
+    }
 }
 
 TEST_CASE( "autodrive_replanning_a_two_step_path_maintains_speed",


### PR DESCRIPTION
## Summary

- preserve the requested cruise velocity when a manually driven vehicle collides with a creature or another vehicle
- keep automated collision safety by cancelling and braking autodrive before vehicle-to-vehicle damage clears the automated state
- add regression coverage for manual and automated creature collisions plus vehicle-to-vehicle collisions

## Root cause

`vehicle::stop_autodriving()` zeroed `cruise_velocity` before checking whether the vehicle was actually autodriving, patrolling, or following. Collision paths call this function unconditionally, so ordinary manual crashes also reset the driver's requested speed to zero.

## User impact

Manual ramming no longer clears the configured vehicle speed. Collision physics can still reduce the vehicle's actual velocity. Vehicles under automated control continue to cancel their route and request braking after a collision.

## Validation

- `CCACHE_DIR=/tmp/cataclysm-ccache make -j10 CATA_ENABLE_LUA_UI=0 tests`
- `tests/cata_test "[vehicle][autodrive],vehicle_to_vehicle_collision" --rng-seed 123456789 --reporter console` — 4 test cases and 44 assertions passed
- AStyle dry-run on all four changed files
- `git diff --check`
