### PR TITLE
[FCL] Quantum solar balance adjustments

### DIFF
--- a/data/mods/FuturismCataclysmLegacy/furniture_and_terrain/appliances.json
+++ b/data/mods/FuturismCataclysmLegacy/furniture_and_terrain/appliances.json
@@ -54,7 +54,7 @@
     "description": "A reinforced quantum solar panel array, mounted on a frame and ready to power other appliances.",
     "copy-from": "ap_ground_solar_panel_v3",
     "item": "reinforced_ground_solar_panel_v3",
-    "proportional": { "epower": 0.9 },
+    "proportional": { "epower": 0.95 },
     "durability": 450,
     "requirements": {
       "install": {  },

--- a/data/mods/FuturismCataclysmLegacy/furniture_and_terrain/appliances.json
+++ b/data/mods/FuturismCataclysmLegacy/furniture_and_terrain/appliances.json
@@ -55,7 +55,7 @@
     "copy-from": "ap_ground_solar_panel_v3",
     "item": "reinforced_ground_solar_panel_v3",
     "proportional": { "epower": 0.9 },
-    "durability": 300,
+    "durability": 450,
     "requirements": {
       "install": {  },
       "removal": { "time": "3 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },

--- a/data/mods/FuturismCataclysmLegacy/items/vehicle/solar.json
+++ b/data/mods/FuturismCataclysmLegacy/items/vehicle/solar.json
@@ -30,7 +30,7 @@
     "material": [ "glass", "lc_steel" ],
     "volume": "6500 ml",
     "price": "10 kUSD 200 USD",
-    "price_postapoc": "82 USD",
+    "price_postapoc": "105 USD",
     "copy-from": "solar_panel"
   },
   {

--- a/data/mods/FuturismCataclysmLegacy/items/vehicle/solar.json
+++ b/data/mods/FuturismCataclysmLegacy/items/vehicle/solar.json
@@ -17,6 +17,7 @@
     "material": [ "glass", "steel" ],
     "volume": "4500 ml",
     "price": "9 kUSD",
+    "price_postapoc": "90 USD",
     "copy-from": "solar_panel"
   },
   {
@@ -29,6 +30,7 @@
     "material": [ "glass", "lc_steel" ],
     "volume": "6500 ml",
     "price": "10 kUSD 200 USD",
+    "price_postapoc": "82 USD",
     "copy-from": "solar_panel"
   },
   {
@@ -38,7 +40,7 @@
     "name": { "str": "quantum solar panel array" },
     "description": "A collection of four quantum solar panels, ready to convert solar radiation into electric power with exotic photovoltaic materials.",
     "copy-from": "solar_panel_v3",
-    "proportional": { "price": 4, "weight": 4, "volume": 4, "longest_side": 2 }
+    "proportional": { "price": 4, "price_postapoc": 4, "weight": 4, "volume": 4, "longest_side": 2 }
   },
   {
     "//": "Four reinforced quantum solar panels stuck together for 1 m x 1 m area",
@@ -47,6 +49,6 @@
     "name": { "str": "reinforced quantum solar panel array" },
     "description": "A collection of four reinforced quantum solar panels, ready to provide static-grid power while better protected from impact damage.",
     "copy-from": "reinforced_solar_panel_v3",
-    "proportional": { "price": 4, "weight": 4, "volume": 4, "longest_side": 2 }
+    "proportional": { "price": 4, "price_postapoc": 4, "weight": 4, "volume": 4, "longest_side": 2 }
   }
 ]

--- a/data/mods/FuturismCataclysmLegacy/vehicleparts/vehicle_parts.json
+++ b/data/mods/FuturismCataclysmLegacy/vehicleparts/vehicle_parts.json
@@ -17,7 +17,7 @@
     "looks_like": "solar_panel_v2",
     "proportional": { "epower": 6.0 },
     "item": "solar_panel_v3",
-    "durability": 40,
+    "durability": 60,
     "description": "An extremely high-performance solar panel.  Will recharge the vehicle's electrical power when exposed to the sun.  Clouds will slow the recharge speed.  Extremely fragile, and reinforcing or modifying it requires unusually careful, advanced work.",
     "requirements": {
       "install": { "skills": [ [ "mechanics", 8 ] ], "time": "60 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
@@ -43,7 +43,7 @@
     "broken_color": "light_gray",
     "proportional": { "epower": 5.4 },
     "damage_modifier": 80,
-    "durability": 300,
+    "durability": 450,
     "item": "reinforced_solar_panel_v3",
     "requirements": {
       "install": { "skills": [ [ "mechanics", 8 ] ], "time": "60 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },

--- a/data/mods/FuturismCataclysmLegacy/vehicleparts/vehicle_parts.json
+++ b/data/mods/FuturismCataclysmLegacy/vehicleparts/vehicle_parts.json
@@ -41,7 +41,7 @@
     "description": "A quantum solar panel that has been covered with a pane of reinforced glass.  The glass causes this panel to produce slightly less power than a normal quantum panel.",
     "color": "light_blue",
     "broken_color": "light_gray",
-    "proportional": { "epower": 5.4 },
+    "proportional": { "epower": 5.7 },
     "damage_modifier": 80,
     "durability": 450,
     "item": "reinforced_solar_panel_v3",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Some players previously reported that the v3 quantum solar series added by Futurism Cataclysm: Legacy did not have appropriate post-cataclysm prices assigned. While addressing that, I also took the opportunity to make several balance adjustments and buffs.

#### Describe the solution
- Added post-Cataclysm prices for the v3 series, following the price ratio between the v1 and v2 series.
- Increased the durability of all v3 solar panels by 50%.
- Increased the efficiency of reinforced v3 variants from 90% of their base versions to 95%.