### PR TITLE
Improve the attribute bonus formula for the Alpha mutation line

### DIFF
--- a/data/json/mutations/mutation_jmath.json
+++ b/data/json/mutations/mutation_jmath.json
@@ -2,10 +2,10 @@
   {
     "type": "jmath_function",
     "id": "alpha_stat_bonus",
-    "//": "the smaller your stat, the bigger the bonus, up to 20, plus 4 of the stat above",
+    "//": "the smaller your stat, the bigger the bonus, up to 18, plus 4 of the stat above",
     "//_0": "your current base stat, like `u_val('intelligence_base')`",
     "num_args": 1,
-    "return": "_0 < 20 ? 14 - (_0 / 2) : 4"
+    "return": "_0 < 18 ? 13 - (_0 / 2) : 4"
   },
   {
     "type": "jmath_function",

--- a/data/json/mutations/mutation_jmath.json
+++ b/data/json/mutations/mutation_jmath.json
@@ -2,10 +2,10 @@
   {
     "type": "jmath_function",
     "id": "alpha_stat_bonus",
-    "//": "the smaller your stat, the bigger the bonus, up to 16, plus 2 of the stat above",
+    "//": "the smaller your stat, the bigger the bonus, up to 20, plus 4 of the stat above",
     "//_0": "your current base stat, like `u_val('intelligence_base')`",
     "num_args": 1,
-    "return": "_0 < 16 ? (10)+(_0/2)-_0 : 2"
+    "return": "_0 < 20 ? 14 - (_0 / 2) : 4"
   },
   {
     "type": "jmath_function",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
 - We have increased the default attribute cap, so there is no longer a need to strictly keep player attributes below 20.
 - Players have reported that the Alpha mutation line has become too weak in the new version due to the addition of negative mutations.

#### Describe the solution
Changed the `jmath_function` formula named with id `alpha_stat_bonus` from `_0 < 16 ? (10)+(_0/2)-_0 : 2` to `_0 < 18 ? 13 - (_0 / 2) : 4`.

Original formula:

| Base attribute | Bonus | Final value |
|---:|---:|---:|
| 6 | +7 | 13 |
| 8 | +6 | 14 |
| 10 | +5 | 15 |
| 12 | +4 | 16 |
| 14 | +3 | 17 |
| 16+ | +2 | 18+ |

New formula:

| Base attribute | Bonus | Final value |
|---:|---:|---:|
| 6 | +10 | 16 |
| 8 | +9 | 17 |
| 10 | +8 | 18 |
| 12 | +7 | 19 |
| 14 | +6 | 20 |
| 16 | +5 | 21 |
| 18+ | +4 | 22+ |