### PR TITLE
Enable Lua in all default builds and releases

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -189,7 +189,6 @@ jobs:
             tiles: 0
             sound: 0
             localize: 1
-            lua_ui: 1
             dont_skip_data_only_changes: 1
             native: linux64
             pch: 1
@@ -226,7 +225,7 @@ jobs:
         SOUND: ${{ matrix.sound }}
         SDL3: ${{ matrix.sdl3 }}
         LOCALIZE: ${{ matrix.localize }}
-        CATA_ENABLE_LUA_UI: ${{ matrix.lua_ui || 0 }}
+        CATA_ENABLE_LUA_UI: 1
         MODS: ${{ matrix.mods }}
         SANITIZE: ${{ matrix.sanitize }}
         TEST_STAGE: ${{ matrix.test-stage }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,6 +290,7 @@ jobs:
     permissions: write-all
     env:
         ZSTD_CLEVEL: 17
+        CATA_ENABLE_LUA_UI: 1
     steps:
       - name: Maximize build space (mac)
         if: ${{ runner.os == 'macos' && matrix.android == '' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ option(CATA_CLANG_TIDY_PLUGIN "Build Cata's custom clang-tidy checks as a plugin
 option(CATA_CLANG_TIDY_EXECUTABLE "Build Cata's custom clang-tidy checks as an executable" "OFF")
 option(WARN_STALE_DATA "Warn if file integrity check fails" "OFF")
 option(TESTS "Compile Cata's tests" "ON")
-option(CATA_ENABLE_LUA_UI "Enable the experimental Lua Mod API" "OFF")
+option(CATA_ENABLE_LUA_UI "Enable the experimental Lua Mod API" "ON")
 option(TRACY "Enable Tracy profiling; see doc/c++/PERFORMANCE.md." OFF)
 option(LTO "Enable link-time optimization for Release and RelWithDebInfo builds." OFF)
 set(CATA_CLANG_TIDY_INCLUDE_DIR "" CACHE STRING

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -150,3 +150,50 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
+Lua is licensed under the MIT license. The full license text is as follows:
+
+Copyright © 1994–2025 Lua.org, PUC-Rio.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+sol2 is licensed under the MIT license. The full license text is as follows:
+
+Copyright (c) 2013-2020 Rapptz, ThePhD and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+--------------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ IMGUI_DIR = $(SRC_DIR)/third-party/imgui
 IMTUI_DIR = $(SRC_DIR)/third-party/imtui
 LOCALIZE = 1
 ASTYLE_BINARY = astyle
-CATA_ENABLE_LUA_UI ?= 0
+CATA_ENABLE_LUA_UI ?= 1
 
 ifneq ($(filter $(CATA_ENABLE_LUA_UI),0 1),$(CATA_ENABLE_LUA_UI))
   $(error CATA_ENABLE_LUA_UI must be 0 or 1)

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -380,7 +380,7 @@ android {
             externalNativeBuild {
                 cmake {
                     arguments "-DCCB_ANDROID_NEW_UI=OFF",
-                              "-DCATA_ENABLE_LUA_UI=OFF"
+                              "-DCATA_ENABLE_LUA_UI=ON"
                 }
             }
         }
@@ -392,7 +392,7 @@ android {
             externalNativeBuild {
                 cmake {
                     arguments "-DCCB_ANDROID_NEW_UI=OFF",
-                              "-DCATA_ENABLE_LUA_UI=OFF"
+                              "-DCATA_ENABLE_LUA_UI=ON"
                 }
             }
         }

--- a/android/app/jni/CMakeLists.txt
+++ b/android/app/jni/CMakeLists.txt
@@ -49,7 +49,7 @@ file(GLOB CATA_SOURCES CONFIGURE_DEPENDS ${CATA_REPO_ROOT}/src/*.cpp
 
 option(CCB_ANDROID_NEW_UI
        "Enable the opt-in Android touch UI and customizable HUD" OFF)
-option(CATA_ENABLE_LUA_UI "Enable the experimental Lua Mod API" OFF)
+option(CATA_ENABLE_LUA_UI "Enable the experimental Lua Mod API" ON)
 
 set(
   CATALUA_UI_ENABLED_SOURCES

--- a/data/lua/README.md
+++ b/data/lua/README.md
@@ -45,11 +45,10 @@ sidebar.
 
 ## Build availability
 
-The Lua Mod runtime is a compile-time experimental feature and is disabled by default for
-desktop, Stable Android, and Experimental Android builds. Enable it explicitly
-with `CATA_ENABLE_LUA_UI=1` when using Make, or
-`-DCATA_ENABLE_LUA_UI=ON` when configuring CMake. The Android `newUi` flavor
-enables it automatically.
+The Lua Mod runtime is compiled into desktop and Android builds by default.
+Developers can still produce a Lua-free build explicitly with
+`CATA_ENABLE_LUA_UI=0` when using Make, or
+`-DCATA_ENABLE_LUA_UI=OFF` when configuring CMake.
 
 When disabled, Lua, sol2, the script runtime, its action queue, and its tests
 are not compiled or linked. The game does not load scripts, create Lua state

--- a/msvc-full-features/Cataclysm-common.props
+++ b/msvc-full-features/Cataclysm-common.props
@@ -64,9 +64,9 @@
       <CompileAsManaged>false</CompileAsManaged>
       <AdditionalOptions>/bigobj /utf-8 %(AdditionalOptions)</AdditionalOptions>
       <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)..\pch;$(MSBuildThisFileDirectory)..\src;$(MSBuildThisFileDirectory)..\src\third-party;$(MSBuildThisFileDirectory)..\src\third-party\asio\asio\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)..\pch;$(MSBuildThisFileDirectory)..\src;$(MSBuildThisFileDirectory)..\src\lua;$(MSBuildThisFileDirectory)..\src\third-party;$(MSBuildThisFileDirectory)..\src\third-party\asio\asio\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4661;4819;4146;26495;26444;26451;4068;6319;6237</DisableSpecificWarnings>
-      <PreprocessorDefinitions>_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;WIN32_LEAN_AND_MEAN;LOCALIZE;USE_VCPKG;ZSTD_STATIC_LINKING_ONLY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;WIN32_LEAN_AND_MEAN;LOCALIZE;USE_VCPKG;ZSTD_STATIC_LINKING_ONLY;CATA_ENABLE_LUA_UI=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <SupportJustMyCode>false</SupportJustMyCode>
       <BasicRuntimeChecks>Default</BasicRuntimeChecks>

--- a/msvc-full-features/Cataclysm-libAL-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-libAL-vcpkg-static.vcxproj
@@ -184,12 +184,15 @@
       <ForcedIncludeFiles />
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="..\src\lua\*.c">
+      <ForcedIncludeFiles />
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>TurnOffAllWarnings</WarningLevel>
+      <CompileAs>CompileAsC</CompileAs>
+    </ClCompile>
     <ClCompile Include="..\src\a*.cpp;..\src\b*.cpp;..\src\c*.cpp;..\src\d*.cpp;..\src\e*.cpp;..\src\f*.cpp;..\src\g*.cpp;..\src\h*.cpp;..\src\i*.cpp;..\src\j*.cpp;..\src\k*.cpp;..\src\l*.cpp" />
-    <!-- The checked-in MSVC solution is a Lua-disabled desktop build.  Keep
-         the lightweight disabled facade and do not archive both implementations:
-         whichever duplicate symbol the librarian selects would otherwise make
-         the result dependent on object ordering. -->
-    <ClCompile Remove="..\src\catalua_ui.cpp;..\src\catalua_ui_actions.cpp;..\src\catalua_ui_game.cpp;..\src\catalua_ui_i18n.cpp;..\src\catalua_ui_imgui.cpp;..\src\catalua_ui_manifest.cpp;..\src\catalua_ui_navigation.cpp;..\src\catalua_ui_renderer.cpp;..\src\catalua_ui_state.cpp" />
+    <!-- The Lua runtime owns the facade symbols in every checked-in MSVC build. -->
+    <ClCompile Remove="..\src\catalua_ui_disabled.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="flatbuffers.vcxproj">

--- a/msvc-full-features/Cataclysm-test-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-test-vcpkg-static.vcxproj
@@ -196,10 +196,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\tests\*.cpp" />
-    <!-- This solution links catalua_ui_disabled.cpp, so only the disabled
-         facade tests apply.  Full Lua runtime tests belong to Lua-enabled
-         Make/CMake configurations. -->
-    <ClCompile Remove="..\tests\catalua_ui_test.cpp" />
+    <!-- Lua runtime tests are part of the default checked-in MSVC build. -->
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\msvc-full-features\Cataclysm-libMZ-vcpkg-static.vcxproj">


### PR DESCRIPTION
## Summary

- enable the Lua Mod API by default for Make and CMake desktop builds
- enable Lua for every Android flavor
- compile the vendored Lua runtime and Lua tests in the checked-in MSVC solution
- enable Lua throughout the general CI and release workflows
- document the default and include the Lua/sol2 license notices

Developers can still opt out with `CATA_ENABLE_LUA_UI=0` for Make or `-DCATA_ENABLE_LUA_UI=OFF` for CMake.

## Validation

- configured a fresh headless CMake build and confirmed `CATA_ENABLE_LUA_UI: ON`
- built the vendored `liblua` target successfully with 12 jobs
- confirmed Make expands the complete Lua source list with `CATA_ENABLE_LUA_UI=1`
- parsed the changed GitHub workflow YAML and MSVC project XML
- ran `git diff --check`

A full multi-platform rebuild is intentionally left to the triggered GitHub Actions build matrix.