### PR TITLE
add github action labeler lua

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -47,6 +47,12 @@ labels:
         - "**/*.cpp"
         - "**/*.h"
 
+  - label: "[Lua]"
+    matcher:
+      files:
+        - "**/*.lua"
+        - "**/lua/**"
+
   - label: "[JSON]"
     matcher:
       files:


### PR DESCRIPTION
Add Lua-related configuration to the `labeler.yml` file for the GitHub Bot automated workflow.