### PR TITLE
fix(lua): restore desktop release builds

### DIFF
--- a/src/catalua_bindings_coords.h
+++ b/src/catalua_bindings_coords.h
@@ -12,9 +12,6 @@
 #include "catalua_sol.h"
 #include "coords_fwd.h"
 
-class point;
-class tripoint;
-
 namespace cata::lua_ui
 {
 

--- a/src/catalua_ui.cpp
+++ b/src/catalua_ui.cpp
@@ -4870,11 +4870,11 @@ void append_native_menu_entries(
         const sol::table entry = object.as<sol::table>();
         sol::optional<std::string> id = entry["id"];
         if( !id ) {
-            id = entry["menu_id"];
+            id = entry.get<sol::optional<std::string>>( "menu_id" );
         }
         sol::optional<std::string> label = entry["label"];
         if( !label ) {
-            label = entry["menu_label"];
+            label = entry.get<sol::optional<std::string>>( "menu_label" );
         }
         if( !id || id->empty() ||
             id->size() > maximum_menu_entry_id_bytes ) {


### PR DESCRIPTION
## Summary

- remove the duplicate `class point` and `class tripoint` declarations from the Lua coordinate bindings
- use explicitly typed sol2 table reads for legacy `menu_id` and `menu_label` fields

## Root cause

PR #545 enabled Lua in the default desktop release builds, exposing two previously dormant cross-platform compiler failures:

- Clang treated the `class` declarations as mismatched with the existing `struct` declarations under `-Werror`
- MSVC could not resolve assignment from a sol2 table proxy to `sol::optional<std::string>`

These caused Experimental Release runs #490 and #491 to fail on Linux, macOS, and Windows. Android builds were unaffected.

## Impact

Lua remains enabled by default. Desktop release builds can compile the Lua runtime without changing the menu callback API or its legacy field compatibility.

## Validation

- `git diff --check`
- complete Clang `-Werror` Lua curses build and link
- `./cataclysm --version`
- `lua_v5_monster_callbacks_collect_menus_and_observe_taming`: 22 assertions passed