### PR TITLE
Fixed JSON parser privilege escalation handling in lua/manifest.json

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -545,8 +545,7 @@ void DynamicDataLoader::load_data_from_path( const cata_path &path, const std::s
 
     // iterate over each file
     for( const cata_path &file : files ) {
-        if( file.get_relative_path().filename().string() == "manifest.json" &&
-            file.get_relative_path().parent_path().filename().string() == "lua" ) {
+        if( file == path / "lua" / "manifest.json" ) {
             continue;
         }
         try {
@@ -582,8 +581,7 @@ void DynamicDataLoader::load_mod_data_from_path( const cata_path &path, const st
 
     // iterate over each file
     for( const cata_path &file : files ) {
-        if( file.get_relative_path().filename().string() == "manifest.json" &&
-            file.get_relative_path().parent_path().filename().string() == "lua" ) {
+        if( file == path / "lua" / "manifest.json" ) {
             continue;
         }
         try {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -545,6 +545,10 @@ void DynamicDataLoader::load_data_from_path( const cata_path &path, const std::s
 
     // iterate over each file
     for( const cata_path &file : files ) {
+        if( file.get_relative_path().filename().string() == "manifest.json" &&
+            file.get_relative_path().parent_path().filename().string() == "lua" ) {
+            continue;
+        }
         try {
             // parse it
             JsonValue jsin = json_loader::from_path( file );
@@ -578,6 +582,10 @@ void DynamicDataLoader::load_mod_data_from_path( const cata_path &path, const st
 
     // iterate over each file
     for( const cata_path &file : files ) {
+        if( file.get_relative_path().filename().string() == "manifest.json" &&
+            file.get_relative_path().parent_path().filename().string() == "lua" ) {
+            continue;
+        }
         try {
             // parse it
             JsonValue jsin = json_loader::from_path( file );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
When @LYHGLYTX developing Lua functionality support, forgot that traditional JSON parsers parse all JSON files under the data resource path, while Lua's main configuration file, lua/manifest.json, is also in JSON format. This causes the manifest.json file to be parsed by both the Lua parser and traditional JSON parsers simultaneously. However, the traditional JSON parser requires all JSON game data to have a type entry, while the Lua parser requires manifest.json to not have a type entry. This causes mods using Lua to fail to load properly, and the game will be forced to quit due to errors from one of the parsers.

#### Describe the solution
Modify the code to skip all files named manifest.json in the Lua parent directory when loading JSON data entries from init.cpp.