### PR TITLE
Make Magiclysm Attunements a little easier

### DIFF
--- a/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
+++ b/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
@@ -5,7 +5,7 @@
     "//": "These need to be u_variables because they don't carry down into the EoC-selector's options otherwise",
     "effect": [
       { "math": [ "u_required_attunement_spell_count = 9" ] },
-      { "math": [ "u_required_attunement_spell_levels = 200" ] },
+      { "math": [ "u_required_attunement_spell_levels = 120" ] },
       {
         "if": {
           "or": [

--- a/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
+++ b/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
@@ -391,6 +391,150 @@
         ]
       },
       {
+        "math": [ "u_required_attunement_qualified_school_count = 0" ]
+      },
+      {
+        "math": [ "u_required_attunement_high_level_school_count = 0" ]
+      },
+      {
+        "if": {
+          "and": [
+            { "u_has_trait": "ANIMIST" },
+            { "math": [ "u_spell_count('school': 'ANIMIST') >= u_required_attunement_spell_count" ] },
+            { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= u_required_attunement_spell_levels" ] }
+          ]
+        },
+        "then": [
+          { "math": [ "u_required_attunement_qualified_school_count += 1" ] },
+          {
+            "if": { "math": [ "u_spell_level_sum('school': 'ANIMIST', 'level': '15') > 0" ] },
+            "then": { "math": [ "u_required_attunement_high_level_school_count += 1" ] }
+          }
+        ]
+      },
+      {
+        "if": {
+          "and": [
+            { "u_has_trait": "BIOMANCER" },
+            { "math": [ "u_spell_count('school': 'BIOMANCER') >= u_required_attunement_spell_count" ] },
+            { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= u_required_attunement_spell_levels" ] }
+          ]
+        },
+        "then": [
+          { "math": [ "u_required_attunement_qualified_school_count += 1" ] },
+          {
+            "if": { "math": [ "u_spell_level_sum('school': 'BIOMANCER', 'level': '15') > 0" ] },
+            "then": { "math": [ "u_required_attunement_high_level_school_count += 1" ] }
+          }
+        ]
+      },
+      {
+        "if": {
+          "and": [
+            { "u_has_trait": "DRUID" },
+            { "math": [ "u_spell_count('school': 'DRUID') >= u_required_attunement_spell_count" ] },
+            { "math": [ "u_spell_level_sum('school': 'DRUID') >= u_required_attunement_spell_levels" ] }
+          ]
+        },
+        "then": [
+          { "math": [ "u_required_attunement_qualified_school_count += 1" ] },
+          {
+            "if": { "math": [ "u_spell_level_sum('school': 'DRUID', 'level': '15') > 0" ] },
+            "then": { "math": [ "u_required_attunement_high_level_school_count += 1" ] }
+          }
+        ]
+      },
+      {
+        "if": {
+          "and": [
+            { "u_has_trait": "EARTHSHAPER" },
+            { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= u_required_attunement_spell_count" ] },
+            { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= u_required_attunement_spell_levels" ] }
+          ]
+        },
+        "then": [
+          { "math": [ "u_required_attunement_qualified_school_count += 1" ] },
+          {
+            "if": { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER', 'level': '15') > 0" ] },
+            "then": { "math": [ "u_required_attunement_high_level_school_count += 1" ] }
+          }
+        ]
+      },
+      {
+        "if": {
+          "and": [
+            { "u_has_trait": "KELVINIST" },
+            { "math": [ "u_spell_count('school': 'KELVINIST') >= u_required_attunement_spell_count" ] },
+            { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] }
+          ]
+        },
+        "then": [
+          { "math": [ "u_required_attunement_qualified_school_count += 1" ] },
+          {
+            "if": { "math": [ "u_spell_level_sum('school': 'KELVINIST', 'level': '15') > 0" ] },
+            "then": { "math": [ "u_required_attunement_high_level_school_count += 1" ] }
+          }
+        ]
+      },
+      {
+        "if": {
+          "and": [
+            { "u_has_trait": "MAGUS" },
+            { "math": [ "u_spell_count('school': 'MAGUS') >= u_required_attunement_spell_count" ] },
+            { "math": [ "u_spell_level_sum('school': 'MAGUS') >= u_required_attunement_spell_levels" ] }
+          ]
+        },
+        "then": [
+          { "math": [ "u_required_attunement_qualified_school_count += 1" ] },
+          {
+            "if": { "math": [ "u_spell_level_sum('school': 'MAGUS', 'level': '15') > 0" ] },
+            "then": { "math": [ "u_required_attunement_high_level_school_count += 1" ] }
+          }
+        ]
+      },
+      {
+        "if": {
+          "and": [
+            { "u_has_trait": "STORMSHAPER" },
+            { "math": [ "u_spell_count('school': 'STORMSHAPER') >= u_required_attunement_spell_count" ] },
+            { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= u_required_attunement_spell_levels" ] }
+          ]
+        },
+        "then": [
+          { "math": [ "u_required_attunement_qualified_school_count += 1" ] },
+          {
+            "if": { "math": [ "u_spell_level_sum('school': 'STORMSHAPER', 'level': '15') > 0" ] },
+            "then": { "math": [ "u_required_attunement_high_level_school_count += 1" ] }
+          }
+        ]
+      },
+      {
+        "if": {
+          "and": [
+            { "u_has_trait": "TECHNOMANCER" },
+            { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= u_required_attunement_spell_count" ] },
+            { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= u_required_attunement_spell_levels" ] }
+          ]
+        },
+        "then": [
+          { "math": [ "u_required_attunement_qualified_school_count += 1" ] },
+          {
+            "if": { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER', 'level': '15') > 0" ] },
+            "then": { "math": [ "u_required_attunement_high_level_school_count += 1" ] }
+          }
+        ]
+      },
+      {
+        "if": {
+          "and": [
+            { "math": [ "u_required_attunement_qualified_school_count >= 2" ] },
+            { "math": [ "u_required_attunement_high_level_school_count >= 1" ] }
+          ]
+        },
+        "then": { "math": [ "u_required_attunement_level_fifteen_is_met = 1" ] },
+        "else": { "math": [ "u_required_attunement_level_fifteen_is_met = -2" ] }
+      },
+      {
         "run_eoc_selector": [
           "EOC_GIVE_ATTUNEMENT_ARTIFICER",
           "EOC_GIVE_ATTUNEMENT_ALCHEMIST",
@@ -426,6 +570,7 @@
           "EOC_CANT_GIVE_ATTUNEMENT_NOT_ENOUGH_SPELLS",
           "EOC_CANT_GIVE_ATTUNEMENT_NOT_ENOUGH_SPELL_LEVELS",
           "EOC_CANT_GIVE_ATTUNEMENT_NOT_ENOUGH_PROFICIENCIES",
+          "EOC_CANT_GIVE_ATTUNEMENT_NO_LEVEL_FIFTEEN_SPELL",
           "EOC_NONE"
         ],
         "title": "You reach out to touch the attunement altar.",
@@ -464,6 +609,7 @@
           "Touch the altar",
           "Touch the altar",
           "Touch the altar",
+          "Touch the altar",
           "Back away"
         ],
         "descriptions": [
@@ -497,6 +643,7 @@
           "<trait_description:VOID_MAGE>",
           "<trait_description:VULCANIST>",
           "<trait_description:WITHER_MAGE>",
+          "Touch the altar",
           "Touch the altar",
           "Touch the altar",
           "Touch the altar",
@@ -2062,6 +2209,24 @@
     "effect": [
       {
         "u_message": "The altar does not respond to your touch.  While your knowledge of spells is considerable, your understanding of the fundamentals of spellcasting needs work.",
+        "type": "bad"
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CANT_GIVE_ATTUNEMENT_NO_LEVEL_FIFTEEN_SPELL",
+    "condition": {
+      "and": [
+        { "math": [ "u_required_attunement_spell_count_is_met == 1" ] },
+        { "math": [ "u_required_spell_levels_is_met == 1" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" },
+        { "math": [ "u_required_attunement_level_fifteen_is_met == -2" ] }
+      ]
+    },
+    "effect": [
+      {
+        "u_message": "The altar does not respond to your touch.  Your spell knowledge is broad and deep, but you must master at least one spell to level 15 before attempting attunement.",
         "type": "bad"
       }
     ]

--- a/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
+++ b/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
@@ -4,7 +4,7 @@
     "id": "EOC_CHECK_ATTUNEMENTS",
     "//": "These need to be u_variables because they don't carry down into the EoC-selector's options otherwise",
     "effect": [
-      { "math": [ "u_required_attunement_spell_count = 12" ] },
+      { "math": [ "u_required_attunement_spell_count = 9" ] },
       { "math": [ "u_required_attunement_spell_levels = 200" ] },
       {
         "if": {

--- a/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
+++ b/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
@@ -552,6 +552,7 @@
         { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'STORMSHAPER', 'level': '15') + u_spell_level_sum('school': 'TECHNOMANCER', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -599,6 +600,7 @@
         { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'ANIMIST', 'level': '15') + u_spell_level_sum('school': 'TECHNOMANCER', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -648,6 +650,7 @@
         { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'BIOMANCER', 'level': '15') + u_spell_level_sum('school': 'TECHNOMANCER', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -695,6 +698,7 @@
         { "math": [ "u_spell_count('school': 'ANIMIST') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'BIOMANCER', 'level': '15') + u_spell_level_sum('school': 'ANIMIST', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -744,6 +748,7 @@
         { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'KELVINIST', 'level': '15') + u_spell_level_sum('school': 'TECHNOMANCER', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -797,6 +802,7 @@
         { "math": [ "u_spell_count('school': 'KELVINIST') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'DRUID') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'DRUID', 'level': '15') + u_spell_level_sum('school': 'KELVINIST', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -844,6 +850,7 @@
         { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'DRUID') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'DRUID', 'level': '15') + u_spell_level_sum('school': 'TECHNOMANCER', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -891,6 +898,7 @@
         { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'BIOMANCER', 'level': '15') + u_spell_level_sum('school': 'EARTHSHAPER', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -940,6 +948,7 @@
         { "math": [ "u_spell_count('school': 'KELVINIST') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'BIOMANCER', 'level': '15') + u_spell_level_sum('school': 'KELVINIST', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -989,6 +998,7 @@
         { "math": [ "u_spell_count('school': 'STORMSHAPER') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'MAGUS') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'MAGUS', 'level': '15') + u_spell_level_sum('school': 'STORMSHAPER', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1036,6 +1046,7 @@
         { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'DRUID') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'DRUID', 'level': '15') + u_spell_level_sum('school': 'EARTHSHAPER', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1085,6 +1096,7 @@
         { "math": [ "u_spell_count('school': 'KELVINIST') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER', 'level': '15') + u_spell_level_sum('school': 'KELVINIST', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1136,6 +1148,7 @@
         { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'ANIMIST', 'level': '15') + u_spell_level_sum('school': 'EARTHSHAPER', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1183,6 +1196,7 @@
         { "math": [ "u_spell_count('school': 'MAGUS') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'MAGUS') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER', 'level': '15') + u_spell_level_sum('school': 'MAGUS', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1232,6 +1246,7 @@
         { "math": [ "u_spell_count('school': 'KELVINIST') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'BIOMANCER', 'level': '15') + u_spell_level_sum('school': 'KELVINIST', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1279,6 +1294,7 @@
         { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'MAGUS') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'MAGUS', 'level': '15') + u_spell_level_sum('school': 'TECHNOMANCER', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1328,6 +1344,7 @@
         { "math": [ "u_spell_count('school': 'STORMSHAPER') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER', 'level': '15') + u_spell_level_sum('school': 'STORMSHAPER', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1377,6 +1394,7 @@
         { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'KELVINIST', 'level': '15') + u_spell_level_sum('school': 'TECHNOMANCER', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1426,6 +1444,7 @@
         { "math": [ "u_spell_count('school': 'MAGUS') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'MAGUS') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'KELVINIST', 'level': '15') + u_spell_level_sum('school': 'MAGUS', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1475,6 +1494,7 @@
         { "math": [ "u_spell_count('school': 'STORMSHAPER') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'ANIMIST', 'level': '15') + u_spell_level_sum('school': 'STORMSHAPER', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1528,6 +1548,7 @@
         { "math": [ "u_spell_count('school': 'DRUID') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'DRUID') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'ANIMIST', 'level': '15') + u_spell_level_sum('school': 'DRUID', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1575,6 +1596,7 @@
         { "math": [ "u_spell_count('school': 'MAGUS') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'MAGUS') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'BIOMANCER', 'level': '15') + u_spell_level_sum('school': 'MAGUS', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1624,6 +1646,7 @@
         { "math": [ "u_spell_count('school': 'KELVINIST') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'ANIMIST', 'level': '15') + u_spell_level_sum('school': 'KELVINIST', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1677,6 +1700,7 @@
         { "math": [ "u_spell_count('school': 'STORMSHAPER') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'BIOMANCER', 'level': '15') + u_spell_level_sum('school': 'STORMSHAPER', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1726,6 +1750,7 @@
         { "math": [ "u_spell_count('school': 'STORMSHAPER') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'DRUID') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'DRUID', 'level': '15') + u_spell_level_sum('school': 'STORMSHAPER', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1775,6 +1800,7 @@
         { "math": [ "u_spell_count('school': 'MAGUS') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'MAGUS') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'KELVINIST', 'level': '15') + u_spell_level_sum('school': 'MAGUS', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1824,6 +1850,7 @@
         { "math": [ "u_spell_count('school': 'KELVINIST') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'DRUID') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'DRUID', 'level': '15') + u_spell_level_sum('school': 'KELVINIST', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1877,6 +1904,7 @@
         { "math": [ "u_spell_count('school': 'KELVINIST') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'ANIMIST', 'level': '15') + u_spell_level_sum('school': 'KELVINIST', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1926,6 +1954,7 @@
         { "math": [ "u_spell_count('school': 'KELVINIST') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER', 'level': '15') + u_spell_level_sum('school': 'KELVINIST', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1973,6 +2002,7 @@
         { "math": [ "u_spell_count('school': 'MAGUS') >= u_required_attunement_spell_count" ] },
         { "math": [ "u_spell_level_sum('school': 'DRUID') >= u_required_attunement_spell_levels" ] },
         { "math": [ "u_spell_level_sum('school': 'MAGUS') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'DRUID', 'level': '15') + u_spell_level_sum('school': 'MAGUS', 'level': '15') > 0" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
 - The prerequisites for Attunement advanced classes in the Magiclysm mod were adjusted by C:DDA previously, and the difficulty before and after the change is worlds apart.
 - In older versions of Magiclysm, the Attunement requirements were practically free, with almost no difficulty.
 - The current version requires both schools to have a combined spell level of 200+ each (400+ total), at least 12 spells learned in each school, and any Master-level spellcasting proficiency.
 - Players have long complained about the difficulty of Attunements in the current version of Magiclysm.

#### Describe the solution
Replaced the 12+200 requirements for Greater Attunements with:

 - Learn at least 9 spells in each of the two required magic schools.
 - Reach a total spell level of at least 120 in each of the two schools.
 - Have at least one spell at level 15 or higher in either of the two schools.

Slightly reduced the difficulty of obtaining Attunements.