### PR TITLE
fix(main-menu): align submenu with selected button and fix tutorial hotkey conflict

### DIFF
--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -721,7 +721,14 @@ void main_menu::display_sub_menu( int sel, const point &bottom_left, int sel_lin
     const int maximum_visible_items = std::max( 1, bottom_left.y - 1 );
     const int height = std::min<int>( sub_opts.size(), maximum_visible_items );
     const int window_height = height + 2;
-    point top_left( bottom_left + point( 0, -( window_height - 1 ) ) );
+    const int window_width = xlen + 4;
+    // bottom_left is the horizontal center of the selected menu button.
+    // Center the submenu window on it and keep the window fully inside the
+    // terminal, so it lines up with the button at any display scale.
+    const int win_x = std::clamp( bottom_left.x - window_width / 2, 0,
+                                  std::max( 0, TERMX - window_width ) );
+    const int win_y = std::max( 0, bottom_left.y - ( window_height - 1 ) );
+    point top_left( win_x, win_y );
 
     if( static_cast<size_t>( height ) != sub_opts.size() ) {
         if( sel2 < sub_opt_off ) {
@@ -735,7 +742,7 @@ void main_menu::display_sub_menu( int sel, const point &bottom_left, int sel_lin
         sub_opt_off = 0;
     }
 
-    catacurses::window w_sub = catacurses::newwin( window_height, xlen + 4, top_left );
+    catacurses::window w_sub = catacurses::newwin( window_height, window_width, top_left );
     werase( w_sub );
     draw_border( w_sub, c_white );
 
@@ -855,10 +862,21 @@ void main_menu::print_menu( const catacurses::window &w_open, int iSel, const po
 
         const point p_offset( catacurses::getbegx( w_open ), catacurses::getbegy( w_open ) );
 
+        // Center the submenu window on the selected button so that it stays
+        // aligned with the menu regardless of display scale.  Without this the
+        // submenu is anchored to the button's left edge and can run off the
+        // right side of the screen when the buttons are spread out (1x scale).
+        const int menu_count = static_cast<int>( vMenuItems.size() );
+        const int btn_left = offsets[iSel];
+        const int btn_right = iSel + 1 < menu_count
+                              ? offsets[iSel + 1] - spacing
+                              : final_offset + menu_length + spacing * ( menu_count - 1 );
+        const int btn_center = btn_left + ( btn_right - btn_left ) / 2;
+
         // Stage the parent before the submenu so the smaller window remains the
         // topmost layer in curses' virtual screen.
         wnoutrefresh( w_open );
-        display_sub_menu( iSel, p_offset + point( offsets[iSel], offset.y - 2 ), sel_line );
+        display_sub_menu( iSel, p_offset + point( btn_center, offset.y - 2 ), sel_line );
     } else {
         wnoutrefresh( w_open );
     }
@@ -984,7 +1002,7 @@ void main_menu::init_strings()
         vNewGameHints.emplace_back(
             _( "Puts you right in the game, randomly choosing scenario and character's traits, profession, skills and other parameters." ) );
     }
-    vNewGameSubItems.emplace_back( pgettext( "Main Menu", "T<u|U>torial" ) );
+    vNewGameSubItems.emplace_back( pgettext( "Main Menu", "<T|t>utorial" ) );
     vNewGameHints.emplace_back(
         _( "Learn the basic controls and survival systems in a guided game." ) );
     vNewGameHotkeys.clear();


### PR DESCRIPTION
## 修复内容

### 1. 主菜单与子菜单对齐(1x/2x 显示缩放下错位)
curses 主菜单(`!is_new_ui_build()` 路径,Linux/Windows/Android 稳定版共用)中,子菜单窗口原来锚定在选中按钮的**左边缘**,1x 缩放下按钮分散时容易超出屏幕右缘,导致"选中哪个哪个就有个菜单"但位置对不上。

- `print_menu`:计算选中按钮的水平中心,传给子菜单
- `display_sub_menu`:子菜单窗口改为以按钮中心**居中**,并 clamp 在终端范围内(`win_x = clamp(center - width/2, 0, TERMX - width)`)

### 2. 教程(Tutorial)快捷键冲突
`T<u|U>torial` 与 `C<u|U>stom Character` 同在 New Game 子菜单,都绑定 `u`。Tutorial 被移入子菜单时保留了主菜单时代的快捷键(上游 CDDA 中 Tutorial 在主菜单,不与 Custom Character 冲突)。

- 改为 `<T|t>utorial`,子菜单快捷键变为 `T/t`,不再重复

## 翻译说明
`lang/po/*.po` 不在本仓库版本控制内(.gitignore 第 143 行),需在翻译平台同步更新:

- msgid `T<u|U>torial` → `<T|t>utorial`
- zh_CN:`<U> 教程` → `<T> 教程`(与 `<U> 新角色` 等子项格式一致,带空格分隔)

其他语言旧翻译会回退英文 "Tutorial"(快捷键 T/t,无冲突),等待翻译流程更新。

## 验证
- `main_menu.cpp` 增量编译通过(Release, 零警告)
- zh_CN 翻译 `msgfmt` 校验通过,`lang/mo/zh_CN/LC_MESSAGES/cataclysm-dda.mo` 已本地重建