### PR TITLE
Allow generators to be mounted on vehicles

### DIFF
--- a/data/json/vehicleparts/generators.json
+++ b/data/json/vehicleparts/generators.json
@@ -3,6 +3,8 @@
     "type": "vehicle_part",
     "id": "veh_portable_generator",
     "copy-from": "ap_portable_generator",
+    "name": { "str": "vehicle-mounted portable gasoline generator" },
+    "description": "A small portable generator, normally used for camping.  This generator is installed in a vehicle.",
     "delete": {
       "flags": [ "ENGINE", "E_DIESEL_FUEL", "OBSTACLE", "COVERED", "APPLIANCE", "FLUIDTANK" ]
     },
@@ -29,6 +31,8 @@
     "type": "vehicle_part",
     "id": "veh_diesel_generator",
     "copy-from": "ap_diesel_generator",
+    "name": { "str": "vehicle-mounted diesel generator" },
+    "description": "A powerful, large generator primarily used for street construction.  This generator is installed in a vehicle.",
     "delete": {
       "flags": [ "ENGINE", "E_DIESEL_FUEL", "OBSTACLE", "COVERED", "APPLIANCE", "FLUIDTANK" ]
     },
@@ -50,6 +54,8 @@
     "type": "vehicle_part",
     "id": "veh_military_generator",
     "copy-from": "ap_military_generator",
+    "name": { "str": "vehicle-mounted military diesel generator" },
+    "description": "A powerful, large generator with a camouflage-painted casing.  This generator is installed in a vehicle.",
     "delete": {
       "flags": [ "ENGINE", "E_DIESEL_FUEL", "OBSTACLE", "COVERED", "APPLIANCE", "FLUIDTANK" ]
     },
@@ -71,6 +77,8 @@
     "type": "vehicle_part",
     "id": "veh_12000_gasoline_generator",
     "copy-from": "ap_12000_gasoline_generator",
+    "name": { "str": "vehicle-mounted high-output gasoline generator" },
+    "description": "A 12,000-watt gasoline generator that remains relatively portable while providing enough power for an entire house.  This generator is installed in a vehicle.",
     "delete": {
       "flags": [ "ENGINE", "E_DIESEL_FUEL", "OBSTACLE", "COVERED", "APPLIANCE", "FLUIDTANK" ]
     },

--- a/data/json/vehicleparts/generators.json
+++ b/data/json/vehicleparts/generators.json
@@ -28,34 +28,64 @@
   {
     "type": "vehicle_part",
     "id": "veh_diesel_generator",
-    "copy-from": "veh_portable_generator",
-    "name": { "str": "diesel generator" },
-    "description": "Big and powerful generator, used for street works.  It just needs to be fueled up, and then turned on.",
-    "power": "8 W",
-    "epower": "7000 W",
-    "item": "diesel_generator",
-    "breaks_into": [ { "item": "diesel_generator", "damage": 4 } ]
+    "copy-from": "ap_diesel_generator",
+    "delete": {
+      "flags": [ "ENGINE", "E_DIESEL_FUEL", "OBSTACLE", "COVERED", "APPLIANCE", "FLUIDTANK" ]
+    },
+    "location": "fuel_source",
+    "requirements": {
+      "install": {
+        "skills": [ [ "mechanics", 3 ] ],
+        "time": "30 m",
+        "using": [ [ "vehicle_bolt_install", 1 ] ]
+      },
+      "removal": {
+        "skills": [ [ "mechanics", 3 ] ],
+        "time": "30 m",
+        "using": [ [ "vehicle_weld_removal", 1 ] ]
+      }
+    }
   },
   {
     "type": "vehicle_part",
     "id": "veh_military_generator",
-    "copy-from": "veh_portable_generator",
-    "name": { "str": "military diesel generator" },
-    "description": "Big and powerful generator, painted in camo.  It just needs to be fueled up, and then turned on.",
-    "power": "8 W",
-    "epower": "10000 W",
-    "item": "military_generator",
-    "breaks_into": [ { "item": "military_generator", "damage": 4 } ]
+    "copy-from": "ap_military_generator",
+    "delete": {
+      "flags": [ "ENGINE", "E_DIESEL_FUEL", "OBSTACLE", "COVERED", "APPLIANCE", "FLUIDTANK" ]
+    },
+    "location": "fuel_source",
+    "requirements": {
+      "install": {
+        "skills": [ [ "mechanics", 3 ] ],
+        "time": "30 m",
+        "using": [ [ "vehicle_bolt_install", 1 ] ]
+      },
+      "removal": {
+        "skills": [ [ "mechanics", 3 ] ],
+        "time": "30 m",
+        "using": [ [ "vehicle_weld_removal", 1 ] ]
+      }
+    }
   },
   {
     "type": "vehicle_part",
     "id": "veh_12000_gasoline_generator",
-    "copy-from": "veh_portable_generator",
-    "name": { "str": "powerful gasoline generator" },
-    "description": "Still reasonably portable, this 12000 W gasoline generator can power up an entire house.  It just needs to be fueled up, and then turned on.",
-    "power": "8 W",
-    "epower": "12000 W",
-    "item": "12000_gasoline_generator",
-    "breaks_into": [ { "item": "12000_gasoline_generator", "damage": 4 } ]
+    "copy-from": "ap_12000_gasoline_generator",
+    "delete": {
+      "flags": [ "ENGINE", "E_DIESEL_FUEL", "OBSTACLE", "COVERED", "APPLIANCE", "FLUIDTANK" ]
+    },
+    "location": "fuel_source",
+    "requirements": {
+      "install": {
+        "skills": [ [ "mechanics", 3 ] ],
+        "time": "30 m",
+        "using": [ [ "vehicle_bolt_install", 1 ] ]
+      },
+      "removal": {
+        "skills": [ [ "mechanics", 3 ] ],
+        "time": "30 m",
+        "using": [ [ "vehicle_weld_removal", 1 ] ]
+      }
+    }
   }
 ]

--- a/data/json/vehicleparts/generators.json
+++ b/data/json/vehicleparts/generators.json
@@ -3,7 +3,7 @@
     "type": "vehicle_part",
     "id": "veh_portable_generator",
     "copy-from": "ap_portable_generator",
-    "name": { "str": "vehicle-mounted portable gasoline generator" },
+    "name": { "str": "portable gasoline generator" },
     "description": "A small portable generator, normally used for camping.  This generator is installed in a vehicle.",
     "delete": {
       "flags": [ "ENGINE", "E_DIESEL_FUEL", "OBSTACLE", "COVERED", "APPLIANCE", "FLUIDTANK" ]
@@ -31,7 +31,7 @@
     "type": "vehicle_part",
     "id": "veh_diesel_generator",
     "copy-from": "ap_diesel_generator",
-    "name": { "str": "vehicle-mounted diesel generator" },
+    "name": { "str": "diesel generator" },
     "description": "A powerful, large generator primarily used for street construction.  This generator is installed in a vehicle.",
     "delete": {
       "flags": [ "ENGINE", "E_DIESEL_FUEL", "OBSTACLE", "COVERED", "APPLIANCE", "FLUIDTANK" ]
@@ -54,7 +54,7 @@
     "type": "vehicle_part",
     "id": "veh_military_generator",
     "copy-from": "ap_military_generator",
-    "name": { "str": "vehicle-mounted military diesel generator" },
+    "name": { "str": "military diesel generator" },
     "description": "A powerful, large generator with a camouflage-painted casing.  This generator is installed in a vehicle.",
     "delete": {
       "flags": [ "ENGINE", "E_DIESEL_FUEL", "OBSTACLE", "COVERED", "APPLIANCE", "FLUIDTANK" ]
@@ -77,7 +77,7 @@
     "type": "vehicle_part",
     "id": "veh_12000_gasoline_generator",
     "copy-from": "ap_12000_gasoline_generator",
-    "name": { "str": "vehicle-mounted high-output gasoline generator" },
+    "name": { "str": "high-output gasoline generator" },
     "description": "A 12,000-watt gasoline generator that remains relatively portable while providing enough power for an entire house.  This generator is installed in a vehicle.",
     "delete": {
       "flags": [ "ENGINE", "E_DIESEL_FUEL", "OBSTACLE", "COVERED", "APPLIANCE", "FLUIDTANK" ]

--- a/data/json/vehicleparts/generators.json
+++ b/data/json/vehicleparts/generators.json
@@ -1,0 +1,182 @@
+[
+ {
+  "type": "vehicle_part",
+  "id": "veh_portable_generator",
+  "name": {"str": "车载 便携式汽油发电机"},
+  "categories": ["energy"],
+  "color": "light_green",
+  "broken_color": "blue",
+  "damage_modifier": 80,
+  "durability": 400,
+  "description": "一种小型便携式发电机，通常用于露营。这个发电机被安装在载具上。",
+  "power": "7 W",
+  "epower": "3000 W",
+  "fuel_type": "gasoline",
+  "item": "portable_generator",
+  "location": "fuel_source",
+  "looks_like":"portable_generator",
+  "requirements": {
+    "install": {
+      "skills": [["mechanics", 3]],
+      "time": "30 m",
+      "using": [["vehicle_bolt_install", 1]]
+    },
+    "removal": {
+      "skills": [["mechanics", 3]],
+      "time": "30 m",
+      "using": [["vehicle_weld_removal", 1]]
+    },
+    "repair": {
+      "skills": [["mechanics", 4]],
+      "time": "60 m",
+      "using": [
+        ["repair_welding_standard", 5],
+        ["soldering_standard", 5]
+      ]
+    }
+  },
+  "flags": ["REACTOR"],
+  "breaks_into": [
+    {"item": "mc_steel_lump", "count": [6, 11]},
+    {"item": "mc_steel_chunk", "count": [6, 11]},
+    {"item": "scrap", "count": [6, 11]}
+  ],
+  "damage_reduction": {"all": 60},
+  "variants": [{"symbols": "O", "symbols_broken": "#"}]
+ },
+ {
+  "type": "vehicle_part",
+  "id": "veh_diesel_generator",
+  "name": {"str": "车载 柴油发电机"},
+  "categories": ["energy"],
+  "color": "green_white",
+  "broken_color": "blue",
+  "damage_modifier": 80,
+  "durability": 400,
+  "description": "一种功率强大的大型发电机，主要用于街道施工。这个发电机被安装在载具上。",
+  "power": "8 W",
+  "epower": "7000 W",
+  "fuel_type": "gasoline",
+  "item": "diesel_generator",
+  "location": "fuel_source",
+  "looks_like":"diesel_generator",
+  "requirements": {
+    "install": {
+      "skills": [["mechanics", 3]],
+      "time": "30 m",
+      "using": [["vehicle_bolt_install", 1]]
+    },
+    "removal": {
+      "skills": [["mechanics", 3]],
+      "time": "30 m",
+      "using": [["vehicle_weld_removal", 1]]
+    },
+    "repair": {
+      "skills": [["mechanics", 4]],
+      "time": "60 m",
+      "using": [
+        ["repair_welding_standard", 5],
+        ["soldering_standard", 5]
+      ]
+    }
+  },
+  "flags": ["REACTOR"],
+  "breaks_into": [
+    {"item": "mc_steel_lump", "count": [6, 11]},
+    {"item": "mc_steel_chunk", "count": [6, 11]},
+    {"item": "scrap", "count": [6, 11]}
+  ],
+  "damage_reduction": {"all": 60},
+  "variants": [{"symbols": "O", "symbols_broken": "#"}]
+ },
+ {
+  "type": "vehicle_part",
+  "id": "veh_military_generator",
+  "name": {"str": "车载 军用柴油发电机"},
+  "categories": ["energy"],
+  "color": "green_white",
+  "broken_color": "blue",
+  "damage_modifier": 80,
+  "durability": 400,
+  "description": "一种功率强大的大型发电机，外壳涂有迷彩。这个发电机被安装在载具上。",
+  "power": "8 W",
+  "epower": "10000 W",
+  "fuel_type": "gasoline",
+  "item": "military_generator",
+  "location": "fuel_source",
+  "looks_like":"military_generator",
+  "requirements": {
+    "install": {
+      "skills": [["mechanics", 3]],
+      "time": "30 m",
+      "using": [["vehicle_bolt_install", 1]]
+    },
+    "removal": {
+      "skills": [["mechanics", 3]],
+      "time": "30 m",
+      "using": [["vehicle_weld_removal", 1]]
+    },
+    "repair": {
+      "skills": [["mechanics", 4]],
+      "time": "60 m",
+      "using": [
+        ["repair_welding_standard", 5],
+        ["soldering_standard", 5]
+      ]
+    }
+  },
+  "flags": ["REACTOR"],
+  "breaks_into": [
+    {"item": "mc_steel_lump", "count": [6, 11]},
+    {"item": "mc_steel_chunk", "count": [6, 11]},
+    {"item": "scrap", "count": [6, 11]}
+  ],
+  "damage_reduction": {"all": 60},
+  "variants": [{"symbols": "O", "symbols_broken": "#"}]
+ },
+ {
+  "type": "vehicle_part",
+  "id": "veh_12000_gasoline_generator",
+  "name": {"str": "车载 大功率汽油发电机"},
+  "categories": ["energy"],
+  "color": "green_white",
+  "broken_color": "blue",
+  "damage_modifier": 80,
+  "durability": 400,
+  "description": "一台12000瓦的汽油发电机，依然保持了相对的便携性，能够为整栋房屋提供电力。这个发电机被安装在载具上。",
+  "power": "8 W",
+  "epower": "12000 W",
+  "fuel_type": "gasoline",
+  "item": "12000_gasoline_generator",
+  "location": "fuel_source",
+  "looks_like":"12000_gasoline_generator",
+  "requirements": {
+    "install": {
+      "skills": [["mechanics", 3]],
+      "time": "30 m",
+      "using": [["vehicle_bolt_install", 1]]
+    },
+    "removal": {
+      "skills": [["mechanics", 3]],
+      "time": "30 m",
+      "using": [["vehicle_weld_removal", 1]]
+    },
+    "repair": {
+      "skills": [["mechanics", 4]],
+      "time": "60 m",
+      "using": [
+        ["repair_welding_standard", 5],
+        ["soldering_standard", 5]
+      ]
+    }
+  },
+  "flags": ["REACTOR"],
+  "breaks_into": [
+    {"item": "mc_steel_lump", "count": [6, 11]},
+    {"item": "mc_steel_chunk", "count": [6, 11]},
+    {"item": "scrap", "count": [6, 11]}
+  ],
+  "damage_reduction": {"all": 60},
+  "variants": [{"symbols": "O", "symbols_broken": "#"}]
+ }
+]

--- a/data/json/vehicleparts/generators.json
+++ b/data/json/vehicleparts/generators.json
@@ -2,19 +2,11 @@
   {
     "type": "vehicle_part",
     "id": "veh_portable_generator",
-    "name": { "str": "vehicle-mounted portable gasoline generator" },
-    "categories": [ "energy" ],
-    "color": "light_green",
-    "broken_color": "blue",
-    "damage_modifier": 80,
-    "durability": 400,
-    "description": "A small portable generator, normally used for camping.  This generator is installed in a vehicle.",
-    "power": "7 W",
-    "epower": "3000 W",
-    "fuel_type": "gasoline",
-    "item": "portable_generator",
+    "copy-from": "ap_portable_generator",
+    "delete": {
+      "flags": [ "ENGINE", "E_DIESEL_FUEL", "OBSTACLE", "COVERED", "APPLIANCE", "FLUIDTANK" ]
+    },
     "location": "fuel_source",
-    "looks_like": "portable_generator",
     "requirements": {
       "install": {
         "skills": [ [ "mechanics", 3 ] ],
@@ -31,140 +23,39 @@
         "time": "60 m",
         "using": [ [ "repair_welding_standard", 5 ], [ "soldering_standard", 5 ] ]
       }
-    },
-    "flags": [ "REACTOR" ],
-    "breaks_into": [
-      { "item": "mc_steel_lump", "count": [ 6, 11 ] },
-      { "item": "mc_steel_chunk", "count": [ 6, 11 ] },
-      { "item": "scrap", "count": [ 6, 11 ] }
-    ],
-    "damage_reduction": { "all": 60 },
-    "variants": [ { "symbols": "O", "symbols_broken": "#" } ]
+    }
   },
   {
     "type": "vehicle_part",
     "id": "veh_diesel_generator",
-    "name": { "str": "vehicle-mounted diesel generator" },
-    "categories": [ "energy" ],
-    "color": "green_white",
-    "broken_color": "blue",
-    "damage_modifier": 80,
-    "durability": 400,
-    "description": "A powerful, large generator primarily used for street construction.  This generator is installed in a vehicle.",
+    "copy-from": "veh_portable_generator",
+    "name": { "str": "diesel generator" },
+    "description": "Big and powerful generator, used for street works.  It just needs to be fueled up, and then turned on.",
     "power": "8 W",
     "epower": "7000 W",
-    "fuel_type": "gasoline",
     "item": "diesel_generator",
-    "location": "fuel_source",
-    "looks_like": "diesel_generator",
-    "requirements": {
-      "install": {
-        "skills": [ [ "mechanics", 3 ] ],
-        "time": "30 m",
-        "using": [ [ "vehicle_bolt_install", 1 ] ]
-      },
-      "removal": {
-        "skills": [ [ "mechanics", 3 ] ],
-        "time": "30 m",
-        "using": [ [ "vehicle_weld_removal", 1 ] ]
-      },
-      "repair": {
-        "skills": [ [ "mechanics", 4 ] ],
-        "time": "60 m",
-        "using": [ [ "repair_welding_standard", 5 ], [ "soldering_standard", 5 ] ]
-      }
-    },
-    "flags": [ "REACTOR" ],
-    "breaks_into": [
-      { "item": "mc_steel_lump", "count": [ 6, 11 ] },
-      { "item": "mc_steel_chunk", "count": [ 6, 11 ] },
-      { "item": "scrap", "count": [ 6, 11 ] }
-    ],
-    "damage_reduction": { "all": 60 },
-    "variants": [ { "symbols": "O", "symbols_broken": "#" } ]
+    "breaks_into": [ { "item": "diesel_generator", "damage": 4 } ]
   },
   {
     "type": "vehicle_part",
     "id": "veh_military_generator",
-    "name": { "str": "vehicle-mounted military diesel generator" },
-    "categories": [ "energy" ],
-    "color": "green_white",
-    "broken_color": "blue",
-    "damage_modifier": 80,
-    "durability": 400,
-    "description": "A powerful, large generator with a camouflage-painted casing.  This generator is installed in a vehicle.",
+    "copy-from": "veh_portable_generator",
+    "name": { "str": "military diesel generator" },
+    "description": "Big and powerful generator, painted in camo.  It just needs to be fueled up, and then turned on.",
     "power": "8 W",
     "epower": "10000 W",
-    "fuel_type": "gasoline",
     "item": "military_generator",
-    "location": "fuel_source",
-    "looks_like": "military_generator",
-    "requirements": {
-      "install": {
-        "skills": [ [ "mechanics", 3 ] ],
-        "time": "30 m",
-        "using": [ [ "vehicle_bolt_install", 1 ] ]
-      },
-      "removal": {
-        "skills": [ [ "mechanics", 3 ] ],
-        "time": "30 m",
-        "using": [ [ "vehicle_weld_removal", 1 ] ]
-      },
-      "repair": {
-        "skills": [ [ "mechanics", 4 ] ],
-        "time": "60 m",
-        "using": [ [ "repair_welding_standard", 5 ], [ "soldering_standard", 5 ] ]
-      }
-    },
-    "flags": [ "REACTOR" ],
-    "breaks_into": [
-      { "item": "mc_steel_lump", "count": [ 6, 11 ] },
-      { "item": "mc_steel_chunk", "count": [ 6, 11 ] },
-      { "item": "scrap", "count": [ 6, 11 ] }
-    ],
-    "damage_reduction": { "all": 60 },
-    "variants": [ { "symbols": "O", "symbols_broken": "#" } ]
+    "breaks_into": [ { "item": "military_generator", "damage": 4 } ]
   },
   {
     "type": "vehicle_part",
     "id": "veh_12000_gasoline_generator",
-    "name": { "str": "vehicle-mounted high-output gasoline generator" },
-    "categories": [ "energy" ],
-    "color": "green_white",
-    "broken_color": "blue",
-    "damage_modifier": 80,
-    "durability": 400,
-    "description": "A 12,000-watt gasoline generator that remains relatively portable while providing enough power for an entire house.  This generator is installed in a vehicle.",
+    "copy-from": "veh_portable_generator",
+    "name": { "str": "powerful gasoline generator" },
+    "description": "Still reasonably portable, this 12000 W gasoline generator can power up an entire house.  It just needs to be fueled up, and then turned on.",
     "power": "8 W",
     "epower": "12000 W",
-    "fuel_type": "gasoline",
     "item": "12000_gasoline_generator",
-    "location": "fuel_source",
-    "looks_like": "12000_gasoline_generator",
-    "requirements": {
-      "install": {
-        "skills": [ [ "mechanics", 3 ] ],
-        "time": "30 m",
-        "using": [ [ "vehicle_bolt_install", 1 ] ]
-      },
-      "removal": {
-        "skills": [ [ "mechanics", 3 ] ],
-        "time": "30 m",
-        "using": [ [ "vehicle_weld_removal", 1 ] ]
-      },
-      "repair": {
-        "skills": [ [ "mechanics", 4 ] ],
-        "time": "60 m",
-        "using": [ [ "repair_welding_standard", 5 ], [ "soldering_standard", 5 ] ]
-      }
-    },
-    "flags": [ "REACTOR" ],
-    "breaks_into": [
-      { "item": "mc_steel_lump", "count": [ 6, 11 ] },
-      { "item": "mc_steel_chunk", "count": [ 6, 11 ] },
-      { "item": "scrap", "count": [ 6, 11 ] }
-    ],
-    "damage_reduction": { "all": 60 },
-    "variants": [ { "symbols": "O", "symbols_broken": "#" } ]
+    "breaks_into": [ { "item": "12000_gasoline_generator", "damage": 4 } ]
   }
 ]

--- a/data/json/vehicleparts/generators.json
+++ b/data/json/vehicleparts/generators.json
@@ -1,182 +1,170 @@
 [
- {
-  "type": "vehicle_part",
-  "id": "veh_portable_generator",
-  "name": {"str": "车载 便携式汽油发电机"},
-  "categories": ["energy"],
-  "color": "light_green",
-  "broken_color": "blue",
-  "damage_modifier": 80,
-  "durability": 400,
-  "description": "一种小型便携式发电机，通常用于露营。这个发电机被安装在载具上。",
-  "power": "7 W",
-  "epower": "3000 W",
-  "fuel_type": "gasoline",
-  "item": "portable_generator",
-  "location": "fuel_source",
-  "looks_like":"portable_generator",
-  "requirements": {
-    "install": {
-      "skills": [["mechanics", 3]],
-      "time": "30 m",
-      "using": [["vehicle_bolt_install", 1]]
+  {
+    "type": "vehicle_part",
+    "id": "veh_portable_generator",
+    "name": { "str": "vehicle-mounted portable gasoline generator" },
+    "categories": [ "energy" ],
+    "color": "light_green",
+    "broken_color": "blue",
+    "damage_modifier": 80,
+    "durability": 400,
+    "description": "A small portable generator, normally used for camping.  This generator is installed in a vehicle.",
+    "power": "7 W",
+    "epower": "3000 W",
+    "fuel_type": "gasoline",
+    "item": "portable_generator",
+    "location": "fuel_source",
+    "looks_like": "portable_generator",
+    "requirements": {
+      "install": {
+        "skills": [ [ "mechanics", 3 ] ],
+        "time": "30 m",
+        "using": [ [ "vehicle_bolt_install", 1 ] ]
+      },
+      "removal": {
+        "skills": [ [ "mechanics", 3 ] ],
+        "time": "30 m",
+        "using": [ [ "vehicle_weld_removal", 1 ] ]
+      },
+      "repair": {
+        "skills": [ [ "mechanics", 4 ] ],
+        "time": "60 m",
+        "using": [ [ "repair_welding_standard", 5 ], [ "soldering_standard", 5 ] ]
+      }
     },
-    "removal": {
-      "skills": [["mechanics", 3]],
-      "time": "30 m",
-      "using": [["vehicle_weld_removal", 1]]
-    },
-    "repair": {
-      "skills": [["mechanics", 4]],
-      "time": "60 m",
-      "using": [
-        ["repair_welding_standard", 5],
-        ["soldering_standard", 5]
-      ]
-    }
+    "flags": [ "REACTOR" ],
+    "breaks_into": [
+      { "item": "mc_steel_lump", "count": [ 6, 11 ] },
+      { "item": "mc_steel_chunk", "count": [ 6, 11 ] },
+      { "item": "scrap", "count": [ 6, 11 ] }
+    ],
+    "damage_reduction": { "all": 60 },
+    "variants": [ { "symbols": "O", "symbols_broken": "#" } ]
   },
-  "flags": ["REACTOR"],
-  "breaks_into": [
-    {"item": "mc_steel_lump", "count": [6, 11]},
-    {"item": "mc_steel_chunk", "count": [6, 11]},
-    {"item": "scrap", "count": [6, 11]}
-  ],
-  "damage_reduction": {"all": 60},
-  "variants": [{"symbols": "O", "symbols_broken": "#"}]
- },
- {
-  "type": "vehicle_part",
-  "id": "veh_diesel_generator",
-  "name": {"str": "车载 柴油发电机"},
-  "categories": ["energy"],
-  "color": "green_white",
-  "broken_color": "blue",
-  "damage_modifier": 80,
-  "durability": 400,
-  "description": "一种功率强大的大型发电机，主要用于街道施工。这个发电机被安装在载具上。",
-  "power": "8 W",
-  "epower": "7000 W",
-  "fuel_type": "gasoline",
-  "item": "diesel_generator",
-  "location": "fuel_source",
-  "looks_like":"diesel_generator",
-  "requirements": {
-    "install": {
-      "skills": [["mechanics", 3]],
-      "time": "30 m",
-      "using": [["vehicle_bolt_install", 1]]
+  {
+    "type": "vehicle_part",
+    "id": "veh_diesel_generator",
+    "name": { "str": "vehicle-mounted diesel generator" },
+    "categories": [ "energy" ],
+    "color": "green_white",
+    "broken_color": "blue",
+    "damage_modifier": 80,
+    "durability": 400,
+    "description": "A powerful, large generator primarily used for street construction.  This generator is installed in a vehicle.",
+    "power": "8 W",
+    "epower": "7000 W",
+    "fuel_type": "gasoline",
+    "item": "diesel_generator",
+    "location": "fuel_source",
+    "looks_like": "diesel_generator",
+    "requirements": {
+      "install": {
+        "skills": [ [ "mechanics", 3 ] ],
+        "time": "30 m",
+        "using": [ [ "vehicle_bolt_install", 1 ] ]
+      },
+      "removal": {
+        "skills": [ [ "mechanics", 3 ] ],
+        "time": "30 m",
+        "using": [ [ "vehicle_weld_removal", 1 ] ]
+      },
+      "repair": {
+        "skills": [ [ "mechanics", 4 ] ],
+        "time": "60 m",
+        "using": [ [ "repair_welding_standard", 5 ], [ "soldering_standard", 5 ] ]
+      }
     },
-    "removal": {
-      "skills": [["mechanics", 3]],
-      "time": "30 m",
-      "using": [["vehicle_weld_removal", 1]]
-    },
-    "repair": {
-      "skills": [["mechanics", 4]],
-      "time": "60 m",
-      "using": [
-        ["repair_welding_standard", 5],
-        ["soldering_standard", 5]
-      ]
-    }
+    "flags": [ "REACTOR" ],
+    "breaks_into": [
+      { "item": "mc_steel_lump", "count": [ 6, 11 ] },
+      { "item": "mc_steel_chunk", "count": [ 6, 11 ] },
+      { "item": "scrap", "count": [ 6, 11 ] }
+    ],
+    "damage_reduction": { "all": 60 },
+    "variants": [ { "symbols": "O", "symbols_broken": "#" } ]
   },
-  "flags": ["REACTOR"],
-  "breaks_into": [
-    {"item": "mc_steel_lump", "count": [6, 11]},
-    {"item": "mc_steel_chunk", "count": [6, 11]},
-    {"item": "scrap", "count": [6, 11]}
-  ],
-  "damage_reduction": {"all": 60},
-  "variants": [{"symbols": "O", "symbols_broken": "#"}]
- },
- {
-  "type": "vehicle_part",
-  "id": "veh_military_generator",
-  "name": {"str": "车载 军用柴油发电机"},
-  "categories": ["energy"],
-  "color": "green_white",
-  "broken_color": "blue",
-  "damage_modifier": 80,
-  "durability": 400,
-  "description": "一种功率强大的大型发电机，外壳涂有迷彩。这个发电机被安装在载具上。",
-  "power": "8 W",
-  "epower": "10000 W",
-  "fuel_type": "gasoline",
-  "item": "military_generator",
-  "location": "fuel_source",
-  "looks_like":"military_generator",
-  "requirements": {
-    "install": {
-      "skills": [["mechanics", 3]],
-      "time": "30 m",
-      "using": [["vehicle_bolt_install", 1]]
+  {
+    "type": "vehicle_part",
+    "id": "veh_military_generator",
+    "name": { "str": "vehicle-mounted military diesel generator" },
+    "categories": [ "energy" ],
+    "color": "green_white",
+    "broken_color": "blue",
+    "damage_modifier": 80,
+    "durability": 400,
+    "description": "A powerful, large generator with a camouflage-painted casing.  This generator is installed in a vehicle.",
+    "power": "8 W",
+    "epower": "10000 W",
+    "fuel_type": "gasoline",
+    "item": "military_generator",
+    "location": "fuel_source",
+    "looks_like": "military_generator",
+    "requirements": {
+      "install": {
+        "skills": [ [ "mechanics", 3 ] ],
+        "time": "30 m",
+        "using": [ [ "vehicle_bolt_install", 1 ] ]
+      },
+      "removal": {
+        "skills": [ [ "mechanics", 3 ] ],
+        "time": "30 m",
+        "using": [ [ "vehicle_weld_removal", 1 ] ]
+      },
+      "repair": {
+        "skills": [ [ "mechanics", 4 ] ],
+        "time": "60 m",
+        "using": [ [ "repair_welding_standard", 5 ], [ "soldering_standard", 5 ] ]
+      }
     },
-    "removal": {
-      "skills": [["mechanics", 3]],
-      "time": "30 m",
-      "using": [["vehicle_weld_removal", 1]]
-    },
-    "repair": {
-      "skills": [["mechanics", 4]],
-      "time": "60 m",
-      "using": [
-        ["repair_welding_standard", 5],
-        ["soldering_standard", 5]
-      ]
-    }
+    "flags": [ "REACTOR" ],
+    "breaks_into": [
+      { "item": "mc_steel_lump", "count": [ 6, 11 ] },
+      { "item": "mc_steel_chunk", "count": [ 6, 11 ] },
+      { "item": "scrap", "count": [ 6, 11 ] }
+    ],
+    "damage_reduction": { "all": 60 },
+    "variants": [ { "symbols": "O", "symbols_broken": "#" } ]
   },
-  "flags": ["REACTOR"],
-  "breaks_into": [
-    {"item": "mc_steel_lump", "count": [6, 11]},
-    {"item": "mc_steel_chunk", "count": [6, 11]},
-    {"item": "scrap", "count": [6, 11]}
-  ],
-  "damage_reduction": {"all": 60},
-  "variants": [{"symbols": "O", "symbols_broken": "#"}]
- },
- {
-  "type": "vehicle_part",
-  "id": "veh_12000_gasoline_generator",
-  "name": {"str": "车载 大功率汽油发电机"},
-  "categories": ["energy"],
-  "color": "green_white",
-  "broken_color": "blue",
-  "damage_modifier": 80,
-  "durability": 400,
-  "description": "一台12000瓦的汽油发电机，依然保持了相对的便携性，能够为整栋房屋提供电力。这个发电机被安装在载具上。",
-  "power": "8 W",
-  "epower": "12000 W",
-  "fuel_type": "gasoline",
-  "item": "12000_gasoline_generator",
-  "location": "fuel_source",
-  "looks_like":"12000_gasoline_generator",
-  "requirements": {
-    "install": {
-      "skills": [["mechanics", 3]],
-      "time": "30 m",
-      "using": [["vehicle_bolt_install", 1]]
+  {
+    "type": "vehicle_part",
+    "id": "veh_12000_gasoline_generator",
+    "name": { "str": "vehicle-mounted high-output gasoline generator" },
+    "categories": [ "energy" ],
+    "color": "green_white",
+    "broken_color": "blue",
+    "damage_modifier": 80,
+    "durability": 400,
+    "description": "A 12,000-watt gasoline generator that remains relatively portable while providing enough power for an entire house.  This generator is installed in a vehicle.",
+    "power": "8 W",
+    "epower": "12000 W",
+    "fuel_type": "gasoline",
+    "item": "12000_gasoline_generator",
+    "location": "fuel_source",
+    "looks_like": "12000_gasoline_generator",
+    "requirements": {
+      "install": {
+        "skills": [ [ "mechanics", 3 ] ],
+        "time": "30 m",
+        "using": [ [ "vehicle_bolt_install", 1 ] ]
+      },
+      "removal": {
+        "skills": [ [ "mechanics", 3 ] ],
+        "time": "30 m",
+        "using": [ [ "vehicle_weld_removal", 1 ] ]
+      },
+      "repair": {
+        "skills": [ [ "mechanics", 4 ] ],
+        "time": "60 m",
+        "using": [ [ "repair_welding_standard", 5 ], [ "soldering_standard", 5 ] ]
+      }
     },
-    "removal": {
-      "skills": [["mechanics", 3]],
-      "time": "30 m",
-      "using": [["vehicle_weld_removal", 1]]
-    },
-    "repair": {
-      "skills": [["mechanics", 4]],
-      "time": "60 m",
-      "using": [
-        ["repair_welding_standard", 5],
-        ["soldering_standard", 5]
-      ]
-    }
-  },
-  "flags": ["REACTOR"],
-  "breaks_into": [
-    {"item": "mc_steel_lump", "count": [6, 11]},
-    {"item": "mc_steel_chunk", "count": [6, 11]},
-    {"item": "scrap", "count": [6, 11]}
-  ],
-  "damage_reduction": {"all": 60},
-  "variants": [{"symbols": "O", "symbols_broken": "#"}]
- }
+    "flags": [ "REACTOR" ],
+    "breaks_into": [
+      { "item": "mc_steel_lump", "count": [ 6, 11 ] },
+      { "item": "mc_steel_chunk", "count": [ 6, 11 ] },
+      { "item": "scrap", "count": [ 6, 11 ] }
+    ],
+    "damage_reduction": { "all": 60 },
+    "variants": [ { "symbols": "O", "symbols_broken": "#" } ]
+  }
 ]


### PR DESCRIPTION
#### Summary
Content "Add proper vehicle part variants for several generators"

#### Purpose of change
Before the appliance system centered around the `APPLIANCE` flag was introduced, electrical devices such as generators were actually designed to be used by installing them on vehicles. Even after the appliance system was implemented, both appliances and vehicle parts still use the same JSON type, `"type": "vehicle_part"`. However, once the appliance system was introduced, these devices were intentionally excluded from being mounted on vehicles.

In practice, some generators can indeed operate while being mounted on moving vehicles. In addition, one of our players, @Nuacepony, provided part of the original implementation.

#### Describe the solution
Added vehicle-mounted variants of the portable gasoline generator, diesel generator, military diesel generator, and powerful gasoline generator.

The original code commit has been properly credited to its author.