### PR TITLE
区域整理放置物品时批量倾倒

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -15127,86 +15127,96 @@ void zone_sort_activity_actor::deliver_picked_items( Character &you,
     while( dest_iter != dropoff_coords.end() ) {
         const tripoint_abs_ms drop_dest = *dest_iter;
         const tripoint_bub_ms drop_bub = here.get_bub( drop_dest );
-        if( here.inbounds( drop_bub ) && !here.is_open_air( drop_bub ) &&
-            ( square_dist( abspos, drop_dest ) <= 1 ||
-              zone_sorting::route_length( you, drop_bub ) != INT_MAX ) ) {
-            auto iter = picked_up_stuff.begin();
-            // Item locations can be invalidated by inventory restacking / charge-merging
-            // between pickup and delivery. Purge stale entries and continue with what remains.
-            auto stale = std::remove_if( picked_up_stuff.begin(), picked_up_stuff.end(),
-            []( const item_location & loc ) {
-                return !loc.get_item();
-            } );
-            if( stale != picked_up_stuff.end() ) {
-                add_msg_debug( debugmode::DF_ACTIVITY,
-                               "zone_sort deliver_picked_items: purged %zu stale item_locations",
-                               static_cast<size_t>( std::distance( stale, picked_up_stuff.end() ) ) );
-                picked_up_stuff.erase( stale, picked_up_stuff.end() );
-            }
-            if( picked_up_stuff.empty() ) {
-                return;
-            }
-            while( iter != picked_up_stuff.end() ) {
-                if( you.get_moves() <= 0 ) { // Ran out of moves dropping stuff
-                    return;
-                }
-
-                // Place item at destination directly. Zone binding
-                // determines the fallback chain: vehicle-only zones skip
-                // ground, everything else tries cargo then ground.
-                const zone_type_id drop_zt = mgr.get_near_zone_type_for_item( **iter,
-                                             drop_dest, 0, fac_id );
-                const bool vehicle_only = drop_zt != zone_type_id::NULL_ID() &&
-                                          mgr.has_vehicle( drop_zt, drop_dest, fac_id ) &&
-                                          !mgr.has_terrain( drop_zt, drop_dest, fac_id );
-                bool placed = false;
-                item copy( **iter );
-                for( const vpart_reference &ovp : zone_sorting::cargo_parts_at( drop_bub ) ) {
-                    if( ovp.vehicle().add_item( here, ovp.part(), copy ) ) {
-                        placed = true;
-                        break;
-                    }
-                }
-                if( !placed && !vehicle_only ) {
-                    item copy( **iter );
-                    item_location ground = here.add_item_or_charges_ret_loc(
-                                               drop_bub, copy, false );
-                    placed = ground.get_item() != nullptr;
-                }
-
-                if( placed ) {
-                    if( square_dist( abspos, drop_dest ) > 1 &&
-                        distance_fee_charged.insert( drop_dest ).second ) {
-                        you.mod_moves( -std::min( 100 * rl_dist( src_bub, drop_bub ), 500 ) );
-                    }
-                    you.mod_moves( -batch_handling_cost( you, **iter ) );
-                    if( const vehicle_cursor *veh_curs = iter->veh_cursor() ) {
-                        vehicle &cart_with_items = veh_curs->veh;
-                        cart_with_items.remove_item( cart_with_items.part( veh_curs->part ), iter->get_item() );
-                    } else if( iter->carrier() ) {
-                        iter->carrier()->i_rem( iter->get_item() );
-                    }
-                    iter = picked_up_stuff.erase( iter );
-                    // dumb. Go through and clear our any now-invalidated item_locations. Then reset iter to the start, to *make sure* we iterate everything.
-                    // Definitely wasteful, but I am not paid enough to figure out a better way.
-                    auto cleanup_iter = picked_up_stuff.begin();
-                    while( cleanup_iter != picked_up_stuff.end() ) {
-                        if( !cleanup_iter->get_item() ) {
-                            cleanup_iter = picked_up_stuff.erase( cleanup_iter );
-                        } else {
-                            cleanup_iter++;
-                        }
-                    }
-                    // Again: Always reset to the start if we dropped stuff.
-                    iter = picked_up_stuff.begin();
-                } else {
-                    iter++; // Failed to drop for some reason?!
-                }
-            }
-            dest_iter = dropoff_coords.erase( dest_iter ); // Done dropping stuff here.
-        } else {
+        if( !here.inbounds( drop_bub ) || here.is_open_air( drop_bub ) ||
+            ( square_dist( abspos, drop_dest ) > 1 &&
+              zone_sorting::route_length( you, drop_bub ) == INT_MAX ) ) {
             dest_iter = dropoff_coords.erase( dest_iter ); // No longer reachable or valid.
+            continue;
         }
+
+        // Item locations can be invalidated by inventory restacking / charge-merging
+        // between pickup and delivery. Purge stale entries once, then deliver.
+        auto stale = std::remove_if( picked_up_stuff.begin(), picked_up_stuff.end(),
+        []( const item_location & loc ) {
+            return !loc.get_item();
+        } );
+        if( stale != picked_up_stuff.end() ) {
+            add_msg_debug( debugmode::DF_ACTIVITY,
+                           "zone_sort deliver_picked_items: purged %zu stale item_locations",
+                           static_cast<size_t>( std::distance( stale, picked_up_stuff.end() ) ) );
+            picked_up_stuff.erase( stale, picked_up_stuff.end() );
+        }
+        if( picked_up_stuff.empty() ) {
+            return;
+        }
+
+        // Deliver the batch. Each item is placed individually because it needs
+        // its own cargo part / capacity check, but handling time is charged
+        // once per destination as a bulk unload instead of per item.
+        units::mass placed_mass = 0_gram;
+        auto iter = picked_up_stuff.begin();
+        while( iter != picked_up_stuff.end() ) {
+            // Skip locations invalidated by an earlier removal in this loop;
+            // their items were merged into other stacks on the carrier.
+            if( !iter->get_item() ) {
+                iter = picked_up_stuff.erase( iter );
+                continue;
+            }
+
+            // Place item at destination directly. Zone binding
+            // determines the fallback chain: vehicle-only zones skip
+            // ground, everything else tries cargo then ground.
+            const zone_type_id drop_zt = mgr.get_near_zone_type_for_item( **iter,
+                                         drop_dest, 0, fac_id );
+            const bool vehicle_only = drop_zt != zone_type_id::NULL_ID() &&
+                                      mgr.has_vehicle( drop_zt, drop_dest, fac_id ) &&
+                                      !mgr.has_terrain( drop_zt, drop_dest, fac_id );
+            bool placed = false;
+            item copy( **iter );
+            for( const vpart_reference &ovp : zone_sorting::cargo_parts_at( drop_bub ) ) {
+                if( ovp.vehicle().add_item( here, ovp.part(), copy ) ) {
+                    placed = true;
+                    break;
+                }
+            }
+            if( !placed && !vehicle_only ) {
+                item copy( **iter );
+                item_location ground = here.add_item_or_charges_ret_loc(
+                                           drop_bub, copy, false );
+                placed = ground.get_item() != nullptr;
+            }
+
+            if( !placed ) {
+                ++iter; // Didn't fit - remaining destinations get a chance at it.
+                continue;
+            }
+            if( square_dist( abspos, drop_dest ) > 1 &&
+                distance_fee_charged.insert( drop_dest ).second ) {
+                you.mod_moves( -std::min( 100 * rl_dist( src_bub, drop_bub ), 500 ) );
+            }
+            placed_mass += ( **iter ).weight();
+            if( const vehicle_cursor *veh_curs = iter->veh_cursor() ) {
+                vehicle &cart_with_items = veh_curs->veh;
+                cart_with_items.remove_item( cart_with_items.part( veh_curs->part ), iter->get_item() );
+            } else if( iter->carrier() ) {
+                iter->carrier()->i_rem( iter->get_item() );
+            }
+            iter = picked_up_stuff.erase( iter );
+        }
+
+        // Single bulk unload cost based on the total weight delivered here,
+        // mirroring the batched drop cost in zone_sorting::unload_item().
+        if( placed_mass > 0_gram ) {
+            int unload_cost = 50;
+            if( you.is_armed() ) {
+                unload_cost += 20;
+            }
+            const int delta = units::to_gram( placed_mass ) - units::to_gram( you.weight_capacity() );
+            unload_cost += std::max( 0, delta / 100 );
+            unload_cost = std::min( 400, unload_cost );
+            you.mod_moves( -std::min( 2 * unload_cost, 500 ) );
+        }
+        dest_iter = dropoff_coords.erase( dest_iter ); // Done dropping stuff here.
     }
 }
 


### PR DESCRIPTION
Summary

   <!-- #### 概述 -->
   Performance "区域整理放置物品时批量倾倒"

   Purpose of change

   <!-- #### 变更目的 -->
   区域整理（zone sort）投放已拾取物品时，原实现逐件计算并扣除动作点，且每放置一件都要全量扫描清理因堆叠合 
   并而失效的 item_location，批次较大时开销高、动作点消耗大。本 PR 将投放改为按目的地批量处理：同一目的地  
   统一结算一次动作点成本，失效条目改为边遍历边清理。

   Describe the solution

   <!-- #### 解决方案描述 -->
   • deliver_picked_items() 重构为逐目的地批量交付：物品仍逐件尝试放入车辆 cargo / 地面（保留 zone 绑定与  
     vehicle-only 回退链），但动作点改为该目的地全部放置完成后统一扣除一次，成本基于实际放下的物品总重量计 
     算，公式与 unload_item() 的批量卸货成本一致（基础 50 + 武装 20 + 超重加成 max(0, (重量-负重)/100)，上 
     限 400，单次扣除 min(2 * cost, 500)）。
   • 失效 item_location 的清理改为循环内边删边查（!loc.get_item() 时 erase），去掉原实现"每放置一件全量重  
     扫并重置迭代器到开头"的冗余做法。
   • 移除逐件放置前的 you.get_moves() <= 0 提前返回，避免批次中途因动作点不足反复跨回合中断；未放置成功的  
     物品保留在队列中，由后续目的地继续尝试。

   Describe alternatives you've considered

   <!-- #### 你考虑过的替代方案 -->
   • 仅合并失效清理、保留逐件计费：收益有限，不能解决大量物品时动作点消耗过高的问题。
   • 直接复用 unload_item() 的整批落地（put_into_vehicle_or_drop）：该路径面向"卸空容器"场景，无法逐件尝试 
     多个目的地并处理部分放置失败的情况，故保留逐件放置、仅统一计费。

   Testing

   <!-- #### 测试 -->
   <!-- TODO: 替换为你的实际测试结果 -->
   • 建议验证：区域整理搬运大量同类型物品与零星物品各一次，确认物品正确落入 cargo/地面、放置失败物品流转到 
     下一目的地、动作点按目的地批量扣除且无悬垂崩溃。
   • 建议运行 zone 相关测试套件："[zones]"。

   Additional context

   <!-- #### 补充说明 -->
   成本口径从"每件物品"变为"每目的地一次"是有意为之：整批搬运明显变便宜（单次上限 500），但零星 1-2 件物品 
   的放置成本会高于旧的逐件折扣价，审阅时请留意这一平衡影响。

   ────────────────────────────────────────────────────────────────────────────────

   <details><summary>原模板说明（可不提交）</summary>

   一点说明：Summary 分类我选了 Performance（核心意图是批量处理降开销）；如果你认为成本结构变化更值得强调  
   ，可换成 Balance。Testing 一节我没有替你编造结果，请按你实际做的验证填写（若确实只做了编译验证，就如实  
   写"编译通过，未做运行时验证"，审阅者更信任诚实的描述）。

   </details>