### PR TITLE
CCB Agent 友好化与双语开发文档重构：修正 Phase 0/1 检查边界

### DIFF
--- a/data/AGENTS.md
+++ b/data/AGENTS.md
@@ -13,6 +13,7 @@ Typical validation:
 
 ```sh
 make -j2 json-check
+make -j2 tools/format/json_formatter.cgi
 tools/format/json_formatter.cgi <changed-json-file>
 ```
 

--- a/tools/agent/check_docs_impact.py
+++ b/tools/agent/check_docs_impact.py
@@ -16,12 +16,15 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
 MAP_PATH = ROOT / "ai/docs-impact.yml"
-REQUIRED_PR_FIELDS = (
-    "Responsible human",
+DOCUMENTATION_PR_FIELDS = (
     "Documentation impact",
     "Related CCB-Docs PR",
     "Affected documentation IDs",
     "Generated reference impact",
+)
+RESPONSIBLE_HUMAN_FIELD = "Responsible human"
+GITHUB_USER_MENTION = re.compile(
+    r"(?<![\w/-])@[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?(?![\w/-])"
 )
 
 
@@ -76,19 +79,27 @@ def field_value(body: str, heading: str) -> str | None:
 
 
 def validate_pr_body(body: str) -> list[str]:
-    errors = []
-    values = {
-        heading: field_value(body, heading) for heading in REQUIRED_PR_FIELDS
-    }
-    for heading, value in values.items():
-        if value is None:
-            errors.append(f"missing PR field: {heading}")
-    responsible = values.get("Responsible human")
-    if responsible is not None and (
-        not responsible or responsible.lower() == "@username"
+    """Return blocking responsibility errors only."""
+    responsible = field_value(body, RESPONSIBLE_HUMAN_FIELD)
+    if responsible is None:
+        return [f"missing PR field: {RESPONSIBLE_HUMAN_FIELD}"]
+    mentions = GITHUB_USER_MENTION.findall(responsible)
+    if not mentions or all(
+        mention.lower() == "@username" for mention in mentions
     ):
-        errors.append("Responsible human must name a real GitHub account")
-    return errors
+        return ["Responsible human must name a real GitHub account"]
+    if "[bot]" in responsible.lower():
+        return ["Responsible human must not be a bot account"]
+    return []
+
+
+def documentation_field_warnings(body: str) -> list[str]:
+    """Return non-blocking Phase 0/1 documentation-field warnings."""
+    warnings = []
+    for heading in DOCUMENTATION_PR_FIELDS:
+        if field_value(body, heading) is None:
+            warnings.append(f"missing advisory PR field: {heading}")
+    return warnings
 
 
 def report(result: list[dict]) -> str:
@@ -131,6 +142,9 @@ def main() -> int:
 
     if args.check_pr_body:
         errors = validate_pr_body(os.environ.get("PR_BODY", ""))
+        warnings = documentation_field_warnings(os.environ.get("PR_BODY", ""))
+        for warning in warnings:
+            print(f"::warning::{warning}", file=sys.stderr)
         for error in errors:
             print(f"::error::{error}", file=sys.stderr)
         if errors:

--- a/tools/agent/check_project_metadata.py
+++ b/tools/agent/check_project_metadata.py
@@ -32,14 +32,7 @@ def load_yaml(path: Path) -> dict:
 
 def tracked_paths() -> list[str]:
     output = subprocess.run(
-        [
-            "git",
-            "ls-files",
-            "-z",
-            "--cached",
-            "--others",
-            "--exclude-standard",
-        ],
+        ["git", "ls-files", "-z", "--cached"],
         cwd=ROOT,
         check=True,
         stdout=subprocess.PIPE,

--- a/tools/agent/test_docs_impact.py
+++ b/tools/agent/test_docs_impact.py
@@ -1,6 +1,10 @@
 import unittest
 
-from check_docs_impact import impacts, validate_pr_body
+from check_docs_impact import (
+    documentation_field_warnings,
+    impacts,
+    validate_pr_body,
+)
 
 
 class DocsImpactTest(unittest.TestCase):
@@ -40,6 +44,19 @@ None
         self.assertEqual([], validate_pr_body(body))
         self.assertTrue(
             validate_pr_body(body.replace("@maintainer", "@username"))
+        )
+
+    def test_documentation_fields_are_advisory_in_phase_zero(self):
+        body = """#### Responsible human
+@maintainer
+"""
+        self.assertEqual(validate_pr_body(body), [])
+        self.assertEqual(len(documentation_field_warnings(body)), 4)
+
+    def test_responsible_human_cannot_be_none_or_a_bot(self):
+        self.assertTrue(validate_pr_body("#### Responsible human\nNone\n"))
+        self.assertTrue(
+            validate_pr_body("#### Responsible human\n@automation[bot]\n")
         )
 
 

--- a/tools/agent/test_project_metadata.py
+++ b/tools/agent/test_project_metadata.py
@@ -1,9 +1,23 @@
 import unittest
+from unittest import mock
 
-from check_project_metadata import validate_context, validate_inventory
+from check_project_metadata import (
+    tracked_paths,
+    validate_context,
+    validate_inventory,
+)
 
 
 class ProjectMetadataTest(unittest.TestCase):
+    @mock.patch("check_project_metadata.subprocess.run")
+    def test_path_discovery_reads_only_the_git_index(self, run):
+        run.return_value.stdout = b"AGENTS.md\0tools/AGENTS.md\0"
+
+        self.assertEqual(tracked_paths(), ["AGENTS.md", "tools/AGENTS.md"])
+        command = run.call_args.args[0]
+        self.assertIn("--cached", command)
+        self.assertNotIn("--others", command)
+
     def test_context_is_valid(self):
         validate_context()
 


### PR DESCRIPTION
#### Summary
Infrastructure "修正 Phase 0/1 Agent 检查的安全与提示边界"

#### Responsible human
@LYHGLYTX

#### Purpose of change
Phase 0/1 收尾审计发现三处边界不准确：

1. `data/AGENTS.md` 在干净 checkout 中直接调用尚未构建的 JSON formatter；
2. 元数据检查把未跟踪路径加入发现范围，可能枚举本地 `obj-lua/`；
3. 文档影响字段本应只提示，但字段缺失会让检查失败。

#### Describe the solution
- 在调用 formatter 前显式运行 `make -j2 tools/format/json_formatter.cgi`。
- 元数据路径发现只读取 Git index（`git ls-files --cached`），不枚举未跟踪工作树。
- Documentation impact、Related CCB-Docs PR、Affected documentation IDs 与 Generated reference impact 在 Phase 0/1 缺失时只产生 warning。
- `Responsible human` 仍是强制项，并校验为非占位、非 `[bot]` 的 GitHub 账号 mention。
- 增加回归测试固定上述边界。

不修改游戏、构建或 Lua/JSON 运行时行为。

#### Testing
- `make -n -j2 tools/format/json_formatter.cgi`
- `python3 tools/agent/generate_markdown_inventory.py --check`
- `python3 tools/agent/check_project_metadata.py`
- `python3 -m unittest discover -s tools/agent -p 'test_*.py'`（10 tests）
- `uvx --from flake8==7.3.0 flake8 -j 1 tools/agent`
- 使用仅含 `Responsible human` 的模拟 PR body 验证文档字段只输出 warning 且进程成功
- `git diff --check`

#### Documentation impact
修正主仓库离线 Agent 命令与 Phase 0/1 检查边界。`ai/docs-impact.yml` 会对 `data/AGENTS.md` 产生 advisory 映射；复核后，对应 CCB-Docs 页面未复制错误的 formatter 构建命令，且其 `source_paths` 不含 `data/AGENTS.md`，因此无需更新页面或刷新 `verified_commit`。

#### Related CCB-Docs PR
https://github.com/CrimsonCrossBunker/CCB-Docs/pull/1

#### Affected documentation IDs
- `getting-started.first-contribution`（advisory mapping only；无需页面更新）
- `contributing.responsible-human`（advisory mapping only；无需页面更新）

#### Generated reference impact
None

#### Additional context
不修改游戏代码、主页、CCB-GUIDE、Lua/JSON API 契约、branch protection 或 `obj-lua/`。