### PR TITLE
fix: align main-menu submenu, tutorial hotkey conflict, and tool-station repair debugmsg

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -226,6 +226,12 @@ static std::optional<item_location> try_form_loc( Character &you, map *here,
 
 static item_location form_loc( Character &you, map *here, const tripoint_bub_ms &p, item &it )
 {
+    // Pseudo tools (e.g. one invoked from a vehicle tool station) are virtual
+    // instances that aren't stored in any inventory or on the map, so there is
+    // no real location to form.  Return a dummy location without complaining.
+    if( it.has_flag( flag_PSEUDO ) ) {
+        return item_location( you, &it );
+    }
     if( std::optional<item_location> loc = try_form_loc( you, here, p, it ) ) {
         return *loc;
     }


### PR DESCRIPTION
## 修复内容

本 PR 包含两个修复(各自独立 commit):

### 1. fix(main-menu): align submenu with selected button and fix tutorial hotkey conflict
主菜单子菜单与选中按钮对齐,并修复教程快捷键冲突。

### 2. fix(vehicle): skip location lookup for pseudo tools invoked from tool stations
在车上使用挂在工具站(modular tool station)上的焊枪选择修理时,会弹出错误:
```
Couldn't find item ... to form item_location, forming dummy location to ensure minimum functionality
REPORTING FUNCTION: form_loc
SOURCE FILE: src/iuse_actor.cpp
```

**根因**: `vehicle::use_vehicle_tool` 会构造一个临时的 PSEUDO 伪物品并就地调用 `invoke_item`。`repair_item_actor::use` 中的 `form_loc` 尝试在玩家/地图/车辆 cargo 中查找该物品——伪物品不存储在任何真实位置,必然找不到,于是每次修理都触发误报 debugmsg。修理本身是正常的(活动执行时由 `weldrig_hack` 通过 `act.coords`/str_values 重新定位工具站的真实工具)。

**修复**: `form_loc` 对带 `PSEUDO` flag 的物品直接返回 dummy `item_location`,不再查找、不再弹窗。非 PSEUDO 物品路径完全不变,真实错误仍会触发 debugmsg。

已验证: `iuse_actor.cpp` 增量编译通过。