### PR TITLE
CCB Agent 友好化与双语开发文档重构：docs: classify all legacy Markdown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ python3 -m unittest discover -s tools/agent -p 'test_*.py'
 python3 tools/agent/check_project_metadata.py
 python3 tools/agent/generate_markdown_inventory.py --check
 python3 tools/agent/generate_documentation_registry.py --check
+python3 tools/agent/generate_migration_reports.py --check
 
 # C++ formatting and unit tests
 make astyle-check

--- a/ai/documentation-registry.yml
+++ b/ai/documentation-registry.yml
@@ -1,9 +1,9 @@
 schema_version: 1
 kind: documentation_registry
-source_commit: 2c899a3db790e11a6ff44d91f319064b1ee65d2a
+source_commit: 0535df12e953dafe15e92bc497c845b103390d94
 scope: Tracked documentation and machine contracts from the Git index; untracked build caches are never
   traversed.
-entry_count: 214
+entry_count: 217
 entries:
 - id: repo.deepcode-plans-sim-render-decoupling-plan-md
   path: .deepcode/plans/sim-render-decoupling-plan.md
@@ -349,25 +349,23 @@ entries:
   include_in_ai_index: true
 - id: repo.data-json-npcs-godco-necc-info-md
   path: data/json/npcs/godco/NECC_INFO.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-json-npcs-godco-necc-info
-  ccb_docs_ids:
-  - legacy.data-json-npcs-godco-necc-info
+  stable_document_id: content.npc.godco-roster
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-json-npcs-refugee-center-free-merchants-info-md
   path: data/json/npcs/refugee_center/FREE_MERCHANTS_INFO.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-json-npcs-refugee-center-free-merchants-info
-  ccb_docs_ids:
-  - legacy.data-json-npcs-refugee-center-free-merchants-info
+  stable_document_id: content.npc.free-merchants-economy
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -388,9 +386,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.data-lua-readme
+  stable_document_id: lua.v5.overview
   ccb_docs_ids:
-  - legacy.data-lua-readme
+  - lua.v5.overview
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -400,9 +398,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.data-lua-examples-api-v5-mod-readme
+  stable_document_id: lua.v5.example-mod
   ccb_docs_ids:
-  - legacy.data-lua-examples-api-v5-mod-readme
+  - lua.v5.example-mod
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -474,145 +472,133 @@ entries:
   include_in_ai_index: true
 - id: repo.data-mods-backrooms-readme-md
   path: data/mods/Backrooms/README.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-backrooms-readme
-  ccb_docs_ids:
-  - legacy.data-mods-backrooms-readme
+  stable_document_id: mods.backrooms.overview
+  ccb_docs_ids: []
   generated: false
   generated_by: null
-  include_in_ai_index: true
+  include_in_ai_index: false
 - id: repo.data-mods-bombasticperks-docs-contributing-md
   path: data/mods/BombasticPerks/docs/contributing.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-bombasticperks-docs-contributing
-  ccb_docs_ids:
-  - legacy.data-mods-bombasticperks-docs-contributing
+  stable_document_id: mods.bombastic-perks.contributing
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-bombasticperks-docs-expanding-with-mods-md
   path: data/mods/BombasticPerks/docs/expanding_with_mods.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-bombasticperks-docs-expanding-with-mods
-  ccb_docs_ids:
-  - legacy.data-mods-bombasticperks-docs-expanding-with-mods
+  stable_document_id: mods.bombastic-perks.extension-contract
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-dinomod-design-md
   path: data/mods/DinoMod/DESIGN.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-dinomod-design
-  ccb_docs_ids:
-  - legacy.data-mods-dinomod-design
+  stable_document_id: mods.dinomod.design
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-dinomod-readme-md
   path: data/mods/DinoMod/README.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-dinomod-readme
-  ccb_docs_ids:
-  - legacy.data-mods-dinomod-readme
+  stable_document_id: mods.dinomod.overview
+  ccb_docs_ids: []
   generated: false
   generated_by: null
-  include_in_ai_index: true
+  include_in_ai_index: false
 - id: repo.data-mods-ma-readme-md
   path: data/mods/MA/README.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-ma-readme
-  ccb_docs_ids:
-  - legacy.data-mods-ma-readme
+  stable_document_id: mods.massachusetts.overview
+  ccb_docs_ids: []
   generated: false
   generated_by: null
-  include_in_ai_index: true
+  include_in_ai_index: false
 - id: repo.data-mods-magiclysm-lore-md
   path: data/mods/Magiclysm/lore.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-magiclysm-lore
-  ccb_docs_ids:
-  - legacy.data-mods-magiclysm-lore
+  stable_document_id: mods.magiclysm.lore
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-magiclysm-magic-balance-md
   path: data/mods/Magiclysm/magic_balance.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-magiclysm-magic-balance
-  ccb_docs_ids:
-  - legacy.data-mods-magiclysm-magic-balance
+  stable_document_id: mods.magiclysm.balance
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-megafauna-readme-md
   path: data/mods/Megafauna/readme.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-megafauna-readme
-  ccb_docs_ids:
-  - legacy.data-mods-megafauna-readme
+  stable_document_id: mods.megafauna.overview
+  ccb_docs_ids: []
   generated: false
   generated_by: null
-  include_in_ai_index: true
+  include_in_ai_index: false
 - id: repo.data-mods-mindovermatter-gainingpowerspoilers-md
   path: data/mods/MindOverMatter/GainingPowerSpoilers.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-mindovermatter-gainingpowerspoilers
-  ccb_docs_ids:
-  - legacy.data-mods-mindovermatter-gainingpowerspoilers
+  stable_document_id: mods.mind-over-matter.gaining-powers
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-mindovermatter-netherattunementspoilers-md
   path: data/mods/MindOverMatter/NetherAttunementSpoilers.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-mindovermatter-netherattunementspoilers
-  ccb_docs_ids:
-  - legacy.data-mods-mindovermatter-netherattunementspoilers
+  stable_document_id: mods.mind-over-matter.nether-attunement
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-mindovermatter-newpowerguide-md
   path: data/mods/MindOverMatter/NewPowerGuide.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-mindovermatter-newpowerguide
-  ccb_docs_ids:
-  - legacy.data-mods-mindovermatter-newpowerguide
+  stable_document_id: mods.mind-over-matter.new-power-guide
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -622,177 +608,163 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.data-mods-mindovermatter-powerdescriptionspoilers
+  stable_document_id: mods.mind-over-matter.power-reference
   ccb_docs_ids:
-  - legacy.data-mods-mindovermatter-powerdescriptionspoilers
+  - mods.mind-over-matter.power-reference
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-mindovermatter-readme-md
   path: data/mods/MindOverMatter/README.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-mindovermatter-readme
-  ccb_docs_ids:
-  - legacy.data-mods-mindovermatter-readme
+  stable_document_id: mods.mind-over-matter.overview
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-mindovermatter-lore-spoilers-md
   path: data/mods/MindOverMatter/lore_spoilers.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-mindovermatter-lore-spoilers
-  ccb_docs_ids:
-  - legacy.data-mods-mindovermatter-lore-spoilers
+  stable_document_id: mods.mind-over-matter.lore
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-mindovermatternoknacks-readme-md
   path: data/mods/MindOverMatterNoKnacks/README.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-mindovermatternoknacks-readme
-  ccb_docs_ids:
-  - legacy.data-mods-mindovermatternoknacks-readme
+  stable_document_id: mods.mind-over-matter.no-knacks
+  ccb_docs_ids: []
   generated: false
   generated_by: null
-  include_in_ai_index: true
+  include_in_ai_index: false
 - id: repo.data-mods-no-hope-contributing-md
   path: data/mods/No_Hope/CONTRIBUTING.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-no-hope-contributing
-  ccb_docs_ids:
-  - legacy.data-mods-no-hope-contributing
+  stable_document_id: mods.no-hope.contributing
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-no-hope-difficulty-options-md
   path: data/mods/No_Hope/DIFFICULTY_OPTIONS.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-no-hope-difficulty-options
-  ccb_docs_ids:
-  - legacy.data-mods-no-hope-difficulty-options
+  stable_document_id: mods.no-hope.difficulty-options
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-sky-island-readme-md
   path: data/mods/Sky_Island/README.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-sky-island-readme
-  ccb_docs_ids:
-  - legacy.data-mods-sky-island-readme
+  stable_document_id: mods.sky-island.overview
+  ccb_docs_ids: []
   generated: false
   generated_by: null
-  include_in_ai_index: true
+  include_in_ai_index: false
 - id: repo.data-mods-sorcerer-readme-md
   path: data/mods/Sorcerer/README.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-sorcerer-readme
-  ccb_docs_ids:
-  - legacy.data-mods-sorcerer-readme
+  stable_document_id: mods.sorcerer.overview
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-test-data-readme-md
   path: data/mods/TEST_DATA/README.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-test-data-readme
-  ccb_docs_ids:
-  - legacy.data-mods-test-data-readme
+  stable_document_id: testing.test-data-mod
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-xedrawood-readme-md
   path: data/mods/XedraWood/README.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-xedrawood-readme
-  ccb_docs_ids:
-  - legacy.data-mods-xedrawood-readme
+  stable_document_id: mods.xedra-wood.overview
+  ccb_docs_ids: []
   generated: false
   generated_by: null
-  include_in_ai_index: true
+  include_in_ai_index: false
 - id: repo.data-mods-xedra-evolved-readme-md
   path: data/mods/Xedra_Evolved/README.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-xedra-evolved-readme
-  ccb_docs_ids:
-  - legacy.data-mods-xedra-evolved-readme
+  stable_document_id: mods.xedra-evolved.overview
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-xedra-evolved-design-doc-spoilers-md
   path: data/mods/Xedra_Evolved/design_doc_spoilers.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-xedra-evolved-design-doc-spoilers
-  ccb_docs_ids:
-  - legacy.data-mods-xedra-evolved-design-doc-spoilers
+  stable_document_id: mods.xedra-evolved.design
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-xedra-evolved-vampire-guide-md
   path: data/mods/Xedra_Evolved/vampire_guide.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-xedra-evolved-vampire-guide
-  ccb_docs_ids:
-  - legacy.data-mods-xedra-evolved-vampire-guide
+  stable_document_id: mods.xedra-evolved.vampire-guide
+  ccb_docs_ids: []
   generated: false
   generated_by: null
-  include_in_ai_index: true
+  include_in_ai_index: false
 - id: repo.data-mods-aftershock-exoplanet-doc-hacking-md
   path: data/mods/aftershock_exoplanet/doc/Hacking.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-aftershock-exoplanet-doc-hacking
-  ccb_docs_ids:
-  - legacy.data-mods-aftershock-exoplanet-doc-hacking
+  stable_document_id: mods.aftershock-exoplanet.hacking
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-aftershock-exoplanet-doc-crafting-system-md
   path: data/mods/aftershock_exoplanet/doc/crafting_system.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-aftershock-exoplanet-doc-crafting-system
-  ccb_docs_ids:
-  - legacy.data-mods-aftershock-exoplanet-doc-crafting-system
+  stable_document_id: mods.aftershock-exoplanet.crafting-system
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -802,45 +774,42 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.data-mods-aftershock-exoplanet-doc-lore-cyberpunk-future
+  stable_document_id: mods.aftershock-exoplanet.lore.cyberpunk-future
   ccb_docs_ids:
-  - legacy.data-mods-aftershock-exoplanet-doc-lore-cyberpunk-future
+  - mods.aftershock-exoplanet.lore.cyberpunk-future
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-aftershock-exoplanet-doc-lore-factions-md
   path: data/mods/aftershock_exoplanet/doc/lore/factions.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-aftershock-exoplanet-doc-lore-factions
-  ccb_docs_ids:
-  - legacy.data-mods-aftershock-exoplanet-doc-lore-factions
+  stable_document_id: mods.aftershock-exoplanet.lore.factions
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-aftershock-exoplanet-doc-lore-organizations-md
   path: data/mods/aftershock_exoplanet/doc/lore/organizations.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-aftershock-exoplanet-doc-lore-organizations
-  ccb_docs_ids:
-  - legacy.data-mods-aftershock-exoplanet-doc-lore-organizations
+  stable_document_id: mods.aftershock-exoplanet.lore.organizations
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-aftershock-exoplanet-doc-lore-points-of-interest-md
   path: data/mods/aftershock_exoplanet/doc/lore/points_of_interest.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-aftershock-exoplanet-doc-lore-points-of-interest
-  ccb_docs_ids:
-  - legacy.data-mods-aftershock-exoplanet-doc-lore-points-of-interest
+  stable_document_id: mods.aftershock-exoplanet.lore.points-of-interest
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -850,201 +819,185 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.data-mods-aftershock-exoplanet-doc-lore-ranged-weapon-balance
+  stable_document_id: mods.aftershock-exoplanet.balance.ranged-weapons
   ccb_docs_ids:
-  - legacy.data-mods-aftershock-exoplanet-doc-lore-ranged-weapon-balance
+  - mods.aftershock-exoplanet.balance.ranged-weapons
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-aftershock-exoplanet-doc-lore-salus-4-md
   path: data/mods/aftershock_exoplanet/doc/lore/salus_4.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-aftershock-exoplanet-doc-lore-salus-4
-  ccb_docs_ids:
-  - legacy.data-mods-aftershock-exoplanet-doc-lore-salus-4
+  stable_document_id: mods.aftershock-exoplanet.lore.salus-iv
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-aftershock-exoplanet-doc-lore-timeline-md
   path: data/mods/aftershock_exoplanet/doc/lore/timeline.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-aftershock-exoplanet-doc-lore-timeline
-  ccb_docs_ids:
-  - legacy.data-mods-aftershock-exoplanet-doc-lore-timeline
+  stable_document_id: mods.aftershock-exoplanet.lore.timeline
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-aftershock-exoplanet-doc-suit-operating-time-md
   path: data/mods/aftershock_exoplanet/doc/suit_operating_time.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-aftershock-exoplanet-doc-suit-operating-time
-  ccb_docs_ids:
-  - legacy.data-mods-aftershock-exoplanet-doc-suit-operating-time
+  stable_document_id: mods.aftershock-exoplanet.balance.powered-armor
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-aftershock-exoplanet-items-armor-exosuit-exosuit-guide-md
   path: data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_guide.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-aftershock-exoplanet-items-armor-exosuit-exosuit-guide
-  ccb_docs_ids:
-  - legacy.data-mods-aftershock-exoplanet-items-armor-exosuit-exosuit-guide
+  stable_document_id: mods.aftershock-exoplanet.exosuit-guide
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-alt-map-key-readme-md
   path: data/mods/alt_map_key/README.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-alt-map-key-readme
-  ccb_docs_ids:
-  - legacy.data-mods-alt-map-key-readme
+  stable_document_id: mods.alternative-map-key.overview
+  ccb_docs_ids: []
   generated: false
   generated_by: null
-  include_in_ai_index: true
+  include_in_ai_index: false
 - id: repo.data-mods-classic-zombies-design-doc-md
   path: data/mods/classic_zombies/design-doc.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-classic-zombies-design-doc
-  ccb_docs_ids:
-  - legacy.data-mods-classic-zombies-design-doc
+  stable_document_id: mods.classic-zombies.design
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-classic-zombies-place-names-md
   path: data/mods/classic_zombies/place_names.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-classic-zombies-place-names
-  ccb_docs_ids:
-  - legacy.data-mods-classic-zombies-place-names
+  stable_document_id: mods.classic-zombies.place-names
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-hunvre-documentation-lore-md
   path: data/mods/hunvre/documentation/lore.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-hunvre-documentation-lore
-  ccb_docs_ids:
-  - legacy.data-mods-hunvre-documentation-lore
+  stable_document_id: mods.hunvre.lore
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-hunvre-progress-tracker-md
   path: data/mods/hunvre/progress_tracker.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-hunvre-progress-tracker
-  ccb_docs_ids:
-  - legacy.data-mods-hunvre-progress-tracker
+  stable_document_id: mods.hunvre.progress
+  ccb_docs_ids: []
   generated: false
   generated_by: null
-  include_in_ai_index: true
+  include_in_ai_index: false
 - id: repo.data-mods-immortal-path-glossary-md
   path: data/mods/immortal_path/GLOSSARY.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-immortal-path-glossary
-  ccb_docs_ids:
-  - legacy.data-mods-immortal-path-glossary
+  stable_document_id: mods.immortal-path.glossary
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-immortal-path-language-convention-md
   path: data/mods/immortal_path/LANGUAGE_CONVENTION.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-immortal-path-language-convention
-  ccb_docs_ids:
-  - legacy.data-mods-immortal-path-language-convention
+  stable_document_id: mods.immortal-path.language-convention
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-immortal-path-doc-game-design-md
   path: data/mods/immortal_path/doc/game-design.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-immortal-path-doc-game-design
-  ccb_docs_ids:
-  - legacy.data-mods-immortal-path-doc-game-design
+  stable_document_id: mods.immortal-path.game-design
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-immortal-path-doc-lore-md
   path: data/mods/immortal_path/doc/lore.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-immortal-path-doc-lore
-  ccb_docs_ids:
-  - legacy.data-mods-immortal-path-doc-lore
+  stable_document_id: mods.immortal-path.lore
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-immortal-path-doc-spell-design-md
   path: data/mods/immortal_path/doc/spell-design.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-immortal-path-doc-spell-design
-  ccb_docs_ids:
-  - legacy.data-mods-immortal-path-doc-spell-design
+  stable_document_id: mods.immortal-path.spell-design
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.data-mods-innawood-readme-md
   path: data/mods/innawood/readme.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-innawood-readme
-  ccb_docs_ids:
-  - legacy.data-mods-innawood-readme
+  stable_document_id: mods.innawood.overview
+  ccb_docs_ids: []
   generated: false
   generated_by: null
-  include_in_ai_index: true
+  include_in_ai_index: false
 - id: repo.data-mods-translate-dialogue-readme-md
   path: data/mods/translate-dialogue/README.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.data-mods-translate-dialogue-readme
-  ccb_docs_ids:
-  - legacy.data-mods-translate-dialogue-readme
+  stable_document_id: mods.translate-dialogue.maintenance
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1054,21 +1007,20 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-ascii-art
+  stable_document_id: content.ascii-art
   ccb_docs_ids:
-  - legacy.doc-ascii-art
+  - content.ascii-art
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.doc-changelog-guidelines-md
   path: doc/CHANGELOG_GUIDELINES.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.doc-changelog-guidelines
-  ccb_docs_ids:
-  - legacy.doc-changelog-guidelines
+  stable_document_id: contributing.changelog-guidelines
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1078,9 +1030,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-developer-faq
+  stable_document_id: contributing.developer-faq
   ccb_docs_ids:
-  - legacy.doc-developer-faq
+  - contributing.developer-faq
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1090,9 +1042,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-frequently-made-suggestions
+  stable_document_id: design.frequently-made-suggestions
   ccb_docs_ids:
-  - legacy.doc-frequently-made-suggestions
+  - design.frequently-made-suggestions
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1102,9 +1054,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-gun-naming-and-inclusion
+  stable_document_id: content.firearms-naming-and-inclusion
   ccb_docs_ids:
-  - legacy.doc-gun-naming-and-inclusion
+  - content.firearms-naming-and-inclusion
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1114,21 +1066,21 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-howto-massage-ma-gun-data
+  stable_document_id: archive.firearms-massachusetts-data-workflow
   ccb_docs_ids:
-  - legacy.doc-howto-massage-ma-gun-data
+  - archive.firearms-massachusetts-data-workflow
   generated: false
   generated_by: null
-  include_in_ai_index: true
+  include_in_ai_index: false
 - id: repo.doc-how-you-can-help-md
   path: doc/HOW_YOU_CAN_HELP.md
   category: legacy_source
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-how-you-can-help
+  stable_document_id: getting-started.how-you-can-help
   ccb_docs_ids:
-  - legacy.doc-how-you-can-help
+  - getting-started.how-you-can-help
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1138,9 +1090,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-in-repo-mods
+  stable_document_id: mods.in-repository-policy
   ccb_docs_ids:
-  - legacy.doc-in-repo-mods
+  - mods.in-repository-policy
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1150,9 +1102,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-issue-triage
+  stable_document_id: maintainers.issue-triage
   ccb_docs_ids:
-  - legacy.doc-issue-triage
+  - maintainers.issue-triage
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1162,9 +1114,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-artifacts
+  stable_document_id: json.artifacts
   ccb_docs_ids:
-  - legacy.doc-json-artifacts
+  - json.artifacts
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1174,9 +1126,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-basecamp
+  stable_document_id: json.basecamp
   ccb_docs_ids:
-  - legacy.doc-json-basecamp
+  - json.basecamp
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1186,9 +1138,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-climbing
+  stable_document_id: json.climbing-aids
   ccb_docs_ids:
-  - legacy.doc-json-climbing
+  - json.climbing-aids
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1198,9 +1150,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-dimensions
+  stable_document_id: json.dimensions
   ccb_docs_ids:
-  - legacy.doc-json-dimensions
+  - json.dimensions
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1210,9 +1162,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-effects-json
+  stable_document_id: json.effects
   ccb_docs_ids:
-  - legacy.doc-json-effects-json
+  - json.effects
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1222,9 +1174,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-effect-on-condition
+  stable_document_id: eoc.reference
   ccb_docs_ids:
-  - legacy.doc-json-effect-on-condition
+  - eoc.reference
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1234,9 +1186,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-examine
+  stable_document_id: json.examine-actions
   ccb_docs_ids:
-  - legacy.doc-json-examine
+  - json.examine-actions
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1246,9 +1198,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-factions
+  stable_document_id: json.npc-factions
   ccb_docs_ids:
-  - legacy.doc-json-factions
+  - json.npc-factions
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1258,9 +1210,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-faction-missions
+  stable_document_id: json.faction-missions
   ccb_docs_ids:
-  - legacy.doc-json-faction-missions
+  - json.faction-missions
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1270,9 +1222,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-guide-comestibles
+  stable_document_id: json.comestibles-placement
   ccb_docs_ids:
-  - legacy.doc-json-guide-comestibles
+  - json.comestibles-placement
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1282,9 +1234,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-help-menu
+  stable_document_id: json.help-menu
   ccb_docs_ids:
-  - legacy.doc-json-help-menu
+  - json.help-menu
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1294,9 +1246,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-item
+  stable_document_id: json.items
   ccb_docs_ids:
-  - legacy.doc-json-item
+  - json.items
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1306,9 +1258,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-item-craft-and-disassembly
+  stable_document_id: json.recipes-and-disassembly
   ccb_docs_ids:
-  - legacy.doc-json-item-craft-and-disassembly
+  - json.recipes-and-disassembly
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1318,9 +1270,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-item-spawn
+  stable_document_id: json.item-groups
   ccb_docs_ids:
-  - legacy.doc-json-item-spawn
+  - json.item-groups
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1330,9 +1282,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-json-flags
+  stable_document_id: json.flags
   ccb_docs_ids:
-  - legacy.doc-json-json-flags
+  - json.flags
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1342,9 +1294,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-json-info
+  stable_document_id: json.object-types
   ccb_docs_ids:
-  - legacy.doc-json-json-info
+  - json.object-types
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1354,9 +1306,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-json-inheritance
+  stable_document_id: json.inheritance
   ccb_docs_ids:
-  - legacy.doc-json-json-inheritance
+  - json.inheritance
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1378,9 +1330,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-json-mapping-guides-guide-for-beginning-mapgen
+  stable_document_id: tutorial.mapgen-beginner
   ccb_docs_ids:
-  - legacy.doc-json-json-mapping-guides-guide-for-beginning-mapgen
+  - tutorial.mapgen-beginner
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1390,9 +1342,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-json-mapping-guides-guide-for-intermediate-mapgen
+  stable_document_id: tutorial.mapgen-intermediate
   ccb_docs_ids:
-  - legacy.doc-json-json-mapping-guides-guide-for-intermediate-mapgen
+  - tutorial.mapgen-intermediate
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1402,9 +1354,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-json-mapping-guides-json-roof-mapgen
+  stable_document_id: tutorial.mapgen-roofs
   ccb_docs_ids:
-  - legacy.doc-json-json-mapping-guides-json-roof-mapgen
+  - tutorial.mapgen-roofs
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1414,9 +1366,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-json-style
+  stable_document_id: contributing.json-style
   ccb_docs_ids:
-  - legacy.doc-json-json-style
+  - contributing.json-style
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1426,9 +1378,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-json-tools
+  stable_document_id: how-to.json-tools
   ccb_docs_ids:
-  - legacy.doc-json-json-tools
+  - how-to.json-tools
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1438,9 +1390,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-magic
+  stable_document_id: json.magic-spells-enchantments
   ccb_docs_ids:
-  - legacy.doc-json-magic
+  - json.magic-spells-enchantments
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1450,9 +1402,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-mapgen
+  stable_document_id: json.mapgen
   ccb_docs_ids:
-  - legacy.doc-json-mapgen
+  - json.mapgen
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1462,9 +1414,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-map-smashing
+  stable_document_id: json.map-smashing
   ccb_docs_ids:
-  - legacy.doc-json-map-smashing
+  - json.map-smashing
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1474,9 +1426,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-martialart-json
+  stable_document_id: json.martial-arts
   ccb_docs_ids:
-  - legacy.doc-json-martialart-json
+  - json.martial-arts
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1486,9 +1438,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-missions-json
+  stable_document_id: json.missions
   ccb_docs_ids:
-  - legacy.doc-json-missions-json
+  - json.missions
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1498,9 +1450,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-monsters
+  stable_document_id: json.monsters
   ccb_docs_ids:
-  - legacy.doc-json-monsters
+  - json.monsters
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1510,9 +1462,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-monster-special-attacks
+  stable_document_id: json.monster-special-attacks
   ccb_docs_ids:
-  - legacy.doc-json-monster-special-attacks
+  - json.monster-special-attacks
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1522,9 +1474,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-move-mode
+  stable_document_id: json.movement-modes
   ccb_docs_ids:
-  - legacy.doc-json-move-mode
+  - json.movement-modes
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1534,9 +1486,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-mutations
+  stable_document_id: json.mutations
   ccb_docs_ids:
-  - legacy.doc-json-mutations
+  - json.mutations
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1546,9 +1498,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-npcs
+  stable_document_id: json.npcs-dialogue
   ccb_docs_ids:
-  - legacy.doc-json-npcs
+  - json.npcs-dialogue
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1558,9 +1510,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-obsoletion-and-migration
+  stable_document_id: json.obsoletion-and-migration
   ccb_docs_ids:
-  - legacy.doc-json-obsoletion-and-migration
+  - json.obsoletion-and-migration
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1570,9 +1522,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-options
+  stable_document_id: json.options
   ccb_docs_ids:
-  - legacy.doc-json-options
+  - json.options
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1582,9 +1534,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-overmap
+  stable_document_id: json.overmap
   ccb_docs_ids:
-  - legacy.doc-json-overmap
+  - json.overmap
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1594,9 +1546,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-practice-recipes
+  stable_document_id: json.practice-recipes
   ccb_docs_ids:
-  - legacy.doc-json-practice-recipes
+  - json.practice-recipes
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1606,9 +1558,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-proficiency
+  stable_document_id: json.proficiencies
   ccb_docs_ids:
-  - legacy.doc-json-proficiency
+  - json.proficiencies
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1618,9 +1570,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-proficiency-list
+  stable_document_id: json.proficiencies-index
   ccb_docs_ids:
-  - legacy.doc-json-proficiency-list
+  - json.proficiencies-index
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1630,9 +1582,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-region-layout
+  stable_document_id: json.region-layout
   ccb_docs_ids:
-  - legacy.doc-json-region-layout
+  - json.region-layout
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1642,9 +1594,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-region-settings
+  stable_document_id: json.region-settings
   ccb_docs_ids:
-  - legacy.doc-json-region-settings
+  - json.region-settings
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1654,9 +1606,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-ter-furn-transform
+  stable_document_id: json.terrain-furniture-transforms
   ccb_docs_ids:
-  - legacy.doc-json-ter-furn-transform
+  - json.terrain-furniture-transforms
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1666,9 +1618,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-vehicles-json
+  stable_document_id: json.vehicle-prototypes
   ccb_docs_ids:
-  - legacy.doc-json-vehicles-json
+  - json.vehicle-prototypes
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1678,9 +1630,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-vitamin
+  stable_document_id: json.vitamins
   ccb_docs_ids:
-  - legacy.doc-json-vitamin
+  - json.vitamins
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1690,9 +1642,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-weather-type
+  stable_document_id: json.weather-types
   ccb_docs_ids:
-  - legacy.doc-json-weather-type
+  - json.weather-types
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1702,9 +1654,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-json-wounds
+  stable_document_id: json.wounds
   ccb_docs_ids:
-  - legacy.doc-json-wounds
+  - json.wounds
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1714,9 +1666,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-manual-of-style
+  stable_document_id: content.manual-of-style
   ccb_docs_ids:
-  - legacy.doc-manual-of-style
+  - content.manual-of-style
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1726,9 +1678,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-modding
+  stable_document_id: modding-overview
   ccb_docs_ids:
-  - legacy.doc-modding
+  - modding-overview
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1738,9 +1690,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-mod-compatibility
+  stable_document_id: mod-compatibility
   ccb_docs_ids:
-  - legacy.doc-mod-compatibility
+  - mod-compatibility
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1750,9 +1702,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-player-activity
+  stable_document_id: cpp-activities
   ccb_docs_ids:
-  - legacy.doc-player-activity
+  - cpp-activities
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1786,9 +1738,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-soundpacks
+  stable_document_id: soundpacks
   ccb_docs_ids:
-  - legacy.doc-soundpacks
+  - soundpacks
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1798,9 +1750,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-testing-your-changes
+  stable_document_id: testing-manual
   ccb_docs_ids:
-  - legacy.doc-testing-your-changes
+  - testing-manual
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1810,9 +1762,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-tileset
+  stable_document_id: tilesets
   ccb_docs_ids:
-  - legacy.doc-tileset
+  - tilesets
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1822,9 +1774,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-translating
+  stable_document_id: translation-guide
   ccb_docs_ids:
-  - legacy.doc-translating
+  - translation-guide
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1834,9 +1786,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-translating-mod
+  stable_document_id: mod-localization
   ccb_docs_ids:
-  - legacy.doc-translating-mod
+  - mod-localization
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1846,9 +1798,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-user-interface-and-accessibility
+  stable_document_id: ui-accessibility
   ccb_docs_ids:
-  - legacy.doc-user-interface-and-accessibility
+  - ui-accessibility
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1858,9 +1810,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-widgets
+  stable_document_id: json-widgets
   ccb_docs_ids:
-  - legacy.doc-widgets
+  - json-widgets
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1870,9 +1822,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-c-code-style
+  stable_document_id: cpp-code-style
   ccb_docs_ids:
-  - legacy.doc-c-code-style
+  - cpp-code-style
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1882,9 +1834,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-c-compiler-support
+  stable_document_id: platform-matrix
   ccb_docs_ids:
-  - legacy.doc-c-compiler-support
+  - platform-matrix
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1906,9 +1858,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-c-compiling-cmake
+  stable_document_id: build-cmake
   ccb_docs_ids:
-  - legacy.doc-c-compiling-cmake
+  - build-cmake
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1918,21 +1870,21 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-c-compiling-cygwin
+  stable_document_id: archive-build-cygwin
   ccb_docs_ids:
-  - legacy.doc-c-compiling-cygwin
+  - archive-build-cygwin
   generated: false
   generated_by: null
-  include_in_ai_index: true
+  include_in_ai_index: false
 - id: repo.doc-c-compiling-devcontainer-md
   path: doc/c++/COMPILING-DEVCONTAINER.md
   category: legacy_source
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-c-compiling-devcontainer
+  stable_document_id: build-devcontainer
   ccb_docs_ids:
-  - legacy.doc-c-compiling-devcontainer
+  - build-devcontainer
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1942,21 +1894,21 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-c-compiling-flatpak
+  stable_document_id: archive-build-flatpak
   ccb_docs_ids:
-  - legacy.doc-c-compiling-flatpak
+  - archive-build-flatpak
   generated: false
   generated_by: null
-  include_in_ai_index: true
+  include_in_ai_index: false
 - id: repo.doc-c-compiling-msys-md
   path: doc/c++/COMPILING-MSYS.md
   category: legacy_source
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-c-compiling-msys
+  stable_document_id: build-windows-msys2
   ccb_docs_ids:
-  - legacy.doc-c-compiling-msys
+  - build-windows-msys2
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1966,9 +1918,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-c-compiling-vs-vcpkg
+  stable_document_id: build-windows-msvc
   ccb_docs_ids:
-  - legacy.doc-c-compiling-vs-vcpkg
+  - build-windows-msvc
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1978,9 +1930,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-c-compiling
+  stable_document_id: build-overview
   ccb_docs_ids:
-  - legacy.doc-c-compiling
+  - build-overview
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1990,9 +1942,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-c-developer-tooling
+  stable_document_id: developer-tooling
   ccb_docs_ids:
-  - legacy.doc-c-developer-tooling
+  - developer-tooling
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -2002,9 +1954,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-c-json-interface
+  stable_document_id: cpp-json-interface
   ccb_docs_ids:
-  - legacy.doc-c-json-interface
+  - cpp-json-interface
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -2014,9 +1966,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-c-performance
+  stable_document_id: cpp-performance
   ccb_docs_ids:
-  - legacy.doc-c-performance
+  - cpp-performance
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -2026,9 +1978,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-c-points-coordinates
+  stable_document_id: cpp-coordinates
   ccb_docs_ids:
-  - legacy.doc-c-points-coordinates
+  - cpp-coordinates
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -2038,9 +1990,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-c-testing
+  stable_document_id: cpp-testing
   ccb_docs_ids:
-  - legacy.doc-c-testing
+  - cpp-testing
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -2050,9 +2002,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-design-balance-lore-armor-balance-and-design
+  stable_document_id: json-armor-design
   ccb_docs_ids:
-  - legacy.doc-design-balance-lore-armor-balance-and-design
+  - json-armor-design
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -2062,12 +2014,12 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-design-balance-lore-construction-balance
+  stable_document_id: archive-construction-balance
   ccb_docs_ids:
-  - legacy.doc-design-balance-lore-construction-balance
+  - archive-construction-balance
   generated: false
   generated_by: null
-  include_in_ai_index: true
+  include_in_ai_index: false
 - id: repo.doc-design-balance-lore-game-balance-md
   path: doc/design-balance-lore/GAME_BALANCE.md
   category: legacy_source
@@ -2086,21 +2038,21 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-design-balance-lore-lore-faq
+  stable_document_id: archive-lore-faq
   ccb_docs_ids:
-  - legacy.doc-design-balance-lore-lore-faq
+  - archive-lore-faq
   generated: false
   generated_by: null
-  include_in_ai_index: true
+  include_in_ai_index: false
 - id: repo.doc-design-balance-lore-portal-storm-balance-and-design-md
   path: doc/design-balance-lore/PORTAL_STORM_BALANCE_AND_DESIGN.md
   category: legacy_source
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-design-balance-lore-portal-storm-balance-and-design
+  stable_document_id: design-portal-storms
   ccb_docs_ids:
-  - legacy.doc-design-balance-lore-portal-storm-balance-and-design
+  - design-portal-storms
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -2110,9 +2062,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-design-balance-lore-postapoc-price-guide
+  stable_document_id: json-item-pricing
   ccb_docs_ids:
-  - legacy.doc-design-balance-lore-postapoc-price-guide
+  - json-item-pricing
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -2122,9 +2074,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-design-balance-lore-steel-crafting
+  stable_document_id: design-steel-crafting
   ccb_docs_ids:
-  - legacy.doc-design-balance-lore-steel-crafting
+  - design-steel-crafting
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -2134,9 +2086,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-design-balance-lore-variants
+  stable_document_id: json-item-variants
   ccb_docs_ids:
-  - legacy.doc-design-balance-lore-variants
+  - json-item-variants
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -2146,9 +2098,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-design-balance-lore-batteries-and-electricity
+  stable_document_id: design-batteries-electricity
   ccb_docs_ids:
-  - legacy.doc-design-balance-lore-batteries-and-electricity
+  - design-batteries-electricity
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -2158,9 +2110,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-design-balance-lore-design-balance
+  stable_document_id: design-balance
   ccb_docs_ids:
-  - legacy.doc-design-balance-lore-design-balance
+  - design-balance
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -2170,9 +2122,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-design-balance-lore-design-doc
+  stable_document_id: design-overview
   ccb_docs_ids:
-  - legacy.doc-design-balance-lore-design-doc
+  - design-overview
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -2182,9 +2134,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-design-balance-lore-design-gameplay
+  stable_document_id: design-gameplay
   ccb_docs_ids:
-  - legacy.doc-design-balance-lore-design-gameplay
+  - design-gameplay
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -2194,9 +2146,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-design-balance-lore-design-user-experience
+  stable_document_id: design-user-experience
   ccb_docs_ids:
-  - legacy.doc-design-balance-lore-design-user-experience
+  - design-user-experience
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -2206,9 +2158,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-design-balance-lore-lore-background
+  stable_document_id: lore-background
   ccb_docs_ids:
-  - legacy.doc-design-balance-lore-lore-background
+  - lore-background
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -2218,9 +2170,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-design-balance-lore-lore-factions
+  stable_document_id: lore-factions
   ccb_docs_ids:
-  - legacy.doc-design-balance-lore-lore-factions
+  - lore-factions
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -2230,9 +2182,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-design-balance-lore-lore
+  stable_document_id: lore-overview
   ccb_docs_ids:
-  - legacy.doc-design-balance-lore-lore
+  - lore-overview
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -2242,21 +2194,21 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-design-balance-lore-melee-weapons-melee-balance-spreadsheet
+  stable_document_id: archive-melee-balance-spreadsheet
   ccb_docs_ids:
-  - legacy.doc-design-balance-lore-melee-weapons-melee-balance-spreadsheet
+  - archive-melee-balance-spreadsheet
   generated: false
   generated_by: null
-  include_in_ai_index: true
+  include_in_ai_index: false
 - id: repo.doc-design-balance-lore-technology-md
   path: doc/design-balance-lore/technology.md
   category: legacy_source
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-design-balance-lore-technology
+  stable_document_id: lore-technology
   ccb_docs_ids:
-  - legacy.doc-design-balance-lore-technology
+  - lore-technology
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -2266,12 +2218,23 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-development-process
+  stable_document_id: archive-upstream-development-process
   ccb_docs_ids:
-  - legacy.doc-development-process
+  - archive-upstream-development-process
   generated: false
   generated_by: null
-  include_in_ai_index: true
+  include_in_ai_index: false
+- id: repo.doc-migration-classification-report-md
+  path: doc/migration/classification-report.md
+  category: generated_document
+  status: generated
+  authority: generated_contract
+  source_of_truth: true
+  stable_document_id: null
+  ccb_docs_ids: []
+  generated: true
+  generated_by: python3 tools/agent/generate_migration_reports.py
+  include_in_ai_index: false
 - id: repo.doc-migration-contributor-anomalies-schema-json
   path: doc/migration/contributor-anomalies.schema.json
   category: historical_document
@@ -2327,15 +2290,37 @@ entries:
   generated: true
   generated_by: python3 tools/agent/generate_markdown_inventory.py
   include_in_ai_index: false
+- id: repo.doc-migration-migration-batches-schema-json
+  path: doc/migration/migration-batches.schema.json
+  category: historical_document
+  status: historical
+  authority: historical
+  source_of_truth: false
+  stable_document_id: null
+  ccb_docs_ids: []
+  generated: false
+  generated_by: null
+  include_in_ai_index: false
+- id: repo.doc-migration-migration-batches-yml
+  path: doc/migration/migration-batches.yml
+  category: generated_document
+  status: generated
+  authority: generated_contract
+  source_of_truth: true
+  stable_document_id: null
+  ccb_docs_ids: []
+  generated: true
+  generated_by: python3 tools/agent/generate_migration_reports.py
+  include_in_ai_index: false
 - id: repo.doc-reviewing-pr-guide-md
   path: doc/reviewing_PR_guide.md
   category: legacy_source
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-reviewing-pr-guide
+  stable_document_id: pr-review-guide
   ccb_docs_ids:
-  - legacy.doc-reviewing-pr-guide
+  - pr-review-guide
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -2345,9 +2330,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-user-guides-color
+  stable_document_id: ui-colors
   ccb_docs_ids:
-  - legacy.doc-user-guides-color
+  - ui-colors
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -2357,9 +2342,9 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.doc-user-guides-font-options
+  stable_document_id: ui-fonts
   ccb_docs_ids:
-  - legacy.doc-user-guides-font-options
+  - ui-fonts
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -2377,16 +2362,15 @@ entries:
   include_in_ai_index: true
 - id: repo.lang-notes-ru-notes-md
   path: lang/notes/ru-notes.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.lang-notes-ru-notes
-  ccb_docs_ids:
-  - legacy.lang-notes-ru-notes
+  stable_document_id: translation-notes-ru
+  ccb_docs_ids: []
   generated: false
   generated_by: null
-  include_in_ai_index: true
+  include_in_ai_index: false
 - id: repo.src-agents-md
   path: src/AGENTS.md
   category: agent_instruction
@@ -2415,12 +2399,11 @@ entries:
   status: legacy
   authority: historical
   source_of_truth: false
-  stable_document_id: legacy.src-lua-readme
-  ccb_docs_ids:
-  - legacy.src-lua-readme
+  stable_document_id: vendor-lua-runtime-provenance
+  ccb_docs_ids: []
   generated: false
   generated_by: null
-  include_in_ai_index: true
+  include_in_ai_index: false
 - id: repo.src-third-party-snmalloc-readme-md
   path: src/third-party/snmalloc/README.md
   category: third_party_document
@@ -2500,25 +2483,23 @@ entries:
   include_in_ai_index: true
 - id: repo.tools-llama-readme-md
   path: tools/llama/README.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.tools-llama-readme
-  ccb_docs_ids:
-  - legacy.tools-llama-readme
+  stable_document_id: tool-llama-build-acceleration
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true
 - id: repo.tools-lua-api-readme-md
   path: tools/lua_api/README.md
-  category: legacy_source
-  status: legacy
-  authority: historical
+  category: maintained_document
+  status: active
+  authority: explanatory
   source_of_truth: false
-  stable_document_id: legacy.tools-lua-api-readme
-  ccb_docs_ids:
-  - legacy.tools-lua-api-readme
+  stable_document_id: tool-lua-api-coverage
+  ccb_docs_ids: []
   generated: false
   generated_by: null
   include_in_ai_index: true

--- a/ai/generated-files.yml
+++ b/ai/generated-files.yml
@@ -17,6 +17,16 @@ entries:
     tracked: true
     generated_by: python3 tools/agent/generate_markdown_inventory.py
     validation_id: agent-context
+  - id: markdown-classification-report
+    paths: [doc/migration/classification-report.md]
+    tracked: true
+    generated_by: python3 tools/agent/generate_migration_reports.py
+    validation_id: agent-context
+  - id: markdown-migration-batches
+    paths: [doc/migration/migration-batches.yml]
+    tracked: true
+    generated_by: python3 tools/agent/generate_migration_reports.py
+    validation_id: agent-context
   - id: version-header
     paths: [src/version.h]
     tracked: false

--- a/doc/migration/classification-report.md
+++ b/doc/migration/classification-report.md
@@ -1,0 +1,243 @@
+# Legacy Markdown classification report
+
+This file is generated from `markdown-inventory.yml`; do not edit it by hand.
+
+- Frozen source commit: `0378ca2b84303cf614c617c9d9eaa50138cd21ff`
+- Documents: **175**
+- Remaining `review` actions: **0**
+- Rejected contributor identities: **157**
+- `obj-lua/` is outside the tracked inventory and was not traversed.
+
+## Actions
+
+| Value | Count |
+| --- | ---: |
+| `archive_public` | 7 |
+| `generated_reference` | 4 |
+| `keep_in_repo` | 57 |
+| `merge_into` | 15 |
+| `migrate_preserve` | 35 |
+| `migrate_rewrite` | 50 |
+| `retain_third_party` | 7 |
+
+## Migration status
+
+| Value | Count |
+| --- | ---: |
+| `classified` | 163 |
+| `verified` | 12 |
+
+## Domains
+
+| Value | Count |
+| --- | ---: |
+| `architecture` | 1 |
+| `build` | 9 |
+| `content` | 2 |
+| `cpp` | 6 |
+| `design` | 14 |
+| `eoc` | 2 |
+| `governance` | 8 |
+| `historical` | 1 |
+| `json` | 47 |
+| `localization` | 4 |
+| `lore` | 5 |
+| `lua` | 3 |
+| `mods` | 48 |
+| `release` | 3 |
+| `resources` | 2 |
+| `testing` | 3 |
+| `third-party` | 7 |
+| `tooling` | 1 |
+| `translation` | 4 |
+| `ui` | 4 |
+| `upstream` | 1 |
+
+## Priorities
+
+| Value | Count |
+| --- | ---: |
+| `P0` | 38 |
+| `P1` | 71 |
+| `P2` | 49 |
+| `P3` | 17 |
+
+## Documents
+
+| Original path | Stable ID | Action | Status | Priority | Batch | Target |
+| --- | --- | --- | --- | --- | --- | --- |
+| `CODE_OF_CONDUCT.md` | `governance.code-of-conduct` | `keep_in_repo` | `verified` | `P0` | `—` | `CODE_OF_CONDUCT.md` |
+| `CONTRIBUTING.md` | `governance.contributing` | `keep_in_repo` | `verified` | `P0` | `—` | `CONTRIBUTING.md` |
+| `ISSUES.md` | `governance.issue-workflow` | `keep_in_repo` | `verified` | `P0` | `—` | `ISSUES.md` |
+| `README.md` | `project.readme` | `keep_in_repo` | `verified` | `P0` | `—` | `README.md` |
+| `SYNC_EXCLUDED_PRS.md` | `upstream.excluded-prs` | `keep_in_repo` | `verified` | `P1` | `—` | `SYNC_EXCLUDED_PRS.md` |
+| `TRANSLATION_CREDITS.md` | `translation.credits` | `keep_in_repo` | `verified` | `P2` | `—` | `TRANSLATION_CREDITS.md` |
+| `data/json/LOADING_ORDER.md` | `legacy.data-json-loading-order` | `merge_into` | `classified` | `P1` | `phase-1-json` | `docs/zh_CN/reference/json/loading-order.md` |
+| `data/json/npcs/godco/NECC_INFO.md` | `content.npc.godco-roster` | `keep_in_repo` | `classified` | `P2` | `phase-2-content` | `data/json/npcs/godco/NECC_INFO.md` |
+| `data/json/npcs/refugee_center/FREE_MERCHANTS_INFO.md` | `content.npc.free-merchants-economy` | `keep_in_repo` | `classified` | `P2` | `phase-2-content` | `data/json/npcs/refugee_center/FREE_MERCHANTS_INFO.md` |
+| `data/lua/README.md` | `lua.v5.overview` | `migrate_rewrite` | `classified` | `P0` | `phase-0-lua` | `docs/zh_CN/api/lua/v5/overview.md` |
+| `data/lua/examples/api_v5_mod/README.md` | `lua.v5.example-mod` | `migrate_rewrite` | `classified` | `P0` | `phase-0-lua` | `docs/zh_CN/api/lua/v5/example-mod.md` |
+| `data/mods/Backrooms/README.md` | `mods.backrooms.overview` | `keep_in_repo` | `classified` | `P2` | `phase-2-mods` | `data/mods/Backrooms/README.md` |
+| `data/mods/BombasticPerks/docs/contributing.md` | `mods.bombastic-perks.contributing` | `keep_in_repo` | `classified` | `P1` | `phase-1-mods` | `data/mods/BombasticPerks/docs/contributing.md` |
+| `data/mods/BombasticPerks/docs/expanding_with_mods.md` | `mods.bombastic-perks.extension-contract` | `keep_in_repo` | `classified` | `P1` | `phase-1-mods` | `data/mods/BombasticPerks/docs/expanding_with_mods.md` |
+| `data/mods/DinoMod/DESIGN.md` | `mods.dinomod.design` | `keep_in_repo` | `classified` | `P1` | `phase-1-mods` | `data/mods/DinoMod/DESIGN.md` |
+| `data/mods/DinoMod/README.md` | `mods.dinomod.overview` | `keep_in_repo` | `classified` | `P2` | `phase-2-mods` | `data/mods/DinoMod/README.md` |
+| `data/mods/MA/README.md` | `mods.massachusetts.overview` | `keep_in_repo` | `classified` | `P2` | `phase-2-mods` | `data/mods/MA/README.md` |
+| `data/mods/Magiclysm/lore.md` | `mods.magiclysm.lore` | `keep_in_repo` | `classified` | `P2` | `phase-2-mods` | `data/mods/Magiclysm/lore.md` |
+| `data/mods/Magiclysm/magic_balance.md` | `mods.magiclysm.balance` | `keep_in_repo` | `classified` | `P1` | `phase-1-mods` | `data/mods/Magiclysm/magic_balance.md` |
+| `data/mods/Megafauna/readme.md` | `mods.megafauna.overview` | `keep_in_repo` | `classified` | `P2` | `phase-2-mods` | `data/mods/Megafauna/readme.md` |
+| `data/mods/MindOverMatter/GainingPowerSpoilers.md` | `mods.mind-over-matter.gaining-powers` | `keep_in_repo` | `classified` | `P1` | `phase-1-mods` | `data/mods/MindOverMatter/GainingPowerSpoilers.md` |
+| `data/mods/MindOverMatter/NetherAttunementSpoilers.md` | `mods.mind-over-matter.nether-attunement` | `keep_in_repo` | `classified` | `P1` | `phase-1-mods` | `data/mods/MindOverMatter/NetherAttunementSpoilers.md` |
+| `data/mods/MindOverMatter/NewPowerGuide.md` | `mods.mind-over-matter.new-power-guide` | `keep_in_repo` | `classified` | `P1` | `phase-1-mods` | `data/mods/MindOverMatter/NewPowerGuide.md` |
+| `data/mods/MindOverMatter/PowerDescriptionSpoilers.md` | `mods.mind-over-matter.power-reference` | `generated_reference` | `classified` | `P1` | `phase-1-mods` | `docs/zh_CN/data/mods/MindOverMatter/PowerDescriptionSpoilers.md` |
+| `data/mods/MindOverMatter/README.md` | `mods.mind-over-matter.overview` | `keep_in_repo` | `classified` | `P1` | `phase-1-mods` | `data/mods/MindOverMatter/README.md` |
+| `data/mods/MindOverMatter/lore_spoilers.md` | `mods.mind-over-matter.lore` | `keep_in_repo` | `classified` | `P2` | `phase-2-mods` | `data/mods/MindOverMatter/lore_spoilers.md` |
+| `data/mods/MindOverMatterNoKnacks/README.md` | `mods.mind-over-matter.no-knacks` | `keep_in_repo` | `classified` | `P2` | `phase-2-mods` | `data/mods/MindOverMatterNoKnacks/README.md` |
+| `data/mods/No_Hope/CONTRIBUTING.md` | `mods.no-hope.contributing` | `keep_in_repo` | `classified` | `P1` | `phase-1-mods` | `data/mods/No_Hope/CONTRIBUTING.md` |
+| `data/mods/No_Hope/DIFFICULTY_OPTIONS.md` | `mods.no-hope.difficulty-options` | `keep_in_repo` | `classified` | `P1` | `phase-1-mods` | `data/mods/No_Hope/DIFFICULTY_OPTIONS.md` |
+| `data/mods/Sky_Island/README.md` | `mods.sky-island.overview` | `keep_in_repo` | `classified` | `P2` | `phase-2-mods` | `data/mods/Sky_Island/README.md` |
+| `data/mods/Sorcerer/README.md` | `mods.sorcerer.overview` | `keep_in_repo` | `classified` | `P1` | `phase-1-mods` | `data/mods/Sorcerer/README.md` |
+| `data/mods/TEST_DATA/README.md` | `testing.test-data-mod` | `keep_in_repo` | `classified` | `P0` | `phase-0-testing` | `data/mods/TEST_DATA/README.md` |
+| `data/mods/XedraWood/README.md` | `mods.xedra-wood.overview` | `keep_in_repo` | `classified` | `P2` | `phase-2-mods` | `data/mods/XedraWood/README.md` |
+| `data/mods/Xedra_Evolved/README.md` | `mods.xedra-evolved.overview` | `keep_in_repo` | `classified` | `P2` | `phase-2-mods` | `data/mods/Xedra_Evolved/README.md` |
+| `data/mods/Xedra_Evolved/design_doc_spoilers.md` | `mods.xedra-evolved.design` | `keep_in_repo` | `classified` | `P1` | `phase-1-mods` | `data/mods/Xedra_Evolved/design_doc_spoilers.md` |
+| `data/mods/Xedra_Evolved/vampire_guide.md` | `mods.xedra-evolved.vampire-guide` | `keep_in_repo` | `classified` | `P2` | `phase-2-mods` | `data/mods/Xedra_Evolved/vampire_guide.md` |
+| `data/mods/aftershock_exoplanet/doc/Hacking.md` | `mods.aftershock-exoplanet.hacking` | `keep_in_repo` | `classified` | `P1` | `phase-1-mods` | `data/mods/aftershock_exoplanet/doc/Hacking.md` |
+| `data/mods/aftershock_exoplanet/doc/crafting_system.md` | `mods.aftershock-exoplanet.crafting-system` | `keep_in_repo` | `classified` | `P1` | `phase-1-mods` | `data/mods/aftershock_exoplanet/doc/crafting_system.md` |
+| `data/mods/aftershock_exoplanet/doc/lore/cyberpunk_future.md` | `mods.aftershock-exoplanet.lore.cyberpunk-future` | `merge_into` | `classified` | `P3` | `phase-3-mods` | `docs/zh_CN/data/mods/aftershock_exoplanet/doc/lore/organizations.md` |
+| `data/mods/aftershock_exoplanet/doc/lore/factions.md` | `mods.aftershock-exoplanet.lore.factions` | `keep_in_repo` | `classified` | `P2` | `phase-2-mods` | `data/mods/aftershock_exoplanet/doc/lore/factions.md` |
+| `data/mods/aftershock_exoplanet/doc/lore/organizations.md` | `mods.aftershock-exoplanet.lore.organizations` | `keep_in_repo` | `classified` | `P2` | `phase-2-mods` | `data/mods/aftershock_exoplanet/doc/lore/organizations.md` |
+| `data/mods/aftershock_exoplanet/doc/lore/points_of_interest.md` | `mods.aftershock-exoplanet.lore.points-of-interest` | `keep_in_repo` | `classified` | `P2` | `phase-2-mods` | `data/mods/aftershock_exoplanet/doc/lore/points_of_interest.md` |
+| `data/mods/aftershock_exoplanet/doc/lore/ranged_weapon_balance.md` | `mods.aftershock-exoplanet.balance.ranged-weapons` | `generated_reference` | `classified` | `P1` | `phase-1-mods` | `docs/zh_CN/data/mods/aftershock_exoplanet/doc/lore/ranged_weapon_balance.md` |
+| `data/mods/aftershock_exoplanet/doc/lore/salus_4.md` | `mods.aftershock-exoplanet.lore.salus-iv` | `keep_in_repo` | `classified` | `P2` | `phase-2-mods` | `data/mods/aftershock_exoplanet/doc/lore/salus_4.md` |
+| `data/mods/aftershock_exoplanet/doc/lore/timeline.md` | `mods.aftershock-exoplanet.lore.timeline` | `keep_in_repo` | `classified` | `P2` | `phase-2-mods` | `data/mods/aftershock_exoplanet/doc/lore/timeline.md` |
+| `data/mods/aftershock_exoplanet/doc/suit_operating_time.md` | `mods.aftershock-exoplanet.balance.powered-armor` | `keep_in_repo` | `classified` | `P1` | `phase-1-mods` | `data/mods/aftershock_exoplanet/doc/suit_operating_time.md` |
+| `data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_guide.md` | `mods.aftershock-exoplanet.exosuit-guide` | `keep_in_repo` | `classified` | `P1` | `phase-1-mods` | `data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_guide.md` |
+| `data/mods/alt_map_key/README.md` | `mods.alternative-map-key.overview` | `keep_in_repo` | `classified` | `P2` | `phase-2-mods` | `data/mods/alt_map_key/README.md` |
+| `data/mods/classic_zombies/design-doc.md` | `mods.classic-zombies.design` | `keep_in_repo` | `classified` | `P1` | `phase-1-mods` | `data/mods/classic_zombies/design-doc.md` |
+| `data/mods/classic_zombies/place_names.md` | `mods.classic-zombies.place-names` | `keep_in_repo` | `classified` | `P2` | `phase-2-mods` | `data/mods/classic_zombies/place_names.md` |
+| `data/mods/hunvre/documentation/lore.md` | `mods.hunvre.lore` | `keep_in_repo` | `classified` | `P1` | `phase-1-mods` | `data/mods/hunvre/documentation/lore.md` |
+| `data/mods/hunvre/progress_tracker.md` | `mods.hunvre.progress` | `keep_in_repo` | `classified` | `P3` | `phase-3-mods` | `data/mods/hunvre/progress_tracker.md` |
+| `data/mods/immortal_path/GLOSSARY.md` | `mods.immortal-path.glossary` | `keep_in_repo` | `classified` | `P0` | `phase-0-mods` | `data/mods/immortal_path/GLOSSARY.md` |
+| `data/mods/immortal_path/LANGUAGE_CONVENTION.md` | `mods.immortal-path.language-convention` | `keep_in_repo` | `classified` | `P0` | `phase-0-translation` | `data/mods/immortal_path/LANGUAGE_CONVENTION.md` |
+| `data/mods/immortal_path/doc/game-design.md` | `mods.immortal-path.game-design` | `keep_in_repo` | `classified` | `P1` | `phase-1-mods` | `data/mods/immortal_path/doc/game-design.md` |
+| `data/mods/immortal_path/doc/lore.md` | `mods.immortal-path.lore` | `keep_in_repo` | `classified` | `P2` | `phase-2-mods` | `data/mods/immortal_path/doc/lore.md` |
+| `data/mods/immortal_path/doc/spell-design.md` | `mods.immortal-path.spell-design` | `keep_in_repo` | `classified` | `P1` | `phase-1-mods` | `data/mods/immortal_path/doc/spell-design.md` |
+| `data/mods/innawood/readme.md` | `mods.innawood.overview` | `keep_in_repo` | `classified` | `P2` | `phase-2-mods` | `data/mods/innawood/readme.md` |
+| `data/mods/translate-dialogue/README.md` | `mods.translate-dialogue.maintenance` | `keep_in_repo` | `classified` | `P1` | `phase-1-translation` | `data/mods/translate-dialogue/README.md` |
+| `doc/ASCII_ART.md` | `content.ascii-art` | `migrate_rewrite` | `classified` | `P2` | `phase-2-ui` | `docs/zh_CN/content/ascii-art.md` |
+| `doc/CHANGELOG_GUIDELINES.md` | `contributing.changelog-guidelines` | `keep_in_repo` | `classified` | `P1` | `phase-1-release` | `doc/CHANGELOG_GUIDELINES.md` |
+| `doc/DEVELOPER_FAQ.md` | `contributing.developer-faq` | `merge_into` | `classified` | `P1` | `phase-1-architecture` | `docs/zh_CN/how-to/common-tasks.md` |
+| `doc/FREQUENTLY_MADE_SUGGESTIONS.md` | `design.frequently-made-suggestions` | `migrate_rewrite` | `classified` | `P1` | `phase-1-design` | `docs/zh_CN/design/frequently-made-suggestions.md` |
+| `doc/GUN_NAMING_AND_INCLUSION.md` | `content.firearms-naming-and-inclusion` | `migrate_rewrite` | `classified` | `P2` | `phase-2-design` | `docs/zh_CN/content/firearms/naming-and-inclusion.md` |
+| `doc/HOWTO_MASSAGE_MA_GUN_DATA.md` | `archive.firearms-massachusetts-data-workflow` | `archive_public` | `classified` | `P3` | `phase-3-historical` | `docs/zh_CN/archive/firearms/massachusetts-data-workflow.md` |
+| `doc/HOW_YOU_CAN_HELP.md` | `getting-started.how-you-can-help` | `merge_into` | `classified` | `P0` | `phase-0-governance` | `docs/zh_CN/getting-started/first-contribution.md` |
+| `doc/IN_REPO_MODS.md` | `mods.in-repository-policy` | `migrate_rewrite` | `classified` | `P1` | `phase-1-mods` | `docs/zh_CN/mods/in-repository-policy.md` |
+| `doc/ISSUE_TRIAGE.md` | `maintainers.issue-triage` | `migrate_rewrite` | `classified` | `P1` | `phase-1-governance` | `docs/zh_CN/maintainers/issue-triage.md` |
+| `doc/JSON/ARTIFACTS.md` | `json.artifacts` | `migrate_preserve` | `classified` | `P1` | `phase-1-json` | `docs/zh_CN/reference/json/artifacts.md` |
+| `doc/JSON/BASECAMP.md` | `json.basecamp` | `migrate_preserve` | `classified` | `P1` | `phase-1-json` | `docs/zh_CN/reference/json/basecamp.md` |
+| `doc/JSON/CLIMBING.md` | `json.climbing-aids` | `migrate_preserve` | `classified` | `P2` | `phase-2-json` | `docs/zh_CN/reference/json/climbing-aids.md` |
+| `doc/JSON/DIMENSIONS.md` | `json.dimensions` | `migrate_preserve` | `classified` | `P1` | `phase-1-json` | `docs/zh_CN/reference/json/dimensions.md` |
+| `doc/JSON/EFFECTS_JSON.md` | `json.effects` | `migrate_preserve` | `classified` | `P1` | `phase-1-json` | `docs/zh_CN/reference/json/effects.md` |
+| `doc/JSON/EFFECT_ON_CONDITION.md` | `eoc.reference` | `migrate_preserve` | `classified` | `P0` | `phase-0-eoc` | `docs/zh_CN/reference/eoc/index.md` |
+| `doc/JSON/EXAMINE.md` | `json.examine-actions` | `migrate_preserve` | `classified` | `P1` | `phase-1-json` | `docs/zh_CN/reference/json/examine-actions.md` |
+| `doc/JSON/FACTIONS.md` | `json.npc-factions` | `migrate_preserve` | `classified` | `P1` | `phase-1-json` | `docs/zh_CN/reference/json/npc-factions.md` |
+| `doc/JSON/FACTION_MISSIONS.md` | `json.faction-missions` | `migrate_preserve` | `classified` | `P2` | `phase-2-json` | `docs/zh_CN/reference/json/faction-missions.md` |
+| `doc/JSON/GUIDE_COMESTIBLES.md` | `json.comestibles-placement` | `migrate_rewrite` | `classified` | `P2` | `phase-2-json` | `docs/zh_CN/how-to/json/comestibles.md` |
+| `doc/JSON/HELP_MENU.md` | `json.help-menu` | `migrate_preserve` | `classified` | `P2` | `phase-2-json` | `docs/zh_CN/reference/json/help-menu.md` |
+| `doc/JSON/ITEM.md` | `json.items` | `migrate_preserve` | `classified` | `P0` | `phase-0-json` | `docs/zh_CN/reference/json/items/index.md` |
+| `doc/JSON/ITEM_CRAFT_AND_DISASSEMBLY.md` | `json.recipes-and-disassembly` | `migrate_preserve` | `classified` | `P0` | `phase-0-json` | `docs/zh_CN/reference/json/recipes-and-disassembly.md` |
+| `doc/JSON/ITEM_SPAWN.md` | `json.item-groups` | `migrate_preserve` | `classified` | `P0` | `phase-0-json` | `docs/zh_CN/reference/json/item-groups.md` |
+| `doc/JSON/JSON_FLAGS.md` | `json.flags` | `generated_reference` | `classified` | `P0` | `phase-0-json` | `docs/zh_CN/reference/json/generated/flags.md` |
+| `doc/JSON/JSON_INFO.md` | `json.object-types` | `migrate_rewrite` | `classified` | `P0` | `phase-0-json` | `docs/zh_CN/reference/json/index.md` |
+| `doc/JSON/JSON_INHERITANCE.md` | `json.inheritance` | `migrate_preserve` | `classified` | `P0` | `phase-0-json` | `docs/zh_CN/reference/json/inheritance.md` |
+| `doc/JSON/JSON_LOADING_ORDER.md` | `legacy.doc-json-json-loading-order` | `merge_into` | `classified` | `P1` | `phase-1-json` | `docs/zh_CN/reference/json/loading-order.md` |
+| `doc/JSON/JSON_Mapping_Guides/Guide_for_beginning_mapgen.md` | `tutorial.mapgen-beginner` | `migrate_rewrite` | `classified` | `P1` | `phase-1-json` | `docs/zh_CN/tutorials/json-mapgen/beginner.md` |
+| `doc/JSON/JSON_Mapping_Guides/Guide_for_intermediate_mapgen.md` | `tutorial.mapgen-intermediate` | `migrate_rewrite` | `classified` | `P1` | `phase-1-json` | `docs/zh_CN/tutorials/json-mapgen/intermediate.md` |
+| `doc/JSON/JSON_Mapping_Guides/JSON_ROOF_MAPGEN.md` | `tutorial.mapgen-roofs` | `merge_into` | `classified` | `P2` | `phase-2-json` | `docs/zh_CN/tutorials/json-mapgen/beginner.md` |
+| `doc/JSON/JSON_STYLE.md` | `contributing.json-style` | `migrate_rewrite` | `classified` | `P0` | `phase-0-json` | `docs/zh_CN/contributing/json-style.md` |
+| `doc/JSON/JSON_TOOLS.md` | `how-to.json-tools` | `migrate_rewrite` | `classified` | `P2` | `phase-2-json` | `docs/zh_CN/how-to/json/tools.md` |
+| `doc/JSON/MAGIC.md` | `json.magic-spells-enchantments` | `migrate_preserve` | `classified` | `P1` | `phase-1-json` | `docs/zh_CN/reference/json/magic-spells-enchantments.md` |
+| `doc/JSON/MAPGEN.md` | `json.mapgen` | `migrate_preserve` | `classified` | `P0` | `phase-0-json` | `docs/zh_CN/reference/json/mapgen.md` |
+| `doc/JSON/MAP_SMASHING.md` | `json.map-smashing` | `merge_into` | `classified` | `P2` | `phase-2-json` | `docs/zh_CN/reference/json/terrain-and-furniture.md` |
+| `doc/JSON/MARTIALART_JSON.md` | `json.martial-arts` | `migrate_preserve` | `classified` | `P1` | `phase-1-json` | `docs/zh_CN/reference/json/martial-arts.md` |
+| `doc/JSON/MISSIONS_JSON.md` | `json.missions` | `migrate_preserve` | `classified` | `P1` | `phase-1-json` | `docs/zh_CN/reference/json/missions.md` |
+| `doc/JSON/MONSTERS.md` | `json.monsters` | `migrate_preserve` | `classified` | `P0` | `phase-0-json` | `docs/zh_CN/reference/json/monsters.md` |
+| `doc/JSON/MONSTER_SPECIAL_ATTACKS.md` | `json.monster-special-attacks` | `migrate_preserve` | `classified` | `P0` | `phase-0-json` | `docs/zh_CN/reference/json/monster-special-attacks.md` |
+| `doc/JSON/MOVE_MODE.md` | `json.movement-modes` | `migrate_preserve` | `classified` | `P2` | `phase-2-json` | `docs/zh_CN/reference/json/movement-modes.md` |
+| `doc/JSON/MUTATIONS.md` | `json.mutations` | `migrate_preserve` | `classified` | `P1` | `phase-1-json` | `docs/zh_CN/reference/json/mutations.md` |
+| `doc/JSON/NPCs.md` | `json.npcs-dialogue` | `migrate_preserve` | `classified` | `P0` | `phase-0-eoc` | `docs/zh_CN/reference/eoc/npcs-and-dialogue.md` |
+| `doc/JSON/OBSOLETION_AND_MIGRATION.md` | `json.obsoletion-and-migration` | `migrate_preserve` | `classified` | `P0` | `phase-0-json` | `docs/zh_CN/reference/json/obsoletion-and-migration.md` |
+| `doc/JSON/OPTIONS.md` | `json.options` | `migrate_preserve` | `classified` | `P2` | `phase-2-json` | `docs/zh_CN/reference/json/options.md` |
+| `doc/JSON/OVERMAP.md` | `json.overmap` | `migrate_preserve` | `classified` | `P0` | `phase-0-json` | `docs/zh_CN/reference/json/overmap.md` |
+| `doc/JSON/PRACTICE_RECIPES.md` | `json.practice-recipes` | `migrate_preserve` | `classified` | `P2` | `phase-2-json` | `docs/zh_CN/reference/json/practice-recipes.md` |
+| `doc/JSON/PROFICIENCY.md` | `json.proficiencies` | `migrate_preserve` | `classified` | `P1` | `phase-1-json` | `docs/zh_CN/reference/json/proficiencies.md` |
+| `doc/JSON/PROFICIENCY_LIST.md` | `json.proficiencies-index` | `generated_reference` | `classified` | `P1` | `phase-1-json` | `docs/zh_CN/reference/json/generated/proficiencies.md` |
+| `doc/JSON/REGION_LAYOUT.md` | `json.region-layout` | `migrate_preserve` | `classified` | `P1` | `phase-1-json` | `docs/zh_CN/reference/json/region-layout.md` |
+| `doc/JSON/REGION_SETTINGS.md` | `json.region-settings` | `migrate_preserve` | `classified` | `P1` | `phase-1-json` | `docs/zh_CN/reference/json/region-settings.md` |
+| `doc/JSON/TER_FURN_TRANSFORM.md` | `json.terrain-furniture-transforms` | `migrate_preserve` | `classified` | `P1` | `phase-1-json` | `docs/zh_CN/reference/json/terrain-furniture-transforms.md` |
+| `doc/JSON/VEHICLES_JSON.md` | `json.vehicle-prototypes` | `migrate_preserve` | `classified` | `P1` | `phase-1-json` | `docs/zh_CN/reference/json/vehicle-prototypes.md` |
+| `doc/JSON/VITAMIN.md` | `json.vitamins` | `migrate_preserve` | `classified` | `P1` | `phase-1-json` | `docs/zh_CN/reference/json/vitamins.md` |
+| `doc/JSON/WEATHER_TYPE.md` | `json.weather-types` | `migrate_preserve` | `classified` | `P1` | `phase-1-json` | `docs/zh_CN/reference/json/weather-types.md` |
+| `doc/JSON/WOUNDS.md` | `json.wounds` | `migrate_preserve` | `classified` | `P1` | `phase-1-json` | `docs/zh_CN/reference/json/wounds.md` |
+| `doc/MANUAL_OF_STYLE.md` | `content.manual-of-style` | `migrate_rewrite` | `classified` | `P1` | `phase-1-translation` | `docs/zh_CN/contributing/in-game-text-style.md` |
+| `doc/MODDING.md` | `modding-overview` | `migrate_rewrite` | `classified` | `P0` | `phase-0-mods` | `docs/zh_CN/modding/overview.md` |
+| `doc/MOD_COMPATIBILITY.md` | `mod-compatibility` | `migrate_rewrite` | `classified` | `P0` | `phase-0-mods` | `docs/zh_CN/modding/compatibility.md` |
+| `doc/PLAYER_ACTIVITY.md` | `cpp-activities` | `migrate_rewrite` | `classified` | `P1` | `phase-1-cpp` | `docs/zh_CN/cpp/activities.md` |
+| `doc/RELEASE_DIFF.md` | `legacy.doc-release-diff` | `merge_into` | `classified` | `P1` | `phase-1-release` | `docs/zh_CN/maintenance/releases.md` |
+| `doc/RELEASE_PROCESS.md` | `legacy.doc-release-process` | `merge_into` | `classified` | `P1` | `phase-1-release` | `docs/zh_CN/maintenance/releases.md` |
+| `doc/SOUNDPACKS.md` | `soundpacks` | `migrate_rewrite` | `classified` | `P2` | `phase-2-resources` | `docs/zh_CN/resources/soundpacks.md` |
+| `doc/TESTING_YOUR_CHANGES.md` | `testing-manual` | `merge_into` | `classified` | `P0` | `phase-0-testing` | `docs/zh_CN/testing/manual-playtesting.md` |
+| `doc/TILESET.md` | `tilesets` | `migrate_rewrite` | `classified` | `P2` | `phase-2-resources` | `docs/zh_CN/resources/tilesets.md` |
+| `doc/TRANSLATING.md` | `translation-guide` | `migrate_rewrite` | `classified` | `P0` | `phase-0-localization` | `docs/zh_CN/localization/translation-guide.md` |
+| `doc/TRANSLATING_MOD.md` | `mod-localization` | `merge_into` | `classified` | `P1` | `phase-1-localization` | `docs/zh_CN/modding/localization.md` |
+| `doc/USER_INTERFACE_AND_ACCESSIBILITY.md` | `ui-accessibility` | `migrate_rewrite` | `classified` | `P1` | `phase-1-ui` | `docs/zh_CN/ui/accessibility.md` |
+| `doc/WIDGETS.md` | `json-widgets` | `migrate_rewrite` | `classified` | `P1` | `phase-1-json` | `docs/zh_CN/json/widgets.md` |
+| `doc/c++/CODE_STYLE.md` | `cpp-code-style` | `migrate_rewrite` | `classified` | `P0` | `phase-0-cpp` | `docs/zh_CN/cpp/code-style.md` |
+| `doc/c++/COMPILER_SUPPORT.md` | `platform-matrix` | `migrate_rewrite` | `classified` | `P0` | `phase-0-build` | `docs/zh_CN/platforms/compiler-support.md` |
+| `doc/c++/COMPILING-CMAKE-VCPKG.md` | `legacy.doc-c-compiling-cmake-vcpkg` | `merge_into` | `classified` | `P0` | `phase-0-build` | `docs/zh_CN/build/windows-msvc.md` |
+| `doc/c++/COMPILING-CMAKE.md` | `build-cmake` | `migrate_rewrite` | `classified` | `P0` | `phase-0-build` | `docs/zh_CN/build/cmake.md` |
+| `doc/c++/COMPILING-CYGWIN.md` | `archive-build-cygwin` | `archive_public` | `classified` | `P3` | `phase-3-build` | `docs/zh_CN/archive/build/cygwin.md` |
+| `doc/c++/COMPILING-DEVCONTAINER.md` | `build-devcontainer` | `migrate_rewrite` | `classified` | `P1` | `phase-1-build` | `docs/zh_CN/build/devcontainer.md` |
+| `doc/c++/COMPILING-FLATPAK.md` | `archive-build-flatpak` | `archive_public` | `classified` | `P3` | `phase-3-build` | `docs/zh_CN/archive/build/flatpak.md` |
+| `doc/c++/COMPILING-MSYS.md` | `build-windows-msys2` | `migrate_rewrite` | `classified` | `P0` | `phase-0-build` | `docs/zh_CN/build/windows-msys2.md` |
+| `doc/c++/COMPILING-VS-VCPKG.md` | `build-windows-msvc` | `migrate_rewrite` | `classified` | `P0` | `phase-0-build` | `docs/zh_CN/build/windows-msvc.md` |
+| `doc/c++/COMPILING.md` | `build-overview` | `migrate_rewrite` | `classified` | `P0` | `phase-0-build` | `docs/zh_CN/build/overview.md` |
+| `doc/c++/DEVELOPER_TOOLING.md` | `developer-tooling` | `migrate_rewrite` | `classified` | `P1` | `phase-1-cpp` | `docs/zh_CN/cpp/developer-tooling.md` |
+| `doc/c++/JSON_INTERFACE.md` | `cpp-json-interface` | `migrate_rewrite` | `classified` | `P1` | `phase-1-cpp` | `docs/zh_CN/cpp/json-interface.md` |
+| `doc/c++/PERFORMANCE.md` | `cpp-performance` | `migrate_rewrite` | `classified` | `P1` | `phase-1-cpp` | `docs/zh_CN/cpp/performance.md` |
+| `doc/c++/POINTS_COORDINATES.md` | `cpp-coordinates` | `migrate_rewrite` | `classified` | `P1` | `phase-1-cpp` | `docs/zh_CN/cpp/coordinates.md` |
+| `doc/c++/TESTING.md` | `cpp-testing` | `migrate_rewrite` | `classified` | `P0` | `phase-0-testing` | `docs/zh_CN/testing/cpp.md` |
+| `doc/design-balance-lore/ARMOR_BALANCE_AND_DESIGN.md` | `json-armor-design` | `migrate_rewrite` | `classified` | `P2` | `phase-2-design` | `docs/zh_CN/json/armor-design.md` |
+| `doc/design-balance-lore/CONSTRUCTION_BALANCE.md` | `archive-construction-balance` | `archive_public` | `classified` | `P3` | `phase-3-design` | `docs/zh_CN/archive/design/construction-balance.md` |
+| `doc/design-balance-lore/GAME_BALANCE.md` | `legacy.doc-design-balance-lore-game-balance` | `merge_into` | `classified` | `P1` | `phase-1-design` | `docs/zh_CN/design/balance.md` |
+| `doc/design-balance-lore/LORE_FAQ.md` | `archive-lore-faq` | `archive_public` | `classified` | `P3` | `phase-3-lore` | `docs/zh_CN/archive/lore/faq.md` |
+| `doc/design-balance-lore/PORTAL_STORM_BALANCE_AND_DESIGN.md` | `design-portal-storms` | `migrate_rewrite` | `classified` | `P2` | `phase-2-design` | `docs/zh_CN/design/portal-storms.md` |
+| `doc/design-balance-lore/POSTAPOC_PRICE_GUIDE.md` | `json-item-pricing` | `migrate_rewrite` | `classified` | `P2` | `phase-2-design` | `docs/zh_CN/json/item-pricing.md` |
+| `doc/design-balance-lore/STEEL_CRAFTING.md` | `design-steel-crafting` | `migrate_rewrite` | `classified` | `P2` | `phase-2-design` | `docs/zh_CN/design/steel-crafting.md` |
+| `doc/design-balance-lore/VARIANTS.md` | `json-item-variants` | `migrate_rewrite` | `classified` | `P1` | `phase-1-json` | `docs/zh_CN/json/item-variants.md` |
+| `doc/design-balance-lore/batteries_and_electricity.md` | `design-batteries-electricity` | `migrate_rewrite` | `classified` | `P2` | `phase-2-design` | `docs/zh_CN/design/batteries-electricity.md` |
+| `doc/design-balance-lore/design-balance.md` | `design-balance` | `migrate_rewrite` | `classified` | `P1` | `phase-1-design` | `docs/zh_CN/design/balance.md` |
+| `doc/design-balance-lore/design-doc.md` | `design-overview` | `merge_into` | `classified` | `P1` | `phase-1-design` | `docs/zh_CN/design/overview.md` |
+| `doc/design-balance-lore/design-gameplay.md` | `design-gameplay` | `migrate_rewrite` | `classified` | `P1` | `phase-1-design` | `docs/zh_CN/design/gameplay.md` |
+| `doc/design-balance-lore/design-user-experience.md` | `design-user-experience` | `migrate_rewrite` | `classified` | `P1` | `phase-1-design` | `docs/zh_CN/design/user-experience.md` |
+| `doc/design-balance-lore/lore-background.md` | `lore-background` | `migrate_rewrite` | `classified` | `P2` | `phase-2-lore` | `docs/zh_CN/lore/background.md` |
+| `doc/design-balance-lore/lore-factions.md` | `lore-factions` | `migrate_rewrite` | `classified` | `P2` | `phase-2-lore` | `docs/zh_CN/lore/factions.md` |
+| `doc/design-balance-lore/lore.md` | `lore-overview` | `migrate_rewrite` | `classified` | `P2` | `phase-2-lore` | `docs/zh_CN/lore/overview.md` |
+| `doc/design-balance-lore/melee_weapons/MELEE_BALANCE_SPREADSHEET.md` | `archive-melee-balance-spreadsheet` | `archive_public` | `classified` | `P3` | `phase-3-design` | `docs/zh_CN/archive/design/melee-balance-spreadsheet.md` |
+| `doc/design-balance-lore/technology.md` | `lore-technology` | `migrate_rewrite` | `classified` | `P2` | `phase-2-lore` | `docs/zh_CN/lore/technology.md` |
+| `doc/development_process.md` | `archive-upstream-development-process` | `archive_public` | `classified` | `P3` | `phase-3-governance` | `docs/zh_CN/archive/governance/development-process.md` |
+| `doc/reviewing_PR_guide.md` | `pr-review-guide` | `migrate_rewrite` | `classified` | `P0` | `phase-0-governance` | `docs/zh_CN/contributing/pr-review.md` |
+| `doc/user-guides/COLOR.md` | `ui-colors` | `migrate_rewrite` | `classified` | `P2` | `phase-2-ui` | `docs/zh_CN/ui/colors.md` |
+| `doc/user-guides/FONT_OPTIONS.md` | `ui-fonts` | `migrate_rewrite` | `classified` | `P2` | `phase-2-ui` | `docs/zh_CN/ui/fonts.md` |
+| `lang/notes/README_all_translators.md` | `legacy.lang-notes-readme-all-translators` | `merge_into` | `classified` | `P1` | `phase-1-localization` | `docs/zh_CN/localization/translation-guide.md` |
+| `lang/notes/ru-notes.md` | `translation-notes-ru` | `keep_in_repo` | `classified` | `P3` | `phase-3-localization` | `lang/notes/ru-notes.md` |
+| `src/lua/LICENSE.md` | `third-party.src-lua-license` | `retain_third_party` | `verified` | `P3` | `—` | `src/lua/LICENSE.md` |
+| `src/lua/README.md` | `vendor-lua-runtime-provenance` | `retain_third_party` | `classified` | `P3` | `phase-3-third-party` | `src/lua/README.md` |
+| `src/third-party/snmalloc/README.md` | `third-party.src-third-party-snmalloc-readme` | `retain_third_party` | `verified` | `P3` | `—` | `src/third-party/snmalloc/README.md` |
+| `src/third-party/snmalloc/stl/README.md` | `third-party.src-third-party-snmalloc-stl-readme` | `retain_third_party` | `verified` | `P3` | `—` | `src/third-party/snmalloc/stl/README.md` |
+| `src/third-party/snmalloc/stl/cxx/README.md` | `third-party.src-third-party-snmalloc-stl-cxx-readme` | `retain_third_party` | `verified` | `P3` | `—` | `src/third-party/snmalloc/stl/cxx/README.md` |
+| `src/third-party/snmalloc/stl/gnu/README.md` | `third-party.src-third-party-snmalloc-stl-gnu-readme` | `retain_third_party` | `verified` | `P3` | `—` | `src/third-party/snmalloc/stl/gnu/README.md` |
+| `src/third-party/zstd/README.md` | `third-party.src-third-party-zstd-readme` | `retain_third_party` | `verified` | `P3` | `—` | `src/third-party/zstd/README.md` |
+| `tools/llama/README.md` | `tool-llama-build-acceleration` | `keep_in_repo` | `classified` | `P2` | `phase-2-tooling` | `tools/llama/README.md` |
+| `tools/lua_api/README.md` | `tool-lua-api-coverage` | `keep_in_repo` | `classified` | `P0` | `phase-0-lua` | `tools/lua_api/README.md` |

--- a/doc/migration/markdown-inventory.yml
+++ b/doc/migration/markdown-inventory.yml
@@ -5,19 +5,19 @@ document_count: 175
 scope: Tracked Markdown at source_commit, excluding dot-prefixed tool/config paths; filesystem caches
   are never traversed.
 classification_summary:
-  review: 98
+  review: 96
   actions:
     archive_public: 1
     generated_reference: 2
     keep_in_repo: 54
     merge_into: 4
-    migrate_preserve: 3
+    migrate_preserve: 5
     migrate_rewrite: 7
     retain_third_party: 6
-    review: 98
+    review: 96
   migration_statuses:
-    classified: 65
-    inventoried: 98
+    classified: 67
+    inventoried: 96
     verified: 12
 documents:
 - original_path: CODE_OF_CONDUCT.md
@@ -2430,59 +2430,70 @@ documents:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-dimensions
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/dimensions/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.dimensions
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: ccb_extended
+  upstream_relation: forked_synced_and_ccb_policy_adjusted
   merge_target: null
   source_paths:
-  - doc/JSON/DIMENSIONS.md
-  source_symbols: []
+  - src/overmap_worldgen.cpp
+  - src/overmap_worldgen.h
+  - data/json/region_settings/region_settings/dimensions/dimensions.json
+  - data/json/effects_on_condition/nether_eocs/dimensions.json
+  source_symbols:
+  - dimension_world::load
+  - dimension_region_layout::load
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 链接 REGION_LAYOUT.MD 在大小写敏感环境中无效；开头给出的 json\region_settings 路径也不是当前仓库路径。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 72 行说明维度切换、NPC/物品携带和清理 EOC，2026-06/07 多次更新且当前 dimension loaders/data 存在；迁移时应修正路径和大小写坏链。
+  migration_batch: phase-1-json
 - original_path: doc/JSON/EFFECTS_JSON.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/effects.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-effects-json
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/effects/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.effects
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_inherited
+  upstream_relation: inherited_contract_with_tests
   merge_target: null
   source_paths:
-  - doc/JSON/EFFECTS_JSON.md
-  source_symbols: []
+  - src/effect.cpp
+  - src/effect.h
+  - data/json/effects.json
+  - tests/effect_test.cpp
+  - tests/creature_effect_test.cpp
+  source_symbols:
+  - load_effect_type
+  - effect_type::load_mod_data
+  - effect_migration::load
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 744 行覆盖 effect_type 必选/可选字段、强度、免疫、修饰器、死亡和示例；当前 loader 与 effect 测试提供可验证契约。
+  migration_batch: phase-1-json
 - original_path: doc/JSON/EFFECT_ON_CONDITION.md
-  target_path: null
+  target_path: docs/zh_CN/reference/eoc/index.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - zihanZheng

--- a/doc/migration/markdown-inventory.yml
+++ b/doc/migration/markdown-inventory.yml
@@ -5,19 +5,19 @@ document_count: 175
 scope: Tracked Markdown at source_commit, excluding dot-prefixed tool/config paths; filesystem caches
   are never traversed.
 classification_summary:
-  review: 87
+  review: 86
   actions:
     archive_public: 1
-    generated_reference: 2
+    generated_reference: 3
     keep_in_repo: 54
     merge_into: 4
     migrate_preserve: 13
     migrate_rewrite: 8
     retain_third_party: 6
-    review: 87
+    review: 86
   migration_statuses:
-    classified: 76
-    inventoried: 87
+    classified: 77
+    inventoried: 86
     verified: 12
 documents:
 - original_path: CODE_OF_CONDUCT.md
@@ -2841,30 +2841,35 @@ documents:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: generated_reference
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-json-flags
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/generated/flags/
+  migration_status: classified
+  history_strategy: filtered_path_history_candidate
+  stable_document_id: json.flags
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P0
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: ccb_extended
+  upstream_relation: forked_and_locally_extended
   merge_target: null
   source_paths:
-  - doc/JSON/JSON_FLAGS.md
-  source_symbols: []
+  - src/flag.cpp
+  - src/flag.h
+  - data/json/flags.json
+  - tools/flagdoc/flagdoc.pl
+  - tools/flagdoc/sections.conf
+  source_symbols:
+  - json_flag::load
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 1,841 行跨子系统手工 flag 表无法证明完整；新生成器需合并注册、flagdoc 配置和 JSON，并保留无法自动提取的解释。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 导入后 26 次更新，包含 CCB SHOCK_*、GUILT_HUMAN、NO_CROP_OVERGROWTH 等差异；仓库已有 flagdoc 工具，最适合作为生成参考而非继续手改。
+  migration_batch: phase-0-json
 - original_path: doc/JSON/JSON_INFO.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/index.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - LunaGlaze

--- a/doc/migration/markdown-inventory.yml
+++ b/doc/migration/markdown-inventory.yml
@@ -5,19 +5,19 @@ document_count: 175
 scope: Tracked Markdown at source_commit, excluding dot-prefixed tool/config paths; filesystem caches
   are never traversed.
 classification_summary:
-  review: 85
+  review: 78
   actions:
     archive_public: 1
     generated_reference: 3
     keep_in_repo: 54
-    merge_into: 4
-    migrate_preserve: 13
-    migrate_rewrite: 9
+    merge_into: 6
+    migrate_preserve: 14
+    migrate_rewrite: 13
     retain_third_party: 6
-    review: 85
+    review: 78
   migration_statuses:
-    classified: 78
-    inventoried: 85
+    classified: 85
+    inventoried: 78
     verified: 12
 documents:
 - original_path: CODE_OF_CONDUCT.md
@@ -2924,204 +2924,239 @@ documents:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-json-inheritance
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/inheritance/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.inheritance
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P0
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: ccb_extended
+  upstream_relation: forked_and_locally_extended
   merge_target: null
   source_paths:
-  - doc/JSON/JSON_INHERITANCE.md
-  source_symbols: []
+  - src/generic_factory.h
+  - src/generic_factory.cpp
+  - src/init.cpp
+  - tests/generic_factory_test.cpp
+  source_symbols:
+  - generic_factory::load
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 示例源码链接指向 CleverRaven master；应改为本地 source badge 和固定 verified commit。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 217 行系统解释 copy-from、extend/delete、relative/proportional 与支持范围；2026-07 加入 CCB vitamin 和 overmap special
+    支持，generic_factory tests 可验证基础语义。
+  - Import-time source-symbol correction was verified against the tracked implementation.
+  migration_batch: phase-0-json
 - original_path: doc/JSON/JSON_LOADING_ORDER.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/loading-order.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: merge_into
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/loading-order/
+  migration_status: classified
+  history_strategy: merge_attribution_and_source_history
   stable_document_id: legacy.doc-json-json-loading-order
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
-  merge_target: null
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_inherited
+  upstream_relation: exact_duplicate_in_repository
+  merge_target: json.loading-order
   source_paths:
-  - doc/JSON/JSON_LOADING_ORDER.md
-  source_symbols: []
+  - src/init.cpp
+  - src/game_io.cpp
+  - data/json/LOADING_ORDER.md
+  source_symbols:
+  - DynamicDataLoader::load_data_from_path
+  - DynamicDataLoader::load_all_from_json
+  - DynamicDataLoader::finalize_loaded_data
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 与 data/json/LOADING_ORDER.md 字节级相同；两个旧路径都应指向同一稳定文档 ID，避免重复维护。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - diff 显示两个文件完全相同；内容描述目录深度和同深度字母顺序，应从实际 loader 行为生成/测试并只发布一份页面。
+  migration_batch: phase-1-json
 - original_path: doc/JSON/JSON_Mapping_Guides/Guide_for_beginning_mapgen.md
-  target_path: null
+  target_path: docs/zh_CN/tutorials/json-mapgen/beginner.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-json-mapping-guides-guide-for-beginning-mapgen
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/tutorials/json-mapgen/beginner/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: tutorial.mapgen-beginner
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_inherited
+  upstream_relation: inherited_tutorial_with_upstream_links
   merge_target: null
   source_paths:
-  - doc/JSON/JSON_Mapping_Guides/Guide_for_beginning_mapgen.md
-  source_symbols: []
+  - src/mapgen.cpp
+  - src/overmap_terrain.cpp
+  - data/json/mapgen/abandoned_barn.json
+  - data/json/overmap/overmap_terrain/overmap_terrain.json
+  - tests/mapgen_function_test.cpp
+  source_symbols:
+  - mapgen_function_json::setup_internal
+  - overmap_terrains::load
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 教程含 11 个 CleverRaven 文件/文档链接和若干作者经验性结论；所有示例需改成本地固定来源并实际加载。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 616 行从 OMT、ASCII map、屋顶、palette 到 special 的完整入门教程仍有价值，但仓库身份和链接全部需要 CCB 化。
+  migration_batch: phase-1-json
 - original_path: doc/JSON/JSON_Mapping_Guides/Guide_for_intermediate_mapgen.md
-  target_path: null
+  target_path: docs/zh_CN/tutorials/json-mapgen/intermediate.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-json-mapping-guides-guide-for-intermediate-mapgen
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/tutorials/json-mapgen/intermediate/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: tutorial.mapgen-intermediate
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_inherited
+  upstream_relation: inherited_tutorial_with_upstream_links
   merge_target: null
   source_paths:
-  - doc/JSON/JSON_Mapping_Guides/Guide_for_intermediate_mapgen.md
-  source_symbols: []
+  - src/mapgen.cpp
+  - src/mapgen.h
+  - data/json/mapgen/nested/road_vehicles_nested.json
+  - tests/nest_conditional_placement_test.cpp
+  - tests/mapgen_function_test.cpp
+  source_symbols:
+  - mapgen_function_json::setup_internal
+  - jmapgen_objects::load_objects
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - Magiclysm/micro_lab 示例与上游锚点需在 CCB 当前数据中逐项重跑；代码块应加入可提取验证标记。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 614 行聚焦 layered/nested mapgen、条件放置与复杂生成，概念仍由 mapgen loader 支持；应保留教程层次但重做可执行示例。
+  migration_batch: phase-1-json
 - original_path: doc/JSON/JSON_Mapping_Guides/JSON_ROOF_MAPGEN.md
-  target_path: null
+  target_path: docs/zh_CN/tutorials/json-mapgen/beginner.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: merge_into
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-json-mapping-guides-json-roof-mapgen
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/tutorials/json-mapgen/beginner/
+  migration_status: classified
+  history_strategy: merge_attribution_and_source_history
+  stable_document_id: tutorial.mapgen-roofs
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
-  merge_target: null
+  priority: P2
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_inherited
+  upstream_relation: inherited_narrow_tutorial
+  merge_target: tutorial.mapgen-beginner
   source_paths:
-  - doc/JSON/JSON_Mapping_Guides/JSON_ROOF_MAPGEN.md
-  source_symbols: []
+  - src/mapgen.cpp
+  - data/json/mapgen/apartment_complex/apartment_complex_roof.json
+  - data/json/overmap/overmap_terrain/overmap_terrain.json
+  source_symbols:
+  - mapgen_function_json::setup_internal
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 引用 CleverRaven MAPGEN 和已过时的 dev.narc.ro formatter；示例需并入可验证的初级 mapgen 路线。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 180 行只讲 roof map、overmap special/terrain 与 region settings 的衔接，内容与初级教程高度重叠，合并可减少重复且保留旧路径 stub。
+  migration_batch: phase-2-json
 - original_path: doc/JSON/JSON_STYLE.md
-  target_path: null
+  target_path: docs/zh_CN/contributing/json-style.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-json-style
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/contributing/json-style/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: contributing.json-style
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P0
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_inherited
+  upstream_relation: inherited_workflow_with_live_targets
   merge_target: null
   source_paths:
-  - doc/JSON/JSON_STYLE.md
-  source_symbols: []
+  - Makefile
+  - .github/workflows/json.yml
+  - tools/format/format_main.cpp
+  - data/AGENTS.md
+  source_symbols:
+  - main
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 正文仍称 Cataclysm-DDA root 并推荐 dev.narc.ro；命令应以当前 Makefile/CI 为准且实际运行。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 107 行样式规则本身仍适用，Makefile 仍有 style-json 且 CI 使用 formatter；站点页需用当前 CCB 命令替换旧网站和上游身份。
+  migration_batch: phase-0-json
 - original_path: doc/JSON/JSON_TOOLS.md
-  target_path: null
+  target_path: docs/zh_CN/how-to/json/tools.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-json-tools
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/how-to/json/tools/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: how-to.json-tools
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P2
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_inherited
+  upstream_relation: inherited_tooling_guide
   merge_target: null
   source_paths:
-  - doc/JSON/JSON_TOOLS.md
-  source_symbols: []
+  - tools/json_tools/keys.py
+  - tools/json_tools/values.py
+  - tools/json_tools/pluck.py
+  - tools/json_tools/table.py
+  - tools/json_tools/lister.py
+  source_symbols:
+  - main
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 正文泛称 Cataclysm-DDA 且不覆盖每个脚本的当前参数；命令必须通过 --help/样例运行验证。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 153 行介绍 keys/values/pluck/table/lister 与 jq，用例仍对应已跟踪脚本；适合作为操作指南按当前 CLI 重写。
+  migration_batch: phase-2-json
 - original_path: doc/JSON/MAGIC.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/magic-spells-enchantments.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - LYHGLYTX

--- a/doc/migration/markdown-inventory.yml
+++ b/doc/migration/markdown-inventory.yml
@@ -5,19 +5,19 @@ document_count: 175
 scope: Tracked Markdown at source_commit, excluding dot-prefixed tool/config paths; filesystem caches
   are never traversed.
 classification_summary:
-  review: 86
+  review: 85
   actions:
     archive_public: 1
     generated_reference: 3
     keep_in_repo: 54
     merge_into: 4
     migrate_preserve: 13
-    migrate_rewrite: 8
+    migrate_rewrite: 9
     retain_third_party: 6
-    review: 86
+    review: 85
   migration_statuses:
-    classified: 77
-    inventoried: 86
+    classified: 78
+    inventoried: 85
     verified: 12
 documents:
 - original_path: CODE_OF_CONDUCT.md
@@ -2885,30 +2885,38 @@ documents:
   - RenechCDDA
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-json-info
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/
+  migration_status: classified
+  history_strategy: filtered_path_history_candidate
+  stable_document_id: json.object-types
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P0
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: ccb_extended
+  upstream_relation: forked_and_locally_extended
   merge_target: null
   source_paths:
-  - doc/JSON/JSON_INFO.md
-  source_symbols: []
+  - src/init.cpp
+  - src/json.cpp
+  - src/generic_factory.cpp
+  - tests/json_load_test.cpp
+  - tests/json_test.cpp
+  source_symbols:
+  - DynamicDataLoader::initialize
+  - DynamicDataLoader::load_object
+  - DynamicDataLoader::load_data_from_path
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 4,696 行把介绍、通用语法、目录导航和约 200 个对象章节混在一起；需拆为手写入口和生成 object type registry，且不得假装 Schema 完整。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 这是广域 JSON 总参考，导入后 14 次更新并含 CCB fertilize_terrain/植物生命周期字段；当前 DynamicDataLoader 注册和 JSON load tests
+    应成为生成清单权威。
+  migration_batch: phase-0-json
 - original_path: doc/JSON/JSON_INHERITANCE.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/inheritance.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - zihanZheng

--- a/doc/migration/markdown-inventory.yml
+++ b/doc/migration/markdown-inventory.yml
@@ -5,19 +5,19 @@ document_count: 175
 scope: Tracked Markdown at source_commit, excluding dot-prefixed tool/config paths; filesystem caches
   are never traversed.
 classification_summary:
-  review: 77
+  review: 69
   actions:
     archive_public: 1
     generated_reference: 3
     keep_in_repo: 54
-    merge_into: 6
-    migrate_preserve: 15
+    merge_into: 7
+    migrate_preserve: 22
     migrate_rewrite: 13
     retain_third_party: 6
-    review: 77
+    review: 69
   migration_statuses:
-    classified: 86
-    inventoried: 77
+    classified: 94
+    inventoried: 69
     verified: 12
 documents:
 - original_path: CODE_OF_CONDUCT.md
@@ -3205,236 +3205,283 @@ documents:
   - Tektolnes
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-mapgen
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/mapgen/
+  migration_status: classified
+  history_strategy: filtered_path_history_candidate
+  stable_document_id: json.mapgen
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P0
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_synced
+  upstream_relation: inherited_then_synced
   merge_target: null
   source_paths:
-  - doc/JSON/MAPGEN.md
-  source_symbols: []
+  - src/mapgen.cpp
+  - src/mapgen.h
+  - src/mapgen_post_process.cpp
+  - tests/mapgen_function_test.cpp
+  - tests/mapgen_post_process_test.cpp
+  source_symbols:
+  - mapgen_function_json::setup_internal
+  - update_mapgen_function_json::setup_update
+  - mapgen_palette::load
+  - pp_generator::load
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 1,792 行仍含 Limitations/TODO；拆分后必须保持字段来源与测试映射，不能把 TODO 当契约。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 核心 mapgen 参考覆盖 placement、palettes、update_mapgen、parameters、post-process 等，导入后继续更新 SKIP_ON_OPEN_AIR
+    和 vision/post-process 行为，当前测试丰富。
+  migration_batch: phase-0-json
 - original_path: doc/JSON/MAP_SMASHING.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/terrain-and-furniture.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: merge_into
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-map-smashing
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/terrain-and-furniture/
+  migration_status: classified
+  history_strategy: merge_attribution_and_source_history
+  stable_document_id: json.map-smashing
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
-  merge_target: null
+  priority: P2
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_inherited
+  upstream_relation: inherited_small_fragment
+  merge_target: json.terrain-and-furniture
   source_paths:
-  - doc/JSON/MAP_SMASHING.md
-  source_symbols: []
+  - src/mapdata.cpp
+  - src/mapdata.h
+  - data/json/bash_damage_profiles.json
+  source_symbols:
+  - map_common_bash_info::load
+  - map_ter_bash_info::load
+  - map_furn_bash_info::load
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 24 行只解释 bash min/max、阻挡与 damage profile，是 terrain/furniture JSON 的小节而非独立完整主题；loader 和 bash profile
+    数据仍存在。
+  migration_batch: phase-2-json
 - original_path: doc/JSON/MARTIALART_JSON.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/martial-arts.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-martialart-json
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/martial-arts/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.martial-arts
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_inherited
+  upstream_relation: inherited_contract_with_tests
   merge_target: null
   source_paths:
-  - doc/JSON/MARTIALART_JSON.md
-  source_symbols: []
+  - src/martialarts.cpp
+  - src/martialarts.h
+  - data/json/martialarts.json
+  - tests/martial_art_test.cpp
+  source_symbols:
+  - martialart::load
+  - ma_technique::load
+  - ma_buff::load
+  - attack_vector::load
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 285 行覆盖武术、buff、technique、bonus、attack vector 与用法，当前 loader/data/test 对应，适合保留结构并双语化。
+  migration_batch: phase-1-json
 - original_path: doc/JSON/MISSIONS_JSON.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/missions.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - Maleclypse
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-missions-json
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/missions/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.missions
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_synced
+  upstream_relation: inherited_then_synced
   merge_target: null
   source_paths:
-  - doc/JSON/MISSIONS_JSON.md
-  source_symbols: []
+  - src/missiondef.cpp
+  - src/mission.cpp
+  - src/npctalk.cpp
+  - data/json/npcs/missiondef.json
+  - tests/mission_test.cpp
+  source_symbols:
+  - mission_type::load
+  - json_talk_topic::load
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 部分 start/end/fail 行为仍需硬编码函数；页面必须区分 mission JSON 与 dialogue/EOC 行为边界。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 355 行逐字段解释 mission、目标、对话和 effects；2026-06 随 mission enum 继续更新，mission loader/test 可验证。
+  migration_batch: phase-1-json
 - original_path: doc/JSON/MONSTERS.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/monsters.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - Maleclypse
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-monsters
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/monsters/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.monsters
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P0
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_synced
+  upstream_relation: inherited_then_synced
   merge_target: null
   source_paths:
-  - doc/JSON/MONSTERS.md
-  source_symbols: []
+  - src/monstergenerator.cpp
+  - src/monstergenerator.h
+  - data/json/monsters/zed-classic.json
+  - tests/monster_test.cpp
+  source_symbols:
+  - MonsterGenerator::load_monster
+  - mtype::load
+  - species_type::load
+  - mon_flag::load
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 771 行字段表应与 mtype loader/object registry 自动比对；当前目录链接应改为可解析文件链接。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 核心 monster JSON 参考覆盖属性、弱点、升级、繁殖、攻击等，2026-06 随 vitals weakpoints 更新；loader 和多组 monster tests 仍是权威。
+  migration_batch: phase-0-json
 - original_path: doc/JSON/MONSTER_SPECIAL_ATTACKS.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/monster-special-attacks.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - Maleclypse
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-monster-special-attacks
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/monster-special-attacks/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.monster-special-attacks
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P0
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_synced
+  upstream_relation: inherited_then_synced
   merge_target: null
   source_paths:
-  - doc/JSON/MONSTER_SPECIAL_ATTACKS.md
-  source_symbols: []
+  - src/monstergenerator.cpp
+  - src/monstergenerator.h
+  - data/json/monster_special_attacks/monster_attacks.json
+  - tests/monster_attack_test.cpp
+  source_symbols:
+  - MonsterGenerator::load_monster_attack
+  - mattack_actor::load
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 正文明确含未完成的 hardcoded attack 描述 TODO；生成覆盖率必须区分硬编码、actor JSON 与 EOC attacks。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 338 行解释选择逻辑、旧/新语法、硬编码与 JSON actor、EOC attack；2026-06 随 body-part targeting 更新，现有 loader/test 可核验。
+  migration_batch: phase-0-json
 - original_path: doc/JSON/MOVE_MODE.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/movement-modes.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-move-mode
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/movement-modes/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.movement-modes
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P2
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_inherited
+  upstream_relation: inherited_contract_with_core_data
   merge_target: null
   source_paths:
-  - doc/JSON/MOVE_MODE.md
-  source_symbols: []
+  - src/move_mode.cpp
+  - src/move_mode.h
+  - data/json/move_modes.json
+  source_symbols:
+  - move_mode::load
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 158 行逐字段说明 movement_mode，当前单一 loader 与 data/json/move_modes.json 直接对应，迁移风险低。
+  migration_batch: phase-2-json
 - original_path: doc/JSON/MUTATIONS.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/mutations.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-mutations
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/mutations/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.mutations
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_inherited
+  upstream_relation: inherited_contract_with_live_eocs
   merge_target: null
   source_paths:
-  - doc/JSON/MUTATIONS.md
-  source_symbols: []
+  - src/mutation_data.cpp
+  - src/mutation.cpp
+  - data/json/mutations/mutations.json
+  - data/json/effects_on_condition/mutation_eocs/changing_eocs.json
+  - tests/mutation_test.cpp
+  source_symbols:
+  - mutation_branch::load
+  - mutation_category_trait::load
+  - mutation_variant::load
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 系统说明同时依赖硬编码检查与 EOC；迁移后需清楚标注两种权威来源并修复目录型链接。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 455 行同时解释 mutagen 系统和 mutation/category/migration JSON，当前 loader、核心 mutation EOCs 与 tests 均存在。
+  migration_batch: phase-1-json
 - original_path: doc/JSON/NPCs.md
-  target_path: null
+  target_path: docs/zh_CN/reference/eoc/npcs-and-dialogue.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - Killa-bite

--- a/doc/migration/markdown-inventory.yml
+++ b/doc/migration/markdown-inventory.yml
@@ -5,19 +5,17 @@ document_count: 175
 scope: Tracked Markdown at source_commit, excluding dot-prefixed tool/config paths; filesystem caches
   are never traversed.
 classification_summary:
-  review: 33
+  review: 0
   actions:
-    archive_public: 3
+    archive_public: 7
     generated_reference: 4
-    keep_in_repo: 54
-    merge_into: 12
+    keep_in_repo: 57
+    merge_into: 15
     migrate_preserve: 35
-    migrate_rewrite: 28
-    retain_third_party: 6
-    review: 33
+    migrate_rewrite: 50
+    retain_third_party: 7
   migration_statuses:
-    classified: 130
-    inventoried: 33
+    classified: 163
     verified: 12
 documents:
 - original_path: CODE_OF_CONDUCT.md
@@ -4732,872 +4730,984 @@ documents:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: build-overview
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-c-compiling
-  domain: cpp
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: build-overview
+  domain: build
+  priority: P0
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: mixed
+  upstream_relation: upstream_derived_with_ccb_extensions
   merge_target: null
   source_paths:
   - doc/c++/COMPILING.md
+  - CMakeLists.txt
+  - Makefile
+  - CMakePresets.json
+  - android/app/jni/CMakeLists.txt
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - The page contains recent CCB SDL3/Android additions mixed with stale upstream clone URLs and platform
+    instructions; split and rewrite around current build contracts.
+  migration_batch: phase-0-build
 - original_path: doc/c++/DEVELOPER_TOOLING.md
-  target_path: null
+  target_path: docs/zh_CN/cpp/developer-tooling.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - dumb-kevin
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: developer-tooling
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-c-developer-tooling
+  stable_document_id: developer-tooling
   domain: cpp
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: mixed
+  upstream_relation: upstream_derived_revalidate
   merge_target: null
   source_paths:
   - doc/c++/DEVELOPER_TOOLING.md
+  - build-scripts/clang-tidy-run.sh
+  - build-scripts/ci-iwyu-run.py
+  - .github/workflows/clang-tidy.yml
+  - .github/workflows/iwyu.yml
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Clang-tidy and IWYU automation is current, but setup and invocation must be derived from the checked-in
+    scripts/workflows.
+  migration_batch: phase-1-cpp
 - original_path: doc/c++/JSON_INTERFACE.md
-  target_path: null
+  target_path: docs/zh_CN/cpp/json-interface.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - ehughsbaird
   contributor_anomaly_count: 0
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: cpp-json-interface
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-c-json-interface
+  stable_document_id: cpp-json-interface
   domain: cpp
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: ccb_specific
+  upstream_relation: ccb_specific_implementation
   merge_target: null
   source_paths:
   - doc/c++/JSON_INTERFACE.md
-  source_symbols: []
+  - src/flexbuffer_json.h
+  - src/flexbuffer_json.cpp
+  - src/generic_factory.h
+  - tests/generic_factory_test.cpp
+  source_symbols:
+  - JsonObject
+  - JsonArray
+  - generic_factory
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - This recent CCB page maps to the FlexBuffers-backed Json classes and generic_factory tests; preserve
+    its intent but add source-linked invariants and examples.
+  migration_batch: phase-1-cpp
 - original_path: doc/c++/PERFORMANCE.md
-  target_path: null
+  target_path: docs/zh_CN/cpp/performance.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - g1ytx
   contributor_anomaly_count: 0
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: cpp-performance
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-c-performance
+  stable_document_id: cpp-performance
   domain: cpp
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: ccb_specific
+  upstream_relation: ccb_specific_implementation
   merge_target: null
   source_paths:
   - doc/c++/PERFORMANCE.md
-  source_symbols: []
+  - src/profiling.h
+  - tests/cata_catch.h
+  - tests/generic_factory_test.cpp
+  source_symbols:
+  - CATA_PROFILE_SCOPE
+  - BENCHMARK_TEST_CASE
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Profiling macros and benchmark-only Catch tags are present and tested in current CCB; expand this
+    recent page with verified commands and artifact guidance.
+  migration_batch: phase-1-cpp
 - original_path: doc/c++/POINTS_COORDINATES.md
-  target_path: null
+  target_path: docs/zh_CN/cpp/coordinates.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: cpp-coordinates
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-c-points-coordinates
+  stable_document_id: cpp-coordinates
   domain: cpp
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: mixed
+  upstream_relation: upstream_derived_revalidate
   merge_target: null
   source_paths:
   - doc/c++/POINTS_COORDINATES.md
-  source_symbols: []
+  - src/point.h
+  - src/coordinates.h
+  - src/coordinate_conversions.cpp
+  - tests/coordinate_test.cpp
+  - tests/point_test.cpp
+  source_symbols:
+  - point
+  - tripoint
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Coordinate types, conversions, and tests remain core contracts; rewrite diagrams and examples against
+    the current typed-coordinate implementation.
+  migration_batch: phase-1-cpp
 - original_path: doc/c++/TESTING.md
-  target_path: null
+  target_path: docs/zh_CN/testing/cpp.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - g1ytx
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: cpp-testing
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-c-testing
-  domain: cpp
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: cpp-testing
+  domain: testing
+  priority: P0
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: mixed
+  upstream_relation: upstream_derived_revalidate
   merge_target: null
   source_paths:
   - doc/c++/TESTING.md
-  source_symbols: []
+  - tests/CMakeLists.txt
+  - tests/Makefile
+  - tests/cata_catch.h
+  - .github/workflows/matrix.yml
+  source_symbols:
+  - BENCHMARK_TEST_CASE
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - The C++ test suite and benchmark conventions are active; rewrite commands and filtering guidance from
+    current CMake/Make/CI contracts.
+  migration_batch: phase-0-testing
 - original_path: doc/design-balance-lore/ARMOR_BALANCE_AND_DESIGN.md
-  target_path: null
+  target_path: docs/zh_CN/json/armor-design.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: json-armor-design
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-design-balance-lore-armor-balance-and-design
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: json-armor-design
+  domain: design
+  priority: P2
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_derived
+  upstream_relation: upstream_derived_revalidate
   merge_target: null
   source_paths:
   - doc/design-balance-lore/ARMOR_BALANCE_AND_DESIGN.md
+  - src/item_armor.cpp
+  - src/item_factory.cpp
+  - data/json/items/armor/torso_armor.json
+  - tests/item_test.cpp
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - The design rationale is useful, but armor fields and behavior must be checked against item loading,
+    current data, and tests before publication.
+  migration_batch: phase-2-design
 - original_path: doc/design-balance-lore/CONSTRUCTION_BALANCE.md
-  target_path: null
+  target_path: docs/zh_CN/archive/design/construction-balance.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
-  archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  action: archive_public
+  archive_reason: Unvalidated historical balance proposal; it is not a current CCB contract or policy.
+  replacement: design-balance
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-design-balance-lore-construction-balance
-  domain: legacy
+  stable_document_id: archive-construction-balance
+  domain: design
   priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  last_applicable_commit: null
+  ccb_specificity: upstream_derived
+  upstream_relation: upstream_historical_proposal
   merge_target: null
   source_paths:
   - doc/design-balance-lore/CONSTRUCTION_BALANCE.md
+  - src/construction.cpp
+  - data/json/construction/terrain.json
   source_symbols: []
-  translation_required: true
-  include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  translation_required: false
+  include_in_ai_index: false
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - This is an old normative balance proposal with no current validation trail; current construction behavior
+    is data/source driven.
+  - 'The exact last-applicable SHA is intentionally unknown: imported snapshot history repeatedly re-adds
+    this path at unrelated commits, so those SHAs are provenance rather than validity evidence.'
+  migration_batch: phase-3-design
 - original_path: doc/design-balance-lore/GAME_BALANCE.md
-  target_path: null
+  target_path: docs/zh_CN/design/balance.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: merge_into
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: design-balance
+  migration_status: classified
   history_strategy: evaluate_filtered_history
   stable_document_id: legacy.doc-design-balance-lore-game-balance
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
-  merge_target: null
+  domain: design
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_derived
+  upstream_relation: upstream_derived_revalidate
+  merge_target: design-balance
   source_paths:
   - doc/design-balance-lore/GAME_BALANCE.md
+  - doc/design-balance-lore/design-balance.md
+  - GOVERNANCE.md
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - The high-level balance principles overlap design-balance.md and should become one explicitly CCB-reviewed
+    policy/explanation page.
+  migration_batch: phase-1-design
 - original_path: doc/design-balance-lore/LORE_FAQ.md
-  target_path: null
+  target_path: docs/zh_CN/archive/lore/faq.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
-  archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  action: archive_public
+  archive_reason: Dated upstream FAQ without a current CCB authority trail; preserve only for historical
+    context.
+  replacement: lore-overview
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-design-balance-lore-lore-faq
-  domain: legacy
+  stable_document_id: archive-lore-faq
+  domain: lore
   priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  last_applicable_commit: null
+  ccb_specificity: upstream_derived
+  upstream_relation: upstream_only_obsolete
   merge_target: null
   source_paths:
   - doc/design-balance-lore/LORE_FAQ.md
+  - doc/design-balance-lore/lore.md
+  - doc/design-balance-lore/lore-background.md
   source_symbols: []
-  translation_required: true
-  include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  translation_required: false
+  include_in_ai_index: false
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - The inherited FAQ encodes dated upstream assumptions and external answers; it cannot serve as current
+    CCB lore authority.
+  - 'The exact last-applicable SHA is intentionally unknown: imported snapshot history repeatedly re-adds
+    this path at unrelated commits, so those SHAs are provenance rather than validity evidence.'
+  migration_batch: phase-3-lore
 - original_path: doc/design-balance-lore/PORTAL_STORM_BALANCE_AND_DESIGN.md
-  target_path: null
+  target_path: docs/zh_CN/design/portal-storms.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: design-portal-storms
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-design-balance-lore-portal-storm-balance-and-design
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: design-portal-storms
+  domain: design
+  priority: P2
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_derived
+  upstream_relation: upstream_derived_revalidate
   merge_target: null
   source_paths:
   - doc/design-balance-lore/PORTAL_STORM_BALANCE_AND_DESIGN.md
-  source_symbols: []
+  - src/game.cpp
+  - data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
+  - data/json/mapgen/portal_storm.json
+  - tests/widget_test.cpp
+  source_symbols:
+  - game::portal_storm_query
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Portal-storm runtime hooks, EOCs, mapgen, and tests remain present; rewrite the rationale with an
+    explicit CCB-divergence and current-data review.
+  migration_batch: phase-2-design
 - original_path: doc/design-balance-lore/POSTAPOC_PRICE_GUIDE.md
-  target_path: null
+  target_path: docs/zh_CN/json/item-pricing.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: json-item-pricing
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-design-balance-lore-postapoc-price-guide
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: json-item-pricing
+  domain: design
+  priority: P2
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_derived
+  upstream_relation: upstream_derived_revalidate
   merge_target: null
   source_paths:
   - doc/design-balance-lore/POSTAPOC_PRICE_GUIDE.md
+  - src/faction.cpp
+  - tests/faction_price_rules_test.cpp
+  - data/json/npcs/factions.json
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Pricing guidance is useful to content authors, but examples and formulas must be reconciled with current
+    faction pricing code/tests.
+  migration_batch: phase-2-design
 - original_path: doc/design-balance-lore/STEEL_CRAFTING.md
-  target_path: null
+  target_path: docs/zh_CN/design/steel-crafting.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - FarFarLakeSea
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: design-steel-crafting
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-design-balance-lore-steel-crafting
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: design-steel-crafting
+  domain: design
+  priority: P2
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_derived
+  upstream_relation: upstream_derived_revalidate
   merge_target: null
   source_paths:
   - doc/design-balance-lore/STEEL_CRAFTING.md
+  - data/json/materials.json
+  - data/json/recipes/other/materials.json
+  - data/json/requirements/materials.json
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - The process rationale can inform content work, but recipe stages, requirements, and terminology must
+    be checked against current JSON.
+  migration_batch: phase-2-design
 - original_path: doc/design-balance-lore/VARIANTS.md
-  target_path: null
+  target_path: docs/zh_CN/json/item-variants.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: json-item-variants
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-design-balance-lore-variants
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: json-item-variants
+  domain: json
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_derived
+  upstream_relation: upstream_derived_revalidate
   merge_target: null
   source_paths:
   - doc/design-balance-lore/VARIANTS.md
-  source_symbols: []
+  - src/item_factory.cpp
+  - src/cata_variant.h
+  - tests/cata_variant_test.cpp
+  - data/json/artifact/artifact_item_types.json
+  source_symbols:
+  - cata_variant
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Item/trait variant concepts remain implemented and tested; rewrite the JSON-facing rules from loaders
+    and representative current data.
+  migration_batch: phase-1-json
 - original_path: doc/design-balance-lore/batteries_and_electricity.md
-  target_path: null
+  target_path: docs/zh_CN/design/batteries-electricity.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: design-batteries-electricity
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-design-balance-lore-batteries-and-electricity
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: design-batteries-electricity
+  domain: design
+  priority: P2
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_derived
+  upstream_relation: upstream_derived_revalidate
   merge_target: null
   source_paths:
   - doc/design-balance-lore/batteries_and_electricity.md
+  - data/json/items/battery.json
+  - data/json/vehicleparts/battery.json
+  - src/vehicle_part.cpp
+  - tests/battery_mod_test.cpp
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Battery/electricity design remains relevant, but values and invariants need reconciliation with current
+    item/vehicle data and battery tests.
+  migration_batch: phase-2-design
 - original_path: doc/design-balance-lore/design-balance.md
-  target_path: null
+  target_path: docs/zh_CN/design/balance.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: design-balance
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-design-balance-lore-design-balance
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: design-balance
+  domain: design
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_derived
+  upstream_relation: upstream_derived_revalidate
   merge_target: null
   source_paths:
   - doc/design-balance-lore/design-balance.md
+  - doc/design-balance-lore/GAME_BALANCE.md
+  - GOVERNANCE.md
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - The principles are useful but originated upstream; publish only after reconciling them into one CCB-owned
+    design/balance explanation.
+  migration_batch: phase-1-design
 - original_path: doc/design-balance-lore/design-doc.md
-  target_path: null
+  target_path: docs/zh_CN/design/overview.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: merge_into
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: design-overview
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-design-balance-lore-design-doc
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
-  merge_target: null
+  stable_document_id: design-overview
+  domain: design
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_derived
+  upstream_relation: upstream_derived_revalidate
+  merge_target: design-overview
   source_paths:
   - doc/design-balance-lore/design-doc.md
+  - doc/design-balance-lore/design-gameplay.md
+  - doc/design-balance-lore/design-user-experience.md
+  - GOVERNANCE.md
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - This is an index/outline for neighboring design essays; merge its useful framing into a maintained
+    CCB design overview.
+  migration_batch: phase-1-design
 - original_path: doc/design-balance-lore/design-gameplay.md
-  target_path: null
+  target_path: docs/zh_CN/design/gameplay.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: design-gameplay
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-design-balance-lore-design-gameplay
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: design-gameplay
+  domain: design
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_derived
+  upstream_relation: upstream_derived_revalidate
   merge_target: null
   source_paths:
   - doc/design-balance-lore/design-gameplay.md
+  - doc/design-balance-lore/design-balance.md
+  - GOVERNANCE.md
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Retain the gameplay design discussion as explanation, clearly labeled non-runtime authority and reviewed
+    for CCB divergence.
+  migration_batch: phase-1-design
 - original_path: doc/design-balance-lore/design-user-experience.md
-  target_path: null
+  target_path: docs/zh_CN/design/user-experience.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: design-user-experience
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-design-balance-lore-design-user-experience
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: design-user-experience
+  domain: design
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_derived
+  upstream_relation: upstream_derived_revalidate
   merge_target: null
   source_paths:
   - doc/design-balance-lore/design-user-experience.md
+  - doc/USER_INTERFACE_AND_ACCESSIBILITY.md
+  - src/options.cpp
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - The UX principles remain useful explanation, but must be tied to CCB accessibility/UI behavior and
+    separated from binding runtime contracts.
+  migration_batch: phase-1-design
 - original_path: doc/design-balance-lore/lore-background.md
-  target_path: null
+  target_path: docs/zh_CN/lore/background.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: lore-background
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-design-balance-lore-lore-background
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: lore-background
+  domain: lore
+  priority: P2
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_derived
+  upstream_relation: upstream_derived_revalidate
   merge_target: null
   source_paths:
   - doc/design-balance-lore/lore-background.md
+  - doc/design-balance-lore/lore.md
+  - data/json/snippets/epilogue_factions.json
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - The inherited background is useful lore context but must be reviewed for CCB canon/divergence and
+    labeled as explanation rather than code authority.
+  migration_batch: phase-2-lore
 - original_path: doc/design-balance-lore/lore-factions.md
-  target_path: null
+  target_path: docs/zh_CN/lore/factions.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: lore-factions
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-design-balance-lore-lore-factions
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: lore-factions
+  domain: lore
+  priority: P2
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_derived
+  upstream_relation: upstream_derived_revalidate
   merge_target: null
   source_paths:
+  - doc/design-balance-lore/lore-factions.md
+  - data/json/npcs/factions.json
+  - src/faction.cpp
+  - tests/monfactions_test.cpp
+  source_symbols: []
+  translation_required: true
+  include_in_ai_index: true
+  blockers: []
+  evidence:
+  - Faction lore should be reconciled with current faction JSON/source and CCB canon before becoming a
+    searchable page.
+  migration_batch: phase-2-lore
+- original_path: doc/design-balance-lore/lore.md
+  target_path: docs/zh_CN/lore/overview.md
+  source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
+  contributors:
+  - thaelina
+  contributor_anomaly_count: 1
+  license: CC-BY-SA-3.0
+  action: migrate_rewrite
+  archive_reason: null
+  replacement: lore-overview
+  migration_status: classified
+  history_strategy: evaluate_filtered_history
+  stable_document_id: lore-overview
+  domain: lore
+  priority: P2
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_derived
+  upstream_relation: upstream_derived_revalidate
+  merge_target: null
+  source_paths:
+  - doc/design-balance-lore/lore.md
+  - doc/design-balance-lore/lore-background.md
   - doc/design-balance-lore/lore-factions.md
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
-- original_path: doc/design-balance-lore/lore.md
-  target_path: null
-  source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  contributors:
-  - thaelina
-  contributor_anomaly_count: 1
-  license: CC-BY-SA-3.0
-  action: review
-  archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-design-balance-lore-lore
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
-  merge_target: null
-  source_paths:
-  - doc/design-balance-lore/lore.md
-  source_symbols: []
-  translation_required: true
-  include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
-  evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Use this inherited overview as input, not authority; rewrite a CCB-reviewed lore navigation/explanation
+    page with explicit provenance.
+  migration_batch: phase-2-lore
 - original_path: doc/design-balance-lore/melee_weapons/MELEE_BALANCE_SPREADSHEET.md
-  target_path: null
+  target_path: docs/zh_CN/archive/design/melee-balance-spreadsheet.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
-  archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  action: archive_public
+  archive_reason: The source page self-identifies as substantially out of date and has no current CCB
+    validation trail.
+  replacement: design-balance
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-design-balance-lore-melee-weapons-melee-balance-spreadsheet
-  domain: legacy
+  stable_document_id: archive-melee-balance-spreadsheet
+  domain: design
   priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  last_applicable_commit: null
+  ccb_specificity: upstream_derived
+  upstream_relation: upstream_only_obsolete
   merge_target: null
   source_paths:
   - doc/design-balance-lore/melee_weapons/MELEE_BALANCE_SPREADSHEET.md
+  - src/melee.cpp
+  - tests/melee_test.cpp
   source_symbols: []
-  translation_required: true
-  include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  translation_required: false
+  include_in_ai_index: false
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - The page explicitly calls the spreadsheet 'quite out of date'; current melee behavior/tests cannot
+    validate it as guidance.
+  - 'The exact last-applicable SHA is intentionally unknown: imported snapshot history repeatedly re-adds
+    this path at unrelated commits, so those SHAs are provenance rather than validity evidence.'
+  migration_batch: phase-3-design
 - original_path: doc/design-balance-lore/technology.md
-  target_path: null
+  target_path: docs/zh_CN/lore/technology.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: lore-technology
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-design-balance-lore-technology
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: lore-technology
+  domain: lore
+  priority: P2
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_derived
+  upstream_relation: upstream_derived_revalidate
   merge_target: null
   source_paths:
   - doc/design-balance-lore/technology.md
+  - doc/design-balance-lore/lore.md
+  - data/json/materials.json
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Technology assumptions affect lore and content design; rewrite after checking CCB divergence and label
+    it as reviewed design explanation.
+  migration_batch: phase-2-lore
 - original_path: doc/development_process.md
-  target_path: null
+  target_path: docs/zh_CN/archive/governance/development-process.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
-  archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  action: archive_public
+  archive_reason: Obsolete upstream governance names, roles, and process conflict with current CCB policy.
+  replacement: getting-started-first-contribution
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-development-process
-  domain: legacy
+  stable_document_id: archive-upstream-development-process
+  domain: governance
   priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  last_applicable_commit: null
+  ccb_specificity: upstream_derived
+  upstream_relation: upstream_only_obsolete
   merge_target: null
   source_paths:
   - doc/development_process.md
+  - CONTRIBUTING.md
+  - GOVERNANCE.md
   source_symbols: []
-  translation_required: true
-  include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  translation_required: false
+  include_in_ai_index: false
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - The page is entirely CleverRaven/Kevin/CDDA governance and conflicts with CCB CONTRIBUTING/GOVERNANCE;
+    it must not remain active guidance.
+  - 'The exact last-applicable SHA is intentionally unknown: imported snapshot history repeatedly re-adds
+    this path at unrelated commits, so those SHAs are provenance rather than validity evidence.'
+  migration_batch: phase-3-governance
 - original_path: doc/reviewing_PR_guide.md
-  target_path: null
+  target_path: docs/zh_CN/contributing/pr-review.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: pr-review-guide
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-reviewing-pr-guide
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: pr-review-guide
+  domain: governance
+  priority: P0
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: ccb_specific
+  upstream_relation: ccb_governance_replaces_upstream_process
   merge_target: null
   source_paths:
   - doc/reviewing_PR_guide.md
+  - CONTRIBUTING.md
+  - GOVERNANCE.md
+  - .github/pull_request_template.md
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Review guidance is valuable but must match CCB Responsible-human, validation, and documentation-impact
+    policy rather than upstream roles.
+  migration_batch: phase-0-governance
 - original_path: doc/user-guides/COLOR.md
-  target_path: null
+  target_path: docs/zh_CN/ui/colors.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: ui-colors
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-user-guides-color
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: ui-colors
+  domain: ui
+  priority: P2
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: mixed
+  upstream_relation: upstream_derived_revalidate
   merge_target: null
   source_paths:
   - doc/user-guides/COLOR.md
-  source_symbols: []
+  - data/raw/colors.json
+  - data/raw/color_templates/default.json
+  - src/color.cpp
+  - tests/light_color_test.cpp
+  source_symbols:
+  - color_manager::load_default
+  - color_manager::load_custom
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Color configuration and themes are active; verify names, fallbacks, and examples against loaders and
+    current data.
+  migration_batch: phase-2-ui
 - original_path: doc/user-guides/FONT_OPTIONS.md
-  target_path: null
+  target_path: docs/zh_CN/ui/fonts.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: ui-fonts
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-user-guides-font-options
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: ui-fonts
+  domain: ui
+  priority: P2
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: mixed
+  upstream_relation: upstream_derived_revalidate
   merge_target: null
   source_paths:
   - doc/user-guides/FONT_OPTIONS.md
-  source_symbols: []
+  - data/fontdata.json
+  - src/font_loader.cpp
+  - src/sdl_font.cpp
+  source_symbols:
+  - font_loader::load
+  - font_loader::save
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Font configuration remains active across SDL paths; rewrite platform-specific instructions from fontdata
+    and the current loader.
+  migration_batch: phase-2-ui
 - original_path: lang/notes/README_all_translators.md
-  target_path: null
+  target_path: docs/zh_CN/localization/translation-guide.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: merge_into
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: translation-guide
+  migration_status: classified
   history_strategy: evaluate_filtered_history
   stable_document_id: legacy.lang-notes-readme-all-translators
-  domain: translation
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
-  merge_target: null
+  domain: localization
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: mixed
+  upstream_relation: upstream_derived_revalidate
+  merge_target: translation-guide
   source_paths:
   - lang/notes/README_all_translators.md
+  - lang/Makefile
+  - lang/update_pot.sh
+  - .github/workflows/build-translations.yml
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - General translator notes duplicate the main translation guide and contain inherited workflow assumptions;
+    merge only verified content.
+  migration_batch: phase-1-localization
 - original_path: lang/notes/ru-notes.md
-  target_path: null
+  target_path: lang/notes/ru-notes.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.lang-notes-ru-notes
-  domain: translation
+  migration_status: classified
+  history_strategy: keep_in_repo
+  stable_document_id: translation-notes-ru
+  domain: localization
   priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_derived
+  upstream_relation: language_team_operational_note
   merge_target: null
   source_paths:
   - lang/notes/ru-notes.md
+  - lang/Makefile
   source_symbols: []
-  translation_required: true
-  include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  translation_required: false
+  include_in_ai_index: false
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - This is language-team-specific operational context best kept beside translation sources, not promoted
+    into bilingual site navigation or AI search.
+  migration_batch: phase-3-localization
 - original_path: src/lua/LICENSE.md
   target_path: src/lua/LICENSE.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
@@ -5627,34 +5737,35 @@ documents:
   - Retained in place under its file-specific third-party license.
   migration_batch: null
 - original_path: src/lua/README.md
-  target_path: null
+  target_path: src/lua/README.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - LYHGLYTX
   contributor_anomaly_count: 0
   license: CC-BY-SA-3.0
-  action: review
+  action: retain_third_party
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.src-lua-readme
-  domain: lua
+  migration_status: classified
+  history_strategy: retain_in_place
+  stable_document_id: vendor-lua-runtime-provenance
+  domain: third-party
   priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: third_party
+  upstream_relation: vendored_provenance
   merge_target: null
   source_paths:
   - src/lua/README.md
+  - src/lua/CMakeLists.txt
   source_symbols: []
-  translation_required: true
-  include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  translation_required: false
+  include_in_ai_index: false
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - This is Lua 5.4.8 vendored-source provenance and belongs beside the third-party runtime; it is not
+    CCB API documentation.
+  migration_batch: phase-3-third-party
 - original_path: src/third-party/snmalloc/README.md
   target_path: src/third-party/snmalloc/README.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
@@ -5796,60 +5907,67 @@ documents:
   - Retained in place under its file-specific third-party license.
   migration_batch: null
 - original_path: tools/llama/README.md
-  target_path: null
+  target_path: tools/llama/README.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.tools-llama-readme
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  migration_status: classified
+  history_strategy: keep_in_repo
+  stable_document_id: tool-llama-build-acceleration
+  domain: tooling
+  priority: P2
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: mixed
+  upstream_relation: upstream_tool_retained_locally
   merge_target: null
   source_paths:
   - tools/llama/README.md
+  - tools/llama/clang_tidy.sh
+  - tools/llama/gcc-focal/Dockerfile
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - The helper scripts still exist, so keep their operational README near the tool; refresh stale CDDA/SDL2
+    wording before marking it verified.
+  migration_batch: phase-2-tooling
 - original_path: tools/lua_api/README.md
-  target_path: null
+  target_path: tools/lua_api/README.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - LYHGLYTX
   contributor_anomaly_count: 0
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.tools-lua-api-readme
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  migration_status: classified
+  history_strategy: keep_in_repo
+  stable_document_id: tool-lua-api-coverage
+  domain: lua
+  priority: P0
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: ccb_specific
+  upstream_relation: ccb_specific_tooling
   merge_target: null
   source_paths:
   - tools/lua_api/README.md
+  - tools/lua_api/check_ccb_inventory.py
+  - tools/lua_api/check_coverage.py
+  - tools/lua_api/check_luals_declarations.py
+  - data/lua/reference/ccb_native_inventory.json
+  - data/lua/types/ccb_api_v5.d.lua
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - This is current CCB operational contract/coverage tooling documentation and should stay beside the
+    scripts, with generated public reference published separately.
+  migration_batch: phase-0-lua

--- a/doc/migration/markdown-inventory.yml
+++ b/doc/migration/markdown-inventory.yml
@@ -5,19 +5,19 @@ document_count: 175
 scope: Tracked Markdown at source_commit, excluding dot-prefixed tool/config paths; filesystem caches
   are never traversed.
 classification_summary:
-  review: 89
+  review: 87
   actions:
     archive_public: 1
     generated_reference: 2
     keep_in_repo: 54
     merge_into: 4
-    migrate_preserve: 11
+    migrate_preserve: 13
     migrate_rewrite: 8
     retain_third_party: 6
-    review: 89
+    review: 87
   migration_statuses:
-    classified: 74
-    inventoried: 89
+    classified: 76
+    inventoried: 87
     verified: 12
 documents:
 - original_path: CODE_OF_CONDUCT.md
@@ -2756,60 +2756,76 @@ documents:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-item-craft-and-disassembly
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/recipes-and-disassembly/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.recipes-and-disassembly
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P0
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_synced
+  upstream_relation: inherited_then_synced
   merge_target: null
   source_paths:
-  - doc/JSON/ITEM_CRAFT_AND_DISASSEMBLY.md
-  source_symbols: []
+  - src/recipe.cpp
+  - src/recipe_dictionary.cpp
+  - data/json/recipes/armor/other.json
+  - data/json/uncraft/ammo/10mm.json
+  - tests/recipe_steps_test.cpp
+  source_symbols:
+  - recipe::load
+  - recipe_dictionary::load
+  - recipe_dictionary::load_uncraft
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 残留两个 CleverRaven PR/Issue 解释历史语义，应改为来源注释而非现行契约链接。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 681 行覆盖配方、步骤、继承、requirements、拆解三种方式；2026-06 对 charged/unattended step 继续同步，且 recipe_steps/uncraft
+    测试可验证。
+  migration_batch: phase-0-json
 - original_path: doc/JSON/ITEM_SPAWN.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/item-groups.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - dumb-kevin
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-item-spawn
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/item-groups/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.item-groups
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P0
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_synced
+  upstream_relation: inherited_then_synced
   merge_target: null
   source_paths:
-  - doc/JSON/ITEM_SPAWN.md
-  source_symbols: []
+  - src/item_factory.cpp
+  - src/item_group.cpp
+  - data/json/itemgroups/Food/food.json
+  - tests/item_group_test.cpp
+  - tests/item_spawn_test.cpp
+  source_symbols:
+  - Item_factory::load_item_group
+  - item_group::load_item_group
+  - Item_spawn_data::relic_generator::load
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - SUS 示例链接指向 CleverRaven；迁移时改为 CCB 固定 commit 或本地样例。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 360 行解释 collection/distribution、entries、弹药/弹匣、嵌套组和测试；2026-04 已更新 multi-well 规则，现有 item_group 与 spawn
+    tests 覆盖核心行为。
+  migration_batch: phase-0-json
 - original_path: doc/JSON/JSON_FLAGS.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/generated/flags.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - LunaGlaze

--- a/doc/migration/markdown-inventory.yml
+++ b/doc/migration/markdown-inventory.yml
@@ -5,19 +5,19 @@ document_count: 175
 scope: Tracked Markdown at source_commit, excluding dot-prefixed tool/config paths; filesystem caches
   are never traversed.
 classification_summary:
-  review: 95
+  review: 90
   actions:
     archive_public: 1
     generated_reference: 2
     keep_in_repo: 54
     merge_into: 4
-    migrate_preserve: 6
-    migrate_rewrite: 7
+    migrate_preserve: 10
+    migrate_rewrite: 8
     retain_third_party: 6
-    review: 95
+    review: 90
   migration_statuses:
-    classified: 68
-    inventoried: 95
+    classified: 73
+    inventoried: 90
     verified: 12
 documents:
 - original_path: CODE_OF_CONDUCT.md
@@ -2542,146 +2542,168 @@ documents:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-examine
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/examine-actions/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.examine-actions
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: ccb_extended
+  upstream_relation: forked_and_locally_extended
   merge_target: null
   source_paths:
-  - doc/JSON/EXAMINE.md
-  source_symbols: []
+  - src/iexamine.cpp
+  - src/iexamine_actors.cpp
+  - src/mapdata.cpp
+  - tests/iexamine_test.cpp
+  source_symbols:
+  - iexamine_functions_from_string
+  - appliance_convert_examine_actor::load
+  - cardreader_examine_actor::load
+  - eoc_examine_actor::load
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 301 行同时记录硬编码 examine_action 和四类 examine actor；2026-07 增加数组动作与 CCB fertilize_terrain 文档，且当前 mapdata/actor
+    loader 可核验。
+  migration_batch: phase-1-json
 - original_path: doc/JSON/FACTIONS.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/npc-factions.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-factions
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/npc-factions/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.npc-factions
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_inherited
+  upstream_relation: inherited_contract_with_tests
   merge_target: null
   source_paths:
-  - doc/JSON/FACTIONS.md
-  source_symbols: []
+  - src/faction.cpp
+  - src/faction.h
+  - data/json/npcs/factions.json
+  - tests/faction_price_rules_test.cpp
+  source_symbols:
+  - faction_template::load
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 115 行覆盖 faction 字段、数值尺度、价格规则与非对称关系；当前 faction_template loader、核心数据和价格规则测试均存在。
+  migration_batch: phase-1-json
 - original_path: doc/JSON/FACTION_MISSIONS.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/faction-missions.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-faction-missions
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/faction-missions/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.faction-missions
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P2
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_inherited
+  upstream_relation: inherited_partial_json_contract
   merge_target: null
   source_paths:
-  - doc/JSON/FACTION_MISSIONS.md
-  source_symbols: []
+  - src/faction_mission.cpp
+  - src/faction_camp.cpp
+  - data/json/faction_missions.json
+  - tests/faction_camp_test.cpp
+  source_symbols:
+  - faction_mission::load
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 正文明确说明任务仍大多硬编码；页面必须区分 JSON 描述字段与 C++ 行为，不能暗示完全数据驱动。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 49 行是紧凑 faction_mission 字段表和示例；当前 loader/data 存在，但实际任务执行仍集中在 faction_camp.cpp。
+  migration_batch: phase-2-json
 - original_path: doc/JSON/GUIDE_COMESTIBLES.md
-  target_path: null
+  target_path: docs/zh_CN/how-to/json/comestibles.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-guide-comestibles
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/how-to/json/comestibles/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.comestibles-placement
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P2
+  last_applicable_commit: b1ee97987589450da70f30ee2feed12c9d18f479
+  ccb_specificity: upstream_inherited
+  upstream_relation: inherited_directory_convention
   merge_target: null
   source_paths:
-  - doc/JSON/GUIDE_COMESTIBLES.md
-  source_symbols: []
+  - src/item_factory.cpp
+  - data/json/items/comestibles/other.json
+  - data/json/items/comestibles/meat_dishes.json
+  - tests/comestible_test.cpp
+  source_symbols:
+  - islot_comestible::deserialize
+  - itype::load
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 正文列出的 meat_dishes_human.json 当前不存在；目录路由是约定而非 JSON 契约，需从 Git index 生成或测试。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 67 行仅说明食物应放入哪个文件，技术字段很少；大部分目录仍在，但至少一个文件名已漂移，适合改写为经 Git 跟踪列表验证的操作指南。
+  migration_batch: phase-2-json
 - original_path: doc/JSON/HELP_MENU.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/help-menu.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-help-menu
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/help-menu/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.help-menu
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P2
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_inherited
+  upstream_relation: inherited_contract_with_core_data
   merge_target: null
   source_paths:
-  - doc/JSON/HELP_MENU.md
-  source_symbols: []
+  - src/help.cpp
+  - src/help.h
+  - data/core/help.json
+  source_symbols:
+  - help::load
+  - help::load_object
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 41 行完整说明 help 类型、排序、颜色/键位/特殊标签和示例；当前 help loader 与 data/core/help.json 直接对应。
+  migration_batch: phase-2-json
 - original_path: doc/JSON/ITEM.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/items/index.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - LunaGlaze

--- a/doc/migration/markdown-inventory.yml
+++ b/doc/migration/markdown-inventory.yml
@@ -5,17 +5,19 @@ document_count: 175
 scope: Tracked Markdown at source_commit, excluding dot-prefixed tool/config paths; filesystem caches
   are never traversed.
 classification_summary:
-  review: 129
+  review: 98
   actions:
-    generated_reference: 1
-    keep_in_repo: 35
-    merge_into: 2
-    migrate_rewrite: 2
+    archive_public: 1
+    generated_reference: 2
+    keep_in_repo: 54
+    merge_into: 4
+    migrate_preserve: 3
+    migrate_rewrite: 7
     retain_third_party: 6
-    review: 129
+    review: 98
   migration_statuses:
-    classified: 34
-    inventoried: 129
+    classified: 65
+    inventoried: 98
     verified: 12
 documents:
 - original_path: CODE_OF_CONDUCT.md
@@ -1374,906 +1376,1052 @@ documents:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-aftershock-exoplanet-doc-lore-organizations
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.aftershock-exoplanet.lore.organizations
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P2
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/aftershock_exoplanet/doc/lore/organizations.md
+  - data/mods/aftershock_exoplanet/modinfo.json
+  - data/mods/aftershock_exoplanet/npcs/factions.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The organization catalogue is the fuller lore source for UICA, TsKBEM, PrepNet, and corporations and
+    should absorb the smaller cyberpunk_future fragment.
+  migration_batch: phase-2-mods
 - original_path: data/mods/aftershock_exoplanet/doc/lore/points_of_interest.md
-  target_path: null
+  target_path: data/mods/aftershock_exoplanet/doc/lore/points_of_interest.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-aftershock-exoplanet-doc-lore-points-of-interest
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.aftershock-exoplanet.lore.points-of-interest
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P2
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/aftershock_exoplanet/doc/lore/points_of_interest.md
+  - data/mods/aftershock_exoplanet/modinfo.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The implemented/planned POI distinctions are source-adjacent world-design context; unimplemented suggestions
+    are clearly phrased as candidates.
+  migration_batch: phase-2-mods
 - original_path: data/mods/aftershock_exoplanet/doc/lore/ranged_weapon_balance.md
-  target_path: null
+  target_path: docs/zh_CN/data/mods/aftershock_exoplanet/doc/lore/ranged_weapon_balance.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - Mihály Verhás
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: generated_reference
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-aftershock-exoplanet-doc-lore-ranged-weapon-balance
+  migration_status: classified
+  history_strategy: retain_path_and_generate_weapon_tables_from_json
+  stable_document_id: mods.aftershock-exoplanet.balance.ranged-weapons
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: null
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/aftershock_exoplanet/doc/lore/ranged_weapon_balance.md
+  - data/mods/aftershock_exoplanet/modinfo.json
+  - data/mods/aftershock_exoplanet/items/weapons.json
+  - data/mods/aftershock_exoplanet/itemgroups/weapons/energy_gun_groups.json
+  - data/mods/aftershock_exoplanet/itemgroups/weapons/balistic_gun_groups.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - Split hand-authored balance policy from generated weapon/armor tables and add parity tests before
+    declaring completeness.
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The prose contains useful balance policy, but its claim to list every ranged weapon and all numeric
+    stats is a manual mirror of loaded JSON and must become generator-owned.
+  migration_batch: phase-1-mods
 - original_path: data/mods/aftershock_exoplanet/doc/lore/salus_4.md
-  target_path: null
+  target_path: data/mods/aftershock_exoplanet/doc/lore/salus_4.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-aftershock-exoplanet-doc-lore-salus-4
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.aftershock-exoplanet.lore.salus-iv
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P2
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/aftershock_exoplanet/doc/lore/salus_4.md
+  - data/mods/aftershock_exoplanet/modinfo.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The concise Salus IV setting remains canonical source-adjacent worldbuilding for the active exoplanet
+    total conversion.
+  migration_batch: phase-2-mods
 - original_path: data/mods/aftershock_exoplanet/doc/lore/timeline.md
-  target_path: null
+  target_path: data/mods/aftershock_exoplanet/doc/lore/timeline.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - Mihály Verhás
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-aftershock-exoplanet-doc-lore-timeline
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.aftershock-exoplanet.lore.timeline
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P2
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/aftershock_exoplanet/doc/lore/timeline.md
+  - data/mods/aftershock_exoplanet/modinfo.json
+  - data/mods/aftershock_exoplanet/doc/lore/organizations.md
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The timeline supplies chronology referenced by the active setting and organization documents and remains
+    local narrative design context.
+  migration_batch: phase-2-mods
 - original_path: data/mods/aftershock_exoplanet/doc/suit_operating_time.md
-  target_path: null
+  target_path: data/mods/aftershock_exoplanet/doc/suit_operating_time.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-aftershock-exoplanet-doc-suit-operating-time
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.aftershock-exoplanet.balance.powered-armor
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/aftershock_exoplanet/doc/suit_operating_time.md
+  - data/mods/aftershock_exoplanet/modinfo.json
+  - data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_frame.json
+  - data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_modules.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - Add a validator for the 277777.78/hour calculation and verify the example against current item JSON.
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The operating-time formula is active mod balance policy and its exosuit sources still use battery/power-draw
+    data, but the worked Magellan snapshot needs automated validation.
+  migration_batch: phase-1-mods
 - original_path: data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_guide.md
-  target_path: null
+  target_path: data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_guide.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-aftershock-exoplanet-items-armor-exosuit-exosuit-guide
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.aftershock-exoplanet.exosuit-guide
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_guide.md
+  - data/mods/aftershock_exoplanet/modinfo.json
+  - data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_frame.json
+  - data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_modules.json
+  - data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_storage.json
+  - data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_ranged.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - Module capacities and item stats are hand-maintained tables and should be validated or generated.
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The frame, module, storage, and weapon families described by the guide remain active JSON and the
+    guide belongs beside those definitions.
+  migration_batch: phase-1-mods
 - original_path: data/mods/alt_map_key/README.md
-  target_path: null
+  target_path: data/mods/alt_map_key/README.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-alt-map-key-readme
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.alternative-map-key.overview
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P2
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/alt_map_key/README.md
+  - data/mods/alt_map_key/modinfo.json
+  - data/mods/alt_map_key/overmap_terrain_blue.json
+  - data/mods/alt_map_key/overmap_terrain_terrain.json
+  - data/mods/alt_map_key/mod_interactions/xedra_evolved/overmap_terrain.json
   source_symbols: []
-  translation_required: true
-  include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  translation_required: false
+  include_in_ai_index: false
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The active mod still implements the documented color/category replacement through core and interaction
+    overmap-terrain JSON.
+  migration_batch: phase-2-mods
 - original_path: data/mods/classic_zombies/design-doc.md
-  target_path: null
+  target_path: data/mods/classic_zombies/design-doc.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-classic-zombies-design-doc
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.classic-zombies.design
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/classic_zombies/design-doc.md
+  - data/mods/classic_zombies/modinfo.json
+  - data/mods/classic_zombies/monsters/zombies.json
+  - data/mods/classic_zombies/monsters/weakpoints.json
+  - data/mods/classic_zombies/monstergroups/classic_upgrades.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The Alberta/Romero conversion's active MOD_INFO and zombie adjustment data implement its central design,
+    while future tense sections remain proposals.
+  migration_batch: phase-1-mods
 - original_path: data/mods/classic_zombies/place_names.md
-  target_path: null
+  target_path: data/mods/classic_zombies/place_names.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-classic-zombies-place-names
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.classic-zombies.place-names
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P2
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/classic_zombies/place_names.md
+  - data/mods/classic_zombies/modinfo.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - Clarify whether the name list is an authoring source or historical draft; it currently has no loaded
+    JSON consumer.
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - This is a source list of Alberta city/world names stored as JSON-shaped design data but not loaded
+    due to its Markdown extension; retain it beside the total conversion until a loader/generator explicitly
+    owns it.
+  migration_batch: phase-2-mods
 - original_path: data/mods/hunvre/documentation/lore.md
-  target_path: null
+  target_path: data/mods/hunvre/documentation/lore.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - BalthazarArgall
   contributor_anomaly_count: 0
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-hunvre-documentation-lore
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.hunvre.lore
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/hunvre/documentation/lore.md
+  - data/mods/hunvre/modinfo.json
+  - data/mods/hunvre/json/monsters/euzhvil_monsters.json
+  - data/mods/hunvre/json/monster_special_attacks/euzhvil_attacks.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The Midas/Dreamer/euzhvil design is reflected in the active total-conversion MOD_INFO and loaded euzhvil
+    monster/attack data.
+  migration_batch: phase-1-mods
 - original_path: data/mods/hunvre/progress_tracker.md
-  target_path: null
+  target_path: data/mods/hunvre/progress_tracker.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - BalthazarArgall
   contributor_anomaly_count: 0
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-hunvre-progress-tracker
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.hunvre.progress
   domain: mods
   priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/hunvre/progress_tracker.md
+  - data/mods/hunvre/modinfo.json
+  - data/mods/hunvre/json/mod_settings/region_settings/regional_map_settings.json
   source_symbols: []
-  translation_required: true
-  include_in_ai_index: true
+  translation_required: false
+  include_in_ai_index: false
   blockers:
-  - Full-text source review is pending.
+  - Any surfaced status must be checked against tracked Hunvre data because the file explicitly may be
+    stale.
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The tracker explicitly disclaims synchronization and coercive authority; retain it as local planning
+    context, never as a runtime or roadmap contract.
+  migration_batch: phase-3-mods
 - original_path: data/mods/immortal_path/GLOSSARY.md
-  target_path: null
+  target_path: data/mods/immortal_path/GLOSSARY.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - Asthmatic123
   - EliadOArias
   contributor_anomaly_count: 0
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-immortal-path-glossary
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.immortal-path.glossary
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P0
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: ccb_specific
+  upstream_relation: ccb_only_bundled_mod_contract
   merge_target: null
   source_paths:
   - data/mods/immortal_path/GLOSSARY.md
+  - data/mods/immortal_path/LANGUAGE_CONVENTION.md
+  - data/mods/immortal_path/modinfo.json
+  - data/mods/immortal_path/magic/meditation.json
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - This CCB-specific bilingual glossary explicitly owns mod terminology and its terms are used by live
+    Chinese values and en_US comment pairs.
+  migration_batch: phase-0-mods
 - original_path: data/mods/immortal_path/LANGUAGE_CONVENTION.md
-  target_path: null
+  target_path: data/mods/immortal_path/LANGUAGE_CONVENTION.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - EliadOArias
   - LYHGLYTX
   contributor_anomaly_count: 0
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-immortal-path-language-convention
-  domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.immortal-path.language-convention
+  domain: translation
+  priority: P0
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: ccb_specific
+  upstream_relation: ccb_only_temporary_translation_contract
   merge_target: null
   source_paths:
   - data/mods/immortal_path/LANGUAGE_CONVENTION.md
+  - data/mods/immortal_path/GLOSSARY.md
+  - data/mods/immortal_path/modinfo.json
+  - data/mods/immortal_path/magic/meditation.json
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - When formal i18n is wired for the mod, this page must drive a scripted migration and then be superseded
+    rather than silently left active.
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The temporary Chinese-live/en_US-comment convention is implemented throughout current mod JSON and
+    remains an explicit CCB-specific source contract until formal i18n migration occurs.
+  migration_batch: phase-0-translation
 - original_path: data/mods/immortal_path/doc/game-design.md
-  target_path: null
+  target_path: data/mods/immortal_path/doc/game-design.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - EliadOArias
   contributor_anomaly_count: 0
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-immortal-path-doc-game-design
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.immortal-path.game-design
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: ccb_specific
+  upstream_relation: ccb_only_bundled_mod_design
   merge_target: null
   source_paths:
   - data/mods/immortal_path/doc/game-design.md
+  - data/mods/immortal_path/modinfo.json
+  - data/mods/immortal_path/jmath/qi_formulas.json
+  - data/mods/immortal_path/magic/meditation.json
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The qi_max/qi_power/polarization and conflicting-phase formulas in the design page are present in
+    current jmath and meditation EOCs.
+  migration_batch: phase-1-mods
 - original_path: data/mods/immortal_path/doc/lore.md
-  target_path: null
+  target_path: data/mods/immortal_path/doc/lore.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - EliadOArias
   contributor_anomaly_count: 0
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-immortal-path-doc-lore
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.immortal-path.lore
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P2
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: ccb_specific
+  upstream_relation: ccb_only_bundled_mod_lore
   merge_target: null
   source_paths:
   - data/mods/immortal_path/doc/lore.md
+  - data/mods/immortal_path/modinfo.json
+  - data/mods/immortal_path/GLOSSARY.md
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - An English counterpart is required if this becomes an active CCB-Docs page; keeping it in-repo does
+    not make it a translated site page.
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The Chinese cultivation setting is core source-adjacent narrative design for the CCB-specific total
+    conversion.
+  migration_batch: phase-2-mods
 - original_path: data/mods/immortal_path/doc/spell-design.md
-  target_path: null
+  target_path: data/mods/immortal_path/doc/spell-design.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - EliadOArias
   contributor_anomaly_count: 0
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-immortal-path-doc-spell-design
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.immortal-path.spell-design
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: ccb_specific
+  upstream_relation: ccb_only_bundled_mod_design
   merge_target: null
   source_paths:
   - data/mods/immortal_path/doc/spell-design.md
+  - data/mods/immortal_path/modinfo.json
+  - data/mods/immortal_path/jmath/qi_formulas.json
+  - data/mods/immortal_path/magic/arts_attack.json
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The documented power formula is directly realized by current fire/water art JSON and the shared qi_power/polarization
+    jmath functions.
+  migration_batch: phase-1-mods
 - original_path: data/mods/innawood/readme.md
-  target_path: null
+  target_path: data/mods/innawood/readme.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-innawood-readme
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.innawood.overview
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P2
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/innawood/readme.md
+  - data/mods/innawood/modinfo.json
+  - data/mods/innawood/overmap/overmap_terrain.json
+  - data/mods/innawood/overmap/specials_kept.json
+  - data/mods/innawood/monsters/mon_blacklist.json
   source_symbols: []
-  translation_required: true
-  include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  translation_required: false
+  include_in_ai_index: false
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The active total conversion still removes conventional world content and supplies wilderness progression
+    through overmap, blacklist, and recipe data.
+  migration_batch: phase-2-mods
 - original_path: data/mods/translate-dialogue/README.md
-  target_path: null
+  target_path: data/mods/translate-dialogue/README.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-translate-dialogue-readme
-  domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.translate-dialogue.maintenance
+  domain: translation
+  priority: P1
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/translate-dialogue/README.md
+  - data/mods/translate-dialogue/modinfo.json
+  - tools/json_tools/update-translate-dialogue-mod.py
+  - doc/JSON/JSON_STYLE.md
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - Rewrite the generic Cataclysm-DDA path wording for CCB and validate the formatter command against
+    the current repository toolchain.
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The named updater and compact marker remain implemented, so this is an active maintenance instruction
+    beside the generated/derived mod.
+  migration_batch: phase-1-translation
 - original_path: doc/ASCII_ART.md
-  target_path: null
+  target_path: docs/zh_CN/content/ascii-art.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-ascii-art
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/content/ascii-art/
+  migration_status: classified
+  history_strategy: evaluate_filtered_history_then_preserve_source_url
+  stable_document_id: content.ascii-art
+  domain: ui
+  priority: P2
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - doc/ASCII_ART.md
-  source_symbols: []
+  - src/ascii_art.cpp
+  - src/ascii_art.h
+  - src/init.cpp
+  - data/json/ascii_art/generic_ascii.json
+  - data/json/bodypart_graphs/arms.json
+  source_symbols:
+  - ascii_art::load_ascii_art
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - Validate REXPaint version, palette/font links, width limits, and export examples; remove doctoc and
+    retain a permanent bilingual moved stub.
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The JSON type, loader, and target directories remain live, but the inherited guide carries obsolete
+    doctoc boilerplate and external-tool snapshots and should be rewritten as a validated bilingual how-to.
+  migration_batch: phase-2-ui
 - original_path: doc/CHANGELOG_GUIDELINES.md
-  target_path: null
+  target_path: doc/CHANGELOG_GUIDELINES.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-changelog-guidelines
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: contributing.changelog-guidelines
+  domain: release
+  priority: P1
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_but_ccb_active_release_contract
   merge_target: null
   source_paths:
   - doc/CHANGELOG_GUIDELINES.md
+  - .github/pull_request_template.md
+  - tools/generate_changelog.py
+  - .github/workflows/weekly-changelog.yml
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - This is still linked directly by the CCB PR template and its categories are parsed by tools/generate_changelog.py
+    and used by the weekly changelog workflow, so it must remain in-repository authority-adjacent guidance.
+  migration_batch: phase-1-release
 - original_path: doc/DEVELOPER_FAQ.md
-  target_path: null
+  target_path: docs/zh_CN/how-to/common-tasks.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: merge_into
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-developer-faq
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
-  merge_target: null
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/how-to/common-tasks/
+  migration_status: classified
+  history_strategy: merge_attribution_and_source_history
+  stable_document_id: contributing.developer-faq
+  domain: architecture
+  priority: P1
+  last_applicable_commit: b1ee97987589450da70f30ee2feed12c9d18f479
+  ccb_specificity: upstream_inherited
+  upstream_relation: inherited_unmodified
+  merge_target: how-to.common-tasks
   source_paths:
-  - doc/DEVELOPER_FAQ.md
-  source_symbols: []
+  - src/monstergenerator.cpp
+  - src/overmap_terrain.cpp
+  - src/item_factory.cpp
+  - src/item_armor.cpp
+  - tests/monster_test.cpp
+  source_symbols:
+  - MonsterGenerator::load_monster
+  - overmap_terrains::load
+  - itype::load
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 文中的 NUM_OMSPECS、player::activate_bionic 和 monattack::function 在当前已跟踪源码中均不存在，不能原样发布。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 全文混合怪物、旧式硬编码 mapgen、仿生、护甲和 iuse FAQ；当前注册点已迁到 monstergenerator、overmap JSON 和 item loader，适合拆入按任务组织的页面而非保留杂项
+    FAQ。
+  migration_batch: phase-1-architecture
 - original_path: doc/FREQUENTLY_MADE_SUGGESTIONS.md
-  target_path: null
+  target_path: docs/zh_CN/design/frequently-made-suggestions.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - LunaGlaze
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-frequently-made-suggestions
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/design/frequently-made-suggestions/
+  migration_status: classified
+  history_strategy: filtered_path_history_candidate
+  stable_document_id: design.frequently-made-suggestions
+  domain: design
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: ccb_customized
+  upstream_relation: forked_and_locally_revised
   merge_target: null
   source_paths:
   - doc/FREQUENTLY_MADE_SUGGESTIONS.md
+  - GOVERNANCE.md
+  - README.md
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 仍含多个 CleverRaven/CDDA Issue 与 discourse 链接；正式发布前必须逐条确认 CCB 是否继续采用相同结论。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 499 行设计答复在 2026-07-28 经 LunaGlaze 三次提交专门删改“不符合本分叉”的内容，已具有 CCB 政策价值；但残留上游链接和时态判断要求按 CCB 当前设计重新表述。
+  migration_batch: phase-1-design
 - original_path: doc/GUN_NAMING_AND_INCLUSION.md
-  target_path: null
+  target_path: docs/zh_CN/content/firearms/naming-and-inclusion.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-gun-naming-and-inclusion
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/content/firearms/naming-and-inclusion/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: content.firearms-naming-and-inclusion
+  domain: design
+  priority: P2
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_inherited
+  upstream_relation: inherited_with_live_validator
   merge_target: null
   source_paths:
-  - doc/GUN_NAMING_AND_INCLUSION.md
-  source_symbols: []
+  - tools/json_tools/gun_variant_validator.py
+  - tools/json_tools/generic_guns_validator.py
+  - data/json/items/gun/9mm.json
+  source_symbols:
+  - guns_are_similar
+  - check_identifiers
+  - check_names
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 文中的阈值是快照；页面必须从验证脚本派生或明确以脚本为准，避免双重契约。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 全文的稀有度、差异阈值和命名规则仍对应已跟踪 gun_variant_validator.py；项目身份仍写 CDDA，且硬编码阈值可能随脚本变化，适合 CCB 双语重写。
+  migration_batch: phase-2-design
 - original_path: doc/HOWTO_MASSAGE_MA_GUN_DATA.md
-  target_path: null
+  target_path: docs/zh_CN/archive/firearms/massachusetts-data-workflow.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
-  archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-howto-massage-ma-gun-data
-  domain: legacy
+  action: archive_public
+  archive_reason: 全文是针对 2004–2023 马萨诸塞州 CSV 的一次性 sqlite/sed 清洗笔记，引用的 fix_serial_numbers.sql 与 remove_empty_entroes.sql
+    未被 Git 跟踪，也不是游戏构建或数据契约。
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/archive/firearms/massachusetts-data-workflow/
+  migration_status: classified
+  history_strategy: archive_snapshot_with_history_url
+  stable_document_id: archive.firearms-massachusetts-data-workflow
+  domain: historical
   priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  last_applicable_commit: b1ee97987589450da70f30ee2feed12c9d18f479
+  ccb_specificity: upstream_historical
+  upstream_relation: upstream_one_off_research_workflow
   merge_target: null
   source_paths:
   - doc/HOWTO_MASSAGE_MA_GUN_DATA.md
   source_symbols: []
-  translation_required: true
-  include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  translation_required: false
+  include_in_ai_index: false
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 全文是针对 2004–2023 马萨诸塞州 CSV 的一次性 sqlite/sed 清洗笔记，引用的 fix_serial_numbers.sql 与 remove_empty_entroes.sql
+    未被 Git 跟踪，也不是游戏构建或数据契约。
+  migration_batch: phase-3-historical
 - original_path: doc/HOW_YOU_CAN_HELP.md
-  target_path: null
+  target_path: docs/zh_CN/getting-started/first-contribution.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: merge_into
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-how-you-can-help
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
-  merge_target: null
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/getting-started/first-contribution/
+  migration_status: classified
+  history_strategy: merge_attribution_and_source_history
+  stable_document_id: getting-started.how-you-can-help
+  domain: governance
+  priority: P0
+  last_applicable_commit: b1ee97987589450da70f30ee2feed12c9d18f479
+  ccb_specificity: upstream_inherited
+  upstream_relation: inherited_but_links_upstream_project
+  merge_target: getting-started.first-contribution
   source_paths:
-  - doc/HOW_YOU_CAN_HELP.md
+  - CONTRIBUTING.md
+  - GOVERNANCE.md
+  - .github/ISSUE_TEMPLATE/bug_report.yml
+  - .github/ISSUE_TEMPLATE/feature_proposal.yml
+  - .github/pull_request_template.md
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 全文 84 个外部链接绝大多数指向 CleverRaven/CDDA labels、Wiki 和 Issue；不得直接搬迁。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 198 行贡献入口与标签表仍指向上游仓库和旧标签体系；其有用内容已由 CCB 的 CONTRIBUTING、Issue Forms、PR 模板及现有双语首次贡献页取代。
+  migration_batch: phase-0-governance
 - original_path: doc/IN_REPO_MODS.md
-  target_path: null
+  target_path: docs/zh_CN/mods/in-repository-policy.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-in-repo-mods
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/mods/in-repository-policy/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: mods.in-repository-policy
+  domain: mods
+  priority: P1
+  last_applicable_commit: b1ee97987589450da70f30ee2feed12c9d18f479
+  ccb_specificity: upstream_inherited
+  upstream_relation: inherited_policy_not_yet_ccb_ratified
   merge_target: null
   source_paths:
-  - doc/IN_REPO_MODS.md
-  source_symbols: []
+  - CONTRIBUTING.md
+  - GOVERNANCE.md
+  - data/mods/AGENTS.md
+  - src/mod_manager.cpp
+  - tools/load_all_mods.sh
+  source_symbols:
+  - mod_manager::load_modfile
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 全文反复指定 CleverRaven 仓库和 curator 合并权；CCB 必须先在 CONTRIBUTING/OWNERSHIP 中确认自己的 mod 责任模型。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 内容解释内置 Mod 的类别、维护责任、淘汰与 modmod 规则，技术上仍有价值；但它是上游治理文本，不能未经 CCB 治理确认就作为现行政策发布。
+  - Import-time source-symbol correction was verified against the tracked implementation.
+  migration_batch: phase-1-mods
 - original_path: doc/ISSUE_TRIAGE.md
-  target_path: null
+  target_path: docs/zh_CN/maintainers/issue-triage.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-issue-triage
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/maintainers/issue-triage/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: maintainers.issue-triage
+  domain: governance
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_inherited
+  upstream_relation: generic_upstream_process_requiring_ccb_mapping
   merge_target: null
   source_paths:
-  - doc/ISSUE_TRIAGE.md
+  - ISSUES.md
+  - GOVERNANCE.md
+  - .github/ISSUE_TEMPLATE/bug_report.yml
+  - .github/ISSUE_TEMPLATE/feature_proposal.yml
+  - .github/labeler.yml
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 优先级和标签名必须映射到最终 CCB Issue Forms/LABELS.md 后才能标为 active。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 全文的 bug/feature 判定、数据丢失优先级和可复现性要求仍合理，但没有绑定 CCB 实际 Issue Forms 与标签，因此应按新工作流重写。
+  migration_batch: phase-1-governance
 - original_path: doc/JSON/ARTIFACTS.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/artifacts.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-artifacts
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/artifacts/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.artifacts
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_inherited
+  upstream_relation: inherited_contract_with_current_sources
   merge_target: null
   source_paths:
-  - doc/JSON/ARTIFACTS.md
-  source_symbols: []
+  - src/relic.cpp
+  - src/relic.h
+  - data/json/artifact/relic_procgen_data.json
+  - data/json/artifact/premade_artifacts.json
+  source_symbols:
+  - relic_procgen_data::load
+  - relic_procgen_data::generation_rules::load
+  - relic_charge_template::load
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 没有专门 artifact 单元测试；字段参考必须以 loader 与已加载 JSON 校验补强。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 154 行完整覆盖生成权重、充能、被动/主动 procgen、强度与 resonance，当前 relic loader 和 artifact JSON 均存在；适合保留结构并补充生成校验。
+  migration_batch: phase-1-json
 - original_path: doc/JSON/BASECAMP.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/basecamp.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-basecamp
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/basecamp/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.basecamp
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_inherited
+  upstream_relation: inherited_contract_with_live_examples
   merge_target: null
   source_paths:
-  - doc/JSON/BASECAMP.md
-  source_symbols: []
+  - src/basecamp.cpp
+  - src/faction_camp.cpp
+  - src/recipe.cpp
+  - data/json/recipes/basecamps/components.json
+  - tests/faction_camp_test.cpp
+  source_symbols:
+  - basecamp::available_upgrades
+  - recipe::load
+  - basecamp::define_camp
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 364 行说明 blueprint requires/provides/excludes、mapgen_update、recipe groups 和模块化营地约定；当前 basecamp/faction_camp
+    实现、配方与测试仍对应这些概念。
+  migration_batch: phase-1-json
 - original_path: doc/JSON/CLIMBING.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/climbing-aids.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - Killa-bite
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-climbing
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/climbing-aids/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.climbing-aids
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P2
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: ccb_extended
+  upstream_relation: forked_and_locally_extended
   merge_target: null
   source_paths:
-  - doc/JSON/CLIMBING.md
-  source_symbols: []
+  - src/climbing.cpp
+  - src/climbing.h
+  - data/json/climbing.json
+  source_symbols:
+  - climbing_aid::load
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 缺少 climbing_aid 专项单元测试；示例需通过 JSON load。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 159 行逐字段解释 climbing_aid，2026-07-02 随 CCB airship gangway 功能更新；loader 和 data/json/climbing.json 当前存在。
+  migration_batch: phase-2-json
 - original_path: doc/JSON/DIMENSIONS.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/dimensions.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - LYHGLYTX

--- a/doc/migration/markdown-inventory.yml
+++ b/doc/migration/markdown-inventory.yml
@@ -5,19 +5,19 @@ document_count: 175
 scope: Tracked Markdown at source_commit, excluding dot-prefixed tool/config paths; filesystem caches
   are never traversed.
 classification_summary:
-  review: 96
+  review: 95
   actions:
     archive_public: 1
     generated_reference: 2
     keep_in_repo: 54
     merge_into: 4
-    migrate_preserve: 5
+    migrate_preserve: 6
     migrate_rewrite: 7
     retain_third_party: 6
-    review: 96
+    review: 95
   migration_statuses:
-    classified: 67
-    inventoried: 96
+    classified: 68
+    inventoried: 95
     verified: 12
 documents:
 - original_path: CODE_OF_CONDUCT.md
@@ -2504,30 +2504,37 @@ documents:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-effect-on-condition
-  domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/eoc/
+  migration_status: classified
+  history_strategy: filtered_path_history_candidate
+  stable_document_id: eoc.reference
+  domain: eoc
+  priority: P0
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: ccb_extended
+  upstream_relation: forked_and_locally_extended
   merge_target: null
   source_paths:
-  - doc/JSON/EFFECT_ON_CONDITION.md
-  source_symbols: []
+  - src/effect_on_condition.cpp
+  - src/condition.cpp
+  - src/npctalk.cpp
+  - data/json/effects_on_condition/example_eocs.json
+  - tests/npc_talk_test.cpp
+  source_symbols:
+  - effect_on_condition::load
+  - effect_on_conditions::load
+  - conditional_t::conditional_t
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 5,913 行手工条件/效果清单含 TODO 与 deprecated 项；必须拆分概念页和由注册表生成的 reference，并做 condition/effect parity。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 这是当前 EOC 主参考，覆盖 talkers、变量、条件、效果、math 和大量示例；2026-06/07 有 8 次导入后更新，包括 CCB 种植事件，必须保留 CCB 差异和作者历史。
+  migration_batch: phase-0-eoc
 - original_path: doc/JSON/EXAMINE.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/examine-actions.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - LunaGlaze

--- a/doc/migration/markdown-inventory.yml
+++ b/doc/migration/markdown-inventory.yml
@@ -5,19 +5,19 @@ document_count: 175
 scope: Tracked Markdown at source_commit, excluding dot-prefixed tool/config paths; filesystem caches
   are never traversed.
 classification_summary:
-  review: 78
+  review: 77
   actions:
     archive_public: 1
     generated_reference: 3
     keep_in_repo: 54
     merge_into: 6
-    migrate_preserve: 14
+    migrate_preserve: 15
     migrate_rewrite: 13
     retain_third_party: 6
-    review: 78
+    review: 77
   migration_statuses:
-    classified: 85
-    inventoried: 78
+    classified: 86
+    inventoried: 77
     verified: 12
 documents:
 - original_path: CODE_OF_CONDUCT.md
@@ -3165,30 +3165,38 @@ documents:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-magic
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/magic-spells-enchantments/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.magic-spells-enchantments
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: ccb_extended
+  upstream_relation: forked_and_locally_extended
   merge_target: null
   source_paths:
-  - doc/JSON/MAGIC.md
-  source_symbols: []
+  - src/magic.cpp
+  - src/magic_enchantment.cpp
+  - src/magic_type.cpp
+  - data/json/enchantments.json
+  - tests/magic_spell_test.cpp
+  source_symbols:
+  - spell_type::load
+  - enchantment::load
+  - magic_type::load
+  - spell_migration::load
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 1,149 行手工枚举 spell effects/flags/enchantment values；应与注册/loader 生成清单做 parity，保留人工解释。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 完整覆盖 spell、magic_type、enchantment 和实例，导入后加入 CCB FOCUS_REGEN 等更新；现有 magic tests 可验证关键示例。
+  migration_batch: phase-1-json
 - original_path: doc/JSON/MAPGEN.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/mapgen.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - dumb-kevin

--- a/doc/migration/markdown-inventory.yml
+++ b/doc/migration/markdown-inventory.yml
@@ -5,19 +5,19 @@ document_count: 175
 scope: Tracked Markdown at source_commit, excluding dot-prefixed tool/config paths; filesystem caches
   are never traversed.
 classification_summary:
-  review: 69
+  review: 33
   actions:
-    archive_public: 1
-    generated_reference: 3
+    archive_public: 3
+    generated_reference: 4
     keep_in_repo: 54
-    merge_into: 7
-    migrate_preserve: 22
-    migrate_rewrite: 13
+    merge_into: 12
+    migrate_preserve: 35
+    migrate_rewrite: 28
     retain_third_party: 6
-    review: 69
+    review: 33
   migration_statuses:
-    classified: 94
-    inventoried: 69
+    classified: 130
+    inventoried: 33
     verified: 12
 documents:
 - original_path: CODE_OF_CONDUCT.md
@@ -3495,383 +3495,465 @@ documents:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-npcs
-  domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/eoc/npcs-and-dialogue/
+  migration_status: classified
+  history_strategy: filtered_path_history_candidate
+  stable_document_id: json.npcs-dialogue
+  domain: eoc
+  priority: P0
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: ccb_extended
+  upstream_relation: forked_and_locally_extended
   merge_target: null
   source_paths:
-  - doc/JSON/NPCs.md
-  source_symbols: []
+  - src/npc.cpp
+  - src/npc_class.cpp
+  - src/npctalk.cpp
+  - data/json/npcs/missiondef.json
+  - tests/npc_talk_test.cpp
+  source_symbols:
+  - npc_template::load
+  - npc_class::load
+  - json_talk_topic::load
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 1,637 行含 NPC 定义、对话、条件、效果和 math 巨量内容；必须与 EOC registry 去重并保留 deprecated 标记。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 导入后 12 次更新，含 CCB NPC vehicle service 与 jmath 条件；当前 npctalk loader 和 npc tests 支持拆分成 NPC 配置与对话/EOC
+    页面。
+  migration_batch: phase-0-eoc
 - original_path: doc/JSON/OBSOLETION_AND_MIGRATION.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/obsoletion-and-migration.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-obsoletion-and-migration
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/obsoletion-and-migration/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.obsoletion-and-migration
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P0
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_inherited
+  upstream_relation: inherited_high_risk_compatibility_contract
   merge_target: null
   source_paths:
-  - doc/JSON/OBSOLETION_AND_MIGRATION.md
-  source_symbols: []
+  - src/item_factory.cpp
+  - src/effect.cpp
+  - src/savegame_json.cpp
+  - data/json/obsoletion_and_migration_0.J/migration_items.json
+  - data/json/obsoletion_and_migration_0.J/eocs.json
+  - src/init.cpp
+  - src/magic.cpp
+  - src/proficiency.cpp
+  source_symbols:
+  - effect_migration::load
+  - ter_furn_migrations::load
+  - spell_migration::load
+  - proficiency_migration::load
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 这是存档兼容高风险文档；每种 migration 类型必须由当前注册、save loader 和加载测试验证后才能 active。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 464 行覆盖 item/vehicle/effect/trait/proficiency/spell/terrain/OMT/EOC/activity/mod 等迁移，直接关系存档兼容，不能压缩成泛化说明。
+  - Import-time source-symbol correction was verified against the tracked implementation.
+  migration_batch: phase-0-json
 - original_path: doc/JSON/OPTIONS.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/options.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-options
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/options/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.options
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P2
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_inherited
+  upstream_relation: inherited_contract_with_tests
   merge_target: null
   source_paths:
-  - doc/JSON/OPTIONS.md
-  source_symbols: []
+  - src/options.cpp
+  - src/options.h
+  - data/core/external_options.json
+  - tests/options_test.cpp
+  source_symbols:
+  - options_manager::add_external
+  - options_manager::load
+  - options_manager::migrateOptionName
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 28 行准确区分 menu/external/world options 及 COPT_HIDE/stub 迁移技巧；当前 options 实现、external_options 数据和 tests
+    均存在。
+  migration_batch: phase-2-json
 - original_path: doc/JSON/OVERMAP.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/overmap.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - dumb-kevin
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-overmap
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/overmap/
+  migration_status: classified
+  history_strategy: filtered_path_history_candidate
+  stable_document_id: json.overmap
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P0
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_synced
+  upstream_relation: inherited_then_synced
   merge_target: null
   source_paths:
-  - doc/JSON/OVERMAP.md
-  source_symbols: []
+  - src/overmap_terrain.cpp
+  - src/overmap_special.cpp
+  - src/overmap_connection.cpp
+  - src/mapgen_post_process.cpp
+  - tests/overmap_test.cpp
+  source_symbols:
+  - overmap_terrains::load
+  - overmap_special::load
+  - overmap_connection::load
+  - pp_generator::load
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 迁移时应把 post-process generator 与 overmap special 的来源和测试保持同页关联。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 1,329 行覆盖 terrain/special/connection/location/city 与 mutable placement，导入后补充 post-process scope/persistence；tests/overmap_test.cpp
+    明确提供大量放置验证。
+  migration_batch: phase-0-json
 - original_path: doc/JSON/PRACTICE_RECIPES.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/practice-recipes.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-practice-recipes
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/practice-recipes/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.practice-recipes
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P2
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_inherited
+  upstream_relation: inherited_contract_with_tests
   merge_target: null
   source_paths:
-  - doc/JSON/PRACTICE_RECIPES.md
-  source_symbols: []
+  - src/recipe.cpp
+  - src/recipe_dictionary.cpp
+  - data/json/recipes/practice/computers.json
+  - tests/crafting_gui_test.cpp
+  source_symbols:
+  - recipe_dictionary::load_practice
+  - recipe::load
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 71 行说明 practice 与普通 recipe 的差异、practice_data 和标准 1h 示例；当前 loader、核心实践配方和 crafting GUI tests 对应。
+  migration_batch: phase-2-json
 - original_path: doc/JSON/PROFICIENCY.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/proficiencies.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-proficiency
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/proficiencies/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.proficiencies
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_inherited
+  upstream_relation: inherited_contract_with_current_sources
   merge_target: null
   source_paths:
-  - doc/JSON/PROFICIENCY.md
-  source_symbols: []
+  - src/proficiency.cpp
+  - src/proficiency.h
+  - data/json/proficiencies/misc.json
+  - tests/crafting_test.cpp
+  source_symbols:
+  - proficiency::load
+  - proficiency_category::load
+  - proficiency_migration::load
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 公式解释引用 CleverRaven PR；应把当前源码公式和测试作为来源。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 192 行解释 proficiency graph、类别、学习效果、penalty/bonus 字段；当前 loader 与大量 crafting 使用点存在。
+  migration_batch: phase-1-json
 - original_path: doc/JSON/PROFICIENCY_LIST.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/generated/proficiencies.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: generated_reference
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-proficiency-list
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/generated/proficiencies/
+  migration_status: classified
+  history_strategy: replace_manual_snapshot_with_generated_reference
+  stable_document_id: json.proficiencies-index
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: b1ee97987589450da70f30ee2feed12c9d18f479
+  ccb_specificity: upstream_inherited
+  upstream_relation: inherited_manual_snapshot
   merge_target: null
   source_paths:
-  - doc/JSON/PROFICIENCY_LIST.md
-  source_symbols: []
+  - src/proficiency.cpp
+  - data/json/proficiencies/misc.json
+  - data/json/proficiencies/proficiency_categories.json
+  - data/mods/Magiclysm/proficiencies.json
+  source_symbols:
+  - proficiency::load
+  - proficiency_category::load
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 122 行却有 41 KB 的手工表，导入后从未更新；必须从 core 与明确纳入的 Mod 数据生成，并标出来源范围。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 页面本质是 ID/name/parent/description 清单且含 Magiclysm 专节，没有解释性结构；这类内容应由 JSON registry 生成，手工快照不可靠。
+  migration_batch: phase-1-json
 - original_path: doc/JSON/REGION_LAYOUT.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/region-layout.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - LYHGLYTX
   - Anton Simakov
   contributor_anomaly_count: 0
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-region-layout
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/region-layout/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.region-layout
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: ccb_sync_policy_adjusted
+  upstream_relation: forked_synced_with_exclusion_note
   merge_target: null
   source_paths:
-  - doc/JSON/REGION_LAYOUT.md
-  source_symbols: []
+  - src/overmap_worldgen.cpp
+  - src/overmap_worldgen.h
+  - data/json/region_settings/region_settings/dimensions/dimension_regions.json
+  source_symbols:
+  - dimension_region_layout::load
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 文档只列 UNIFORM 动态模式；生成 reference 必须从 loader 明确标记支持范围，不能暗示 STATIC 已完整实现。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 29 行定义 dimension_region_layout、STATIC/DYNAMIC 概念和 UNIFORM 字段；2026-07 随 dimension-id 及 CCB sync exclusion
+    更新。
+  migration_batch: phase-1-json
 - original_path: doc/JSON/REGION_SETTINGS.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/region-settings.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-region-settings
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/region-settings/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.region-settings
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_inherited
+  upstream_relation: inherited_contract_with_test_data
   merge_target: null
   source_paths:
-  - doc/JSON/REGION_SETTINGS.md
-  source_symbols: []
+  - src/regional_settings.cpp
+  - src/regional_settings.h
+  - data/json/region_settings/region_settings/regional_map_settings.json
+  - data/json/region_settings/region_settings/test_regional_map_settings.json
+  source_symbols:
+  - region_settings::load
+  - region_settings_forest::load
+  - region_settings_city::load
+  - region_settings_map_extras::load
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 624 行字段表无专项 C++ test；应至少通过 test_regional_map_settings 的全量 JSON load 验证。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 完整覆盖地形、湖泊、森林、道路、城市、map extras、天气和 feature flags，当前 regional_settings loaders/data 对应。
+  migration_batch: phase-1-json
 - original_path: doc/JSON/TER_FURN_TRANSFORM.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/terrain-furniture-transforms.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-ter-furn-transform
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/terrain-furniture-transforms/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.terrain-furniture-transforms
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_inherited
+  upstream_relation: inherited_contract_with_multiple_consumers
   merge_target: null
   source_paths:
-  - doc/JSON/TER_FURN_TRANSFORM.md
-  source_symbols: []
+  - src/magic_ter_fur_transform.cpp
+  - src/magic_ter_furn_transform.h
+  - src/mapgen.cpp
+  - data/json/mapgen/haunting.json
+  source_symbols:
+  - ter_furn_transform::load
+  - ter_furn_data<T>::load
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 已选择核心 mapgen 实例作为示例；迁移时仍需用 JSON load 验证该实例。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 83 行解释 terrain/furniture/field/trap 的 ID、权重与 flag 转换，并链接 EOC/mapgen/spell 三种调用方；C++ loader 当前存在。
+  migration_batch: phase-1-json
 - original_path: doc/JSON/VEHICLES_JSON.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/vehicle-prototypes.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - LunaGlaze
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-vehicles-json
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/vehicle-prototypes/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.vehicle-prototypes
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: ccb_extended
+  upstream_relation: forked_and_locally_extended
   merge_target: null
   source_paths:
-  - doc/JSON/VEHICLES_JSON.md
-  source_symbols: []
+  - src/veh_type.cpp
+  - src/veh_type.h
+  - data/json/road_vehicles.json
+  - data/json/vehicleparts/vehicle_parts.json
+  - tests/vehicle_export_test.cpp
+  source_symbols:
+  - vehicle_prototype::load
+  - vehicles::parts::load
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 182 行覆盖 prototype part order、parts/items/zones、variants 与 debug export；2026-07 加入 CCB default_tint_color，vehicle
+    export test 可验证导出流程。
+  migration_batch: phase-1-json
 - original_path: doc/JSON/VITAMIN.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/vitamins.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - zihanZheng
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-vitamin
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/vitamins/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.vitamins
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: ccb_extended
+  upstream_relation: forked_and_locally_extended
   merge_target: null
   source_paths:
-  - doc/JSON/VITAMIN.md
-  source_symbols: []
+  - src/vitamin.cpp
+  - src/vitamin.h
+  - data/json/vitamin.json
+  - tests/vitamin_test.cpp
+  source_symbols:
+  - vitamin::load
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 204 行逐字段解释 vitamin/toxin/counter/drug、继承和 flags；2026-07 CCB 增加 copy-from、extend/delete、decays_into
+    语义，且有专项测试。
+  migration_batch: phase-1-json
 - original_path: doc/JSON/WEATHER_TYPE.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/weather-types.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - Anton Simakov
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-weather-type
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/weather-types/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.weather-types
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_synced
+  upstream_relation: inherited_then_synced
   merge_target: null
   source_paths:
-  - doc/JSON/WEATHER_TYPE.md
-  source_symbols: []
+  - src/weather_type.cpp
+  - src/weather_type.h
+  - src/weather_gen.cpp
+  - data/json/weather_type.json
+  - tests/weather_test.cpp
+  source_symbols:
+  - weather_type::load
+  - weather_types::load
+  - weather_generator::load
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 81 行字段表和完整天气示例，2026-07 随 temperature_modifier 实现更新；loader/data/weather tests 对应。
+  migration_batch: phase-1-json
 - original_path: doc/JSON/WOUNDS.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/wounds.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - Anton Simakov
@@ -3879,642 +3961,731 @@ documents:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-wounds
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/wounds/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: json.wounds
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_synced
+  upstream_relation: inherited_then_synced
   merge_target: null
   source_paths:
-  - doc/JSON/WOUNDS.md
-  source_symbols: []
+  - src/wound.cpp
+  - src/wound.h
+  - src/init.cpp
+  source_symbols:
+  - wound_type::load
+  - wound_fix::load
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - Git index 中未发现第一方 wound/wound_fix JSON 实例或专项测试；示例只能标记 schema-style，不能宣称已加载验证。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 54 行给出 wound 与 wound_fix 两个完整示例，2026-06 连续加入 limit、progression、limb score；类型已在 DynamicDataLoader 注册，但缺少第一方数据覆盖。
+  migration_batch: phase-1-json
 - original_path: doc/MANUAL_OF_STYLE.md
-  target_path: null
+  target_path: docs/zh_CN/contributing/in-game-text-style.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-manual-of-style
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/contributing/in-game-text-style/
+  migration_status: classified
+  history_strategy: preserve_source_commit_and_history_url
+  stable_document_id: content.manual-of-style
+  domain: translation
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: upstream_inherited
+  upstream_relation: inherited_style_policy_requiring_ccb_confirmation
   merge_target: null
   source_paths:
-  - doc/MANUAL_OF_STYLE.md
+  - CONTRIBUTING.md
+  - lang/notes/README_all_translators.md
+  - tools/check_translation_tags.py
+  - src/translations.cpp
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 链接 ../lang/notes 指向目录而非页面；双句空格、专名和方言规则应由 CCB 维护者在 CONTRIBUTING/治理来源中确认后发布。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 30 行是英文游戏文本与 NPC 对话风格规范，仍有贡献价值但属于规范性内容；需与翻译说明、提取器和 CCB 贡献政策对齐后双语发布。
+  migration_batch: phase-1-translation
 - original_path: doc/MODDING.md
-  target_path: null
+  target_path: docs/zh_CN/modding/overview.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - SpinosaurusBoat
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: modding-overview
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-modding
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: modding-overview
+  domain: mods
+  priority: P0
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: mixed
+  upstream_relation: upstream_derived_with_ccb_extensions
   merge_target: null
   source_paths:
   - doc/MODDING.md
-  source_symbols: []
+  - src/mod_manager.cpp
+  - src/init.cpp
+  - src/game_io.cpp
+  - build-scripts/get_all_mods.py
+  source_symbols:
+  - DynamicDataLoader::load_mod_interaction_files_from_path
+  - game::load_mod_interaction_data_from_dir
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - The mod loader and mod_interactions path are live in init/game I/O, while the inherited guide still
+    points at upstream CDDA processes.
+  - Rewrite against current CCB MOD_INFO fields and validate examples with the all-mod loader.
+  migration_batch: phase-0-mods
 - original_path: doc/MOD_COMPATIBILITY.md
-  target_path: null
+  target_path: docs/zh_CN/modding/compatibility.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: mod-compatibility
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-mod-compatibility
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: mod-compatibility
+  domain: mods
+  priority: P0
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: mixed
+  upstream_relation: upstream_derived_with_ccb_extensions
   merge_target: null
   source_paths:
   - doc/MOD_COMPATIBILITY.md
-  source_symbols: []
+  - src/mod_manager.cpp
+  - src/init.cpp
+  - build-scripts/get_all_mods.py
+  - data/mods/MindOverMatter/mod_interactions/innawood/recipes.json
+  source_symbols:
+  - DynamicDataLoader::load_mod_interaction_files_from_path
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Compatibility overlays remain implemented and have first-party examples, but the old document must
+    distinguish CCB behavior from inherited upstream assumptions.
+  migration_batch: phase-0-mods
 - original_path: doc/PLAYER_ACTIVITY.md
-  target_path: null
+  target_path: docs/zh_CN/cpp/activities.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - Antonín Drdácký
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: cpp-activities
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-player-activity
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: cpp-activities
+  domain: cpp
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: mixed
+  upstream_relation: upstream_derived_revalidate
   merge_target: null
   source_paths:
   - doc/PLAYER_ACTIVITY.md
-  source_symbols: []
+  - src/activity_actor.h
+  - src/activity_type.cpp
+  - data/json/player_activities.json
+  - tests/player_activities_test.cpp
+  source_symbols:
+  - activity_type::load
+  - activity_type::load_all
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Activity actors, JSON activity types, completion_eoc/do_turn_eoc fields, and tests are current; the
+    page should be rebuilt as a source-linked subsystem guide.
+  migration_batch: phase-1-cpp
 - original_path: doc/RELEASE_DIFF.md
-  target_path: null
+  target_path: docs/zh_CN/maintenance/releases.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: merge_into
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: release-maintenance
+  migration_status: classified
   history_strategy: evaluate_filtered_history
   stable_document_id: legacy.doc-release-diff
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
-  merge_target: null
+  domain: release
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: ccb_specific
+  upstream_relation: ccb_workflow_replaces_upstream_process
+  merge_target: release-maintenance
   source_paths:
   - doc/RELEASE_DIFF.md
+  - .github/workflows/release.yml
+  - build-scripts/generate-release-notes.js
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - The useful release-diff procedure belongs with the current CCB release workflow and generated release
+    notes rather than as a standalone inherited page.
+  migration_batch: phase-1-release
 - original_path: doc/RELEASE_PROCESS.md
-  target_path: null
+  target_path: docs/zh_CN/maintenance/releases.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: merge_into
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: release-maintenance
+  migration_status: classified
   history_strategy: evaluate_filtered_history
   stable_document_id: legacy.doc-release-process
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
-  merge_target: null
+  domain: release
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: ccb_specific
+  upstream_relation: ccb_workflow_replaces_upstream_process
+  merge_target: release-maintenance
   source_paths:
   - doc/RELEASE_PROCESS.md
+  - .github/workflows/release.yml
+  - .github/workflows/release-android-bundle.yaml
+  - build-scripts/generate-release-notes.js
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Release automation is CCB-specific and active, but this upstream-oriented process page duplicates
+    the release-diff material and must be reconciled with Actions.
+  migration_batch: phase-1-release
 - original_path: doc/SOUNDPACKS.md
-  target_path: null
+  target_path: docs/zh_CN/resources/soundpacks.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: soundpacks
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-soundpacks
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: soundpacks
+  domain: resources
+  priority: P2
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: mixed
+  upstream_relation: upstream_derived_revalidate
   merge_target: null
   source_paths:
   - doc/SOUNDPACKS.md
-  source_symbols: []
+  - src/sdlsound.cpp
+  - src/sdlsound.h
+  source_symbols:
+  - load_soundset
+  - sfx::load_sound_effects
+  - sfx::load_playlist
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - SDL soundpack loading remains active; static ID lists in the old guide should be generated or checked
+    against sdlsound.cpp instead of copied forward.
+  migration_batch: phase-2-resources
 - original_path: doc/TESTING_YOUR_CHANGES.md
-  target_path: null
+  target_path: docs/zh_CN/testing/manual-playtesting.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: merge_into
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: testing-manual
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-testing-your-changes
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
-  merge_target: null
+  stable_document_id: testing-manual
+  domain: testing
+  priority: P0
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: mixed
+  upstream_relation: upstream_derived_revalidate
+  merge_target: testing-manual
   source_paths:
   - doc/TESTING_YOUR_CHANGES.md
+  - tests/AGENTS.md
+  - Makefile
+  - CMakeLists.txt
+  - .github/workflows/matrix.yml
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Manual playtesting guidance is still useful but overlaps the test guide; merge it into a CCB test
+    matrix backed by current build and CI commands.
+  migration_batch: phase-0-testing
 - original_path: doc/TILESET.md
-  target_path: null
+  target_path: docs/zh_CN/resources/tilesets.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: tilesets
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-tileset
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: tilesets
+  domain: resources
+  priority: P2
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: mixed
+  upstream_relation: upstream_derived_revalidate
   merge_target: null
   source_paths:
   - doc/TILESET.md
+  - tools/gfx_tools/compose.py
+  - tools/gfx_tools/decompose.py
+  - .github/workflows/compose-tilesets.yml
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Compose/decompose tooling and CI are current, but the guide has upstream-only links and unfinished
+    platform sections; rewrite with commands exercised in CCB.
+  migration_batch: phase-2-resources
 - original_path: doc/TRANSLATING.md
-  target_path: null
+  target_path: docs/zh_CN/localization/translation-guide.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - LunaGlaze
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: translation-guide
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-translating
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: translation-guide
+  domain: localization
+  priority: P0
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: ccb_specific
+  upstream_relation: ccb_workflow_replaces_upstream_process
   merge_target: null
   source_paths:
   - doc/TRANSLATING.md
-  source_symbols: []
+  - lang/Makefile
+  - src/translations.cpp
+  - .github/workflows/build-translations.yml
+  - .github/workflows/push-translation-template.yml
+  - src/translation_manager.cpp
+  source_symbols:
+  - TranslationManager::LoadDocuments
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - CCB translation extraction/build workflows are active; the old page retains CDDA wording and inconsistent
+    POT filenames, so commands and service references need replacement.
+  - Import-time source-symbol correction was verified against the tracked implementation.
+  migration_batch: phase-0-localization
 - original_path: doc/TRANSLATING_MOD.md
-  target_path: null
+  target_path: docs/zh_CN/modding/localization.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: merge_into
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: mod-localization
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-translating-mod
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
-  merge_target: null
+  stable_document_id: mod-localization
+  domain: localization
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: mixed
+  upstream_relation: upstream_derived_revalidate
+  merge_target: mod-localization
   source_paths:
   - doc/TRANSLATING_MOD.md
+  - lang/extract_json_strings.py
+  - lang/string_extractor/parsers/mod_info.py
+  - src/translations.cpp
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Mod-specific extraction rules remain relevant but should be part of the mod documentation and verified
+    against the current extractor.
+  migration_batch: phase-1-localization
 - original_path: doc/USER_INTERFACE_AND_ACCESSIBILITY.md
-  target_path: null
+  target_path: docs/zh_CN/ui/accessibility.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: ui-accessibility
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-user-interface-and-accessibility
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: ui-accessibility
+  domain: ui
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: mixed
+  upstream_relation: upstream_derived_revalidate
   merge_target: null
   source_paths:
   - doc/USER_INTERFACE_AND_ACCESSIBILITY.md
-  source_symbols: []
+  - src/options.cpp
+  - src/newcharacter.cpp
+  - src/player_difficulty.cpp
+  source_symbols:
+  - SCREEN_READER_MODE
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Screen reader mode is registered and consumed in current CCB code; rewrite this conceptual guide with
+    tested UI entry points and known limits.
+  migration_batch: phase-1-ui
 - original_path: doc/WIDGETS.md
-  target_path: null
+  target_path: docs/zh_CN/json/widgets.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: json-widgets
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-widgets
-  domain: legacy
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: json-widgets
+  domain: json
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: mixed
+  upstream_relation: upstream_derived_revalidate
   merge_target: null
   source_paths:
   - doc/WIDGETS.md
-  source_symbols: []
+  - src/widget.cpp
+  - src/widget.h
+  - tests/widget_test.cpp
+  - data/json/ui/layout.json
+  source_symbols:
+  - widget::load_widget
+  - widget::load
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Widgets are implemented, loaded from data/json/ui, and extensively tested; regenerate or validate
+    variable/reference lists from source during the rewrite.
+  migration_batch: phase-1-json
 - original_path: doc/c++/CODE_STYLE.md
-  target_path: null
+  target_path: docs/zh_CN/cpp/code-style.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: cpp-code-style
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-c-code-style
+  stable_document_id: cpp-code-style
   domain: cpp
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P0
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: mixed
+  upstream_relation: upstream_derived_revalidate
   merge_target: null
   source_paths:
   - doc/c++/CODE_STYLE.md
+  - .astylerc
+  - .clang-tidy
+  - .github/workflows/astyle.yml
+  - tools/format/format.cpp
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Style policy must reflect the checked-in formatter/linter configuration and current CI, not inherited
+    prose alone.
+  migration_batch: phase-0-cpp
 - original_path: doc/c++/COMPILER_SUPPORT.md
-  target_path: null
+  target_path: docs/zh_CN/platforms/compiler-support.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: platform-matrix
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-c-compiler-support
-  domain: cpp
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: platform-matrix
+  domain: build
+  priority: P0
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: ccb_specific
+  upstream_relation: ccb_ci_is_authoritative
   merge_target: null
   source_paths:
   - doc/c++/COMPILER_SUPPORT.md
+  - CMakeLists.txt
+  - .github/workflows/matrix.yml
+  - .github/workflows/msvc-full-features.yml
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - CMake requires 3.20 and C++17, while active CI defines the real compiler matrix; rewrite the support
+    claims from those contracts.
+  migration_batch: phase-0-build
 - original_path: doc/c++/COMPILING-CMAKE-VCPKG.md
-  target_path: null
+  target_path: docs/zh_CN/build/windows-msvc.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: merge_into
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: build-windows-msvc
+  migration_status: classified
   history_strategy: evaluate_filtered_history
   stable_document_id: legacy.doc-c-compiling-cmake-vcpkg
-  domain: cpp
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
-  merge_target: null
+  domain: build
+  priority: P0
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: mixed
+  upstream_relation: upstream_derived_revalidate
+  merge_target: build-windows-msvc
   source_paths:
   - doc/c++/COMPILING-CMAKE-VCPKG.md
+  - CMakeLists.txt
+  - CMakePresets.json
+  - build-scripts/x64-windows-static.cmake
+  - .github/workflows/msvc-full-features.yml
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - This is one Windows/vcpkg route and should be reconciled with the maintained MSVC preset/workflow
+    instead of published as a parallel guide.
+  migration_batch: phase-0-build
 - original_path: doc/c++/COMPILING-CMAKE.md
-  target_path: null
+  target_path: docs/zh_CN/build/cmake.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: build-cmake
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-c-compiling-cmake
-  domain: cpp
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: build-cmake
+  domain: build
+  priority: P0
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: ccb_specific
+  upstream_relation: ccb_build_contract_is_authoritative
   merge_target: null
   source_paths:
   - doc/c++/COMPILING-CMAKE.md
+  - CMakeLists.txt
+  - CMakePresets.json
+  - build-scripts/CMakeUserPresets.json.in
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - The old statement that CMake is unsupported is false; current CMake configuration and presets are
+    authoritative and require a clean rewrite.
+  migration_batch: phase-0-build
 - original_path: doc/c++/COMPILING-CYGWIN.md
-  target_path: null
+  target_path: docs/zh_CN/archive/build/cygwin.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
-  archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  action: archive_public
+  archive_reason: No current CCB CI/support evidence; Cygwin instructions are obsolete and superseded
+    by maintained Windows paths.
+  replacement: build-windows-msys2
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-c-compiling-cygwin
-  domain: cpp
+  stable_document_id: archive-build-cygwin
+  domain: build
   priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  last_applicable_commit: null
+  ccb_specificity: upstream_derived
+  upstream_relation: upstream_only_obsolete
   merge_target: null
   source_paths:
   - doc/c++/COMPILING-CYGWIN.md
+  - Makefile
   source_symbols: []
-  translation_required: true
-  include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  translation_required: false
+  include_in_ai_index: false
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - The Makefile retains Cygwin conditionals, but no current CI or maintained support evidence exists;
+    preserve the page only as historical material.
+  - 'The exact last-applicable SHA is intentionally unknown: imported snapshot history repeatedly re-adds
+    this path at unrelated commits, so those SHAs are provenance rather than validity evidence.'
+  migration_batch: phase-3-build
 - original_path: doc/c++/COMPILING-DEVCONTAINER.md
-  target_path: null
+  target_path: docs/zh_CN/build/devcontainer.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: build-devcontainer
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-c-compiling-devcontainer
-  domain: cpp
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: build-devcontainer
+  domain: build
+  priority: P1
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: ccb_specific
+  upstream_relation: ccb_configuration_is_authoritative
   merge_target: null
   source_paths:
   - doc/c++/COMPILING-DEVCONTAINER.md
+  - .devcontainer/devcontainer.json
+  - .devcontainer/Dockerfile
+  - .devcontainer/graphical/devcontainer.json
+  - .devcontainer/cross-compile/devcontainer.json
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Multiple tracked devcontainer variants are live; rewrite the page around the actual CCB configurations
+    and validation commands.
+  migration_batch: phase-1-build
 - original_path: doc/c++/COMPILING-FLATPAK.md
-  target_path: null
+  target_path: docs/zh_CN/archive/build/flatpak.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
-  archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  action: archive_public
+  archive_reason: No maintained Flatpak manifest, workflow, or validation path exists in CCB.
+  replacement: build-overview
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-c-compiling-flatpak
-  domain: cpp
+  stable_document_id: archive-build-flatpak
+  domain: build
   priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  last_applicable_commit: null
+  ccb_specificity: upstream_derived
+  upstream_relation: upstream_only_obsolete
   merge_target: null
   source_paths:
   - doc/c++/COMPILING-FLATPAK.md
   source_symbols: []
-  translation_required: true
-  include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  translation_required: false
+  include_in_ai_index: false
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - No tracked Flatpak manifest or CI path exists on the reviewed default branch; only historical remnants
+    support this page.
+  - 'The exact last-applicable SHA is intentionally unknown: imported snapshot history repeatedly re-adds
+    this path at unrelated commits, so those SHAs are provenance rather than validity evidence.'
+  migration_batch: phase-3-build
 - original_path: doc/c++/COMPILING-MSYS.md
-  target_path: null
+  target_path: docs/zh_CN/build/windows-msys2.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: build-windows-msys2
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-c-compiling-msys
-  domain: cpp
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: build-windows-msys2
+  domain: build
+  priority: P0
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: mixed
+  upstream_relation: upstream_derived_revalidate
   merge_target: null
   source_paths:
   - doc/c++/COMPILING-MSYS.md
+  - Makefile
+  - CMakeLists.txt
+  - .github/workflows/sdl3-matrix.yml
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - MSYS2 remains a relevant Windows route, but package names, SDL generation, clone URLs, and commands
+    must be verified against current CCB build files.
+  migration_batch: phase-0-build
 - original_path: doc/c++/COMPILING-VS-VCPKG.md
-  target_path: null
+  target_path: docs/zh_CN/build/windows-msvc.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - Maleclypse
@@ -4522,30 +4693,34 @@ documents:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
+  replacement: build-windows-msvc
+  migration_status: classified
   history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-c-compiling-vs-vcpkg
-  domain: cpp
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  stable_document_id: build-windows-msvc
+  domain: build
+  priority: P0
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: ccb_specific
+  upstream_relation: ccb_build_contract_is_authoritative
   merge_target: null
   source_paths:
   - doc/c++/COMPILING-VS-VCPKG.md
+  - CMakePresets.json
+  - build-scripts/x64-windows-static.cmake
+  - build-scripts/windows-tiles-sounds-x64-msvc.cmake
+  - .github/workflows/msvc-full-features.yml
   source_symbols: []
   translation_required: true
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - MSVC/vcpkg is maintained in presets and CI; consolidate current flags and dependencies while removing
+    CleverRaven URLs.
+  migration_batch: phase-0-build
 - original_path: doc/c++/COMPILING.md
-  target_path: null
+  target_path: docs/zh_CN/build/overview.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - LYHGLYTX

--- a/doc/migration/markdown-inventory.yml
+++ b/doc/migration/markdown-inventory.yml
@@ -5,13 +5,17 @@ document_count: 175
 scope: Tracked Markdown at source_commit, excluding dot-prefixed tool/config paths; filesystem caches
   are never traversed.
 classification_summary:
-  review: 163
+  review: 129
   actions:
-    keep_in_repo: 6
+    generated_reference: 1
+    keep_in_repo: 35
+    merge_into: 2
+    migrate_rewrite: 2
     retain_third_party: 6
-    review: 163
+    review: 129
   migration_statuses:
-    inventoried: 163
+    classified: 34
+    inventoried: 129
     verified: 12
 documents:
 - original_path: CODE_OF_CONDUCT.md
@@ -191,968 +195,1144 @@ documents:
   - Retained as a repository authority or project entry point.
   migration_batch: null
 - original_path: data/json/LOADING_ORDER.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/loading-order.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: merge_into
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/loading-order/
+  migration_status: classified
+  history_strategy: merge_attribution_and_source_history
   stable_document_id: legacy.data-json-loading-order
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
-  merge_target: null
+  priority: P1
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
+  merge_target: json.loading-order
   source_paths:
   - data/json/LOADING_ORDER.md
-  source_symbols: []
+  - doc/JSON/JSON_LOADING_ORDER.md
+  - src/filesystem.cpp
+  - src/init.cpp
+  source_symbols:
+  - DynamicDataLoader::load_data_from_path
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - Both old repository paths must become permanent bilingual moved stubs after the shared page is published.
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The two Markdown files are byte-identical; filesystem.cpp still documents breadth-first traversal
+    with lexical ordering, and init.cpp owns the loader entry point.
+  migration_batch: phase-1-json
 - original_path: data/json/npcs/godco/NECC_INFO.md
-  target_path: null
+  target_path: data/json/npcs/godco/NECC_INFO.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-json-npcs-godco-necc-info
-  domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: content.npc.godco-roster
+  domain: content
+  priority: P2
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/json/npcs/godco/NECC_INFO.md
+  - data/json/npcs/godco/npcs.json
+  - data/json/npcs/godco/members/NPC_Arturo_Maldonado.json
+  - data/json/npcs/godco/members/NPC_Helena_Misinter.json
+  - data/json/npcs/godco/godco_missions.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The roster remains source-adjacent design context and named members such as Arturo and Helena have
+    live JSON definitions and missions.
+  migration_batch: phase-2-content
 - original_path: data/json/npcs/refugee_center/FREE_MERCHANTS_INFO.md
-  target_path: null
+  target_path: data/json/npcs/refugee_center/FREE_MERCHANTS_INFO.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-json-npcs-refugee-center-free-merchants-info
-  domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: content.npc.free-merchants-economy
+  domain: content
+  priority: P2
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/json/npcs/refugee_center/FREE_MERCHANTS_INFO.md
+  - data/json/npcs/refugee_center/missiondef_free_merchants.json
+  - data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_goods.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The economy principles remain close to active Free Merchant mission and shop inventories; the shop
+    data still explicitly describes merch and deliberate stock exclusions.
+  migration_batch: phase-2-content
 - original_path: data/lua/README.md
-  target_path: null
+  target_path: docs/zh_CN/api/lua/v5/overview.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - LYHGLYTX
   contributor_anomaly_count: 0
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-lua-readme
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/api/lua/v5/overview/
+  migration_status: classified
+  history_strategy: evaluate_filtered_history_then_preserve_source_url
+  stable_document_id: lua.v5.overview
   domain: lua
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P0
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: ccb_specific
+  upstream_relation: ccb_native_lua_v5_contract
   merge_target: null
   source_paths:
   - data/lua/README.md
-  source_symbols: []
+  - data/lua/manifest.schema.json
+  - data/lua/types/ccb_api_v5.d.lua
+  - data/lua/reference/ccb_native_inventory.json
+  - src/catalua_ui_manifest.cpp
+  - tests/catalua_ui_test.cpp
+  source_symbols:
+  - supported_script_capabilities
+  - read_script_manifest
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - Do not preserve manual symbol counts as prose; regenerate them and prove LuaLS/native/inventory/test
+    parity before publishing.
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The 1,150-line CCB-specific v5 overview is current high-value material, but it combines many contracts
+    that must be split and generated from Schema, LuaLS, native inventory, registration, and tests.
+  migration_batch: phase-0-lua
 - original_path: data/lua/examples/api_v5_mod/README.md
-  target_path: null
+  target_path: docs/zh_CN/api/lua/v5/example-mod.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - LYHGLYTX
   contributor_anomaly_count: 0
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_rewrite
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-lua-examples-api-v5-mod-readme
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/api/lua/v5/example-mod/
+  migration_status: classified
+  history_strategy: evaluate_filtered_history_then_preserve_source_url
+  stable_document_id: lua.v5.example-mod
   domain: lua
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P0
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: ccb_specific
+  upstream_relation: ccb_native_lua_v5_example
   merge_target: null
   source_paths:
   - data/lua/examples/api_v5_mod/README.md
-  source_symbols: []
+  - data/lua/examples/api_v5_mod/lua/main.lua
+  - data/lua/examples/api_v5_mod/lua/lib/model.lua
+  - data/lua/examples/api_v5_mod/lua/manifest.json
+  - tests/catalua_ui_test.cpp
+  source_symbols:
+  - read_script_manifest
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - The published example must pass manifest Schema, Lua syntax, native loading, and generated-reference
+    checks.
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The README accurately enumerates the checked-in complete v5 example surfaces; the formal page should
+    be bilingual and validated against the example manifest and Lua files.
+  migration_batch: phase-0-lua
 - original_path: data/mods/Backrooms/README.md
-  target_path: null
+  target_path: data/mods/Backrooms/README.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-backrooms-readme
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.backrooms.overview
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P2
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/Backrooms/README.md
+  - data/mods/Backrooms/modinfo.json
+  - data/mods/Backrooms/overmap_terrain.json
+  - data/mods/Backrooms/overmap_specials.json
   source_symbols: []
-  translation_required: true
-  include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  translation_required: false
+  include_in_ai_index: false
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - This is an active source-adjacent player/mod overview; MOD_INFO still requires the Backrooms world
+    conversion and its worldgen files remain present.
+  migration_batch: phase-2-mods
 - original_path: data/mods/BombasticPerks/docs/contributing.md
-  target_path: null
+  target_path: data/mods/BombasticPerks/docs/contributing.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-bombasticperks-docs-contributing
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.bombastic-perks.contributing
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/BombasticPerks/docs/contributing.md
+  - data/mods/BombasticPerks/modinfo.json
+  - data/mods/BombasticPerks/perkmenu.json
+  - data/mods/BombasticPerks/perks.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The documented perk_ naming and TALK_PERK_MENU entry points are present in the active mod JSON, so
+    this remains a local contribution contract.
+  migration_batch: phase-1-mods
 - original_path: data/mods/BombasticPerks/docs/expanding_with_mods.md
-  target_path: null
+  target_path: data/mods/BombasticPerks/docs/expanding_with_mods.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-bombasticperks-docs-expanding-with-mods
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.bombastic-perks.extension-contract
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/BombasticPerks/docs/expanding_with_mods.md
+  - data/mods/BombasticPerks/modinfo.json
+  - data/mods/BombasticPerks/perkmenu.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - The abbreviated JSON fragment is illustrative rather than parseable and must be explicitly marked
+    or replaced with a validated example.
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The extension mechanism still targets TALK_PERK_MENU_MAIN and is best retained beside the mod that
+    owns that EOC/dialogue contract.
+  migration_batch: phase-1-mods
 - original_path: data/mods/DinoMod/DESIGN.md
-  target_path: null
+  target_path: data/mods/DinoMod/DESIGN.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-dinomod-design
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.dinomod.design
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/DinoMod/DESIGN.md
+  - data/mods/DinoMod/modinfo.json
+  - data/mods/DinoMod/monsters/dinosaur.json
+  - data/mods/DinoMod/monstergroups/dinosaur.json
+  - data/mods/DinoMod/monstergroups/wilderness.json
+  - data/mods/DinoMod/regional_overlay.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - Before substantive edits, re-check the enumerated file workflow because the current mod has grown
+    beyond the document's minimum list.
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The contribution/design guide still maps to live dinosaur, hatchling, monster-group, map-extra, and
+    regional-overlay data, though its file-count wording is only a snapshot.
+  migration_batch: phase-1-mods
 - original_path: data/mods/DinoMod/README.md
-  target_path: null
+  target_path: data/mods/DinoMod/README.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-dinomod-readme
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.dinomod.overview
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P2
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/DinoMod/README.md
+  - data/mods/DinoMod/modinfo.json
+  - data/mods/DinoMod/monsters/dinosaur.json
   source_symbols: []
-  translation_required: true
-  include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  translation_required: false
+  include_in_ai_index: false
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The short overview agrees with active DinoMod MOD_INFO and loaded dinosaur content and should stay
+    next to the mod.
+  migration_batch: phase-2-mods
 - original_path: data/mods/MA/README.md
-  target_path: null
+  target_path: data/mods/MA/README.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-ma-readme
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.massachusetts.overview
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P2
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/MA/README.md
+  - data/mods/MA/modinfo.json
+  - data/mods/MA/MA_overmap_index.png
+  - data/mods/MA/MA_overmap_cities.xlsx
   source_symbols: []
-  translation_required: true
-  include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  translation_required: false
+  include_in_ai_index: false
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The total-conversion MOD_INFO and both named supporting assets still exist, so this remains useful
+    local orientation for an active bundled mod.
+  migration_batch: phase-2-mods
 - original_path: data/mods/Magiclysm/lore.md
-  target_path: null
+  target_path: data/mods/Magiclysm/lore.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-magiclysm-lore
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.magiclysm.lore
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P2
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/Magiclysm/lore.md
+  - data/mods/Magiclysm/modinfo.json
+  - data/mods/Magiclysm/Spells/druid.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The class/lore design remains relevant to the active Magiclysm spell classes and is source-adjacent
+    authoring context rather than a general CCB contract.
+  migration_batch: phase-2-mods
 - original_path: data/mods/Magiclysm/magic_balance.md
-  target_path: null
+  target_path: data/mods/Magiclysm/magic_balance.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-magiclysm-magic-balance
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.magiclysm.balance
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/Magiclysm/magic_balance.md
+  - data/mods/Magiclysm/modinfo.json
+  - data/mods/Magiclysm/flags.json
+  - data/mods/Magiclysm/Spells/druid.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - Specific damage, cost, and casting-time examples are snapshots and must be checked against JSON whenever
+    reused.
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - Tier and proficiency guidance corresponds to live spell_class values and EVOCATION/CHANNELING/RESTORATION
+    flags, so it remains an active balancing contract.
+  migration_batch: phase-1-mods
 - original_path: data/mods/Megafauna/readme.md
-  target_path: null
+  target_path: data/mods/Megafauna/readme.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-megafauna-readme
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.megafauna.overview
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P2
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/Megafauna/readme.md
+  - data/mods/Megafauna/modinfo.json
+  - data/mods/Megafauna/monsters/mf_wild.json
+  - data/mods/Megafauna/monsters/mf_domestic.json
+  - data/mods/Megafauna/monstergroups/wilderness.json
   source_symbols: []
-  translation_required: true
-  include_in_ai_index: true
+  translation_required: false
+  include_in_ai_index: false
   blockers:
-  - Full-text source review is pending.
+  - Do not present the hard-coded species counts or TODO completion states as generated facts.
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The active MOD_INFO and wild/domestic monster data implement the described Pleistocene fauna scope;
+    TODO and species counts remain editorial snapshots.
+  migration_batch: phase-2-mods
 - original_path: data/mods/MindOverMatter/GainingPowerSpoilers.md
-  target_path: null
+  target_path: data/mods/MindOverMatter/GainingPowerSpoilers.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-mindovermatter-gainingpowerspoilers
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.mind-over-matter.gaining-powers
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/MindOverMatter/GainingPowerSpoilers.md
+  - data/mods/MindOverMatter/modinfo.json
+  - data/mods/MindOverMatter/effectoncondition/eoc_awakening.json
+  - data/mods/MindOverMatter/powers/learning_eocs/overall.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - Revalidate every numeric formula against current awakening and learning EOCs before treating the guide
+    as exact.
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The awakening and insight systems still have live EOC implementations, but the prose embeds formulas
+    and cooldown numbers that can drift.
+  migration_batch: phase-1-mods
 - original_path: data/mods/MindOverMatter/NetherAttunementSpoilers.md
-  target_path: null
+  target_path: data/mods/MindOverMatter/NetherAttunementSpoilers.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-mindovermatter-netherattunementspoilers
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.mind-over-matter.nether-attunement
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/MindOverMatter/NetherAttunementSpoilers.md
+  - data/mods/MindOverMatter/modinfo.json
+  - data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+  - data/mods/MindOverMatter/effects/effects_nether_attunement.json
+  - data/mods/MindOverMatter/enchantments/enchantments_nether_attunement.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - Probability, threshold, and weight tables need contract extraction or explicit source-linked validation.
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The attunement vitamin, effects, and consequence EOCs remain live; the large hand-maintained probability
+    table is not itself authoritative.
+  migration_batch: phase-1-mods
 - original_path: data/mods/MindOverMatter/NewPowerGuide.md
-  target_path: null
+  target_path: data/mods/MindOverMatter/NewPowerGuide.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-mindovermatter-newpowerguide
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.mind-over-matter.new-power-guide
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/MindOverMatter/NewPowerGuide.md
+  - data/mods/MindOverMatter/modinfo.json
+  - data/mods/MindOverMatter/powers/learning_eocs/overall.json
+  - data/mods/MindOverMatter/powers/biokinesis.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - The sample math formula and per-path limitations are design policy, not a substitute for validating
+    current spell/EOC fields.
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - This is source-adjacent design guidance for adding powers and path boundaries; the power and learning-EOC
+    directories it names remain active.
+  migration_batch: phase-1-mods
 - original_path: data/mods/MindOverMatter/PowerDescriptionSpoilers.md
-  target_path: null
+  target_path: docs/zh_CN/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - Standing-Storm
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: generated_reference
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-mindovermatter-powerdescriptionspoilers
+  migration_status: classified
+  history_strategy: retain_path_and_generate_from_power_json
+  stable_document_id: mods.mind-over-matter.power-reference
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: null
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_bundled_mod_manual_reference
   merge_target: null
   source_paths:
   - data/mods/MindOverMatter/PowerDescriptionSpoilers.md
+  - data/mods/MindOverMatter/modinfo.json
+  - data/mods/MindOverMatter/powers/biokinesis.json
+  - data/mods/MindOverMatter/powers/clairsentience.json
+  - data/mods/MindOverMatter/powers/electrokinesis.json
+  - data/mods/MindOverMatter/powers/photokinesis.json
+  - data/mods/MindOverMatter/powers/pyrokinesis.json
+  - data/mods/MindOverMatter/powers/telekinesis.json
+  - data/mods/MindOverMatter/powers/telepathy.json
+  - data/mods/MindOverMatter/powers/teleportation.json
+  - data/mods/MindOverMatter/powers/vitakinesis.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - No current evidence proves all hand-copied values match the nine power JSON files; generation and
+    parity tests are required.
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The 1,838-line reference manually mirrors loaded spell JSON and contains visible placeholders and
+    copy errors; it should be generator-owned while retaining its source path and attribution.
+  migration_batch: phase-1-mods
 - original_path: data/mods/MindOverMatter/README.md
-  target_path: null
+  target_path: data/mods/MindOverMatter/README.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - Standing-Storm
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-mindovermatter-readme
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.mind-over-matter.overview
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/MindOverMatter/README.md
+  - data/mods/MindOverMatter/modinfo.json
+  - data/mods/MindOverMatter/effectoncondition/eoc_awakening.json
+  - data/mods/MindOverMatter/powers/learning_eocs/overall.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - Replace the two upstream GitHub links with permanent local/CCB links and revalidate embedded numeric
+    claims.
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The overview matches the active nine-path mod and its awakening/learning implementation, but its further-information
+    links still point at CleverRaven instead of local CCB paths.
+  migration_batch: phase-1-mods
 - original_path: data/mods/MindOverMatter/lore_spoilers.md
-  target_path: null
+  target_path: data/mods/MindOverMatter/lore_spoilers.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-mindovermatter-lore-spoilers
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.mind-over-matter.lore
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P2
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/MindOverMatter/lore_spoilers.md
+  - data/mods/MindOverMatter/modinfo.json
+  - data/mods/MindOverMatter/items/matrix_crystals.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The PHAVIAN and matrix-crystal lore remains source-adjacent narrative context for the active mod.
+  migration_batch: phase-2-mods
 - original_path: data/mods/MindOverMatterNoKnacks/README.md
-  target_path: null
+  target_path: data/mods/MindOverMatterNoKnacks/README.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-mindovermatternoknacks-readme
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.mind-over-matter.no-knacks
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P2
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/MindOverMatterNoKnacks/README.md
+  - data/mods/MindOverMatterNoKnacks/modinfo.json
+  - data/mods/MindOverMatterNoKnacks/eocs/eocs_game_start.json
+  - data/mods/MindOverMatterNoKnacks/items/item_blacklist.json
   source_symbols: []
-  translation_required: true
-  include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  translation_required: false
+  include_in_ai_index: false
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The four-line overview remains accurate orientation for the active compatibility/variant mod and its
+    EOC and blacklist overrides.
+  migration_batch: phase-2-mods
 - original_path: data/mods/No_Hope/CONTRIBUTING.md
-  target_path: null
+  target_path: data/mods/No_Hope/CONTRIBUTING.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-no-hope-contributing
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.no-hope.contributing
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/No_Hope/CONTRIBUTING.md
+  - data/mods/No_Hope/modinfo.json
+  - data/mods/No_Hope/difficulty_options.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 'Resolve or replace the bare upstream #70325 reference and re-check the list of missing C++-dependent
+    features.'
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The source-adjacent design ethos still governs an active mod, while the temporary-feature and upstream
+    issue references are historical planning notes.
+  migration_batch: phase-1-mods
 - original_path: data/mods/No_Hope/DIFFICULTY_OPTIONS.md
-  target_path: null
+  target_path: data/mods/No_Hope/DIFFICULTY_OPTIONS.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-no-hope-difficulty-options
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.no-hope.difficulty-options
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/No_Hope/DIFFICULTY_OPTIONS.md
+  - data/mods/No_Hope/modinfo.json
+  - data/mods/No_Hope/difficulty_options.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - Regenerate or validate the item-category list and count against the current registry and difficulty_options.json.
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The active EOCs still call set_item_category_spawn_rates, but the prose's count and inclusion table
+    are manually copied snapshots.
+  migration_batch: phase-1-mods
 - original_path: data/mods/Sky_Island/README.md
-  target_path: null
+  target_path: data/mods/Sky_Island/README.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-sky-island-readme
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.sky-island.overview
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P2
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/Sky_Island/README.md
+  - data/mods/Sky_Island/modinfo.json
+  - data/mods/Sky_Island/effectoncondition/raid_missions.json
+  - data/mods/Sky_Island/missions/raid_missions.json
   source_symbols: []
-  translation_required: true
-  include_in_ai_index: true
+  translation_required: false
+  include_in_ai_index: false
   blockers:
-  - Full-text source review is pending.
+  - Separate or refresh the stale embedded changelog before presenting version-specific behavior as current.
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The expedition, warp-shard, and mission concepts remain implemented, but the embedded changelog stops
+    at v0.3.0 while MOD_INFO declares v0.4.0.
+  migration_batch: phase-2-mods
 - original_path: data/mods/Sorcerer/README.md
-  target_path: null
+  target_path: data/mods/Sorcerer/README.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-sorcerer-readme
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.sorcerer.overview
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/Sorcerer/README.md
+  - data/mods/Sorcerer/modinfo.json
+  - data/mods/Sorcerer/tools/generate_code.py
+  - data/mods/Sorcerer/tools/spell_data.txt
+  - data/mods/Sorcerer/generated_code/learn_spell/learn_spells.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - Generated-code ownership should be registered machine-readably and the generator must run without
+    path edits before its instructions are treated as complete.
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - 'The README''s generator boundary is real: editable source/tool files and checked-in generated spell
+    JSON coexist in the active mod.'
+  migration_batch: phase-1-mods
 - original_path: data/mods/TEST_DATA/README.md
-  target_path: null
+  target_path: data/mods/TEST_DATA/README.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-test-data-readme
-  domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: testing.test-data-mod
+  domain: testing
+  priority: P0
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_active_test_contract
   merge_target: null
   source_paths:
   - data/mods/TEST_DATA/README.md
+  - data/mods/TEST_DATA/modinfo.json
+  - tests/test_main.cpp
+  - data/mods/TEST_DATA/items.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - tests/test_main.cpp still adds the test_data mod and the directory contains controlled fixtures, so
+    this is an active offline testing contract that belongs beside the fixtures.
+  migration_batch: phase-0-testing
 - original_path: data/mods/XedraWood/README.md
-  target_path: null
+  target_path: data/mods/XedraWood/README.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - Standing-Storm
   contributor_anomaly_count: 0
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-xedrawood-readme
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.xedra-wood.overview
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P2
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/XedraWood/README.md
+  - data/mods/XedraWood/modinfo.json
+  - data/mods/XedraWood/monsters/factions.json
   source_symbols: []
-  translation_required: true
-  include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  translation_required: false
+  include_in_ai_index: false
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The overview remains valid source-adjacent context for the active Xedra Evolved/Innawood compatibility
+    expansion.
+  migration_batch: phase-2-mods
 - original_path: data/mods/Xedra_Evolved/README.md
-  target_path: null
+  target_path: data/mods/Xedra_Evolved/README.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-xedra-evolved-readme
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.xedra-evolved.overview
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P2
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/Xedra_Evolved/README.md
+  - data/mods/Xedra_Evolved/modinfo.json
+  - data/mods/Xedra_Evolved/effects/vampvirus.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - Do not publish feature counts as exact until derived from current JSON registries.
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The chapter-based overview and active MOD_INFO still describe a broad bundled content mod, though
+    shipping counts are manually maintained.
+  migration_batch: phase-2-mods
 - original_path: data/mods/Xedra_Evolved/design_doc_spoilers.md
-  target_path: null
+  target_path: data/mods/Xedra_Evolved/design_doc_spoilers.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - SariusSkelrets
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-xedra-evolved-design-doc-spoilers
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.xedra-evolved.design
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/Xedra_Evolved/design_doc_spoilers.md
+  - data/mods/Xedra_Evolved/modinfo.json
+  - data/mods/Xedra_Evolved/effects/vampvirus.json
+  - data/mods/Xedra_Evolved/monsters/cryptids.json
+  - data/mods/Xedra_Evolved/mutations/dhampir_eocs.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The supernatural-exclusivity, vampire, dhampir, and cryptid principles map to active JSON and remain
+    important local design policy; explicit TBD sections are drafts, not stale contracts.
+  migration_batch: phase-1-mods
 - original_path: data/mods/Xedra_Evolved/vampire_guide.md
-  target_path: null
+  target_path: data/mods/Xedra_Evolved/vampire_guide.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-xedra-evolved-vampire-guide
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.xedra-evolved.vampire-guide
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P2
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/Xedra_Evolved/vampire_guide.md
+  - data/mods/Xedra_Evolved/effects/vampvirus.json
+  - data/mods/Xedra_Evolved/mutations/dhampir_eocs.json
   source_symbols: []
-  translation_required: true
-  include_in_ai_index: true
+  translation_required: false
+  include_in_ai_index: false
   blockers:
-  - Full-text source review is pending.
+  - Timing and progression statements must be checked against the virus EOCs when changed.
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - This is a compact player-facing walkthrough tied to the live vampirism EOCs; it should remain next
+    to the mod and out of the general developer AI index.
+  migration_batch: phase-2-mods
 - original_path: data/mods/aftershock_exoplanet/doc/Hacking.md
-  target_path: null
+  target_path: data/mods/aftershock_exoplanet/doc/Hacking.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-aftershock-exoplanet-doc-hacking
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.aftershock-exoplanet.hacking
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/aftershock_exoplanet/doc/Hacking.md
+  - data/mods/aftershock_exoplanet/modinfo.json
+  - data/mods/aftershock_exoplanet/EOC/hacking_eoc.json
+  - data/mods/aftershock_exoplanet/EOC/hacking_results_eoc.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - The second code block contains invalid JSON syntax and must be replaced with a formatter-validated
+    example.
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - EOC_start_lock_hack, power-cost scaling, HACK quality, and HACK_NO_CHARGE remain implemented, making
+    this a live mod-specific authoring contract.
+  migration_batch: phase-1-mods
 - original_path: data/mods/aftershock_exoplanet/doc/crafting_system.md
-  target_path: null
+  target_path: data/mods/aftershock_exoplanet/doc/crafting_system.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - Mihály Verhás
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-aftershock-exoplanet-doc-crafting-system
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.aftershock-exoplanet.crafting-system
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P1
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/aftershock_exoplanet/doc/crafting_system.md
+  - data/mods/aftershock_exoplanet/modinfo.json
+  - data/mods/aftershock_exoplanet/items/crafting_scrap/abstract_scrap.json
+  - data/mods/aftershock_exoplanet/items/crafting_scrap/circuity_scrap.json
+  - data/mods/aftershock_exoplanet/itemgroups/scrap_groups.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - Category names and tier completeness should be compared to all crafting_scrap JSON when edited.
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - The tiered scrap categories remain represented by active item and item-group JSON; the prose is local
+    balance policy rather than generic crafting documentation.
+  migration_batch: phase-1-mods
 - original_path: data/mods/aftershock_exoplanet/doc/lore/cyberpunk_future.md
-  target_path: null
+  target_path: docs/zh_CN/data/mods/aftershock_exoplanet/doc/lore/organizations.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: merge_into
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-aftershock-exoplanet-doc-lore-cyberpunk-future
+  replacement: mods.aftershock-exoplanet.lore.organizations
+  migration_status: classified
+  history_strategy: merge_attribution_and_source_history
+  stable_document_id: mods.aftershock-exoplanet.lore.cyberpunk-future
   domain: mods
   priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
-  merge_target: null
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
+  merge_target: mods.aftershock-exoplanet.lore.organizations
   source_paths:
   - data/mods/aftershock_exoplanet/doc/lore/cyberpunk_future.md
+  - data/mods/aftershock_exoplanet/doc/lore/organizations.md
+  - data/mods/aftershock_exoplanet/doc/lore/timeline.md
+  - data/mods/aftershock_exoplanet/modinfo.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - Retain a permanent lightweight moved stub at the old path after merging the unique technology paragraph.
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - This 13-line fragment duplicates corporation and lost-technology context developed more fully in organizations.md
+    and timeline.md.
+  migration_batch: phase-3-mods
 - original_path: data/mods/aftershock_exoplanet/doc/lore/factions.md
-  target_path: null
+  target_path: data/mods/aftershock_exoplanet/doc/lore/factions.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - Mihály Verhás
@@ -1160,30 +1340,33 @@ documents:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: keep_in_repo
   archive_reason: null
   replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.data-mods-aftershock-exoplanet-doc-lore-factions
+  migration_status: classified
+  history_strategy: keep_in_repo_path_history
+  stable_document_id: mods.aftershock-exoplanet.lore.factions
   domain: mods
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P2
+  last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
+  ccb_specificity: upstream_inherited
+  upstream_relation: upstream_inherited_bundled_content
   merge_target: null
   source_paths:
   - data/mods/aftershock_exoplanet/doc/lore/factions.md
+  - data/mods/aftershock_exoplanet/modinfo.json
+  - data/mods/aftershock_exoplanet/npcs/factions.json
   source_symbols: []
-  translation_required: true
+  translation_required: false
   include_in_ai_index: true
-  blockers:
-  - Full-text source review is pending.
+  blockers: []
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - Read the complete tracked document and reviewed its declared sources at origin/master@5f23722ff28c5cc552baa0422b32b1f10fd890fa.
+  - This file records gameplay-facing faction goals, offers, and bases, distinct from the historical organization
+    catalogue; active faction JSON provides implementation context.
+  migration_batch: phase-2-mods
 - original_path: data/mods/aftershock_exoplanet/doc/lore/organizations.md
-  target_path: null
+  target_path: data/mods/aftershock_exoplanet/doc/lore/organizations.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - Mihály Verhás

--- a/doc/migration/markdown-inventory.yml
+++ b/doc/migration/markdown-inventory.yml
@@ -5,19 +5,19 @@ document_count: 175
 scope: Tracked Markdown at source_commit, excluding dot-prefixed tool/config paths; filesystem caches
   are never traversed.
 classification_summary:
-  review: 90
+  review: 89
   actions:
     archive_public: 1
     generated_reference: 2
     keep_in_repo: 54
     merge_into: 4
-    migrate_preserve: 10
+    migrate_preserve: 11
     migrate_rewrite: 8
     retain_third_party: 6
-    review: 90
+    review: 89
   migration_statuses:
-    classified: 73
-    inventoried: 90
+    classified: 74
+    inventoried: 89
     verified: 12
 documents:
 - original_path: CODE_OF_CONDUCT.md
@@ -2716,30 +2716,37 @@ documents:
   - thaelina
   contributor_anomaly_count: 1
   license: CC-BY-SA-3.0
-  action: review
+  action: migrate_preserve
   archive_reason: null
-  replacement: null
-  migration_status: inventoried
-  history_strategy: evaluate_filtered_history
-  stable_document_id: legacy.doc-json-item
+  replacement: https://crimsoncrossbunker.github.io/CCB-Docs/reference/json/items/
+  migration_status: classified
+  history_strategy: filtered_path_history_candidate
+  stable_document_id: json.items
   domain: json
-  priority: P3
-  last_applicable_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
-  ccb_specificity: pending_review
-  upstream_relation: pending_review
+  priority: P0
+  last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
+  ccb_specificity: ccb_extended
+  upstream_relation: forked_and_locally_extended
   merge_target: null
   source_paths:
-  - doc/JSON/ITEM.md
-  source_symbols: []
+  - src/item_factory.cpp
+  - src/item_factory.h
+  - data/json/items/generic.json
+  - data/json/items/classes/gun.json
+  - tests/item_test.cpp
+  source_symbols:
+  - itype::load
+  - items::load
+  - islot_comestible::deserialize
   translation_required: true
   include_in_ai_index: true
   blockers:
-  - Full-text source review is pending.
+  - 1,666 行手工覆盖众多 subtype，必须拆分为概念/专题页并与 JSON object registry 做字段覆盖校验。
   evidence:
-  - Frozen tracked Markdown path at source_commit.
-  migration_batch: null
+  - 核心 item 参考在导入后有 11 次更新，包含 CCB FIRING_EXT_POWER、植物生命周期与 Mod 内容字段；应保留细节和历史，但不能继续作为单一巨页维护。
+  migration_batch: phase-0-json
 - original_path: doc/JSON/ITEM_CRAFT_AND_DISASSEMBLY.md
-  target_path: null
+  target_path: docs/zh_CN/reference/json/recipes-and-disassembly.md
   source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
   contributors:
   - Anton Simakov

--- a/doc/migration/migration-batches.schema.json
+++ b/doc/migration/migration-batches.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://crimsoncrossbunker.github.io/schemas/migration-batches-v1.json",
+  "title": "CCB legacy Markdown migration batches",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "kind",
+    "source_commit",
+    "batch_count",
+    "document_count",
+    "batches"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "kind": { "const": "markdown_migration_batches" },
+    "source_commit": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "batch_count": { "type": "integer", "minimum": 0 },
+    "document_count": { "type": "integer", "minimum": 0 },
+    "batches": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [ "id", "priorities", "document_count", "documents" ],
+        "properties": {
+          "id": { "type": "string", "pattern": "^phase-[0-3]-[a-z0-9-]+$" },
+          "priorities": {
+            "type": "array",
+            "items": { "enum": [ "P0", "P1", "P2", "P3" ] },
+            "minItems": 1,
+            "uniqueItems": true
+          },
+          "document_count": { "type": "integer", "minimum": 1 },
+          "documents": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": [
+                "stable_document_id",
+                "original_path",
+                "action",
+                "priority",
+                "domain",
+                "target_path",
+                "blockers"
+              ],
+              "properties": {
+                "stable_document_id": { "type": "string", "minLength": 1 },
+                "original_path": { "type": "string", "minLength": 1 },
+                "action": { "type": "string", "minLength": 1 },
+                "priority": { "enum": [ "P0", "P1", "P2", "P3" ] },
+                "domain": { "type": "string", "minLength": 1 },
+                "target_path": { "type": [ "string", "null" ] },
+                "blockers": {
+                  "type": "array",
+                  "items": { "type": "string", "minLength": 1 },
+                  "uniqueItems": true
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/doc/migration/migration-batches.yml
+++ b/doc/migration/migration-batches.yml
@@ -1,0 +1,1422 @@
+schema_version: 1
+kind: markdown_migration_batches
+source_commit: 0378ca2b84303cf614c617c9d9eaa50138cd21ff
+batch_count: 37
+document_count: 163
+batches:
+- id: phase-0-build
+  priorities:
+  - P0
+  document_count: 6
+  documents:
+  - stable_document_id: platform-matrix
+    original_path: doc/c++/COMPILER_SUPPORT.md
+    action: migrate_rewrite
+    priority: P0
+    domain: build
+    target_path: docs/zh_CN/platforms/compiler-support.md
+    blockers: []
+  - stable_document_id: legacy.doc-c-compiling-cmake-vcpkg
+    original_path: doc/c++/COMPILING-CMAKE-VCPKG.md
+    action: merge_into
+    priority: P0
+    domain: build
+    target_path: docs/zh_CN/build/windows-msvc.md
+    blockers: []
+  - stable_document_id: build-cmake
+    original_path: doc/c++/COMPILING-CMAKE.md
+    action: migrate_rewrite
+    priority: P0
+    domain: build
+    target_path: docs/zh_CN/build/cmake.md
+    blockers: []
+  - stable_document_id: build-windows-msys2
+    original_path: doc/c++/COMPILING-MSYS.md
+    action: migrate_rewrite
+    priority: P0
+    domain: build
+    target_path: docs/zh_CN/build/windows-msys2.md
+    blockers: []
+  - stable_document_id: build-windows-msvc
+    original_path: doc/c++/COMPILING-VS-VCPKG.md
+    action: migrate_rewrite
+    priority: P0
+    domain: build
+    target_path: docs/zh_CN/build/windows-msvc.md
+    blockers: []
+  - stable_document_id: build-overview
+    original_path: doc/c++/COMPILING.md
+    action: migrate_rewrite
+    priority: P0
+    domain: build
+    target_path: docs/zh_CN/build/overview.md
+    blockers: []
+- id: phase-0-cpp
+  priorities:
+  - P0
+  document_count: 1
+  documents:
+  - stable_document_id: cpp-code-style
+    original_path: doc/c++/CODE_STYLE.md
+    action: migrate_rewrite
+    priority: P0
+    domain: cpp
+    target_path: docs/zh_CN/cpp/code-style.md
+    blockers: []
+- id: phase-0-eoc
+  priorities:
+  - P0
+  document_count: 2
+  documents:
+  - stable_document_id: eoc.reference
+    original_path: doc/JSON/EFFECT_ON_CONDITION.md
+    action: migrate_preserve
+    priority: P0
+    domain: eoc
+    target_path: docs/zh_CN/reference/eoc/index.md
+    blockers:
+    - 5,913 行手工条件/效果清单含 TODO 与 deprecated 项；必须拆分概念页和由注册表生成的 reference，并做 condition/effect parity。
+  - stable_document_id: json.npcs-dialogue
+    original_path: doc/JSON/NPCs.md
+    action: migrate_preserve
+    priority: P0
+    domain: eoc
+    target_path: docs/zh_CN/reference/eoc/npcs-and-dialogue.md
+    blockers:
+    - 1,637 行含 NPC 定义、对话、条件、效果和 math 巨量内容；必须与 EOC registry 去重并保留 deprecated 标记。
+- id: phase-0-governance
+  priorities:
+  - P0
+  document_count: 2
+  documents:
+  - stable_document_id: getting-started.how-you-can-help
+    original_path: doc/HOW_YOU_CAN_HELP.md
+    action: merge_into
+    priority: P0
+    domain: governance
+    target_path: docs/zh_CN/getting-started/first-contribution.md
+    blockers:
+    - 全文 84 个外部链接绝大多数指向 CleverRaven/CDDA labels、Wiki 和 Issue；不得直接搬迁。
+  - stable_document_id: pr-review-guide
+    original_path: doc/reviewing_PR_guide.md
+    action: migrate_rewrite
+    priority: P0
+    domain: governance
+    target_path: docs/zh_CN/contributing/pr-review.md
+    blockers: []
+- id: phase-0-json
+  priorities:
+  - P0
+  document_count: 12
+  documents:
+  - stable_document_id: json.items
+    original_path: doc/JSON/ITEM.md
+    action: migrate_preserve
+    priority: P0
+    domain: json
+    target_path: docs/zh_CN/reference/json/items/index.md
+    blockers:
+    - 1,666 行手工覆盖众多 subtype，必须拆分为概念/专题页并与 JSON object registry 做字段覆盖校验。
+  - stable_document_id: json.recipes-and-disassembly
+    original_path: doc/JSON/ITEM_CRAFT_AND_DISASSEMBLY.md
+    action: migrate_preserve
+    priority: P0
+    domain: json
+    target_path: docs/zh_CN/reference/json/recipes-and-disassembly.md
+    blockers:
+    - 残留两个 CleverRaven PR/Issue 解释历史语义，应改为来源注释而非现行契约链接。
+  - stable_document_id: json.item-groups
+    original_path: doc/JSON/ITEM_SPAWN.md
+    action: migrate_preserve
+    priority: P0
+    domain: json
+    target_path: docs/zh_CN/reference/json/item-groups.md
+    blockers:
+    - SUS 示例链接指向 CleverRaven；迁移时改为 CCB 固定 commit 或本地样例。
+  - stable_document_id: json.flags
+    original_path: doc/JSON/JSON_FLAGS.md
+    action: generated_reference
+    priority: P0
+    domain: json
+    target_path: docs/zh_CN/reference/json/generated/flags.md
+    blockers:
+    - 1,841 行跨子系统手工 flag 表无法证明完整；新生成器需合并注册、flagdoc 配置和 JSON，并保留无法自动提取的解释。
+  - stable_document_id: json.object-types
+    original_path: doc/JSON/JSON_INFO.md
+    action: migrate_rewrite
+    priority: P0
+    domain: json
+    target_path: docs/zh_CN/reference/json/index.md
+    blockers:
+    - 4,696 行把介绍、通用语法、目录导航和约 200 个对象章节混在一起；需拆为手写入口和生成 object type registry，且不得假装 Schema 完整。
+  - stable_document_id: json.inheritance
+    original_path: doc/JSON/JSON_INHERITANCE.md
+    action: migrate_preserve
+    priority: P0
+    domain: json
+    target_path: docs/zh_CN/reference/json/inheritance.md
+    blockers:
+    - 示例源码链接指向 CleverRaven master；应改为本地 source badge 和固定 verified commit。
+  - stable_document_id: contributing.json-style
+    original_path: doc/JSON/JSON_STYLE.md
+    action: migrate_rewrite
+    priority: P0
+    domain: json
+    target_path: docs/zh_CN/contributing/json-style.md
+    blockers:
+    - 正文仍称 Cataclysm-DDA root 并推荐 dev.narc.ro；命令应以当前 Makefile/CI 为准且实际运行。
+  - stable_document_id: json.mapgen
+    original_path: doc/JSON/MAPGEN.md
+    action: migrate_preserve
+    priority: P0
+    domain: json
+    target_path: docs/zh_CN/reference/json/mapgen.md
+    blockers:
+    - 1,792 行仍含 Limitations/TODO；拆分后必须保持字段来源与测试映射，不能把 TODO 当契约。
+  - stable_document_id: json.monsters
+    original_path: doc/JSON/MONSTERS.md
+    action: migrate_preserve
+    priority: P0
+    domain: json
+    target_path: docs/zh_CN/reference/json/monsters.md
+    blockers:
+    - 771 行字段表应与 mtype loader/object registry 自动比对；当前目录链接应改为可解析文件链接。
+  - stable_document_id: json.monster-special-attacks
+    original_path: doc/JSON/MONSTER_SPECIAL_ATTACKS.md
+    action: migrate_preserve
+    priority: P0
+    domain: json
+    target_path: docs/zh_CN/reference/json/monster-special-attacks.md
+    blockers:
+    - 正文明确含未完成的 hardcoded attack 描述 TODO；生成覆盖率必须区分硬编码、actor JSON 与 EOC attacks。
+  - stable_document_id: json.obsoletion-and-migration
+    original_path: doc/JSON/OBSOLETION_AND_MIGRATION.md
+    action: migrate_preserve
+    priority: P0
+    domain: json
+    target_path: docs/zh_CN/reference/json/obsoletion-and-migration.md
+    blockers:
+    - 这是存档兼容高风险文档；每种 migration 类型必须由当前注册、save loader 和加载测试验证后才能 active。
+  - stable_document_id: json.overmap
+    original_path: doc/JSON/OVERMAP.md
+    action: migrate_preserve
+    priority: P0
+    domain: json
+    target_path: docs/zh_CN/reference/json/overmap.md
+    blockers:
+    - 迁移时应把 post-process generator 与 overmap special 的来源和测试保持同页关联。
+- id: phase-0-localization
+  priorities:
+  - P0
+  document_count: 1
+  documents:
+  - stable_document_id: translation-guide
+    original_path: doc/TRANSLATING.md
+    action: migrate_rewrite
+    priority: P0
+    domain: localization
+    target_path: docs/zh_CN/localization/translation-guide.md
+    blockers: []
+- id: phase-0-lua
+  priorities:
+  - P0
+  document_count: 3
+  documents:
+  - stable_document_id: lua.v5.overview
+    original_path: data/lua/README.md
+    action: migrate_rewrite
+    priority: P0
+    domain: lua
+    target_path: docs/zh_CN/api/lua/v5/overview.md
+    blockers:
+    - Do not preserve manual symbol counts as prose; regenerate them and prove LuaLS/native/inventory/test
+      parity before publishing.
+  - stable_document_id: lua.v5.example-mod
+    original_path: data/lua/examples/api_v5_mod/README.md
+    action: migrate_rewrite
+    priority: P0
+    domain: lua
+    target_path: docs/zh_CN/api/lua/v5/example-mod.md
+    blockers:
+    - The published example must pass manifest Schema, Lua syntax, native loading, and generated-reference
+      checks.
+  - stable_document_id: tool-lua-api-coverage
+    original_path: tools/lua_api/README.md
+    action: keep_in_repo
+    priority: P0
+    domain: lua
+    target_path: tools/lua_api/README.md
+    blockers: []
+- id: phase-0-mods
+  priorities:
+  - P0
+  document_count: 3
+  documents:
+  - stable_document_id: mods.immortal-path.glossary
+    original_path: data/mods/immortal_path/GLOSSARY.md
+    action: keep_in_repo
+    priority: P0
+    domain: mods
+    target_path: data/mods/immortal_path/GLOSSARY.md
+    blockers: []
+  - stable_document_id: modding-overview
+    original_path: doc/MODDING.md
+    action: migrate_rewrite
+    priority: P0
+    domain: mods
+    target_path: docs/zh_CN/modding/overview.md
+    blockers: []
+  - stable_document_id: mod-compatibility
+    original_path: doc/MOD_COMPATIBILITY.md
+    action: migrate_rewrite
+    priority: P0
+    domain: mods
+    target_path: docs/zh_CN/modding/compatibility.md
+    blockers: []
+- id: phase-0-testing
+  priorities:
+  - P0
+  document_count: 3
+  documents:
+  - stable_document_id: testing.test-data-mod
+    original_path: data/mods/TEST_DATA/README.md
+    action: keep_in_repo
+    priority: P0
+    domain: testing
+    target_path: data/mods/TEST_DATA/README.md
+    blockers: []
+  - stable_document_id: testing-manual
+    original_path: doc/TESTING_YOUR_CHANGES.md
+    action: merge_into
+    priority: P0
+    domain: testing
+    target_path: docs/zh_CN/testing/manual-playtesting.md
+    blockers: []
+  - stable_document_id: cpp-testing
+    original_path: doc/c++/TESTING.md
+    action: migrate_rewrite
+    priority: P0
+    domain: testing
+    target_path: docs/zh_CN/testing/cpp.md
+    blockers: []
+- id: phase-0-translation
+  priorities:
+  - P0
+  document_count: 1
+  documents:
+  - stable_document_id: mods.immortal-path.language-convention
+    original_path: data/mods/immortal_path/LANGUAGE_CONVENTION.md
+    action: keep_in_repo
+    priority: P0
+    domain: translation
+    target_path: data/mods/immortal_path/LANGUAGE_CONVENTION.md
+    blockers:
+    - When formal i18n is wired for the mod, this page must drive a scripted migration and then be superseded
+      rather than silently left active.
+- id: phase-1-architecture
+  priorities:
+  - P1
+  document_count: 1
+  documents:
+  - stable_document_id: contributing.developer-faq
+    original_path: doc/DEVELOPER_FAQ.md
+    action: merge_into
+    priority: P1
+    domain: architecture
+    target_path: docs/zh_CN/how-to/common-tasks.md
+    blockers:
+    - 文中的 NUM_OMSPECS、player::activate_bionic 和 monattack::function 在当前已跟踪源码中均不存在，不能原样发布。
+- id: phase-1-build
+  priorities:
+  - P1
+  document_count: 1
+  documents:
+  - stable_document_id: build-devcontainer
+    original_path: doc/c++/COMPILING-DEVCONTAINER.md
+    action: migrate_rewrite
+    priority: P1
+    domain: build
+    target_path: docs/zh_CN/build/devcontainer.md
+    blockers: []
+- id: phase-1-cpp
+  priorities:
+  - P1
+  document_count: 5
+  documents:
+  - stable_document_id: cpp-activities
+    original_path: doc/PLAYER_ACTIVITY.md
+    action: migrate_rewrite
+    priority: P1
+    domain: cpp
+    target_path: docs/zh_CN/cpp/activities.md
+    blockers: []
+  - stable_document_id: developer-tooling
+    original_path: doc/c++/DEVELOPER_TOOLING.md
+    action: migrate_rewrite
+    priority: P1
+    domain: cpp
+    target_path: docs/zh_CN/cpp/developer-tooling.md
+    blockers: []
+  - stable_document_id: cpp-json-interface
+    original_path: doc/c++/JSON_INTERFACE.md
+    action: migrate_rewrite
+    priority: P1
+    domain: cpp
+    target_path: docs/zh_CN/cpp/json-interface.md
+    blockers: []
+  - stable_document_id: cpp-performance
+    original_path: doc/c++/PERFORMANCE.md
+    action: migrate_rewrite
+    priority: P1
+    domain: cpp
+    target_path: docs/zh_CN/cpp/performance.md
+    blockers: []
+  - stable_document_id: cpp-coordinates
+    original_path: doc/c++/POINTS_COORDINATES.md
+    action: migrate_rewrite
+    priority: P1
+    domain: cpp
+    target_path: docs/zh_CN/cpp/coordinates.md
+    blockers: []
+- id: phase-1-design
+  priorities:
+  - P1
+  document_count: 6
+  documents:
+  - stable_document_id: design.frequently-made-suggestions
+    original_path: doc/FREQUENTLY_MADE_SUGGESTIONS.md
+    action: migrate_rewrite
+    priority: P1
+    domain: design
+    target_path: docs/zh_CN/design/frequently-made-suggestions.md
+    blockers:
+    - 仍含多个 CleverRaven/CDDA Issue 与 discourse 链接；正式发布前必须逐条确认 CCB 是否继续采用相同结论。
+  - stable_document_id: legacy.doc-design-balance-lore-game-balance
+    original_path: doc/design-balance-lore/GAME_BALANCE.md
+    action: merge_into
+    priority: P1
+    domain: design
+    target_path: docs/zh_CN/design/balance.md
+    blockers: []
+  - stable_document_id: design-balance
+    original_path: doc/design-balance-lore/design-balance.md
+    action: migrate_rewrite
+    priority: P1
+    domain: design
+    target_path: docs/zh_CN/design/balance.md
+    blockers: []
+  - stable_document_id: design-overview
+    original_path: doc/design-balance-lore/design-doc.md
+    action: merge_into
+    priority: P1
+    domain: design
+    target_path: docs/zh_CN/design/overview.md
+    blockers: []
+  - stable_document_id: design-gameplay
+    original_path: doc/design-balance-lore/design-gameplay.md
+    action: migrate_rewrite
+    priority: P1
+    domain: design
+    target_path: docs/zh_CN/design/gameplay.md
+    blockers: []
+  - stable_document_id: design-user-experience
+    original_path: doc/design-balance-lore/design-user-experience.md
+    action: migrate_rewrite
+    priority: P1
+    domain: design
+    target_path: docs/zh_CN/design/user-experience.md
+    blockers: []
+- id: phase-1-governance
+  priorities:
+  - P1
+  document_count: 1
+  documents:
+  - stable_document_id: maintainers.issue-triage
+    original_path: doc/ISSUE_TRIAGE.md
+    action: migrate_rewrite
+    priority: P1
+    domain: governance
+    target_path: docs/zh_CN/maintainers/issue-triage.md
+    blockers:
+    - 优先级和标签名必须映射到最终 CCB Issue Forms/LABELS.md 后才能标为 active。
+- id: phase-1-json
+  priorities:
+  - P1
+  document_count: 25
+  documents:
+  - stable_document_id: legacy.data-json-loading-order
+    original_path: data/json/LOADING_ORDER.md
+    action: merge_into
+    priority: P1
+    domain: json
+    target_path: docs/zh_CN/reference/json/loading-order.md
+    blockers:
+    - Both old repository paths must become permanent bilingual moved stubs after the shared page is published.
+  - stable_document_id: json.artifacts
+    original_path: doc/JSON/ARTIFACTS.md
+    action: migrate_preserve
+    priority: P1
+    domain: json
+    target_path: docs/zh_CN/reference/json/artifacts.md
+    blockers:
+    - 没有专门 artifact 单元测试；字段参考必须以 loader 与已加载 JSON 校验补强。
+  - stable_document_id: json.basecamp
+    original_path: doc/JSON/BASECAMP.md
+    action: migrate_preserve
+    priority: P1
+    domain: json
+    target_path: docs/zh_CN/reference/json/basecamp.md
+    blockers: []
+  - stable_document_id: json.dimensions
+    original_path: doc/JSON/DIMENSIONS.md
+    action: migrate_preserve
+    priority: P1
+    domain: json
+    target_path: docs/zh_CN/reference/json/dimensions.md
+    blockers:
+    - 链接 REGION_LAYOUT.MD 在大小写敏感环境中无效；开头给出的 json\region_settings 路径也不是当前仓库路径。
+  - stable_document_id: json.effects
+    original_path: doc/JSON/EFFECTS_JSON.md
+    action: migrate_preserve
+    priority: P1
+    domain: json
+    target_path: docs/zh_CN/reference/json/effects.md
+    blockers: []
+  - stable_document_id: json.examine-actions
+    original_path: doc/JSON/EXAMINE.md
+    action: migrate_preserve
+    priority: P1
+    domain: json
+    target_path: docs/zh_CN/reference/json/examine-actions.md
+    blockers: []
+  - stable_document_id: json.npc-factions
+    original_path: doc/JSON/FACTIONS.md
+    action: migrate_preserve
+    priority: P1
+    domain: json
+    target_path: docs/zh_CN/reference/json/npc-factions.md
+    blockers: []
+  - stable_document_id: legacy.doc-json-json-loading-order
+    original_path: doc/JSON/JSON_LOADING_ORDER.md
+    action: merge_into
+    priority: P1
+    domain: json
+    target_path: docs/zh_CN/reference/json/loading-order.md
+    blockers:
+    - 与 data/json/LOADING_ORDER.md 字节级相同；两个旧路径都应指向同一稳定文档 ID，避免重复维护。
+  - stable_document_id: tutorial.mapgen-beginner
+    original_path: doc/JSON/JSON_Mapping_Guides/Guide_for_beginning_mapgen.md
+    action: migrate_rewrite
+    priority: P1
+    domain: json
+    target_path: docs/zh_CN/tutorials/json-mapgen/beginner.md
+    blockers:
+    - 教程含 11 个 CleverRaven 文件/文档链接和若干作者经验性结论；所有示例需改成本地固定来源并实际加载。
+  - stable_document_id: tutorial.mapgen-intermediate
+    original_path: doc/JSON/JSON_Mapping_Guides/Guide_for_intermediate_mapgen.md
+    action: migrate_rewrite
+    priority: P1
+    domain: json
+    target_path: docs/zh_CN/tutorials/json-mapgen/intermediate.md
+    blockers:
+    - Magiclysm/micro_lab 示例与上游锚点需在 CCB 当前数据中逐项重跑；代码块应加入可提取验证标记。
+  - stable_document_id: json.magic-spells-enchantments
+    original_path: doc/JSON/MAGIC.md
+    action: migrate_preserve
+    priority: P1
+    domain: json
+    target_path: docs/zh_CN/reference/json/magic-spells-enchantments.md
+    blockers:
+    - 1,149 行手工枚举 spell effects/flags/enchantment values；应与注册/loader 生成清单做 parity，保留人工解释。
+  - stable_document_id: json.martial-arts
+    original_path: doc/JSON/MARTIALART_JSON.md
+    action: migrate_preserve
+    priority: P1
+    domain: json
+    target_path: docs/zh_CN/reference/json/martial-arts.md
+    blockers: []
+  - stable_document_id: json.missions
+    original_path: doc/JSON/MISSIONS_JSON.md
+    action: migrate_preserve
+    priority: P1
+    domain: json
+    target_path: docs/zh_CN/reference/json/missions.md
+    blockers:
+    - 部分 start/end/fail 行为仍需硬编码函数；页面必须区分 mission JSON 与 dialogue/EOC 行为边界。
+  - stable_document_id: json.mutations
+    original_path: doc/JSON/MUTATIONS.md
+    action: migrate_preserve
+    priority: P1
+    domain: json
+    target_path: docs/zh_CN/reference/json/mutations.md
+    blockers:
+    - 系统说明同时依赖硬编码检查与 EOC；迁移后需清楚标注两种权威来源并修复目录型链接。
+  - stable_document_id: json.proficiencies
+    original_path: doc/JSON/PROFICIENCY.md
+    action: migrate_preserve
+    priority: P1
+    domain: json
+    target_path: docs/zh_CN/reference/json/proficiencies.md
+    blockers:
+    - 公式解释引用 CleverRaven PR；应把当前源码公式和测试作为来源。
+  - stable_document_id: json.proficiencies-index
+    original_path: doc/JSON/PROFICIENCY_LIST.md
+    action: generated_reference
+    priority: P1
+    domain: json
+    target_path: docs/zh_CN/reference/json/generated/proficiencies.md
+    blockers:
+    - 122 行却有 41 KB 的手工表，导入后从未更新；必须从 core 与明确纳入的 Mod 数据生成，并标出来源范围。
+  - stable_document_id: json.region-layout
+    original_path: doc/JSON/REGION_LAYOUT.md
+    action: migrate_preserve
+    priority: P1
+    domain: json
+    target_path: docs/zh_CN/reference/json/region-layout.md
+    blockers:
+    - 文档只列 UNIFORM 动态模式；生成 reference 必须从 loader 明确标记支持范围，不能暗示 STATIC 已完整实现。
+  - stable_document_id: json.region-settings
+    original_path: doc/JSON/REGION_SETTINGS.md
+    action: migrate_preserve
+    priority: P1
+    domain: json
+    target_path: docs/zh_CN/reference/json/region-settings.md
+    blockers:
+    - 624 行字段表无专项 C++ test；应至少通过 test_regional_map_settings 的全量 JSON load 验证。
+  - stable_document_id: json.terrain-furniture-transforms
+    original_path: doc/JSON/TER_FURN_TRANSFORM.md
+    action: migrate_preserve
+    priority: P1
+    domain: json
+    target_path: docs/zh_CN/reference/json/terrain-furniture-transforms.md
+    blockers:
+    - 已选择核心 mapgen 实例作为示例；迁移时仍需用 JSON load 验证该实例。
+  - stable_document_id: json.vehicle-prototypes
+    original_path: doc/JSON/VEHICLES_JSON.md
+    action: migrate_preserve
+    priority: P1
+    domain: json
+    target_path: docs/zh_CN/reference/json/vehicle-prototypes.md
+    blockers: []
+  - stable_document_id: json.vitamins
+    original_path: doc/JSON/VITAMIN.md
+    action: migrate_preserve
+    priority: P1
+    domain: json
+    target_path: docs/zh_CN/reference/json/vitamins.md
+    blockers: []
+  - stable_document_id: json.weather-types
+    original_path: doc/JSON/WEATHER_TYPE.md
+    action: migrate_preserve
+    priority: P1
+    domain: json
+    target_path: docs/zh_CN/reference/json/weather-types.md
+    blockers: []
+  - stable_document_id: json.wounds
+    original_path: doc/JSON/WOUNDS.md
+    action: migrate_preserve
+    priority: P1
+    domain: json
+    target_path: docs/zh_CN/reference/json/wounds.md
+    blockers:
+    - Git index 中未发现第一方 wound/wound_fix JSON 实例或专项测试；示例只能标记 schema-style，不能宣称已加载验证。
+  - stable_document_id: json-widgets
+    original_path: doc/WIDGETS.md
+    action: migrate_rewrite
+    priority: P1
+    domain: json
+    target_path: docs/zh_CN/json/widgets.md
+    blockers: []
+  - stable_document_id: json-item-variants
+    original_path: doc/design-balance-lore/VARIANTS.md
+    action: migrate_rewrite
+    priority: P1
+    domain: json
+    target_path: docs/zh_CN/json/item-variants.md
+    blockers: []
+- id: phase-1-localization
+  priorities:
+  - P1
+  document_count: 2
+  documents:
+  - stable_document_id: mod-localization
+    original_path: doc/TRANSLATING_MOD.md
+    action: merge_into
+    priority: P1
+    domain: localization
+    target_path: docs/zh_CN/modding/localization.md
+    blockers: []
+  - stable_document_id: legacy.lang-notes-readme-all-translators
+    original_path: lang/notes/README_all_translators.md
+    action: merge_into
+    priority: P1
+    domain: localization
+    target_path: docs/zh_CN/localization/translation-guide.md
+    blockers: []
+- id: phase-1-mods
+  priorities:
+  - P1
+  document_count: 23
+  documents:
+  - stable_document_id: mods.bombastic-perks.contributing
+    original_path: data/mods/BombasticPerks/docs/contributing.md
+    action: keep_in_repo
+    priority: P1
+    domain: mods
+    target_path: data/mods/BombasticPerks/docs/contributing.md
+    blockers: []
+  - stable_document_id: mods.bombastic-perks.extension-contract
+    original_path: data/mods/BombasticPerks/docs/expanding_with_mods.md
+    action: keep_in_repo
+    priority: P1
+    domain: mods
+    target_path: data/mods/BombasticPerks/docs/expanding_with_mods.md
+    blockers:
+    - The abbreviated JSON fragment is illustrative rather than parseable and must be explicitly marked
+      or replaced with a validated example.
+  - stable_document_id: mods.dinomod.design
+    original_path: data/mods/DinoMod/DESIGN.md
+    action: keep_in_repo
+    priority: P1
+    domain: mods
+    target_path: data/mods/DinoMod/DESIGN.md
+    blockers:
+    - Before substantive edits, re-check the enumerated file workflow because the current mod has grown
+      beyond the document's minimum list.
+  - stable_document_id: mods.magiclysm.balance
+    original_path: data/mods/Magiclysm/magic_balance.md
+    action: keep_in_repo
+    priority: P1
+    domain: mods
+    target_path: data/mods/Magiclysm/magic_balance.md
+    blockers:
+    - Specific damage, cost, and casting-time examples are snapshots and must be checked against JSON
+      whenever reused.
+  - stable_document_id: mods.mind-over-matter.gaining-powers
+    original_path: data/mods/MindOverMatter/GainingPowerSpoilers.md
+    action: keep_in_repo
+    priority: P1
+    domain: mods
+    target_path: data/mods/MindOverMatter/GainingPowerSpoilers.md
+    blockers:
+    - Revalidate every numeric formula against current awakening and learning EOCs before treating the
+      guide as exact.
+  - stable_document_id: mods.mind-over-matter.nether-attunement
+    original_path: data/mods/MindOverMatter/NetherAttunementSpoilers.md
+    action: keep_in_repo
+    priority: P1
+    domain: mods
+    target_path: data/mods/MindOverMatter/NetherAttunementSpoilers.md
+    blockers:
+    - Probability, threshold, and weight tables need contract extraction or explicit source-linked validation.
+  - stable_document_id: mods.mind-over-matter.new-power-guide
+    original_path: data/mods/MindOverMatter/NewPowerGuide.md
+    action: keep_in_repo
+    priority: P1
+    domain: mods
+    target_path: data/mods/MindOverMatter/NewPowerGuide.md
+    blockers:
+    - The sample math formula and per-path limitations are design policy, not a substitute for validating
+      current spell/EOC fields.
+  - stable_document_id: mods.mind-over-matter.power-reference
+    original_path: data/mods/MindOverMatter/PowerDescriptionSpoilers.md
+    action: generated_reference
+    priority: P1
+    domain: mods
+    target_path: docs/zh_CN/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
+    blockers:
+    - No current evidence proves all hand-copied values match the nine power JSON files; generation and
+      parity tests are required.
+  - stable_document_id: mods.mind-over-matter.overview
+    original_path: data/mods/MindOverMatter/README.md
+    action: keep_in_repo
+    priority: P1
+    domain: mods
+    target_path: data/mods/MindOverMatter/README.md
+    blockers:
+    - Replace the two upstream GitHub links with permanent local/CCB links and revalidate embedded numeric
+      claims.
+  - stable_document_id: mods.no-hope.contributing
+    original_path: data/mods/No_Hope/CONTRIBUTING.md
+    action: keep_in_repo
+    priority: P1
+    domain: mods
+    target_path: data/mods/No_Hope/CONTRIBUTING.md
+    blockers:
+    - 'Resolve or replace the bare upstream #70325 reference and re-check the list of missing C++-dependent
+      features.'
+  - stable_document_id: mods.no-hope.difficulty-options
+    original_path: data/mods/No_Hope/DIFFICULTY_OPTIONS.md
+    action: keep_in_repo
+    priority: P1
+    domain: mods
+    target_path: data/mods/No_Hope/DIFFICULTY_OPTIONS.md
+    blockers:
+    - Regenerate or validate the item-category list and count against the current registry and difficulty_options.json.
+  - stable_document_id: mods.sorcerer.overview
+    original_path: data/mods/Sorcerer/README.md
+    action: keep_in_repo
+    priority: P1
+    domain: mods
+    target_path: data/mods/Sorcerer/README.md
+    blockers:
+    - Generated-code ownership should be registered machine-readably and the generator must run without
+      path edits before its instructions are treated as complete.
+  - stable_document_id: mods.xedra-evolved.design
+    original_path: data/mods/Xedra_Evolved/design_doc_spoilers.md
+    action: keep_in_repo
+    priority: P1
+    domain: mods
+    target_path: data/mods/Xedra_Evolved/design_doc_spoilers.md
+    blockers: []
+  - stable_document_id: mods.aftershock-exoplanet.hacking
+    original_path: data/mods/aftershock_exoplanet/doc/Hacking.md
+    action: keep_in_repo
+    priority: P1
+    domain: mods
+    target_path: data/mods/aftershock_exoplanet/doc/Hacking.md
+    blockers:
+    - The second code block contains invalid JSON syntax and must be replaced with a formatter-validated
+      example.
+  - stable_document_id: mods.aftershock-exoplanet.crafting-system
+    original_path: data/mods/aftershock_exoplanet/doc/crafting_system.md
+    action: keep_in_repo
+    priority: P1
+    domain: mods
+    target_path: data/mods/aftershock_exoplanet/doc/crafting_system.md
+    blockers:
+    - Category names and tier completeness should be compared to all crafting_scrap JSON when edited.
+  - stable_document_id: mods.aftershock-exoplanet.balance.ranged-weapons
+    original_path: data/mods/aftershock_exoplanet/doc/lore/ranged_weapon_balance.md
+    action: generated_reference
+    priority: P1
+    domain: mods
+    target_path: docs/zh_CN/data/mods/aftershock_exoplanet/doc/lore/ranged_weapon_balance.md
+    blockers:
+    - Split hand-authored balance policy from generated weapon/armor tables and add parity tests before
+      declaring completeness.
+  - stable_document_id: mods.aftershock-exoplanet.balance.powered-armor
+    original_path: data/mods/aftershock_exoplanet/doc/suit_operating_time.md
+    action: keep_in_repo
+    priority: P1
+    domain: mods
+    target_path: data/mods/aftershock_exoplanet/doc/suit_operating_time.md
+    blockers:
+    - Add a validator for the 277777.78/hour calculation and verify the example against current item JSON.
+  - stable_document_id: mods.aftershock-exoplanet.exosuit-guide
+    original_path: data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_guide.md
+    action: keep_in_repo
+    priority: P1
+    domain: mods
+    target_path: data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_guide.md
+    blockers:
+    - Module capacities and item stats are hand-maintained tables and should be validated or generated.
+  - stable_document_id: mods.classic-zombies.design
+    original_path: data/mods/classic_zombies/design-doc.md
+    action: keep_in_repo
+    priority: P1
+    domain: mods
+    target_path: data/mods/classic_zombies/design-doc.md
+    blockers: []
+  - stable_document_id: mods.hunvre.lore
+    original_path: data/mods/hunvre/documentation/lore.md
+    action: keep_in_repo
+    priority: P1
+    domain: mods
+    target_path: data/mods/hunvre/documentation/lore.md
+    blockers: []
+  - stable_document_id: mods.immortal-path.game-design
+    original_path: data/mods/immortal_path/doc/game-design.md
+    action: keep_in_repo
+    priority: P1
+    domain: mods
+    target_path: data/mods/immortal_path/doc/game-design.md
+    blockers: []
+  - stable_document_id: mods.immortal-path.spell-design
+    original_path: data/mods/immortal_path/doc/spell-design.md
+    action: keep_in_repo
+    priority: P1
+    domain: mods
+    target_path: data/mods/immortal_path/doc/spell-design.md
+    blockers: []
+  - stable_document_id: mods.in-repository-policy
+    original_path: doc/IN_REPO_MODS.md
+    action: migrate_rewrite
+    priority: P1
+    domain: mods
+    target_path: docs/zh_CN/mods/in-repository-policy.md
+    blockers:
+    - 全文反复指定 CleverRaven 仓库和 curator 合并权；CCB 必须先在 CONTRIBUTING/OWNERSHIP 中确认自己的 mod 责任模型。
+- id: phase-1-release
+  priorities:
+  - P1
+  document_count: 3
+  documents:
+  - stable_document_id: contributing.changelog-guidelines
+    original_path: doc/CHANGELOG_GUIDELINES.md
+    action: keep_in_repo
+    priority: P1
+    domain: release
+    target_path: doc/CHANGELOG_GUIDELINES.md
+    blockers: []
+  - stable_document_id: legacy.doc-release-diff
+    original_path: doc/RELEASE_DIFF.md
+    action: merge_into
+    priority: P1
+    domain: release
+    target_path: docs/zh_CN/maintenance/releases.md
+    blockers: []
+  - stable_document_id: legacy.doc-release-process
+    original_path: doc/RELEASE_PROCESS.md
+    action: merge_into
+    priority: P1
+    domain: release
+    target_path: docs/zh_CN/maintenance/releases.md
+    blockers: []
+- id: phase-1-translation
+  priorities:
+  - P1
+  document_count: 2
+  documents:
+  - stable_document_id: mods.translate-dialogue.maintenance
+    original_path: data/mods/translate-dialogue/README.md
+    action: keep_in_repo
+    priority: P1
+    domain: translation
+    target_path: data/mods/translate-dialogue/README.md
+    blockers:
+    - Rewrite the generic Cataclysm-DDA path wording for CCB and validate the formatter command against
+      the current repository toolchain.
+  - stable_document_id: content.manual-of-style
+    original_path: doc/MANUAL_OF_STYLE.md
+    action: migrate_rewrite
+    priority: P1
+    domain: translation
+    target_path: docs/zh_CN/contributing/in-game-text-style.md
+    blockers:
+    - 链接 ../lang/notes 指向目录而非页面；双句空格、专名和方言规则应由 CCB 维护者在 CONTRIBUTING/治理来源中确认后发布。
+- id: phase-1-ui
+  priorities:
+  - P1
+  document_count: 1
+  documents:
+  - stable_document_id: ui-accessibility
+    original_path: doc/USER_INTERFACE_AND_ACCESSIBILITY.md
+    action: migrate_rewrite
+    priority: P1
+    domain: ui
+    target_path: docs/zh_CN/ui/accessibility.md
+    blockers: []
+- id: phase-2-content
+  priorities:
+  - P2
+  document_count: 2
+  documents:
+  - stable_document_id: content.npc.godco-roster
+    original_path: data/json/npcs/godco/NECC_INFO.md
+    action: keep_in_repo
+    priority: P2
+    domain: content
+    target_path: data/json/npcs/godco/NECC_INFO.md
+    blockers: []
+  - stable_document_id: content.npc.free-merchants-economy
+    original_path: data/json/npcs/refugee_center/FREE_MERCHANTS_INFO.md
+    action: keep_in_repo
+    priority: P2
+    domain: content
+    target_path: data/json/npcs/refugee_center/FREE_MERCHANTS_INFO.md
+    blockers: []
+- id: phase-2-design
+  priorities:
+  - P2
+  document_count: 6
+  documents:
+  - stable_document_id: content.firearms-naming-and-inclusion
+    original_path: doc/GUN_NAMING_AND_INCLUSION.md
+    action: migrate_rewrite
+    priority: P2
+    domain: design
+    target_path: docs/zh_CN/content/firearms/naming-and-inclusion.md
+    blockers:
+    - 文中的阈值是快照；页面必须从验证脚本派生或明确以脚本为准，避免双重契约。
+  - stable_document_id: json-armor-design
+    original_path: doc/design-balance-lore/ARMOR_BALANCE_AND_DESIGN.md
+    action: migrate_rewrite
+    priority: P2
+    domain: design
+    target_path: docs/zh_CN/json/armor-design.md
+    blockers: []
+  - stable_document_id: design-portal-storms
+    original_path: doc/design-balance-lore/PORTAL_STORM_BALANCE_AND_DESIGN.md
+    action: migrate_rewrite
+    priority: P2
+    domain: design
+    target_path: docs/zh_CN/design/portal-storms.md
+    blockers: []
+  - stable_document_id: json-item-pricing
+    original_path: doc/design-balance-lore/POSTAPOC_PRICE_GUIDE.md
+    action: migrate_rewrite
+    priority: P2
+    domain: design
+    target_path: docs/zh_CN/json/item-pricing.md
+    blockers: []
+  - stable_document_id: design-steel-crafting
+    original_path: doc/design-balance-lore/STEEL_CRAFTING.md
+    action: migrate_rewrite
+    priority: P2
+    domain: design
+    target_path: docs/zh_CN/design/steel-crafting.md
+    blockers: []
+  - stable_document_id: design-batteries-electricity
+    original_path: doc/design-balance-lore/batteries_and_electricity.md
+    action: migrate_rewrite
+    priority: P2
+    domain: design
+    target_path: docs/zh_CN/design/batteries-electricity.md
+    blockers: []
+- id: phase-2-json
+  priorities:
+  - P2
+  document_count: 10
+  documents:
+  - stable_document_id: json.climbing-aids
+    original_path: doc/JSON/CLIMBING.md
+    action: migrate_preserve
+    priority: P2
+    domain: json
+    target_path: docs/zh_CN/reference/json/climbing-aids.md
+    blockers:
+    - 缺少 climbing_aid 专项单元测试；示例需通过 JSON load。
+  - stable_document_id: json.faction-missions
+    original_path: doc/JSON/FACTION_MISSIONS.md
+    action: migrate_preserve
+    priority: P2
+    domain: json
+    target_path: docs/zh_CN/reference/json/faction-missions.md
+    blockers:
+    - 正文明确说明任务仍大多硬编码；页面必须区分 JSON 描述字段与 C++ 行为，不能暗示完全数据驱动。
+  - stable_document_id: json.comestibles-placement
+    original_path: doc/JSON/GUIDE_COMESTIBLES.md
+    action: migrate_rewrite
+    priority: P2
+    domain: json
+    target_path: docs/zh_CN/how-to/json/comestibles.md
+    blockers:
+    - 正文列出的 meat_dishes_human.json 当前不存在；目录路由是约定而非 JSON 契约，需从 Git index 生成或测试。
+  - stable_document_id: json.help-menu
+    original_path: doc/JSON/HELP_MENU.md
+    action: migrate_preserve
+    priority: P2
+    domain: json
+    target_path: docs/zh_CN/reference/json/help-menu.md
+    blockers: []
+  - stable_document_id: tutorial.mapgen-roofs
+    original_path: doc/JSON/JSON_Mapping_Guides/JSON_ROOF_MAPGEN.md
+    action: merge_into
+    priority: P2
+    domain: json
+    target_path: docs/zh_CN/tutorials/json-mapgen/beginner.md
+    blockers:
+    - 引用 CleverRaven MAPGEN 和已过时的 dev.narc.ro formatter；示例需并入可验证的初级 mapgen 路线。
+  - stable_document_id: how-to.json-tools
+    original_path: doc/JSON/JSON_TOOLS.md
+    action: migrate_rewrite
+    priority: P2
+    domain: json
+    target_path: docs/zh_CN/how-to/json/tools.md
+    blockers:
+    - 正文泛称 Cataclysm-DDA 且不覆盖每个脚本的当前参数；命令必须通过 --help/样例运行验证。
+  - stable_document_id: json.map-smashing
+    original_path: doc/JSON/MAP_SMASHING.md
+    action: merge_into
+    priority: P2
+    domain: json
+    target_path: docs/zh_CN/reference/json/terrain-and-furniture.md
+    blockers: []
+  - stable_document_id: json.movement-modes
+    original_path: doc/JSON/MOVE_MODE.md
+    action: migrate_preserve
+    priority: P2
+    domain: json
+    target_path: docs/zh_CN/reference/json/movement-modes.md
+    blockers: []
+  - stable_document_id: json.options
+    original_path: doc/JSON/OPTIONS.md
+    action: migrate_preserve
+    priority: P2
+    domain: json
+    target_path: docs/zh_CN/reference/json/options.md
+    blockers: []
+  - stable_document_id: json.practice-recipes
+    original_path: doc/JSON/PRACTICE_RECIPES.md
+    action: migrate_preserve
+    priority: P2
+    domain: json
+    target_path: docs/zh_CN/reference/json/practice-recipes.md
+    blockers: []
+- id: phase-2-lore
+  priorities:
+  - P2
+  document_count: 4
+  documents:
+  - stable_document_id: lore-background
+    original_path: doc/design-balance-lore/lore-background.md
+    action: migrate_rewrite
+    priority: P2
+    domain: lore
+    target_path: docs/zh_CN/lore/background.md
+    blockers: []
+  - stable_document_id: lore-factions
+    original_path: doc/design-balance-lore/lore-factions.md
+    action: migrate_rewrite
+    priority: P2
+    domain: lore
+    target_path: docs/zh_CN/lore/factions.md
+    blockers: []
+  - stable_document_id: lore-overview
+    original_path: doc/design-balance-lore/lore.md
+    action: migrate_rewrite
+    priority: P2
+    domain: lore
+    target_path: docs/zh_CN/lore/overview.md
+    blockers: []
+  - stable_document_id: lore-technology
+    original_path: doc/design-balance-lore/technology.md
+    action: migrate_rewrite
+    priority: P2
+    domain: lore
+    target_path: docs/zh_CN/lore/technology.md
+    blockers: []
+- id: phase-2-mods
+  priorities:
+  - P2
+  document_count: 20
+  documents:
+  - stable_document_id: mods.backrooms.overview
+    original_path: data/mods/Backrooms/README.md
+    action: keep_in_repo
+    priority: P2
+    domain: mods
+    target_path: data/mods/Backrooms/README.md
+    blockers: []
+  - stable_document_id: mods.dinomod.overview
+    original_path: data/mods/DinoMod/README.md
+    action: keep_in_repo
+    priority: P2
+    domain: mods
+    target_path: data/mods/DinoMod/README.md
+    blockers: []
+  - stable_document_id: mods.massachusetts.overview
+    original_path: data/mods/MA/README.md
+    action: keep_in_repo
+    priority: P2
+    domain: mods
+    target_path: data/mods/MA/README.md
+    blockers: []
+  - stable_document_id: mods.magiclysm.lore
+    original_path: data/mods/Magiclysm/lore.md
+    action: keep_in_repo
+    priority: P2
+    domain: mods
+    target_path: data/mods/Magiclysm/lore.md
+    blockers: []
+  - stable_document_id: mods.megafauna.overview
+    original_path: data/mods/Megafauna/readme.md
+    action: keep_in_repo
+    priority: P2
+    domain: mods
+    target_path: data/mods/Megafauna/readme.md
+    blockers:
+    - Do not present the hard-coded species counts or TODO completion states as generated facts.
+  - stable_document_id: mods.mind-over-matter.lore
+    original_path: data/mods/MindOverMatter/lore_spoilers.md
+    action: keep_in_repo
+    priority: P2
+    domain: mods
+    target_path: data/mods/MindOverMatter/lore_spoilers.md
+    blockers: []
+  - stable_document_id: mods.mind-over-matter.no-knacks
+    original_path: data/mods/MindOverMatterNoKnacks/README.md
+    action: keep_in_repo
+    priority: P2
+    domain: mods
+    target_path: data/mods/MindOverMatterNoKnacks/README.md
+    blockers: []
+  - stable_document_id: mods.sky-island.overview
+    original_path: data/mods/Sky_Island/README.md
+    action: keep_in_repo
+    priority: P2
+    domain: mods
+    target_path: data/mods/Sky_Island/README.md
+    blockers:
+    - Separate or refresh the stale embedded changelog before presenting version-specific behavior as
+      current.
+  - stable_document_id: mods.xedra-wood.overview
+    original_path: data/mods/XedraWood/README.md
+    action: keep_in_repo
+    priority: P2
+    domain: mods
+    target_path: data/mods/XedraWood/README.md
+    blockers: []
+  - stable_document_id: mods.xedra-evolved.overview
+    original_path: data/mods/Xedra_Evolved/README.md
+    action: keep_in_repo
+    priority: P2
+    domain: mods
+    target_path: data/mods/Xedra_Evolved/README.md
+    blockers:
+    - Do not publish feature counts as exact until derived from current JSON registries.
+  - stable_document_id: mods.xedra-evolved.vampire-guide
+    original_path: data/mods/Xedra_Evolved/vampire_guide.md
+    action: keep_in_repo
+    priority: P2
+    domain: mods
+    target_path: data/mods/Xedra_Evolved/vampire_guide.md
+    blockers:
+    - Timing and progression statements must be checked against the virus EOCs when changed.
+  - stable_document_id: mods.aftershock-exoplanet.lore.factions
+    original_path: data/mods/aftershock_exoplanet/doc/lore/factions.md
+    action: keep_in_repo
+    priority: P2
+    domain: mods
+    target_path: data/mods/aftershock_exoplanet/doc/lore/factions.md
+    blockers: []
+  - stable_document_id: mods.aftershock-exoplanet.lore.organizations
+    original_path: data/mods/aftershock_exoplanet/doc/lore/organizations.md
+    action: keep_in_repo
+    priority: P2
+    domain: mods
+    target_path: data/mods/aftershock_exoplanet/doc/lore/organizations.md
+    blockers: []
+  - stable_document_id: mods.aftershock-exoplanet.lore.points-of-interest
+    original_path: data/mods/aftershock_exoplanet/doc/lore/points_of_interest.md
+    action: keep_in_repo
+    priority: P2
+    domain: mods
+    target_path: data/mods/aftershock_exoplanet/doc/lore/points_of_interest.md
+    blockers: []
+  - stable_document_id: mods.aftershock-exoplanet.lore.salus-iv
+    original_path: data/mods/aftershock_exoplanet/doc/lore/salus_4.md
+    action: keep_in_repo
+    priority: P2
+    domain: mods
+    target_path: data/mods/aftershock_exoplanet/doc/lore/salus_4.md
+    blockers: []
+  - stable_document_id: mods.aftershock-exoplanet.lore.timeline
+    original_path: data/mods/aftershock_exoplanet/doc/lore/timeline.md
+    action: keep_in_repo
+    priority: P2
+    domain: mods
+    target_path: data/mods/aftershock_exoplanet/doc/lore/timeline.md
+    blockers: []
+  - stable_document_id: mods.alternative-map-key.overview
+    original_path: data/mods/alt_map_key/README.md
+    action: keep_in_repo
+    priority: P2
+    domain: mods
+    target_path: data/mods/alt_map_key/README.md
+    blockers: []
+  - stable_document_id: mods.classic-zombies.place-names
+    original_path: data/mods/classic_zombies/place_names.md
+    action: keep_in_repo
+    priority: P2
+    domain: mods
+    target_path: data/mods/classic_zombies/place_names.md
+    blockers:
+    - Clarify whether the name list is an authoring source or historical draft; it currently has no loaded
+      JSON consumer.
+  - stable_document_id: mods.immortal-path.lore
+    original_path: data/mods/immortal_path/doc/lore.md
+    action: keep_in_repo
+    priority: P2
+    domain: mods
+    target_path: data/mods/immortal_path/doc/lore.md
+    blockers:
+    - An English counterpart is required if this becomes an active CCB-Docs page; keeping it in-repo does
+      not make it a translated site page.
+  - stable_document_id: mods.innawood.overview
+    original_path: data/mods/innawood/readme.md
+    action: keep_in_repo
+    priority: P2
+    domain: mods
+    target_path: data/mods/innawood/readme.md
+    blockers: []
+- id: phase-2-resources
+  priorities:
+  - P2
+  document_count: 2
+  documents:
+  - stable_document_id: soundpacks
+    original_path: doc/SOUNDPACKS.md
+    action: migrate_rewrite
+    priority: P2
+    domain: resources
+    target_path: docs/zh_CN/resources/soundpacks.md
+    blockers: []
+  - stable_document_id: tilesets
+    original_path: doc/TILESET.md
+    action: migrate_rewrite
+    priority: P2
+    domain: resources
+    target_path: docs/zh_CN/resources/tilesets.md
+    blockers: []
+- id: phase-2-tooling
+  priorities:
+  - P2
+  document_count: 1
+  documents:
+  - stable_document_id: tool-llama-build-acceleration
+    original_path: tools/llama/README.md
+    action: keep_in_repo
+    priority: P2
+    domain: tooling
+    target_path: tools/llama/README.md
+    blockers: []
+- id: phase-2-ui
+  priorities:
+  - P2
+  document_count: 3
+  documents:
+  - stable_document_id: content.ascii-art
+    original_path: doc/ASCII_ART.md
+    action: migrate_rewrite
+    priority: P2
+    domain: ui
+    target_path: docs/zh_CN/content/ascii-art.md
+    blockers:
+    - Validate REXPaint version, palette/font links, width limits, and export examples; remove doctoc
+      and retain a permanent bilingual moved stub.
+  - stable_document_id: ui-colors
+    original_path: doc/user-guides/COLOR.md
+    action: migrate_rewrite
+    priority: P2
+    domain: ui
+    target_path: docs/zh_CN/ui/colors.md
+    blockers: []
+  - stable_document_id: ui-fonts
+    original_path: doc/user-guides/FONT_OPTIONS.md
+    action: migrate_rewrite
+    priority: P2
+    domain: ui
+    target_path: docs/zh_CN/ui/fonts.md
+    blockers: []
+- id: phase-3-build
+  priorities:
+  - P3
+  document_count: 2
+  documents:
+  - stable_document_id: archive-build-cygwin
+    original_path: doc/c++/COMPILING-CYGWIN.md
+    action: archive_public
+    priority: P3
+    domain: build
+    target_path: docs/zh_CN/archive/build/cygwin.md
+    blockers: []
+  - stable_document_id: archive-build-flatpak
+    original_path: doc/c++/COMPILING-FLATPAK.md
+    action: archive_public
+    priority: P3
+    domain: build
+    target_path: docs/zh_CN/archive/build/flatpak.md
+    blockers: []
+- id: phase-3-design
+  priorities:
+  - P3
+  document_count: 2
+  documents:
+  - stable_document_id: archive-construction-balance
+    original_path: doc/design-balance-lore/CONSTRUCTION_BALANCE.md
+    action: archive_public
+    priority: P3
+    domain: design
+    target_path: docs/zh_CN/archive/design/construction-balance.md
+    blockers: []
+  - stable_document_id: archive-melee-balance-spreadsheet
+    original_path: doc/design-balance-lore/melee_weapons/MELEE_BALANCE_SPREADSHEET.md
+    action: archive_public
+    priority: P3
+    domain: design
+    target_path: docs/zh_CN/archive/design/melee-balance-spreadsheet.md
+    blockers: []
+- id: phase-3-governance
+  priorities:
+  - P3
+  document_count: 1
+  documents:
+  - stable_document_id: archive-upstream-development-process
+    original_path: doc/development_process.md
+    action: archive_public
+    priority: P3
+    domain: governance
+    target_path: docs/zh_CN/archive/governance/development-process.md
+    blockers: []
+- id: phase-3-historical
+  priorities:
+  - P3
+  document_count: 1
+  documents:
+  - stable_document_id: archive.firearms-massachusetts-data-workflow
+    original_path: doc/HOWTO_MASSAGE_MA_GUN_DATA.md
+    action: archive_public
+    priority: P3
+    domain: historical
+    target_path: docs/zh_CN/archive/firearms/massachusetts-data-workflow.md
+    blockers: []
+- id: phase-3-localization
+  priorities:
+  - P3
+  document_count: 1
+  documents:
+  - stable_document_id: translation-notes-ru
+    original_path: lang/notes/ru-notes.md
+    action: keep_in_repo
+    priority: P3
+    domain: localization
+    target_path: lang/notes/ru-notes.md
+    blockers: []
+- id: phase-3-lore
+  priorities:
+  - P3
+  document_count: 1
+  documents:
+  - stable_document_id: archive-lore-faq
+    original_path: doc/design-balance-lore/LORE_FAQ.md
+    action: archive_public
+    priority: P3
+    domain: lore
+    target_path: docs/zh_CN/archive/lore/faq.md
+    blockers: []
+- id: phase-3-mods
+  priorities:
+  - P3
+  document_count: 2
+  documents:
+  - stable_document_id: mods.aftershock-exoplanet.lore.cyberpunk-future
+    original_path: data/mods/aftershock_exoplanet/doc/lore/cyberpunk_future.md
+    action: merge_into
+    priority: P3
+    domain: mods
+    target_path: docs/zh_CN/data/mods/aftershock_exoplanet/doc/lore/organizations.md
+    blockers:
+    - Retain a permanent lightweight moved stub at the old path after merging the unique technology paragraph.
+  - stable_document_id: mods.hunvre.progress
+    original_path: data/mods/hunvre/progress_tracker.md
+    action: keep_in_repo
+    priority: P3
+    domain: mods
+    target_path: data/mods/hunvre/progress_tracker.md
+    blockers:
+    - Any surfaced status must be checked against tracked Hunvre data because the file explicitly may
+      be stale.
+- id: phase-3-third-party
+  priorities:
+  - P3
+  document_count: 1
+  documents:
+  - stable_document_id: vendor-lua-runtime-provenance
+    original_path: src/lua/README.md
+    action: retain_third_party
+    priority: P3
+    domain: third-party
+    target_path: src/lua/README.md
+    blockers: []

--- a/tools/agent/check_project_metadata.py
+++ b/tools/agent/check_project_metadata.py
@@ -200,6 +200,33 @@ def validate_inventory() -> None:
     if any("value" in entry for entry in anomalies["entries"]):
         raise ValueError("raw rejected contributor identities must not be published")
 
+    batches_path = ROOT / "doc/migration/migration-batches.yml"
+    batches_schema_path = ROOT / "doc/migration/migration-batches.schema.json"
+    batches = load_yaml(batches_path)
+    batches_schema = json.loads(
+        batches_schema_path.read_text(encoding="utf-8")
+    )
+    jsonschema.Draft202012Validator(batches_schema).validate(batches)
+    batch_documents = [
+        document
+        for batch in batches["batches"]
+        for document in batch["documents"]
+    ]
+    if batches["batch_count"] != len(batches["batches"]):
+        raise ValueError("migration batch_count is stale")
+    if batches["document_count"] != len(batch_documents):
+        raise ValueError("migration batch document_count is stale")
+    expected_batched = {
+        entry["stable_document_id"]
+        for entry in inventory["documents"]
+        if entry["migration_batch"]
+    }
+    actual_batched = {
+        entry["stable_document_id"] for entry in batch_documents
+    }
+    if actual_batched != expected_batched:
+        raise ValueError("migration batches do not match the inventory")
+
 
 def validate_documentation_registry() -> None:
     registry_path = ROOT / "ai/documentation-registry.yml"

--- a/tools/agent/generate_migration_reports.py
+++ b/tools/agent/generate_migration_reports.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Generate human and machine migration summaries from the frozen inventory."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+INVENTORY = ROOT / "doc/migration/markdown-inventory.yml"
+DEFAULT_REPORT = ROOT / "doc/migration/classification-report.md"
+DEFAULT_BATCHES = ROOT / "doc/migration/migration-batches.yml"
+
+
+def load_inventory(path: Path = INVENTORY) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def counter_table(title: str, values: Counter) -> list[str]:
+    lines = [f"## {title}", "", "| Value | Count |", "| --- | ---: |"]
+    lines.extend(f"| `{key}` | {count} |" for key, count in sorted(values.items()))
+    lines.append("")
+    return lines
+
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/agent/generate_migration_reports.py
+++ b/tools/agent/generate_migration_reports.py
@@ -28,6 +28,49 @@ def counter_table(title: str, values: Counter) -> list[str]:
     return lines
 
 
+def render_report(data: dict) -> str:
+    documents = data["documents"]
+    actions = Counter(item["action"] for item in documents)
+    statuses = Counter(item["migration_status"] for item in documents)
+    domains = Counter(item["domain"] for item in documents)
+    priorities = Counter(item["priority"] for item in documents)
+    anomaly_count = sum(item["contributor_anomaly_count"] for item in documents)
+    lines = [
+        "# Legacy Markdown classification report",
+        "",
+        "This file is generated from `markdown-inventory.yml`; do not edit it by hand.",
+        "",
+        f"- Frozen source commit: `{data['source_commit']}`",
+        f"- Documents: **{len(documents)}**",
+        f"- Remaining `review` actions: **{data['classification_summary']['review']}**",
+        f"- Rejected contributor identities: **{anomaly_count}**",
+        "- `obj-lua/` is outside the tracked inventory and was not traversed.",
+        "",
+    ]
+    lines.extend(counter_table("Actions", actions))
+    lines.extend(counter_table("Migration status", statuses))
+    lines.extend(counter_table("Domains", domains))
+    lines.extend(counter_table("Priorities", priorities))
+    lines.extend(
+        [
+            "## Documents",
+            "",
+            "| Original path | Stable ID | Action | Status | Priority | Batch | Target |",
+            "| --- | --- | --- | --- | --- | --- | --- |",
+        ]
+    )
+    for item in documents:
+        target = item["target_path"] or item["replacement"] or "—"
+        batch = item["migration_batch"] or "—"
+        lines.append(
+            f"| `{item['original_path']}` | `{item['stable_document_id']}` | "
+            f"`{item['action']}` | `{item['migration_status']}` | "
+            f"`{item['priority']}` | `{batch}` | `{target}` |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/tools/agent/generate_migration_reports.py
+++ b/tools/agent/generate_migration_reports.py
@@ -71,6 +71,50 @@ def render_report(data: dict) -> str:
     return "\n".join(lines)
 
 
+def build_batches(data: dict) -> dict:
+    grouped: dict[str, list[dict]] = defaultdict(list)
+    for item in data["documents"]:
+        if not item["migration_batch"]:
+            continue
+        grouped[item["migration_batch"]].append(
+            {
+                "stable_document_id": item["stable_document_id"],
+                "original_path": item["original_path"],
+                "action": item["action"],
+                "priority": item["priority"],
+                "domain": item["domain"],
+                "target_path": item["target_path"],
+                "blockers": item["blockers"],
+            }
+        )
+    batches = []
+    for batch_id, entries in sorted(grouped.items()):
+        priorities = sorted({entry["priority"] for entry in entries})
+        batches.append(
+            {
+                "id": batch_id,
+                "priorities": priorities,
+                "document_count": len(entries),
+                "documents": sorted(
+                    entries,
+                    key=lambda entry: (
+                        entry["priority"],
+                        entry["domain"],
+                        entry["original_path"],
+                    ),
+                ),
+            }
+        )
+    return {
+        "schema_version": 1,
+        "kind": "markdown_migration_batches",
+        "source_commit": data["source_commit"],
+        "batch_count": len(batches),
+        "document_count": sum(batch["document_count"] for batch in batches),
+        "batches": batches,
+    }
+
+
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/tools/agent/generate_migration_reports.py
+++ b/tools/agent/generate_migration_reports.py
@@ -115,6 +115,40 @@ def build_batches(data: dict) -> dict:
     }
 
 
+def render_yaml(data: dict) -> str:
+    return yaml.safe_dump(data, allow_unicode=True, sort_keys=False, width=100)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--inventory", type=Path, default=INVENTORY)
+    parser.add_argument("--report", type=Path, default=DEFAULT_REPORT)
+    parser.add_argument("--batches", type=Path, default=DEFAULT_BATCHES)
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+
+    inventory_path = args.inventory if args.inventory.is_absolute() else ROOT / args.inventory
+    report_path = args.report if args.report.is_absolute() else ROOT / args.report
+    batches_path = args.batches if args.batches.is_absolute() else ROOT / args.batches
+    data = load_inventory(inventory_path)
+    outputs = {
+        report_path: render_report(data),
+        batches_path: render_yaml(build_batches(data)),
+    }
+    if args.check:
+        stale = [path for path, content in outputs.items() if path.read_text() != content]
+        if stale:
+            for path in stale:
+                print(f"stale migration output: {path.relative_to(ROOT)}", file=sys.stderr)
+            return 1
+        print("migration classification report and batches are current")
+        return 0
+    for path, content in outputs.items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    print(f"wrote {len(outputs)} migration outputs")
+    return 0
+
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/tools/agent/test_markdown_inventory.py
+++ b/tools/agent/test_markdown_inventory.py
@@ -59,6 +59,21 @@ class MarkdownInventoryTest(unittest.TestCase):
             self.assertTrue(item["contributors"])
             self.assertEqual(data["source_commit"], item["source_commit"])
 
+    def test_all_legacy_reviews_are_classified(self):
+        path = ROOT / "doc/migration/markdown-inventory.yml"
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+
+        self.assertEqual(data["classification_summary"]["review"], 0)
+        self.assertFalse(
+            any(item["action"] == "review" for item in data["documents"])
+        )
+        self.assertFalse(
+            any(
+                item["migration_status"] == "inventoried"
+                for item in data["documents"]
+            )
+        )
+
     def test_command_fragment_identity_is_rejected(self):
         clean, anomalies = inventory.sanitize_contributors(
             [

--- a/tools/agent/test_migration_reports.py
+++ b/tools/agent/test_migration_reports.py
@@ -1,0 +1,28 @@
+import unittest
+
+import generate_migration_reports as reports
+
+
+class MigrationReportsTest(unittest.TestCase):
+    def test_report_covers_the_frozen_inventory(self):
+        data = reports.load_inventory()
+        rendered = reports.render_report(data)
+
+        self.assertEqual(data["document_count"], 175)
+        for item in data["documents"]:
+            self.assertIn(f"`{item['stable_document_id']}`", rendered)
+        self.assertIn("Remaining `review` actions: **0**", rendered)
+
+    def test_batch_counts_match_documents(self):
+        data = reports.load_inventory()
+        batches = reports.build_batches(data)
+        expected = sum(
+            1 for item in data["documents"] if item["migration_batch"]
+        )
+
+        self.assertEqual(batches["document_count"], expected)
+        self.assertEqual(batches["batch_count"], len(batches["batches"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Applies the three independently reviewed legacy-document shards to the frozen 175-file inventory.

- classifies all 163 former `review` entries after full-text/source/test/Git-history review;
- leaves 12 retained/third-party entries verified;
- reduces `review` and `inventoried` counts to zero;
- gives every source a unique stable ID while representing many-to-one merges through `merge_target`;
- validates every declared source path and all 150 declared source symbols against tracked files;
- generates a human classification report and 37 machine-readable migration batches.

Program tracker: #558
Stack base: tooling registry PR on `agent/ccb-docs-program-registry`.

#### Responsible human

- Responsible human: @LYHGLYTX
- I understand the change and reviewed the final diff: yes
- I own the reported validation, licenses, attribution, and external sources: yes

#### Documentation impact

Complete legacy classification and migration routing.

#### Related CCB-Docs PR

Pending; migration pages remain uncreated/draft until later stack layers.

#### Affected documentation IDs

All 175 frozen source IDs.

#### Generated reference impact

Classification report, 37 migration batches, and documentation-registry mappings.

#### Runtime/gameplay/save impact

None.

## Validation

- [x] `python3 tools/agent/generate_markdown_inventory.py --check`
- [x] `python3 tools/agent/generate_migration_reports.py --check`
- [x] `python3 tools/agent/generate_documentation_registry.py --check`
- [x] `python3 tools/agent/check_project_metadata.py`
- [x] 23 Agent tests
- [x] flake8 7.3.0
- [x] `git diff --cached --check`

## Stack

Base branch is `agent/ccb-docs-program-registry`. Merge after #560 and the registry PR. No document migration/stub deletion occurs here; those are later reviewable stack layers. No auto-merge, Bot approval, CCB-GUIDE change, or game behavior change.

## Commit split

- Previous commit count: 1
- New commit count: 26
- Incremental changed lines: 8583
- Average changed lines: 330
- Largest atomic commit: see commit log
- Tree-equivalence result: PASS (git diff --exit-code <old-head> <new-head>)
- Previous head: `876d81f2db7511f40064346d5688784ceb5f19ac`
- New head: `e4407daaf35e6016b45a7f7eaeccd2f555342d3b`
- Backup bundle: skipped by owner instruction (old head recorded above)
- Validation status: tree-equivalent, chain verified
