### PR TITLE
CCB Agent 友好化与双语开发文档重构：tooling: add JSON and EOC contract inventories

### DIFF
--- a/.github/workflows/agent-context.yml
+++ b/.github/workflows/agent-context.yml
@@ -25,6 +25,11 @@ jobs:
           python3 tools/agent/check_project_metadata.py
           python3 -m unittest discover -s tools/agent -p 'test_*.py'
 
+      - name: Validate generated JSON and EOC contracts
+        run: |
+          python3 tools/json_api/generate_contracts.py --check
+          python3 -m unittest discover -s tools/json_api -p 'test_*.py'
+
       - name: Report documentation impact and validate PR responsibility
         env:
           PR_BODY: ${{ github.event.pull_request.body }}

--- a/ai/docs-impact.yml
+++ b/ai/docs-impact.yml
@@ -27,9 +27,22 @@ entries:
     generated_reference_impact: true
     risk_group: lua-api
     risk_level: high
-  - id: json-contracts
-    patterns: [data/json/*, data/core/*, src/*factory*, src/*json*]
+  - id: json-eoc-contracts
+    patterns:
+      - data/json/*
+      - data/core/*
+      - data/mods/*
+      - data/sound/*
+      - data/reference/json/*
+      - doc/JSON/*
+      - src/*factory*
+      - src/*json*
+      - src/init.cpp
+      - src/condition.cpp
+      - src/npctalk.cpp
+      - src/effect_on_condition.cpp
+      - tools/json_api/*
     documentation_ids: []
     generated_reference_impact: true
-    risk_group: json-api
+    risk_group: json-eoc-api
     risk_level: high

--- a/ai/generated-files.yml
+++ b/ai/generated-files.yml
@@ -67,6 +67,14 @@ entries:
     tracked: true
     generated_by: python3 tools/lua_api/generate_public_contract.py
     validation_id: lua-contract
+  - id: json-eoc-contract-inventories
+    paths:
+      - data/reference/json/ccb_json_object_types.json
+      - data/reference/json/ccb_eoc_conditions.json
+      - data/reference/json/ccb_eoc_effects.json
+    tracked: true
+    generated_by: python3 tools/json_api/generate_contracts.py
+    validation_id: json-eoc-contract
   - id: shader-artifacts
     paths: [data/shaders/*.spv, data/shaders/*.dxil, data/shaders/*.msl, data/shaders/build-*.stamp]
     tracked: false

--- a/ai/test-matrix.yml
+++ b/ai/test-matrix.yml
@@ -27,6 +27,22 @@ entries:
     command: make -j2 json-check
     workdir: .
     cost: medium
+  - id: json-eoc-contract
+    paths:
+      - src/init.cpp
+      - src/condition.cpp
+      - src/npctalk.cpp
+      - src/effect_on_condition.cpp
+      - data/core/
+      - data/json/
+      - data/mods/
+      - data/sound/
+      - data/reference/json/
+      - doc/JSON/
+      - tools/json_api/
+    command: python3 tools/json_api/generate_contracts.py --check && python3 -m unittest discover -s tools/json_api -p 'test_*.py'
+    workdir: .
+    cost: medium
   - id: lua-contract
     paths: ['src/catalua*.cpp', 'src/catalua*.h', src/event.h, data/lua/, tools/lua_api/]
     command: python3 tools/lua_api/check_luals_declarations.py && python3 tools/lua_api/check_ccb_inventory.py && python3 tools/lua_api/generate_public_contract.py --check && python3 tools/lua_api/check_public_contract.py && python3 tools/lua_api/check_examples.py && python3 -m unittest discover -s tools/lua_api -p 'test_*.py'

--- a/data/reference/json/ccb_eoc_conditions.json
+++ b/data/reference/json/ccb_eoc_conditions.json
@@ -1,0 +1,12186 @@
+{
+  "$schema": "../../../tools/json_api/contract-inventory.schema.json",
+  "schema_version": 1,
+  "inventory_kind": "eoc_conditions",
+  "source": {
+    "project": "Cataclysm-Cleanwater-Bomb",
+    "source_fingerprint": "sha256:43df0cec7f2e7a64ea037a329cd3056ef5bd18416bec39e6bd8bb79bed0f5ffc",
+    "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ],
+    "discovery": "git ls-files",
+    "parser": "src/condition.cpp#conditional_t::conditional_t",
+    "variable_parser": "src/condition.cpp#var_info::_deserialize"
+  },
+  "summary": {
+    "complex_parser_registrations": 89,
+    "simple_parser_registrations": 77,
+    "public_keys": 275,
+    "keys_with_example_candidates": 164,
+    "fully_classified_keys": 3
+  },
+  "global_contract": {
+    "parser_order": "first matching parser wins",
+    "unknown_object_condition": "JsonError",
+    "unknown_string_condition": "predicate returning false",
+    "variable_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ],
+    "value_helpers": [ "value_or_var", "value_or_var_pair", "dbl_or_var", "duration_or_var", "str_or_var", "translation_or_var", "eoc_math" ]
+  },
+  "entries": [
+    {
+      "key": "and",
+      "syntaxes": [ "logical_operator" ],
+      "accepted_json_shapes": [ "array" ],
+      "handlers": [ "conditional_t::conditional_t" ],
+      "aliases": [ "and" ],
+      "parser_registrations": [
+        {
+          "registration_order": -1,
+          "alias_role": "special",
+          "alias_group": [ "and" ],
+          "source": { "path": "src/condition.cpp", "line": 2676, "symbol": "conditional_t::conditional_t" }
+        }
+      ],
+      "parameters": { "status": "complete", "items": [  ] },
+      "value_types": { "status": "complete", "items": [ "array" ] },
+      "defaults": { "status": "complete", "items": [  ] },
+      "nesting": { "status": "complete", "allows": [ "condition_object", "condition_string" ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "not_applicable",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "complete", "requirements": [  ] },
+      "contract_status": "complete",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 5355,
+        "examples": [ { "path": "data/json/bionics.json", "pointer": "/51/enchantments/0/special_vision/0/condition/or/1/and" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/ARTIFACTS.md", "line": 11 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "at_safe_space",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_at_safe_space" ],
+      "aliases": [ "at_safe_space", "u_at_safe_space" ],
+      "parser_registrations": [
+        {
+          "registration_order": 114,
+          "alias_role": "beta",
+          "alias_group": [ "u_at_safe_space", "at_safe_space" ],
+          "source": { "path": "src/condition.cpp", "line": 2604, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 17,
+        "examples": [ { "path": "data/json/npcs/Kindred/Brigitte_LaCroix_main.json", "pointer": "/0/responses/4/condition/and/0" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1102 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "compare_string",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_compare_string" ],
+      "aliases": [ "compare_string" ],
+      "parser_registrations": [
+        {
+          "registration_order": 84,
+          "alias_role": "alpha",
+          "alias_group": [ "compare_string" ],
+          "source": { "path": "src/condition.cpp", "line": 2566, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 3162,
+        "examples": [ { "path": "data/json/effects_on_condition/anomalous_mp3_eocs.json", "pointer": "/2/effect/1/if/compare_string" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 94 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "compare_string_match_all",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_compare_string_match_all" ],
+      "aliases": [ "compare_string_match_all" ],
+      "parser_registrations": [
+        {
+          "registration_order": 85,
+          "alias_role": "alpha",
+          "alias_group": [ "compare_string_match_all" ],
+          "source": { "path": "src/condition.cpp", "line": 2567, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 5,
+        "examples": [ { "path": "data/mods/TEST_DATA/effect_on_condition.json", "pointer": "/26/effect/0/if/compare_string_match_all" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 599 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "current_dimension",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::current_dimension" ],
+      "aliases": [ "current_dimension" ],
+      "parser_registrations": [
+        {
+          "registration_order": 24,
+          "alias_role": "alpha",
+          "alias_group": [ "current_dimension" ],
+          "source": { "path": "src/condition.cpp", "line": 2506, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 66,
+        "examples": [ { "path": "data/json/debug/teleportation.json", "pointer": "/0/effect/0/if/current_dimension" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1373 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "expects_vars",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_expects_vars" ],
+      "aliases": [ "expects_vars" ],
+      "parser_registrations": [
+        {
+          "registration_order": 39,
+          "alias_role": "alpha",
+          "alias_group": [ "expects_vars" ],
+          "source": { "path": "src/condition.cpp", "line": 2521, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 35,
+        "examples": [ { "path": "data/json/artifact/altered_object_active.json", "pointer": "/25/condition/expects_vars" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 543 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "follower_present",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "string" ],
+      "handlers": [ "conditional_fun::f_follower_present" ],
+      "aliases": [ "follower_present" ],
+      "parser_registrations": [
+        {
+          "registration_order": 38,
+          "alias_role": "alpha",
+          "alias_group": [ "follower_present" ],
+          "source": { "path": "src/condition.cpp", "line": 2520, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 11,
+        "examples": [ { "path": "data/json/npcs/exodii/common_talk.json", "pointer": "/2/dynamic_line/0/concatenate/1/follower_present" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "get_condition",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_get_condition" ],
+      "aliases": [ "get_condition" ],
+      "parser_registrations": [
+        {
+          "registration_order": 86,
+          "alias_role": "alpha",
+          "alias_group": [ "get_condition" ],
+          "source": { "path": "src/condition.cpp", "line": 2568, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 12,
+        "examples": [ { "path": "data/json/effects_on_condition/generalized_eocs.json", "pointer": "/1/condition/and/6/get_condition" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3978 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "has_alpha",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_has_alpha" ],
+      "aliases": [ "has_alpha" ],
+      "parser_registrations": [
+        {
+          "registration_order": 151,
+          "alias_role": "alpha",
+          "alias_group": [ "has_alpha" ],
+          "source": { "path": "src/condition.cpp", "line": 2641, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 28,
+        "examples": [ { "path": "data/json/effects_on_condition/anomalous_mp3_eocs.json", "pointer": "/3/effect/0/if" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 87 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "has_ammo",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_has_ammo" ],
+      "aliases": [ "has_ammo" ],
+      "parser_registrations": [
+        {
+          "registration_order": 147,
+          "alias_role": "alpha",
+          "alias_group": [ "has_ammo" ],
+          "source": { "path": "src/condition.cpp", "line": 2637, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 5,
+        "examples": [ { "path": "data/json/effects_on_condition/item_eocs.json", "pointer": "/12/effect/0/if" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1726 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "has_assigned_mission",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_has_assigned_mission" ],
+      "aliases": [ "has_assigned_mission" ],
+      "parser_registrations": [
+        {
+          "registration_order": 93,
+          "alias_role": "alpha",
+          "alias_group": [ "has_assigned_mission" ],
+          "source": { "path": "src/condition.cpp", "line": 2583, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 52,
+        "examples": [ { "path": "data/json/npcs/Lighthouse_Family/NPC_lighthouse_girl.json", "pointer": "/3/responses/0/condition" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/MISSIONS_JSON.md", "line": 345 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "has_available_mission",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_has_available_mission" ],
+      "aliases": [ "has_available_mission", "u_has_available_mission" ],
+      "parser_registrations": [
+        {
+          "registration_order": 97,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_available_mission", "has_available_mission" ],
+          "source": { "path": "src/condition.cpp", "line": 2587, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1106 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "has_beta",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_has_beta" ],
+      "aliases": [ "has_beta" ],
+      "parser_registrations": [
+        {
+          "registration_order": 152,
+          "alias_role": "alpha",
+          "alias_group": [ "has_beta" ],
+          "source": { "path": "src/condition.cpp", "line": 2642, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 23,
+        "examples": [ { "path": "data/json/effects_on_condition/weakpoints_eocs.json", "pointer": "/0/condition" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 89 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "has_many_assigned_missions",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_has_many_assigned_missions" ],
+      "aliases": [ "has_many_assigned_missions" ],
+      "parser_registrations": [
+        {
+          "registration_order": 94,
+          "alias_role": "alpha",
+          "alias_group": [ "has_many_assigned_missions" ],
+          "source": { "path": "src/condition.cpp", "line": 2584, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 42,
+        "examples": [
+          {
+            "path": "data/json/npcs/Kindred/NPC_Brigitte_LaCroix.json",
+            "pointer": "/24/dynamic_line/has_no_available_mission/no/has_many_assigned_missions"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/MISSIONS_JSON.md", "line": 350 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "has_many_available_missions",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_has_many_available_missions" ],
+      "aliases": [ "has_many_available_missions", "u_has_many_available_missions" ],
+      "parser_registrations": [
+        {
+          "registration_order": 99,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_many_available_missions", "has_many_available_missions" ],
+          "source": { "path": "src/condition.cpp", "line": 2589, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 3,
+        "examples": [
+          {
+            "path": "data/json/npcs/Kindred/NPC_Brigitte_LaCroix.json",
+            "pointer": "/24/dynamic_line/no/has_many_available_missions"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1107 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "has_no_assigned_mission",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_no_assigned_mission" ],
+      "aliases": [ "has_no_assigned_mission" ],
+      "parser_registrations": [
+        {
+          "registration_order": 92,
+          "alias_role": "alpha",
+          "alias_group": [ "has_no_assigned_mission" ],
+          "source": { "path": "src/condition.cpp", "line": 2582, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 12,
+        "examples": [
+          {
+            "path": "data/json/npcs/Kindred/NPC_Brigitte_LaCroix.json",
+            "pointer": "/24/dynamic_line/has_no_available_mission/has_no_assigned_mission"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "has_no_available_mission",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_no_available_mission" ],
+      "aliases": [ "has_no_available_mission", "u_has_no_available_mission" ],
+      "parser_registrations": [
+        {
+          "registration_order": 95,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_no_available_mission", "has_no_available_mission" ],
+          "source": { "path": "src/condition.cpp", "line": 2585, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 14,
+        "examples": [
+          { "path": "data/json/npcs/Kindred/NPC_Brigitte_LaCroix.json", "pointer": "/24/dynamic_line/has_no_available_mission" }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1105 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "has_pickup_list",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_has_pickup_list" ],
+      "aliases": [ "has_pickup_list", "u_has_pickup_list" ],
+      "parser_registrations": [
+        {
+          "registration_order": 129,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_pickup_list", "has_pickup_list" ],
+          "source": { "path": "src/condition.cpp", "line": 2619, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1134 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "has_reason",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_has_reason" ],
+      "aliases": [ "has_reason" ],
+      "parser_registrations": [
+        {
+          "registration_order": 132,
+          "alias_role": "alpha",
+          "alias_group": [ "has_reason" ],
+          "source": { "path": "src/condition.cpp", "line": 2622, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 5,
+        "examples": [ { "path": "data/json/npcs/Kindred/Brigitte_LaCroix_main.json", "pointer": "/0/dynamic_line/no/has_reason" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 558 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "is_by_radio",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_by_radio" ],
+      "aliases": [ "is_by_radio" ],
+      "parser_registrations": [
+        {
+          "registration_order": 131,
+          "alias_role": "alpha",
+          "alias_group": [ "is_by_radio" ],
+          "source": { "path": "src/condition.cpp", "line": 2621, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 49,
+        "examples": [ { "path": "data/json/npcs/Kindred/Brigitte_LaCroix_main.json", "pointer": "/0/dynamic_line/is_by_radio" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1119 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "is_day",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_day" ],
+      "aliases": [ "is_day" ],
+      "parser_registrations": [
+        {
+          "registration_order": 123,
+          "alias_role": "alpha",
+          "alias_group": [ "is_day" ],
+          "source": { "path": "src/condition.cpp", "line": 2613, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 119,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json",
+            "pointer": "/6/effect/cases/0/effect/then/if"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3998 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "is_outside",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_tile_is_outside" ],
+      "aliases": [ "is_outside" ],
+      "parser_registrations": [
+        {
+          "registration_order": 23,
+          "alias_role": "alpha",
+          "alias_group": [ "is_outside" ],
+          "source": { "path": "src/condition.cpp", "line": 2505, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [
+          {
+            "path": "data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json",
+            "pointer": "/83/effect/1/then/0/condition/and/0/not/is_outside"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1150 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "is_rotten",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_rotten" ],
+      "aliases": [ "is_rotten" ],
+      "parser_registrations": [
+        {
+          "registration_order": 165,
+          "alias_role": "alpha",
+          "alias_group": [ "is_rotten" ],
+          "source": { "path": "src/condition.cpp", "line": 2655, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1730 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "is_season",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_is_season" ],
+      "aliases": [ "is_season" ],
+      "parser_registrations": [
+        {
+          "registration_order": 52,
+          "alias_role": "alpha",
+          "alias_group": [ "is_season" ],
+          "source": { "path": "src/condition.cpp", "line": 2534, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 59,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/mutation_eocs/mutation_effect_eocs.json",
+            "pointer": "/30/condition/and/1/or/0/is_season"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3998 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "is_weather",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_is_weather" ],
+      "aliases": [ "is_weather" ],
+      "parser_registrations": [
+        {
+          "registration_order": 72,
+          "alias_role": "alpha",
+          "alias_group": [ "is_weather" ],
+          "source": { "path": "src/condition.cpp", "line": 2554, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 254,
+        "examples": [ { "path": "data/json/effects_on_condition/item_eocs.json", "pointer": "/3/condition/or/0/is_weather" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 236 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "line_of_sight",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_line_of_sight" ],
+      "aliases": [ "line_of_sight" ],
+      "parser_registrations": [
+        {
+          "registration_order": 59,
+          "alias_role": "alpha",
+          "alias_group": [ "line_of_sight" ],
+          "source": { "path": "src/condition.cpp", "line": 2541, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 9,
+        "examples": [ { "path": "data/json/effects_on_condition/example_eocs.json", "pointer": "/23/effect/0/u_query_tile" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1520 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "map_field_id",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_map_ter_furn_id" ],
+      "aliases": [ "map_field_id" ],
+      "parser_registrations": [
+        {
+          "registration_order": 77,
+          "alias_role": "alpha",
+          "alias_group": [ "map_field_id" ],
+          "source": { "path": "src/condition.cpp", "line": 2559, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 6,
+        "examples": [ { "path": "data/mods/MindOverMatter/powers/artifacts.json", "pointer": "/33/effect/0/condition/map_field_id" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1303 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "map_furniture_id",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_map_ter_furn_id" ],
+      "aliases": [ "map_furniture_id" ],
+      "parser_registrations": [
+        {
+          "registration_order": 76,
+          "alias_role": "alpha",
+          "alias_group": [ "map_furniture_id" ],
+          "source": { "path": "src/condition.cpp", "line": 2558, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 9,
+        "examples": [
+          {
+            "path": "data/mods/BombasticPerks/perkdata/closetland.json",
+            "pointer": "/3/effect/5/condition/or/1/map_furniture_id"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1303 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "map_furniture_with_flag",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_map_ter_furn_with_flag" ],
+      "aliases": [ "map_furniture_with_flag" ],
+      "parser_registrations": [
+        {
+          "registration_order": 74,
+          "alias_role": "alpha",
+          "alias_group": [ "map_furniture_with_flag" ],
+          "source": { "path": "src/condition.cpp", "line": 2556, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 6,
+        "examples": [ { "path": "data/json/effects_on_condition/example_eocs.json", "pointer": "/19/effect/4/if/map_furniture_with_flag" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 479 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "map_in_city",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_map_in_city" ],
+      "aliases": [ "map_in_city" ],
+      "parser_registrations": [
+        {
+          "registration_order": 79,
+          "alias_role": "alpha",
+          "alias_group": [ "map_in_city" ],
+          "source": { "path": "src/condition.cpp", "line": 2561, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 6,
+        "examples": [ { "path": "data/json/effects_on_condition/example_eocs.json", "pointer": "/19/effect/1/if/map_in_city" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1332 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "map_is_outside",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_map_is_outside" ],
+      "aliases": [ "map_is_outside" ],
+      "parser_registrations": [
+        {
+          "registration_order": 78,
+          "alias_role": "alpha",
+          "alias_group": [ "map_is_outside" ],
+          "source": { "path": "src/condition.cpp", "line": 2560, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 3,
+        "examples": [
+          {
+            "path": "data/mods/Xedra_Evolved/eocs/eoc_strange_events.json",
+            "pointer": "/3/effect/0/true_eocs/0/condition/not/map_is_outside"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1336 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "map_terrain_id",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_map_ter_furn_id" ],
+      "aliases": [ "map_terrain_id" ],
+      "parser_registrations": [
+        {
+          "registration_order": 75,
+          "alias_role": "alpha",
+          "alias_group": [ "map_terrain_id" ],
+          "source": { "path": "src/condition.cpp", "line": 2557, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 16,
+        "examples": [ { "path": "data/mods/BombasticPerks/perkdata/closetland.json", "pointer": "/3/effect/8/if/or/2/map_terrain_id" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1303 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "map_terrain_with_flag",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_map_ter_furn_with_flag" ],
+      "aliases": [ "map_terrain_with_flag" ],
+      "parser_registrations": [
+        {
+          "registration_order": 73,
+          "alias_role": "alpha",
+          "alias_group": [ "map_terrain_with_flag" ],
+          "source": { "path": "src/condition.cpp", "line": 2555, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 40,
+        "examples": [ { "path": "data/json/effects_on_condition/example_eocs.json", "pointer": "/19/effect/3/if/map_terrain_with_flag" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 479 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "math",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_math" ],
+      "aliases": [ "math" ],
+      "parser_registrations": [
+        {
+          "registration_order": 82,
+          "alias_role": "alpha",
+          "alias_group": [ "math" ],
+          "source": { "path": "src/condition.cpp", "line": 2564, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 21922,
+        "examples": [ { "path": "data/json/artifact/altered_object_active.json", "pointer": "/14/min_damage/math" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 98 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "mission_complete",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_mission_complete" ],
+      "aliases": [ "mission_complete", "u_mission_complete" ],
+      "parser_registrations": [
+        {
+          "registration_order": 101,
+          "alias_role": "beta",
+          "alias_group": [ "u_mission_complete", "mission_complete" ],
+          "source": { "path": "src/condition.cpp", "line": 2591, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 25,
+        "examples": [ { "path": "data/json/npcs/Lighthouse_Family/NPC_lighthouse_man.json", "pointer": "/8/responses/1/condition" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1112 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "mission_failed",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_mission_failed" ],
+      "aliases": [ "mission_failed", "u_mission_failed" ],
+      "parser_registrations": [
+        {
+          "registration_order": 105,
+          "alias_role": "beta",
+          "alias_group": [ "u_mission_failed", "mission_failed" ],
+          "source": { "path": "src/condition.cpp", "line": 2595, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_MISSION.json", "pointer": "/8/responses/0/condition" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1114 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "mission_goal",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_mission_goal" ],
+      "aliases": [ "mission_goal", "u_mission_goal" ],
+      "parser_registrations": [
+        {
+          "registration_order": 53,
+          "alias_role": "beta",
+          "alias_group": [ "u_mission_goal", "mission_goal" ],
+          "source": { "path": "src/condition.cpp", "line": 2535, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 25,
+        "examples": [ { "path": "data/json/npcs/TALK_TEST.json", "pointer": "/13/responses/1/condition/mission_goal" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1108 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "mission_has_generic_rewards",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_mission_has_generic_rewards" ],
+      "aliases": [ "mission_has_generic_rewards" ],
+      "parser_registrations": [
+        {
+          "registration_order": 133,
+          "alias_role": "alpha",
+          "alias_group": [ "mission_has_generic_rewards" ],
+          "source": { "path": "src/condition.cpp", "line": 2623, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 6,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_MISSION.json", "pointer": "/9/responses/0/condition" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1115 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "mission_incomplete",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_mission_incomplete" ],
+      "aliases": [ "mission_incomplete", "u_mission_incomplete" ],
+      "parser_registrations": [
+        {
+          "registration_order": 103,
+          "alias_role": "beta",
+          "alias_group": [ "u_mission_incomplete", "mission_incomplete" ],
+          "source": { "path": "src/condition.cpp", "line": 2593, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 3,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_MISSION.json", "pointer": "/8/responses/2/condition" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1113 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "mod_is_loaded",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_mod_is_loaded" ],
+      "aliases": [ "mod_is_loaded" ],
+      "parser_registrations": [
+        {
+          "registration_order": 80,
+          "alias_role": "alpha",
+          "alias_group": [ "mod_is_loaded" ],
+          "source": { "path": "src/condition.cpp", "line": 2562, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 51,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/nether_eocs/nether_glass_effect_on_condition.json",
+            "pointer": "/0/effect/run_eocs/2/effect/4/if/mod_is_loaded"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1160 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "not",
+      "syntaxes": [ "logical_operator" ],
+      "accepted_json_shapes": [ "object_or_string" ],
+      "handlers": [ "conditional_t::conditional_t" ],
+      "aliases": [ "not" ],
+      "parser_registrations": [
+        {
+          "registration_order": -1,
+          "alias_role": "special",
+          "alias_group": [ "not" ],
+          "source": { "path": "src/condition.cpp", "line": 2692, "symbol": "conditional_t::conditional_t" }
+        }
+      ],
+      "parameters": { "status": "complete", "items": [  ] },
+      "value_types": { "status": "complete", "items": [ "object_or_string" ] },
+      "defaults": { "status": "complete", "items": [  ] },
+      "nesting": { "status": "complete", "allows": [ "condition_object", "condition_string" ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "not_applicable",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "complete", "requirements": [  ] },
+      "contract_status": "complete",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 6666,
+        "examples": [ { "path": "data/json/artifact/altered_object_active.json", "pointer": "/10/condition/not" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/ARTIFACTS.md", "line": 28 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_aim_rule",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_npc_aim_rule" ],
+      "aliases": [ "npc_aim_rule", "u_aim_rule" ],
+      "parser_registrations": [
+        {
+          "registration_order": 46,
+          "alias_role": "beta",
+          "alias_group": [ "u_aim_rule", "npc_aim_rule" ],
+          "source": { "path": "src/condition.cpp", "line": 2528, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/TALK_TEST.json", "pointer": "/11/responses/2/condition/npc_aim_rule" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 578 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_allies",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "member" ],
+      "handlers": [ "conditional_fun::f_npc_allies" ],
+      "aliases": [ "npc_allies" ],
+      "parser_registrations": [
+        {
+          "registration_order": 41,
+          "alias_role": "alpha",
+          "alias_group": [ "npc_allies" ],
+          "source": { "path": "src/condition.cpp", "line": 2523, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 10,
+        "examples": [ { "path": "data/json/monsters/singularities.json", "pointer": "/20/condition/and/1/or/0/npc_allies" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1117 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_allies_global",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "member" ],
+      "handlers": [ "conditional_fun::f_npc_allies_global" ],
+      "aliases": [ "npc_allies_global" ],
+      "parser_registrations": [
+        {
+          "registration_order": 42,
+          "alias_role": "alpha",
+          "alias_group": [ "npc_allies_global" ],
+          "source": { "path": "src/condition.cpp", "line": 2524, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 3,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/misc_effect_on_condition.json",
+            "pointer": "/7/condition/and/0/npc_allies_global"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1118 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_at_om_location",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_at_om_location" ],
+      "aliases": [ "npc_at_om_location", "u_at_om_location" ],
+      "parser_registrations": [
+        {
+          "registration_order": 36,
+          "alias_role": "beta",
+          "alias_group": [ "u_at_om_location", "npc_at_om_location" ],
+          "source": { "path": "src/condition.cpp", "line": 2518, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 31,
+        "examples": [
+          {
+            "path": "data/json/npcs/Lighthouse_Family/NPC_lighthouse_girl.json",
+            "pointer": "/1/responses/1/condition/npc_at_om_location"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 351 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_at_safe_space",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_at_safe_space" ],
+      "aliases": [ "npc_at_safe_space", "u_at_safe_space" ],
+      "parser_registrations": [
+        {
+          "registration_order": 115,
+          "alias_role": "beta",
+          "alias_group": [ "u_at_safe_space", "npc_at_safe_space" ],
+          "source": { "path": "src/condition.cpp", "line": 2605, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1102 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_available",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_npc_available" ],
+      "aliases": [ "npc_available", "u_available" ],
+      "parser_registrations": [
+        {
+          "registration_order": 107,
+          "alias_role": "beta",
+          "alias_group": [ "u_available", "npc_available" ],
+          "source": { "path": "src/condition.cpp", "line": 2597, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 5,
+        "examples": [ { "path": "data/json/npcs/TALK_TEST.json", "pointer": "/6/responses/3/condition" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1120 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_bodytype",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_bodytype" ],
+      "aliases": [ "npc_bodytype", "u_bodytype" ],
+      "parser_registrations": [
+        {
+          "registration_order": 10,
+          "alias_role": "beta",
+          "alias_group": [ "u_bodytype", "npc_bodytype" ],
+          "source": { "path": "src/condition.cpp", "line": 2492, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 96,
+        "examples": [ { "path": "data/json/techniques.json", "pointer": "/16/condition/and/2/not/npc_bodytype" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 526 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_can_drop_weapon",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_can_drop_weapon" ],
+      "aliases": [ "npc_can_drop_weapon", "u_can_drop_weapon" ],
+      "parser_registrations": [
+        {
+          "registration_order": 117,
+          "alias_role": "beta",
+          "alias_group": [ "u_can_drop_weapon", "npc_can_drop_weapon" ],
+          "source": { "path": "src/condition.cpp", "line": 2607, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 909 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_can_float",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_can_float" ],
+      "aliases": [ "npc_can_float", "u_can_float" ],
+      "parser_registrations": [
+        {
+          "registration_order": 157,
+          "alias_role": "beta",
+          "alias_group": [ "u_can_float", "npc_can_float" ],
+          "source": { "path": "src/condition.cpp", "line": 2647, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1597 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_can_fly",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_can_fly" ],
+      "aliases": [ "npc_can_fly", "u_can_fly" ],
+      "parser_registrations": [
+        {
+          "registration_order": 155,
+          "alias_role": "beta",
+          "alias_group": [ "u_can_fly", "npc_can_fly" ],
+          "source": { "path": "src/condition.cpp", "line": 2645, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1565 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_can_see",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_can_see" ],
+      "aliases": [ "npc_can_see", "u_can_see" ],
+      "parser_registrations": [
+        {
+          "registration_order": 134,
+          "alias_role": "beta",
+          "alias_group": [ "u_can_see", "npc_can_see" ],
+          "source": { "path": "src/condition.cpp", "line": 2624, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1117 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_can_see_location",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_can_see_location" ],
+      "aliases": [ "npc_can_see_location", "u_can_see_location" ],
+      "parser_registrations": [
+        {
+          "registration_order": 71,
+          "alias_role": "beta",
+          "alias_group": [ "u_can_see_location", "npc_can_see_location" ],
+          "source": { "path": "src/condition.cpp", "line": 2553, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [
+          {
+            "path": "data/mods/Isolation-Protocol/Player/Perks/perk_eoc.json",
+            "pointer": "/4/effect/2/if/and/2/npc_can_see_location"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1440 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_can_stow_weapon",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_can_stow_weapon" ],
+      "aliases": [ "npc_can_stow_weapon", "u_can_stow_weapon" ],
+      "parser_registrations": [
+        {
+          "registration_order": 116,
+          "alias_role": "beta",
+          "alias_group": [ "u_can_stow_weapon", "npc_can_stow_weapon" ],
+          "source": { "path": "src/condition.cpp", "line": 2606, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 888 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_cbm_recharge_rule",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_npc_cbm_recharge_rule" ],
+      "aliases": [ "npc_cbm_recharge_rule", "u_cbm_recharge_rule" ],
+      "parser_registrations": [
+        {
+          "registration_order": 49,
+          "alias_role": "beta",
+          "alias_group": [ "u_cbm_recharge_rule", "npc_cbm_recharge_rule" ],
+          "source": { "path": "src/condition.cpp", "line": 2531, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1131 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_cbm_reserve_rule",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_npc_cbm_reserve_rule" ],
+      "aliases": [ "npc_cbm_reserve_rule", "u_cbm_reserve_rule" ],
+      "parser_registrations": [
+        {
+          "registration_order": 48,
+          "alias_role": "beta",
+          "alias_group": [ "u_cbm_reserve_rule", "npc_cbm_reserve_rule" ],
+          "source": { "path": "src/condition.cpp", "line": 2530, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1130 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_controlling_vehicle",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_controlling_vehicle" ],
+      "aliases": [ "npc_controlling_vehicle", "u_controlling_vehicle" ],
+      "parser_registrations": [
+        {
+          "registration_order": 119,
+          "alias_role": "beta",
+          "alias_group": [ "u_controlling_vehicle", "npc_controlling_vehicle" ],
+          "source": { "path": "src/condition.cpp", "line": 2609, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 957 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_driving",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_driving" ],
+      "aliases": [ "npc_driving", "u_driving" ],
+      "parser_registrations": [
+        {
+          "registration_order": 120,
+          "alias_role": "beta",
+          "alias_group": [ "u_driving", "npc_driving" ],
+          "source": { "path": "src/condition.cpp", "line": 2610, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 21,
+        "examples": [ { "path": "data/json/npcs/Kindred/Brigitte_LaCroix_main.json", "pointer": "/3/responses/0/trial/condition/or/6" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 978 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_engagement_rule",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_npc_engagement_rule" ],
+      "aliases": [ "npc_engagement_rule", "u_engagement_rule" ],
+      "parser_registrations": [
+        {
+          "registration_order": 47,
+          "alias_role": "beta",
+          "alias_group": [ "u_engagement_rule", "npc_engagement_rule" ],
+          "source": { "path": "src/condition.cpp", "line": 2529, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/TALK_TEST.json", "pointer": "/11/responses/1/condition/npc_engagement_rule" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1129 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_exists",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_exists" ],
+      "aliases": [ "npc_exists", "u_exists" ],
+      "parser_registrations": [
+        {
+          "registration_order": 138,
+          "alias_role": "beta",
+          "alias_group": [ "u_exists", "npc_exists" ],
+          "source": { "path": "src/condition.cpp", "line": 2628, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1196 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_female",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_female" ],
+      "aliases": [ "npc_female", "u_female" ],
+      "parser_registrations": [
+        {
+          "registration_order": 90,
+          "alias_role": "beta",
+          "alias_group": [ "u_female", "npc_female" ],
+          "source": { "path": "src/condition.cpp", "line": 2580, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 10,
+        "examples": [ { "path": "data/json/npcs/Backgrounds/lost_partner_1.json", "pointer": "/0/dynamic_line/0/npc_female" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 309 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_following",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_npc_following" ],
+      "aliases": [ "npc_following", "u_following" ],
+      "parser_registrations": [
+        {
+          "registration_order": 108,
+          "alias_role": "beta",
+          "alias_group": [ "u_following", "npc_following" ],
+          "source": { "path": "src/condition.cpp", "line": 2598, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 8,
+        "examples": [ { "path": "data/json/npcs/Kindred/NPC_Brigitte_LaCroix.json", "pointer": "/6/responses/6/condition/and/0/not" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1121 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_friend",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_npc_friend" ],
+      "aliases": [ "npc_friend", "u_friend" ],
+      "parser_registrations": [
+        {
+          "registration_order": 109,
+          "alias_role": "beta",
+          "alias_group": [ "u_friend", "npc_friend" ],
+          "source": { "path": "src/condition.cpp", "line": 2599, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 3,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_GREET.json", "pointer": "/2/responses/0/condition/and/1/not" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1122 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_activity",
+      "syntaxes": [ "condition_string", "object_member" ],
+      "accepted_json_shapes": [ "condition_string", "string" ],
+      "handlers": [ "conditional_fun::f_has_activity" ],
+      "aliases": [ "npc_has_activity", "u_has_activity" ],
+      "parser_registrations": [
+        {
+          "registration_order": 12,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_activity", "npc_has_activity" ],
+          "source": { "path": "src/condition.cpp", "line": 2494, "symbol": "parsers" }
+        },
+        {
+          "registration_order": 121,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_activity", "npc_has_activity" ],
+          "source": { "path": "src/condition.cpp", "line": 2611, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": {
+        "status": "partial",
+        "items": [ "condition_string", "string" ],
+        "note": "Only parser dispatch shapes are proven here."
+      },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 19,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_ALLY.json", "pointer": "/9/dynamic_line/npc_has_activity" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1109 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_any_effect",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array" ],
+      "handlers": [ "conditional_fun::f_has_any_effect" ],
+      "aliases": [ "npc_has_any_effect", "u_has_any_effect" ],
+      "parser_registrations": [
+        {
+          "registration_order": 32,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_any_effect", "npc_has_any_effect" ],
+          "source": { "path": "src/condition.cpp", "line": 2514, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 54,
+        "examples": [
+          {
+            "path": "data/json/monster_weakpoints/abomination_weakpoints.json",
+            "pointer": "/2/weakpoints/2/condition/npc_has_any_effect"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 838 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_any_trait",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array" ],
+      "handlers": [ "conditional_fun::f_has_any_trait" ],
+      "aliases": [ "npc_has_any_trait", "u_has_any_trait" ],
+      "parser_registrations": [
+        {
+          "registration_order": 0,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_any_trait", "npc_has_any_trait" ],
+          "source": { "path": "src/condition.cpp", "line": 2482, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 16,
+        "examples": [
+          { "path": "data/json/effects_on_condition/general_conditions.json", "pointer": "/0/condition/or/5/npc_has_any_trait" }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 379 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_assigned_camp",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_npc_has_assigned_camp" ],
+      "aliases": [ "npc_has_assigned_camp" ],
+      "parser_registrations": [
+        {
+          "registration_order": 128,
+          "alias_role": "alpha",
+          "alias_group": [ "npc_has_assigned_camp" ],
+          "source": { "path": "src/condition.cpp", "line": 2618, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_ALLY.json", "pointer": "/2/responses/7/condition" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "npc_has_available_mission",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_has_available_mission" ],
+      "aliases": [ "npc_has_available_mission", "u_has_available_mission" ],
+      "parser_registrations": [
+        {
+          "registration_order": 98,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_available_mission", "npc_has_available_mission" ],
+          "source": { "path": "src/condition.cpp", "line": 2588, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1106 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_bionics",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_bionics" ],
+      "aliases": [ "npc_has_bionics", "u_has_bionics" ],
+      "parser_registrations": [
+        {
+          "registration_order": 31,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_bionics", "npc_has_bionics" ],
+          "source": { "path": "src/condition.cpp", "line": 2513, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [ { "path": "data/json/npcs/TALK_TEST.json", "pointer": "/27/responses/2/condition/npc_has_bionics" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 817 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_class",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_npc_has_class" ],
+      "aliases": [ "npc_has_class", "u_has_class" ],
+      "parser_registrations": [
+        {
+          "registration_order": 11,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_class", "npc_has_class" ],
+          "source": { "path": "src/condition.cpp", "line": 2493, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/TALK_TEST.json", "pointer": "/9/responses/1/condition/npc_has_class" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1126 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_dexterity",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "member" ],
+      "handlers": [ "conditional_fun::f_has_dexterity" ],
+      "aliases": [ "npc_has_dexterity", "u_has_dexterity" ],
+      "parser_registrations": [
+        {
+          "registration_order": 18,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_dexterity", "npc_has_dexterity" ],
+          "source": { "path": "src/condition.cpp", "line": 2500, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 639 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_effect",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_effect" ],
+      "aliases": [ "npc_has_effect", "u_has_effect" ],
+      "parser_registrations": [
+        {
+          "registration_order": 33,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_effect", "npc_has_effect" ],
+          "source": { "path": "src/condition.cpp", "line": 2515, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 433,
+        "examples": [ { "path": "data/json/effects_on_condition/general_conditions.json", "pointer": "/0/condition/or/6/npc_has_effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 58 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_flag",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_flag" ],
+      "aliases": [ "npc_has_flag", "u_has_flag" ],
+      "parser_registrations": [
+        {
+          "registration_order": 8,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_flag", "npc_has_flag" ],
+          "source": { "path": "src/condition.cpp", "line": 2490, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 328,
+        "examples": [ { "path": "data/json/bionics.json", "pointer": "/51/enchantments/0/special_vision/0/condition/or/0/npc_has_flag" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 469 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_intelligence",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "member" ],
+      "handlers": [ "conditional_fun::f_has_intelligence" ],
+      "aliases": [ "npc_has_intelligence", "u_has_intelligence" ],
+      "parser_registrations": [
+        {
+          "registration_order": 19,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_intelligence", "npc_has_intelligence" ],
+          "source": { "path": "src/condition.cpp", "line": 2501, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 3,
+        "examples": [
+          {
+            "path": "data/json/npcs/common_chat/TALK_FRIEND_CONVERSATION.json",
+            "pointer": "/2/dynamic_line/0/yes/9/npc_has_intelligence"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 639 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_item",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_item" ],
+      "aliases": [ "npc_has_item", "u_has_item" ],
+      "parser_registrations": [
+        {
+          "registration_order": 25,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_item", "npc_has_item" ],
+          "source": { "path": "src/condition.cpp", "line": 2507, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 22,
+        "examples": [
+          {
+            "path": "data/json/npcs/godco/members/NPC_Sonia_Greene.json",
+            "pointer": "/0/responses/3/condition/and/1/npc_has_item"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 672 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_item_category",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_item_category" ],
+      "aliases": [ "npc_has_item_category", "u_has_item_category" ],
+      "parser_registrations": [
+        {
+          "registration_order": 29,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_item_category", "npc_has_item_category" ],
+          "source": { "path": "src/condition.cpp", "line": 2511, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 694 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_item_with_flag",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_item_with_flag" ],
+      "aliases": [ "npc_has_item_with_flag", "u_has_item_with_flag" ],
+      "parser_registrations": [
+        {
+          "registration_order": 26,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_item_with_flag", "npc_has_item_with_flag" ],
+          "source": { "path": "src/condition.cpp", "line": 2508, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1016 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_items",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_items" ],
+      "aliases": [ "npc_has_items", "u_has_items" ],
+      "parser_registrations": [
+        {
+          "registration_order": 27,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_items", "npc_has_items" ],
+          "source": { "path": "src/condition.cpp", "line": 2509, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 672 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_items_sum",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array" ],
+      "handlers": [ "conditional_fun::f_has_items_sum" ],
+      "aliases": [ "npc_has_items_sum", "u_has_items_sum" ],
+      "parser_registrations": [
+        {
+          "registration_order": 28,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_items_sum", "npc_has_items_sum" ],
+          "source": { "path": "src/condition.cpp", "line": 2510, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 752 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_many_available_missions",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_has_many_available_missions" ],
+      "aliases": [ "npc_has_many_available_missions", "u_has_many_available_missions" ],
+      "parser_registrations": [
+        {
+          "registration_order": 100,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_many_available_missions", "npc_has_many_available_missions" ],
+          "source": { "path": "src/condition.cpp", "line": 2590, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "npc_has_martial_art",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_martial_art" ],
+      "aliases": [ "npc_has_martial_art", "u_has_martial_art" ],
+      "parser_registrations": [
+        {
+          "registration_order": 5,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_martial_art", "npc_has_martial_art" ],
+          "source": { "path": "src/condition.cpp", "line": 2487, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 439 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_move_mode",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_move_mode" ],
+      "aliases": [ "npc_has_move_mode", "u_has_move_mode" ],
+      "parser_registrations": [
+        {
+          "registration_order": 70,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_move_mode", "npc_has_move_mode" ],
+          "source": { "path": "src/condition.cpp", "line": 2552, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "npc_has_no_available_mission",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_no_available_mission" ],
+      "aliases": [ "npc_has_no_available_mission", "u_has_no_available_mission" ],
+      "parser_registrations": [
+        {
+          "registration_order": 96,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_no_available_mission", "npc_has_no_available_mission" ],
+          "source": { "path": "src/condition.cpp", "line": 2586, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1105 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_part_flag",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "string" ],
+      "handlers": [ "conditional_fun::f_has_part_flag" ],
+      "aliases": [ "npc_has_part_flag", "u_has_part_flag" ],
+      "parser_registrations": [
+        {
+          "registration_order": 88,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_part_flag", "npc_has_part_flag" ],
+          "source": { "path": "src/condition.cpp", "line": 2570, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 487 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_part_temp",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "member" ],
+      "handlers": [ "conditional_fun::f_has_part_temp" ],
+      "aliases": [ "npc_has_part_temp", "u_has_part_temp" ],
+      "parser_registrations": [
+        {
+          "registration_order": 21,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_part_temp", "npc_has_part_temp" ],
+          "source": { "path": "src/condition.cpp", "line": 2503, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 655 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_perception",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "member" ],
+      "handlers": [ "conditional_fun::f_has_perception" ],
+      "aliases": [ "npc_has_perception", "u_has_perception" ],
+      "parser_registrations": [
+        {
+          "registration_order": 20,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_perception", "npc_has_perception" ],
+          "source": { "path": "src/condition.cpp", "line": 2502, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 3,
+        "examples": [
+          {
+            "path": "data/json/npcs/common_chat/TALK_FRIEND_CONVERSATION.json",
+            "pointer": "/2/dynamic_line/0/yes/10/npc_has_perception"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 639 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_pickup_list",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_has_pickup_list" ],
+      "aliases": [ "npc_has_pickup_list", "u_has_pickup_list" ],
+      "parser_registrations": [
+        {
+          "registration_order": 130,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_pickup_list", "npc_has_pickup_list" ],
+          "source": { "path": "src/condition.cpp", "line": 2620, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1134 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_profession",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "string" ],
+      "handlers": [ "conditional_fun::f_has_profession" ],
+      "aliases": [ "npc_has_profession", "u_has_profession" ],
+      "parser_registrations": [
+        {
+          "registration_order": 4,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_profession", "npc_has_profession" ],
+          "source": { "path": "src/condition.cpp", "line": 2486, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 611 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_proficiency",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_proficiency" ],
+      "aliases": [ "npc_has_proficiency", "u_has_proficiency" ],
+      "parser_registrations": [
+        {
+          "registration_order": 7,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_proficiency", "npc_has_proficiency" ],
+          "source": { "path": "src/condition.cpp", "line": 2489, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 872 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_software",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_software" ],
+      "aliases": [ "npc_has_software", "u_has_software" ],
+      "parser_registrations": [
+        {
+          "registration_order": 30,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_software", "npc_has_software" ],
+          "source": { "path": "src/condition.cpp", "line": 2512, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 717 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_species",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_species" ],
+      "aliases": [ "npc_has_species", "u_has_species" ],
+      "parser_registrations": [
+        {
+          "registration_order": 9,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_species", "npc_has_species" ],
+          "source": { "path": "src/condition.cpp", "line": 2491, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 641,
+        "examples": [ { "path": "data/json/effects_on_condition/general_conditions.json", "pointer": "/0/condition/or/0/npc_has_species" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 510 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_stolen_item",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_has_stolen_item" ],
+      "aliases": [ "npc_has_stolen_item", "u_has_stolen_item" ],
+      "parser_registrations": [
+        {
+          "registration_order": 124,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_stolen_item", "npc_has_stolen_item" ],
+          "source": { "path": "src/condition.cpp", "line": 2614, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "npc_has_strength",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "member" ],
+      "handlers": [ "conditional_fun::f_has_strength" ],
+      "aliases": [ "npc_has_strength", "u_has_strength" ],
+      "parser_registrations": [
+        {
+          "registration_order": 17,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_strength", "npc_has_strength" ],
+          "source": { "path": "src/condition.cpp", "line": 2499, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 639 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_trait",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_trait" ],
+      "aliases": [ "npc_has_trait", "u_has_trait" ],
+      "parser_registrations": [
+        {
+          "registration_order": 1,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_trait", "npc_has_trait" ],
+          "source": { "path": "src/condition.cpp", "line": 2483, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 557,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/misc_effect_on_condition.json",
+            "pointer": "/24/condition/and/1/not/npc_has_trait"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_visible_trait",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_visible_trait" ],
+      "aliases": [ "npc_has_visible_trait", "u_has_visible_trait" ],
+      "parser_registrations": [
+        {
+          "registration_order": 3,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_visible_trait", "npc_has_visible_trait" ],
+          "source": { "path": "src/condition.cpp", "line": 2485, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [
+          {
+            "path": "data/json/npcs/refugee_center/surface_visitors/NPC_arsonist.json",
+            "pointer": "/6/responses/5/condition/npc_has_visible_trait"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 405 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_weapon",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_has_weapon" ],
+      "aliases": [ "npc_has_weapon", "u_has_weapon" ],
+      "parser_registrations": [
+        {
+          "registration_order": 118,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_weapon", "npc_has_weapon" ],
+          "source": { "path": "src/condition.cpp", "line": 2608, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 3,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_GREET.json", "pointer": "/2/responses/0/condition/and/0" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 936 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_wielded_with_ammotype",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_wielded_with_ammotype" ],
+      "aliases": [ "npc_has_wielded_with_ammotype", "u_has_wielded_with_ammotype" ],
+      "parser_registrations": [
+        {
+          "registration_order": 64,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_wielded_with_ammotype", "npc_has_wielded_with_ammotype" ],
+          "source": { "path": "src/condition.cpp", "line": 2546, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1100 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_wielded_with_flag",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_wielded_with_flag" ],
+      "aliases": [ "npc_has_wielded_with_flag", "u_has_wielded_with_flag" ],
+      "parser_registrations": [
+        {
+          "registration_order": 61,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_wielded_with_flag", "npc_has_wielded_with_flag" ],
+          "source": { "path": "src/condition.cpp", "line": 2543, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1050 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_wielded_with_skill",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_wielded_with_skill" ],
+      "aliases": [ "npc_has_wielded_with_skill", "u_has_wielded_with_skill" ],
+      "parser_registrations": [
+        {
+          "registration_order": 63,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_wielded_with_skill", "npc_has_wielded_with_skill" ],
+          "source": { "path": "src/condition.cpp", "line": 2545, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [
+          {
+            "path": "data/mods/BombasticPerks/perkdata/boomstick_blast.json",
+            "pointer": "/0/effect/0/if/and/1/npc_has_wielded_with_skill"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1082 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_wielded_with_weapon_category",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_wielded_with_weapon_category" ],
+      "aliases": [ "npc_has_wielded_with_weapon_category", "u_has_wielded_with_weapon_category" ],
+      "parser_registrations": [
+        {
+          "registration_order": 62,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_wielded_with_weapon_category", "npc_has_wielded_with_weapon_category" ],
+          "source": { "path": "src/condition.cpp", "line": 2544, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1066 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_has_worn_with_flag",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_worn_with_flag" ],
+      "aliases": [ "npc_has_worn_with_flag", "u_has_worn_with_flag" ],
+      "parser_registrations": [
+        {
+          "registration_order": 60,
+          "alias_role": "beta",
+          "alias_group": [ "u_has_worn_with_flag", "npc_has_worn_with_flag" ],
+          "source": { "path": "src/condition.cpp", "line": 2542, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 4,
+        "examples": [ { "path": "data/mods/MindOverMatter/damage_types.json", "pointer": "/9/condition/and/0/npc_has_worn_with_flag" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1034 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_hostile",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_npc_hostile" ],
+      "aliases": [ "npc_hostile", "u_hostile" ],
+      "parser_registrations": [
+        {
+          "registration_order": 110,
+          "alias_role": "beta",
+          "alias_group": [ "u_hostile", "npc_hostile" ],
+          "source": { "path": "src/condition.cpp", "line": 2600, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [
+          {
+            "path": "data/mods/MindOverMatter/effects/effects_psionic.json",
+            "pointer": "/41/enchantments/0/special_vision/0/condition/or/1/and/1"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1123 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_alive",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_alive" ],
+      "aliases": [ "npc_is_alive", "u_is_alive" ],
+      "parser_registrations": [
+        {
+          "registration_order": 136,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_alive", "npc_is_alive" ],
+          "source": { "path": "src/condition.cpp", "line": 2626, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/mods/Perk_melee/EOC/tempo_eocs.json", "pointer": "/0/condition/and/2/not" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1159 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_avatar",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_avatar" ],
+      "aliases": [ "npc_is_avatar", "u_is_avatar" ],
+      "parser_registrations": [
+        {
+          "registration_order": 139,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_avatar", "npc_is_avatar" ],
+          "source": { "path": "src/condition.cpp", "line": 2629, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 6,
+        "examples": [ { "path": "data/json/effects_on_condition/npc_eocs/robofac_npc_eocs.json", "pointer": "/2/effect/1/if/and/0" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 325 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_avatar_passenger",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_avatar_passenger" ],
+      "aliases": [ "npc_is_avatar_passenger", "u_is_avatar_passenger" ],
+      "parser_registrations": [
+        {
+          "registration_order": 163,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_avatar_passenger", "npc_is_avatar_passenger" ],
+          "source": { "path": "src/condition.cpp", "line": 2653, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1694 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_character",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_character" ],
+      "aliases": [ "npc_is_character", "u_is_character" ],
+      "parser_registrations": [
+        {
+          "registration_order": 141,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_character", "npc_is_character" ],
+          "source": { "path": "src/condition.cpp", "line": 2631, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 25,
+        "examples": [ { "path": "data/json/monster_special_attacks/spells.json", "pointer": "/33/condition/and/2" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 325 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_deaf",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_deaf" ],
+      "aliases": [ "npc_is_deaf", "u_is_deaf" ],
+      "parser_registrations": [
+        {
+          "registration_order": 135,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_deaf", "npc_is_deaf" ],
+          "source": { "path": "src/condition.cpp", "line": 2625, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1138 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_driven",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_driven" ],
+      "aliases": [ "npc_is_driven", "u_is_driven" ],
+      "parser_registrations": [
+        {
+          "registration_order": 153,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_driven", "npc_is_driven" ],
+          "source": { "path": "src/condition.cpp", "line": 2643, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1478 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_falling",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_falling" ],
+      "aliases": [ "npc_is_falling", "u_is_falling" ],
+      "parser_registrations": [
+        {
+          "registration_order": 159,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_falling", "npc_is_falling" ],
+          "source": { "path": "src/condition.cpp", "line": 2649, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1630 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_floating",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_floating" ],
+      "aliases": [ "npc_is_floating", "u_is_floating" ],
+      "parser_registrations": [
+        {
+          "registration_order": 158,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_floating", "npc_is_floating" ],
+          "source": { "path": "src/condition.cpp", "line": 2648, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1613 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_flying",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_flying" ],
+      "aliases": [ "npc_is_flying", "u_is_flying" ],
+      "parser_registrations": [
+        {
+          "registration_order": 156,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_flying", "npc_is_flying" ],
+          "source": { "path": "src/condition.cpp", "line": 2646, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1581 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_furniture",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_furniture" ],
+      "aliases": [ "npc_is_furniture", "u_is_furniture" ],
+      "parser_registrations": [
+        {
+          "registration_order": 144,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_furniture", "npc_is_furniture" ],
+          "source": { "path": "src/condition.cpp", "line": 2634, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 325 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_in_field",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_is_in_field" ],
+      "aliases": [ "npc_is_in_field", "u_is_in_field" ],
+      "parser_registrations": [
+        {
+          "registration_order": 69,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_in_field", "npc_is_in_field" ],
+          "source": { "path": "src/condition.cpp", "line": 2551, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1238 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_in_vehicle",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_in_vehicle" ],
+      "aliases": [ "npc_is_in_vehicle", "u_is_in_vehicle" ],
+      "parser_registrations": [
+        {
+          "registration_order": 164,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_in_vehicle", "npc_is_in_vehicle" ],
+          "source": { "path": "src/condition.cpp", "line": 2654, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1710 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_item",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_item" ],
+      "aliases": [ "npc_is_item", "u_is_item" ],
+      "parser_registrations": [
+        {
+          "registration_order": 143,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_item", "npc_is_item" ],
+          "source": { "path": "src/condition.cpp", "line": 2633, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 325 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_monster",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_monster" ],
+      "aliases": [ "npc_is_monster", "u_is_monster" ],
+      "parser_registrations": [
+        {
+          "registration_order": 142,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_monster", "npc_is_monster" ],
+          "source": { "path": "src/condition.cpp", "line": 2632, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/mods/aftershock_exoplanet/monster_attacks/monster_attacks.json", "pointer": "/3/condition/and/2" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 325 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_npc",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_npc" ],
+      "aliases": [ "npc_is_npc", "u_is_npc" ],
+      "parser_registrations": [
+        {
+          "registration_order": 140,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_npc", "npc_is_npc" ],
+          "source": { "path": "src/condition.cpp", "line": 2630, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 5,
+        "examples": [ { "path": "data/json/effects_on_condition/example_eocs.json", "pointer": "/32/effect/2/then/run_eocs/effect/0/if" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 325 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_on_furniture",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_is_on_furniture" ],
+      "aliases": [ "npc_is_on_furniture", "u_is_on_furniture" ],
+      "parser_registrations": [
+        {
+          "registration_order": 67,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_on_furniture", "npc_is_on_furniture" ],
+          "source": { "path": "src/condition.cpp", "line": 2549, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1206 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_on_furniture_with_flag",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_is_on_furniture_with_flag" ],
+      "aliases": [ "npc_is_on_furniture_with_flag", "u_is_on_furniture_with_flag" ],
+      "parser_registrations": [
+        {
+          "registration_order": 68,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_on_furniture_with_flag", "npc_is_on_furniture_with_flag" ],
+          "source": { "path": "src/condition.cpp", "line": 2550, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1222 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_on_rails",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_on_rails" ],
+      "aliases": [ "npc_is_on_rails", "u_is_on_rails" ],
+      "parser_registrations": [
+        {
+          "registration_order": 162,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_on_rails", "npc_is_on_rails" ],
+          "source": { "path": "src/condition.cpp", "line": 2652, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1678 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_on_terrain",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_is_on_terrain" ],
+      "aliases": [ "npc_is_on_terrain", "u_is_on_terrain" ],
+      "parser_registrations": [
+        {
+          "registration_order": 65,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_on_terrain", "npc_is_on_terrain" ],
+          "source": { "path": "src/condition.cpp", "line": 2547, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [
+          {
+            "path": "data/mods/Xedra_Evolved/spells/bloodthorne_druid_spells.json",
+            "pointer": "/6/target_condition/or/1/npc_is_on_terrain"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1206 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_on_terrain_with_flag",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_is_on_terrain_with_flag" ],
+      "aliases": [ "npc_is_on_terrain_with_flag", "u_is_on_terrain_with_flag" ],
+      "parser_registrations": [
+        {
+          "registration_order": 66,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_on_terrain_with_flag", "npc_is_on_terrain_with_flag" ],
+          "source": { "path": "src/condition.cpp", "line": 2548, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 20,
+        "examples": [
+          {
+            "path": "data/json/monsters/singularities.json",
+            "pointer": "/0/special_attacks/2/condition/and/0/npc_is_on_terrain_with_flag"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1222 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_outside",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_outside" ],
+      "aliases": [ "npc_is_outside", "u_is_outside" ],
+      "parser_registrations": [
+        {
+          "registration_order": 125,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_outside", "npc_is_outside" ],
+          "source": { "path": "src/condition.cpp", "line": 2615, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 20,
+        "examples": [ { "path": "data/mods/Magiclysm/monsters/nature_spirits.json", "pointer": "/6/special_attacks/2/condition/and/0" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1150 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_remote_controlled",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_remote_controlled" ],
+      "aliases": [ "npc_is_remote_controlled", "u_is_remote_controlled" ],
+      "parser_registrations": [
+        {
+          "registration_order": 154,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_remote_controlled", "npc_is_remote_controlled" ],
+          "source": { "path": "src/condition.cpp", "line": 2644, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1549 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_riding",
+      "syntaxes": [ "condition_string", "object_member" ],
+      "accepted_json_shapes": [ "condition_string", "string" ],
+      "handlers": [ "conditional_fun::f_is_riding" ],
+      "aliases": [ "npc_is_riding", "u_is_riding" ],
+      "parser_registrations": [
+        {
+          "registration_order": 13,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_riding", "npc_is_riding" ],
+          "source": { "path": "src/condition.cpp", "line": 2495, "symbol": "parsers" }
+        },
+        {
+          "registration_order": 122,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_riding", "npc_is_riding" ],
+          "source": { "path": "src/condition.cpp", "line": 2612, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": {
+        "status": "partial",
+        "items": [ "condition_string", "string" ],
+        "note": "Only parser dispatch shapes are proven here."
+      },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 8,
+        "examples": [ { "path": "data/json/npcs/Kindred/Brigitte_LaCroix_main.json", "pointer": "/3/responses/7/condition/and/0/not" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "npc_is_sinking",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_sinking" ],
+      "aliases": [ "npc_is_sinking", "u_is_sinking" ],
+      "parser_registrations": [
+        {
+          "registration_order": 161,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_sinking", "npc_is_sinking" ],
+          "source": { "path": "src/condition.cpp", "line": 2651, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1662 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_skidding",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_skidding" ],
+      "aliases": [ "npc_is_skidding", "u_is_skidding" ],
+      "parser_registrations": [
+        {
+          "registration_order": 160,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_skidding", "npc_is_skidding" ],
+          "source": { "path": "src/condition.cpp", "line": 2650, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1646 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_trait_purifiable",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_is_trait_purifiable" ],
+      "aliases": [ "npc_is_trait_purifiable", "u_is_trait_purifiable" ],
+      "parser_registrations": [
+        {
+          "registration_order": 2,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_trait_purifiable", "npc_is_trait_purifiable" ],
+          "source": { "path": "src/condition.cpp", "line": 2484, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 421 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_travelling",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_npc_is_travelling" ],
+      "aliases": [ "npc_is_travelling", "u_is_travelling" ],
+      "parser_registrations": [
+        {
+          "registration_order": 91,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_travelling", "npc_is_travelling" ],
+          "source": { "path": "src/condition.cpp", "line": 2581, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_ALLY.json", "pointer": "/11/dynamic_line/npc_is_travelling" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1110 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_underwater",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_underwater" ],
+      "aliases": [ "npc_is_underwater", "u_is_underwater" ],
+      "parser_registrations": [
+        {
+          "registration_order": 126,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_underwater", "npc_is_underwater" ],
+          "source": { "path": "src/condition.cpp", "line": 2616, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [ { "path": "data/json/bionics.json", "pointer": "/51/enchantments/0/special_vision/0/condition/or/1/and/0" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1151 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_vehicle",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_vehicle" ],
+      "aliases": [ "npc_is_vehicle", "u_is_vehicle" ],
+      "parser_registrations": [
+        {
+          "registration_order": 145,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_vehicle", "npc_is_vehicle" ],
+          "source": { "path": "src/condition.cpp", "line": 2635, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 325 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_warm",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_warm" ],
+      "aliases": [ "npc_is_warm", "u_is_warm" ],
+      "parser_registrations": [
+        {
+          "registration_order": 137,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_warm", "npc_is_warm" ],
+          "source": { "path": "src/condition.cpp", "line": 2627, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 3,
+        "examples": [ { "path": "data/json/enchantments.json", "pointer": "/7/special_vision/0/condition/and/1" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1180 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_is_wearing",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_is_wearing" ],
+      "aliases": [ "npc_is_wearing", "u_is_wearing" ],
+      "parser_registrations": [
+        {
+          "registration_order": 22,
+          "alias_role": "beta",
+          "alias_group": [ "u_is_wearing", "npc_is_wearing" ],
+          "source": { "path": "src/condition.cpp", "line": 2504, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [
+          {
+            "path": "data/mods/Xedra_Evolved/npc/follower_ask_for_dreams.json",
+            "pointer": "/0/responses/0/effect/0/if/npc_is_wearing"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "npc_male",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_male" ],
+      "aliases": [ "npc_male", "u_male" ],
+      "parser_registrations": [
+        {
+          "registration_order": 89,
+          "alias_role": "beta",
+          "alias_group": [ "u_male", "npc_male" ],
+          "source": { "path": "src/condition.cpp", "line": 2579, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 3,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_GREET.json", "pointer": "/9/dynamic_line/npc_male" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 309 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_mission_complete",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_mission_complete" ],
+      "aliases": [ "npc_mission_complete", "u_mission_complete" ],
+      "parser_registrations": [
+        {
+          "registration_order": 102,
+          "alias_role": "beta",
+          "alias_group": [ "u_mission_complete", "npc_mission_complete" ],
+          "source": { "path": "src/condition.cpp", "line": 2592, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1112 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_mission_failed",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_mission_failed" ],
+      "aliases": [ "npc_mission_failed", "u_mission_failed" ],
+      "parser_registrations": [
+        {
+          "registration_order": 106,
+          "alias_role": "beta",
+          "alias_group": [ "u_mission_failed", "npc_mission_failed" ],
+          "source": { "path": "src/condition.cpp", "line": 2596, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1114 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_mission_goal",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_mission_goal" ],
+      "aliases": [ "npc_mission_goal", "u_mission_goal" ],
+      "parser_registrations": [
+        {
+          "registration_order": 54,
+          "alias_role": "beta",
+          "alias_group": [ "u_mission_goal", "npc_mission_goal" ],
+          "source": { "path": "src/condition.cpp", "line": 2536, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1108 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_mission_incomplete",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_mission_incomplete" ],
+      "aliases": [ "npc_mission_incomplete", "u_mission_incomplete" ],
+      "parser_registrations": [
+        {
+          "registration_order": 104,
+          "alias_role": "beta",
+          "alias_group": [ "u_mission_incomplete", "npc_mission_incomplete" ],
+          "source": { "path": "src/condition.cpp", "line": 2594, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1113 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_near_om_location",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_near_om_location" ],
+      "aliases": [ "npc_near_om_location", "u_near_om_location" ],
+      "parser_registrations": [
+        {
+          "registration_order": 37,
+          "alias_role": "beta",
+          "alias_group": [ "u_near_om_location", "npc_near_om_location" ],
+          "source": { "path": "src/condition.cpp", "line": 2519, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 73,
+        "examples": [
+          { "path": "data/json/effects_on_condition/item_eocs.json", "pointer": "/27/condition/and/2/or/0/npc_near_om_location" }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1127 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_need",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_need" ],
+      "aliases": [ "npc_need", "u_need" ],
+      "parser_registrations": [
+        {
+          "registration_order": 34,
+          "alias_role": "beta",
+          "alias_group": [ "u_need", "npc_need" ],
+          "source": { "path": "src/condition.cpp", "line": 2516, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 54,
+        "examples": [
+          {
+            "path": "data/json/npcs/Kindred/Brigitte_LaCroix_main.json",
+            "pointer": "/3/responses/0/trial/condition/or/0/npc_need"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 572 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_override",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_npc_override" ],
+      "aliases": [ "npc_override", "u_override" ],
+      "parser_registrations": [
+        {
+          "registration_order": 51,
+          "alias_role": "beta",
+          "alias_group": [ "u_override", "npc_override" ],
+          "source": { "path": "src/condition.cpp", "line": 2533, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1133 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_query",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_query" ],
+      "aliases": [ "npc_query", "u_query" ],
+      "parser_registrations": [
+        {
+          "registration_order": 35,
+          "alias_role": "beta",
+          "alias_group": [ "u_query", "npc_query" ],
+          "source": { "path": "src/condition.cpp", "line": 2517, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1254 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_role_nearby",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "string" ],
+      "handlers": [ "conditional_fun::f_npc_role_nearby" ],
+      "aliases": [ "npc_role_nearby" ],
+      "parser_registrations": [
+        {
+          "registration_order": 40,
+          "alias_role": "alpha",
+          "alias_group": [ "npc_role_nearby" ],
+          "source": { "path": "src/condition.cpp", "line": 2522, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/TALK_TEST.json", "pointer": "/8/responses/1/condition/npc_role_nearby" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1141 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_rule",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_npc_rule" ],
+      "aliases": [ "npc_rule", "u_rule" ],
+      "parser_registrations": [
+        {
+          "registration_order": 50,
+          "alias_role": "beta",
+          "alias_group": [ "u_rule", "npc_rule" ],
+          "source": { "path": "src/condition.cpp", "line": 2532, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/TALK_TEST.json", "pointer": "/11/responses/3/condition/npc_rule" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1132 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_see_u",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_see_opposite" ],
+      "aliases": [ "npc_see_u", "u_see_npc" ],
+      "parser_registrations": [
+        {
+          "registration_order": 149,
+          "alias_role": "beta",
+          "alias_group": [ "u_see_npc", "npc_see_u" ],
+          "source": { "path": "src/condition.cpp", "line": 2639, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "npc_see_u_loc",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_see_opposite_coordinates" ],
+      "aliases": [ "npc_see_u_loc", "u_see_npc_loc" ],
+      "parser_registrations": [
+        {
+          "registration_order": 150,
+          "alias_role": "beta",
+          "alias_group": [ "u_see_npc_loc", "npc_see_u_loc" ],
+          "source": { "path": "src/condition.cpp", "line": 2640, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "npc_service",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_npc_service" ],
+      "aliases": [ "npc_service", "u_service" ],
+      "parser_registrations": [
+        {
+          "registration_order": 43,
+          "alias_role": "beta",
+          "alias_group": [ "u_service", "npc_service" ],
+          "source": { "path": "src/condition.cpp", "line": 2525, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 7,
+        "examples": [ { "path": "data/json/npcs/TALK_TEST.json", "pointer": "/6/responses/2/condition/npc_service" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1116 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_train_skills",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_npc_train_skills" ],
+      "aliases": [ "npc_train_skills", "u_train_skills" ],
+      "parser_registrations": [
+        {
+          "registration_order": 111,
+          "alias_role": "beta",
+          "alias_group": [ "u_train_skills", "npc_train_skills" ],
+          "source": { "path": "src/condition.cpp", "line": 2601, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_MISSION.json", "pointer": "/9/responses/2/condition/and/1/or/0" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1124 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_train_spells",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_npc_train_spells" ],
+      "aliases": [ "npc_train_spells", "u_train_spells" ],
+      "parser_registrations": [
+        {
+          "registration_order": 113,
+          "alias_role": "beta",
+          "alias_group": [ "u_train_spells", "npc_train_spells" ],
+          "source": { "path": "src/condition.cpp", "line": 2603, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "npc_train_styles",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_npc_train_styles" ],
+      "aliases": [ "npc_train_styles", "u_train_styles" ],
+      "parser_registrations": [
+        {
+          "registration_order": 112,
+          "alias_role": "beta",
+          "alias_group": [ "u_train_styles", "npc_train_styles" ],
+          "source": { "path": "src/condition.cpp", "line": 2602, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_MISSION.json", "pointer": "/9/responses/2/condition/and/1/or/1" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1125 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_using_martial_art",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_using_martial_art" ],
+      "aliases": [ "npc_using_martial_art", "u_using_martial_art" ],
+      "parser_registrations": [
+        {
+          "registration_order": 6,
+          "alias_role": "beta",
+          "alias_group": [ "u_using_martial_art", "npc_using_martial_art" ],
+          "source": { "path": "src/condition.cpp", "line": 2488, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 454 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_vehicle_owned_by_avatar",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_vehicle_owned_by_avatar" ],
+      "aliases": [ "npc_vehicle_owned_by_avatar", "u_vehicle_owned_by_avatar" ],
+      "parser_registrations": [
+        {
+          "registration_order": 146,
+          "alias_role": "beta",
+          "alias_group": [ "u_vehicle_owned_by_avatar", "npc_vehicle_owned_by_avatar" ],
+          "source": { "path": "src/condition.cpp", "line": 2636, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1111 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "one_in_chance",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "member" ],
+      "handlers": [ "conditional_fun::f_one_in_chance" ],
+      "aliases": [ "one_in_chance" ],
+      "parser_registrations": [
+        {
+          "registration_order": 57,
+          "alias_role": "alpha",
+          "alias_group": [ "one_in_chance" ],
+          "source": { "path": "src/condition.cpp", "line": 2539, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 97,
+        "examples": [ { "path": "data/json/artifact/altered_object_active.json", "pointer": "/27/effect/0/if/one_in_chance" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1152 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "or",
+      "syntaxes": [ "logical_operator" ],
+      "accepted_json_shapes": [ "array" ],
+      "handlers": [ "conditional_t::conditional_t" ],
+      "aliases": [ "or" ],
+      "parser_registrations": [
+        {
+          "registration_order": -1,
+          "alias_role": "special",
+          "alias_group": [ "or" ],
+          "source": { "path": "src/condition.cpp", "line": 2684, "symbol": "conditional_t::conditional_t" }
+        }
+      ],
+      "parameters": { "status": "complete", "items": [  ] },
+      "value_types": { "status": "complete", "items": [ "array" ] },
+      "defaults": { "status": "complete", "items": [  ] },
+      "nesting": { "status": "complete", "allows": [ "condition_object", "condition_string" ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "not_applicable",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "complete", "requirements": [  ] },
+      "contract_status": "complete",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1724,
+        "examples": [ { "path": "data/json/bionics.json", "pointer": "/51/enchantments/0/special_vision/0/condition/or" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/ARTIFACTS.md", "line": 26 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "overmap_at_point",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_overmap_at_point" ],
+      "aliases": [ "overmap_at_point" ],
+      "parser_registrations": [
+        {
+          "registration_order": 83,
+          "alias_role": "alpha",
+          "alias_group": [ "overmap_at_point" ],
+          "source": { "path": "src/condition.cpp", "line": 2565, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/mods/aftershock_exoplanet/EOC/ship_eoc.json", "pointer": "/5/effect/3/if/and/1/overmap_at_point" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "player_see_npc",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_player_see" ],
+      "aliases": [ "player_see_npc", "player_see_u" ],
+      "parser_registrations": [
+        {
+          "registration_order": 148,
+          "alias_role": "beta",
+          "alias_group": [ "player_see_u", "player_see_npc" ],
+          "source": { "path": "src/condition.cpp", "line": 2638, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/monster_special_attacks/spells.json", "pointer": "/78/condition" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1424 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "player_see_u",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_player_see" ],
+      "aliases": [ "player_see_npc", "player_see_u" ],
+      "parser_registrations": [
+        {
+          "registration_order": 148,
+          "alias_role": "alpha",
+          "alias_group": [ "player_see_u", "player_see_npc" ],
+          "source": { "path": "src/condition.cpp", "line": 2638, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 20,
+        "examples": [ { "path": "data/json/effects_on_condition/example_eocs.json", "pointer": "/25/effect/0/u_run_npc_eocs/0/condition" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1424 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "roll_contested",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_roll_contested" ],
+      "aliases": [ "roll_contested" ],
+      "parser_registrations": [
+        {
+          "registration_order": 55,
+          "alias_role": "alpha",
+          "alias_group": [ "roll_contested" ],
+          "source": { "path": "src/condition.cpp", "line": 2537, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 72,
+        "examples": [ { "path": "data/json/techniques.json", "pointer": "/13/condition/and/3/or/0/and/2/roll_contested" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1135 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "test_eoc",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_test_eoc" ],
+      "aliases": [ "test_eoc" ],
+      "parser_registrations": [
+        {
+          "registration_order": 87,
+          "alias_role": "alpha",
+          "alias_group": [ "test_eoc" ],
+          "source": { "path": "src/condition.cpp", "line": 2569, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 834,
+        "examples": [ { "path": "data/json/effects_on_condition/anomalous_mp3_eocs.json", "pointer": "/3/effect/0/then/if/test_eoc" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1734 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_aim_rule",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_npc_aim_rule" ],
+      "aliases": [ "npc_aim_rule", "u_aim_rule" ],
+      "parser_registrations": [
+        {
+          "registration_order": 46,
+          "alias_role": "alpha",
+          "alias_group": [ "u_aim_rule", "npc_aim_rule" ],
+          "source": { "path": "src/condition.cpp", "line": 2528, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1128 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_are_owed",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "member" ],
+      "handlers": [ "conditional_fun::f_u_are_owed" ],
+      "aliases": [ "u_are_owed" ],
+      "parser_registrations": [
+        {
+          "registration_order": 45,
+          "alias_role": "alpha",
+          "alias_group": [ "u_are_owed" ],
+          "source": { "path": "src/condition.cpp", "line": 2527, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 10,
+        "examples": [ { "path": "data/json/npcs/TALK_TEST.json", "pointer": "/31/speaker_effect/condition/u_are_owed" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1094 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_at_om_location",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_at_om_location" ],
+      "aliases": [ "npc_at_om_location", "u_at_om_location" ],
+      "parser_registrations": [
+        {
+          "registration_order": 36,
+          "alias_role": "alpha",
+          "alias_group": [ "u_at_om_location", "npc_at_om_location" ],
+          "source": { "path": "src/condition.cpp", "line": 2518, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 465,
+        "examples": [
+          { "path": "data/json/effects_on_condition/anomalous_mp3_eocs.json", "pointer": "/1/condition/or/0/u_at_om_location" }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 351 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_at_safe_space",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_at_safe_space" ],
+      "aliases": [ "at_safe_space", "npc_at_safe_space", "u_at_safe_space" ],
+      "parser_registrations": [
+        {
+          "registration_order": 114,
+          "alias_role": "alpha",
+          "alias_group": [ "u_at_safe_space", "at_safe_space" ],
+          "source": { "path": "src/condition.cpp", "line": 2604, "symbol": "parsers_simple" }
+        },
+        {
+          "registration_order": 115,
+          "alias_role": "alpha",
+          "alias_group": [ "u_at_safe_space", "npc_at_safe_space" ],
+          "source": { "path": "src/condition.cpp", "line": 2605, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1102 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_available",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_npc_available" ],
+      "aliases": [ "npc_available", "u_available" ],
+      "parser_registrations": [
+        {
+          "registration_order": 107,
+          "alias_role": "alpha",
+          "alias_group": [ "u_available", "npc_available" ],
+          "source": { "path": "src/condition.cpp", "line": 2597, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1120 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_bodytype",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_bodytype" ],
+      "aliases": [ "npc_bodytype", "u_bodytype" ],
+      "parser_registrations": [
+        {
+          "registration_order": 10,
+          "alias_role": "alpha",
+          "alias_group": [ "u_bodytype", "npc_bodytype" ],
+          "source": { "path": "src/condition.cpp", "line": 2492, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 526 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_can_drop_weapon",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_can_drop_weapon" ],
+      "aliases": [ "npc_can_drop_weapon", "u_can_drop_weapon" ],
+      "parser_registrations": [
+        {
+          "registration_order": 117,
+          "alias_role": "alpha",
+          "alias_group": [ "u_can_drop_weapon", "npc_can_drop_weapon" ],
+          "source": { "path": "src/condition.cpp", "line": 2607, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 26,
+        "examples": [ { "path": "data/json/enchantments.json", "pointer": "/24/condition/and/4/not" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 909 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_can_float",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_can_float" ],
+      "aliases": [ "npc_can_float", "u_can_float" ],
+      "parser_registrations": [
+        {
+          "registration_order": 157,
+          "alias_role": "alpha",
+          "alias_group": [ "u_can_float", "npc_can_float" ],
+          "source": { "path": "src/condition.cpp", "line": 2647, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1597 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_can_fly",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_can_fly" ],
+      "aliases": [ "npc_can_fly", "u_can_fly" ],
+      "parser_registrations": [
+        {
+          "registration_order": 155,
+          "alias_role": "alpha",
+          "alias_group": [ "u_can_fly", "npc_can_fly" ],
+          "source": { "path": "src/condition.cpp", "line": 2645, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1565 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_can_see",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_can_see" ],
+      "aliases": [ "npc_can_see", "u_can_see" ],
+      "parser_registrations": [
+        {
+          "registration_order": 134,
+          "alias_role": "alpha",
+          "alias_group": [ "u_can_see", "npc_can_see" ],
+          "source": { "path": "src/condition.cpp", "line": 2624, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 42,
+        "examples": [ { "path": "data/json/effects_on_condition/misc_effect_on_condition.json", "pointer": "/20/condition/and/2" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1117 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_can_see_location",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_can_see_location" ],
+      "aliases": [ "npc_can_see_location", "u_can_see_location" ],
+      "parser_registrations": [
+        {
+          "registration_order": 71,
+          "alias_role": "alpha",
+          "alias_group": [ "u_can_see_location", "npc_can_see_location" ],
+          "source": { "path": "src/condition.cpp", "line": 2553, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [
+          { "path": "data/json/effects_on_condition/example_eocs.json", "pointer": "/26/effect/1/then/0/if/u_can_see_location" }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1440 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_can_stow_weapon",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_can_stow_weapon" ],
+      "aliases": [ "npc_can_stow_weapon", "u_can_stow_weapon" ],
+      "parser_registrations": [
+        {
+          "registration_order": 116,
+          "alias_role": "alpha",
+          "alias_group": [ "u_can_stow_weapon", "npc_can_stow_weapon" ],
+          "source": { "path": "src/condition.cpp", "line": 2606, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_GREET.json", "pointer": "/1/responses/0/condition" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 888 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_cbm_recharge_rule",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_npc_cbm_recharge_rule" ],
+      "aliases": [ "npc_cbm_recharge_rule", "u_cbm_recharge_rule" ],
+      "parser_registrations": [
+        {
+          "registration_order": 49,
+          "alias_role": "alpha",
+          "alias_group": [ "u_cbm_recharge_rule", "npc_cbm_recharge_rule" ],
+          "source": { "path": "src/condition.cpp", "line": 2531, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1131 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_cbm_reserve_rule",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_npc_cbm_reserve_rule" ],
+      "aliases": [ "npc_cbm_reserve_rule", "u_cbm_reserve_rule" ],
+      "parser_registrations": [
+        {
+          "registration_order": 48,
+          "alias_role": "alpha",
+          "alias_group": [ "u_cbm_reserve_rule", "npc_cbm_reserve_rule" ],
+          "source": { "path": "src/condition.cpp", "line": 2530, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1130 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_controlling_vehicle",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_controlling_vehicle" ],
+      "aliases": [ "npc_controlling_vehicle", "u_controlling_vehicle" ],
+      "parser_registrations": [
+        {
+          "registration_order": 119,
+          "alias_role": "alpha",
+          "alias_group": [ "u_controlling_vehicle", "npc_controlling_vehicle" ],
+          "source": { "path": "src/condition.cpp", "line": 2609, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 3,
+        "examples": [ { "path": "data/json/ui/structured/structured_speed_vehicle.json", "pointer": "/3/clauses/0/condition/not" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 957 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_driving",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_driving" ],
+      "aliases": [ "npc_driving", "u_driving" ],
+      "parser_registrations": [
+        {
+          "registration_order": 120,
+          "alias_role": "alpha",
+          "alias_group": [ "u_driving", "npc_driving" ],
+          "source": { "path": "src/condition.cpp", "line": 2610, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 58,
+        "examples": [ { "path": "data/json/artifact/altered_object_active.json", "pointer": "/10/condition/not" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 978 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_engagement_rule",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_npc_engagement_rule" ],
+      "aliases": [ "npc_engagement_rule", "u_engagement_rule" ],
+      "parser_registrations": [
+        {
+          "registration_order": 47,
+          "alias_role": "alpha",
+          "alias_group": [ "u_engagement_rule", "npc_engagement_rule" ],
+          "source": { "path": "src/condition.cpp", "line": 2529, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1129 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_exists",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_exists" ],
+      "aliases": [ "npc_exists", "u_exists" ],
+      "parser_registrations": [
+        {
+          "registration_order": 138,
+          "alias_role": "alpha",
+          "alias_group": [ "u_exists", "npc_exists" ],
+          "source": { "path": "src/condition.cpp", "line": 2628, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [ { "path": "data/json/effects_on_condition/item_eocs.json", "pointer": "/25/condition/and/0" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1196 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_female",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_female" ],
+      "aliases": [ "npc_female", "u_female" ],
+      "parser_registrations": [
+        {
+          "registration_order": 90,
+          "alias_role": "alpha",
+          "alias_group": [ "u_female", "npc_female" ],
+          "source": { "path": "src/condition.cpp", "line": 2580, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 3,
+        "examples": [ { "path": "data/json/npcs/Kindred/Brigitte_LaCroix_main.json", "pointer": "/0/dynamic_line/is_by_radio/u_female" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 107 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_following",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_npc_following" ],
+      "aliases": [ "npc_following", "u_following" ],
+      "parser_registrations": [
+        {
+          "registration_order": 108,
+          "alias_role": "alpha",
+          "alias_group": [ "u_following", "npc_following" ],
+          "source": { "path": "src/condition.cpp", "line": 2598, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 5,
+        "examples": [
+          {
+            "path": "data/mods/Sky_Island/effectoncondition/teleport.json",
+            "pointer": "/1/effect/8/then/1/u_run_npc_eocs/0/condition/and/0"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1121 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_friend",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_npc_friend" ],
+      "aliases": [ "npc_friend", "u_friend" ],
+      "parser_registrations": [
+        {
+          "registration_order": 109,
+          "alias_role": "alpha",
+          "alias_group": [ "u_friend", "npc_friend" ],
+          "source": { "path": "src/condition.cpp", "line": 2599, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1122 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_activity",
+      "syntaxes": [ "condition_string", "object_member" ],
+      "accepted_json_shapes": [ "condition_string", "string" ],
+      "handlers": [ "conditional_fun::f_has_activity" ],
+      "aliases": [ "npc_has_activity", "u_has_activity" ],
+      "parser_registrations": [
+        {
+          "registration_order": 12,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_activity", "npc_has_activity" ],
+          "source": { "path": "src/condition.cpp", "line": 2494, "symbol": "parsers" }
+        },
+        {
+          "registration_order": 121,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_activity", "npc_has_activity" ],
+          "source": { "path": "src/condition.cpp", "line": 2611, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": {
+        "status": "partial",
+        "items": [ "condition_string", "string" ],
+        "note": "Only parser dispatch shapes are proven here."
+      },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1109 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_any_effect",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array" ],
+      "handlers": [ "conditional_fun::f_has_any_effect" ],
+      "aliases": [ "npc_has_any_effect", "u_has_any_effect" ],
+      "parser_registrations": [
+        {
+          "registration_order": 32,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_any_effect", "npc_has_any_effect" ],
+          "source": { "path": "src/condition.cpp", "line": 2514, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 102,
+        "examples": [ { "path": "data/json/effects_on_condition/example_eocs.json", "pointer": "/13/condition/u_has_any_effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 838 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_any_trait",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array" ],
+      "handlers": [ "conditional_fun::f_has_any_trait" ],
+      "aliases": [ "npc_has_any_trait", "u_has_any_trait" ],
+      "parser_registrations": [
+        {
+          "registration_order": 0,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_any_trait", "npc_has_any_trait" ],
+          "source": { "path": "src/condition.cpp", "line": 2482, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 281,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/medicine_eocs/super_soldier_serum_eoc.json",
+            "pointer": "/2/enchantments/1/condition/not/u_has_any_trait"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 379 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_available_mission",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_has_available_mission" ],
+      "aliases": [ "has_available_mission", "npc_has_available_mission", "u_has_available_mission" ],
+      "parser_registrations": [
+        {
+          "registration_order": 97,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_available_mission", "has_available_mission" ],
+          "source": { "path": "src/condition.cpp", "line": 2587, "symbol": "parsers_simple" }
+        },
+        {
+          "registration_order": 98,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_available_mission", "npc_has_available_mission" ],
+          "source": { "path": "src/condition.cpp", "line": 2588, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1106 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_bionics",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_bionics" ],
+      "aliases": [ "npc_has_bionics", "u_has_bionics" ],
+      "parser_registrations": [
+        {
+          "registration_order": 31,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_bionics", "npc_has_bionics" ],
+          "source": { "path": "src/condition.cpp", "line": 2513, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 184,
+        "examples": [ { "path": "data/json/effects_on_condition/bionic_eocs.json", "pointer": "/0/condition/and/0/u_has_bionics" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 817 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_camp",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_u_has_camp" ],
+      "aliases": [ "u_has_camp" ],
+      "parser_registrations": [
+        {
+          "registration_order": 127,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_camp" ],
+          "source": { "path": "src/condition.cpp", "line": 2617, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 16,
+        "examples": [ { "path": "data/json/effects_on_condition/misc_effect_on_condition.json", "pointer": "/17/effect/0/else/0/if" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1095 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_cash",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "member" ],
+      "handlers": [ "conditional_fun::f_u_has_cash" ],
+      "aliases": [ "u_has_cash" ],
+      "parser_registrations": [
+        {
+          "registration_order": 44,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_cash" ],
+          "source": { "path": "src/condition.cpp", "line": 2526, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 11,
+        "examples": [ { "path": "data/json/npcs/Backgrounds/prepper_2.json", "pointer": "/3/responses/0/condition/u_has_cash" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 721 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_class",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_npc_has_class" ],
+      "aliases": [ "npc_has_class", "u_has_class" ],
+      "parser_registrations": [
+        {
+          "registration_order": 11,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_class", "npc_has_class" ],
+          "source": { "path": "src/condition.cpp", "line": 2493, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1126 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_dexterity",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "member" ],
+      "handlers": [ "conditional_fun::f_has_dexterity" ],
+      "aliases": [ "npc_has_dexterity", "u_has_dexterity" ],
+      "parser_registrations": [
+        {
+          "registration_order": 18,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_dexterity", "npc_has_dexterity" ],
+          "source": { "path": "src/condition.cpp", "line": 2500, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 3,
+        "examples": [ { "path": "data/json/npcs/TALK_TEST.json", "pointer": "/2/responses/2/condition/u_has_dexterity" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 639 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_effect",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_effect" ],
+      "aliases": [ "npc_has_effect", "u_has_effect" ],
+      "parser_registrations": [
+        {
+          "registration_order": 33,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_effect", "npc_has_effect" ],
+          "source": { "path": "src/condition.cpp", "line": 2515, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2257,
+        "examples": [ { "path": "data/json/effects.json", "pointer": "/78/enchantments/1/condition/u_has_effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 236 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_faction_trust",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "member" ],
+      "handlers": [ "conditional_fun::f_has_faction_trust" ],
+      "aliases": [ "u_has_faction_trust" ],
+      "parser_registrations": [
+        {
+          "registration_order": 81,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_faction_trust" ],
+          "source": { "path": "src/condition.cpp", "line": 2563, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 21,
+        "examples": [ { "path": "data/json/npcs/TALK_TEST.json", "pointer": "/47/responses/1/condition/u_has_faction_trust" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1096 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_flag",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_flag" ],
+      "aliases": [ "npc_has_flag", "u_has_flag" ],
+      "parser_registrations": [
+        {
+          "registration_order": 8,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_flag", "npc_has_flag" ],
+          "source": { "path": "src/condition.cpp", "line": 2490, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 820,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/misc_effect_on_condition.json",
+            "pointer": "/19/effect/3/if/not/or/0/u_has_flag"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 469 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_intelligence",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "member" ],
+      "handlers": [ "conditional_fun::f_has_intelligence" ],
+      "aliases": [ "npc_has_intelligence", "u_has_intelligence" ],
+      "parser_registrations": [
+        {
+          "registration_order": 19,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_intelligence", "npc_has_intelligence" ],
+          "source": { "path": "src/condition.cpp", "line": 2501, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 31,
+        "examples": [
+          { "path": "data/json/npcs/Backgrounds/no_past_4.json", "pointer": "/3/responses/1/condition/or/1/u_has_intelligence" }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 639 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_item",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_item" ],
+      "aliases": [ "npc_has_item", "u_has_item" ],
+      "parser_registrations": [
+        {
+          "registration_order": 25,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_item", "npc_has_item" ],
+          "source": { "path": "src/condition.cpp", "line": 2507, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 427,
+        "examples": [ { "path": "data/json/effects_on_condition/item_eocs.json", "pointer": "/4/condition/not/u_has_item" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 672 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_item_category",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_item_category" ],
+      "aliases": [ "npc_has_item_category", "u_has_item_category" ],
+      "parser_registrations": [
+        {
+          "registration_order": 29,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_item_category", "npc_has_item_category" ],
+          "source": { "path": "src/condition.cpp", "line": 2511, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 4,
+        "examples": [ { "path": "data/json/npcs/TALK_TEST.json", "pointer": "/22/responses/5/condition/u_has_item_category" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 694 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_item_with_flag",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_item_with_flag" ],
+      "aliases": [ "npc_has_item_with_flag", "u_has_item_with_flag" ],
+      "parser_registrations": [
+        {
+          "registration_order": 26,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_item_with_flag", "npc_has_item_with_flag" ],
+          "source": { "path": "src/condition.cpp", "line": 2508, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [ { "path": "data/json/starting_missions.json", "pointer": "/18/goal_condition/u_has_item_with_flag" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1016 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_items",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_items" ],
+      "aliases": [ "npc_has_items", "u_has_items" ],
+      "parser_registrations": [
+        {
+          "registration_order": 27,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_items", "npc_has_items" ],
+          "source": { "path": "src/condition.cpp", "line": 2509, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 418,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/nether_eocs/labyrinth_effect_on_condition.json",
+            "pointer": "/52/condition/and/0/u_has_items"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 672 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_items_sum",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array" ],
+      "handlers": [ "conditional_fun::f_has_items_sum" ],
+      "aliases": [ "npc_has_items_sum", "u_has_items_sum" ],
+      "parser_registrations": [
+        {
+          "registration_order": 28,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_items_sum", "npc_has_items_sum" ],
+          "source": { "path": "src/condition.cpp", "line": 2510, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 17,
+        "examples": [
+          { "path": "data/json/npcs/balthazar_fac/balthazar.json", "pointer": "/4/responses/0/condition/and/0/u_has_items_sum" }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 752 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_many_available_missions",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_has_many_available_missions" ],
+      "aliases": [ "has_many_available_missions", "npc_has_many_available_missions", "u_has_many_available_missions" ],
+      "parser_registrations": [
+        {
+          "registration_order": 99,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_many_available_missions", "has_many_available_missions" ],
+          "source": { "path": "src/condition.cpp", "line": 2589, "symbol": "parsers_simple" }
+        },
+        {
+          "registration_order": 100,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_many_available_missions", "npc_has_many_available_missions" ],
+          "source": { "path": "src/condition.cpp", "line": 2590, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "u_has_martial_art",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_martial_art" ],
+      "aliases": [ "npc_has_martial_art", "u_has_martial_art" ],
+      "parser_registrations": [
+        {
+          "registration_order": 5,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_martial_art", "npc_has_martial_art" ],
+          "source": { "path": "src/condition.cpp", "line": 2487, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/mods/TEST_DATA/EOC.json", "pointer": "/92/condition/not/u_has_martial_art" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 439 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_mission",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "string" ],
+      "handlers": [ "conditional_fun::f_u_has_mission" ],
+      "aliases": [ "u_has_mission" ],
+      "parser_registrations": [
+        {
+          "registration_order": 14,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_mission" ],
+          "source": { "path": "src/condition.cpp", "line": 2496, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 666,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/npc_eocs/isherwood_barry_rescue_eocs.json",
+            "pointer": "/6/effect/2/if/u_has_mission"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 56 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_move_mode",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_move_mode" ],
+      "aliases": [ "npc_has_move_mode", "u_has_move_mode" ],
+      "parser_registrations": [
+        {
+          "registration_order": 70,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_move_mode", "npc_has_move_mode" ],
+          "source": { "path": "src/condition.cpp", "line": 2552, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 36,
+        "examples": [ { "path": "data/json/enchantments.json", "pointer": "/24/condition/and/3/or/0/u_has_move_mode" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "u_has_no_available_mission",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_no_available_mission" ],
+      "aliases": [ "has_no_available_mission", "npc_has_no_available_mission", "u_has_no_available_mission" ],
+      "parser_registrations": [
+        {
+          "registration_order": 95,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_no_available_mission", "has_no_available_mission" ],
+          "source": { "path": "src/condition.cpp", "line": 2585, "symbol": "parsers_simple" }
+        },
+        {
+          "registration_order": 96,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_no_available_mission", "npc_has_no_available_mission" ],
+          "source": { "path": "src/condition.cpp", "line": 2586, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1105 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_part_flag",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "string" ],
+      "handlers": [ "conditional_fun::f_has_part_flag" ],
+      "aliases": [ "npc_has_part_flag", "u_has_part_flag" ],
+      "parser_registrations": [
+        {
+          "registration_order": 88,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_part_flag", "npc_has_part_flag" ],
+          "source": { "path": "src/condition.cpp", "line": 2570, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 487 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_part_temp",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "member" ],
+      "handlers": [ "conditional_fun::f_has_part_temp" ],
+      "aliases": [ "npc_has_part_temp", "u_has_part_temp" ],
+      "parser_registrations": [
+        {
+          "registration_order": 21,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_part_temp", "npc_has_part_temp" ],
+          "source": { "path": "src/condition.cpp", "line": 2503, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 655 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_perception",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "member" ],
+      "handlers": [ "conditional_fun::f_has_perception" ],
+      "aliases": [ "npc_has_perception", "u_has_perception" ],
+      "parser_registrations": [
+        {
+          "registration_order": 20,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_perception", "npc_has_perception" ],
+          "source": { "path": "src/condition.cpp", "line": 2502, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 25,
+        "examples": [ { "path": "data/json/npcs/Backgrounds/evacuee_5.json", "pointer": "/0/responses/1/condition/u_has_perception" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 639 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_pickup_list",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_has_pickup_list" ],
+      "aliases": [ "has_pickup_list", "npc_has_pickup_list", "u_has_pickup_list" ],
+      "parser_registrations": [
+        {
+          "registration_order": 129,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_pickup_list", "has_pickup_list" ],
+          "source": { "path": "src/condition.cpp", "line": 2619, "symbol": "parsers_simple" }
+        },
+        {
+          "registration_order": 130,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_pickup_list", "npc_has_pickup_list" ],
+          "source": { "path": "src/condition.cpp", "line": 2620, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1134 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_profession",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "string" ],
+      "handlers": [ "conditional_fun::f_has_profession" ],
+      "aliases": [ "npc_has_profession", "u_has_profession" ],
+      "parser_registrations": [
+        {
+          "registration_order": 4,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_profession", "npc_has_profession" ],
+          "source": { "path": "src/condition.cpp", "line": 2486, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 7,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/scenario_specific_eocs.json",
+            "pointer": "/32/condition/and/0/u_has_profession"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 611 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_proficiency",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_proficiency" ],
+      "aliases": [ "npc_has_proficiency", "u_has_proficiency" ],
+      "parser_registrations": [
+        {
+          "registration_order": 7,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_proficiency", "npc_has_proficiency" ],
+          "source": { "path": "src/condition.cpp", "line": 2489, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 43,
+        "examples": [
+          {
+            "path": "data/mods/BombasticPerks/perkmenu.json",
+            "pointer": "/0/responses/35/effect/4/condition/or/1/u_has_proficiency"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 872 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_software",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_software" ],
+      "aliases": [ "npc_has_software", "u_has_software" ],
+      "parser_registrations": [
+        {
+          "registration_order": 30,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_software", "npc_has_software" ],
+          "source": { "path": "src/condition.cpp", "line": 2512, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 4,
+        "examples": [ { "path": "data/json/effects_on_condition/computer_eocs.json", "pointer": "/6/condition/and/0/u_has_software" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 717 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_species",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_species" ],
+      "aliases": [ "npc_has_species", "u_has_species" ],
+      "parser_registrations": [
+        {
+          "registration_order": 9,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_species", "npc_has_species" ],
+          "source": { "path": "src/condition.cpp", "line": 2491, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 179,
+        "examples": [ { "path": "data/json/items/relics/highland_censer.json", "pointer": "/22/effect/0/if/and/0/u_has_species" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 510 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_stolen_item",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_has_stolen_item" ],
+      "aliases": [ "npc_has_stolen_item", "u_has_stolen_item" ],
+      "parser_registrations": [
+        {
+          "registration_order": 124,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_stolen_item", "npc_has_stolen_item" ],
+          "source": { "path": "src/condition.cpp", "line": 2614, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 5,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_OTHER.json", "pointer": "/26/responses/0/condition" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "u_has_strength",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "member" ],
+      "handlers": [ "conditional_fun::f_has_strength" ],
+      "aliases": [ "npc_has_strength", "u_has_strength" ],
+      "parser_registrations": [
+        {
+          "registration_order": 17,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_strength", "npc_has_strength" ],
+          "source": { "path": "src/condition.cpp", "line": 2499, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 4,
+        "examples": [ { "path": "data/json/npcs/TALK_TEST.json", "pointer": "/2/responses/1/condition/u_has_strength" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 215 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_trait",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_trait" ],
+      "aliases": [ "npc_has_trait", "u_has_trait" ],
+      "parser_registrations": [
+        {
+          "registration_order": 1,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_trait", "npc_has_trait" ],
+          "source": { "path": "src/condition.cpp", "line": 2483, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 4097,
+        "examples": [ { "path": "data/json/effects_on_condition/addictions_eocs.json", "pointer": "/6/condition/u_has_trait" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 207 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_visible_trait",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_visible_trait" ],
+      "aliases": [ "npc_has_visible_trait", "u_has_visible_trait" ],
+      "parser_registrations": [
+        {
+          "registration_order": 3,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_visible_trait", "npc_has_visible_trait" ],
+          "source": { "path": "src/condition.cpp", "line": 2485, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 405 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_weapon",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_has_weapon" ],
+      "aliases": [ "npc_has_weapon", "u_has_weapon" ],
+      "parser_registrations": [
+        {
+          "registration_order": 118,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_weapon", "npc_has_weapon" ],
+          "source": { "path": "src/condition.cpp", "line": 2608, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 63,
+        "examples": [ { "path": "data/json/bionics.json", "pointer": "/84/enchantments/0/condition/not" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 936 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_wielded_with_ammotype",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_wielded_with_ammotype" ],
+      "aliases": [ "npc_has_wielded_with_ammotype", "u_has_wielded_with_ammotype" ],
+      "parser_registrations": [
+        {
+          "registration_order": 64,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_wielded_with_ammotype", "npc_has_wielded_with_ammotype" ],
+          "source": { "path": "src/condition.cpp", "line": 2546, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 30,
+        "examples": [
+          {
+            "path": "data/mods/BombasticPerks/perks.json",
+            "pointer": "/118/enchantments/0/condition/u_has_wielded_with_ammotype"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1100 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_wielded_with_flag",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_wielded_with_flag" ],
+      "aliases": [ "npc_has_wielded_with_flag", "u_has_wielded_with_flag" ],
+      "parser_registrations": [
+        {
+          "registration_order": 61,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_wielded_with_flag", "npc_has_wielded_with_flag" ],
+          "source": { "path": "src/condition.cpp", "line": 2543, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 57,
+        "examples": [ { "path": "data/json/starting_missions.json", "pointer": "/6/goal_condition/u_has_wielded_with_flag" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 930 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_wielded_with_skill",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_wielded_with_skill" ],
+      "aliases": [ "npc_has_wielded_with_skill", "u_has_wielded_with_skill" ],
+      "parser_registrations": [
+        {
+          "registration_order": 63,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_wielded_with_skill", "npc_has_wielded_with_skill" ],
+          "source": { "path": "src/condition.cpp", "line": 2545, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 35,
+        "examples": [
+          {
+            "path": "data/mods/BombasticPerks/perks.json",
+            "pointer": "/117/enchantments/0/condition/and/1/u_has_wielded_with_skill"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1082 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_wielded_with_weapon_category",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_wielded_with_weapon_category" ],
+      "aliases": [ "npc_has_wielded_with_weapon_category", "u_has_wielded_with_weapon_category" ],
+      "parser_registrations": [
+        {
+          "registration_order": 62,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_wielded_with_weapon_category", "npc_has_wielded_with_weapon_category" ],
+          "source": { "path": "src/condition.cpp", "line": 2544, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 5,
+        "examples": [
+          { "path": "data/json/npcs/TALK_TEST.json", "pointer": "/24/responses/1/condition/u_has_wielded_with_weapon_category" }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1066 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_has_worn_with_flag",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_has_worn_with_flag" ],
+      "aliases": [ "npc_has_worn_with_flag", "u_has_worn_with_flag" ],
+      "parser_registrations": [
+        {
+          "registration_order": 60,
+          "alias_role": "alpha",
+          "alias_group": [ "u_has_worn_with_flag", "npc_has_worn_with_flag" ],
+          "source": { "path": "src/condition.cpp", "line": 2542, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 85,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/misc_effect_on_condition.json",
+            "pointer": "/19/effect/3/if/not/or/1/u_has_worn_with_flag"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 285 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_hostile",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_npc_hostile" ],
+      "aliases": [ "npc_hostile", "u_hostile" ],
+      "parser_registrations": [
+        {
+          "registration_order": 110,
+          "alias_role": "alpha",
+          "alias_group": [ "u_hostile", "npc_hostile" ],
+          "source": { "path": "src/condition.cpp", "line": 2600, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1123 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_alive",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_alive" ],
+      "aliases": [ "npc_is_alive", "u_is_alive" ],
+      "parser_registrations": [
+        {
+          "registration_order": 136,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_alive", "npc_is_alive" ],
+          "source": { "path": "src/condition.cpp", "line": 2626, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 16,
+        "examples": [ { "path": "data/json/end_screen.json", "pointer": "/0/condition/not" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1159 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_avatar",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_avatar" ],
+      "aliases": [ "npc_is_avatar", "u_is_avatar" ],
+      "parser_registrations": [
+        {
+          "registration_order": 139,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_avatar", "npc_is_avatar" ],
+          "source": { "path": "src/condition.cpp", "line": 2629, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 31,
+        "examples": [ { "path": "data/json/effects_on_condition/item_eocs.json", "pointer": "/25/condition/and/1" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 325 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_avatar_passenger",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_avatar_passenger" ],
+      "aliases": [ "npc_is_avatar_passenger", "u_is_avatar_passenger" ],
+      "parser_registrations": [
+        {
+          "registration_order": 163,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_avatar_passenger", "npc_is_avatar_passenger" ],
+          "source": { "path": "src/condition.cpp", "line": 2653, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1694 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_character",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_character" ],
+      "aliases": [ "npc_is_character", "u_is_character" ],
+      "parser_registrations": [
+        {
+          "registration_order": 141,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_character", "npc_is_character" ],
+          "source": { "path": "src/condition.cpp", "line": 2631, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 32,
+        "examples": [ { "path": "data/json/effects_on_condition/mutation_eocs/mutation_effect_eocs.json", "pointer": "/39/condition" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 325 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_deaf",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_deaf" ],
+      "aliases": [ "npc_is_deaf", "u_is_deaf" ],
+      "parser_registrations": [
+        {
+          "registration_order": 135,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_deaf", "npc_is_deaf" ],
+          "source": { "path": "src/condition.cpp", "line": 2625, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 10,
+        "examples": [ { "path": "data/json/effects_on_condition/bionic_eocs.json", "pointer": "/7/effect/1/run_eocs/0/condition/not" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 107 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_driven",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_driven" ],
+      "aliases": [ "npc_is_driven", "u_is_driven" ],
+      "parser_registrations": [
+        {
+          "registration_order": 153,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_driven", "npc_is_driven" ],
+          "source": { "path": "src/condition.cpp", "line": 2643, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1478 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_falling",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_falling" ],
+      "aliases": [ "npc_is_falling", "u_is_falling" ],
+      "parser_registrations": [
+        {
+          "registration_order": 159,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_falling", "npc_is_falling" ],
+          "source": { "path": "src/condition.cpp", "line": 2649, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1630 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_floating",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_floating" ],
+      "aliases": [ "npc_is_floating", "u_is_floating" ],
+      "parser_registrations": [
+        {
+          "registration_order": 158,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_floating", "npc_is_floating" ],
+          "source": { "path": "src/condition.cpp", "line": 2648, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1613 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_flying",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_flying" ],
+      "aliases": [ "npc_is_flying", "u_is_flying" ],
+      "parser_registrations": [
+        {
+          "registration_order": 156,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_flying", "npc_is_flying" ],
+          "source": { "path": "src/condition.cpp", "line": 2646, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1581 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_furniture",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_furniture" ],
+      "aliases": [ "npc_is_furniture", "u_is_furniture" ],
+      "parser_registrations": [
+        {
+          "registration_order": 144,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_furniture", "npc_is_furniture" ],
+          "source": { "path": "src/condition.cpp", "line": 2634, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/mods/TEST_DATA/EOC.json", "pointer": "/85/effect/5/if" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 325 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_in_field",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_is_in_field" ],
+      "aliases": [ "npc_is_in_field", "u_is_in_field" ],
+      "parser_registrations": [
+        {
+          "registration_order": 69,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_in_field", "npc_is_in_field" ],
+          "source": { "path": "src/condition.cpp", "line": 2551, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 30,
+        "examples": [ { "path": "data/json/effects.json", "pointer": "/409/enchantments/0/condition/u_is_in_field" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1238 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_in_vehicle",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_in_vehicle" ],
+      "aliases": [ "npc_is_in_vehicle", "u_is_in_vehicle" ],
+      "parser_registrations": [
+        {
+          "registration_order": 164,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_in_vehicle", "npc_is_in_vehicle" ],
+          "source": { "path": "src/condition.cpp", "line": 2654, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [ { "path": "data/mods/Xedra_Evolved/eocs/eoc_strange_events.json", "pointer": "/0/condition/and/2/and/2/not" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1710 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_item",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_item" ],
+      "aliases": [ "npc_is_item", "u_is_item" ],
+      "parser_registrations": [
+        {
+          "registration_order": 143,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_item", "npc_is_item" ],
+          "source": { "path": "src/condition.cpp", "line": 2633, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/mods/TEST_DATA/EOC.json", "pointer": "/85/effect/4/if" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 325 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_monster",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_monster" ],
+      "aliases": [ "npc_is_monster", "u_is_monster" ],
+      "parser_registrations": [
+        {
+          "registration_order": 142,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_monster", "npc_is_monster" ],
+          "source": { "path": "src/condition.cpp", "line": 2632, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 3,
+        "examples": [ { "path": "data/mods/MindOverMatter/monsters/monster_eoc_spells.json", "pointer": "/34/effect/2/if/and/0" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 325 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_npc",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_npc" ],
+      "aliases": [ "npc_is_npc", "u_is_npc" ],
+      "parser_registrations": [
+        {
+          "registration_order": 140,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_npc", "npc_is_npc" ],
+          "source": { "path": "src/condition.cpp", "line": 2630, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 14,
+        "examples": [
+          { "path": "data/mods/MindOverMatter/powers/telepathy_eoc.json", "pointer": "/3/false_effect/0/run_eocs/0/condition" }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 325 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_on_furniture",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_is_on_furniture" ],
+      "aliases": [ "npc_is_on_furniture", "u_is_on_furniture" ],
+      "parser_registrations": [
+        {
+          "registration_order": 67,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_on_furniture", "npc_is_on_furniture" ],
+          "source": { "path": "src/condition.cpp", "line": 2549, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 15,
+        "examples": [
+          {
+            "path": "data/mods/Magiclysm/effect_on_conditions/condition_eocs.json",
+            "pointer": "/3/condition/or/7/u_is_on_furniture"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1206 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_on_furniture_with_flag",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_is_on_furniture_with_flag" ],
+      "aliases": [ "npc_is_on_furniture_with_flag", "u_is_on_furniture_with_flag" ],
+      "parser_registrations": [
+        {
+          "registration_order": 68,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_on_furniture_with_flag", "npc_is_on_furniture_with_flag" ],
+          "source": { "path": "src/condition.cpp", "line": 2550, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1222 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_on_rails",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_on_rails" ],
+      "aliases": [ "npc_is_on_rails", "u_is_on_rails" ],
+      "parser_registrations": [
+        {
+          "registration_order": 162,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_on_rails", "npc_is_on_rails" ],
+          "source": { "path": "src/condition.cpp", "line": 2652, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1678 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_on_terrain",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_is_on_terrain" ],
+      "aliases": [ "npc_is_on_terrain", "u_is_on_terrain" ],
+      "parser_registrations": [
+        {
+          "registration_order": 65,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_on_terrain", "npc_is_on_terrain" ],
+          "source": { "path": "src/condition.cpp", "line": 2547, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 483,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/nether_eocs/highland_dimension.json",
+            "pointer": "/3/effect/0/if/and/0/u_is_on_terrain"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1206 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_on_terrain_with_flag",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_is_on_terrain_with_flag" ],
+      "aliases": [ "npc_is_on_terrain_with_flag", "u_is_on_terrain_with_flag" ],
+      "parser_registrations": [
+        {
+          "registration_order": 66,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_on_terrain_with_flag", "npc_is_on_terrain_with_flag" ],
+          "source": { "path": "src/condition.cpp", "line": 2548, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 112,
+        "examples": [
+          {
+            "path": "data/mods/BombasticPerks/perks.json",
+            "pointer": "/60/enchantments/0/condition/and/0/u_is_on_terrain_with_flag"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1222 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_outside",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_outside" ],
+      "aliases": [ "npc_is_outside", "u_is_outside" ],
+      "parser_registrations": [
+        {
+          "registration_order": 125,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_outside", "npc_is_outside" ],
+          "source": { "path": "src/condition.cpp", "line": 2615, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 251,
+        "examples": [ { "path": "data/json/effects_on_condition/misc_effect_on_condition.json", "pointer": "/20/condition/and/1" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 286 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_remote_controlled",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_remote_controlled" ],
+      "aliases": [ "npc_is_remote_controlled", "u_is_remote_controlled" ],
+      "parser_registrations": [
+        {
+          "registration_order": 154,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_remote_controlled", "npc_is_remote_controlled" ],
+          "source": { "path": "src/condition.cpp", "line": 2644, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1549 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_riding",
+      "syntaxes": [ "condition_string", "object_member" ],
+      "accepted_json_shapes": [ "condition_string", "string" ],
+      "handlers": [ "conditional_fun::f_is_riding" ],
+      "aliases": [ "npc_is_riding", "u_is_riding" ],
+      "parser_registrations": [
+        {
+          "registration_order": 13,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_riding", "npc_is_riding" ],
+          "source": { "path": "src/condition.cpp", "line": 2495, "symbol": "parsers" }
+        },
+        {
+          "registration_order": 122,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_riding", "npc_is_riding" ],
+          "source": { "path": "src/condition.cpp", "line": 2612, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": {
+        "status": "partial",
+        "items": [ "condition_string", "string" ],
+        "note": "Only parser dispatch shapes are proven here."
+      },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "u_is_sinking",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_sinking" ],
+      "aliases": [ "npc_is_sinking", "u_is_sinking" ],
+      "parser_registrations": [
+        {
+          "registration_order": 161,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_sinking", "npc_is_sinking" ],
+          "source": { "path": "src/condition.cpp", "line": 2651, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1662 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_skidding",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_skidding" ],
+      "aliases": [ "npc_is_skidding", "u_is_skidding" ],
+      "parser_registrations": [
+        {
+          "registration_order": 160,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_skidding", "npc_is_skidding" ],
+          "source": { "path": "src/condition.cpp", "line": 2650, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1646 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_trait_purifiable",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_is_trait_purifiable" ],
+      "aliases": [ "npc_is_trait_purifiable", "u_is_trait_purifiable" ],
+      "parser_registrations": [
+        {
+          "registration_order": 2,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_trait_purifiable", "npc_is_trait_purifiable" ],
+          "source": { "path": "src/condition.cpp", "line": 2484, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 421 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_travelling",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_npc_is_travelling" ],
+      "aliases": [ "npc_is_travelling", "u_is_travelling" ],
+      "parser_registrations": [
+        {
+          "registration_order": 91,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_travelling", "npc_is_travelling" ],
+          "source": { "path": "src/condition.cpp", "line": 2581, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1110 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_underwater",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_underwater" ],
+      "aliases": [ "npc_is_underwater", "u_is_underwater" ],
+      "parser_registrations": [
+        {
+          "registration_order": 126,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_underwater", "npc_is_underwater" ],
+          "source": { "path": "src/condition.cpp", "line": 2616, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 13,
+        "examples": [ { "path": "data/json/effects_on_condition/item_eocs.json", "pointer": "/12/condition/not" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1151 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_vehicle",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_vehicle" ],
+      "aliases": [ "npc_is_vehicle", "u_is_vehicle" ],
+      "parser_registrations": [
+        {
+          "registration_order": 145,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_vehicle", "npc_is_vehicle" ],
+          "source": { "path": "src/condition.cpp", "line": 2635, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 325 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_warm",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_warm" ],
+      "aliases": [ "npc_is_warm", "u_is_warm" ],
+      "parser_registrations": [
+        {
+          "registration_order": 137,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_warm", "npc_is_warm" ],
+          "source": { "path": "src/condition.cpp", "line": 2627, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1180 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_is_wearing",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_is_wearing" ],
+      "aliases": [ "npc_is_wearing", "u_is_wearing" ],
+      "parser_registrations": [
+        {
+          "registration_order": 22,
+          "alias_role": "alpha",
+          "alias_group": [ "u_is_wearing", "npc_is_wearing" ],
+          "source": { "path": "src/condition.cpp", "line": 2504, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 146,
+        "examples": [ { "path": "data/json/npcs/TALK_TEST.json", "pointer": "/4/responses/3/condition/u_is_wearing" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/MISSIONS_JSON.md", "line": 345 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_know_recipe",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_u_know_recipe" ],
+      "aliases": [ "u_know_recipe" ],
+      "parser_registrations": [
+        {
+          "registration_order": 56,
+          "alias_role": "alpha",
+          "alias_group": [ "u_know_recipe" ],
+          "source": { "path": "src/condition.cpp", "line": 2538, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 173,
+        "examples": [ { "path": "data/mods/BombasticPerks/perkdata/frankenstein.json", "pointer": "/1/condition/u_know_recipe" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 56 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_male",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_is_male" ],
+      "aliases": [ "npc_male", "u_male" ],
+      "parser_registrations": [
+        {
+          "registration_order": 89,
+          "alias_role": "alpha",
+          "alias_group": [ "u_male", "npc_male" ],
+          "source": { "path": "src/condition.cpp", "line": 2579, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 27,
+        "examples": [ { "path": "data/json/npcs/godco/members/NPC_Father_Greenwood.json", "pointer": "/2/dynamic_line/no/no/yes/u_male" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 309 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_mission_complete",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_mission_complete" ],
+      "aliases": [ "mission_complete", "npc_mission_complete", "u_mission_complete" ],
+      "parser_registrations": [
+        {
+          "registration_order": 101,
+          "alias_role": "alpha",
+          "alias_group": [ "u_mission_complete", "mission_complete" ],
+          "source": { "path": "src/condition.cpp", "line": 2591, "symbol": "parsers_simple" }
+        },
+        {
+          "registration_order": 102,
+          "alias_role": "alpha",
+          "alias_group": [ "u_mission_complete", "npc_mission_complete" ],
+          "source": { "path": "src/condition.cpp", "line": 2592, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1112 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_mission_failed",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_mission_failed" ],
+      "aliases": [ "mission_failed", "npc_mission_failed", "u_mission_failed" ],
+      "parser_registrations": [
+        {
+          "registration_order": 105,
+          "alias_role": "alpha",
+          "alias_group": [ "u_mission_failed", "mission_failed" ],
+          "source": { "path": "src/condition.cpp", "line": 2595, "symbol": "parsers_simple" }
+        },
+        {
+          "registration_order": 106,
+          "alias_role": "alpha",
+          "alias_group": [ "u_mission_failed", "npc_mission_failed" ],
+          "source": { "path": "src/condition.cpp", "line": 2596, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1114 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_mission_goal",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_mission_goal" ],
+      "aliases": [ "mission_goal", "npc_mission_goal", "u_mission_goal" ],
+      "parser_registrations": [
+        {
+          "registration_order": 53,
+          "alias_role": "alpha",
+          "alias_group": [ "u_mission_goal", "mission_goal" ],
+          "source": { "path": "src/condition.cpp", "line": 2535, "symbol": "parsers" }
+        },
+        {
+          "registration_order": 54,
+          "alias_role": "alpha",
+          "alias_group": [ "u_mission_goal", "npc_mission_goal" ],
+          "source": { "path": "src/condition.cpp", "line": 2536, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1108 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_mission_incomplete",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_mission_incomplete" ],
+      "aliases": [ "mission_incomplete", "npc_mission_incomplete", "u_mission_incomplete" ],
+      "parser_registrations": [
+        {
+          "registration_order": 103,
+          "alias_role": "alpha",
+          "alias_group": [ "u_mission_incomplete", "mission_incomplete" ],
+          "source": { "path": "src/condition.cpp", "line": 2593, "symbol": "parsers_simple" }
+        },
+        {
+          "registration_order": 104,
+          "alias_role": "alpha",
+          "alias_group": [ "u_mission_incomplete", "npc_mission_incomplete" ],
+          "source": { "path": "src/condition.cpp", "line": 2594, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1113 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_monsters_in_direction",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "string" ],
+      "handlers": [ "conditional_fun::f_u_monsters_in_direction" ],
+      "aliases": [ "u_monsters_in_direction" ],
+      "parser_registrations": [
+        {
+          "registration_order": 15,
+          "alias_role": "alpha",
+          "alias_group": [ "u_monsters_in_direction" ],
+          "source": { "path": "src/condition.cpp", "line": 2497, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 8,
+        "examples": [ { "path": "data/json/ui/compass_danger.json", "pointer": "/0/clauses/1/condition/u_monsters_in_direction" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "u_near_om_location",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_near_om_location" ],
+      "aliases": [ "npc_near_om_location", "u_near_om_location" ],
+      "parser_registrations": [
+        {
+          "registration_order": 37,
+          "alias_role": "alpha",
+          "alias_group": [ "u_near_om_location", "npc_near_om_location" ],
+          "source": { "path": "src/condition.cpp", "line": 2519, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 642,
+        "examples": [
+          { "path": "data/json/effects_on_condition/generalized_eocs.json", "pointer": "/1/condition/and/2/u_near_om_location" }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 246 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_need",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_need" ],
+      "aliases": [ "npc_need", "u_need" ],
+      "parser_registrations": [
+        {
+          "registration_order": 34,
+          "alias_role": "alpha",
+          "alias_group": [ "u_need", "npc_need" ],
+          "source": { "path": "src/condition.cpp", "line": 2516, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "u_override",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_npc_override" ],
+      "aliases": [ "npc_override", "u_override" ],
+      "parser_registrations": [
+        {
+          "registration_order": 51,
+          "alias_role": "alpha",
+          "alias_group": [ "u_override", "npc_override" ],
+          "source": { "path": "src/condition.cpp", "line": 2533, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1133 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_query",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_query" ],
+      "aliases": [ "npc_query", "u_query" ],
+      "parser_registrations": [
+        {
+          "registration_order": 35,
+          "alias_role": "alpha",
+          "alias_group": [ "u_query", "npc_query" ],
+          "source": { "path": "src/condition.cpp", "line": 2517, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 17,
+        "examples": [
+          { "path": "data/json/effects_on_condition/medicine_eocs/contant_lenses_eocs.json", "pointer": "/2/effect/0/if/u_query" }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1254 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_rule",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_npc_rule" ],
+      "aliases": [ "npc_rule", "u_rule" ],
+      "parser_registrations": [
+        {
+          "registration_order": 50,
+          "alias_role": "alpha",
+          "alias_group": [ "u_rule", "npc_rule" ],
+          "source": { "path": "src/condition.cpp", "line": 2532, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1132 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_safe_mode_trigger",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_u_safe_mode_trigger" ],
+      "aliases": [ "u_safe_mode_trigger" ],
+      "parser_registrations": [
+        {
+          "registration_order": 16,
+          "alias_role": "alpha",
+          "alias_group": [ "u_safe_mode_trigger" ],
+          "source": { "path": "src/condition.cpp", "line": 2498, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 8,
+        "examples": [ { "path": "data/json/ui/compass_danger.json", "pointer": "/0/clauses/0/condition/u_safe_mode_trigger" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "u_see_npc",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_see_opposite" ],
+      "aliases": [ "npc_see_u", "u_see_npc" ],
+      "parser_registrations": [
+        {
+          "registration_order": 149,
+          "alias_role": "alpha",
+          "alias_group": [ "u_see_npc", "npc_see_u" ],
+          "source": { "path": "src/condition.cpp", "line": 2639, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1467 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_see_npc_loc",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_see_opposite_coordinates" ],
+      "aliases": [ "npc_see_u_loc", "u_see_npc_loc" ],
+      "parser_registrations": [
+        {
+          "registration_order": 150,
+          "alias_role": "alpha",
+          "alias_group": [ "u_see_npc_loc", "npc_see_u_loc" ],
+          "source": { "path": "src/condition.cpp", "line": 2640, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 5,
+        "examples": [ { "path": "data/json/enchantments.json", "pointer": "/7/special_vision/0/condition/and/0" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1498 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_service",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_npc_service" ],
+      "aliases": [ "npc_service", "u_service" ],
+      "parser_registrations": [
+        {
+          "registration_order": 43,
+          "alias_role": "alpha",
+          "alias_group": [ "u_service", "npc_service" ],
+          "source": { "path": "src/condition.cpp", "line": 2525, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "u_train_skills",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_npc_train_skills" ],
+      "aliases": [ "npc_train_skills", "u_train_skills" ],
+      "parser_registrations": [
+        {
+          "registration_order": 111,
+          "alias_role": "alpha",
+          "alias_group": [ "u_train_skills", "npc_train_skills" ],
+          "source": { "path": "src/condition.cpp", "line": 2601, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1124 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_train_spells",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_npc_train_spells" ],
+      "aliases": [ "npc_train_spells", "u_train_spells" ],
+      "parser_registrations": [
+        {
+          "registration_order": 113,
+          "alias_role": "alpha",
+          "alias_group": [ "u_train_spells", "npc_train_spells" ],
+          "source": { "path": "src/condition.cpp", "line": 2603, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "u_train_styles",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_npc_train_styles" ],
+      "aliases": [ "npc_train_styles", "u_train_styles" ],
+      "parser_registrations": [
+        {
+          "registration_order": 112,
+          "alias_role": "alpha",
+          "alias_group": [ "u_train_styles", "npc_train_styles" ],
+          "source": { "path": "src/condition.cpp", "line": 2602, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1125 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_using_martial_art",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "conditional_fun::f_using_martial_art" ],
+      "aliases": [ "npc_using_martial_art", "u_using_martial_art" ],
+      "parser_registrations": [
+        {
+          "registration_order": 6,
+          "alias_role": "alpha",
+          "alias_group": [ "u_using_martial_art", "npc_using_martial_art" ],
+          "source": { "path": "src/condition.cpp", "line": 2488, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 4,
+        "examples": [ { "path": "data/mods/Perk_melee/EOC/Insight_eocs.json", "pointer": "/0/condition/and/1/u_using_martial_art" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 454 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_vehicle_owned_by_avatar",
+      "syntaxes": [ "condition_string" ],
+      "accepted_json_shapes": [ "condition_string" ],
+      "handlers": [ "conditional_fun::f_vehicle_owned_by_avatar" ],
+      "aliases": [ "npc_vehicle_owned_by_avatar", "u_vehicle_owned_by_avatar" ],
+      "parser_registrations": [
+        {
+          "registration_order": 146,
+          "alias_role": "alpha",
+          "alias_group": [ "u_vehicle_owned_by_avatar", "npc_vehicle_owned_by_avatar" ],
+          "source": { "path": "src/condition.cpp", "line": 2636, "symbol": "parsers_simple" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "condition_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1111 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "x_in_y_chance",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "object" ],
+      "handlers": [ "conditional_fun::f_x_in_y_chance" ],
+      "aliases": [ "x_in_y_chance" ],
+      "parser_registrations": [
+        {
+          "registration_order": 58,
+          "alias_role": "alpha",
+          "alias_group": [ "x_in_y_chance" ],
+          "source": { "path": "src/condition.cpp", "line": 2540, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "object" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "condition",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 254,
+        "examples": [ { "path": "data/json/effects_on_condition/artifact_eocs.json", "pointer": "/0/condition/x_in_y_chance" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1153 } ],
+        "confidence": "lexical_only"
+      }
+    }
+  ]
+}

--- a/data/reference/json/ccb_eoc_effects.json
+++ b/data/reference/json/ccb_eoc_effects.json
@@ -1,0 +1,13168 @@
+{
+  "$schema": "../../../tools/json_api/contract-inventory.schema.json",
+  "schema_version": 1,
+  "inventory_kind": "eoc_effects",
+  "source": {
+    "project": "Cataclysm-Cleanwater-Bomb",
+    "source_fingerprint": "sha256:43df0cec7f2e7a64ea037a329cd3056ef5bd18416bec39e6bd8bb79bed0f5ffc",
+    "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ],
+    "discovery": "git ls-files",
+    "object_parser": "src/npctalk.cpp#talk_effect_t::parse_sub_effect",
+    "string_parser": "src/npctalk.cpp#talk_effect_t::parse_string_effect"
+  },
+  "summary": {
+    "object_parser_registrations": 134,
+    "string_parser_registrations": 117,
+    "public_keys": 306,
+    "keys_with_example_candidates": 229,
+    "fully_classified_keys": 0
+  },
+  "global_contract": {
+    "parser_order": "first matching parser wins",
+    "accepted_effect_container_shapes": [ "string", "object", "array" ],
+    "unknown_effect": "JsonError",
+    "variable_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ],
+    "value_helpers": [ "value_or_var", "value_or_var_pair", "dbl_or_var", "duration_or_var", "str_or_var", "translation_or_var", "eoc_math" ]
+  },
+  "entries": [
+    {
+      "key": "abandon_camp",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::abandon_camp" ],
+      "aliases": [ "abandon_camp" ],
+      "parser_registrations": [
+        {
+          "registration_order": 163,
+          "alias_role": "alpha",
+          "alias_group": [ "abandon_camp" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8834, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_ALLY.json", "pointer": "/14/responses/0/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "add_debt",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array" ],
+      "handlers": [ "talk_effect_fun::f_add_debt" ],
+      "aliases": [ "add_debt" ],
+      "parser_registrations": [
+        {
+          "registration_order": 127,
+          "alias_role": "alpha",
+          "alias_group": [ "add_debt" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8769, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 944 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "add_mission",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_add_mission" ],
+      "aliases": [ "add_mission" ],
+      "parser_registrations": [
+        {
+          "registration_order": 78,
+          "alias_role": "alpha",
+          "alias_group": [ "add_mission" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8720, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 17,
+        "examples": [
+          {
+            "path": "data/json/npcs/Lighthouse_Family/NPC_lighthouse_girl.json",
+            "pointer": "/1/speaker_effect/effect/1/add_mission"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "alter_timed_events",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_alter_timed_events" ],
+      "aliases": [ "alter_timed_events" ],
+      "parser_registrations": [
+        {
+          "registration_order": 95,
+          "alias_role": "alpha",
+          "alias_group": [ "alter_timed_events" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8737, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 16,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/nether_eocs/LIXA_EOCs_spells_traps.json",
+            "pointer": "/132/effect/1/alter_timed_events"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5407 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "assign_camp",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::assign_camp" ],
+      "aliases": [ "assign_camp" ],
+      "parser_registrations": [
+        {
+          "registration_order": 162,
+          "alias_role": "alpha",
+          "alias_group": [ "assign_camp" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8833, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_ALLY.json", "pointer": "/13/responses/0/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "assign_guard",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::assign_guard" ],
+      "aliases": [ "assign_guard" ],
+      "parser_registrations": [
+        {
+          "registration_order": 161,
+          "alias_role": "alpha",
+          "alias_group": [ "assign_guard" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8832, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 12,
+        "examples": [ { "path": "data/json/npcs/Kindred/Brigitte_LaCroix_main.json", "pointer": "/3/responses/6/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1021 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "assign_mission",
+      "syntaxes": [ "effect_string", "object_member" ],
+      "accepted_json_shapes": [ "effect_string", "member" ],
+      "handlers": [ "talk_effect_fun::f_assign_mission", "talk_function::assign_mission" ],
+      "aliases": [ "assign_mission" ],
+      "parser_registrations": [
+        {
+          "registration_order": 106,
+          "alias_role": "alpha",
+          "alias_group": [ "assign_mission" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8748, "symbol": "parsers" }
+        },
+        {
+          "registration_order": 134,
+          "alias_role": "alpha",
+          "alias_group": [ "assign_mission" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8805, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 347,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json",
+            "pointer": "/7/effect/4/assign_mission"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2030 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "barber_beard",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::barber_beard" ],
+      "aliases": [ "barber_beard" ],
+      "parser_registrations": [
+        {
+          "registration_order": 180,
+          "alias_role": "alpha",
+          "alias_group": [ "barber_beard" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8851, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 5,
+        "examples": [ { "path": "data/json/effects_on_condition/item_eocs.json", "pointer": "/16/id" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 107 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "barber_hair",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::barber_hair" ],
+      "aliases": [ "barber_hair" ],
+      "parser_registrations": [
+        {
+          "registration_order": 181,
+          "alias_role": "alpha",
+          "alias_group": [ "barber_hair" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8852, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 5,
+        "examples": [ { "path": "data/json/effects_on_condition/item_eocs.json", "pointer": "/15/id" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4140 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "basecamp_mission",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::basecamp_mission" ],
+      "aliases": [ "basecamp_mission" ],
+      "parser_registrations": [
+        {
+          "registration_order": 170,
+          "alias_role": "alpha",
+          "alias_group": [ "basecamp_mission" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8841, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 3,
+        "examples": [ { "path": "data/json/npcs/TALK_FACTION_CAMP.json", "pointer": "/0/responses/6/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1044 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "bionic_install",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::bionic_install" ],
+      "aliases": [ "bionic_install" ],
+      "parser_registrations": [
+        {
+          "registration_order": 185,
+          "alias_role": "alpha",
+          "alias_group": [ "bionic_install" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8856, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 5,
+        "examples": [ { "path": "data/json/npcs/exodii/exodii_Venn.json", "pointer": "/4/responses/0/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1045 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "bionic_install_allies",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::bionic_install_allies" ],
+      "aliases": [ "bionic_install_allies" ],
+      "parser_registrations": [
+        {
+          "registration_order": 186,
+          "alias_role": "alpha",
+          "alias_group": [ "bionic_install_allies" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8857, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [
+          { "path": "data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json", "pointer": "/17/responses/4/effect" }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "bionic_remove",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::bionic_remove" ],
+      "aliases": [ "bionic_remove" ],
+      "parser_registrations": [
+        {
+          "registration_order": 187,
+          "alias_role": "alpha",
+          "alias_group": [ "bionic_remove" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8858, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 5,
+        "examples": [ { "path": "data/json/npcs/exodii/exodii_Venn.json", "pointer": "/4/responses/1/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1046 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "bionic_remove_allies",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::bionic_remove_allies" ],
+      "aliases": [ "bionic_remove_allies" ],
+      "parser_registrations": [
+        {
+          "registration_order": 188,
+          "alias_role": "alpha",
+          "alias_group": [ "bionic_remove_allies" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8859, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [
+          { "path": "data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json", "pointer": "/17/responses/6/effect" }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "buy_chicken",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::buy_chicken" ],
+      "aliases": [ "buy_chicken" ],
+      "parser_registrations": [
+        {
+          "registration_order": 168,
+          "alias_role": "alpha",
+          "alias_group": [ "buy_chicken" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8839, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "buy_cow",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::buy_cow" ],
+      "aliases": [ "buy_cow" ],
+      "parser_registrations": [
+        {
+          "registration_order": 167,
+          "alias_role": "alpha",
+          "alias_group": [ "buy_cow" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8838, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "buy_haircut",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::buy_haircut" ],
+      "aliases": [ "buy_haircut" ],
+      "parser_registrations": [
+        {
+          "registration_order": 182,
+          "alias_role": "alpha",
+          "alias_group": [ "buy_haircut" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8853, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [
+          {
+            "path": "data/json/npcs/refugee_center/surface_refugees/NPC_Vanessa_Toby.json",
+            "pointer": "/15/responses/0/effect/1"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 919 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "buy_horse",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::buy_horse" ],
+      "aliases": [ "buy_horse" ],
+      "parser_registrations": [
+        {
+          "registration_order": 169,
+          "alias_role": "alpha",
+          "alias_group": [ "buy_horse" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8840, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "buy_shave",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::buy_shave" ],
+      "aliases": [ "buy_shave" ],
+      "parser_registrations": [
+        {
+          "registration_order": 183,
+          "alias_role": "alpha",
+          "alias_group": [ "buy_shave" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8854, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [
+          {
+            "path": "data/json/npcs/refugee_center/surface_refugees/NPC_Vanessa_Toby.json",
+            "pointer": "/15/responses/1/effect/1"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 920 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "clear_dimension",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_clear_dimension" ],
+      "aliases": [ "clear_dimension" ],
+      "parser_registrations": [
+        {
+          "registration_order": 93,
+          "alias_role": "alpha",
+          "alias_group": [ "clear_dimension" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8735, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 17,
+        "examples": [ { "path": "data/json/effects_on_condition/example_eocs.json", "pointer": "/38/effect/1/clear_dimension" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/DIMENSIONS.md", "line": 63 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "clear_mission",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::clear_mission" ],
+      "aliases": [ "clear_mission" ],
+      "parser_registrations": [
+        {
+          "registration_order": 137,
+          "alias_role": "alpha",
+          "alias_group": [ "clear_mission" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8808, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 14,
+        "examples": [ { "path": "data/json/npcs/Lighthouse_Family/NPC_lighthouse_girl.json", "pointer": "/1/responses/1/effect/1" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 908 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "clear_npc_rule",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_clear_npc_rule" ],
+      "aliases": [ "clear_npc_rule" ],
+      "parser_registrations": [
+        {
+          "registration_order": 87,
+          "alias_role": "alpha",
+          "alias_group": [ "clear_npc_rule" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8729, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 6,
+        "examples": [ { "path": "data/json/npcs/missiondef.json", "pointer": "/1/start/effect/3/clear_npc_rule" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1053 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "clear_overrides",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::clear_overrides" ],
+      "aliases": [ "clear_overrides" ],
+      "parser_registrations": [
+        {
+          "registration_order": 219,
+          "alias_role": "alpha",
+          "alias_group": [ "clear_overrides" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8890, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "closest_city",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "object" ],
+      "handlers": [ "talk_effect_fun::f_closest_city" ],
+      "aliases": [ "closest_city" ],
+      "parser_registrations": [
+        {
+          "registration_order": 73,
+          "alias_role": "alpha",
+          "alias_group": [ "closest_city" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8715, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "object" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3086 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "companion_mission",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "string" ],
+      "handlers": [ "talk_effect_fun::f_companion_mission" ],
+      "aliases": [ "companion_mission" ],
+      "parser_registrations": [
+        {
+          "registration_order": 68,
+          "alias_role": "alpha",
+          "alias_group": [ "companion_mission" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8710, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 6,
+        "examples": [
+          {
+            "path": "data/json/npcs/tacoma_ranch/NPC_ranch_crop_overseer.json",
+            "pointer": "/1/responses/2/effect/companion_mission"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1043 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "copy_location",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_copy_location" ],
+      "aliases": [ "copy_location" ],
+      "parser_registrations": [
+        {
+          "registration_order": 97,
+          "alias_role": "alpha",
+          "alias_group": [ "copy_location" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8739, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [ { "path": "data/mods/aftershock_exoplanet/EOC/ship_eoc.json", "pointer": "/4/effect/3/then/2/copy_location" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "copy_npc_rules",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::copy_npc_rules" ],
+      "aliases": [ "copy_npc_rules" ],
+      "parser_registrations": [
+        {
+          "registration_order": 216,
+          "alias_role": "alpha",
+          "alias_group": [ "copy_npc_rules" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8887, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "copy_var",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_copy_var" ],
+      "aliases": [ "copy_var" ],
+      "parser_registrations": [
+        {
+          "registration_order": 69,
+          "alias_role": "alpha",
+          "alias_group": [ "copy_var" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8711, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 76,
+        "examples": [ { "path": "data/json/effects_on_condition/effects_eocs.json", "pointer": "/6/effect/0/copy_var" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3824 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "custom_light_level",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "member" ],
+      "handlers": [ "talk_effect_fun::f_custom_light_level" ],
+      "aliases": [ "custom_light_level" ],
+      "parser_registrations": [
+        {
+          "registration_order": 117,
+          "alias_role": "alpha",
+          "alias_group": [ "custom_light_level" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8759, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 11,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/nether_eocs/labyrinth_effect_on_condition.json",
+            "pointer": "/6/effect/3/custom_light_level"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5485 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "deny_equipment",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::deny_equipment" ],
+      "aliases": [ "deny_equipment" ],
+      "parser_registrations": [
+        {
+          "registration_order": 195,
+          "alias_role": "alpha",
+          "alias_group": [ "deny_equipment" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8866, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "deny_follow",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::deny_follow" ],
+      "aliases": [ "deny_follow" ],
+      "parser_registrations": [
+        {
+          "registration_order": 193,
+          "alias_role": "alpha",
+          "alias_group": [ "deny_follow" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8864, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 18,
+        "examples": [ { "path": "data/json/npcs/TALK_CYBORG_1.json", "pointer": "/1/responses/0/failure/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 826 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "deny_lead",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::deny_lead" ],
+      "aliases": [ "deny_lead" ],
+      "parser_registrations": [
+        {
+          "registration_order": 194,
+          "alias_role": "alpha",
+          "alias_group": [ "deny_lead" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8865, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1072 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "deny_personal_info",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::deny_personal_info" ],
+      "aliases": [ "deny_personal_info" ],
+      "parser_registrations": [
+        {
+          "registration_order": 197,
+          "alias_role": "alpha",
+          "alias_group": [ "deny_personal_info" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8868, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1072 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "deny_train",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::deny_train" ],
+      "aliases": [ "deny_train" ],
+      "parser_registrations": [
+        {
+          "registration_order": 196,
+          "alias_role": "alpha",
+          "alias_group": [ "deny_train" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8867, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1072 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "dimension_name",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "object" ],
+      "handlers": [ "talk_effect_fun::f_dimension_name" ],
+      "aliases": [ "dimension_name" ],
+      "parser_registrations": [
+        {
+          "registration_order": 16,
+          "alias_role": "alpha",
+          "alias_group": [ "dimension_name" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8658, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "object" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 6,
+        "examples": [ { "path": "data/json/effects_on_condition/anomalous_mp3_eocs.json", "pointer": "/2/effect/0/dimension_name" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4011 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "dismount",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::dismount" ],
+      "aliases": [ "dismount" ],
+      "parser_registrations": [
+        {
+          "registration_order": 142,
+          "alias_role": "alpha",
+          "alias_group": [ "dismount" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8813, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 4,
+        "examples": [ { "path": "data/json/npcs/Kindred/Brigitte_LaCroix_main.json", "pointer": "/3/responses/9/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "distribute_food_auto",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::distribute_food_auto" ],
+      "aliases": [ "distribute_food_auto" ],
+      "parser_registrations": [
+        {
+          "registration_order": 222,
+          "alias_role": "alpha",
+          "alias_group": [ "distribute_food_auto" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8893, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [
+          {
+            "path": "data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json",
+            "pointer": "/1/speaker_effect/0/effect"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1024 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "do_butcher",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::do_butcher" ],
+      "aliases": [ "do_butcher" ],
+      "parser_registrations": [
+        {
+          "registration_order": 159,
+          "alias_role": "alpha",
+          "alias_group": [ "do_butcher" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8830, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_ALLY.json", "pointer": "/9/responses/14/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "do_chop_plank",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::do_chop_plank" ],
+      "aliases": [ "do_chop_plank" ],
+      "parser_registrations": [
+        {
+          "registration_order": 143,
+          "alias_role": "alpha",
+          "alias_group": [ "do_chop_plank" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8814, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_ALLY.json", "pointer": "/9/responses/13/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "do_chop_trees",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::do_chop_trees" ],
+      "aliases": [ "do_chop_trees" ],
+      "parser_registrations": [
+        {
+          "registration_order": 149,
+          "alias_role": "alpha",
+          "alias_group": [ "do_chop_trees" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8820, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_ALLY.json", "pointer": "/9/responses/15/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "do_construction",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::do_construction" ],
+      "aliases": [ "do_construction" ],
+      "parser_registrations": [
+        {
+          "registration_order": 151,
+          "alias_role": "alpha",
+          "alias_group": [ "do_construction" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8822, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_ALLY.json", "pointer": "/9/responses/4/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "do_craft",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::do_craft" ],
+      "aliases": [ "do_craft" ],
+      "parser_registrations": [
+        {
+          "registration_order": 158,
+          "alias_role": "alpha",
+          "alias_group": [ "do_craft" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8829, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_ALLY.json", "pointer": "/9/responses/19/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "do_disassembly",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::do_disassembly" ],
+      "aliases": [ "do_disassembly" ],
+      "parser_registrations": [
+        {
+          "registration_order": 221,
+          "alias_role": "alpha",
+          "alias_group": [ "do_disassembly" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8892, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_ALLY.json", "pointer": "/9/responses/18/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "do_eread",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::do_eread" ],
+      "aliases": [ "do_eread" ],
+      "parser_registrations": [
+        {
+          "registration_order": 155,
+          "alias_role": "alpha",
+          "alias_group": [ "do_eread" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8826, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_ALLY.json", "pointer": "/9/responses/8/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "do_farming",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::do_farming" ],
+      "aliases": [ "do_farming" ],
+      "parser_registrations": [
+        {
+          "registration_order": 160,
+          "alias_role": "alpha",
+          "alias_group": [ "do_farming" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8831, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_ALLY.json", "pointer": "/9/responses/17/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "do_fishing",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::do_fishing" ],
+      "aliases": [ "do_fishing" ],
+      "parser_registrations": [
+        {
+          "registration_order": 150,
+          "alias_role": "alpha",
+          "alias_group": [ "do_fishing" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8821, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_ALLY.json", "pointer": "/9/responses/16/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "do_mining",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::do_mining" ],
+      "aliases": [ "do_mining" ],
+      "parser_registrations": [
+        {
+          "registration_order": 152,
+          "alias_role": "alpha",
+          "alias_group": [ "do_mining" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8823, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_ALLY.json", "pointer": "/9/responses/5/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "do_mopping",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::do_mopping" ],
+      "aliases": [ "do_mopping" ],
+      "parser_registrations": [
+        {
+          "registration_order": 153,
+          "alias_role": "alpha",
+          "alias_group": [ "do_mopping" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8824, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_ALLY.json", "pointer": "/9/responses/6/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "do_read",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::do_read" ],
+      "aliases": [ "do_read" ],
+      "parser_registrations": [
+        {
+          "registration_order": 154,
+          "alias_role": "alpha",
+          "alias_group": [ "do_read" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8825, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_ALLY.json", "pointer": "/9/responses/7/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "do_read_repeatedly",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::do_read_repeatedly" ],
+      "aliases": [ "do_read_repeatedly" ],
+      "parser_registrations": [
+        {
+          "registration_order": 156,
+          "alias_role": "alpha",
+          "alias_group": [ "do_read_repeatedly" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8827, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_ALLY.json", "pointer": "/9/responses/9/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "do_study",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::do_study" ],
+      "aliases": [ "do_study" ],
+      "parser_registrations": [
+        {
+          "registration_order": 157,
+          "alias_role": "alpha",
+          "alias_group": [ "do_study" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8828, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_ALLY.json", "pointer": "/9/responses/10/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "do_vehicle_deconstruct",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::do_vehicle_deconstruct" ],
+      "aliases": [ "do_vehicle_deconstruct" ],
+      "parser_registrations": [
+        {
+          "registration_order": 144,
+          "alias_role": "alpha",
+          "alias_group": [ "do_vehicle_deconstruct" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8815, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_ALLY.json", "pointer": "/9/responses/11/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "do_vehicle_repair",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::do_vehicle_repair" ],
+      "aliases": [ "do_vehicle_repair" ],
+      "parser_registrations": [
+        {
+          "registration_order": 145,
+          "alias_role": "alpha",
+          "alias_group": [ "do_vehicle_repair" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8816, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_ALLY.json", "pointer": "/9/responses/12/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "drop_items_in_place",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::drop_items_in_place" ],
+      "aliases": [ "drop_items_in_place" ],
+      "parser_registrations": [
+        {
+          "registration_order": 190,
+          "alias_role": "alpha",
+          "alias_group": [ "drop_items_in_place" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8861, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 4,
+        "examples": [ { "path": "data/json/npcs/Kindred/Brigitte_LaCroix_main.json", "pointer": "/3/responses/8/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "drop_stolen_item",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::drop_stolen_item" ],
+      "aliases": [ "drop_stolen_item" ],
+      "parser_registrations": [
+        {
+          "registration_order": 208,
+          "alias_role": "alpha",
+          "alias_group": [ "drop_stolen_item" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8879, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_OTHER.json", "pointer": "/26/responses/0/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "drop_weapon",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::drop_weapon" ],
+      "aliases": [ "drop_weapon" ],
+      "parser_registrations": [
+        {
+          "registration_order": 207,
+          "alias_role": "alpha",
+          "alias_group": [ "drop_weapon" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8878, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 17,
+        "examples": [ { "path": "data/json/npcs/cabin_chemist/chemist_npc.json", "pointer": "/3/responses/1/success/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1036 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "end_conversation",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::end_conversation" ],
+      "aliases": [ "end_conversation" ],
+      "parser_registrations": [
+        {
+          "registration_order": 173,
+          "alias_role": "alpha",
+          "alias_group": [ "end_conversation" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8844, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 24,
+        "examples": [ { "path": "data/json/npcs/Lighthouse_Family/NPC_lighthouse_man.json", "pointer": "/13/responses/0/effect/2" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1027 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "find_mount",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::find_mount" ],
+      "aliases": [ "find_mount" ],
+      "parser_registrations": [
+        {
+          "registration_order": 141,
+          "alias_role": "alpha",
+          "alias_group": [ "find_mount" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8812, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 4,
+        "examples": [ { "path": "data/json/npcs/Kindred/Brigitte_LaCroix_main.json", "pointer": "/3/responses/7/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "finish_mission",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_finish_mission" ],
+      "aliases": [ "finish_mission" ],
+      "parser_registrations": [
+        {
+          "registration_order": 107,
+          "alias_role": "alpha",
+          "alias_group": [ "finish_mission" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8749, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 86,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/nether_eocs/labyrinth_effect_on_condition.json",
+            "pointer": "/2/effect/0/else/0/then/3/finish_mission"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2072 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "flee",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::flee" ],
+      "aliases": [ "flee" ],
+      "parser_registrations": [
+        {
+          "registration_order": 199,
+          "alias_role": "alpha",
+          "alias_group": [ "flee" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8870, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 22,
+        "examples": [ { "path": "data/json/npcs/TALK_CYBORG_1.json", "pointer": "/3/responses/1/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/MONSTERS.md", "line": 117 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "follow",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::follow" ],
+      "aliases": [ "follow" ],
+      "parser_registrations": [
+        {
+          "registration_order": 191,
+          "alias_role": "alpha",
+          "alias_group": [ "follow" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8862, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 62,
+        "examples": [
+          { "path": "data/json/effects_on_condition/example_eocs.json", "pointer": "/32/effect/2/then/run_eocs/effect/0/then/0" }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/BASECAMP.md", "line": 354 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "follow_only",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::follow_only" ],
+      "aliases": [ "follow_only" ],
+      "parser_registrations": [
+        {
+          "registration_order": 192,
+          "alias_role": "alpha",
+          "alias_group": [ "follow_only" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8863, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 26,
+        "examples": [ { "path": "data/json/npcs/Lighthouse_Family/NPC_lighthouse_girl.json", "pointer": "/1/speaker_effect/effect/0" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1033 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "foreach",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "string" ],
+      "handlers": [ "talk_effect_fun::f_foreach" ],
+      "aliases": [ "foreach" ],
+      "parser_registrations": [
+        {
+          "registration_order": 115,
+          "alias_role": "alpha",
+          "alias_group": [ "foreach" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8757, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 20,
+        "examples": [ { "path": "data/json/effects_on_condition/example_eocs.json", "pointer": "/20/effect/1/foreach" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2534 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "give_achievement",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_give_achievment" ],
+      "aliases": [ "give_achievement" ],
+      "parser_registrations": [
+        {
+          "registration_order": 105,
+          "alias_role": "alpha",
+          "alias_group": [ "give_achievement" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8747, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 31,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/nether_eocs/LIXA_EOCs_spells_traps.json",
+            "pointer": "/132/effect/17/give_achievement"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2011 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "give_aid",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::give_aid" ],
+      "aliases": [ "give_aid" ],
+      "parser_registrations": [
+        {
+          "registration_order": 178,
+          "alias_role": "alpha",
+          "alias_group": [ "give_aid" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8849, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 7,
+        "examples": [ { "path": "data/json/npcs/godco/members/NPC_Jane_Schulz.json", "pointer": "/14/responses/0/effect/1" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 917 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "give_all_aid",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::give_all_aid" ],
+      "aliases": [ "give_all_aid" ],
+      "parser_registrations": [
+        {
+          "registration_order": 179,
+          "alias_role": "alpha",
+          "alias_group": [ "give_all_aid" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8850, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 4,
+        "examples": [
+          { "path": "data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json", "pointer": "/16/responses/1/effect/1" }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "give_equipment",
+      "syntaxes": [ "effect_string", "object_member" ],
+      "accepted_json_shapes": [ "effect_string", "object" ],
+      "handlers": [ "talk_effect_fun::f_give_equipment", "talk_function::give_equipment" ],
+      "aliases": [ "give_equipment" ],
+      "parser_registrations": [
+        {
+          "registration_order": 120,
+          "alias_role": "alpha",
+          "alias_group": [ "give_equipment" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8762, "symbol": "parsers" }
+        },
+        {
+          "registration_order": 175,
+          "alias_role": "alpha",
+          "alias_group": [ "give_equipment" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8846, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string", "object" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 5,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_OTHER.json", "pointer": "/24/responses/1/effect/give_equipment" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 934 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "goto_location",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::goto_location" ],
+      "aliases": [ "goto_location" ],
+      "parser_registrations": [
+        {
+          "registration_order": 203,
+          "alias_role": "alpha",
+          "alias_group": [ "goto_location" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8874, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 5,
+        "examples": [ { "path": "data/json/npcs/Kindred/Brigitte_LaCroix_main.json", "pointer": "/0/responses/2/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "hostile",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::hostile" ],
+      "aliases": [ "hostile" ],
+      "parser_registrations": [
+        {
+          "registration_order": 198,
+          "alias_role": "alpha",
+          "alias_group": [ "hostile" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8869, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1076,
+        "examples": [ { "path": "data/json/artifact/altered_object_active.json", "pointer": "/2/valid_targets/2" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1858 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "if",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_if" ],
+      "aliases": [ "if" ],
+      "parser_registrations": [
+        {
+          "registration_order": 113,
+          "alias_role": "alpha",
+          "alias_group": [ "if" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8755, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1908,
+        "examples": [ { "path": "data/json/artifact/altered_object_active.json", "pointer": "/27/effect/0/if" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/ARTIFACTS.md", "line": 26 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "insult_combat",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::insult_combat" ],
+      "aliases": [ "insult_combat" ],
+      "parser_registrations": [
+        {
+          "registration_order": 174,
+          "alias_role": "alpha",
+          "alias_group": [ "insult_combat" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8845, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 8,
+        "examples": [ { "path": "data/json/npcs/Backgrounds/prepper_1.json", "pointer": "/11/responses/0/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1028 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "lead_to_safety",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::lead_to_safety" ],
+      "aliases": [ "lead_to_safety" ],
+      "parser_registrations": [
+        {
+          "registration_order": 212,
+          "alias_role": "alpha",
+          "alias_group": [ "lead_to_safety" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8883, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_OTHER.json", "pointer": "/11/responses/1/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1039 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "leave",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::leave" ],
+      "aliases": [ "leave" ],
+      "parser_registrations": [
+        {
+          "registration_order": 200,
+          "alias_role": "alpha",
+          "alias_group": [ "leave" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8871, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 3,
+        "examples": [ { "path": "data/json/npcs/Backgrounds/prepper_1.json", "pointer": "/13/responses/0/effect/1" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/CLIMBING.md", "line": 97 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "lesser_give_aid",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::lesser_give_aid" ],
+      "aliases": [ "lesser_give_aid" ],
+      "parser_registrations": [
+        {
+          "registration_order": 176,
+          "alias_role": "alpha",
+          "alias_group": [ "lesser_give_aid" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8847, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/tacoma_ranch/NPC_ranch_nurse.json", "pointer": "/4/responses/0/effect/1" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 915 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "lesser_give_all_aid",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::lesser_give_all_aid" ],
+      "aliases": [ "lesser_give_all_aid" ],
+      "parser_registrations": [
+        {
+          "registration_order": 177,
+          "alias_role": "alpha",
+          "alias_group": [ "lesser_give_all_aid" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8848, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/tacoma_ranch/NPC_ranch_nurse.json", "pointer": "/4/responses/1/effect/1" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "lightning",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [  ],
+      "aliases": [ "lightning" ],
+      "parser_registrations": [
+        {
+          "registration_order": 230,
+          "alias_role": "alpha",
+          "alias_group": [ "lightning" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8912, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "explicit_branch"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 15,
+        "examples": [ { "path": "data/json/effects_on_condition/weather_eocs.json", "pointer": "/0/condition/and/0/or/1/is_weather" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 234 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "location_variable_adjust",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_location_variable_adjust" ],
+      "aliases": [ "location_variable_adjust" ],
+      "parser_registrations": [
+        {
+          "registration_order": 100,
+          "alias_role": "alpha",
+          "alias_group": [ "location_variable_adjust" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8742, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 20,
+        "examples": [ { "path": "data/json/artifact/altered_object_active.json", "pointer": "/20/effect/1/location_variable_adjust" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4106 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "map_spawn_item",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_spawn_item" ],
+      "aliases": [ "map_spawn_item" ],
+      "parser_registrations": [
+        {
+          "registration_order": 92,
+          "alias_role": "alpha",
+          "alias_group": [ "map_spawn_item" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8734, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 16,
+        "examples": [ { "path": "data/json/effects_on_condition/example_eocs.json", "pointer": "/18/effect/1/map_spawn_item" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5371 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "mapgen_update",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_mapgen_update" ],
+      "aliases": [ "mapgen_update" ],
+      "parser_registrations": [
+        {
+          "registration_order": 94,
+          "alias_role": "alpha",
+          "alias_group": [ "mapgen_update" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8736, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 337,
+        "examples": [ { "path": "data/json/effects_on_condition/generalized_eocs.json", "pointer": "/1/effect/0/mapgen_update" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/DIMENSIONS.md", "line": 25 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "math",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array" ],
+      "handlers": [ "talk_effect_fun::f_math" ],
+      "aliases": [ "math" ],
+      "parser_registrations": [
+        {
+          "registration_order": 116,
+          "alias_role": "alpha",
+          "alias_group": [ "math" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8758, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 21922,
+        "examples": [ { "path": "data/json/artifact/altered_object_active.json", "pointer": "/14/min_damage/math" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 98 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "message",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_message" ],
+      "aliases": [ "message" ],
+      "parser_registrations": [
+        {
+          "registration_order": 133,
+          "alias_role": "alpha",
+          "alias_group": [ "message", "message" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8777, "symbol": "parsers" }
+        },
+        {
+          "registration_order": 133,
+          "alias_role": "beta",
+          "alias_group": [ "message", "message" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8777, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2482,
+        "examples": [ { "path": "data/json/artifact/altered_object_active.json", "pointer": "/0/message" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/CLIMBING.md", "line": 125 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "mirror_coordinates",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_mirror_coordinates" ],
+      "aliases": [ "mirror_coordinates" ],
+      "parser_registrations": [
+        {
+          "registration_order": 118,
+          "alias_role": "alpha",
+          "alias_group": [ "mirror_coordinates" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8760, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [
+          {
+            "path": "data/mods/MindOverMatter/powers/telekinesis_eoc.json",
+            "pointer": "/0/effect/7/else/else/0/then/1/run_eocs/0/effect/2/mirror_coordinates"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4900 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "mission_failure",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::mission_failure" ],
+      "aliases": [ "mission_failure" ],
+      "parser_registrations": [
+        {
+          "registration_order": 136,
+          "alias_role": "alpha",
+          "alias_group": [ "mission_failure" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8807, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/Lighthouse_Family/NPC_lighthouse_man.json", "pointer": "/13/responses/0/effect/0" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 906 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "mission_reward",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::mission_reward" ],
+      "aliases": [ "mission_reward" ],
+      "parser_registrations": [
+        {
+          "registration_order": 138,
+          "alias_role": "alpha",
+          "alias_group": [ "mission_reward" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8809, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_MISSION.json", "pointer": "/9/responses/1/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 909 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "mission_success",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::mission_success" ],
+      "aliases": [ "mission_success" ],
+      "parser_registrations": [
+        {
+          "registration_order": 135,
+          "alias_role": "alpha",
+          "alias_group": [ "mission_success" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8806, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 18,
+        "examples": [ { "path": "data/json/npcs/Lighthouse_Family/NPC_lighthouse_girl.json", "pointer": "/1/responses/1/effect/0" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 905 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "morale_chat_activity",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::morale_chat_activity" ],
+      "aliases": [ "morale_chat_activity" ],
+      "parser_registrations": [
+        {
+          "registration_order": 184,
+          "alias_role": "alpha",
+          "alias_group": [ "morale_chat_activity" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8855, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 9,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_FRIEND_CONVERSATION.json", "pointer": "/2/responses/0/effect/0" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "next_weather",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [  ],
+      "aliases": [ "next_weather" ],
+      "parser_registrations": [
+        {
+          "registration_order": 237,
+          "alias_role": "alpha",
+          "alias_group": [ "next_weather" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8948, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "explicit_branch"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 19,
+        "examples": [
+          { "path": "data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json", "pointer": "/7/effect/2" }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5482 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "nothing",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::nothing" ],
+      "aliases": [ "nothing" ],
+      "parser_registrations": [
+        {
+          "registration_order": 223,
+          "alias_role": "alpha",
+          "alias_group": [ "nothing" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8894, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 12,
+        "examples": [ { "path": "data/core/sentinels.json", "pointer": "/5/intensity_levels/0/name" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3528 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_activate",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_activate" ],
+      "aliases": [ "npc_activate", "u_activate" ],
+      "parser_registrations": [
+        {
+          "registration_order": 57,
+          "alias_role": "beta",
+          "alias_group": [ "u_activate", "npc_activate" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8699, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5288 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_activate_trait",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_activate_trait" ],
+      "aliases": [ "npc_activate_trait", "u_activate_trait" ],
+      "parser_registrations": [
+        {
+          "registration_order": 8,
+          "alias_role": "beta",
+          "alias_group": [ "u_activate_trait", "npc_activate_trait" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8650, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3610 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_add_bionic",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_add_bionic" ],
+      "aliases": [ "npc_add_bionic", "u_add_bionic" ],
+      "parser_registrations": [
+        {
+          "registration_order": 40,
+          "alias_role": "beta",
+          "alias_group": [ "u_add_bionic", "npc_add_bionic" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8682, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3442 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_add_effect",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_add_effect" ],
+      "aliases": [ "npc_add_effect", "u_add_effect" ],
+      "parser_registrations": [
+        {
+          "registration_order": 0,
+          "alias_role": "beta",
+          "alias_group": [ "u_add_effect", "npc_add_effect" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8642, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 207,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/npc_eocs/ref_center_beggar_npc_eocs.json",
+            "pointer": "/0/effect/0/false_eocs/0/effect/0/npc_add_effect"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3401 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_add_morale",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_add_morale" ],
+      "aliases": [ "npc_add_morale", "u_add_morale" ],
+      "parser_registrations": [
+        {
+          "registration_order": 38,
+          "alias_role": "beta",
+          "alias_group": [ "u_add_morale", "npc_add_morale" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8680, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [
+          {
+            "path": "data/mods/MindOverMatter/mod_interactions/crazy_cataclysm/monsters.json",
+            "pointer": "/1/effect/0/npc_add_morale"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4359 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_add_trait",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_add_trait" ],
+      "aliases": [ "npc_add_trait", "u_add_trait" ],
+      "parser_registrations": [
+        {
+          "registration_order": 4,
+          "alias_role": "beta",
+          "alias_group": [ "u_add_trait", "npc_add_trait" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8646, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 15,
+        "examples": [ { "path": "data/json/npcs/TALK_TEST.json", "pointer": "/21/responses/6/effect/npc_add_trait" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3322 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_add_var",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "string" ],
+      "handlers": [ "talk_effect_fun::f_add_var" ],
+      "aliases": [ "npc_add_var", "u_add_var" ],
+      "parser_registrations": [
+        {
+          "registration_order": 2,
+          "alias_role": "beta",
+          "alias_group": [ "u_add_var", "npc_add_var" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8644, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 290,
+        "examples": [ { "path": "data/json/effects_on_condition/computer_eocs.json", "pointer": "/0/false_effect/0/npc_add_var" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3710 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_add_wet",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "member" ],
+      "handlers": [ "talk_effect_fun::f_add_wet" ],
+      "aliases": [ "npc_add_wet", "u_add_wet" ],
+      "parser_registrations": [
+        {
+          "registration_order": 28,
+          "alias_role": "beta",
+          "alias_group": [ "u_add_wet", "npc_add_wet" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8670, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4277 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_add_wound",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_add_wound" ],
+      "aliases": [ "npc_add_wound", "u_add_wound" ],
+      "parser_registrations": [
+        {
+          "registration_order": 83,
+          "alias_role": "beta",
+          "alias_group": [ "u_add_wound", "npc_add_wound" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8725, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3226 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_assign_activity",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_assign_activity" ],
+      "aliases": [ "npc_assign_activity", "u_assign_activity" ],
+      "parser_registrations": [
+        {
+          "registration_order": 29,
+          "alias_role": "beta",
+          "alias_group": [ "u_assign_activity", "npc_assign_activity" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8671, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [
+          {
+            "path": "data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json",
+            "pointer": "/6/effect/0/then/10/npc_assign_activity"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4686 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_attack",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_attack" ],
+      "aliases": [ "npc_attack", "u_attack" ],
+      "parser_registrations": [
+        {
+          "registration_order": 42,
+          "alias_role": "beta",
+          "alias_group": [ "u_attack", "npc_attack" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8684, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5189 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_bulk_donate",
+      "syntaxes": [ "effect_string", "object_member" ],
+      "accepted_json_shapes": [ "effect_string", "member" ],
+      "handlers": [ "talk_effect_fun::f_bulk_trade_accept" ],
+      "aliases": [ "npc_bulk_donate", "u_bulk_donate" ],
+      "parser_registrations": [
+        {
+          "registration_order": 63,
+          "alias_role": "beta",
+          "alias_group": [ "u_bulk_donate", "npc_bulk_donate" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8705, "symbol": "parsers" }
+        },
+        {
+          "registration_order": 227,
+          "alias_role": "alpha",
+          "alias_group": [ "npc_bulk_donate" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8905, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "explicit_branch"
+        },
+        {
+          "registration_order": 229,
+          "alias_role": "alpha",
+          "alias_group": [ "npc_bulk_donate" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8906, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "explicit_branch"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 942 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_bulk_trade_accept",
+      "syntaxes": [ "effect_string", "object_member" ],
+      "accepted_json_shapes": [ "effect_string", "member" ],
+      "handlers": [ "talk_effect_fun::f_bulk_trade_accept" ],
+      "aliases": [ "npc_bulk_trade_accept", "u_bulk_trade_accept" ],
+      "parser_registrations": [
+        {
+          "registration_order": 61,
+          "alias_role": "beta",
+          "alias_group": [ "u_bulk_trade_accept", "npc_bulk_trade_accept" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8703, "symbol": "parsers" }
+        },
+        {
+          "registration_order": 225,
+          "alias_role": "alpha",
+          "alias_group": [ "npc_bulk_trade_accept" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8904, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "explicit_branch"
+        },
+        {
+          "registration_order": 228,
+          "alias_role": "alpha",
+          "alias_group": [ "npc_bulk_trade_accept" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8906, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "explicit_branch"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 941 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_cancel_activity",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [  ],
+      "aliases": [ "npc_cancel_activity" ],
+      "parser_registrations": [
+        {
+          "registration_order": 234,
+          "alias_role": "alpha",
+          "alias_group": [ "npc_cancel_activity" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8932, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "explicit_branch"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4708 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_cast_spell",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_cast_spell" ],
+      "aliases": [ "npc_cast_spell", "u_cast_spell" ],
+      "parser_registrations": [
+        {
+          "registration_order": 64,
+          "alias_role": "beta",
+          "alias_group": [ "u_cast_spell", "npc_cast_spell" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8706, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 22,
+        "examples": [ { "path": "data/json/monster_special_attacks/spells.json", "pointer": "/84/effect/0/then/0/npc_cast_spell" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4600 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_change_class",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_npc_change_class" ],
+      "aliases": [ "npc_change_class" ],
+      "parser_registrations": [
+        {
+          "registration_order": 76,
+          "alias_role": "alpha",
+          "alias_group": [ "npc_change_class" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8718, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/TALK_TEST.json", "pointer": "/21/responses/18/effect/npc_change_class" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "npc_change_faction",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_npc_change_faction" ],
+      "aliases": [ "npc_change_faction" ],
+      "parser_registrations": [
+        {
+          "registration_order": 75,
+          "alias_role": "alpha",
+          "alias_group": [ "npc_change_faction" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8717, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 6,
+        "examples": [
+          {
+            "path": "data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_guard3.json",
+            "pointer": "/5/responses/0/success/effect/0/npc_change_faction"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1076 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_choose_adjacent_highlight",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_choose_adjacent_highlight" ],
+      "aliases": [ "npc_choose_adjacent_highlight", "u_choose_adjacent_highlight" ],
+      "parser_registrations": [
+        {
+          "registration_order": 21,
+          "alias_role": "beta",
+          "alias_group": [ "u_choose_adjacent_highlight", "npc_choose_adjacent_highlight" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8663, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [
+          {
+            "path": "data/mods/MindOverMatter/powers/telekinesis_eoc.json",
+            "pointer": "/0/effect/7/else/else/0/then/1/run_eocs/0/effect/1/npc_choose_adjacent_highlight"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5021 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_consume_item",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_consume_item" ],
+      "aliases": [ "npc_consume_item", "u_consume_item" ],
+      "parser_registrations": [
+        {
+          "registration_order": 58,
+          "alias_role": "beta",
+          "alias_group": [ "u_consume_item", "npc_consume_item" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8700, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 4,
+        "examples": [ { "path": "data/json/npcs/TALK_TEST.json", "pointer": "/21/responses/15/effect/npc_consume_item" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 945 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_consume_item_sum",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array" ],
+      "handlers": [ "talk_effect_fun::f_consume_item_sum" ],
+      "aliases": [ "npc_consume_item_sum", "u_consume_item_sum" ],
+      "parser_registrations": [
+        {
+          "registration_order": 59,
+          "alias_role": "beta",
+          "alias_group": [ "u_consume_item_sum", "npc_consume_item_sum" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8701, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4424 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_deactivate_trait",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_deactivate_trait" ],
+      "aliases": [ "npc_deactivate_trait", "u_deactivate_trait" ],
+      "parser_registrations": [
+        {
+          "registration_order": 7,
+          "alias_role": "beta",
+          "alias_group": [ "u_deactivate_trait", "npc_deactivate_trait" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8649, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3635 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_deal_damage",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_deal_damage" ],
+      "aliases": [ "npc_deal_damage", "u_deal_damage" ],
+      "parser_registrations": [
+        {
+          "registration_order": 62,
+          "alias_role": "beta",
+          "alias_group": [ "u_deal_damage", "npc_deal_damage" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8704, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/mods/BombasticPerks/perkdata/dice_addition_damage.json", "pointer": "/0/effect/5/npc_deal_damage" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3286 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_die",
+      "syntaxes": [ "effect_string", "object_member" ],
+      "accepted_json_shapes": [ "effect_string", "object" ],
+      "handlers": [ "talk_effect_fun::f_die_advanced" ],
+      "aliases": [ "npc_die", "u_die" ],
+      "parser_registrations": [
+        {
+          "registration_order": 43,
+          "alias_role": "beta",
+          "alias_group": [ "u_die", "npc_die" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8685, "symbol": "parsers" }
+        },
+        {
+          "registration_order": 232,
+          "alias_role": "alpha",
+          "alias_group": [ "npc_die" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8922, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "explicit_branch"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string", "object" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 28,
+        "examples": [
+          { "path": "data/json/effects_on_condition/scenario_specific_eocs.json", "pointer": "/30/effect/true_eocs/0/effect/0" }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5119 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_emit",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_emit" ],
+      "aliases": [ "npc_emit", "u_emit" ],
+      "parser_registrations": [
+        {
+          "registration_order": 50,
+          "alias_role": "beta",
+          "alias_group": [ "u_emit", "npc_emit" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8692, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 5,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/nether_eocs/nether_monster_death.json",
+            "pointer": "/0/effect/1/cases/4/effect/0/npc_emit"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5770 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_explosion",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_explosion" ],
+      "aliases": [ "npc_explosion", "u_explosion" ],
+      "parser_registrations": [
+        {
+          "registration_order": 18,
+          "alias_role": "beta",
+          "alias_group": [ "u_explosion", "npc_explosion" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8660, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4792 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_first_topic",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_npc_first_topic" ],
+      "aliases": [ "npc_first_topic" ],
+      "parser_registrations": [
+        {
+          "registration_order": 103,
+          "alias_role": "alpha",
+          "alias_group": [ "npc_first_topic" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8745, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 68,
+        "examples": [
+          {
+            "path": "data/json/npcs/Lighthouse_Family/NPC_lighthouse_girl.json",
+            "pointer": "/1/responses/1/effect/3/npc_first_topic"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4257 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_forget_martial_art",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_forget_martial_art" ],
+      "aliases": [ "npc_forget_martial_art", "u_forget_martial_art" ],
+      "parser_registrations": [
+        {
+          "registration_order": 14,
+          "alias_role": "beta",
+          "alias_group": [ "u_forget_martial_art", "npc_forget_martial_art" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8656, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3685 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_forget_recipe",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_forget_recipe" ],
+      "aliases": [ "npc_forget_recipe", "u_forget_recipe" ],
+      "parser_registrations": [
+        {
+          "registration_order": 26,
+          "alias_role": "beta",
+          "alias_group": [ "u_forget_recipe", "npc_forget_recipe" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8668, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4220 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_gets_item",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [  ],
+      "aliases": [ "npc_gets_item" ],
+      "parser_registrations": [
+        {
+          "registration_order": 238,
+          "alias_role": "alpha",
+          "alias_group": [ "npc_gets_item" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8953, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "explicit_branch"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 4,
+        "examples": [ { "path": "data/json/npcs/Kindred/Brigitte_LaCroix_main.json", "pointer": "/3/responses/5/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 936 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_gets_item_to_use",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [  ],
+      "aliases": [ "npc_gets_item_to_use" ],
+      "parser_registrations": [
+        {
+          "registration_order": 239,
+          "alias_role": "alpha",
+          "alias_group": [ "npc_gets_item_to_use" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8953, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "explicit_branch"
+        },
+        {
+          "registration_order": 240,
+          "alias_role": "alpha",
+          "alias_group": [ "npc_gets_item_to_use" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8954, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "explicit_branch"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 7,
+        "examples": [ { "path": "data/json/npcs/Kindred/Brigitte_LaCroix_main.json", "pointer": "/3/responses/4/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 937 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_knockback",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_knockback" ],
+      "aliases": [ "npc_knockback", "u_knockback" ],
+      "parser_registrations": [
+        {
+          "registration_order": 119,
+          "alias_role": "beta",
+          "alias_group": [ "u_knockback", "npc_knockback" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8761, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4872 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_learn_martial_art",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_learn_martial_art" ],
+      "aliases": [ "npc_learn_martial_art", "u_learn_martial_art" ],
+      "parser_registrations": [
+        {
+          "registration_order": 13,
+          "alias_role": "beta",
+          "alias_group": [ "u_learn_martial_art", "npc_learn_martial_art" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8655, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3660 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_learn_recipe",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_learn_recipe" ],
+      "aliases": [ "npc_learn_recipe", "u_learn_recipe" ],
+      "parser_registrations": [
+        {
+          "registration_order": 25,
+          "alias_role": "beta",
+          "alias_group": [ "u_learn_recipe", "npc_learn_recipe" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8667, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4195 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_level_spell_class",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_level_spell_class" ],
+      "aliases": [ "npc_level_spell_class", "u_level_spell_class" ],
+      "parser_registrations": [
+        {
+          "registration_order": 24,
+          "alias_role": "beta",
+          "alias_group": [ "u_level_spell_class", "npc_level_spell_class" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8666, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4658 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_location_variable",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "object" ],
+      "handlers": [ "talk_effect_fun::f_location_variable" ],
+      "aliases": [ "npc_location_variable", "u_location_variable" ],
+      "parser_registrations": [
+        {
+          "registration_order": 15,
+          "alias_role": "beta",
+          "alias_group": [ "u_location_variable", "npc_location_variable" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8657, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "object" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 36,
+        "examples": [
+          {
+            "path": "data/json/artifact/altered_object_active.json",
+            "pointer": "/24/effect/0/true_eocs/0/effect/0/npc_location_variable"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 115 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_lose_bionic",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_lose_bionic" ],
+      "aliases": [ "npc_lose_bionic", "u_lose_bionic" ],
+      "parser_registrations": [
+        {
+          "registration_order": 41,
+          "alias_role": "beta",
+          "alias_group": [ "u_lose_bionic", "npc_lose_bionic" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8683, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3467 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_lose_category",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_remove_category" ],
+      "aliases": [ "npc_lose_category", "u_lose_category" ],
+      "parser_registrations": [
+        {
+          "registration_order": 6,
+          "alias_role": "beta",
+          "alias_group": [ "u_lose_category", "npc_lose_category" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8648, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3549 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_lose_effect",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_remove_effect" ],
+      "aliases": [ "npc_lose_effect", "u_lose_effect" ],
+      "parser_registrations": [
+        {
+          "registration_order": 1,
+          "alias_role": "beta",
+          "alias_group": [ "u_lose_effect", "npc_lose_effect" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8643, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 19,
+        "examples": [ { "path": "data/json/npcs/TALK_TEST.json", "pointer": "/21/responses/4/effect/npc_lose_effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3570 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_lose_morale",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_lose_morale" ],
+      "aliases": [ "npc_lose_morale", "u_lose_morale" ],
+      "parser_registrations": [
+        {
+          "registration_order": 39,
+          "alias_role": "beta",
+          "alias_group": [ "u_lose_morale", "npc_lose_morale" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8681, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4398 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_lose_trait",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_remove_trait" ],
+      "aliases": [ "npc_lose_trait", "u_lose_trait" ],
+      "parser_registrations": [
+        {
+          "registration_order": 5,
+          "alias_role": "beta",
+          "alias_group": [ "u_lose_trait", "npc_lose_trait" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8647, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 35,
+        "examples": [ { "path": "data/json/npcs/TALK_TEST.json", "pointer": "/21/responses/8/effect/npc_lose_trait" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3523 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_lose_var",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "string" ],
+      "handlers": [ "talk_effect_fun::f_remove_var" ],
+      "aliases": [ "npc_lose_var", "u_lose_var" ],
+      "parser_registrations": [
+        {
+          "registration_order": 3,
+          "alias_role": "beta",
+          "alias_group": [ "u_lose_var", "npc_lose_var" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8645, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 49,
+        "examples": [ { "path": "data/json/npcs/Lighthouse_Family/NPC_lighthouse_man.json", "pointer": "/15/end/effect/2/npc_lose_var" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3798 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_make_radio_representative",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [  ],
+      "aliases": [ "npc_make_radio_representative" ],
+      "parser_registrations": [
+        {
+          "registration_order": 247,
+          "alias_role": "alpha",
+          "alias_group": [ "npc_make_radio_representative" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8985, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "explicit_branch"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1995 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_make_sound",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_make_sound" ],
+      "aliases": [ "npc_make_sound", "u_make_sound" ],
+      "parser_registrations": [
+        {
+          "registration_order": 30,
+          "alias_role": "beta",
+          "alias_group": [ "u_make_sound", "npc_make_sound" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8672, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 6,
+        "examples": [ { "path": "data/json/effects_on_condition/item_eocs.json", "pointer": "/13/effect/then/1/npc_make_sound" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4298 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_map_run_eocs",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_map_run_eocs" ],
+      "aliases": [ "npc_map_run_eocs", "u_map_run_eocs" ],
+      "parser_registrations": [
+        {
+          "registration_order": 65,
+          "alias_role": "beta",
+          "alias_group": [ "u_map_run_eocs", "npc_map_run_eocs" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8707, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2815 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_map_run_item_eocs",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_map_run_item_eocs" ],
+      "aliases": [ "npc_map_run_item_eocs", "u_map_run_item_eocs" ],
+      "parser_registrations": [
+        {
+          "registration_order": 66,
+          "alias_role": "beta",
+          "alias_group": [ "u_map_run_item_eocs", "npc_map_run_item_eocs" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8708, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2875 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_message",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_message" ],
+      "aliases": [ "npc_message", "u_message" ],
+      "parser_registrations": [
+        {
+          "registration_order": 27,
+          "alias_role": "beta",
+          "alias_group": [ "u_message", "npc_message" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8669, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 99,
+        "examples": [ { "path": "data/mods/Isolation-Protocol/Player/Perks/perk_eoc.json", "pointer": "/4/effect/2/then/1/npc_message" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4551 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_mutate",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "member" ],
+      "handlers": [ "talk_effect_fun::f_mutate" ],
+      "aliases": [ "npc_mutate", "u_mutate" ],
+      "parser_registrations": [
+        {
+          "registration_order": 9,
+          "alias_role": "beta",
+          "alias_group": [ "u_mutate", "npc_mutate" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8651, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3320 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_mutate_category",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_mutate_category" ],
+      "aliases": [ "npc_mutate_category", "u_mutate_category" ],
+      "parser_registrations": [
+        {
+          "registration_order": 10,
+          "alias_role": "beta",
+          "alias_group": [ "u_mutate_category", "npc_mutate_category" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8652, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/monster_special_attacks/spells.json", "pointer": "/33/effect/1/npc_mutate_category" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3345 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_mutate_towards",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_mutate_towards" ],
+      "aliases": [ "npc_mutate_towards", "u_mutate_towards" ],
+      "parser_registrations": [
+        {
+          "registration_order": 11,
+          "alias_role": "beta",
+          "alias_group": [ "u_mutate_towards", "npc_mutate_towards" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8653, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3364 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_pick_bodypart",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_pick_bodypart" ],
+      "aliases": [ "npc_pick_bodypart", "u_pick_bodypart" ],
+      "parser_registrations": [
+        {
+          "registration_order": 82,
+          "alias_role": "beta",
+          "alias_group": [ "u_pick_bodypart", "npc_pick_bodypart" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8724, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3193 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_pickup_items",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "object" ],
+      "handlers": [ "talk_effect_fun::f_pickup_items" ],
+      "aliases": [ "npc_pickup_items", "u_pickup_items" ],
+      "parser_registrations": [
+        {
+          "registration_order": 67,
+          "alias_role": "beta",
+          "alias_group": [ "u_pickup_items", "npc_pickup_items" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8709, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "object" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2570 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_prevent_death",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [  ],
+      "aliases": [ "npc_prevent_death" ],
+      "parser_registrations": [
+        {
+          "registration_order": 236,
+          "alias_role": "alpha",
+          "alias_group": [ "npc_prevent_death" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8943, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "explicit_branch"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5154 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_query_omt",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_query_omt" ],
+      "aliases": [ "npc_query_omt", "u_query_omt" ],
+      "parser_registrations": [
+        {
+          "registration_order": 20,
+          "alias_role": "beta",
+          "alias_group": [ "u_query_omt", "npc_query_omt" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8662, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4924 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_query_tile",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_query_tile" ],
+      "aliases": [ "npc_query_tile", "u_query_tile" ],
+      "parser_registrations": [
+        {
+          "registration_order": 19,
+          "alias_role": "beta",
+          "alias_group": [ "u_query_tile", "npc_query_tile" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8661, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4993 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_ranged_attack",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [  ],
+      "aliases": [ "npc_ranged_attack" ],
+      "parser_registrations": [
+        {
+          "registration_order": 242,
+          "alias_role": "alpha",
+          "alias_group": [ "npc_ranged_attack" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8964, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "explicit_branch"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "npc_remove_item_with",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_remove_item_with" ],
+      "aliases": [ "npc_remove_item_with", "u_remove_item_with" ],
+      "parser_registrations": [
+        {
+          "registration_order": 60,
+          "alias_role": "beta",
+          "alias_group": [ "u_remove_item_with", "npc_remove_item_with" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8702, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 19,
+        "examples": [ { "path": "data/json/npcs/missiondef.json", "pointer": "/1/start/effect/1/npc_remove_item_with" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 946 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_remove_wound",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_remove_wound" ],
+      "aliases": [ "npc_remove_wound", "u_remove_wound" ],
+      "parser_registrations": [
+        {
+          "registration_order": 84,
+          "alias_role": "beta",
+          "alias_group": [ "u_remove_wound", "npc_remove_wound" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8726, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3256 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_roll_remainder",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_roll_remainder" ],
+      "aliases": [ "npc_roll_remainder", "u_roll_remainder" ],
+      "parser_registrations": [
+        {
+          "registration_order": 36,
+          "alias_role": "beta",
+          "alias_group": [ "u_roll_remainder", "npc_roll_remainder" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8678, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2432 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_rules_menu",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [  ],
+      "aliases": [ "npc_rules_menu" ],
+      "parser_registrations": [
+        {
+          "registration_order": 250,
+          "alias_role": "alpha",
+          "alias_group": [ "npc_rules_menu" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8997, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "explicit_branch"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 5,
+        "examples": [ { "path": "data/json/npcs/Kindred/Brigitte_LaCroix_main.json", "pointer": "/0/responses/0/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "npc_run_fixed_zone_eocs",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array" ],
+      "handlers": [ "talk_effect_fun::f_run_fixed_zone_eocs" ],
+      "aliases": [ "npc_run_fixed_zone_eocs", "u_run_fixed_zone_eocs" ],
+      "parser_registrations": [
+        {
+          "registration_order": 34,
+          "alias_role": "beta",
+          "alias_group": [ "u_run_fixed_zone_eocs", "npc_run_fixed_zone_eocs" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8676, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2771 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_run_inv_eocs",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_run_inv_eocs" ],
+      "aliases": [ "npc_run_inv_eocs", "u_run_inv_eocs" ],
+      "parser_registrations": [
+        {
+          "registration_order": 35,
+          "alias_role": "beta",
+          "alias_group": [ "u_run_inv_eocs", "npc_run_inv_eocs" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8677, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/npc_eocs/ref_center_beggar_npc_eocs.json",
+            "pointer": "/0/effect/0/npc_run_inv_eocs"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2710 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_run_monster_eocs",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array" ],
+      "handlers": [ "talk_effect_fun::f_run_monster_eocs" ],
+      "aliases": [ "npc_run_monster_eocs", "u_run_monster_eocs" ],
+      "parser_registrations": [
+        {
+          "registration_order": 32,
+          "alias_role": "beta",
+          "alias_group": [ "u_run_monster_eocs", "npc_run_monster_eocs" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8674, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [
+          {
+            "path": "data/json/monster_special_attacks/void_spider_mechanics.json",
+            "pointer": "/13/effect/0/then/1/npc_run_monster_eocs"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2661 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_run_npc_eocs",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array" ],
+      "handlers": [ "talk_effect_fun::f_run_npc_eocs" ],
+      "aliases": [ "npc_run_npc_eocs", "u_run_npc_eocs" ],
+      "parser_registrations": [
+        {
+          "registration_order": 31,
+          "alias_role": "beta",
+          "alias_group": [ "u_run_npc_eocs", "npc_run_npc_eocs" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8673, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2593 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_run_vehicle_eocs",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array" ],
+      "handlers": [ "talk_effect_fun::f_run_vehicle_eocs" ],
+      "aliases": [ "npc_run_vehicle_eocs", "u_run_vehicle_eocs" ],
+      "parser_registrations": [
+        {
+          "registration_order": 33,
+          "alias_role": "beta",
+          "alias_group": [ "u_run_vehicle_eocs", "npc_run_vehicle_eocs" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8675, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "npc_set_fac_relation",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_set_fac_relation" ],
+      "aliases": [ "npc_set_fac_relation", "u_set_fac_relation" ],
+      "parser_registrations": [
+        {
+          "registration_order": 37,
+          "alias_role": "beta",
+          "alias_group": [ "u_set_fac_relation", "npc_set_fac_relation" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8679, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4502 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_set_fault",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_set_fault" ],
+      "aliases": [ "npc_set_fault", "u_set_fault" ],
+      "parser_registrations": [
+        {
+          "registration_order": 55,
+          "alias_role": "beta",
+          "alias_group": [ "u_set_fault", "npc_set_fault" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8697, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 3,
+        "examples": [
+          {
+            "path": "data/json/items/tool/debug_tools.json",
+            "pointer": "/4/use_action/effect_on_conditions/0/effect/true_eocs/effect/3/else/0/then/npc_set_fault"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5308 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_set_field",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_field" ],
+      "aliases": [ "npc_set_field", "u_set_field" ],
+      "parser_registrations": [
+        {
+          "registration_order": 49,
+          "alias_role": "beta",
+          "alias_group": [ "u_set_field", "npc_set_field" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8691, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/mods/Xedra_Evolved/martial_arts/elemental.json", "pointer": "/5/effect/0/npc_set_field" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5750 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_set_flag",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_set_flag" ],
+      "aliases": [ "npc_set_flag", "u_set_flag" ],
+      "parser_registrations": [
+        {
+          "registration_order": 53,
+          "alias_role": "beta",
+          "alias_group": [ "u_set_flag", "npc_set_flag" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8695, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 34,
+        "examples": [
+          {
+            "path": "data/mods/BombasticPerks/perkdata/forge_blood.json",
+            "pointer": "/0/effect/0/true_eocs/0/effect/0/run_eocs/0/effect/0/npc_set_flag"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5250 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_set_goal",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_npc_goal" ],
+      "aliases": [ "npc_set_goal", "u_set_goal" ],
+      "parser_registrations": [
+        {
+          "registration_order": 22,
+          "alias_role": "beta",
+          "alias_group": [ "u_set_goal", "npc_set_goal" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8664, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1057 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_set_guard_pos",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_guard_pos" ],
+      "aliases": [ "npc_set_guard_pos", "u_set_guard_pos" ],
+      "parser_registrations": [
+        {
+          "registration_order": 23,
+          "alias_role": "beta",
+          "alias_group": [ "u_set_guard_pos", "npc_set_guard_pos" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8665, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1058 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_set_random_fault_of_type",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_set_random_fault_of_type" ],
+      "aliases": [ "npc_set_random_fault_of_type", "u_set_random_fault_of_type" ],
+      "parser_registrations": [
+        {
+          "registration_order": 56,
+          "alias_role": "beta",
+          "alias_group": [ "u_set_random_fault_of_type", "npc_set_random_fault_of_type" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8698, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5329 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_set_talker",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_set_talker" ],
+      "aliases": [ "npc_set_talker", "u_set_talker" ],
+      "parser_registrations": [
+        {
+          "registration_order": 128,
+          "alias_role": "beta",
+          "alias_group": [ "u_set_talker", "npc_set_talker" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8770, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2414 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_set_trait_purifiability",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_set_trait_purifiability" ],
+      "aliases": [ "npc_set_trait_purifiability", "u_set_trait_purifiability" ],
+      "parser_registrations": [
+        {
+          "registration_order": 12,
+          "alias_role": "beta",
+          "alias_group": [ "u_set_trait_purifiability", "npc_set_trait_purifiability" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8654, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 424 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_spawn_monster",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_spawn_monster" ],
+      "aliases": [ "npc_spawn_monster", "u_spawn_monster" ],
+      "parser_registrations": [
+        {
+          "registration_order": 44,
+          "alias_role": "beta",
+          "alias_group": [ "u_spawn_monster", "npc_spawn_monster" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8686, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 4,
+        "examples": [ { "path": "data/mods/MindOverMatter/monsters/death_effects.json", "pointer": "/11/effect/1/npc_spawn_monster" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5588 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_spawn_npc",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_spawn_npc" ],
+      "aliases": [ "npc_spawn_npc", "u_spawn_npc" ],
+      "parser_registrations": [
+        {
+          "registration_order": 45,
+          "alias_role": "beta",
+          "alias_group": [ "u_spawn_npc", "npc_spawn_npc" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8687, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5646 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_teleport",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "object" ],
+      "handlers": [ "talk_effect_fun::f_teleport" ],
+      "aliases": [ "npc_teleport", "u_teleport" ],
+      "parser_registrations": [
+        {
+          "registration_order": 51,
+          "alias_role": "beta",
+          "alias_group": [ "u_teleport", "npc_teleport" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8693, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "object" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 25,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/example_eocs.json",
+            "pointer": "/8/effect/0/true_eocs/0/effect/1/npc_teleport"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2931 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_thankful",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::npc_thankful" ],
+      "aliases": [ "npc_thankful" ],
+      "parser_registrations": [
+        {
+          "registration_order": 218,
+          "alias_role": "alpha",
+          "alias_group": [ "npc_thankful" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8889, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 8,
+        "examples": [ { "path": "data/json/npcs/missiondef.json", "pointer": "/1/end/effect/3" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1035 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_transform_radius",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "member" ],
+      "handlers": [ "talk_effect_fun::f_transform_radius" ],
+      "aliases": [ "npc_transform_radius", "u_transform_radius" ],
+      "parser_registrations": [
+        {
+          "registration_order": 17,
+          "alias_role": "beta",
+          "alias_group": [ "u_transform_radius", "npc_transform_radius" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8659, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 8,
+        "examples": [
+          { "path": "data/mods/Magiclysm/effect_on_conditions/death_effects.json", "pointer": "/0/effect/0/npc_transform_radius" }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5505 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_unset_flag",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_unset_flag" ],
+      "aliases": [ "npc_unset_flag", "u_unset_flag" ],
+      "parser_registrations": [
+        {
+          "registration_order": 54,
+          "alias_role": "beta",
+          "alias_group": [ "u_unset_flag", "npc_unset_flag" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8696, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 23,
+        "examples": [
+          {
+            "path": "data/mods/BombasticPerks/perkdata/unopenable_grip.json",
+            "pointer": "/0/effect/0/true_eocs/0/false_effect/0/run_eocs/0/effect/0/npc_unset_flag"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4431 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "npc_wants_to_talk",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [  ],
+      "aliases": [ "npc_wants_to_talk" ],
+      "parser_registrations": [
+        {
+          "registration_order": 249,
+          "alias_role": "alpha",
+          "alias_group": [ "npc_wants_to_talk" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8993, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "explicit_branch"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "offer_mission",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "string" ],
+      "handlers": [ "talk_effect_fun::f_offer_mission" ],
+      "aliases": [ "offer_mission" ],
+      "parser_registrations": [
+        {
+          "registration_order": 109,
+          "alias_role": "alpha",
+          "alias_group": [ "offer_mission" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8751, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 15,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/npc_eocs/generic_npc_eocs.json",
+            "pointer": "/0/effect/0/weighted_list_eocs/0/0/effect/offer_mission"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2104 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "open_dialogue",
+      "syntaxes": [ "effect_string", "object_member" ],
+      "accepted_json_shapes": [ "effect_string", "member" ],
+      "handlers": [ "talk_effect_fun::f_open_dialogue" ],
+      "aliases": [ "open_dialogue" ],
+      "parser_registrations": [
+        {
+          "registration_order": 124,
+          "alias_role": "alpha",
+          "alias_group": [ "open_dialogue" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8766, "symbol": "parsers" }
+        },
+        {
+          "registration_order": 243,
+          "alias_role": "alpha",
+          "alias_group": [ "open_dialogue" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8969, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "explicit_branch"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 81,
+        "examples": [ { "path": "data/json/effects_on_condition/bionic_eocs.json", "pointer": "/23/effect/open_dialogue" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1924 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "pick_style",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::pick_style" ],
+      "aliases": [ "pick_style" ],
+      "parser_registrations": [
+        {
+          "registration_order": 220,
+          "alias_role": "alpha",
+          "alias_group": [ "pick_style" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8891, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 935 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "place_override",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_place_override" ],
+      "aliases": [ "place_override" ],
+      "parser_registrations": [
+        {
+          "registration_order": 98,
+          "alias_role": "alpha",
+          "alias_group": [ "place_override" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8740, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 6,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/nether_eocs/LIXA_EOCs_spells_traps.json",
+            "pointer": "/32/effect/0/place_override"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3943 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "player_leaving",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::player_leaving" ],
+      "aliases": [ "player_leaving" ],
+      "parser_registrations": [
+        {
+          "registration_order": 206,
+          "alias_role": "alpha",
+          "alias_group": [ "player_leaving" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8877, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_GREET.json", "pointer": "/10/responses/0/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "player_weapon_away",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::player_weapon_away" ],
+      "aliases": [ "player_weapon_away" ],
+      "parser_registrations": [
+        {
+          "registration_order": 210,
+          "alias_role": "alpha",
+          "alias_group": [ "player_weapon_away" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8881, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_GREET.json", "pointer": "/1/responses/0/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 922 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "player_weapon_drop",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::player_weapon_drop" ],
+      "aliases": [ "player_weapon_drop" ],
+      "parser_registrations": [
+        {
+          "registration_order": 211,
+          "alias_role": "alpha",
+          "alias_group": [ "player_weapon_drop" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8882, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 4,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_GREET.json", "pointer": "/1/responses/1/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 923 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "quote_vehicle_full_repair",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::quote_vehicle_full_repair" ],
+      "aliases": [ "quote_vehicle_full_repair" ],
+      "parser_registrations": [
+        {
+          "registration_order": 147,
+          "alias_role": "alpha",
+          "alias_group": [ "quote_vehicle_full_repair" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8818, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 977 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "remove_active_mission",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_remove_active_mission" ],
+      "aliases": [ "remove_active_mission" ],
+      "parser_registrations": [
+        {
+          "registration_order": 108,
+          "alias_role": "alpha",
+          "alias_group": [ "remove_active_mission" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8750, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 38,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json",
+            "pointer": "/9/effect/1/remove_active_mission"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2052 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "remove_stolen_status",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::remove_stolen_status" ],
+      "aliases": [ "remove_stolen_status" ],
+      "parser_registrations": [
+        {
+          "registration_order": 209,
+          "alias_role": "alpha",
+          "alias_group": [ "remove_stolen_status" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8880, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 5,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_OTHER.json", "pointer": "/26/responses/3/success/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "repair_bionic_limbs",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::repair_bionic_limbs" ],
+      "aliases": [ "repair_bionic_limbs" ],
+      "parser_registrations": [
+        {
+          "registration_order": 189,
+          "alias_role": "alpha",
+          "alias_group": [ "repair_bionic_limbs" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8860, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [ { "path": "data/json/npcs/exodii/exodii_Venn.json", "pointer": "/3/responses/0/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1047 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "return_to_camp_duties",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::return_to_camp_duties" ],
+      "aliases": [ "return_to_camp_duties" ],
+      "parser_registrations": [
+        {
+          "registration_order": 165,
+          "alias_role": "alpha",
+          "alias_group": [ "return_to_camp_duties" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8836, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_ALLY.json", "pointer": "/2/responses/7/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "reveal_map",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "object" ],
+      "handlers": [ "talk_effect_fun::f_reveal_map" ],
+      "aliases": [ "reveal_map" ],
+      "parser_registrations": [
+        {
+          "registration_order": 71,
+          "alias_role": "alpha",
+          "alias_group": [ "reveal_map" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8713, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "object" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 61,
+        "examples": [ { "path": "data/json/effects_on_condition/computer_eocs.json", "pointer": "/1/effect/0/else/1/reveal_map" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2992 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "reveal_route",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "object" ],
+      "handlers": [ "talk_effect_fun::f_reveal_route" ],
+      "aliases": [ "reveal_route" ],
+      "parser_registrations": [
+        {
+          "registration_order": 72,
+          "alias_role": "alpha",
+          "alias_group": [ "reveal_route" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8714, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "object" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [
+          {
+            "path": "data/mods/Magiclysm/items/currency.json",
+            "pointer": "/0/use_action/effect_on_conditions/0/effect/4/reveal_route"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3041 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "reveal_stats",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::reveal_stats" ],
+      "aliases": [ "reveal_stats" ],
+      "parser_registrations": [
+        {
+          "registration_order": 172,
+          "alias_role": "alpha",
+          "alias_group": [ "reveal_stats" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8843, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 4,
+        "examples": [ { "path": "data/json/npcs/Kindred/Brigitte_LaCroix_main.json", "pointer": "/0/responses/1/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1026 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "revert_activity",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::revert_activity" ],
+      "aliases": [ "revert_activity" ],
+      "parser_registrations": [
+        {
+          "registration_order": 202,
+          "alias_role": "alpha",
+          "alias_group": [ "revert_activity" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8873, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_ALLY.json", "pointer": "/9/responses/2/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "revert_location",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_revert_location" ],
+      "aliases": [ "revert_location" ],
+      "parser_registrations": [
+        {
+          "registration_order": 96,
+          "alias_role": "alpha",
+          "alias_group": [ "revert_location" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8738, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 14,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json",
+            "pointer": "/54/effect/5/revert_location"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5436 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "run_eoc_selector",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_run_eoc_selector" ],
+      "aliases": [ "run_eoc_selector" ],
+      "parser_registrations": [
+        {
+          "registration_order": 111,
+          "alias_role": "alpha",
+          "alias_group": [ "run_eoc_selector" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8753, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 121,
+        "examples": [ { "path": "data/json/effects_on_condition/bionic_eocs.json", "pointer": "/14/effect/0/run_eoc_selector" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3154 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "run_eocs",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "member" ],
+      "handlers": [ "talk_effect_fun::f_run_eocs" ],
+      "aliases": [ "run_eocs" ],
+      "parser_registrations": [
+        {
+          "registration_order": 110,
+          "alias_role": "alpha",
+          "alias_group": [ "run_eocs" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8752, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 5452,
+        "examples": [ { "path": "data/json/artifact/altered_object_active.json", "pointer": "/8/effect/1/run_eocs" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2135 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "sample_range",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "object" ],
+      "handlers": [ "talk_effect_fun::f_sample_range" ],
+      "aliases": [ "sample_range" ],
+      "parser_registrations": [
+        {
+          "registration_order": 70,
+          "alias_role": "alpha",
+          "alias_group": [ "sample_range" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8712, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "object" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3842 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "select_vehicle_part_service",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::select_vehicle_part_service" ],
+      "aliases": [ "select_vehicle_part_service" ],
+      "parser_registrations": [
+        {
+          "registration_order": 146,
+          "alias_role": "alpha",
+          "alias_group": [ "select_vehicle_part_service" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8817, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 951 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "set_browsed",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_set_browsed" ],
+      "aliases": [ "set_browsed" ],
+      "parser_registrations": [
+        {
+          "registration_order": 132,
+          "alias_role": "alpha",
+          "alias_group": [ "set_browsed" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8774, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5350 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "set_condition",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_set_condition" ],
+      "aliases": [ "set_condition" ],
+      "parser_registrations": [
+        {
+          "registration_order": 122,
+          "alias_role": "alpha",
+          "alias_group": [ "set_condition" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8764, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 239,
+        "examples": [ { "path": "data/json/encounters/randec_independent_travelers.json", "pointer": "/0/effect/0/set_condition" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3977 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "set_furniture",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_set_furniture" ],
+      "aliases": [ "set_furniture" ],
+      "parser_registrations": [
+        {
+          "registration_order": 48,
+          "alias_role": "alpha",
+          "alias_group": [ "set_furniture" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8690, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5726 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "set_item_category_spawn_rates",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "member" ],
+      "handlers": [ "talk_effect_fun::f_set_item_category_spawn_rates" ],
+      "aliases": [ "set_item_category_spawn_rates" ],
+      "parser_registrations": [
+        {
+          "registration_order": 123,
+          "alias_role": "alpha",
+          "alias_group": [ "set_item_category_spawn_rates" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8765, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 3,
+        "examples": [ { "path": "data/mods/No_Hope/difficulty_options.json", "pointer": "/7/effect/0/set_item_category_spawn_rates" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "set_npc_aim_rule",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_npc_aim_rule" ],
+      "aliases": [ "set_npc_aim_rule" ],
+      "parser_registrations": [
+        {
+          "registration_order": 89,
+          "alias_role": "alpha",
+          "alias_group": [ "set_npc_aim_rule" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8731, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1055 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "set_npc_cbm_recharge_rule",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_npc_cbm_recharge_rule" ],
+      "aliases": [ "set_npc_cbm_recharge_rule" ],
+      "parser_registrations": [
+        {
+          "registration_order": 91,
+          "alias_role": "alpha",
+          "alias_group": [ "set_npc_cbm_recharge_rule" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8733, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "set_npc_cbm_reserve_rule",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_npc_cbm_reserve_rule" ],
+      "aliases": [ "set_npc_cbm_reserve_rule" ],
+      "parser_registrations": [
+        {
+          "registration_order": 90,
+          "alias_role": "alpha",
+          "alias_group": [ "set_npc_cbm_reserve_rule" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8732, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "set_npc_engagement_rule",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_npc_engagement_rule" ],
+      "aliases": [ "set_npc_engagement_rule" ],
+      "parser_registrations": [
+        {
+          "registration_order": 88,
+          "alias_role": "alpha",
+          "alias_group": [ "set_npc_engagement_rule" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8730, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1054 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "set_npc_pickup",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::set_npc_pickup" ],
+      "aliases": [ "set_npc_pickup" ],
+      "parser_registrations": [
+        {
+          "registration_order": 217,
+          "alias_role": "alpha",
+          "alias_group": [ "set_npc_pickup" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8888, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_ALLY.json", "pointer": "/4/responses/11/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "set_npc_rule",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_set_npc_rule" ],
+      "aliases": [ "set_npc_rule" ],
+      "parser_registrations": [
+        {
+          "registration_order": 86,
+          "alias_role": "alpha",
+          "alias_group": [ "set_npc_rule" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8728, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 4,
+        "examples": [ { "path": "data/json/npcs/missiondef.json", "pointer": "/1/end/effect/1/set_npc_rule" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1052 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "set_string_var",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "member" ],
+      "handlers": [ "talk_effect_fun::f_set_string_var" ],
+      "aliases": [ "set_string_var" ],
+      "parser_registrations": [
+        {
+          "registration_order": 121,
+          "alias_role": "alpha",
+          "alias_group": [ "set_string_var" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8763, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1471,
+        "examples": [ { "path": "data/json/debug/teleportation.json", "pointer": "/0/effect/0/then/set_string_var" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1288 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "set_terrain",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_set_terrain" ],
+      "aliases": [ "set_terrain" ],
+      "parser_registrations": [
+        {
+          "registration_order": 47,
+          "alias_role": "alpha",
+          "alias_group": [ "set_terrain" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8689, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5702 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "set_trap",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_set_trap" ],
+      "aliases": [ "set_trap" ],
+      "parser_registrations": [
+        {
+          "registration_order": 46,
+          "alias_role": "alpha",
+          "alias_group": [ "set_trap" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8688, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 3,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json",
+            "pointer": "/60/effect/1/set_trap"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5679 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "signal_hordes",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_signal_hordes" ],
+      "aliases": [ "signal_hordes" ],
+      "parser_registrations": [
+        {
+          "registration_order": 131,
+          "alias_role": "alpha",
+          "alias_group": [ "signal_hordes" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8773, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 4,
+        "examples": [ { "path": "data/json/effects_on_condition/scenario_specific_eocs.json", "pointer": "/35/effect/1/signal_hordes" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2970 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "sort_loot",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::sort_loot" ],
+      "aliases": [ "sort_loot" ],
+      "parser_registrations": [
+        {
+          "registration_order": 140,
+          "alias_role": "alpha",
+          "alias_group": [ "sort_loot" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8811, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_ALLY.json", "pointer": "/9/responses/3/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "sound_effect",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_sound_effect" ],
+      "aliases": [ "sound_effect" ],
+      "parser_registrations": [
+        {
+          "registration_order": 104,
+          "alias_role": "alpha",
+          "alias_group": [ "sound_effect" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8746, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 17,
+        "examples": [ { "path": "data/json/effects_on_condition/bionic_eocs.json", "pointer": "/0/effect/1/sound_effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1899 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "start_camp",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::start_camp" ],
+      "aliases": [ "start_camp" ],
+      "parser_registrations": [
+        {
+          "registration_order": 166,
+          "alias_role": "alpha",
+          "alias_group": [ "start_camp" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8837, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 3,
+        "examples": [ { "path": "data/json/npcs/TALK_FACTION_CAMP.json", "pointer": "/0/responses/3/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1023 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "start_mugging",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::start_mugging" ],
+      "aliases": [ "start_mugging" ],
+      "parser_registrations": [
+        {
+          "registration_order": 205,
+          "alias_role": "alpha",
+          "alias_group": [ "start_mugging" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8876, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_GREET.json", "pointer": "/8/responses/3/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1038 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "start_trade",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::start_trade" ],
+      "aliases": [ "start_trade" ],
+      "parser_registrations": [
+        {
+          "registration_order": 139,
+          "alias_role": "alpha",
+          "alias_group": [ "start_trade" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8810, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 179,
+        "examples": [ { "path": "data/json/npcs/Kindred/Brigitte_LaCroix_main.json", "pointer": "/3/responses/3/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 933 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "start_training",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::start_training" ],
+      "aliases": [ "start_training" ],
+      "parser_registrations": [
+        {
+          "registration_order": 213,
+          "alias_role": "alpha",
+          "alias_group": [ "start_training" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8884, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_OTHER.json", "pointer": "/13/responses/0/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1040 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "start_training_npc",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::start_training_npc" ],
+      "aliases": [ "start_training_npc" ],
+      "parser_registrations": [
+        {
+          "registration_order": 214,
+          "alias_role": "alpha",
+          "alias_group": [ "start_training_npc" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8885, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_OTHER.json", "pointer": "/11/responses/0/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1041 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "start_training_seminar",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::start_training_seminar" ],
+      "aliases": [ "start_training_seminar" ],
+      "parser_registrations": [
+        {
+          "registration_order": 215,
+          "alias_role": "alpha",
+          "alias_group": [ "start_training_seminar" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8886, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_OTHER.json", "pointer": "/12/responses/0/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1042 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "start_vehicle_full_repair",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::start_vehicle_full_repair" ],
+      "aliases": [ "start_vehicle_full_repair" ],
+      "parser_registrations": [
+        {
+          "registration_order": 148,
+          "alias_role": "alpha",
+          "alias_group": [ "start_vehicle_full_repair" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8819, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 977 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "stop_following",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::stop_following" ],
+      "aliases": [ "stop_following" ],
+      "parser_registrations": [
+        {
+          "registration_order": 201,
+          "alias_role": "alpha",
+          "alias_group": [ "stop_following" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8872, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 16,
+        "examples": [ { "path": "data/json/npcs/Lighthouse_Family/NPC_lighthouse_girl.json", "pointer": "/1/responses/1/effect/2" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1034 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "stop_guard",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::stop_guard" ],
+      "aliases": [ "stop_guard" ],
+      "parser_registrations": [
+        {
+          "registration_order": 164,
+          "alias_role": "alpha",
+          "alias_group": [ "stop_guard" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8835, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 10,
+        "examples": [ { "path": "data/json/npcs/Kindred/Brigitte_LaCroix_main.json", "pointer": "/1/responses/0/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1022 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "stranger_neutral",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::stranger_neutral" ],
+      "aliases": [ "stranger_neutral" ],
+      "parser_registrations": [
+        {
+          "registration_order": 204,
+          "alias_role": "alpha",
+          "alias_group": [ "stranger_neutral" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8875, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 8,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_GREET.json", "pointer": "/1/responses/2/success/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1037 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "switch",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_switch" ],
+      "aliases": [ "switch" ],
+      "parser_registrations": [
+        {
+          "registration_order": 114,
+          "alias_role": "alpha",
+          "alias_group": [ "switch" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8756, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 445,
+        "examples": [ { "path": "data/json/effects_on_condition/dream_eocs.json", "pointer": "/2/effect/0/switch" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2497 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "take_control",
+      "syntaxes": [ "effect_string", "object_member" ],
+      "accepted_json_shapes": [ "effect_string", "member" ],
+      "handlers": [ "talk_effect_fun::f_take_control" ],
+      "aliases": [ "take_control" ],
+      "parser_registrations": [
+        {
+          "registration_order": 125,
+          "alias_role": "alpha",
+          "alias_group": [ "take_control" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8767, "symbol": "parsers" }
+        },
+        {
+          "registration_order": 244,
+          "alias_role": "alpha",
+          "alias_group": [ "take_control" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8973, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "explicit_branch"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 5,
+        "examples": [
+          { "path": "data/json/effects_on_condition/example_eocs.json", "pointer": "/32/effect/2/then/run_eocs/effect/0/then/1" }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1953 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "take_control_menu",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [  ],
+      "aliases": [ "take_control_menu" ],
+      "parser_registrations": [
+        {
+          "registration_order": 245,
+          "alias_role": "alpha",
+          "alias_group": [ "take_control_menu" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8977, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "explicit_branch"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [ { "path": "data/json/effects_on_condition/misc_effect_on_condition.json", "pointer": "/7/effect/0" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1979 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "toggle_npc_rule",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_toggle_npc_rule" ],
+      "aliases": [ "toggle_npc_rule" ],
+      "parser_registrations": [
+        {
+          "registration_order": 85,
+          "alias_role": "alpha",
+          "alias_group": [ "toggle_npc_rule" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8727, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1051 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "transform_item",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_transform_item" ],
+      "aliases": [ "transform_item" ],
+      "parser_registrations": [
+        {
+          "registration_order": 130,
+          "alias_role": "alpha",
+          "alias_group": [ "transform_item" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8772, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 23,
+        "examples": [ { "path": "data/json/effects_on_condition/anomalous_mp3_eocs.json", "pointer": "/3/effect/0/else/transform_item" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5814 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "transform_line",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_transform_line" ],
+      "aliases": [ "transform_line" ],
+      "parser_registrations": [
+        {
+          "registration_order": 99,
+          "alias_role": "alpha",
+          "alias_group": [ "transform_line" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8741, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [
+          {
+            "path": "data/json/monster_special_attacks/spells.json",
+            "pointer": "/56/effect/cases/2/effect/0/cases/0/effect/3/transform_line"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5533 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "trigger_event",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_trigger_event" ],
+      "aliases": [ "trigger_event" ],
+      "parser_registrations": [
+        {
+          "registration_order": 126,
+          "alias_role": "alpha",
+          "alias_group": [ "trigger_event" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8768, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json",
+            "pointer": "/11/effect/14/trigger_event"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "turn_cost",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_turn_cost" ],
+      "aliases": [ "turn_cost" ],
+      "parser_registrations": [
+        {
+          "registration_order": 129,
+          "alias_role": "alpha",
+          "alias_group": [ "turn_cost" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8771, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 34,
+        "examples": [ { "path": "data/json/effects_on_condition/bionic_active_eocs.json", "pointer": "/2/false_effect/1/turn_cost" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5790 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_activate",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_activate" ],
+      "aliases": [ "npc_activate", "u_activate" ],
+      "parser_registrations": [
+        {
+          "registration_order": 57,
+          "alias_role": "alpha",
+          "alias_group": [ "u_activate", "npc_activate" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8699, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 41,
+        "examples": [
+          {
+            "path": "data/json/furniture_and_terrain/furniture-storage.json",
+            "pointer": "/38/examine_action/effect_on_conditions/0/effect/0/true_eocs/0/effect/0/u_activate"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5288 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_activate_trait",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_activate_trait" ],
+      "aliases": [ "npc_activate_trait", "u_activate_trait" ],
+      "parser_registrations": [
+        {
+          "registration_order": 8,
+          "alias_role": "alpha",
+          "alias_group": [ "u_activate_trait", "npc_activate_trait" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8650, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 10,
+        "examples": [ { "path": "data/mods/Magiclysm/Spells/druid.json", "pointer": "/31/effect/1/u_activate_trait" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3610 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_add_bionic",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_add_bionic" ],
+      "aliases": [ "npc_add_bionic", "u_add_bionic" ],
+      "parser_registrations": [
+        {
+          "registration_order": 40,
+          "alias_role": "alpha",
+          "alias_group": [ "u_add_bionic", "npc_add_bionic" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8682, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 62,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/nether_eocs/labyrinth_effect_on_condition.json",
+            "pointer": "/2/effect/0/else/0/then/1/u_add_bionic"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3442 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_add_effect",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_add_effect" ],
+      "aliases": [ "npc_add_effect", "u_add_effect" ],
+      "parser_registrations": [
+        {
+          "registration_order": 0,
+          "alias_role": "alpha",
+          "alias_group": [ "u_add_effect", "npc_add_effect" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8642, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1342,
+        "examples": [ { "path": "data/json/effects_on_condition/addictions_eocs.json", "pointer": "/1/effect/3/then/1/u_add_effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 209 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_add_faction_trust",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "member" ],
+      "handlers": [ "talk_effect_fun::f_add_faction_trust" ],
+      "aliases": [ "u_add_faction_trust" ],
+      "parser_registrations": [
+        {
+          "registration_order": 102,
+          "alias_role": "alpha",
+          "alias_group": [ "u_add_faction_trust" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8744, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 116,
+        "examples": [ { "path": "data/json/npcs/TALK_TEST.json", "pointer": "/47/responses/2/effect/u_add_faction_trust" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4527 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_add_morale",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_add_morale" ],
+      "aliases": [ "npc_add_morale", "u_add_morale" ],
+      "parser_registrations": [
+        {
+          "registration_order": 38,
+          "alias_role": "alpha",
+          "alias_group": [ "u_add_morale", "npc_add_morale" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8680, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 250,
+        "examples": [ { "path": "data/json/effects_on_condition/addictions_eocs.json", "pointer": "/1/effect/1/u_add_morale" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 159 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_add_trait",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_add_trait" ],
+      "aliases": [ "npc_add_trait", "u_add_trait" ],
+      "parser_registrations": [
+        {
+          "registration_order": 4,
+          "alias_role": "alpha",
+          "alias_group": [ "u_add_trait", "npc_add_trait" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8646, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 731,
+        "examples": [ { "path": "data/json/effects_on_condition/bionic_eocs.json", "pointer": "/35/effect/0/then/1/u_add_trait" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3322 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_add_var",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "string" ],
+      "handlers": [ "talk_effect_fun::f_add_var" ],
+      "aliases": [ "npc_add_var", "u_add_var" ],
+      "parser_registrations": [
+        {
+          "registration_order": 2,
+          "alias_role": "alpha",
+          "alias_group": [ "u_add_var", "npc_add_var" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8644, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 881,
+        "examples": [ { "path": "data/json/effects_on_condition/example_eocs.json", "pointer": "/7/effect/1/u_add_var" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2488 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_add_wet",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "member" ],
+      "handlers": [ "talk_effect_fun::f_add_wet" ],
+      "aliases": [ "npc_add_wet", "u_add_wet" ],
+      "parser_registrations": [
+        {
+          "registration_order": 28,
+          "alias_role": "alpha",
+          "alias_group": [ "u_add_wet", "npc_add_wet" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8670, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 3,
+        "examples": [ { "path": "data/json/effects_on_condition/weather_eocs.json", "pointer": "/2/effect/0/u_add_wet" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4277 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_add_wound",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_add_wound" ],
+      "aliases": [ "npc_add_wound", "u_add_wound" ],
+      "parser_registrations": [
+        {
+          "registration_order": 83,
+          "alias_role": "alpha",
+          "alias_group": [ "u_add_wound", "npc_add_wound" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8725, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3226 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_assign_activity",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_assign_activity" ],
+      "aliases": [ "npc_assign_activity", "u_assign_activity" ],
+      "parser_registrations": [
+        {
+          "registration_order": 29,
+          "alias_role": "alpha",
+          "alias_group": [ "u_assign_activity", "npc_assign_activity" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8671, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 310,
+        "examples": [ { "path": "data/json/effects_on_condition/computer_eocs.json", "pointer": "/4/effect/0/u_assign_activity" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4686 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_attack",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_attack" ],
+      "aliases": [ "npc_attack", "u_attack" ],
+      "parser_registrations": [
+        {
+          "registration_order": 42,
+          "alias_role": "alpha",
+          "alias_group": [ "u_attack", "npc_attack" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8684, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 4,
+        "examples": [
+          {
+            "path": "data/json/monster_special_attacks/void_spider_mechanics.json",
+            "pointer": "/12/effect/4/cases/0/effect/0/u_attack"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5189 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_bulk_donate",
+      "syntaxes": [ "effect_string", "object_member" ],
+      "accepted_json_shapes": [ "effect_string", "member" ],
+      "handlers": [ "talk_effect_fun::f_bulk_trade_accept" ],
+      "aliases": [ "npc_bulk_donate", "u_bulk_donate" ],
+      "parser_registrations": [
+        {
+          "registration_order": 63,
+          "alias_role": "alpha",
+          "alias_group": [ "u_bulk_donate", "npc_bulk_donate" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8705, "symbol": "parsers" }
+        },
+        {
+          "registration_order": 226,
+          "alias_role": "alpha",
+          "alias_group": [ "u_bulk_donate" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8905, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "explicit_branch"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 4,
+        "examples": [
+          {
+            "path": "data/json/npcs/refugee_center/beggars/BEGGAR_1_Reena_Sandhu.json",
+            "pointer": "/7/speaker_effect/0/effect/u_bulk_donate"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 942 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_bulk_trade_accept",
+      "syntaxes": [ "effect_string", "object_member" ],
+      "accepted_json_shapes": [ "effect_string", "member" ],
+      "handlers": [ "talk_effect_fun::f_bulk_trade_accept" ],
+      "aliases": [ "npc_bulk_trade_accept", "u_bulk_trade_accept" ],
+      "parser_registrations": [
+        {
+          "registration_order": 61,
+          "alias_role": "alpha",
+          "alias_group": [ "u_bulk_trade_accept", "npc_bulk_trade_accept" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8703, "symbol": "parsers" }
+        },
+        {
+          "registration_order": 224,
+          "alias_role": "alpha",
+          "alias_group": [ "u_bulk_trade_accept" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8904, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "explicit_branch"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_OTHER.json", "pointer": "/33/responses/0/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 941 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_buy_item",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_u_buy_item" ],
+      "aliases": [ "u_buy_item" ],
+      "parser_registrations": [
+        {
+          "registration_order": 80,
+          "alias_role": "alpha",
+          "alias_group": [ "u_buy_item" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8722, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 41,
+        "examples": [ { "path": "data/json/npcs/TALK_TEST.json", "pointer": "/21/responses/9/effect/u_buy_item" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/MISSIONS_JSON.md", "line": 48 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_buy_monster",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_u_buy_monster" ],
+      "aliases": [ "u_buy_monster" ],
+      "parser_registrations": [
+        {
+          "registration_order": 101,
+          "alias_role": "alpha",
+          "alias_group": [ "u_buy_monster" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8743, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 9,
+        "examples": [ { "path": "data/json/npcs/isherwood_farm/NPC_Eddie_Isherwood.json", "pointer": "/21/end/effect/2/u_buy_monster" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 947 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_cancel_activity",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [  ],
+      "aliases": [ "u_cancel_activity" ],
+      "parser_registrations": [
+        {
+          "registration_order": 233,
+          "alias_role": "alpha",
+          "alias_group": [ "u_cancel_activity" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8927, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "explicit_branch"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 28,
+        "examples": [ { "path": "data/mods/BombasticPerks/perkdata/closetland.json", "pointer": "/10/effect/1" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4708 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_cast_spell",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_cast_spell" ],
+      "aliases": [ "npc_cast_spell", "u_cast_spell" ],
+      "parser_registrations": [
+        {
+          "registration_order": 64,
+          "alias_role": "alpha",
+          "alias_group": [ "u_cast_spell", "npc_cast_spell" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8706, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 229,
+        "examples": [ { "path": "data/json/artifact/altered_object_active.json", "pointer": "/27/effect/0/then/0/u_cast_spell" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2517 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_choose_adjacent_highlight",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_choose_adjacent_highlight" ],
+      "aliases": [ "npc_choose_adjacent_highlight", "u_choose_adjacent_highlight" ],
+      "parser_registrations": [
+        {
+          "registration_order": 21,
+          "alias_role": "alpha",
+          "alias_group": [ "u_choose_adjacent_highlight", "npc_choose_adjacent_highlight" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8663, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 9,
+        "examples": [
+          { "path": "data/json/effects_on_condition/example_eocs.json", "pointer": "/24/effect/0/u_choose_adjacent_highlight" }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1321 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_consume_item",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_consume_item" ],
+      "aliases": [ "npc_consume_item", "u_consume_item" ],
+      "parser_registrations": [
+        {
+          "registration_order": 58,
+          "alias_role": "alpha",
+          "alias_group": [ "u_consume_item", "npc_consume_item" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8700, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 310,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/computer_eocs.json",
+            "pointer": "/5/effect/0/true_eocs/0/effect/0/u_consume_item"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 945 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_consume_item_sum",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array" ],
+      "handlers": [ "talk_effect_fun::f_consume_item_sum" ],
+      "aliases": [ "npc_consume_item_sum", "u_consume_item_sum" ],
+      "parser_registrations": [
+        {
+          "registration_order": 59,
+          "alias_role": "alpha",
+          "alias_group": [ "u_consume_item_sum", "npc_consume_item_sum" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8701, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 17,
+        "examples": [
+          { "path": "data/json/npcs/balthazar_fac/balthazar.json", "pointer": "/5/speaker_effect/effect/3/u_consume_item_sum" }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4424 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_deactivate_trait",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_deactivate_trait" ],
+      "aliases": [ "npc_deactivate_trait", "u_deactivate_trait" ],
+      "parser_registrations": [
+        {
+          "registration_order": 7,
+          "alias_role": "alpha",
+          "alias_group": [ "u_deactivate_trait", "npc_deactivate_trait" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8649, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 105,
+        "examples": [ { "path": "data/mods/BombasticPerks/perkdata/closetland.json", "pointer": "/4/effect/u_deactivate_trait" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3631 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_deal_damage",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_deal_damage" ],
+      "aliases": [ "npc_deal_damage", "u_deal_damage" ],
+      "parser_registrations": [
+        {
+          "registration_order": 62,
+          "alias_role": "alpha",
+          "alias_group": [ "u_deal_damage", "npc_deal_damage" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8704, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 33,
+        "examples": [
+          {
+            "path": "data/json/monster_special_attacks/void_spider_mechanics.json",
+            "pointer": "/13/effect/0/then/1/npc_run_monster_eocs/0/effect/u_deal_damage"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3286 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_die",
+      "syntaxes": [ "effect_string", "object_member" ],
+      "accepted_json_shapes": [ "effect_string", "object" ],
+      "handlers": [ "talk_effect_fun::f_die_advanced" ],
+      "aliases": [ "npc_die", "u_die" ],
+      "parser_registrations": [
+        {
+          "registration_order": 43,
+          "alias_role": "alpha",
+          "alias_group": [ "u_die", "npc_die" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8685, "symbol": "parsers" }
+        },
+        {
+          "registration_order": 231,
+          "alias_role": "alpha",
+          "alias_group": [ "u_die" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8917, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "explicit_branch"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string", "object" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 21,
+        "examples": [ { "path": "data/json/npcs/EOC_talkers/portal_storm.json", "pointer": "/10/responses/0/effect/0" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5119 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_emit",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_emit" ],
+      "aliases": [ "npc_emit", "u_emit" ],
+      "parser_registrations": [
+        {
+          "registration_order": 50,
+          "alias_role": "alpha",
+          "alias_group": [ "u_emit", "npc_emit" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8692, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/mods/aftershock_exoplanet/items/armor/energy_shield.json", "pointer": "/8/effect/1/u_emit" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5770 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_explosion",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_explosion" ],
+      "aliases": [ "npc_explosion", "u_explosion" ],
+      "parser_registrations": [
+        {
+          "registration_order": 18,
+          "alias_role": "alpha",
+          "alias_group": [ "u_explosion", "npc_explosion" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8660, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 3,
+        "examples": [ { "path": "data/json/artifact/altered_object_active.json", "pointer": "/25/effect/0/u_explosion" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4792 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_faction_rep",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "member" ],
+      "handlers": [ "talk_effect_fun::f_change_faction_rep" ],
+      "aliases": [ "u_faction_rep" ],
+      "parser_registrations": [
+        {
+          "registration_order": 77,
+          "alias_role": "alpha",
+          "alias_group": [ "u_faction_rep" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8719, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 20,
+        "examples": [
+          {
+            "path": "data/json/npcs/common_chat/TALK_COMMON_OTHER.json",
+            "pointer": "/26/responses/1/success/effect/u_faction_rep"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1050 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_forget_martial_art",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_forget_martial_art" ],
+      "aliases": [ "npc_forget_martial_art", "u_forget_martial_art" ],
+      "parser_registrations": [
+        {
+          "registration_order": 14,
+          "alias_role": "alpha",
+          "alias_group": [ "u_forget_martial_art", "npc_forget_martial_art" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8656, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/mods/TEST_DATA/EOC.json", "pointer": "/93/effect/u_forget_martial_art" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2524 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_forget_recipe",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_forget_recipe" ],
+      "aliases": [ "npc_forget_recipe", "u_forget_recipe" ],
+      "parser_registrations": [
+        {
+          "registration_order": 26,
+          "alias_role": "alpha",
+          "alias_group": [ "u_forget_recipe", "npc_forget_recipe" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8668, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 169,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/mutation_eocs/mutation_effect_eocs.json",
+            "pointer": "/6/effect/3/u_forget_recipe"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4220 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_knockback",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_knockback" ],
+      "aliases": [ "npc_knockback", "u_knockback" ],
+      "parser_registrations": [
+        {
+          "registration_order": 119,
+          "alias_role": "alpha",
+          "alias_group": [ "u_knockback", "npc_knockback" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8761, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 9,
+        "examples": [
+          { "path": "data/mods/BombasticPerks/perkdata/boomstick_blast.json", "pointer": "/0/effect/0/then/1/then/0/u_knockback" }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4872 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_learn_martial_art",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_learn_martial_art" ],
+      "aliases": [ "npc_learn_martial_art", "u_learn_martial_art" ],
+      "parser_registrations": [
+        {
+          "registration_order": 13,
+          "alias_role": "alpha",
+          "alias_group": [ "u_learn_martial_art", "npc_learn_martial_art" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8655, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/mods/TEST_DATA/EOC.json", "pointer": "/92/effect/u_learn_martial_art" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3660 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_learn_recipe",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_learn_recipe" ],
+      "aliases": [ "npc_learn_recipe", "u_learn_recipe" ],
+      "parser_registrations": [
+        {
+          "registration_order": 25,
+          "alias_role": "alpha",
+          "alias_group": [ "u_learn_recipe", "npc_learn_recipe" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8667, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 521,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/mutation_eocs/mutation_effect_eocs.json",
+            "pointer": "/1/effect/0/u_learn_recipe"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4195 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_level_spell_class",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_level_spell_class" ],
+      "aliases": [ "npc_level_spell_class", "u_level_spell_class" ],
+      "parser_registrations": [
+        {
+          "registration_order": 24,
+          "alias_role": "alpha",
+          "alias_group": [ "u_level_spell_class", "npc_level_spell_class" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8666, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [ { "path": "data/mods/Isolation-Protocol/EOC/sorcery_eoc.json", "pointer": "/5/effect/0/u_level_spell_class" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4658 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_location_variable",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "object" ],
+      "handlers": [ "talk_effect_fun::f_location_variable" ],
+      "aliases": [ "npc_location_variable", "u_location_variable" ],
+      "parser_registrations": [
+        {
+          "registration_order": 15,
+          "alias_role": "alpha",
+          "alias_group": [ "u_location_variable", "npc_location_variable" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8657, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "object" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 358,
+        "examples": [ { "path": "data/json/artifact/altered_object_active.json", "pointer": "/8/effect/0/u_location_variable" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/DIMENSIONS.md", "line": 22 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_lose_bionic",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_lose_bionic" ],
+      "aliases": [ "npc_lose_bionic", "u_lose_bionic" ],
+      "parser_registrations": [
+        {
+          "registration_order": 41,
+          "alias_role": "alpha",
+          "alias_group": [ "u_lose_bionic", "npc_lose_bionic" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8683, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 16,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/nether_eocs/labyrinth_effect_on_condition.json",
+            "pointer": "/61/effect/0/else/1/u_lose_bionic"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2519 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_lose_category",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_remove_category" ],
+      "aliases": [ "npc_lose_category", "u_lose_category" ],
+      "parser_registrations": [
+        {
+          "registration_order": 6,
+          "alias_role": "alpha",
+          "alias_group": [ "u_lose_category", "npc_lose_category" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8648, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/mods/Xedra_Evolved/effects/effect_on_condition.json", "pointer": "/10/effect/0/u_lose_category" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3549 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_lose_effect",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_remove_effect" ],
+      "aliases": [ "npc_lose_effect", "u_lose_effect" ],
+      "parser_registrations": [
+        {
+          "registration_order": 1,
+          "alias_role": "alpha",
+          "alias_group": [ "u_lose_effect", "npc_lose_effect" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8643, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 629,
+        "examples": [ { "path": "data/json/effects_on_condition/bionic_active_eocs.json", "pointer": "/6/effect/0/u_lose_effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3570 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_lose_morale",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_lose_morale" ],
+      "aliases": [ "npc_lose_morale", "u_lose_morale" ],
+      "parser_registrations": [
+        {
+          "registration_order": 39,
+          "alias_role": "alpha",
+          "alias_group": [ "u_lose_morale", "npc_lose_morale" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8681, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 119,
+        "examples": [ { "path": "data/json/effects_on_condition/effects_eocs.json", "pointer": "/0/false_effect/0/u_lose_morale" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4398 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_lose_trait",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_remove_trait" ],
+      "aliases": [ "npc_lose_trait", "u_lose_trait" ],
+      "parser_registrations": [
+        {
+          "registration_order": 5,
+          "alias_role": "alpha",
+          "alias_group": [ "u_lose_trait", "npc_lose_trait" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8647, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 949,
+        "examples": [ { "path": "data/json/effects_on_condition/bionic_eocs.json", "pointer": "/24/effect/0/u_lose_trait" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3523 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_lose_var",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "string" ],
+      "handlers": [ "talk_effect_fun::f_remove_var" ],
+      "aliases": [ "npc_lose_var", "u_lose_var" ],
+      "parser_registrations": [
+        {
+          "registration_order": 3,
+          "alias_role": "alpha",
+          "alias_group": [ "u_lose_var", "npc_lose_var" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8645, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 126,
+        "examples": [ { "path": "data/json/effects_on_condition/npc_eocs/godco_npc_eocs.json", "pointer": "/1/effect/1/u_lose_var" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3719 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_make_radio_representative",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [  ],
+      "aliases": [ "u_make_radio_representative" ],
+      "parser_registrations": [
+        {
+          "registration_order": 246,
+          "alias_role": "alpha",
+          "alias_group": [ "u_make_radio_representative" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8981, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "explicit_branch"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1995 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_make_sound",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_make_sound" ],
+      "aliases": [ "npc_make_sound", "u_make_sound" ],
+      "parser_registrations": [
+        {
+          "registration_order": 30,
+          "alias_role": "alpha",
+          "alias_group": [ "u_make_sound", "npc_make_sound" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8672, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 25,
+        "examples": [ { "path": "data/json/effects_on_condition/bionic_active_eocs.json", "pointer": "/3/effect/1/u_make_sound" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 169 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_map_run_eocs",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_map_run_eocs" ],
+      "aliases": [ "npc_map_run_eocs", "u_map_run_eocs" ],
+      "parser_registrations": [
+        {
+          "registration_order": 65,
+          "alias_role": "alpha",
+          "alias_group": [ "u_map_run_eocs", "npc_map_run_eocs" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8707, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 16,
+        "examples": [ { "path": "data/mods/BombasticPerks/perkdata/closetland.json", "pointer": "/3/effect/4/u_map_run_eocs" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2815 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_map_run_item_eocs",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_map_run_item_eocs" ],
+      "aliases": [ "npc_map_run_item_eocs", "u_map_run_item_eocs" ],
+      "parser_registrations": [
+        {
+          "registration_order": 66,
+          "alias_role": "alpha",
+          "alias_group": [ "u_map_run_item_eocs", "npc_map_run_item_eocs" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8708, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 14,
+        "examples": [ { "path": "data/json/artifact/altered_object_active.json", "pointer": "/24/effect/0/u_map_run_item_eocs" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2875 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_message",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_message" ],
+      "aliases": [ "npc_message", "u_message" ],
+      "parser_registrations": [
+        {
+          "registration_order": 27,
+          "alias_role": "alpha",
+          "alias_group": [ "u_message", "npc_message" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8669, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 3252,
+        "examples": [ { "path": "data/json/debug/quick_setup_eoc.json", "pointer": "/0/effect/0/u_message" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 635 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_mutate",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "member" ],
+      "handlers": [ "talk_effect_fun::f_mutate" ],
+      "aliases": [ "npc_mutate", "u_mutate" ],
+      "parser_registrations": [
+        {
+          "registration_order": 9,
+          "alias_role": "alpha",
+          "alias_group": [ "u_mutate", "npc_mutate" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8651, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 21,
+        "examples": [
+          { "path": "data/json/effects_on_condition/medicine_eocs/regen_serum_eoc.json", "pointer": "/4/effect/0/else/u_mutate" }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3320 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_mutate_category",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_mutate_category" ],
+      "aliases": [ "npc_mutate_category", "u_mutate_category" ],
+      "parser_registrations": [
+        {
+          "registration_order": 10,
+          "alias_role": "alpha",
+          "alias_group": [ "u_mutate_category", "npc_mutate_category" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8652, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 6,
+        "examples": [ { "path": "data/json/effects_on_condition/artifact_eocs.json", "pointer": "/0/effect/2/u_mutate_category" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3345 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_mutate_towards",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_mutate_towards" ],
+      "aliases": [ "npc_mutate_towards", "u_mutate_towards" ],
+      "parser_registrations": [
+        {
+          "registration_order": 11,
+          "alias_role": "alpha",
+          "alias_group": [ "u_mutate_towards", "npc_mutate_towards" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8653, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 17,
+        "examples": [ { "path": "data/mods/BombasticPerks/perkmenu.json", "pointer": "/5/responses/0/effect/0/u_mutate_towards" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3364 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_pick_bodypart",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_pick_bodypart" ],
+      "aliases": [ "npc_pick_bodypart", "u_pick_bodypart" ],
+      "parser_registrations": [
+        {
+          "registration_order": 82,
+          "alias_role": "alpha",
+          "alias_group": [ "u_pick_bodypart", "npc_pick_bodypart" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8724, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3193 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_pickup_items",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "object" ],
+      "handlers": [ "talk_effect_fun::f_pickup_items" ],
+      "aliases": [ "npc_pickup_items", "u_pickup_items" ],
+      "parser_registrations": [
+        {
+          "registration_order": 67,
+          "alias_role": "alpha",
+          "alias_group": [ "u_pickup_items", "npc_pickup_items" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8709, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "object" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2570 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_prevent_death",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [  ],
+      "aliases": [ "u_prevent_death" ],
+      "parser_registrations": [
+        {
+          "registration_order": 235,
+          "alias_role": "alpha",
+          "alias_group": [ "u_prevent_death" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8938, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "explicit_branch"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 11,
+        "examples": [ { "path": "data/json/effects_on_condition/example_eocs.json", "pointer": "/15/effect/0" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5154 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_query_omt",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_query_omt" ],
+      "aliases": [ "npc_query_omt", "u_query_omt" ],
+      "parser_registrations": [
+        {
+          "registration_order": 20,
+          "alias_role": "alpha",
+          "alias_group": [ "u_query_omt", "npc_query_omt" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8662, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [
+          {
+            "path": "data/json/items/tool/debug_tools.json",
+            "pointer": "/3/use_action/effect_on_conditions/0/effect/0/u_query_omt"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4813 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_query_tile",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_query_tile" ],
+      "aliases": [ "npc_query_tile", "u_query_tile" ],
+      "parser_registrations": [
+        {
+          "registration_order": 19,
+          "alias_role": "alpha",
+          "alias_group": [ "u_query_tile", "npc_query_tile" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8661, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 16,
+        "examples": [ { "path": "data/json/effects_on_condition/example_eocs.json", "pointer": "/22/effect/0/u_query_tile" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1455 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_ranged_attack",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [  ],
+      "aliases": [ "u_ranged_attack" ],
+      "parser_registrations": [
+        {
+          "registration_order": 241,
+          "alias_role": "alpha",
+          "alias_group": [ "u_ranged_attack" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8959, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "explicit_branch"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/mods/aftershock_exoplanet/effects_on_condition.json", "pointer": "/8/effect/0" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "u_remove_item_with",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_remove_item_with" ],
+      "aliases": [ "npc_remove_item_with", "u_remove_item_with" ],
+      "parser_registrations": [
+        {
+          "registration_order": 60,
+          "alias_role": "alpha",
+          "alias_group": [ "u_remove_item_with", "npc_remove_item_with" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8702, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 226,
+        "examples": [ { "path": "data/json/effects_on_condition/bionic_eocs.json", "pointer": "/19/effect/0/u_remove_item_with" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 946 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_remove_wound",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_remove_wound" ],
+      "aliases": [ "npc_remove_wound", "u_remove_wound" ],
+      "parser_registrations": [
+        {
+          "registration_order": 84,
+          "alias_role": "alpha",
+          "alias_group": [ "u_remove_wound", "npc_remove_wound" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8726, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3256 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_roll_remainder",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_roll_remainder" ],
+      "aliases": [ "npc_roll_remainder", "u_roll_remainder" ],
+      "parser_registrations": [
+        {
+          "registration_order": 36,
+          "alias_role": "alpha",
+          "alias_group": [ "u_roll_remainder", "npc_roll_remainder" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8678, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 103,
+        "examples": [
+          {
+            "path": "data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json",
+            "pointer": "/50/effect/u_roll_remainder"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2432 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_run_fixed_zone_eocs",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array" ],
+      "handlers": [ "talk_effect_fun::f_run_fixed_zone_eocs" ],
+      "aliases": [ "npc_run_fixed_zone_eocs", "u_run_fixed_zone_eocs" ],
+      "parser_registrations": [
+        {
+          "registration_order": 34,
+          "alias_role": "alpha",
+          "alias_group": [ "u_run_fixed_zone_eocs", "npc_run_fixed_zone_eocs" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8676, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/mods/aftershock_exoplanet/EOC/ship_eoc.json", "pointer": "/11/effect/0/u_run_fixed_zone_eocs" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2771 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_run_inv_eocs",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_run_inv_eocs" ],
+      "aliases": [ "npc_run_inv_eocs", "u_run_inv_eocs" ],
+      "parser_registrations": [
+        {
+          "registration_order": 35,
+          "alias_role": "alpha",
+          "alias_group": [ "u_run_inv_eocs", "npc_run_inv_eocs" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8677, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 190,
+        "examples": [ { "path": "data/json/effects_on_condition/computer_eocs.json", "pointer": "/5/effect/0/u_run_inv_eocs" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2710 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_run_monster_eocs",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array" ],
+      "handlers": [ "talk_effect_fun::f_run_monster_eocs" ],
+      "aliases": [ "npc_run_monster_eocs", "u_run_monster_eocs" ],
+      "parser_registrations": [
+        {
+          "registration_order": 32,
+          "alias_role": "alpha",
+          "alias_group": [ "u_run_monster_eocs", "npc_run_monster_eocs" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8674, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 14,
+        "examples": [
+          { "path": "data/json/effects_on_condition/scenario_specific_eocs.json", "pointer": "/5/effect/10/u_run_monster_eocs" }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2661 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_run_npc_eocs",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array" ],
+      "handlers": [ "talk_effect_fun::f_run_npc_eocs" ],
+      "aliases": [ "npc_run_npc_eocs", "u_run_npc_eocs" ],
+      "parser_registrations": [
+        {
+          "registration_order": 31,
+          "alias_role": "alpha",
+          "alias_group": [ "u_run_npc_eocs", "npc_run_npc_eocs" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8673, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 26,
+        "examples": [ { "path": "data/json/effects_on_condition/example_eocs.json", "pointer": "/25/effect/0/u_run_npc_eocs" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2593 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_run_vehicle_eocs",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array" ],
+      "handlers": [ "talk_effect_fun::f_run_vehicle_eocs" ],
+      "aliases": [ "npc_run_vehicle_eocs", "u_run_vehicle_eocs" ],
+      "parser_registrations": [
+        {
+          "registration_order": 33,
+          "alias_role": "alpha",
+          "alias_group": [ "u_run_vehicle_eocs", "npc_run_vehicle_eocs" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8675, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/mods/aftershock_exoplanet/EOC/ship_eoc.json", "pointer": "/8/effect/0/u_run_vehicle_eocs" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "u_sell_item",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_u_sell_item" ],
+      "aliases": [ "u_sell_item" ],
+      "parser_registrations": [
+        {
+          "registration_order": 79,
+          "alias_role": "alpha",
+          "alias_group": [ "u_sell_item" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8721, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 110,
+        "examples": [ { "path": "data/json/effects_on_condition/npc_eocs/generic_npc_eocs.json", "pointer": "/1/effect/0/u_sell_item" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 940 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_set_fac_relation",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_set_fac_relation" ],
+      "aliases": [ "npc_set_fac_relation", "u_set_fac_relation" ],
+      "parser_registrations": [
+        {
+          "registration_order": 37,
+          "alias_role": "alpha",
+          "alias_group": [ "u_set_fac_relation", "npc_set_fac_relation" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8679, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 6,
+        "examples": [
+          { "path": "data/json/npcs/godco/members/NPC_Julian_Ray.json", "pointer": "/4/responses/0/effect/u_set_fac_relation" }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4502 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_set_fault",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_set_fault" ],
+      "aliases": [ "npc_set_fault", "u_set_fault" ],
+      "parser_registrations": [
+        {
+          "registration_order": 55,
+          "alias_role": "alpha",
+          "alias_group": [ "u_set_fault", "npc_set_fault" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8697, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5308 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_set_field",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_field" ],
+      "aliases": [ "npc_set_field", "u_set_field" ],
+      "parser_registrations": [
+        {
+          "registration_order": 49,
+          "alias_role": "alpha",
+          "alias_group": [ "u_set_field", "npc_set_field" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8691, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 28,
+        "examples": [ { "path": "data/json/effects_on_condition/effects_eocs.json", "pointer": "/8/effect/0/then/4/u_set_field" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2870 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_set_flag",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_set_flag" ],
+      "aliases": [ "npc_set_flag", "u_set_flag" ],
+      "parser_registrations": [
+        {
+          "registration_order": 53,
+          "alias_role": "alpha",
+          "alias_group": [ "u_set_flag", "npc_set_flag" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8695, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5250 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_set_goal",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_npc_goal" ],
+      "aliases": [ "npc_set_goal", "u_set_goal" ],
+      "parser_registrations": [
+        {
+          "registration_order": 22,
+          "alias_role": "alpha",
+          "alias_group": [ "u_set_goal", "npc_set_goal" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8664, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/npc_eocs/isherwood_barry_rescue_eocs.json",
+            "pointer": "/6/effect/6/u_run_npc_eocs/0/effect/0/u_set_goal"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1057 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_set_guard_pos",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_guard_pos" ],
+      "aliases": [ "npc_set_guard_pos", "u_set_guard_pos" ],
+      "parser_registrations": [
+        {
+          "registration_order": 23,
+          "alias_role": "alpha",
+          "alias_group": [ "u_set_guard_pos", "npc_set_guard_pos" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8665, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [
+          {
+            "path": "data/json/effects_on_condition/npc_eocs/generic_npc_eocs.json",
+            "pointer": "/7/effect/0/u_run_npc_eocs/0/effect/u_set_guard_pos"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2650 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_set_random_fault_of_type",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_set_random_fault_of_type" ],
+      "aliases": [ "npc_set_random_fault_of_type", "u_set_random_fault_of_type" ],
+      "parser_registrations": [
+        {
+          "registration_order": 56,
+          "alias_role": "alpha",
+          "alias_group": [ "u_set_random_fault_of_type", "npc_set_random_fault_of_type" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8698, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [
+          {
+            "path": "data/json/items/tool/debug_tools.json",
+            "pointer": "/4/use_action/effect_on_conditions/0/effect/true_eocs/effect/3/then/0/then/u_set_random_fault_of_type"
+          }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5329 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_set_talker",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_set_talker" ],
+      "aliases": [ "npc_set_talker", "u_set_talker" ],
+      "parser_registrations": [
+        {
+          "registration_order": 128,
+          "alias_role": "alpha",
+          "alias_group": [ "u_set_talker", "npc_set_talker" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8770, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [ { "path": "data/json/effects_on_condition/example_eocs.json", "pointer": "/32/effect/0/u_set_talker" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2146 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_set_trait_purifiability",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_set_trait_purifiability" ],
+      "aliases": [ "npc_set_trait_purifiability", "u_set_trait_purifiability" ],
+      "parser_registrations": [
+        {
+          "registration_order": 12,
+          "alias_role": "alpha",
+          "alias_group": [ "u_set_trait_purifiability", "npc_set_trait_purifiability" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8654, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 4,
+        "examples": [ { "path": "data/mods/TEST_DATA/EOC.json", "pointer": "/0/effect/0/u_set_trait_purifiability" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3384 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_spawn_item",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_spawn_item" ],
+      "aliases": [ "u_spawn_item" ],
+      "parser_registrations": [
+        {
+          "registration_order": 81,
+          "alias_role": "alpha",
+          "alias_group": [ "u_spawn_item" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8723, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 828,
+        "examples": [ { "path": "data/json/effects_on_condition/bionic_eocs.json", "pointer": "/15/effect/0/u_spawn_item" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 153 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_spawn_monster",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_spawn_monster" ],
+      "aliases": [ "npc_spawn_monster", "u_spawn_monster" ],
+      "parser_registrations": [
+        {
+          "registration_order": 44,
+          "alias_role": "alpha",
+          "alias_group": [ "u_spawn_monster", "npc_spawn_monster" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8686, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 118,
+        "examples": [ { "path": "data/json/effects_on_condition/effects_eocs.json", "pointer": "/8/effect/0/then/3/u_spawn_monster" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5588 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_spawn_npc",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_spawn_npc" ],
+      "aliases": [ "npc_spawn_npc", "u_spawn_npc" ],
+      "parser_registrations": [
+        {
+          "registration_order": 45,
+          "alias_role": "alpha",
+          "alias_group": [ "u_spawn_npc", "npc_spawn_npc" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8687, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 25,
+        "examples": [ { "path": "data/json/effects_on_condition/example_eocs.json", "pointer": "/14/effect/0/u_spawn_npc" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5646 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_spend_cash",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "member" ],
+      "handlers": [ "talk_effect_fun::f_u_spend_cash" ],
+      "aliases": [ "u_spend_cash" ],
+      "parser_registrations": [
+        {
+          "registration_order": 74,
+          "alias_role": "alpha",
+          "alias_group": [ "u_spend_cash" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8716, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 56,
+        "examples": [ { "path": "data/json/npcs/Backgrounds/prepper_2.json", "pointer": "/3/responses/0/effect/u_spend_cash" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 943 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_teleport",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "object" ],
+      "handlers": [ "talk_effect_fun::f_teleport" ],
+      "aliases": [ "npc_teleport", "u_teleport" ],
+      "parser_registrations": [
+        {
+          "registration_order": 51,
+          "alias_role": "alpha",
+          "alias_group": [ "u_teleport", "npc_teleport" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8693, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "object" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 242,
+        "examples": [ { "path": "data/json/artifact/altered_object_active.json", "pointer": "/10/effect/u_teleport" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/DIMENSIONS.md", "line": 32 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_transform_radius",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array", "member" ],
+      "handlers": [ "talk_effect_fun::f_transform_radius" ],
+      "aliases": [ "npc_transform_radius", "u_transform_radius" ],
+      "parser_registrations": [
+        {
+          "registration_order": 17,
+          "alias_role": "alpha",
+          "alias_group": [ "u_transform_radius", "npc_transform_radius" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8659, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array", "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 68,
+        "examples": [ { "path": "data/json/effects_on_condition/item_eocs.json", "pointer": "/5/effect/4/u_transform_radius" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5505 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_travel_to_dimension",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_travel_to_dimension" ],
+      "aliases": [ "u_travel_to_dimension" ],
+      "parser_registrations": [
+        {
+          "registration_order": 52,
+          "alias_role": "alpha",
+          "alias_group": [ "u_travel_to_dimension" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8694, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 62,
+        "examples": [ { "path": "data/json/debug/teleportation.json", "pointer": "/0/effect/1/u_travel_to_dimension" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/DIMENSIONS.md", "line": 24 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_unset_flag",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "member" ],
+      "handlers": [ "talk_effect_fun::f_unset_flag" ],
+      "aliases": [ "npc_unset_flag", "u_unset_flag" ],
+      "parser_registrations": [
+        {
+          "registration_order": 54,
+          "alias_role": "alpha",
+          "alias_group": [ "u_unset_flag", "npc_unset_flag" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8696, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "member" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "not_found",
+        "occurrences": 0,
+        "examples": [  ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4431 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "u_wants_to_talk",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [  ],
+      "aliases": [ "u_wants_to_talk" ],
+      "parser_registrations": [
+        {
+          "registration_order": 248,
+          "alias_role": "alpha",
+          "alias_group": [ "u_wants_to_talk" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8989, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "explicit_branch"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [  ],
+        "note": "u_/npc_ identifies alpha/beta legacy routing; it does not prove that either talker is a concrete avatar or NPC."
+      },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 1,
+        "examples": [ { "path": "data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_eocs.json", "pointer": "/9/effect/1/then/1" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" }
+    },
+    {
+      "key": "wake_up",
+      "syntaxes": [ "effect_string" ],
+      "accepted_json_shapes": [ "effect_string" ],
+      "handlers": [ "talk_function::wake_up" ],
+      "aliases": [ "wake_up" ],
+      "parser_registrations": [
+        {
+          "registration_order": 171,
+          "alias_role": "alpha",
+          "alias_group": [ "wake_up" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8842, "symbol": "talk_effect_t::parse_string_effect" },
+          "registration_kind": "static_map"
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "effect_string" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 2,
+        "examples": [ { "path": "data/json/npcs/common_chat/TALK_COMMON_ALLY.json", "pointer": "/0/responses/0/effect" } ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 1025 } ],
+        "confidence": "lexical_only"
+      }
+    },
+    {
+      "key": "weighted_list_eocs",
+      "syntaxes": [ "object_member" ],
+      "accepted_json_shapes": [ "array" ],
+      "handlers": [ "talk_effect_fun::f_weighted_list_eocs" ],
+      "aliases": [ "weighted_list_eocs" ],
+      "parser_registrations": [
+        {
+          "registration_order": 112,
+          "alias_role": "alpha",
+          "alias_group": [ "weighted_list_eocs" ],
+          "source": { "path": "src/npctalk.cpp", "line": 8754, "symbol": "parsers" }
+        }
+      ],
+      "parameters": { "status": "unclassified", "items": [  ], "note": "Handler-specific members require source-backed review." },
+      "value_types": { "status": "partial", "items": [ "array" ], "note": "Only parser dispatch shapes are proven here." },
+      "defaults": { "status": "unclassified", "items": [  ] },
+      "nesting": { "status": "unclassified", "allows": [  ] },
+      "talker_semantics": { "status": "unknown", "talkers": [  ], "note": "Concrete talker compatibility is not inferred from the parser key." },
+      "variables": {
+        "status": "unclassified",
+        "scopes": [  ],
+        "known_global_scopes": [ "u_val", "npc_val", "global_val", "var_val", "context_val" ]
+      },
+      "context": { "status": "unclassified", "requirements": [  ] },
+      "contract_status": "partial",
+      "contract_kind": "effect",
+      "example_evidence": {
+        "status": "lexical_candidate",
+        "occurrences": 72,
+        "examples": [
+          { "path": "data/json/effects_on_condition/mapgen_eocs/furniture_eocs.json", "pointer": "/2/effect/weighted_list_eocs" }
+        ],
+        "confidence": "lexical_only",
+        "note": "A lexical match is evidence of use, not proof that the full surrounding object is a minimal valid example."
+      },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3126 } ],
+        "confidence": "lexical_only"
+      }
+    }
+  ]
+}

--- a/data/reference/json/ccb_json_object_types.json
+++ b/data/reference/json/ccb_json_object_types.json
@@ -1,0 +1,6799 @@
+{
+  "$schema": "../../../tools/json_api/contract-inventory.schema.json",
+  "schema_version": 1,
+  "inventory_kind": "json_object_types",
+  "source": {
+    "project": "Cataclysm-Cleanwater-Bomb",
+    "source_fingerprint": "sha256:43df0cec7f2e7a64ea037a329cd3056ef5bd18416bec39e6bd8bb79bed0f5ffc",
+    "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ],
+    "discovery": "git ls-files",
+    "registrations": "src/init.cpp#DynamicDataLoader::initialize"
+  },
+  "summary": {
+    "registration_calls": 191,
+    "registered_types": 190,
+    "observed_types": 183,
+    "registered_and_observed": 183,
+    "registered_not_observed": [ "TRAIT_BLACKLIST", "WORLD_OPTION", "colordef", "sound_effect_preload", "spell_migration", "wound", "wound_fix" ],
+    "observed_not_registered": [  ],
+    "tracked_json_files": 6714,
+    "top_level_objects": 94146,
+    "top_level_objects_without_string_type": 1,
+    "schema_complete_types": 0
+  },
+  "policy": {
+    "requiredness": "explicit mandatory() or Schema evidence only",
+    "data_frequency": "evidence of use only; never requiredness",
+    "unknown_fields": "retained as unclassified"
+  },
+  "entries": [
+    {
+      "type": "EXTERNAL_OPTION",
+      "registrations": [
+        {
+          "registration_order": 1,
+          "type": "EXTERNAL_OPTION",
+          "handler_kind": "direct_function",
+          "handler_symbol": "load_external_option",
+          "handler_expression": "&load_external_option",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 275, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 163,
+        "examples": [ { "path": "data/core/damage_indicators.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "ITEM",
+      "registrations": [
+        {
+          "registration_order": 81,
+          "type": "ITEM",
+          "handler_kind": "direct_function",
+          "handler_symbol": "items::load",
+          "handler_expression": "&items::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 372, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 15017,
+        "examples": [ { "path": "data/json/artifact/artifact_item_types.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/ITEM.md", "line": 80 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "ITEM_BLACKLIST",
+      "registrations": [
+        {
+          "registration_order": 141,
+          "type": "ITEM_BLACKLIST",
+          "handler_kind": "lambda",
+          "handler_symbol": "load_item_blacklist",
+          "handler_expression": "[]( const JsonObject & jo ) { item_controller->load_item_blacklist( jo ); }",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 454, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 8,
+        "examples": [ { "path": "data/mods/Generic_Guns/gunmods/gg_gunmods_blacklist.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "ITEM_CATEGORY",
+      "registrations": [
+        {
+          "registration_order": 82,
+          "type": "ITEM_CATEGORY",
+          "handler_kind": "direct_function",
+          "handler_symbol": "item_category::load_item_cat",
+          "handler_expression": "&item_category::load_item_cat",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 373, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 36,
+        "examples": [ { "path": "data/json/item_category.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "LOOT_ZONE",
+      "registrations": [
+        {
+          "registration_order": 90,
+          "type": "LOOT_ZONE",
+          "handler_kind": "direct_function",
+          "handler_symbol": "zone_type::load_zones",
+          "handler_expression": "&zone_type::load_zones",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 391, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 67,
+        "examples": [ { "path": "data/json/loot_zones.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 1648 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "MIGRATION",
+      "registrations": [
+        {
+          "registration_order": 83,
+          "type": "MIGRATION",
+          "handler_kind": "lambda",
+          "handler_symbol": "load_migration",
+          "handler_expression": "[]( const JsonObject & jo ) { item_controller->load_migration( jo ); }",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 375, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 1069,
+        "examples": [ { "path": "data/json/items/comestibles/irradiated_fruit_migration.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/OBSOLETION_AND_MIGRATION.md", "line": 52 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "MOD_INFO",
+      "registrations": [
+        {
+          "registration_order": 145,
+          "type": "MOD_INFO",
+          "handler_kind": "direct_function",
+          "handler_symbol": "load_ignored_type",
+          "handler_expression": "&load_ignored_type",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 468, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 53,
+        "examples": [ { "path": "data/mods/Backrooms/modinfo.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/OBSOLETION_AND_MIGRATION.md", "line": 399 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "MONSTER",
+      "registrations": [
+        {
+          "registration_order": 87,
+          "type": "MONSTER",
+          "handler_kind": "lambda",
+          "handler_symbol": "MonsterGenerator::generator",
+          "handler_expression": "[]( const JsonObject & jo, const std::string & src ) { MonsterGenerator::generator().load_monster( jo, src ); }",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 383, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 4149,
+        "examples": [ { "path": "data/json/monsters/LIXA_monsters.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/ITEM_SPAWN.md", "line": 295 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "MONSTER_BLACKLIST",
+      "registrations": [
+        {
+          "registration_order": 48,
+          "type": "MONSTER_BLACKLIST",
+          "handler_kind": "direct_function",
+          "handler_symbol": "MonsterGroupManager::LoadMonsterBlacklist",
+          "handler_expression": "&MonsterGroupManager::LoadMonsterBlacklist",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 322, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 9,
+        "examples": [ { "path": "data/json/default_blacklist.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "MONSTER_FACTION",
+      "registrations": [
+        {
+          "registration_order": 151,
+          "type": "MONSTER_FACTION",
+          "handler_kind": "direct_function",
+          "handler_symbol": "monfactions::load_monster_faction",
+          "handler_expression": "&monfactions::load_monster_faction",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 476, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 398,
+        "examples": [ { "path": "data/json/monster_factions.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INHERITANCE.md", "line": 171 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "MONSTER_WHITELIST",
+      "registrations": [
+        {
+          "registration_order": 49,
+          "type": "MONSTER_WHITELIST",
+          "handler_kind": "direct_function",
+          "handler_symbol": "MonsterGroupManager::LoadMonsterWhitelist",
+          "handler_expression": "&MonsterGroupManager::LoadMonsterWhitelist",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 323, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 6,
+        "examples": [ { "path": "data/mods/CrazyCataclysm/modinfo.json", "pointer": "/1" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "SCENARIO_BLACKLIST",
+      "registrations": [
+        {
+          "registration_order": 54,
+          "type": "SCENARIO_BLACKLIST",
+          "handler_kind": "direct_function",
+          "handler_symbol": "scen_blacklist::load_scen_blacklist",
+          "handler_expression": "&scen_blacklist::load_scen_blacklist",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 328, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 18,
+        "examples": [ { "path": "data/json/obsoletion_and_migration_0.I/blacklist_scenarios.json", "pointer": "/1" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "SPECIES",
+      "registrations": [
+        {
+          "registration_order": 88,
+          "type": "SPECIES",
+          "handler_kind": "lambda",
+          "handler_symbol": "MonsterGenerator::generator",
+          "handler_expression": "[]( const JsonObject & jo, const std::string & src ) { MonsterGenerator::generator().load_species( jo, src ); }",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 386, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 127,
+        "examples": [ { "path": "data/json/species.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/MAGIC.md", "line": 269 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "SPELL",
+      "registrations": [
+        {
+          "registration_order": 171,
+          "type": "SPELL",
+          "handler_kind": "direct_function",
+          "handler_symbol": "spell_type::load_spell",
+          "handler_expression": "&spell_type::load_spell",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 502, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 2329,
+        "examples": [ { "path": "data/core/sentinels.json", "pointer": "/8" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3757 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "TRAIT_BLACKLIST",
+      "registrations": [
+        {
+          "registration_order": 142,
+          "type": "TRAIT_BLACKLIST",
+          "handler_kind": "lambda",
+          "handler_symbol": "mutation_branch::load_trait_blacklist",
+          "handler_expression": "[]( const JsonObject & jo ) { mutation_branch::load_trait_blacklist( jo ); }",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 457, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": { "occurrences": 0, "examples": [  ], "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ] },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "TRAIT_MIGRATION",
+      "registrations": [
+        {
+          "registration_order": 143,
+          "type": "TRAIT_MIGRATION",
+          "handler_kind": "lambda",
+          "handler_symbol": "mutation_branch::load_trait_migration",
+          "handler_expression": "[]( const JsonObject & jo ) { mutation_branch::load_trait_migration( jo ); }",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 461, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 41,
+        "examples": [ { "path": "data/json/obsoletion_and_migration_0.I/migration_mutation.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/MUTATIONS.md", "line": 427 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "WORLD_OPTION",
+      "registrations": [
+        {
+          "registration_order": 0,
+          "type": "WORLD_OPTION",
+          "handler_kind": "direct_function",
+          "handler_symbol": "load_world_option",
+          "handler_expression": "&load_world_option",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 274, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": { "occurrences": 0, "examples": [  ], "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ] },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "achievement",
+      "registrations": [
+        {
+          "registration_order": 179,
+          "type": "achievement",
+          "handler_kind": "direct_function",
+          "handler_symbol": "achievement::load_achievement",
+          "handler_expression": "&achievement::load_achievement",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 510, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 310,
+        "examples": [ { "path": "data/json/achievements.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1864 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "activity_type",
+      "registrations": [
+        {
+          "registration_order": 21,
+          "type": "activity_type",
+          "handler_kind": "direct_function",
+          "handler_symbol": "activity_type::load_all",
+          "handler_expression": "&activity_type::load_all",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 295, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 205,
+        "examples": [ { "path": "data/json/obsoletion_and_migration_0.J/player_activities.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 77 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "addiction_type",
+      "registrations": [
+        {
+          "registration_order": 22,
+          "type": "addiction_type",
+          "handler_kind": "direct_function",
+          "handler_symbol": "add_type::load_add_types",
+          "handler_expression": "&add_type::load_add_types",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 296, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 18,
+        "examples": [ { "path": "data/json/addictions.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 79 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "ammo_effect",
+      "registrations": [
+        {
+          "registration_order": 17,
+          "type": "ammo_effect",
+          "handler_kind": "direct_function",
+          "handler_symbol": "ammo_effects::load",
+          "handler_expression": "&ammo_effects::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 291, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 121,
+        "examples": [ { "path": "data/json/ammo_effects.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 89 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "ammunition_type",
+      "registrations": [
+        {
+          "registration_order": 51,
+          "type": "ammunition_type",
+          "handler_kind": "direct_function",
+          "handler_symbol": "ammunition_type::load_ammunition_type",
+          "handler_expression": "&ammunition_type::load_ammunition_type",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 325, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 228,
+        "examples": [ { "path": "data/core/sentinels.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/ITEM.md", "line": 223 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "anatomy",
+      "registrations": [
+        {
+          "registration_order": 169,
+          "type": "anatomy",
+          "handler_kind": "direct_function",
+          "handler_symbol": "anatomy::load_anatomy",
+          "handler_expression": "&anatomy::load_anatomy",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 500, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 2,
+        "examples": [ { "path": "data/json/anatomy.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 493 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "ascii_art",
+      "registrations": [
+        {
+          "registration_order": 62,
+          "type": "ascii_art",
+          "handler_kind": "direct_function",
+          "handler_symbol": "ascii_art::load_ascii_art",
+          "handler_expression": "&ascii_art::load_ascii_art",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 336, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 432,
+        "examples": [ { "path": "data/json/ascii_art/ammo/10mm.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 655 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "attack_vector",
+      "registrations": [
+        {
+          "registration_order": 103,
+          "type": "attack_vector",
+          "handler_kind": "direct_function",
+          "handler_symbol": "attack_vector::load_attack_vectors",
+          "handler_expression": "&attack_vector::load_attack_vectors",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 405, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 45,
+        "examples": [ { "path": "data/core/sentinels.json", "pointer": "/7" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/MARTIALART_JSON.md", "line": 264 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "bash_damage_profile",
+      "registrations": [
+        {
+          "registration_order": 26,
+          "type": "bash_damage_profile",
+          "handler_kind": "direct_function",
+          "handler_symbol": "bash_damage_profile::load_all",
+          "handler_expression": "&bash_damage_profile::load_all",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 300, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 2,
+        "examples": [ { "path": "data/json/bash_damage_profiles.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/MAP_SMASHING.md", "line": 16 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "behavior",
+      "registrations": [
+        {
+          "registration_order": 150,
+          "type": "behavior",
+          "handler_kind": "direct_function",
+          "handler_symbol": "behavior::load_behavior",
+          "handler_expression": "&behavior::load_behavior",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 474, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 32,
+        "examples": [ { "path": "data/json/monsters/monster_goals.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/ITEM.md", "line": 82 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "bionic",
+      "registrations": [
+        {
+          "registration_order": 27,
+          "type": "bionic",
+          "handler_kind": "direct_function",
+          "handler_symbol": "bionic_data::load_bionic",
+          "handler_expression": "&bionic_data::load_bionic",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 301, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 234,
+        "examples": [ { "path": "data/json/bionics.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 35 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "bionic_migration",
+      "registrations": [
+        {
+          "registration_order": 28,
+          "type": "bionic_migration",
+          "handler_kind": "direct_function",
+          "handler_symbol": "bionic_data::load_bionic_migration",
+          "handler_expression": "&bionic_data::load_bionic_migration",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 302, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 7,
+        "examples": [ { "path": "data/mods/aftershock_exoplanet/migration.json", "pointer": "/7" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/OBSOLETION_AND_MIGRATION.md", "line": 119 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "body_graph",
+      "registrations": [
+        {
+          "registration_order": 168,
+          "type": "body_graph",
+          "handler_kind": "direct_function",
+          "handler_symbol": "bodygraph::load_bodygraphs",
+          "handler_expression": "&bodygraph::load_bodygraphs",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 499, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 16,
+        "examples": [ { "path": "data/json/bodypart_graphs/arms.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 963 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "body_part",
+      "registrations": [
+        {
+          "registration_order": 166,
+          "type": "body_part",
+          "handler_kind": "direct_function",
+          "handler_symbol": "body_part_type::load_bp",
+          "handler_expression": "&body_part_type::load_bp",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 497, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 212,
+        "examples": [ { "path": "data/core/sentinels.json", "pointer": "/1" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1776 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "butchery_requirement",
+      "registrations": [
+        {
+          "registration_order": 158,
+          "type": "butchery_requirement",
+          "handler_kind": "direct_function",
+          "handler_symbol": "butchery_requirements::load_butchery_req",
+          "handler_expression": "&butchery_requirements::load_butchery_req",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 487, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/butchery_requirements.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "camp_migration",
+      "registrations": [
+        {
+          "registration_order": 107,
+          "type": "camp_migration",
+          "handler_kind": "direct_function",
+          "handler_symbol": "overmap::load_oter_id_camp_migration",
+          "handler_expression": "&overmap::load_oter_id_camp_migration",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 409, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 13,
+        "examples": [ { "path": "data/json/obsoletion_and_migration_0.I/camp_placement.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "character_mod",
+      "registrations": [
+        {
+          "registration_order": 165,
+          "type": "character_mod",
+          "handler_kind": "direct_function",
+          "handler_symbol": "character_modifier::load_character_modifiers",
+          "handler_expression": "&character_modifier::load_character_modifiers",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 496, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 35,
+        "examples": [ { "path": "data/json/character_modifiers.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 1240 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "charge_removal_blacklist",
+      "registrations": [
+        {
+          "registration_order": 84,
+          "type": "charge_removal_blacklist",
+          "handler_kind": "callable",
+          "handler_symbol": "load_charge_removal_blacklist",
+          "handler_expression": "load_charge_removal_blacklist",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 379, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 2,
+        "examples": [ { "path": "data/json/obsoletion_and_migration_0.I/blacklist_charge_removal.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/OBSOLETION_AND_MIGRATION.md", "line": 74 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "city",
+      "registrations": [
+        {
+          "registration_order": 117,
+          "type": "city",
+          "handler_kind": "direct_function",
+          "handler_symbol": "city::load_city",
+          "handler_expression": "&city::load_city",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 419, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 351,
+        "examples": [ { "path": "data/mods/MA/cities.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/ARTIFACTS.md", "line": 95 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "city_building",
+      "registrations": [
+        {
+          "registration_order": 120,
+          "type": "city_building",
+          "handler_kind": "direct_function",
+          "handler_symbol": "city_buildings::load",
+          "handler_expression": "&city_buildings::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 422, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 483,
+        "examples": [ { "path": "data/json/obsoletion_and_migration_0.I/obsolete_city_building.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INHERITANCE.md", "line": 183 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "climbing_aid",
+      "registrations": [
+        {
+          "registration_order": 102,
+          "type": "climbing_aid",
+          "handler_kind": "direct_function",
+          "handler_symbol": "climbing_aid::load_climbing_aid",
+          "handler_expression": "&climbing_aid::load_climbing_aid",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 404, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 23,
+        "examples": [ { "path": "data/json/climbing.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/CLIMBING.md", "line": 7 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "clothing_mod",
+      "registrations": [
+        {
+          "registration_order": 174,
+          "type": "clothing_mod",
+          "handler_kind": "direct_function",
+          "handler_symbol": "clothing_mods::load",
+          "handler_expression": "&clothing_mods::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 505, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 5,
+        "examples": [ { "path": "data/json/clothing_mods.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 186 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "colordef",
+      "registrations": [
+        {
+          "registration_order": 144,
+          "type": "colordef",
+          "handler_kind": "direct_function",
+          "handler_symbol": "load_ignored_type",
+          "handler_expression": "&load_ignored_type",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 466, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": { "occurrences": 0, "examples": [  ], "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ] },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "conduct",
+      "registrations": [
+        {
+          "registration_order": 180,
+          "type": "conduct",
+          "handler_kind": "direct_function",
+          "handler_symbol": "achievement::load_achievement",
+          "handler_expression": "&achievement::load_achievement",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 511, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 19,
+        "examples": [ { "path": "data/json/conducts.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1863 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "connect_group",
+      "registrations": [
+        {
+          "registration_order": 6,
+          "type": "connect_group",
+          "handler_kind": "direct_function",
+          "handler_symbol": "connect_group::load",
+          "handler_expression": "&connect_group::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 280, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 41,
+        "examples": [ { "path": "data/json/connect_groups.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_FLAGS.md", "line": 665 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "construction",
+      "registrations": [
+        {
+          "registration_order": 112,
+          "type": "construction",
+          "handler_kind": "direct_function",
+          "handler_symbol": "load_construction",
+          "handler_expression": "&load_construction",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 414, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 906,
+        "examples": [ { "path": "data/json/construction/appliances.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/BASECAMP.md", "line": 348 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "construction_category",
+      "registrations": [
+        {
+          "registration_order": 110,
+          "type": "construction_category",
+          "handler_kind": "direct_function",
+          "handler_symbol": "construction_categories::load",
+          "handler_expression": "&construction_categories::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 412, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 15,
+        "examples": [ { "path": "data/json/construction_category.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "construction_group",
+      "registrations": [
+        {
+          "registration_order": 111,
+          "type": "construction_group",
+          "handler_kind": "direct_function",
+          "handler_symbol": "construction_groups::load",
+          "handler_expression": "&construction_groups::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 413, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 522,
+        "examples": [ { "path": "data/json/construction_group.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "damage_info_order",
+      "registrations": [
+        {
+          "registration_order": 184,
+          "type": "damage_info_order",
+          "handler_kind": "direct_function",
+          "handler_symbol": "damage_info_order::load_damage_info_orders",
+          "handler_expression": "&damage_info_order::load_damage_info_orders",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 515, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 38,
+        "examples": [ { "path": "data/json/damage_types.json", "pointer": "/1" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 1483 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "damage_type",
+      "registrations": [
+        {
+          "registration_order": 183,
+          "type": "damage_type",
+          "handler_kind": "direct_function",
+          "handler_symbol": "damage_type::load_damage_types",
+          "handler_expression": "&damage_type::load_damage_types",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 514, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 39,
+        "examples": [ { "path": "data/json/damage_types.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1891 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "dimension",
+      "registrations": [
+        {
+          "registration_order": 139,
+          "type": "dimension",
+          "handler_kind": "direct_function",
+          "handler_symbol": "dimension_world::load_dimensions",
+          "handler_expression": "&dimension_world::load_dimensions",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 451, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 24,
+        "examples": [ { "path": "data/json/region_settings/region_settings/dimensions/dimensions.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/DIMENSIONS.md", "line": 5 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "dimension_region_layout",
+      "registrations": [
+        {
+          "registration_order": 140,
+          "type": "dimension_region_layout",
+          "handler_kind": "direct_function",
+          "handler_symbol": "dimension_region_layout::load_dimension_regions",
+          "handler_expression": "&dimension_region_layout::load_dimension_regions",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 452, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 24,
+        "examples": [ { "path": "data/json/region_settings/region_settings/dimensions/dimension_regions.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/REGION_LAYOUT.md", "line": 7 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "disease_type",
+      "registrations": [
+        {
+          "registration_order": 61,
+          "type": "disease_type",
+          "handler_kind": "direct_function",
+          "handler_symbol": "disease_type::load_disease_type",
+          "handler_expression": "&disease_type::load_disease_type",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 335, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 7,
+        "examples": [ { "path": "data/json/disease.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 1542 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "dream",
+      "registrations": [
+        {
+          "registration_order": 40,
+          "type": "dream",
+          "handler_kind": "direct_function",
+          "handler_symbol": "dream::load",
+          "handler_expression": "&dream::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 314, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 134,
+        "examples": [ { "path": "data/json/dreams.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 503 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "effect_migration",
+      "registrations": [
+        {
+          "registration_order": 105,
+          "type": "effect_migration",
+          "handler_kind": "direct_function",
+          "handler_symbol": "effect_migration::load",
+          "handler_expression": "&effect_migration::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 407, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 8,
+        "examples": [ { "path": "data/json/obsoletion_and_migration_0.J/obsolete_effects.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/OBSOLETION_AND_MIGRATION.md", "line": 104 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "effect_on_condition",
+      "registrations": [
+        {
+          "registration_order": 12,
+          "type": "effect_on_condition",
+          "handler_kind": "direct_function",
+          "handler_symbol": "effect_on_conditions::load",
+          "handler_expression": "&effect_on_conditions::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 286, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 5508,
+        "examples": [ { "path": "data/json/artifact/altered_object_active.json", "pointer": "/8" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "partial",
+        "fields": [
+          {
+            "name": "condition",
+            "required": false,
+            "requiredness_evidence": "guarded_or_loader_optional_path",
+            "default_expression": null,
+            "source": { "path": "src/effect_on_condition.cpp", "line": 110, "symbol": "effect_on_condition::load" }
+          },
+          {
+            "name": "deactivate_condition",
+            "required": false,
+            "requiredness_evidence": "guarded_or_loader_optional_path",
+            "default_expression": null,
+            "source": { "path": "src/effect_on_condition.cpp", "line": 106, "symbol": "effect_on_condition::load" }
+          },
+          {
+            "name": "effect",
+            "required": false,
+            "requiredness_evidence": "guarded_or_loader_optional_path",
+            "default_expression": null,
+            "source": { "path": "src/effect_on_condition.cpp", "line": 114, "symbol": "effect_on_condition::load" }
+          },
+          {
+            "name": "eoc_type",
+            "required": false,
+            "requiredness_evidence": "optional",
+            "default_expression": "eoc_type::NUM_EOC_TYPES",
+            "source": { "path": "src/effect_on_condition.cpp", "line": 94, "symbol": "effect_on_condition::load" }
+          },
+          {
+            "name": "false_effect",
+            "required": false,
+            "requiredness_evidence": "guarded_or_loader_optional_path",
+            "default_expression": null,
+            "source": { "path": "src/effect_on_condition.cpp", "line": 116, "symbol": "effect_on_condition::load" }
+          },
+          {
+            "name": "global",
+            "required": false,
+            "requiredness_evidence": "optional",
+            "default_expression": "false",
+            "source": { "path": "src/effect_on_condition.cpp", "line": 122, "symbol": "effect_on_condition::load" }
+          },
+          {
+            "name": "id",
+            "required": true,
+            "requiredness_evidence": "mandatory",
+            "default_expression": null,
+            "source": { "path": "src/effect_on_condition.cpp", "line": 93, "symbol": "effect_on_condition::load" }
+          },
+          {
+            "name": "recurrence",
+            "required": false,
+            "requiredness_evidence": "optional",
+            "default_expression": null,
+            "source": { "path": "src/effect_on_condition.cpp", "line": 100, "symbol": "effect_on_condition::load" }
+          },
+          {
+            "name": "required_event",
+            "required": true,
+            "requiredness_evidence": "mandatory",
+            "default_expression": null,
+            "source": { "path": "src/effect_on_condition.cpp", "line": 128, "symbol": "effect_on_condition::load" }
+          },
+          {
+            "name": "run_for_npcs",
+            "required": false,
+            "requiredness_evidence": "optional",
+            "default_expression": "false",
+            "source": { "path": "src/effect_on_condition.cpp", "line": 121, "symbol": "effect_on_condition::load" }
+          }
+        ],
+        "inheritance": "generic_factory_handle_inheritance",
+        "copy_from": "supported_by_generic_factory",
+        "validation": "partial",
+        "note": "Only fields directly proven in effect_on_condition::load are listed."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "effect_type",
+      "registrations": [
+        {
+          "registration_order": 104,
+          "type": "effect_type",
+          "handler_kind": "direct_function",
+          "handler_symbol": "load_effect_type",
+          "handler_expression": "&load_effect_type",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 406, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 1652,
+        "examples": [ { "path": "data/json/effects.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECTS_JSON.md", "line": 112 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "emit",
+      "registrations": [
+        {
+          "registration_order": 19,
+          "type": "emit",
+          "handler_kind": "direct_function",
+          "handler_symbol": "emit::load_emit",
+          "handler_expression": "&emit::load_emit",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 293, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 128,
+        "examples": [ { "path": "data/json/emit.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5771 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "enchantment",
+      "registrations": [
+        {
+          "registration_order": 58,
+          "type": "enchantment",
+          "handler_kind": "direct_function",
+          "handler_symbol": "enchantment::load_enchantment",
+          "handler_expression": "&enchantment::load_enchantment",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 332, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 278,
+        "examples": [ { "path": "data/json/artifact/legacy_artifact_passive.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/ARTIFACTS.md", "line": 110 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "end_screen",
+      "registrations": [
+        {
+          "registration_order": 63,
+          "type": "end_screen",
+          "handler_kind": "direct_function",
+          "handler_symbol": "end_screen::load_end_screen",
+          "handler_expression": "&end_screen::load_end_screen",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 337, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 13,
+        "examples": [ { "path": "data/json/end_screen.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 1567 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "event_statistic",
+      "registrations": [
+        {
+          "registration_order": 177,
+          "type": "event_statistic",
+          "handler_kind": "direct_function",
+          "handler_symbol": "event_statistic::load_statistic",
+          "handler_expression": "&event_statistic::load_statistic",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 508, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 193,
+        "examples": [ { "path": "data/json/statistics.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 71 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "event_transformation",
+      "registrations": [
+        {
+          "registration_order": 176,
+          "type": "event_transformation",
+          "handler_kind": "direct_function",
+          "handler_symbol": "event_transformation::load_transformation",
+          "handler_expression": "&event_transformation::load_transformation",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 507, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 181,
+        "examples": [ { "path": "data/json/statistics.json", "pointer": "/2" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 70 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "explosion_light",
+      "registrations": [
+        {
+          "registration_order": 18,
+          "type": "explosion_light",
+          "handler_kind": "direct_function",
+          "handler_symbol": "explosion_lights::load",
+          "handler_expression": "&explosion_lights::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 292, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 16,
+        "examples": [ { "path": "data/json/explosion_lights.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "faction",
+      "registrations": [
+        {
+          "registration_order": 146,
+          "type": "faction",
+          "handler_kind": "direct_function",
+          "handler_symbol": "faction_template::load",
+          "handler_expression": "&faction_template::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 470, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 40,
+        "examples": [ { "path": "data/json/npcs/factions.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/BASECAMP.md", "line": 88 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "faction_mission",
+      "registrations": [
+        {
+          "registration_order": 188,
+          "type": "faction_mission",
+          "handler_kind": "direct_function",
+          "handler_symbol": "faction_mission::load_faction_missions",
+          "handler_expression": "&faction_mission::load_faction_missions",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 519, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 17,
+        "examples": [ { "path": "data/json/faction_missions.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/FACTION_MISSIONS.md", "line": 18 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "fault",
+      "registrations": [
+        {
+          "registration_order": 7,
+          "type": "fault",
+          "handler_kind": "direct_function",
+          "handler_symbol": "faults::load_fault",
+          "handler_expression": "&faults::load_fault",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 281, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 88,
+        "examples": [ { "path": "data/core/sentinels.json", "pointer": "/6" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5309 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "fault_fix",
+      "registrations": [
+        {
+          "registration_order": 9,
+          "type": "fault_fix",
+          "handler_kind": "direct_function",
+          "handler_symbol": "faults::load_fix",
+          "handler_expression": "&faults::load_fix",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 283, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 74,
+        "examples": [ { "path": "data/json/faults/fault_fixes_armor.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 1701 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "fault_group",
+      "registrations": [
+        {
+          "registration_order": 10,
+          "type": "fault_group",
+          "handler_kind": "direct_function",
+          "handler_symbol": "faults::load_group",
+          "handler_expression": "&faults::load_group",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 284, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 27,
+        "examples": [ { "path": "data/json/faults/fault_groups_armor.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/ITEM.md", "line": 851 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "field_type",
+      "registrations": [
+        {
+          "registration_order": 13,
+          "type": "field_type",
+          "handler_kind": "direct_function",
+          "handler_symbol": "field_types::load",
+          "handler_expression": "&field_types::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 287, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 239,
+        "examples": [ { "path": "data/core/sentinels.json", "pointer": "/5" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/ITEM.md", "line": 264 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "field_type_migration",
+      "registrations": [
+        {
+          "registration_order": 14,
+          "type": "field_type_migration",
+          "handler_kind": "direct_function",
+          "handler_symbol": "field_type_migrations::load",
+          "handler_expression": "&field_type_migrations::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 288, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 1,
+        "examples": [ { "path": "data/mods/TEST_DATA/field_type_migrations.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/OBSOLETION_AND_MIGRATION.md", "line": 291 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "forest_biome_component",
+      "registrations": [
+        {
+          "registration_order": 135,
+          "type": "forest_biome_component",
+          "handler_kind": "direct_function",
+          "handler_symbol": "forest_biome_component::load_forest_biome_feature",
+          "handler_expression": "&forest_biome_component::load_forest_biome_feature",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 444, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 57,
+        "examples": [ { "path": "data/json/region_settings/region_settings/regional_map_settings.json", "pointer": "/12" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/REGION_SETTINGS.md", "line": 271 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "forest_biome_mapgen",
+      "registrations": [
+        {
+          "registration_order": 136,
+          "type": "forest_biome_mapgen",
+          "handler_kind": "direct_function",
+          "handler_symbol": "forest_biome_mapgen::load_forest_biome_mapgen",
+          "handler_expression": "&forest_biome_mapgen::load_forest_biome_mapgen",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 446, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 20,
+        "examples": [ { "path": "data/json/region_settings/region_settings/regional_map_settings.json", "pointer": "/9" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/REGION_SETTINGS.md", "line": 219 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "furniture",
+      "registrations": [
+        {
+          "registration_order": 44,
+          "type": "furniture",
+          "handler_kind": "direct_function",
+          "handler_symbol": "load_furniture",
+          "handler_expression": "&load_furniture",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 318, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 1060,
+        "examples": [ { "path": "data/json/furniture_and_terrain/LIXA_furniture_and_terrain.json", "pointer": "/27" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/CLIMBING.md", "line": 46 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "gate",
+      "registrations": [
+        {
+          "registration_order": 155,
+          "type": "gate",
+          "handler_kind": "direct_function",
+          "handler_symbol": "gates::load",
+          "handler_expression": "&gates::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 482, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 12,
+        "examples": [ { "path": "data/json/furniture_and_terrain/netherum/terrain_labyrinth_cybernetic.json", "pointer": "/26" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EXAMINE.md", "line": 59 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "harvest",
+      "registrations": [
+        {
+          "registration_order": 160,
+          "type": "harvest",
+          "handler_kind": "direct_function",
+          "handler_symbol": "harvest_list::load_harvest_list",
+          "handler_expression": "&harvest_list::load_harvest_list",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 489, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 623,
+        "examples": [ { "path": "data/json/harvest.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1881 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "harvest_drop_type",
+      "registrations": [
+        {
+          "registration_order": 159,
+          "type": "harvest_drop_type",
+          "handler_kind": "direct_function",
+          "handler_symbol": "harvest_drop_type::load_harvest_drop_types",
+          "handler_expression": "&harvest_drop_type::load_harvest_drop_types",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 488, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 9,
+        "examples": [ { "path": "data/json/harvest_drop_type.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 3183 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "help",
+      "registrations": [
+        {
+          "registration_order": 20,
+          "type": "help",
+          "handler_kind": "direct_function",
+          "handler_symbol": "help::load",
+          "handler_expression": "&help::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 294, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 39,
+        "examples": [ { "path": "data/core/help.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/GUIDE_COMESTIBLES.md", "line": 3 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "hit_range",
+      "registrations": [
+        {
+          "registration_order": 59,
+          "type": "hit_range",
+          "handler_kind": "direct_function",
+          "handler_symbol": "Creature::load_hit_range",
+          "handler_expression": "&Creature::load_hit_range",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 333, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/hit_range.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "item_action",
+      "registrations": [
+        {
+          "registration_order": 67,
+          "type": "item_action",
+          "handler_kind": "lambda",
+          "handler_symbol": "item_action_generator::generator",
+          "handler_expression": "[]( const JsonObject & jo ) { item_action_generator::generator().load_item_action( jo ); }",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 350, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 193,
+        "examples": [ { "path": "data/json/item_actions.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "item_group",
+      "registrations": [
+        {
+          "registration_order": 65,
+          "type": "item_group",
+          "handler_kind": "lambda",
+          "handler_symbol": "load_item_group",
+          "handler_expression": "[]( const JsonObject & jo ) { item_controller->load_item_group( jo ); }",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 344, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 7735,
+        "examples": [ { "path": "data/json/deconstruction.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2539 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "jmath_function",
+      "registrations": [
+        {
+          "registration_order": 4,
+          "type": "jmath_function",
+          "handler_kind": "direct_function",
+          "handler_symbol": "jmath_func::load_func",
+          "handler_expression": "&jmath_func::load_func",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 278, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 229,
+        "examples": [ { "path": "data/json/effects_on_condition/addictions_eocs.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/MAGIC.md", "line": 673 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "json_flag",
+      "registrations": [
+        {
+          "registration_order": 3,
+          "type": "json_flag",
+          "handler_kind": "direct_function",
+          "handler_symbol": "json_flag::load_all",
+          "handler_expression": "&json_flag::load_all",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 277, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 904,
+        "examples": [ { "path": "data/json/flags.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_FLAGS.md", "line": 74 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "limb_score",
+      "registrations": [
+        {
+          "registration_order": 164,
+          "type": "limb_score",
+          "handler_kind": "direct_function",
+          "handler_symbol": "limb_score::load_limb_scores",
+          "handler_expression": "&limb_score::load_limb_scores",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 495, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 16,
+        "examples": [ { "path": "data/json/limb_scores.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECTS_JSON.md", "line": 442 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "magic_type",
+      "registrations": [
+        {
+          "registration_order": 173,
+          "type": "magic_type",
+          "handler_kind": "direct_function",
+          "handler_symbol": "magic_type::load_magic_type",
+          "handler_expression": "&magic_type::load_magic_type",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 504, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 28,
+        "examples": [ { "path": "data/mods/Isolation-Protocol/Player/sorcery.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/MAGIC.md", "line": 80 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "map_extra",
+      "registrations": [
+        {
+          "registration_order": 121,
+          "type": "map_extra",
+          "handler_kind": "direct_function",
+          "handler_symbol": "MapExtras::load",
+          "handler_expression": "&MapExtras::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 423, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 246,
+        "examples": [ { "path": "data/core/sentinels.json", "pointer": "/3" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/MAPGEN.md", "line": 85 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "map_extra_collection",
+      "registrations": [
+        {
+          "registration_order": 137,
+          "type": "map_extra_collection",
+          "handler_kind": "direct_function",
+          "handler_symbol": "map_extra_collection::load_map_extra_collection",
+          "handler_expression": "&map_extra_collection::load_map_extra_collection",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 448, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 83,
+        "examples": [ { "path": "data/json/region_settings/region_settings/dimensions/portal_storm_dungeon.json", "pointer": "/8" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/REGION_SETTINGS.md", "line": 509 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "mapgen",
+      "registrations": [
+        {
+          "registration_order": 113,
+          "type": "mapgen",
+          "handler_kind": "direct_function",
+          "handler_symbol": "load_mapgen",
+          "handler_expression": "&load_mapgen",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 415, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 9550,
+        "examples": [ { "path": "data/json/effects_on_condition/npc_eocs/ref_center_exodii_updater.json", "pointer": "/6" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/ARTIFACTS.md", "line": 147 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "martial_art",
+      "registrations": [
+        {
+          "registration_order": 101,
+          "type": "martial_art",
+          "handler_kind": "direct_function",
+          "handler_symbol": "load_martial_art",
+          "handler_expression": "&load_martial_art",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 403, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 58,
+        "examples": [ { "path": "data/json/martialarts.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1855 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "material",
+      "registrations": [
+        {
+          "registration_order": 25,
+          "type": "material",
+          "handler_kind": "direct_function",
+          "handler_symbol": "materials::load",
+          "handler_expression": "&materials::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 299, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 269,
+        "examples": [ { "path": "data/json/materials.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/BASECAMP.md", "line": 38 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "mission_definition",
+      "registrations": [
+        {
+          "registration_order": 157,
+          "type": "mission_definition",
+          "handler_kind": "lambda",
+          "handler_symbol": "mission_type::load_mission_type",
+          "handler_expression": "[]( const JsonObject & jo, const std::string & src ) { mission_type::load_mission_type( jo, src ); }",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 484, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 604,
+        "examples": [ { "path": "data/json/npcs/Backgrounds/OtherSurvivorStories/Brigitte_LaCroix_Background.json", "pointer": "/2" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/MISSIONS_JSON.md", "line": 38 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "mod_migration",
+      "registrations": [
+        {
+          "registration_order": 187,
+          "type": "mod_migration",
+          "handler_kind": "direct_function",
+          "handler_symbol": "mod_migrations::load",
+          "handler_expression": "&mod_migrations::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 518, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 9,
+        "examples": [ { "path": "data/core/mod_migrations.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/OBSOLETION_AND_MIGRATION.md", "line": 435 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "mod_tileset",
+      "registrations": [
+        {
+          "registration_order": 189,
+          "type": "mod_tileset",
+          "handler_kind": "direct_function",
+          "handler_symbol": "load_mod_tileset",
+          "handler_expression": "&load_mod_tileset",
+          "compile_context": [ "if defined(TILES)" ],
+          "source": { "path": "src/init.cpp", "line": 521, "symbol": "DynamicDataLoader::initialize" }
+        },
+        {
+          "registration_order": 190,
+          "type": "mod_tileset",
+          "handler_kind": "callable",
+          "handler_symbol": "load_ignored_type",
+          "handler_expression": "load_ignored_type",
+          "compile_context": [ "else (if defined(TILES))" ],
+          "source": { "path": "src/init.cpp", "line": 524, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": true,
+      "instance_evidence": {
+        "occurrences": 7,
+        "examples": [ { "path": "data/mods/CrazyCataclysm/mod_tileset.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 4452 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "monster_adjustment",
+      "registrations": [
+        {
+          "registration_order": 91,
+          "type": "monster_adjustment",
+          "handler_kind": "direct_function",
+          "handler_symbol": "load_monster_adjustment",
+          "handler_expression": "&load_monster_adjustment",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 392, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 7,
+        "examples": [ { "path": "data/mods/XedraWood/external_options_and_monster_adjustments.json", "pointer": "/8" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "monster_attack",
+      "registrations": [
+        {
+          "registration_order": 161,
+          "type": "monster_attack",
+          "handler_kind": "lambda",
+          "handler_symbol": "MonsterGenerator::generator",
+          "handler_expression": "[]( const JsonObject & jo, const std::string & src ) { MonsterGenerator::generator().load_monster_attack( jo, src ); }",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 490, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 133,
+        "examples": [ { "path": "data/json/monster_special_attacks/feral_weapon_attacks.json", "pointer": "/1" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 72 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "monster_flag",
+      "registrations": [
+        {
+          "registration_order": 89,
+          "type": "monster_flag",
+          "handler_kind": "direct_function",
+          "handler_symbol": "mon_flag::load_mon_flags",
+          "handler_expression": "&mon_flag::load_mon_flags",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 389, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 163,
+        "examples": [ { "path": "data/json/monsters/monster_flags.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/MONSTERS.md", "line": 563 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "monstergroup",
+      "registrations": [
+        {
+          "registration_order": 47,
+          "type": "monstergroup",
+          "handler_kind": "direct_function",
+          "handler_symbol": "MonsterGroupManager::LoadMonsterGroup",
+          "handler_expression": "&MonsterGroupManager::LoadMonsterGroup",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 321, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 1099,
+        "examples": [ { "path": "data/json/mapgen/animalpound.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2539 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "mood_face",
+      "registrations": [
+        {
+          "registration_order": 37,
+          "type": "mood_face",
+          "handler_kind": "direct_function",
+          "handler_symbol": "mood_face::load_mood_faces",
+          "handler_expression": "&mood_face::load_mood_faces",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 311, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 10,
+        "examples": [ { "path": "data/json/mood_faces.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 2625 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "morale_type",
+      "registrations": [
+        {
+          "registration_order": 170,
+          "type": "morale_type",
+          "handler_kind": "direct_function",
+          "handler_symbol": "morale_type_data::load_type",
+          "handler_expression": "&morale_type_data::load_type",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 501, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 119,
+        "examples": [ { "path": "data/json/effects_on_condition/misc_effect_on_condition.json", "pointer": "/15" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4365 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "movement_mode",
+      "registrations": [
+        {
+          "registration_order": 23,
+          "type": "movement_mode",
+          "handler_kind": "direct_function",
+          "handler_symbol": "move_mode::load_move_mode",
+          "handler_expression": "&move_mode::load_move_mode",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 297, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 4,
+        "examples": [ { "path": "data/json/move_modes.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1772 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "mutation",
+      "registrations": [
+        {
+          "registration_order": 43,
+          "type": "mutation",
+          "handler_kind": "direct_function",
+          "handler_symbol": "mutation_branch::load_trait",
+          "handler_expression": "&mutation_branch::load_trait",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 317, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 2959,
+        "examples": [ { "path": "data/json/items/relics/highland_censer.json", "pointer": "/20" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 83 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "mutation_category",
+      "registrations": [
+        {
+          "registration_order": 41,
+          "type": "mutation_category",
+          "handler_kind": "direct_function",
+          "handler_symbol": "mutation_category_trait::load",
+          "handler_expression": "&mutation_category_trait::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 315, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 58,
+        "examples": [ { "path": "data/json/mutations/mutation_category.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 561 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "mutation_type",
+      "registrations": [
+        {
+          "registration_order": 42,
+          "type": "mutation_type",
+          "handler_kind": "direct_function",
+          "handler_symbol": "load_mutation_type",
+          "handler_expression": "&load_mutation_type",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 316, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 95,
+        "examples": [ { "path": "data/json/mutations/cybernetic_traits.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "named_color",
+      "registrations": [
+        {
+          "registration_order": 77,
+          "type": "named_color",
+          "handler_kind": "direct_function",
+          "handler_symbol": "RGBColor::load_named_color",
+          "handler_expression": "&RGBColor::load_named_color",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 364, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 217,
+        "examples": [ { "path": "data/json/named_colors.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "nested_category",
+      "registrations": [
+        {
+          "registration_order": 96,
+          "type": "nested_category",
+          "handler_kind": "direct_function",
+          "handler_symbol": "recipe_dictionary::load_nested_category",
+          "handler_expression": "&recipe_dictionary::load_nested_category",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 397, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 614,
+        "examples": [ { "path": "data/json/recipes/nested.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/ITEM_CRAFT_AND_DISASSEMBLY.md", "line": 296 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "npc",
+      "registrations": [
+        {
+          "registration_order": 147,
+          "type": "npc",
+          "handler_kind": "direct_function",
+          "handler_symbol": "npc_template::load",
+          "handler_expression": "&npc_template::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 471, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 304,
+        "examples": [ { "path": "data/json/npcs/Kindred/NPC_Brigitte_LaCroix.json", "pointer": "/5" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "npc_class",
+      "registrations": [
+        {
+          "registration_order": 148,
+          "type": "npc_class",
+          "handler_kind": "direct_function",
+          "handler_symbol": "npc_class::load_npc_class",
+          "handler_expression": "&npc_class::load_npc_class",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 472, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 285,
+        "examples": [ { "path": "data/json/npcs/Kindred/NPC_Brigitte_LaCroix.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 29 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "omt_placeholder",
+      "registrations": [
+        {
+          "registration_order": 122,
+          "type": "omt_placeholder",
+          "handler_kind": "direct_function",
+          "handler_symbol": "map_data_placeholders::load",
+          "handler_expression": "&map_data_placeholders::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 424, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 4,
+        "examples": [ { "path": "data/json/overmap/omt_placeholders.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "option_slider",
+      "registrations": [
+        {
+          "registration_order": 2,
+          "type": "option_slider",
+          "handler_kind": "direct_function",
+          "handler_symbol": "option_slider::load_option_sliders",
+          "handler_expression": "&option_slider::load_option_sliders",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 276, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 4,
+        "examples": [ { "path": "data/core/world_option_sliders.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 4641 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "oter_id_migration",
+      "registrations": [
+        {
+          "registration_order": 106,
+          "type": "oter_id_migration",
+          "handler_kind": "direct_function",
+          "handler_symbol": "overmap::load_oter_id_migration",
+          "handler_expression": "&overmap::load_oter_id_migration",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 408, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 29,
+        "examples": [ { "path": "data/json/obsoletion_and_migration_0.I/obsolete_overmap_terrain.json", "pointer": "/1" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/OBSOLETION_AND_MIGRATION.md", "line": 326 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "oter_vision",
+      "registrations": [
+        {
+          "registration_order": 109,
+          "type": "oter_vision",
+          "handler_kind": "direct_function",
+          "handler_symbol": "oter_vision::load_oter_vision",
+          "handler_expression": "&oter_vision::load_oter_vision",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 411, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 66,
+        "examples": [ { "path": "data/json/overmap/vision_levels.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/OVERMAP.md", "line": 13 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "overlay_order",
+      "registrations": [
+        {
+          "registration_order": 156,
+          "type": "overlay_order",
+          "handler_kind": "direct_function",
+          "handler_symbol": "load_overlay_ordering",
+          "handler_expression": "&load_overlay_ordering",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 483, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 4,
+        "examples": [ { "path": "data/json/mutations/mutation_ordering.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 4416 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "overmap_connection",
+      "registrations": [
+        {
+          "registration_order": 115,
+          "type": "overmap_connection",
+          "handler_kind": "direct_function",
+          "handler_symbol": "overmap_connections::load",
+          "handler_expression": "&overmap_connections::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 417, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 10,
+        "examples": [ { "path": "data/json/overmap/overmap_connections.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/OVERMAP.md", "line": 11 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "overmap_land_use_code",
+      "registrations": [
+        {
+          "registration_order": 114,
+          "type": "overmap_land_use_code",
+          "handler_kind": "direct_function",
+          "handler_symbol": "overmap_land_use_codes::load",
+          "handler_expression": "&overmap_land_use_codes::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 416, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 34,
+        "examples": [ { "path": "data/json/overmap/overmap_land_use_codes.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "overmap_location",
+      "registrations": [
+        {
+          "registration_order": 116,
+          "type": "overmap_location",
+          "handler_kind": "direct_function",
+          "handler_symbol": "overmap_locations::load",
+          "handler_expression": "&overmap_locations::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 418, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 95,
+        "examples": [ { "path": "data/json/npcs/destination_locations.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/OVERMAP.md", "line": 12 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "overmap_special",
+      "registrations": [
+        {
+          "registration_order": 118,
+          "type": "overmap_special",
+          "handler_kind": "direct_function",
+          "handler_symbol": "overmap_specials::load",
+          "handler_expression": "&overmap_specials::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 420, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 531,
+        "examples": [ { "path": "data/json/mapgen/debug.json", "pointer": "/2" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INHERITANCE.md", "line": 183 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "overmap_special_migration",
+      "registrations": [
+        {
+          "registration_order": 119,
+          "type": "overmap_special_migration",
+          "handler_kind": "direct_function",
+          "handler_symbol": "overmap_special_migration::load_migrations",
+          "handler_expression": "&overmap_special_migration::load_migrations",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 421, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 52,
+        "examples": [ { "path": "data/json/obsoletion_and_migration_0.I/obsolete_overmap_special.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/OBSOLETION_AND_MIGRATION.md", "line": 337 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "overmap_terrain",
+      "registrations": [
+        {
+          "registration_order": 108,
+          "type": "overmap_terrain",
+          "handler_kind": "direct_function",
+          "handler_symbol": "overmap_terrains::load",
+          "handler_expression": "&overmap_terrains::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 410, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 2715,
+        "examples": [ { "path": "data/json/mapgen/debug.json", "pointer": "/1" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/BASECAMP.md", "line": 362 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "palette",
+      "registrations": [
+        {
+          "registration_order": 162,
+          "type": "palette",
+          "handler_kind": "callable",
+          "handler_symbol": "mapgen_palette::load",
+          "handler_expression": "mapgen_palette::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 493, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 666,
+        "examples": [ { "path": "data/json/mapgen/abandoned_shopping_plaza.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_Mapping_Guides/Guide_for_beginning_mapgen.md", "line": 31 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "playlist",
+      "registrations": [
+        {
+          "registration_order": 154,
+          "type": "playlist",
+          "handler_kind": "direct_function",
+          "handler_symbol": "sfx::load_playlist",
+          "handler_expression": "&sfx::load_playlist",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 480, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 1,
+        "examples": [ { "path": "data/sound/Menu_Sound_Test/musicset.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "pp_generator",
+      "registrations": [
+        {
+          "registration_order": 8,
+          "type": "pp_generator",
+          "handler_kind": "direct_function",
+          "handler_symbol": "pp_generators::load",
+          "handler_expression": "&pp_generators::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 282, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 10,
+        "examples": [ { "path": "data/json/post_process_generators.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/OVERMAP.md", "line": 337 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "practice",
+      "registrations": [
+        {
+          "registration_order": 95,
+          "type": "practice",
+          "handler_kind": "direct_function",
+          "handler_symbol": "recipe_dictionary::load_practice",
+          "handler_expression": "&recipe_dictionary::load_practice",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 396, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 148,
+        "examples": [ { "path": "data/json/recipes/practice/aircraft.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 138 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "profession",
+      "registrations": [
+        {
+          "registration_order": 29,
+          "type": "profession",
+          "handler_kind": "direct_function",
+          "handler_symbol": "profession::load_profession",
+          "handler_expression": "&profession::load_profession",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 303, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 743,
+        "examples": [ { "path": "data/json/hobbies.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 613 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "profession_blacklist",
+      "registrations": [
+        {
+          "registration_order": 30,
+          "type": "profession_blacklist",
+          "handler_kind": "direct_function",
+          "handler_symbol": "profession_blacklist::load_profession_blacklist",
+          "handler_expression": "&profession_blacklist::load_profession_blacklist",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 304, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 3,
+        "examples": [ { "path": "data/mods/MindOverMatterNoKnacks/profession_blacklist.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "profession_group",
+      "registrations": [
+        {
+          "registration_order": 31,
+          "type": "profession_group",
+          "handler_kind": "direct_function",
+          "handler_symbol": "profession_group::load_profession_group",
+          "handler_expression": "&profession_group::load_profession_group",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 305, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 2,
+        "examples": [ { "path": "data/json/profession_groups.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 2115 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "profession_item_substitutions",
+      "registrations": [
+        {
+          "registration_order": 32,
+          "type": "profession_item_substitutions",
+          "handler_kind": "direct_function",
+          "handler_symbol": "profession::load_item_substitutions",
+          "handler_expression": "&profession::load_item_substitutions",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 306, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 30,
+        "examples": [ { "path": "data/json/professions.json", "pointer": "/65" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 1946 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "proficiency",
+      "registrations": [
+        {
+          "registration_order": 33,
+          "type": "proficiency",
+          "handler_kind": "direct_function",
+          "handler_symbol": "proficiency::load_proficiencies",
+          "handler_expression": "&proficiency::load_proficiencies",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 307, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 321,
+        "examples": [ { "path": "data/json/proficiencies/athletics.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 874 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "proficiency_category",
+      "registrations": [
+        {
+          "registration_order": 34,
+          "type": "proficiency_category",
+          "handler_kind": "direct_function",
+          "handler_symbol": "proficiency_category::load_proficiency_categories",
+          "handler_expression": "&proficiency_category::load_proficiency_categories",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 308, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 31,
+        "examples": [ { "path": "data/json/proficiencies/proficiency_categories.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/PROFICIENCY.md", "line": 96 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "proficiency_migration",
+      "registrations": [
+        {
+          "registration_order": 35,
+          "type": "proficiency_migration",
+          "handler_kind": "direct_function",
+          "handler_symbol": "proficiency_migration::load",
+          "handler_expression": "&proficiency_migration::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 309, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 4,
+        "examples": [ { "path": "data/json/obsoletion_and_migration_0.J/proficiencies.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/OBSOLETION_AND_MIGRATION.md", "line": 171 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "recipe",
+      "registrations": [
+        {
+          "registration_order": 93,
+          "type": "recipe",
+          "handler_kind": "direct_function",
+          "handler_symbol": "recipe_dictionary::load_recipe",
+          "handler_expression": "&recipe_dictionary::load_recipe",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 394, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 8156,
+        "examples": [ { "path": "data/json/items/armor/jewelry.json", "pointer": "/392" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/BASECAMP.md", "line": 8 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "recipe_category",
+      "registrations": [
+        {
+          "registration_order": 92,
+          "type": "recipe_category",
+          "handler_kind": "direct_function",
+          "handler_symbol": "load_recipe_category",
+          "handler_expression": "&load_recipe_category",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 393, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 23,
+        "examples": [ { "path": "data/json/recipes/recipes.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "recipe_group",
+      "registrations": [
+        {
+          "registration_order": 97,
+          "type": "recipe_group",
+          "handler_kind": "direct_function",
+          "handler_symbol": "recipe_group::load",
+          "handler_expression": "&recipe_group::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 398, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 64,
+        "examples": [
+          {
+            "path": "data/json/recipes/basecamps/base/recipe_bare_bones_basecamp/bare_bones_basecamp_personal_recipe_groups.json",
+            "pointer": "/0"
+          }
+        ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/BASECAMP.md", "line": 40 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "region_settings",
+      "registrations": [
+        {
+          "registration_order": 138,
+          "type": "region_settings",
+          "handler_kind": "direct_function",
+          "handler_symbol": "region_settings::load_region_settings",
+          "handler_expression": "&region_settings::load_region_settings",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 450, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 42,
+        "examples": [ { "path": "data/json/region_settings/region_settings/dimensions/highland_dimension.json", "pointer": "/2" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/DIMENSIONS.md", "line": 2 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "region_settings_city",
+      "registrations": [
+        {
+          "registration_order": 130,
+          "type": "region_settings_city",
+          "handler_kind": "direct_function",
+          "handler_symbol": "region_settings_city::load_region_settings_city",
+          "handler_expression": "&region_settings_city::load_region_settings_city",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 434, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 13,
+        "examples": [ { "path": "data/json/region_settings/region_settings/regional_map_settings.json", "pointer": "/24" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/REGION_SETTINGS.md", "line": 34 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "region_settings_forest",
+      "registrations": [
+        {
+          "registration_order": 127,
+          "type": "region_settings_forest",
+          "handler_kind": "direct_function",
+          "handler_symbol": "region_settings_forest::load_region_settings_forest",
+          "handler_expression": "&region_settings_forest::load_region_settings_forest",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 430, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 8,
+        "examples": [ { "path": "data/json/region_settings/region_settings/regional_map_settings.json", "pointer": "/6" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/REGION_SETTINGS.md", "line": 30 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "region_settings_forest_mapgen",
+      "registrations": [
+        {
+          "registration_order": 133,
+          "type": "region_settings_forest_mapgen",
+          "handler_kind": "direct_function",
+          "handler_symbol": "region_settings_forest_mapgen::load_region_settings_forest_mapgen",
+          "handler_expression": "&region_settings_forest_mapgen::load_region_settings_forest_mapgen",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 440, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 7,
+        "examples": [ { "path": "data/json/region_settings/region_settings/regional_map_settings.json", "pointer": "/8" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/REGION_SETTINGS.md", "line": 31 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "region_settings_forest_trail",
+      "registrations": [
+        {
+          "registration_order": 129,
+          "type": "region_settings_forest_trail",
+          "handler_kind": "direct_function",
+          "handler_symbol": "region_settings_forest_trail::load_region_settings_forest_trail",
+          "handler_expression": "&region_settings_forest_trail::load_region_settings_forest_trail",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 432, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 5,
+        "examples": [ { "path": "data/json/region_settings/region_settings/regional_map_settings.json", "pointer": "/7" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/REGION_SETTINGS.md", "line": 32 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "region_settings_highway",
+      "registrations": [
+        {
+          "registration_order": 128,
+          "type": "region_settings_highway",
+          "handler_kind": "direct_function",
+          "handler_symbol": "region_settings_highway::load_region_settings_highway",
+          "handler_expression": "&region_settings_highway::load_region_settings_highway",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 431, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/region_settings/region_settings/regional_map_settings.json", "pointer": "/4" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/REGION_SETTINGS.md", "line": 33 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "region_settings_lake",
+      "registrations": [
+        {
+          "registration_order": 124,
+          "type": "region_settings_lake",
+          "handler_kind": "direct_function",
+          "handler_symbol": "region_settings_lake::load_region_settings_lake",
+          "handler_expression": "&region_settings_lake::load_region_settings_lake",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 427, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 4,
+        "examples": [ { "path": "data/json/region_settings/region_settings/regional_map_settings.json", "pointer": "/2" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/REGION_SETTINGS.md", "line": 27 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "region_settings_map_extras",
+      "registrations": [
+        {
+          "registration_order": 134,
+          "type": "region_settings_map_extras",
+          "handler_kind": "direct_function",
+          "handler_symbol": "region_settings_map_extras::load_region_settings_map_extras",
+          "handler_expression": "&region_settings_map_extras::load_region_settings_map_extras",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 442, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 10,
+        "examples": [ { "path": "data/json/region_settings/region_settings/dimensions/portal_storm_dungeon.json", "pointer": "/7" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/REGION_SETTINGS.md", "line": 35 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "region_settings_ocean",
+      "registrations": [
+        {
+          "registration_order": 125,
+          "type": "region_settings_ocean",
+          "handler_kind": "direct_function",
+          "handler_symbol": "region_settings_ocean::load_region_settings_ocean",
+          "handler_expression": "&region_settings_ocean::load_region_settings_ocean",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 428, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 5,
+        "examples": [ { "path": "data/json/region_settings/region_settings/regional_map_settings.json", "pointer": "/3" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/REGION_SETTINGS.md", "line": 28 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "region_settings_ravine",
+      "registrations": [
+        {
+          "registration_order": 126,
+          "type": "region_settings_ravine",
+          "handler_kind": "direct_function",
+          "handler_symbol": "region_settings_ravine::load_region_settings_ravine",
+          "handler_expression": "&region_settings_ravine::load_region_settings_ravine",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 429, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 4,
+        "examples": [ { "path": "data/json/region_settings/region_settings/dimensions/highland_dimension.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/REGION_SETTINGS.md", "line": 29 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "region_settings_river",
+      "registrations": [
+        {
+          "registration_order": 123,
+          "type": "region_settings_river",
+          "handler_kind": "direct_function",
+          "handler_symbol": "region_settings_river::load_region_settings_river",
+          "handler_expression": "&region_settings_river::load_region_settings_river",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 426, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 4,
+        "examples": [ { "path": "data/json/region_settings/region_settings/regional_map_settings.json", "pointer": "/1" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/REGION_SETTINGS.md", "line": 26 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "region_settings_terrain_furniture",
+      "registrations": [
+        {
+          "registration_order": 131,
+          "type": "region_settings_terrain_furniture",
+          "handler_kind": "direct_function",
+          "handler_symbol": "region_settings_terrain_furniture::load_region_settings_terrain_furniture",
+          "handler_expression": "&region_settings_terrain_furniture::load_region_settings_terrain_furniture",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 436, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 9,
+        "examples": [ { "path": "data/json/region_settings/region_settings/dimensions/highland_dimension.json", "pointer": "/1" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/REGION_SETTINGS.md", "line": 36 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "region_terrain_furniture",
+      "registrations": [
+        {
+          "registration_order": 132,
+          "type": "region_terrain_furniture",
+          "handler_kind": "direct_function",
+          "handler_symbol": "region_terrain_furniture::load_region_terrain_furniture",
+          "handler_expression": "&region_terrain_furniture::load_region_terrain_furniture",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 438, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 156,
+        "examples": [ { "path": "data/json/region_settings/region_settings/dimensions/highland_dimension.json", "pointer": "/3" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/REGION_SETTINGS.md", "line": 77 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "relic_procgen_data",
+      "registrations": [
+        {
+          "registration_order": 11,
+          "type": "relic_procgen_data",
+          "handler_kind": "direct_function",
+          "handler_symbol": "relic_procgen_data::load_relic_procgen_data",
+          "handler_expression": "&relic_procgen_data::load_relic_procgen_data",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 285, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 35,
+        "examples": [ { "path": "data/json/artifact/relic_procgen_data.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/ARTIFACTS.md", "line": 37 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "requirement",
+      "registrations": [
+        {
+          "registration_order": 78,
+          "type": "requirement",
+          "handler_kind": "lambda",
+          "handler_symbol": "requirement_data::load_requirement",
+          "handler_expression": "[]( const JsonObject & jo ) { requirement_data::load_requirement( jo, string_id<requirement_data>::NULL_ID(), true ); }",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 366, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 757,
+        "examples": [ { "path": "data/json/recipes/basecamps/components.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/BASECAMP.md", "line": 257 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "rotatable_symbol",
+      "registrations": [
+        {
+          "registration_order": 163,
+          "type": "rotatable_symbol",
+          "handler_kind": "direct_function",
+          "handler_symbol": "rotatable_symbols::load",
+          "handler_expression": "&rotatable_symbols::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 494, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 24,
+        "examples": [ { "path": "data/json/rotatable_symbols.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "scenario",
+      "registrations": [
+        {
+          "registration_order": 53,
+          "type": "scenario",
+          "handler_kind": "direct_function",
+          "handler_symbol": "scenario::load_scenario",
+          "handler_expression": "&scenario::load_scenario",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 327, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 204,
+        "examples": [ { "path": "data/json/obsoletion_and_migration_0.I/blacklist_scenarios.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 2690 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "scent_type",
+      "registrations": [
+        {
+          "registration_order": 60,
+          "type": "scent_type",
+          "handler_kind": "direct_function",
+          "handler_symbol": "scent_type::load_scent_type",
+          "handler_expression": "&scent_type::load_scent_type",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 334, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 7,
+        "examples": [ { "path": "data/json/scent_types.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 2216 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "score",
+      "registrations": [
+        {
+          "registration_order": 178,
+          "type": "score",
+          "handler_kind": "direct_function",
+          "handler_symbol": "score::load_score",
+          "handler_expression": "&score::load_score",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 509, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 42,
+        "examples": [ { "path": "data/json/scores.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECTS_JSON.md", "line": 33 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "shopkeeper_blacklist",
+      "registrations": [
+        {
+          "registration_order": 55,
+          "type": "shopkeeper_blacklist",
+          "handler_kind": "direct_function",
+          "handler_symbol": "shopkeeper_blacklist::load_blacklist",
+          "handler_expression": "&shopkeeper_blacklist::load_blacklist",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 329, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 5,
+        "examples": [ { "path": "data/json/npcs/exodii/exodii_merchant_definitions.json", "pointer": "/3" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 75 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "shopkeeper_consumption_rates",
+      "registrations": [
+        {
+          "registration_order": 57,
+          "type": "shopkeeper_consumption_rates",
+          "handler_kind": "direct_function",
+          "handler_symbol": "shopkeeper_cons_rates::load_rate",
+          "handler_expression": "&shopkeeper_cons_rates::load_rate",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 331, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 5,
+        "examples": [ { "path": "data/json/npcs/campus/NPC_Elvira_Fish.json", "pointer": "/3" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 71 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "shopkeeper_whitelist",
+      "registrations": [
+        {
+          "registration_order": 56,
+          "type": "shopkeeper_whitelist",
+          "handler_kind": "direct_function",
+          "handler_symbol": "shopkeeper_whitelist::load_whitelist",
+          "handler_expression": "&shopkeeper_whitelist::load_whitelist",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 330, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 7,
+        "examples": [ { "path": "data/mods/Magiclysm/npc/TALK_FORGE_ALCHEMIST.json", "pointer": "/8" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/NPCs.md", "line": 89 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "skill",
+      "registrations": [
+        {
+          "registration_order": 38,
+          "type": "skill",
+          "handler_kind": "direct_function",
+          "handler_symbol": "Skill::load_skill",
+          "handler_expression": "&Skill::load_skill",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 312, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 37,
+        "examples": [ { "path": "data/json/skills.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/BASECAMP.md", "line": 38 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "skill_display_type",
+      "registrations": [
+        {
+          "registration_order": 39,
+          "type": "skill_display_type",
+          "handler_kind": "direct_function",
+          "handler_symbol": "SkillDisplayType::load",
+          "handler_expression": "&SkillDisplayType::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 313, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 4,
+        "examples": [ { "path": "data/json/skillDisplayType.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "snippet",
+      "registrations": [
+        {
+          "registration_order": 64,
+          "type": "snippet",
+          "handler_kind": "lambda",
+          "handler_symbol": "load_snippet",
+          "handler_expression": "[]( const JsonObject & jo, const std::string & src ) { SNIPPET.load_snippet( jo, src ); }",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 341, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 902,
+        "examples": [ { "path": "data/core/tips.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4307 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "sound_effect",
+      "registrations": [
+        {
+          "registration_order": 152,
+          "type": "sound_effect",
+          "handler_kind": "direct_function",
+          "handler_symbol": "sfx::load_sound_effects",
+          "handler_expression": "&sfx::load_sound_effects",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 478, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 2,
+        "examples": [ { "path": "data/sound/Menu_Sound_Test/soundset.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1899 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "sound_effect_preload",
+      "registrations": [
+        {
+          "registration_order": 153,
+          "type": "sound_effect_preload",
+          "handler_kind": "direct_function",
+          "handler_symbol": "sfx::load_sound_effect_preload",
+          "handler_expression": "&sfx::load_sound_effect_preload",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 479, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": { "occurrences": 0, "examples": [  ], "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ] },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "speech",
+      "registrations": [
+        {
+          "registration_order": 50,
+          "type": "speech",
+          "handler_kind": "direct_function",
+          "handler_symbol": "load_speech",
+          "handler_expression": "&load_speech",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 324, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 964,
+        "examples": [ { "path": "data/json/speech.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3911 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "speed_description",
+      "registrations": [
+        {
+          "registration_order": 36,
+          "type": "speed_description",
+          "handler_kind": "direct_function",
+          "handler_symbol": "speed_description::load_speed_descriptions",
+          "handler_expression": "&speed_description::load_speed_descriptions",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 310, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 3,
+        "examples": [ { "path": "data/json/speed_descriptions.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 2583 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "spell_migration",
+      "registrations": [
+        {
+          "registration_order": 172,
+          "type": "spell_migration",
+          "handler_kind": "direct_function",
+          "handler_symbol": "spell_migration::load",
+          "handler_expression": "&spell_migration::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 503, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": { "occurrences": 0, "examples": [  ], "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ] },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/OBSOLETION_AND_MIGRATION.md", "line": 187 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "start_location",
+      "registrations": [
+        {
+          "registration_order": 52,
+          "type": "start_location",
+          "handler_kind": "direct_function",
+          "handler_symbol": "start_locations::load",
+          "handler_expression": "&start_locations::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 326, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 152,
+        "examples": [ { "path": "data/json/start_locations.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 4295 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "sub_body_part",
+      "registrations": [
+        {
+          "registration_order": 167,
+          "type": "sub_body_part",
+          "handler_kind": "direct_function",
+          "handler_symbol": "sub_body_part_type::load_bp",
+          "handler_expression": "&sub_body_part_type::load_bp",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 498, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 569,
+        "examples": [ { "path": "data/core/sentinels.json", "pointer": "/2" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 1026 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "talk_topic",
+      "registrations": [
+        {
+          "registration_order": 149,
+          "type": "talk_topic",
+          "handler_kind": "direct_function",
+          "handler_symbol": "load_talk_topic",
+          "handler_expression": "&load_talk_topic",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 473, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 4649,
+        "examples": [ { "path": "data/json/effects_on_condition/mapgen_eocs/furniture_eocs.json", "pointer": "/1" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 4258 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "technique",
+      "registrations": [
+        {
+          "registration_order": 99,
+          "type": "technique",
+          "handler_kind": "direct_function",
+          "handler_symbol": "load_technique",
+          "handler_expression": "&load_technique",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 401, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 343,
+        "examples": [ { "path": "data/json/martialarts_fictional.json", "pointer": "/7" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 1769 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "temperature_removal_blacklist",
+      "registrations": [
+        {
+          "registration_order": 85,
+          "type": "temperature_removal_blacklist",
+          "handler_kind": "callable",
+          "handler_symbol": "load_temperature_removal_blacklist",
+          "handler_expression": "load_temperature_removal_blacklist",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 380, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/obsoletion_and_migration_0.I/blacklist_temperature_removal.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/OBSOLETION_AND_MIGRATION.md", "line": 79 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "ter_furn_migration",
+      "registrations": [
+        {
+          "registration_order": 46,
+          "type": "ter_furn_migration",
+          "handler_kind": "direct_function",
+          "handler_symbol": "ter_furn_migrations::load",
+          "handler_expression": "&ter_furn_migrations::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 320, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 16,
+        "examples": [ { "path": "data/json/obsoletion_and_migration_0.I/migration_terrain.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/OBSOLETION_AND_MIGRATION.md", "line": 211 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "ter_furn_transform",
+      "registrations": [
+        {
+          "registration_order": 175,
+          "type": "ter_furn_transform",
+          "handler_kind": "direct_function",
+          "handler_symbol": "ter_furn_transform::load_transform",
+          "handler_expression": "&ter_furn_transform::load_transform",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 506, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 182,
+        "examples": [ { "path": "data/json/effects_on_condition/mutation_eocs/mutation_sleep_eocs.json", "pointer": "/1" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 5506 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "terrain",
+      "registrations": [
+        {
+          "registration_order": 45,
+          "type": "terrain",
+          "handler_kind": "direct_function",
+          "handler_symbol": "load_terrain",
+          "handler_expression": "&load_terrain",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 319, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 1602,
+        "examples": [ { "path": "data/json/furniture_and_terrain/LIXA_furniture_and_terrain.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/BASECAMP.md", "line": 259 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "test_data",
+      "registrations": [
+        {
+          "registration_order": 86,
+          "type": "test_data",
+          "handler_kind": "direct_function",
+          "handler_symbol": "test_data::load",
+          "handler_expression": "&test_data::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 381, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 47,
+        "examples": [ { "path": "data/mods/TEST_DATA/container_spawn_test.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "tool_quality",
+      "registrations": [
+        {
+          "registration_order": 98,
+          "type": "tool_quality",
+          "handler_kind": "direct_function",
+          "handler_symbol": "quality::load_static",
+          "handler_expression": "&quality::load_static",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 400, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 104,
+        "examples": [ { "path": "data/json/tool_qualities.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/ITEM.md", "line": 1370 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "trait_group",
+      "registrations": [
+        {
+          "registration_order": 66,
+          "type": "trait_group",
+          "handler_kind": "lambda",
+          "handler_symbol": "mutation_branch::load_trait_group",
+          "handler_expression": "[]( const JsonObject & jo ) { mutation_branch::load_trait_group( jo ); }",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 347, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 426,
+        "examples": [ { "path": "data/json/npcs/BG_trait_groups.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "trap",
+      "registrations": [
+        {
+          "registration_order": 79,
+          "type": "trap",
+          "handler_kind": "direct_function",
+          "handler_symbol": "trap::load_trap",
+          "handler_expression": "&trap::load_trap",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 369, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 179,
+        "examples": [ { "path": "data/core/sentinels.json", "pointer": "/4" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 71 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "trap_migration",
+      "registrations": [
+        {
+          "registration_order": 80,
+          "type": "trap_migration",
+          "handler_kind": "direct_function",
+          "handler_symbol": "trap_migrations::load",
+          "handler_expression": "&trap_migrations::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 370, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 1,
+        "examples": [ { "path": "data/json/obsoletion_and_migration_0.I/obsolete_traps.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/OBSOLETION_AND_MIGRATION.md", "line": 257 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "uncraft",
+      "registrations": [
+        {
+          "registration_order": 94,
+          "type": "uncraft",
+          "handler_kind": "direct_function",
+          "handler_symbol": "recipe_dictionary::load_uncraft",
+          "handler_expression": "&recipe_dictionary::load_uncraft",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 395, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 1607,
+        "examples": [ { "path": "data/json/recipes/armor/mutant_clothing.json", "pointer": "/1" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/ITEM_CRAFT_AND_DISASSEMBLY.md", "line": 15 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "var_migration",
+      "registrations": [
+        {
+          "registration_order": 5,
+          "type": "var_migration",
+          "handler_kind": "direct_function",
+          "handler_symbol": "global_variables::load_migrations",
+          "handler_expression": "&global_variables::load_migrations",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 279, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 2,
+        "examples": [ { "path": "data/json/npcs/exodii/exodii_merchant_missions.json", "pointer": "/17" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/OBSOLETION_AND_MIGRATION.md", "line": 352 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "vehicle",
+      "registrations": [
+        {
+          "registration_order": 72,
+          "type": "vehicle",
+          "handler_kind": "direct_function",
+          "handler_symbol": "vehicles::load_prototype",
+          "handler_expression": "&vehicles::load_prototype",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 358, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 374,
+        "examples": [ { "path": "data/json/debug/teleportation.json", "pointer": "/3" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/CLIMBING.md", "line": 53 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "vehicle_color_palette",
+      "registrations": [
+        {
+          "registration_order": 76,
+          "type": "vehicle_color_palette",
+          "handler_kind": "direct_function",
+          "handler_symbol": "VehiclePalette::load",
+          "handler_expression": "&VehiclePalette::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 363, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 20,
+        "examples": [ { "path": "data/json/vehicle_palette.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "vehicle_group",
+      "registrations": [
+        {
+          "registration_order": 73,
+          "type": "vehicle_group",
+          "handler_kind": "direct_function",
+          "handler_symbol": "VehicleGroup::load",
+          "handler_expression": "&VehicleGroup::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 359, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 108,
+        "examples": [ { "path": "data/json/mapgen/animalshelter.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 3039 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "vehicle_part",
+      "registrations": [
+        {
+          "registration_order": 68,
+          "type": "vehicle_part",
+          "handler_kind": "direct_function",
+          "handler_symbol": "vehicles::parts::load",
+          "handler_expression": "&vehicles::parts::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 354, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 592,
+        "examples": [ { "path": "data/json/debug/teleportation.json", "pointer": "/2" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 258 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "vehicle_part_category",
+      "registrations": [
+        {
+          "registration_order": 69,
+          "type": "vehicle_part_category",
+          "handler_kind": "direct_function",
+          "handler_symbol": "vpart_category::load_all",
+          "handler_expression": "&vpart_category::load_all",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 355, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 12,
+        "examples": [ { "path": "data/json/vehicleparts/vp_categories.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "vehicle_part_location",
+      "registrations": [
+        {
+          "registration_order": 70,
+          "type": "vehicle_part_location",
+          "handler_kind": "direct_function",
+          "handler_symbol": "vpart_location::load_vehicle_part_locations",
+          "handler_expression": "&vpart_location::load_vehicle_part_locations",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 356, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 21,
+        "examples": [ { "path": "data/core/sentinels.json", "pointer": "/9" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 2988 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "vehicle_part_migration",
+      "registrations": [
+        {
+          "registration_order": 71,
+          "type": "vehicle_part_migration",
+          "handler_kind": "direct_function",
+          "handler_symbol": "vpart_migration::load",
+          "handler_expression": "&vpart_migration::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 357, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 9,
+        "examples": [ { "path": "data/json/obsoletion_and_migration_0.I/migrated_vehicleparts.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/OBSOLETION_AND_MIGRATION.md", "line": 89 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "vehicle_placement",
+      "registrations": [
+        {
+          "registration_order": 74,
+          "type": "vehicle_placement",
+          "handler_kind": "direct_function",
+          "handler_symbol": "VehiclePlacement::load",
+          "handler_expression": "&VehiclePlacement::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 360, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 7,
+        "examples": [ { "path": "data/json/road_vehicles.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 3040 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "vehicle_spawn",
+      "registrations": [
+        {
+          "registration_order": 75,
+          "type": "vehicle_spawn",
+          "handler_kind": "direct_function",
+          "handler_symbol": "VehicleSpawn::load",
+          "handler_expression": "&VehicleSpawn::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 361, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 5,
+        "examples": [ { "path": "data/json/road_vehicles.json", "pointer": "/2" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 3034 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "vitamin",
+      "registrations": [
+        {
+          "registration_order": 24,
+          "type": "vitamin",
+          "handler_kind": "direct_function",
+          "handler_symbol": "vitamins::load",
+          "handler_expression": "&vitamins::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 298, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 128,
+        "examples": [ { "path": "data/json/obsoletion_and_migration_0.I/migration_mutation.json", "pointer": "/1" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECTS_JSON.md", "line": 31 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "weakpoint_set",
+      "registrations": [
+        {
+          "registration_order": 182,
+          "type": "weakpoint_set",
+          "handler_kind": "direct_function",
+          "handler_symbol": "weakpoints::load_weakpoint_sets",
+          "handler_expression": "&weakpoints::load_weakpoint_sets",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 513, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 85,
+        "examples": [ { "path": "data/json/monster_weakpoints/abomination_weakpoints.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 3074 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "weapon_category",
+      "registrations": [
+        {
+          "registration_order": 100,
+          "type": "weapon_category",
+          "handler_kind": "direct_function",
+          "handler_symbol": "weapon_category::load_weapon_categories",
+          "handler_expression": "&weapon_category::load_weapon_categories",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 402, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 34,
+        "examples": [ { "path": "data/json/weapon_categories.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/ITEM.md", "line": 147 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "weather_generator",
+      "registrations": [
+        {
+          "registration_order": 16,
+          "type": "weather_generator",
+          "handler_kind": "direct_function",
+          "handler_symbol": "weather_generator::load_weather_generator",
+          "handler_expression": "&weather_generator::load_weather_generator",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 290, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 22,
+        "examples": [ { "path": "data/json/region_settings/region_settings/dimensions/highland_dimension.json", "pointer": "/4" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/REGION_SETTINGS.md", "line": 37 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "weather_type",
+      "registrations": [
+        {
+          "registration_order": 15,
+          "type": "weather_type",
+          "handler_kind": "direct_function",
+          "handler_symbol": "weather_types::load",
+          "handler_expression": "&weather_types::load",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 289, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 49,
+        "examples": [ { "path": "data/core/weather.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/JSON_INFO.md", "line": 4600 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "widget",
+      "registrations": [
+        {
+          "registration_order": 181,
+          "type": "widget",
+          "handler_kind": "direct_function",
+          "handler_symbol": "widget::load_widget",
+          "handler_expression": "&widget::load_widget",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 512, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": {
+        "occurrences": 1469,
+        "examples": [ { "path": "data/json/ui/activity.json", "pointer": "/0" } ],
+        "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ]
+      },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": { "status": "not_found", "evidence": [  ], "confidence": "lexical_only" },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "wound",
+      "registrations": [
+        {
+          "registration_order": 185,
+          "type": "wound",
+          "handler_kind": "direct_function",
+          "handler_symbol": "wound_type::load_wounds",
+          "handler_expression": "&wound_type::load_wounds",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 516, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": { "occurrences": 0, "examples": [  ], "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ] },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/EFFECT_ON_CONDITION.md", "line": 3228 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    },
+    {
+      "type": "wound_fix",
+      "registrations": [
+        {
+          "registration_order": 186,
+          "type": "wound_fix",
+          "handler_kind": "direct_function",
+          "handler_symbol": "wound_fix::load_wound_fixes",
+          "handler_expression": "&wound_fix::load_wound_fixes",
+          "compile_context": [  ],
+          "source": { "path": "src/init.cpp", "line": 517, "symbol": "DynamicDataLoader::initialize" }
+        }
+      ],
+      "compile_conditional_variants": false,
+      "instance_evidence": { "occurrences": 0, "examples": [  ], "contract_roots": [ "data/core", "data/json", "data/mods", "data/sound" ] },
+      "schema": { "status": "none", "paths": [  ], "note": "No general validator-backed Schema exists for this object type." },
+      "documentation": {
+        "status": "lexically_mentioned",
+        "evidence": [ { "path": "doc/JSON/WOUNDS.md", "line": 3 } ],
+        "confidence": "lexical_only"
+      },
+      "field_contract": {
+        "status": "unclassified",
+        "required_fields": [  ],
+        "optional_fields": [  ],
+        "inheritance": "unknown",
+        "copy_from": "unknown",
+        "validation": "unknown",
+        "note": "No field contract is inferred from instance frequency. Only mandatory()/optional() or validator-backed evidence may classify it."
+      },
+      "contract_status": "partial"
+    }
+  ]
+}

--- a/tools/json_api/README.md
+++ b/tools/json_api/README.md
@@ -1,0 +1,60 @@
+# JSON and EOC contract inventories
+
+`generate_contracts.py` creates three checked, machine-readable snapshots:
+
+- `data/reference/json/ccb_json_object_types.json`
+- `data/reference/json/ccb_eoc_conditions.json`
+- `data/reference/json/ccb_eoc_effects.json`
+
+The current snapshots cover all 191 `DynamicDataLoader` registration calls
+(190 unique types), all 275 detected public condition keys, and all 306
+detected public effect keys.  CI pins these counts until the source registries
+change intentionally.  These are parser-registry coverage figures, not a
+claim that every handler's field contract has been classified.
+
+The output directory is outside `data/json/`, so the game data loader does not
+mistake reference metadata for runtime content.  Discovery is restricted to
+tracked paths returned by `git ls-files`; the generator never walks a checkout
+or build cache.
+
+Run the generator after changing `DynamicDataLoader` registrations, EOC parser
+tables, or tracked JSON examples:
+
+```sh
+python3 tools/json_api/generate_contracts.py
+make -j2 tools/format/json_formatter.cgi RELEASE=1
+tools/format/json_formatter.cgi data/reference/json/ccb_json_object_types.json
+tools/format/json_formatter.cgi data/reference/json/ccb_eoc_conditions.json
+tools/format/json_formatter.cgi data/reference/json/ccb_eoc_effects.json
+python3 tools/json_api/generate_contracts.py --check
+python3 -m unittest discover -s tools/json_api -p 'test_*.py'
+```
+
+`--check` compares parsed JSON so the repository formatter remains the single
+authority for whitespace.  The JSON style workflow separately rejects a
+non-canonical layout.  The tests validate the inventory Schema, hard coverage
+counts, source symbols and line numbers, documentation evidence, and every
+published example JSON Pointer.
+
+## Confidence boundaries
+
+The inventories separate facts directly proven by source from incomplete
+classification:
+
+- loader registrations and parser order come from their C++ registries;
+- source evidence includes a tracked path, line, and symbol;
+- data examples include a tracked path and JSON Pointer;
+- `mandatory()` and `optional()` are accepted as field-requiredness evidence;
+- occurrence counts never establish requiredness;
+- lexical examples and documentation mentions are labelled lexical-only;
+- handler parameters, defaults, talkers, variables, and contexts remain
+  `unclassified` until reviewed source evidence can prove them;
+- `u_` and `npc_` names are only legacy alpha/beta aliases and do not prove a
+  concrete runtime talker type;
+- no complete general JSON or EOC Schema is claimed.
+
+`contract-inventory.schema.json` describes the generated inventory format.  It
+is not a Schema for game JSON and must never be presented as one.
+
+Generated snapshots must not be edited by hand.  Extend the extractor or add
+source-adjacent, non-behavioural metadata when a contract can be proven.

--- a/tools/json_api/contract-inventory.schema.json
+++ b/tools/json_api/contract-inventory.schema.json
@@ -1,0 +1,1005 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docs.crimsoncrossbunker.org/schemas/contract-inventory-v1.json",
+  "title": "CCB JSON and EOC contract inventory",
+  "type": "object",
+  "required": [
+    "$schema",
+    "schema_version",
+    "inventory_kind",
+    "source",
+    "summary",
+    "entries"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "minLength": 1
+    },
+    "schema_version": {
+      "const": 1
+    },
+    "inventory_kind": {
+      "enum": [
+        "json_object_types",
+        "eoc_conditions",
+        "eoc_effects"
+      ]
+    },
+    "source": {
+      "$ref": "#/$defs/source"
+    },
+    "summary": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "type": "integer",
+            "minimum": 0
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true
+          }
+        ]
+      }
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "global_contract": {
+      "$ref": "#/$defs/eoc_global_contract"
+    },
+    "entries": {
+      "type": "array",
+      "minItems": 1
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "inventory_kind": {
+            "const": "json_object_types"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "policy"
+        ],
+        "properties": {
+          "entries": {
+            "items": {
+              "$ref": "#/$defs/json_entry"
+            }
+          }
+        }
+      },
+      "else": {
+        "required": [
+          "global_contract"
+        ],
+        "properties": {
+          "entries": {
+            "items": {
+              "$ref": "#/$defs/eoc_entry"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "additionalProperties": false,
+  "$defs": {
+    "source": {
+      "type": "object",
+      "required": [
+        "project",
+        "source_fingerprint",
+        "contract_roots",
+        "discovery"
+      ],
+      "properties": {
+        "project": {
+          "const": "Cataclysm-Cleanwater-Bomb"
+        },
+        "source_fingerprint": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "contract_roots": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^data/"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "discovery": {
+          "const": "git ls-files"
+        },
+        "registrations": {
+          "type": "string",
+          "minLength": 1
+        },
+        "parser": {
+          "type": "string",
+          "minLength": 1
+        },
+        "variable_parser": {
+          "type": "string",
+          "minLength": 1
+        },
+        "object_parser": {
+          "type": "string",
+          "minLength": 1
+        },
+        "string_parser": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "source_reference": {
+      "type": "object",
+      "required": [
+        "path",
+        "line",
+        "symbol"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "pattern": "^src/"
+        },
+        "line": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "symbol": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "eoc_global_contract": {
+      "type": "object",
+      "required": [
+        "parser_order",
+        "variable_scopes",
+        "value_helpers"
+      ],
+      "properties": {
+        "parser_order": {
+          "const": "first matching parser wins"
+        },
+        "unknown_object_condition": {
+          "type": "string",
+          "minLength": 1
+        },
+        "unknown_string_condition": {
+          "type": "string",
+          "minLength": 1
+        },
+        "accepted_effect_container_shapes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "unknown_effect": {
+          "type": "string",
+          "minLength": 1
+        },
+        "variable_scopes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "value_helpers": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "unknown_object_condition",
+            "unknown_string_condition"
+          ]
+        },
+        {
+          "required": [
+            "accepted_effect_container_shapes",
+            "unknown_effect"
+          ]
+        }
+      ],
+      "additionalProperties": false
+    },
+    "data_reference": {
+      "type": "object",
+      "required": [
+        "path",
+        "pointer"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "pattern": "^data/"
+        },
+        "pointer": {
+          "type": "string",
+          "pattern": "^(?:$|/)"
+        }
+      },
+      "additionalProperties": false
+    },
+    "documentation": {
+      "type": "object",
+      "required": [
+        "status",
+        "evidence",
+        "confidence"
+      ],
+      "properties": {
+        "status": {
+          "enum": [
+            "lexically_mentioned",
+            "not_found"
+          ]
+        },
+        "evidence": {
+          "type": "array",
+          "maxItems": 1,
+          "items": {
+            "type": "object",
+            "required": [
+              "path",
+              "line"
+            ],
+            "properties": {
+              "path": {
+                "type": "string",
+                "pattern": "^doc/JSON/"
+              },
+              "line": {
+                "type": "integer",
+                "minimum": 1
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "confidence": {
+          "const": "lexical_only"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "not_found"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "maxItems": 0
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "evidence": {
+                "minItems": 1,
+                "maxItems": 1
+              }
+            }
+          }
+        }
+      ],
+      "additionalProperties": false
+    },
+    "json_entry": {
+      "type": "object",
+      "required": [
+        "type",
+        "registrations",
+        "compile_conditional_variants",
+        "instance_evidence",
+        "schema",
+        "documentation",
+        "field_contract",
+        "contract_status"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "registrations": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": [
+              "registration_order",
+              "type",
+              "handler_kind",
+              "handler_symbol",
+              "handler_expression",
+              "compile_context",
+              "source"
+            ],
+            "properties": {
+              "registration_order": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "type": {
+                "type": "string",
+                "minLength": 1
+              },
+              "handler_kind": {
+                "enum": [
+                  "direct_function",
+                  "lambda",
+                  "callable"
+                ]
+              },
+              "handler_symbol": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "handler_expression": {
+                "type": "string",
+                "minLength": 1
+              },
+              "compile_context": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "uniqueItems": true
+              },
+              "source": {
+                "$ref": "#/$defs/source_reference"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "compile_conditional_variants": {
+          "type": "boolean"
+        },
+        "instance_evidence": {
+          "type": "object",
+          "required": [
+            "occurrences",
+            "examples",
+            "contract_roots"
+          ],
+          "properties": {
+            "occurrences": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "examples": {
+              "type": "array",
+              "maxItems": 1,
+              "items": {
+                "$ref": "#/$defs/data_reference"
+              }
+            },
+            "contract_roots": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^data/"
+              },
+              "minItems": 1,
+              "uniqueItems": true
+            }
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "occurrences": {
+                    "const": 0
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "examples": {
+                    "maxItems": 0
+                  }
+                }
+              },
+              "else": {
+                "properties": {
+                  "examples": {
+                    "minItems": 1,
+                    "maxItems": 1
+                  }
+                }
+              }
+            }
+          ],
+          "additionalProperties": false
+        },
+        "schema": {
+          "type": "object",
+          "required": [
+            "status",
+            "paths",
+            "note"
+          ],
+          "properties": {
+            "status": {
+              "enum": [
+                "none",
+                "partial",
+                "complete"
+              ]
+            },
+            "paths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "uniqueItems": true
+            },
+            "note": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "status": {
+                    "const": "none"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "paths": {
+                    "maxItems": 0
+                  }
+                }
+              },
+              "else": {
+                "properties": {
+                  "paths": {
+                    "minItems": 1
+                  }
+                }
+              }
+            }
+          ],
+          "additionalProperties": false
+        },
+        "documentation": {
+          "$ref": "#/$defs/documentation"
+        },
+        "field_contract": {
+          "$ref": "#/$defs/field_contract"
+        },
+        "contract_status": {
+          "enum": [
+            "partial",
+            "complete"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "field_evidence": {
+      "type": "object",
+      "required": [
+        "name",
+        "required",
+        "requiredness_evidence",
+        "default_expression",
+        "source"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "requiredness_evidence": {
+          "enum": [
+            "mandatory",
+            "optional",
+            "guarded_or_loader_optional_path"
+          ]
+        },
+        "default_expression": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source": {
+          "$ref": "#/$defs/source_reference"
+        }
+      },
+      "additionalProperties": false
+    },
+    "field_contract": {
+      "type": "object",
+      "required": [
+        "status",
+        "inheritance",
+        "copy_from",
+        "validation",
+        "note"
+      ],
+      "properties": {
+        "status": {
+          "enum": [
+            "unclassified",
+            "partial",
+            "complete"
+          ]
+        },
+        "required_fields": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "optional_fields": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "fields": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/field_evidence"
+          }
+        },
+        "inheritance": {
+          "type": "string",
+          "minLength": 1
+        },
+        "copy_from": {
+          "type": "string",
+          "minLength": 1
+        },
+        "validation": {
+          "type": "string",
+          "minLength": 1
+        },
+        "note": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "unclassified"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "required_fields",
+              "optional_fields"
+            ]
+          },
+          "else": {
+            "required": [
+              "fields"
+            ]
+          }
+        }
+      ],
+      "additionalProperties": false
+    },
+    "classification_block": {
+      "type": "object",
+      "required": [
+        "status",
+        "items"
+      ],
+      "properties": {
+        "status": {
+          "enum": [
+            "unclassified",
+            "partial",
+            "complete",
+            "not_applicable"
+          ]
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object"
+              }
+            ]
+          }
+        },
+        "note": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "variable_contract": {
+      "type": "object",
+      "required": [
+        "status",
+        "scopes",
+        "known_global_scopes"
+      ],
+      "properties": {
+        "status": {
+          "enum": [
+            "unclassified",
+            "partial",
+            "complete",
+            "not_applicable"
+          ]
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "known_global_scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "note": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "context_contract": {
+      "type": "object",
+      "required": [
+        "status",
+        "requirements"
+      ],
+      "properties": {
+        "status": {
+          "enum": [
+            "unclassified",
+            "partial",
+            "complete",
+            "not_applicable"
+          ]
+        },
+        "requirements": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "note": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "eoc_entry": {
+      "type": "object",
+      "required": [
+        "key",
+        "syntaxes",
+        "accepted_json_shapes",
+        "handlers",
+        "aliases",
+        "parser_registrations",
+        "parameters",
+        "value_types",
+        "defaults",
+        "nesting",
+        "talker_semantics",
+        "variables",
+        "context",
+        "contract_status",
+        "contract_kind",
+        "example_evidence",
+        "documentation"
+      ],
+      "properties": {
+        "key": {
+          "type": "string",
+          "minLength": 1
+        },
+        "syntaxes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "accepted_json_shapes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "handlers": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "aliases": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "parser_registrations": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": [
+              "registration_order",
+              "alias_role",
+              "alias_group",
+              "source"
+            ],
+            "properties": {
+              "registration_order": {
+                "type": "integer",
+                "minimum": -1
+              },
+              "alias_role": {
+                "enum": [
+                  "alpha",
+                  "beta",
+                  "special"
+                ]
+              },
+              "alias_group": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "registration_kind": {
+                "enum": [
+                  "static_map",
+                  "explicit_branch"
+                ]
+              },
+              "source": {
+                "$ref": "#/$defs/source_reference"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "parameters": {
+          "$ref": "#/$defs/classification_block"
+        },
+        "value_types": {
+          "$ref": "#/$defs/classification_block"
+        },
+        "defaults": {
+          "$ref": "#/$defs/classification_block"
+        },
+        "nesting": {
+          "type": "object",
+          "required": [
+            "status",
+            "allows"
+          ],
+          "properties": {
+            "status": {
+              "enum": [
+                "unclassified",
+                "partial",
+                "complete",
+                "not_applicable"
+              ]
+            },
+            "allows": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "uniqueItems": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "talker_semantics": {
+          "type": "object",
+          "required": [
+            "status",
+            "talkers",
+            "note"
+          ],
+          "properties": {
+            "status": {
+              "enum": [
+                "unknown",
+                "legacy_alpha_beta_alias",
+                "partial",
+                "complete"
+              ]
+            },
+            "talkers": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "uniqueItems": true
+            },
+            "note": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "additionalProperties": false
+        },
+        "variables": {
+          "$ref": "#/$defs/variable_contract"
+        },
+        "context": {
+          "$ref": "#/$defs/context_contract"
+        },
+        "contract_status": {
+          "enum": [
+            "partial",
+            "complete"
+          ]
+        },
+        "contract_kind": {
+          "enum": [
+            "condition",
+            "effect"
+          ]
+        },
+        "example_evidence": {
+          "type": "object",
+          "required": [
+            "status",
+            "occurrences",
+            "examples",
+            "confidence",
+            "note"
+          ],
+          "properties": {
+            "status": {
+              "enum": [
+                "lexical_candidate",
+                "not_found"
+              ]
+            },
+            "occurrences": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "examples": {
+              "type": "array",
+              "maxItems": 1,
+              "items": {
+                "$ref": "#/$defs/data_reference"
+              }
+            },
+            "confidence": {
+              "const": "lexical_only"
+            },
+            "note": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "status": {
+                    "const": "not_found"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "occurrences": {
+                    "const": 0
+                  },
+                  "examples": {
+                    "maxItems": 0
+                  }
+                }
+              },
+              "else": {
+                "properties": {
+                  "occurrences": {
+                    "minimum": 1
+                  },
+                  "examples": {
+                    "minItems": 1,
+                    "maxItems": 1
+                  }
+                }
+              }
+            }
+          ],
+          "additionalProperties": false
+        },
+        "documentation": {
+          "$ref": "#/$defs/documentation"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/tools/json_api/generate_contracts.py
+++ b/tools/json_api/generate_contracts.py
@@ -42,3 +42,32 @@ VALUE_HELPERS = (
     "translation_or_var",
     "eoc_math",
 )
+
+def git_tracked_files(root: Path, *pathspecs: str) -> list[str]:
+    """Return tracked paths without walking the checkout."""
+    completed = subprocess.run(
+        ["git", "ls-files", "-z", "--", *pathspecs],
+        cwd=root,
+        check=True,
+        capture_output=True,
+    )
+    return sorted(
+        item.decode("utf-8")
+        for item in completed.stdout.split(b"\0")
+        if item
+    )
+
+def read_text(root: Path, relative_path: str) -> str:
+    return (root / relative_path).read_text(encoding="utf-8")
+
+def line_number(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+def source_reference(
+    path: str, text: str, offset: int, symbol: str
+) -> dict[str, object]:
+    return {
+        "path": path,
+        "line": line_number(text, offset),
+        "symbol": symbol,
+    }

--- a/tools/json_api/generate_contracts.py
+++ b/tools/json_api/generate_contracts.py
@@ -503,3 +503,163 @@ def aggregate_parser_entries(
             }
         )
     return result
+
+def add_logical_conditions(
+    entries: list[dict[str, object]], condition_contents: str
+) -> None:
+    by_key = {str(entry["key"]): entry for entry in entries}
+    specifications = {
+        "and": ("array", ["condition_object", "condition_string"]),
+        "or": ("array", ["condition_object", "condition_string"]),
+        "not": ("object_or_string", ["condition_object", "condition_string"]),
+    }
+    for key, (shape, nesting) in specifications.items():
+        member_kind = "array" if key != "not" else "object"
+        needle = f'jo.has_{member_kind}( "{key}" )'
+        offset = condition_contents.find(needle)
+        if offset < 0:
+            raise RuntimeError(
+                f"logical condition parser was not found: {key}")
+        by_key[key] = {
+            "key": key,
+            "syntaxes": ["logical_operator"],
+            "accepted_json_shapes": [shape],
+            "handlers": ["conditional_t::conditional_t"],
+            "aliases": [key],
+            "parser_registrations": [
+                {
+                    "registration_order": -1,
+                    "alias_role": "special",
+                    "alias_group": [key],
+                    "source": source_reference(
+                        "src/condition.cpp",
+                        condition_contents,
+                        offset,
+                        "conditional_t::conditional_t",
+                    ),
+                }
+            ],
+            "parameters": {"status": "complete", "items": []},
+            "value_types": {"status": "complete", "items": [shape]},
+            "defaults": {"status": "complete", "items": []},
+            "nesting": {"status": "complete", "allows": nesting},
+            "talker_semantics": legacy_alias_note([key]),
+            "variables": {
+                "status": "not_applicable",
+                "scopes": [],
+                "known_global_scopes": list(VARIABLE_SCOPES),
+            },
+            "context": {"status": "complete", "requirements": []},
+            "contract_status": "complete",
+            "contract_kind": "condition",
+        }
+    entries[:] = [by_key[key] for key in sorted(by_key)]
+
+def walk_json(
+        value: object, pointer: str = "") -> Iterable[tuple[object, str]]:
+    yield value, pointer
+    if isinstance(value, dict):
+        for key, child in value.items():
+            escaped = str(key).replace("~", "~0").replace("/", "~1")
+            yield from walk_json(child, f"{pointer}/{escaped}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            yield from walk_json(child, f"{pointer}/{index}")
+
+def tracked_json_scan(
+    root: Path, condition_keys: set[str], effect_keys: set[str]
+) -> dict[str, object]:
+    paths = [
+        path
+        for path in git_tracked_files(root, *CONTRACT_ROOTS)
+        if path.endswith(".json")
+    ]
+    type_counts: collections.Counter[str] = collections.Counter()
+    type_examples: dict[str, dict[str, str]] = {}
+    condition_counts: collections.Counter[str] = collections.Counter()
+    condition_examples: dict[str, dict[str, str]] = {}
+    effect_counts: collections.Counter[str] = collections.Counter()
+    effect_examples: dict[str, dict[str, str]] = {}
+    missing_type = 0
+    top_level_objects = 0
+    for path in paths:
+        try:
+            payload = json.loads(read_text(root, path))
+        except (OSError, UnicodeError, json.JSONDecodeError) as error:
+            raise RuntimeError(
+                f"tracked JSON cannot be parsed: {path}: {error}") from error
+        top_level = payload if isinstance(payload, list) else [payload]
+        for index, item in enumerate(top_level):
+            if not isinstance(item, dict):
+                continue
+            top_level_objects += 1
+            pointer = f"/{index}" if isinstance(payload, list) else ""
+            object_type = item.get("type")
+            if isinstance(object_type, str):
+                type_counts[object_type] += 1
+                type_examples.setdefault(
+                    object_type, {
+                        "path": path, "pointer": pointer})
+            else:
+                missing_type += 1
+        for item, pointer in walk_json(payload):
+            if isinstance(item, dict):
+                for key in item:
+                    if key in condition_keys:
+                        condition_counts[key] += 1
+                        condition_examples.setdefault(
+                            key, {"path": path, "pointer": f"{pointer}/{key}"}
+                        )
+                    if key in effect_keys:
+                        effect_counts[key] += 1
+                        effect_examples.setdefault(
+                            key, {"path": path, "pointer": f"{pointer}/{key}"}
+                        )
+            elif isinstance(item, str):
+                if item in condition_keys:
+                    condition_counts[item] += 1
+                    condition_examples.setdefault(
+                        item, {"path": path, "pointer": pointer})
+                if item in effect_keys:
+                    effect_counts[item] += 1
+                    effect_examples.setdefault(
+                        item, {"path": path, "pointer": pointer})
+    return {
+        "tracked_json_files": len(paths),
+        "top_level_objects": top_level_objects,
+        "top_level_objects_without_string_type": missing_type,
+        "type_counts": type_counts,
+        "type_examples": type_examples,
+        "condition_counts": condition_counts,
+        "condition_examples": condition_examples,
+        "effect_counts": effect_counts,
+        "effect_examples": effect_examples,
+        "paths": paths,
+    }
+
+def lexical_documentation(
+    root: Path, keys: Iterable[str]
+) -> dict[str, dict[str, object]]:
+    paths = [path for path in git_tracked_files(
+        root, "doc/JSON") if path.endswith(".md")]
+    contents = {path: read_text(root, path) for path in paths}
+    result: dict[str, dict[str, object]] = {}
+    for key in keys:
+        evidence: dict[str, object] | None = None
+        pattern = re.compile(
+            rf"(?<![A-Za-z0-9_]){re.escape(key)}(?![A-Za-z0-9_])")
+        for path in paths:
+            match = pattern.search(contents[path])
+            if match:
+                evidence = {
+                    "path": path,
+                    "line": line_number(
+                        contents[path],
+                        match.start())}
+                break
+        result[key] = {
+            "status": "lexically_mentioned" if evidence else "not_found",
+            "evidence": [evidence] if evidence else [],
+            "confidence": "lexical_only",
+        }
+    return result

--- a/tools/json_api/generate_contracts.py
+++ b/tools/json_api/generate_contracts.py
@@ -400,3 +400,106 @@ def parse_string_effects(contents: str) -> list[dict[str, object]]:
             }
         )
     return registrations
+
+def legacy_alias_note(aliases: list[str]) -> dict[str, object]:
+    if not any(item.startswith(("u_", "npc_")) for item in aliases):
+        return {
+            "status": "unknown",
+            "talkers": [],
+            "note": (
+                "Concrete talker compatibility is not inferred from the "
+                "parser key."
+            ),
+        }
+    return {
+        "status": "legacy_alpha_beta_alias",
+        "talkers": [],
+        "note": (
+            "u_/npc_ identifies alpha/beta legacy routing; it does not prove "
+            "that either talker is a concrete avatar or NPC."
+        ),
+    }
+
+def aggregate_parser_entries(
+    registrations: list[dict[str, object]], contract_kind: str
+) -> list[dict[str, object]]:
+    aggregate: dict[str, dict[str, object]] = {}
+    for registration in registrations:
+        keys = registration["keys"]
+        if not isinstance(keys, list):
+            raise RuntimeError("parser registration keys are invalid")
+        for alias_index, key_value in enumerate(keys):
+            key = str(key_value)
+            entry = aggregate.setdefault(
+                key,
+                {
+                    "syntaxes": set(),
+                    "accepted_json_shapes": set(),
+                    "handlers": set(),
+                    "parser_registrations": [],
+                    "alias_groups": set(),
+                },
+            )
+            entry["syntaxes"].add(registration["syntax"])
+            entry["accepted_json_shapes"].update(
+                registration["accepted_json_shapes"])
+            if registration.get("handler"):
+                entry["handlers"].add(registration["handler"])
+            alias_tuple = tuple(str(item) for item in keys)
+            entry["alias_groups"].add(alias_tuple)
+            detail = {
+                "registration_order": registration["registration_order"],
+                "alias_role": "alpha" if alias_index == 0 else "beta",
+                "alias_group": list(alias_tuple),
+                "source": registration["source"],
+            }
+            if "registration_kind" in registration:
+                detail["registration_kind"] = registration["registration_kind"]
+            entry["parser_registrations"].append(detail)
+
+    result: list[dict[str, object]] = []
+    for key in sorted(aggregate):
+        raw = aggregate[key]
+        alias_groups = sorted(raw["alias_groups"])
+        aliases = sorted({item for group in alias_groups for item in group})
+        result.append(
+            {
+                "key": key,
+                "syntaxes": sorted(raw["syntaxes"]),
+                "accepted_json_shapes": sorted(raw["accepted_json_shapes"]),
+                "handlers": sorted(raw["handlers"]),
+                "aliases": aliases,
+                "parser_registrations": sorted(
+                    raw["parser_registrations"],
+                    key=lambda item: (
+                        int(item["registration_order"]),
+                        str(item["alias_role"]),
+                    ),
+                ),
+                "parameters": {
+                    "status": "unclassified",
+                    "items": [],
+                    "note": (
+                        "Handler-specific members require source-backed "
+                        "review."
+                    ),
+                },
+                "value_types": {
+                    "status": "partial",
+                    "items": sorted(raw["accepted_json_shapes"]),
+                    "note": "Only parser dispatch shapes are proven here.",
+                },
+                "defaults": {"status": "unclassified", "items": []},
+                "nesting": {"status": "unclassified", "allows": []},
+                "talker_semantics": legacy_alias_note(aliases),
+                "variables": {
+                    "status": "unclassified",
+                    "scopes": [],
+                    "known_global_scopes": list(VARIABLE_SCOPES),
+                },
+                "context": {"status": "unclassified", "requirements": []},
+                "contract_status": "partial",
+                "contract_kind": contract_kind,
+            }
+        )
+    return result

--- a/tools/json_api/generate_contracts.py
+++ b/tools/json_api/generate_contracts.py
@@ -250,3 +250,153 @@ def parse_json_registrations(contents: str) -> list[dict[str, object]]:
     if not registrations:
         raise RuntimeError("no DynamicDataLoader registrations were found")
     return registrations
+
+def initializer_entries(
+    contents: str, marker: str, source_path: str
+) -> list[tuple[str, int]]:
+    marker_offset = contents.find(marker)
+    if marker_offset < 0:
+        raise RuntimeError(
+            f"initializer marker not found in {source_path}: {
+                marker!r}")
+    opening = contents.find("{", marker_offset + len(marker))
+    closing = find_matching(contents, opening, "{", "}")
+    body = contents[opening + 1: closing]
+    masked = mask_comments(body)
+    entries: list[tuple[str, int]] = []
+    depth = 0
+    entry_start: int | None = None
+    quote: str | None = None
+    escaped = False
+    for index, char in enumerate(masked):
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            continue
+        if char in {'"', "'"}:
+            quote = char
+        elif char == "{":
+            if depth == 0:
+                entry_start = index
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth < 0:
+                raise RuntimeError(f"malformed initializer in {source_path}")
+            if depth == 0 and entry_start is not None:
+                absolute = opening + 1 + entry_start
+                entries.append((body[entry_start: index + 1], absolute))
+                entry_start = None
+    if depth or not entries:
+        raise RuntimeError(f"empty or malformed initializer in {source_path}")
+    residue = mask_comments(body)
+    for raw, absolute in reversed(entries):
+        relative = absolute - opening - 1
+        residue = residue[:relative] + " " * \
+            len(raw) + residue[relative + len(raw):]
+    if residue.replace(",", "").strip():
+        raise RuntimeError(f"unparsed initializer content in {source_path}")
+    return entries
+
+def parse_parser_vector(
+    contents: str,
+    marker: str,
+    source_path: str,
+    syntax: str,
+    order_offset: int = 0,
+    source_symbol: str | None = None,
+) -> list[dict[str, object]]:
+    parsed: list[dict[str, object]] = []
+    for local_order, (raw, offset) in enumerate(
+        initializer_entries(contents, marker, source_path)
+    ):
+        strings = re.findall(r'"(?:\\.|[^"\\])*"', raw)
+        keys = [json.loads(item) for item in strings]
+        handler = re.search(r"&\s*([A-Za-z_][A-Za-z0-9_:]*)", raw)
+        shapes = re.findall(r"jarg::([a-z_]+)", raw)
+        if not 1 <= len(keys) <= 2 or handler is None:
+            raise RuntimeError(
+                f"unrecognized parser registration at {source_path}:"
+                f"{line_number(contents, offset)}"
+            )
+        if syntax == "object_member" and not shapes:
+            raise RuntimeError(
+                f"parser registration lacks jarg shape at {source_path}:"
+                f"{line_number(contents, offset)}"
+            )
+        if syntax == "condition_string" and shapes:
+            raise RuntimeError(
+                f"simple parser unexpectedly has jarg shape at {source_path}:"
+                f"{line_number(contents, offset)}"
+            )
+        parsed.append(
+            {
+                "registration_order": order_offset +
+                local_order,
+                "keys": keys,
+                "syntax": syntax,
+                "accepted_json_shapes": shapes or ["condition_string"],
+                "handler": handler.group(1),
+                "source": source_reference(
+                    source_path,
+                    contents,
+                    offset,
+                    source_symbol or (
+                        "parsers_simple"
+                        if syntax == "condition_string"
+                        else "parsers"
+                    ),
+                ),
+            })
+    return parsed
+
+def function_body(contents: str, signature: str) -> tuple[str, int]:
+    start = contents.find(signature)
+    if start < 0:
+        raise RuntimeError(f"function not found: {signature}")
+    opening = contents.find("{", start + len(signature))
+    closing = find_matching(contents, opening, "{", "}")
+    return contents[opening + 1: closing], opening + 1
+
+def parse_string_effects(contents: str) -> list[dict[str, object]]:
+    body, base = function_body(
+        contents, "void talk_effect_t::parse_string_effect")
+    matches: list[tuple[int, str, str | None, str]] = []
+    for match in re.finditer(
+        r"\bWRAP\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)",
+            body):
+        key = match.group(1)
+        if key != "function":
+            matches.append(
+                (match.start(), key, f"talk_function::{key}", "static_map"))
+    for match in re.finditer(r'effect_id\s*==\s*"([^"]+)"', body):
+        matches.append(
+            (match.start(),
+             match.group(1),
+             None,
+             "explicit_branch"))
+    if not matches:
+        raise RuntimeError("no string effects were found")
+    registrations: list[dict[str, object]] = []
+    for order, (offset, key, handler, kind) in enumerate(sorted(matches)):
+        registrations.append(
+            {
+                "registration_order": order,
+                "keys": [key],
+                "syntax": "effect_string",
+                "accepted_json_shapes": ["effect_string"],
+                "handler": handler,
+                "registration_kind": kind,
+                "source": source_reference(
+                    "src/npctalk.cpp",
+                    contents,
+                    base + offset,
+                    "talk_effect_t::parse_string_effect",
+                ),
+            }
+        )
+    return registrations

--- a/tools/json_api/generate_contracts.py
+++ b/tools/json_api/generate_contracts.py
@@ -20,19 +20,14 @@ from typing import Iterable
 
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
-
 DEFAULT_OUTPUT_DIRECTORY = REPOSITORY_ROOT / "data/reference/json"
-
 OUTPUT_NAMES = {
     "json_object_types": "ccb_json_object_types.json",
     "eoc_conditions": "ccb_eoc_conditions.json",
     "eoc_effects": "ccb_eoc_effects.json",
 }
-
 CONTRACT_ROOTS = ("data/core", "data/json", "data/mods", "data/sound")
-
 VARIABLE_SCOPES = ("u_val", "npc_val", "global_val", "var_val", "context_val")
-
 VALUE_HELPERS = (
     "value_or_var",
     "value_or_var_pair",
@@ -42,6 +37,7 @@ VALUE_HELPERS = (
     "translation_or_var",
     "eoc_math",
 )
+
 
 def git_tracked_files(root: Path, *pathspecs: str) -> list[str]:
     """Return tracked paths without walking the checkout."""
@@ -57,11 +53,14 @@ def git_tracked_files(root: Path, *pathspecs: str) -> list[str]:
         if item
     )
 
+
 def read_text(root: Path, relative_path: str) -> str:
     return (root / relative_path).read_text(encoding="utf-8")
 
+
 def line_number(text: str, offset: int) -> int:
     return text.count("\n", 0, offset) + 1
+
 
 def source_reference(
     path: str, text: str, offset: int, symbol: str
@@ -71,6 +70,7 @@ def source_reference(
         "line": line_number(text, offset),
         "symbol": symbol,
     }
+
 
 def mask_comments(text: str) -> str:
     """Replace C++ comments with spaces while retaining offsets and strings."""
@@ -114,6 +114,7 @@ def mask_comments(text: str) -> str:
         index += 1
     return "".join(result)
 
+
 def find_matching(text: str, opening: int, left: str, right: str) -> int:
     """Find a balanced delimiter while ignoring strings and comments."""
     masked = mask_comments(text)
@@ -140,6 +141,7 @@ def find_matching(text: str, opening: int, left: str, right: str) -> int:
                 return index
     raise RuntimeError(f"unbalanced {left}{right} delimiters")
 
+
 def split_first_argument(call: str) -> tuple[str, str]:
     depth = 0
     quote: str | None = None
@@ -162,6 +164,7 @@ def split_first_argument(call: str) -> tuple[str, str]:
         elif char == "," and depth == 0:
             return call[:index].strip(), call[index + 1:].strip()
     raise RuntimeError("registration call has no handler argument")
+
 
 def preprocessor_contexts(text: str) -> dict[int, list[str]]:
     contexts: dict[int, list[str]] = {}
@@ -192,6 +195,7 @@ def preprocessor_contexts(text: str) -> dict[int, list[str]]:
         raise RuntimeError("unterminated preprocessor conditional")
     return contexts
 
+
 def handler_metadata(expression: str) -> tuple[str, str | None]:
     normalized = re.sub(r"\s+", " ", expression).strip()
     direct = re.match(r"&\s*([A-Za-z_][A-Za-z0-9_:]*)", normalized)
@@ -204,6 +208,7 @@ def handler_metadata(expression: str) -> tuple[str, str | None]:
             (item for item in called if item not in ignored), None)
     callable_match = re.match(r"([A-Za-z_][A-Za-z0-9_:]*)", normalized)
     return "callable", callable_match.group(1) if callable_match else None
+
 
 def parse_json_registrations(contents: str) -> list[dict[str, object]]:
     signature = "void DynamicDataLoader::initialize()"
@@ -250,6 +255,7 @@ def parse_json_registrations(contents: str) -> list[dict[str, object]]:
     if not registrations:
         raise RuntimeError("no DynamicDataLoader registrations were found")
     return registrations
+
 
 def initializer_entries(
     contents: str, marker: str, source_path: str
@@ -301,6 +307,7 @@ def initializer_entries(
     if residue.replace(",", "").strip():
         raise RuntimeError(f"unparsed initializer content in {source_path}")
     return entries
+
 
 def parse_parser_vector(
     contents: str,
@@ -354,6 +361,7 @@ def parse_parser_vector(
             })
     return parsed
 
+
 def function_body(contents: str, signature: str) -> tuple[str, int]:
     start = contents.find(signature)
     if start < 0:
@@ -361,6 +369,7 @@ def function_body(contents: str, signature: str) -> tuple[str, int]:
     opening = contents.find("{", start + len(signature))
     closing = find_matching(contents, opening, "{", "}")
     return contents[opening + 1: closing], opening + 1
+
 
 def parse_string_effects(contents: str) -> list[dict[str, object]]:
     body, base = function_body(
@@ -401,6 +410,7 @@ def parse_string_effects(contents: str) -> list[dict[str, object]]:
         )
     return registrations
 
+
 def legacy_alias_note(aliases: list[str]) -> dict[str, object]:
     if not any(item.startswith(("u_", "npc_")) for item in aliases):
         return {
@@ -419,6 +429,7 @@ def legacy_alias_note(aliases: list[str]) -> dict[str, object]:
             "that either talker is a concrete avatar or NPC."
         ),
     }
+
 
 def aggregate_parser_entries(
     registrations: list[dict[str, object]], contract_kind: str
@@ -504,6 +515,7 @@ def aggregate_parser_entries(
         )
     return result
 
+
 def add_logical_conditions(
     entries: list[dict[str, object]], condition_contents: str
 ) -> None:
@@ -555,6 +567,7 @@ def add_logical_conditions(
         }
     entries[:] = [by_key[key] for key in sorted(by_key)]
 
+
 def walk_json(
         value: object, pointer: str = "") -> Iterable[tuple[object, str]]:
     yield value, pointer
@@ -565,6 +578,7 @@ def walk_json(
     elif isinstance(value, list):
         for index, child in enumerate(value):
             yield from walk_json(child, f"{pointer}/{index}")
+
 
 def tracked_json_scan(
     root: Path, condition_keys: set[str], effect_keys: set[str]
@@ -637,6 +651,7 @@ def tracked_json_scan(
         "paths": paths,
     }
 
+
 def lexical_documentation(
     root: Path, keys: Iterable[str]
 ) -> dict[str, dict[str, object]]:
@@ -664,6 +679,7 @@ def lexical_documentation(
         }
     return result
 
+
 def attach_examples_and_docs(
     entries: list[dict[str, object]],
     counts: collections.Counter[str],
@@ -684,6 +700,7 @@ def attach_examples_and_docs(
             ),
         }
         entry["documentation"] = documentation[key]
+
 
 def extract_eoc_base_fields(contents: str) -> list[dict[str, object]]:
     body, base = function_body(contents, "void effect_on_condition::load")
@@ -731,6 +748,7 @@ def extract_eoc_base_fields(contents: str) -> list[dict[str, object]]:
             }
     return [results[key] for key in sorted(results)]
 
+
 def source_fingerprint(root: Path, paths: Iterable[str]) -> str:
     digest = hashlib.sha256()
     for path in sorted(set(paths)):
@@ -739,6 +757,7 @@ def source_fingerprint(root: Path, paths: Iterable[str]) -> str:
         digest.update((root / path).read_bytes())
         digest.update(b"\0")
     return f"sha256:{digest.hexdigest()}"
+
 
 def build_contracts(
         root: Path = REPOSITORY_ROOT) -> dict[str, dict[str, object]]:
@@ -983,6 +1002,7 @@ def build_contracts(
     validate_contracts(payloads, root)
     return payloads
 
+
 def resolve_json_pointer(value: object, pointer: str) -> object:
     """Resolve an RFC 6901 pointer and fail closed on malformed evidence."""
     if pointer == "":
@@ -1004,6 +1024,7 @@ def resolve_json_pointer(value: object, pointer: str) -> object:
         else:
             raise RuntimeError(f"unresolved JSON Pointer: {pointer!r}")
     return current
+
 
 def validate_source_reference(
     evidence: object,
@@ -1037,6 +1058,7 @@ def validate_source_reference(
         raise RuntimeError(
             f"source evidence token is stale: {path}:{line}: {token}"
         )
+
 
 def validate_data_reference(
     evidence: object,
@@ -1075,6 +1097,7 @@ def validate_data_reference(
             f"EOC example does not resolve to {key}: {path}#{pointer}"
         )
 
+
 def validate_documentation_reference(
     documentation: object,
     key: str,
@@ -1112,6 +1135,7 @@ def validate_documentation_reference(
         raise RuntimeError(
             f"documentation evidence is stale: {path}:{line}: {key}"
         )
+
 
 def validate_summary(payload: dict[str, object], kind: str) -> None:
     entries = payload["entries"]
@@ -1192,6 +1216,7 @@ def validate_summary(payload: dict[str, object], kind: str) -> None:
     for key, value in expected.items():
         if summary.get(key) != value:
             raise RuntimeError(f"stale {kind} summary field: {key}")
+
 
 def validate_contracts(
     payloads: dict[str, dict[str, object]], root: Path = REPOSITORY_ROOT
@@ -1291,8 +1316,10 @@ def validate_contracts(
                 root,
             )
 
+
 def serialize(payload: dict[str, object]) -> str:
     return json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+
 
 def write_or_check(
     payloads: dict[str, dict[str, object]], output_directory: Path, check: bool
@@ -1311,6 +1338,7 @@ def write_or_check(
             path.parent.mkdir(parents=True, exist_ok=True)
             path.write_text(serialize(payloads[kind]), encoding="utf-8")
     return stale
+
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
@@ -1345,3 +1373,7 @@ def main() -> int:
     for kind, payload in payloads.items():
         print(f"{kind}: {len(payload['entries'])} entries")
     return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/json_api/generate_contracts.py
+++ b/tools/json_api/generate_contracts.py
@@ -982,3 +982,58 @@ def build_contracts(
     }
     validate_contracts(payloads, root)
     return payloads
+
+def resolve_json_pointer(value: object, pointer: str) -> object:
+    """Resolve an RFC 6901 pointer and fail closed on malformed evidence."""
+    if pointer == "":
+        return value
+    if not pointer.startswith("/"):
+        raise RuntimeError(f"invalid JSON Pointer: {pointer!r}")
+    current = value
+    for raw_token in pointer[1:].split("/"):
+        token = raw_token.replace("~1", "/").replace("~0", "~")
+        if isinstance(current, list):
+            try:
+                current = current[int(token)]
+            except (ValueError, IndexError) as error:
+                raise RuntimeError(
+                    f"unresolved JSON Pointer: {pointer!r}"
+                ) from error
+        elif isinstance(current, dict) and token in current:
+            current = current[token]
+        else:
+            raise RuntimeError(f"unresolved JSON Pointer: {pointer!r}")
+    return current
+
+def validate_source_reference(
+    evidence: object,
+    token: str,
+    tracked_sources: set[str],
+    source_cache: dict[str, str],
+    root: Path,
+) -> None:
+    if not isinstance(evidence, dict):
+        raise RuntimeError(f"invalid source evidence: {evidence!r}")
+    path = evidence.get("path")
+    line = evidence.get("line")
+    symbol = evidence.get("symbol")
+    valid = (isinstance(path, str) and
+             isinstance(line, int) and
+             isinstance(symbol, str) and
+             path in tracked_sources)
+    if not valid:
+        raise RuntimeError(f"invalid source evidence: {evidence!r}")
+    if path not in source_cache:
+        source_cache[path] = read_text(root, path)
+    contents = source_cache[path]
+    lines = contents.splitlines()
+    if line < 1 or line > len(lines):
+        raise RuntimeError(f"source evidence line is stale: {path}:{line}")
+    if symbol not in contents:
+        raise RuntimeError(
+            f"source evidence symbol is stale: {path}#{symbol}"
+        )
+    if token not in lines[line - 1]:
+        raise RuntimeError(
+            f"source evidence token is stale: {path}:{line}: {token}"
+        )

--- a/tools/json_api/generate_contracts.py
+++ b/tools/json_api/generate_contracts.py
@@ -1037,3 +1037,78 @@ def validate_source_reference(
         raise RuntimeError(
             f"source evidence token is stale: {path}:{line}: {token}"
         )
+
+def validate_data_reference(
+    evidence: object,
+    key: str,
+    contract_kind: str,
+    tracked_data: set[str],
+    data_cache: dict[str, object],
+    root: Path,
+) -> None:
+    if not isinstance(evidence, dict):
+        raise RuntimeError(f"invalid data evidence: {evidence!r}")
+    path = evidence.get("path")
+    pointer = evidence.get("pointer")
+    valid = (isinstance(path, str) and
+             isinstance(pointer, str) and
+             path in tracked_data)
+    if not valid:
+        raise RuntimeError(f"invalid data evidence: {evidence!r}")
+    if path not in data_cache:
+        data_cache[path] = json.loads(read_text(root, path))
+    value = resolve_json_pointer(data_cache[path], pointer)
+    if contract_kind == "json_object_types":
+        if not isinstance(value, dict) or value.get("type") != key:
+            raise RuntimeError(
+                f"JSON type example does not resolve to {key}: "
+                f"{path}#{pointer}"
+            )
+        return
+    pointer_token = (
+        pointer.rsplit("/", 1)[-1].replace("~1", "/").replace("~0", "~")
+        if pointer
+        else ""
+    )
+    if pointer_token != key and value != key:
+        raise RuntimeError(
+            f"EOC example does not resolve to {key}: {path}#{pointer}"
+        )
+
+def validate_documentation_reference(
+    documentation: object,
+    key: str,
+    tracked_docs: set[str],
+    documentation_cache: dict[str, str],
+    root: Path,
+) -> None:
+    if not isinstance(documentation, dict):
+        raise RuntimeError(f"invalid documentation evidence for {key}")
+    status = documentation.get("status")
+    evidence = documentation.get("evidence")
+    if not isinstance(evidence, list):
+        raise RuntimeError(f"invalid documentation evidence for {key}")
+    if status == "not_found":
+        if evidence:
+            raise RuntimeError(f"unexpected documentation evidence for {key}")
+        return
+    if status != "lexically_mentioned" or len(evidence) != 1:
+        raise RuntimeError(f"invalid documentation status for {key}")
+    reference = evidence[0]
+    if not isinstance(reference, dict):
+        raise RuntimeError(f"invalid documentation evidence for {key}")
+    path = reference.get("path")
+    line = reference.get("line")
+    valid = (isinstance(path, str) and
+             isinstance(line, int) and
+             path in tracked_docs)
+    if not valid:
+        raise RuntimeError(f"invalid documentation evidence for {key}")
+    if path not in documentation_cache:
+        documentation_cache[path] = read_text(root, path)
+    contents = documentation_cache[path]
+    lines = contents.splitlines()
+    if line < 1 or line > len(lines) or key not in lines[line - 1]:
+        raise RuntimeError(
+            f"documentation evidence is stale: {path}:{line}: {key}"
+        )

--- a/tools/json_api/generate_contracts.py
+++ b/tools/json_api/generate_contracts.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Generate deterministic, source-backed JSON and EOC contract inventories.
+
+Only tracked files returned by ``git ls-files`` are considered.  The extractor
+records unknown details instead of inferring required fields or semantics from
+data frequency.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+DEFAULT_OUTPUT_DIRECTORY = REPOSITORY_ROOT / "data/reference/json"
+
+OUTPUT_NAMES = {
+    "json_object_types": "ccb_json_object_types.json",
+    "eoc_conditions": "ccb_eoc_conditions.json",
+    "eoc_effects": "ccb_eoc_effects.json",
+}
+
+CONTRACT_ROOTS = ("data/core", "data/json", "data/mods", "data/sound")
+
+VARIABLE_SCOPES = ("u_val", "npc_val", "global_val", "var_val", "context_val")
+
+VALUE_HELPERS = (
+    "value_or_var",
+    "value_or_var_pair",
+    "dbl_or_var",
+    "duration_or_var",
+    "str_or_var",
+    "translation_or_var",
+    "eoc_math",
+)

--- a/tools/json_api/generate_contracts.py
+++ b/tools/json_api/generate_contracts.py
@@ -663,3 +663,322 @@ def lexical_documentation(
             "confidence": "lexical_only",
         }
     return result
+
+def attach_examples_and_docs(
+    entries: list[dict[str, object]],
+    counts: collections.Counter[str],
+    examples: dict[str, dict[str, str]],
+    documentation: dict[str, dict[str, object]],
+) -> None:
+    for entry in entries:
+        key = str(entry["key"])
+        evidence = examples.get(key)
+        entry["example_evidence"] = {
+            "status": "lexical_candidate" if evidence else "not_found",
+            "occurrences": counts[key],
+            "examples": [evidence] if evidence else [],
+            "confidence": "lexical_only",
+            "note": (
+                "A lexical match is evidence of use, not proof that the full "
+                "surrounding object is a minimal valid example."
+            ),
+        }
+        entry["documentation"] = documentation[key]
+
+def extract_eoc_base_fields(contents: str) -> list[dict[str, object]]:
+    body, base = function_body(contents, "void effect_on_condition::load")
+    results: dict[str, dict[str, object]] = {}
+    pattern = re.compile(
+        r"\b(mandatory|optional)\s*\(\s*jo\s*,\s*was_loaded\s*,\s*"
+        r'"([^"]+)"(?P<tail>[^;]*)\);'
+    )
+    for match in pattern.finditer(body):
+        kind, field = match.group(1), match.group(2)
+        arguments = [part.strip() for part in match.group(
+            "tail").split(",") if part.strip()]
+        default_expression = arguments[-1] if kind == "optional" and len(
+            arguments) > 1 else None
+        results[field] = {
+            "name": field,
+            "required": kind == "mandatory",
+            "requiredness_evidence": kind,
+            "default_expression": default_expression,
+            "source": source_reference(
+                "src/effect_on_condition.cpp",
+                contents,
+                base + match.start(),
+                "effect_on_condition::load",
+            ),
+        }
+    for field in (
+        "deactivate_condition",
+        "condition",
+        "effect",
+            "false_effect"):
+        match = re.search(re.escape(f'"{field}"'), body)
+        if match and field not in results:
+            results[field] = {
+                "name": field,
+                "required": False,
+                "requiredness_evidence": "guarded_or_loader_optional_path",
+                "default_expression": None,
+                "source": source_reference(
+                    "src/effect_on_condition.cpp",
+                    contents,
+                    base + match.start(),
+                    "effect_on_condition::load",
+                ),
+            }
+    return [results[key] for key in sorted(results)]
+
+def source_fingerprint(root: Path, paths: Iterable[str]) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(set(paths)):
+        digest.update(path.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update((root / path).read_bytes())
+        digest.update(b"\0")
+    return f"sha256:{digest.hexdigest()}"
+
+def build_contracts(
+        root: Path = REPOSITORY_ROOT) -> dict[str, dict[str, object]]:
+    init_cpp = read_text(root, "src/init.cpp")
+    condition_cpp = read_text(root, "src/condition.cpp")
+    npctalk_cpp = read_text(root, "src/npctalk.cpp")
+    eoc_cpp = read_text(root, "src/effect_on_condition.cpp")
+    registrations = parse_json_registrations(init_cpp)
+    grouped: dict[str, list[dict[str, object]]] = collections.defaultdict(list)
+    for registration in registrations:
+        grouped[str(registration["type"])].append(registration)
+
+    complex_conditions = parse_parser_vector(
+        condition_cpp,
+        "std::vector<condition_parser>\nparsers =",
+        "src/condition.cpp",
+        "object_member",
+        source_symbol="parsers",
+    )
+    simple_conditions = parse_parser_vector(
+        condition_cpp,
+        "std::vector<condition_parser>\nparsers_simple =",
+        "src/condition.cpp",
+        "condition_string",
+        order_offset=len(complex_conditions),
+        source_symbol="parsers_simple",
+    )
+    condition_entries = aggregate_parser_entries(
+        complex_conditions + simple_conditions, "condition"
+    )
+    add_logical_conditions(condition_entries, condition_cpp)
+    object_effects = parse_parser_vector(
+        npctalk_cpp,
+        "std::vector<sub_effect_parser>\nparsers =",
+        "src/npctalk.cpp",
+        "object_member",
+        source_symbol="parsers",
+    )
+    string_effects = parse_string_effects(npctalk_cpp)
+    for registration in string_effects:
+        registration["registration_order"] = len(object_effects) + int(
+            registration["registration_order"]
+        )
+    effect_entries = aggregate_parser_entries(
+        object_effects + string_effects, "effect")
+
+    condition_keys = {str(entry["key"]) for entry in condition_entries}
+    effect_keys = {str(entry["key"]) for entry in effect_entries}
+    scan = tracked_json_scan(root, condition_keys, effect_keys)
+    observed_types = set(scan["type_counts"])
+    registered_types = set(grouped)
+    unknown_observed = sorted(observed_types - registered_types)
+    if unknown_observed:
+        raise RuntimeError(
+            "top-level DynamicDataLoader types are not registered: " +
+            ", ".join(unknown_observed)
+        )
+
+    json_docs = lexical_documentation(root, registered_types)
+    condition_docs = lexical_documentation(root, condition_keys)
+    effect_docs = lexical_documentation(root, effect_keys)
+    eoc_fields = extract_eoc_base_fields(eoc_cpp)
+    json_entries: list[dict[str, object]] = []
+    for object_type in sorted(registered_types):
+        type_registrations = grouped[object_type]
+        evidence = scan["type_examples"].get(object_type)
+        field_contract: dict[str, object] = {
+            "status": "unclassified",
+            "required_fields": [],
+            "optional_fields": [],
+            "inheritance": "unknown",
+            "copy_from": "unknown",
+            "validation": "unknown",
+            "note": (
+                "No field contract is inferred from instance frequency. Only "
+                "mandatory()/optional() or validator-backed evidence may "
+                "classify it."
+            ),
+        }
+        if object_type == "effect_on_condition":
+            field_contract = {
+                "status": "partial",
+                "fields": eoc_fields,
+                "inheritance": "generic_factory_handle_inheritance",
+                "copy_from": "supported_by_generic_factory",
+                "validation": "partial",
+                "note": (
+                    "Only fields directly proven in "
+                    "effect_on_condition::load are listed."
+                ),
+            }
+        json_entries.append(
+            {
+                "type": object_type,
+                "registrations": type_registrations,
+                "compile_conditional_variants": len(type_registrations) > 1,
+                "instance_evidence": {
+                    "occurrences": scan["type_counts"][object_type],
+                    "examples": [evidence] if evidence else [],
+                    "contract_roots": list(CONTRACT_ROOTS),
+                },
+                "schema": {
+                    "status": "none",
+                    "paths": [],
+                    "note": (
+                        "No general validator-backed Schema exists for this "
+                        "object type."
+                    ),
+                },
+                "documentation": json_docs[object_type],
+                "field_contract": field_contract,
+                "contract_status": "partial",
+            })
+
+    attach_examples_and_docs(
+        condition_entries,
+        scan["condition_counts"],
+        scan["condition_examples"],
+        condition_docs,
+    )
+    attach_examples_and_docs(
+        effect_entries,
+        scan["effect_counts"],
+        scan["effect_examples"],
+        effect_docs,
+    )
+    input_paths = [
+        "src/init.cpp",
+        "src/condition.cpp",
+        "src/npctalk.cpp",
+        "src/effect_on_condition.cpp",
+        *scan["paths"],
+        *git_tracked_files(root, "doc/JSON"),
+    ]
+    fingerprint = source_fingerprint(root, input_paths)
+    common_source = {
+        "project": "Cataclysm-Cleanwater-Bomb",
+        "source_fingerprint": fingerprint,
+        "contract_roots": list(CONTRACT_ROOTS),
+        "discovery": "git ls-files",
+    }
+    json_payload = {
+        "$schema": "../../../tools/json_api/contract-inventory.schema.json",
+        "schema_version": 1,
+        "inventory_kind": "json_object_types",
+        "source": {
+            **common_source,
+            "registrations": "src/init.cpp#DynamicDataLoader::initialize",
+        },
+        "summary": {
+            "registration_calls": len(registrations),
+            "registered_types": len(registered_types),
+            "observed_types": len(observed_types),
+            "registered_and_observed": len(registered_types & observed_types),
+            "registered_not_observed": sorted(
+                registered_types - observed_types
+            ),
+            "observed_not_registered": unknown_observed,
+            "tracked_json_files": scan["tracked_json_files"],
+            "top_level_objects": scan["top_level_objects"],
+            "top_level_objects_without_string_type": scan[
+                "top_level_objects_without_string_type"
+            ],
+            "schema_complete_types": 0,
+        },
+        "policy": {
+            "requiredness": "explicit mandatory() or Schema evidence only",
+            "data_frequency": "evidence of use only; never requiredness",
+            "unknown_fields": "retained as unclassified",
+        },
+        "entries": json_entries,
+    }
+    condition_payload = {
+        "$schema": "../../../tools/json_api/contract-inventory.schema.json",
+        "schema_version": 1,
+        "inventory_kind": "eoc_conditions",
+        "source": {
+            **common_source,
+            "parser": "src/condition.cpp#conditional_t::conditional_t",
+            "variable_parser": "src/condition.cpp#var_info::_deserialize",
+        },
+        "summary": {
+            "complex_parser_registrations": len(complex_conditions),
+            "simple_parser_registrations": len(simple_conditions),
+            "public_keys": len(condition_entries),
+            "keys_with_example_candidates": sum(
+                bool(scan["condition_counts"][key]) for key in condition_keys
+            ),
+            "fully_classified_keys": sum(
+                entry["contract_status"] == "complete"
+                for entry in condition_entries
+            ),
+        },
+        "global_contract": {
+            "parser_order": "first matching parser wins",
+            "unknown_object_condition": "JsonError",
+            "unknown_string_condition": "predicate returning false",
+            "variable_scopes": list(VARIABLE_SCOPES),
+            "value_helpers": list(VALUE_HELPERS),
+        },
+        "entries": condition_entries,
+    }
+    effect_payload = {
+        "$schema": "../../../tools/json_api/contract-inventory.schema.json",
+        "schema_version": 1,
+        "inventory_kind": "eoc_effects",
+        "source": {
+            **common_source,
+            "object_parser": (
+                "src/npctalk.cpp#talk_effect_t::parse_sub_effect"
+            ),
+            "string_parser": (
+                "src/npctalk.cpp#talk_effect_t::parse_string_effect"
+            ),
+        },
+        "summary": {
+            "object_parser_registrations": len(object_effects),
+            "string_parser_registrations": len(string_effects),
+            "public_keys": len(effect_entries),
+            "keys_with_example_candidates": sum(
+                bool(scan["effect_counts"][key]) for key in effect_keys
+            ),
+            "fully_classified_keys": sum(
+                entry["contract_status"] == "complete"
+                for entry in effect_entries
+            ),
+        },
+        "global_contract": {
+            "parser_order": "first matching parser wins",
+            "accepted_effect_container_shapes": ["string", "object", "array"],
+            "unknown_effect": "JsonError",
+            "variable_scopes": list(VARIABLE_SCOPES),
+            "value_helpers": list(VALUE_HELPERS),
+        },
+        "entries": effect_entries,
+    }
+    payloads = {
+        "json_object_types": json_payload,
+        "eoc_conditions": condition_payload,
+        "eoc_effects": effect_payload,
+    }
+    validate_contracts(payloads, root)
+    return payloads

--- a/tools/json_api/generate_contracts.py
+++ b/tools/json_api/generate_contracts.py
@@ -71,3 +71,71 @@ def source_reference(
         "line": line_number(text, offset),
         "symbol": symbol,
     }
+
+def mask_comments(text: str) -> str:
+    """Replace C++ comments with spaces while retaining offsets and strings."""
+    result = list(text)
+    quote: str | None = None
+    escaped = False
+    index = 0
+    while index < len(text):
+        char = text[index]
+        following = text[index + 1] if index + 1 < len(text) else ""
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            index += 1
+            continue
+        if char in {'"', "'"}:
+            quote = char
+            index += 1
+            continue
+        if char == "/" and following == "/":
+            end = text.find("\n", index)
+            if end < 0:
+                end = len(text)
+            for position in range(index, end):
+                result[position] = " "
+            index = end
+            continue
+        if char == "/" and following == "*":
+            end = text.find("*/", index + 2)
+            if end < 0:
+                raise RuntimeError("unterminated C++ block comment")
+            for position in range(index, end + 2):
+                if result[position] != "\n":
+                    result[position] = " "
+            index = end + 2
+            continue
+        index += 1
+    return "".join(result)
+
+def find_matching(text: str, opening: int, left: str, right: str) -> int:
+    """Find a balanced delimiter while ignoring strings and comments."""
+    masked = mask_comments(text)
+    depth = 0
+    quote: str | None = None
+    escaped = False
+    for index in range(opening, len(masked)):
+        char = masked[index]
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            continue
+        if char in {'"', "'"}:
+            quote = char
+        elif char == left:
+            depth += 1
+        elif char == right:
+            depth -= 1
+            if depth == 0:
+                return index
+    raise RuntimeError(f"unbalanced {left}{right} delimiters")

--- a/tools/json_api/generate_contracts.py
+++ b/tools/json_api/generate_contracts.py
@@ -1112,3 +1112,181 @@ def validate_documentation_reference(
         raise RuntimeError(
             f"documentation evidence is stale: {path}:{line}: {key}"
         )
+
+def validate_summary(payload: dict[str, object], kind: str) -> None:
+    entries = payload["entries"]
+    summary = payload["summary"]
+    if not isinstance(entries, list) or not isinstance(summary, dict):
+        raise RuntimeError(f"invalid inventory structure: {kind}")
+    if kind == "json_object_types":
+        registration_count = sum(
+            len(entry["registrations"]) for entry in entries
+        )
+        observed = [
+            entry for entry in entries
+            if entry["instance_evidence"]["occurrences"] > 0
+        ]
+        expected = {
+            "registration_calls": registration_count,
+            "registered_types": len(entries),
+            "observed_types": len(observed),
+            "registered_and_observed": len(observed),
+            "registered_not_observed": sorted(
+                entry["type"] for entry in entries
+                if entry["instance_evidence"]["occurrences"] == 0
+            ),
+            "observed_not_registered": [],
+            "schema_complete_types": sum(
+                entry["schema"]["status"] == "complete"
+                for entry in entries
+            ),
+        }
+    else:
+        parser_registrations = {
+            (
+                registration["registration_order"],
+                tuple(registration["alias_group"]),
+                registration["source"]["path"],
+                registration["source"]["line"],
+                registration["source"]["symbol"],
+                registration.get("registration_kind"),
+            )
+            for entry in entries
+            for registration in entry["parser_registrations"]
+            if registration["registration_order"] >= 0
+        }
+        expected = {
+            "public_keys": len(entries),
+            "keys_with_example_candidates": sum(
+                entry["example_evidence"]["occurrences"] > 0
+                for entry in entries
+            ),
+            "fully_classified_keys": sum(
+                entry["contract_status"] == "complete"
+                for entry in entries
+            ),
+        }
+        if kind == "eoc_conditions":
+            expected.update({
+                "complex_parser_registrations": sum(
+                    registration[4] == "parsers"
+                    for registration in parser_registrations
+                ),
+                "simple_parser_registrations": sum(
+                    registration[4] == "parsers_simple"
+                    for registration in parser_registrations
+                ),
+            })
+        else:
+            expected.update({
+                "object_parser_registrations": sum(
+                    registration[4] == "parsers"
+                    for registration in parser_registrations
+                ),
+                "string_parser_registrations": sum(
+                    registration[4] ==
+                    "talk_effect_t::parse_string_effect"
+                    for registration in parser_registrations
+                ),
+            })
+    for key, value in expected.items():
+        if summary.get(key) != value:
+            raise RuntimeError(f"stale {kind} summary field: {key}")
+
+def validate_contracts(
+    payloads: dict[str, dict[str, object]], root: Path = REPOSITORY_ROOT
+) -> None:
+    if set(payloads) != set(OUTPUT_NAMES):
+        raise RuntimeError("contract payload set is incomplete")
+    tracked_sources = set(git_tracked_files(root, "src"))
+    tracked_data = {
+        path for path in git_tracked_files(root, *CONTRACT_ROOTS)
+        if path.endswith(".json")
+    }
+    tracked_docs = {
+        path for path in git_tracked_files(root, "doc/JSON")
+        if path.endswith(".md")
+    }
+    source_cache: dict[str, str] = {}
+    data_cache: dict[str, object] = {}
+    documentation_cache: dict[str, str] = {}
+    for kind, payload in payloads.items():
+        if payload.get("schema_version") != 1 or payload.get(
+                "inventory_kind") != kind:
+            raise RuntimeError(f"invalid inventory header: {kind}")
+        entries = payload.get("entries")
+        if not isinstance(entries, list) or not entries:
+            raise RuntimeError(f"inventory has no entries: {kind}")
+        key_name = "type" if kind == "json_object_types" else "key"
+        keys = [entry.get(key_name)
+                for entry in entries if isinstance(entry, dict)]
+        if len(keys) != len(entries) or keys != sorted(
+                keys) or len(keys) != len(set(keys)):
+            raise RuntimeError(
+                f"inventory keys are invalid or non-deterministic: {kind}")
+        validate_summary(payload, kind)
+        for entry in entries:
+            key = str(entry[key_name])
+            fields: list[dict[str, object]] = []
+            if kind == "json_object_types":
+                sources = [item["source"] for item in entry["registrations"]]
+                fields = entry["field_contract"].get("fields", [])
+                if entry["field_contract"]["status"] not in {
+                    "unclassified",
+                    "partial",
+                    "complete",
+                }:
+                    raise RuntimeError(f"invalid field status for {key}")
+                field_names = [field.get("name") for field in fields]
+                if field_names != sorted(field_names) or len(
+                        field_names) != len(set(field_names)):
+                    raise RuntimeError(
+                        f"field evidence is invalid or unsorted for {key}"
+                    )
+                for field in fields:
+                    required = field.get("required")
+                    requiredness = field.get("requiredness_evidence")
+                    if required != (requiredness == "mandatory"):
+                        raise RuntimeError(
+                            f"field requiredness evidence conflicts for "
+                            f"{key}.{field.get('name')}"
+                        )
+                examples = entry["instance_evidence"]["examples"]
+            else:
+                sources = [item["source"]
+                           for item in entry["parser_registrations"]]
+                if entry["contract_status"] not in {"partial", "complete"}:
+                    raise RuntimeError(f"invalid contract status for {key}")
+                examples = entry["example_evidence"]["examples"]
+            for evidence in sources:
+                validate_source_reference(
+                    evidence,
+                    key,
+                    tracked_sources,
+                    source_cache,
+                    root,
+                )
+            for field in (fields if kind == "json_object_types" else []):
+                validate_source_reference(
+                    field["source"],
+                    str(field["name"]),
+                    tracked_sources,
+                    source_cache,
+                    root,
+                )
+            for evidence in examples:
+                validate_data_reference(
+                    evidence,
+                    key,
+                    kind,
+                    tracked_data,
+                    data_cache,
+                    root,
+                )
+            validate_documentation_reference(
+                entry["documentation"],
+                key,
+                tracked_docs,
+                documentation_cache,
+                root,
+            )

--- a/tools/json_api/generate_contracts.py
+++ b/tools/json_api/generate_contracts.py
@@ -1290,3 +1290,58 @@ def validate_contracts(
                 documentation_cache,
                 root,
             )
+
+def serialize(payload: dict[str, object]) -> str:
+    return json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+
+def write_or_check(
+    payloads: dict[str, dict[str, object]], output_directory: Path, check: bool
+) -> list[str]:
+    stale: list[str] = []
+    for kind, filename in OUTPUT_NAMES.items():
+        path = output_directory / filename
+        if check:
+            try:
+                current = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, UnicodeError, json.JSONDecodeError):
+                current = None
+            if current != payloads[kind]:
+                stale.append(path.as_posix())
+        else:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(serialize(payloads[kind]), encoding="utf-8")
+    return stale
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="fail if outputs are stale")
+    parser.add_argument(
+        "--output-directory",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIRECTORY,
+        help="directory for the three checked inventories",
+    )
+    arguments = parser.parse_args()
+    try:
+        payloads = build_contracts()
+        stale = write_or_check(
+            payloads,
+            arguments.output_directory,
+            arguments.check)
+    except (OSError, RuntimeError, subprocess.CalledProcessError) as error:
+        print(f"JSON/EOC contract generation failed: {error}", file=sys.stderr)
+        return 1
+    if stale:
+        print(
+            "stale generated JSON/EOC contract inventories:",
+            file=sys.stderr,
+        )
+        for path in stale:
+            print(f"  {path}", file=sys.stderr)
+        return 1
+    for kind, payload in payloads.items():
+        print(f"{kind}: {len(payload['entries'])} entries")
+    return 0

--- a/tools/json_api/generate_contracts.py
+++ b/tools/json_api/generate_contracts.py
@@ -139,3 +139,114 @@ def find_matching(text: str, opening: int, left: str, right: str) -> int:
             if depth == 0:
                 return index
     raise RuntimeError(f"unbalanced {left}{right} delimiters")
+
+def split_first_argument(call: str) -> tuple[str, str]:
+    depth = 0
+    quote: str | None = None
+    escaped = False
+    for index, char in enumerate(call):
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            continue
+        if char in {'"', "'"}:
+            quote = char
+        elif char in "([{<":
+            depth += 1
+        elif char in ")]}>" and depth:
+            depth -= 1
+        elif char == "," and depth == 0:
+            return call[:index].strip(), call[index + 1:].strip()
+    raise RuntimeError("registration call has no handler argument")
+
+def preprocessor_contexts(text: str) -> dict[int, list[str]]:
+    contexts: dict[int, list[str]] = {}
+    stack: list[str] = []
+    for number, line in enumerate(text.splitlines(), 1):
+        directive = re.match(
+            r"#\s*(if|ifdef|ifndef|elif|else|endif)\b(.*)", line.strip()
+        )
+        if directive:
+            kind = directive.group(1)
+            expression = directive.group(2).strip()
+            if kind in {"if", "ifdef", "ifndef"}:
+                stack.append(f"{kind} {expression}".strip())
+            elif kind == "elif":
+                if not stack:
+                    raise RuntimeError(f"orphan #elif at line {number}")
+                stack[-1] = f"elif {expression}"
+            elif kind == "else":
+                if not stack:
+                    raise RuntimeError(f"orphan #else at line {number}")
+                stack[-1] = f"else ({stack[-1]})"
+            elif kind == "endif":
+                if not stack:
+                    raise RuntimeError(f"orphan #endif at line {number}")
+                stack.pop()
+        contexts[number] = list(stack)
+    if stack:
+        raise RuntimeError("unterminated preprocessor conditional")
+    return contexts
+
+def handler_metadata(expression: str) -> tuple[str, str | None]:
+    normalized = re.sub(r"\s+", " ", expression).strip()
+    direct = re.match(r"&\s*([A-Za-z_][A-Za-z0-9_:]*)", normalized)
+    if direct:
+        return "direct_function", direct.group(1)
+    if normalized.startswith("["):
+        called = re.findall(r"\b([A-Za-z_][A-Za-z0-9_:]*)\s*\(", normalized)
+        ignored = {"if", "for", "while", "switch"}
+        return "lambda", next(
+            (item for item in called if item not in ignored), None)
+    callable_match = re.match(r"([A-Za-z_][A-Za-z0-9_:]*)", normalized)
+    return "callable", callable_match.group(1) if callable_match else None
+
+def parse_json_registrations(contents: str) -> list[dict[str, object]]:
+    signature = "void DynamicDataLoader::initialize()"
+    start = contents.find(signature)
+    if start < 0:
+        raise RuntimeError("DynamicDataLoader::initialize was not found")
+    body_open = contents.find("{", start)
+    body_close = find_matching(contents, body_open, "{", "}")
+    section = contents[body_open + 1: body_close]
+    masked = mask_comments(section)
+    contexts = preprocessor_contexts(contents)
+    registrations: list[dict[str, object]] = []
+    for order, match in enumerate(re.finditer(r"\badd\s*\(", masked)):
+        absolute = body_open + 1 + match.start()
+        open_paren = contents.find("(", absolute)
+        close_paren = find_matching(contents, open_paren, "(", ")")
+        first, handler_expression = split_first_argument(
+            contents[open_paren + 1: close_paren]
+        )
+        literal = re.fullmatch(r'"([^"\\]*(?:\\.[^"\\]*)*)"', first)
+        if literal is None:
+            raise RuntimeError(
+                "non-literal DynamicDataLoader registration at "
+                f"line {line_number(contents, absolute)}"
+            )
+        kind, symbol = handler_metadata(handler_expression)
+        source_line = line_number(contents, absolute)
+        normalized_handler = re.sub(r"\s+", " ", handler_expression).strip()
+        registrations.append(
+            {
+                "registration_order": order,
+                "type": json.loads(first),
+                "handler_kind": kind,
+                "handler_symbol": symbol,
+                "handler_expression": normalized_handler,
+                "compile_context": contexts[source_line],
+                "source": {
+                    "path": "src/init.cpp",
+                    "line": source_line,
+                    "symbol": "DynamicDataLoader::initialize",
+                },
+            }
+        )
+    if not registrations:
+        raise RuntimeError("no DynamicDataLoader registrations were found")
+    return registrations

--- a/tools/json_api/test_generate_contracts.py
+++ b/tools/json_api/test_generate_contracts.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Regression and parity tests for JSON/EOC contract generation."""
+
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import jsonschema
+
+try:
+    from .generate_contracts import (
+        DEFAULT_OUTPUT_DIRECTORY,
+        OUTPUT_NAMES,
+        REPOSITORY_ROOT,
+        aggregate_parser_entries,
+        build_contracts,
+        git_tracked_files,
+        parse_json_registrations,
+        parse_parser_vector,
+        resolve_json_pointer,
+        validate_contracts,
+        write_or_check,
+    )
+except ImportError:
+    from generate_contracts import (
+        DEFAULT_OUTPUT_DIRECTORY,
+        OUTPUT_NAMES,
+        REPOSITORY_ROOT,
+        aggregate_parser_entries,
+        build_contracts,
+        git_tracked_files,
+        parse_json_registrations,
+        parse_parser_vector,
+        resolve_json_pointer,
+        validate_contracts,
+        write_or_check,
+    )
+
+
+class ParserFixtureTest(unittest.TestCase):
+    def test_json_registration_preserves_variants_and_handlers(self) -> None:
+        source = """
+        void DynamicDataLoader::initialize()
+        {
+        #if defined(TILES)
+            add( "one", &loader::load );
+        #else
+            add( "one", []( const JsonObject &jo ) { other::load( jo ); } );
+        #endif
+        }
+        """
+        entries = parse_json_registrations(source)
+        self.assertEqual([entry["type"] for entry in entries], ["one", "one"])
+        self.assertEqual(entries[0]["handler_symbol"], "loader::load")
+        self.assertEqual(entries[1]["handler_kind"], "lambda")
+        self.assertNotEqual(
+            entries[0]["compile_context"],
+            entries[1]["compile_context"])
+
+    def test_non_literal_json_registration_fails_closed(self) -> None:
+        source = """
+        void DynamicDataLoader::initialize()
+        {
+            add( dynamic_name, &loader::load );
+        }
+        """
+        with self.assertRaisesRegex(RuntimeError, "non-literal"):
+            parse_json_registrations(source)
+
+    def test_parser_aliases_and_shapes_are_preserved(self) -> None:
+        source = """
+        std::vector<condition_parser>
+        parsers = {
+            { "u_key", "npc_key", jarg::member | jarg::array,
+              &scope::handler },
+            { "other", jarg::string, &scope::other }
+        };
+        """
+        parsed = parse_parser_vector(
+            source,
+            "std::vector<condition_parser>\n        parsers =",
+            "src/condition.cpp",
+            "object_member",
+        )
+        entries = aggregate_parser_entries(parsed, "condition")
+        by_key = {entry["key"]: entry for entry in entries}
+        self.assertEqual(by_key["u_key"]["aliases"], ["npc_key", "u_key"])
+        self.assertEqual(
+            by_key["u_key"]["accepted_json_shapes"], ["array", "member"]
+        )
+        self.assertEqual(
+            by_key["npc_key"]["parser_registrations"][0]["alias_role"], "beta"
+        )
+
+
+class RepositoryParityTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.payloads = build_contracts()
+
+    def test_runtime_registry_parity(self) -> None:
+        payload = self.payloads["json_object_types"]
+        self.assertEqual(payload["summary"]["registration_calls"], 191)
+        self.assertEqual(payload["summary"]["registered_types"], 190)
+        self.assertEqual(payload["summary"]["observed_types"], 183)
+        self.assertEqual(payload["summary"]["observed_not_registered"], [])
+        registrations = sum(len(entry["registrations"])
+                            for entry in payload["entries"])
+        self.assertEqual(registrations, 191)
+
+    def test_eoc_parser_parity(self) -> None:
+        conditions = self.payloads["eoc_conditions"]
+        effects = self.payloads["eoc_effects"]
+        self.assertEqual(
+            conditions["summary"]["complex_parser_registrations"], 89)
+        self.assertEqual(
+            conditions["summary"]["simple_parser_registrations"], 77)
+        self.assertEqual(
+            effects["summary"]["object_parser_registrations"], 134)
+        self.assertEqual(
+            effects["summary"]["string_parser_registrations"], 117)
+        self.assertEqual(conditions["summary"]["public_keys"], 275)
+        self.assertEqual(effects["summary"]["public_keys"], 306)
+        self.assertEqual({entry["key"] for entry in conditions["entries"]} & {
+            "and", "or", "not"}, {"and", "or", "not"}, )
+        self.assertEqual(
+            conditions["global_contract"]["parser_order"],
+            "first matching parser wins")
+        self.assertEqual(
+            effects["global_contract"]["parser_order"],
+            "first matching parser wins")
+
+    def test_generated_snapshots_match(self) -> None:
+        for kind, filename in OUTPUT_NAMES.items():
+            self.assertEqual(
+                json.loads(
+                    (DEFAULT_OUTPUT_DIRECTORY / filename).read_text(
+                        encoding="utf-8")),
+                self.payloads[kind],
+            )
+
+    def test_generated_snapshots_match_schema(self) -> None:
+        schema = json.loads(
+            (REPOSITORY_ROOT /
+             "tools/json_api/contract-inventory.schema.json").read_text(
+                encoding="utf-8"))
+        jsonschema.Draft202012Validator.check_schema(schema)
+        validator = jsonschema.Draft202012Validator(schema)
+        for payload in self.payloads.values():
+            validator.validate(payload)
+
+    def test_inventory_schema_rejects_missing_contract_blocks(self) -> None:
+        schema = json.loads(
+            (REPOSITORY_ROOT /
+             "tools/json_api/contract-inventory.schema.json").read_text(
+                encoding="utf-8"))
+        payload = copy.deepcopy(self.payloads["eoc_conditions"])
+        del payload["entries"][0]["variables"]
+        with self.assertRaises(jsonschema.ValidationError):
+            jsonschema.Draft202012Validator(schema).validate(payload)
+
+    def test_incomplete_contracts_are_explicit(self) -> None:
+        json_entries = self.payloads["json_object_types"]["entries"]
+        unclassified = [
+            entry
+            for entry in json_entries
+            if entry["field_contract"]["status"] == "unclassified"
+        ]
+        self.assertEqual(len(unclassified), 189)
+        self.assertTrue(all(entry["schema"]["status"] ==
+                        "none" for entry in json_entries))
+        condition = next(
+            entry
+            for entry in self.payloads["eoc_conditions"]["entries"]
+            if entry["key"] == "u_has_trait"
+        )
+        self.assertEqual(condition["parameters"]["status"], "unclassified")
+        self.assertEqual(
+            condition["talker_semantics"]["status"],
+            "legacy_alpha_beta_alias")
+
+    def test_requiredness_comes_from_loader_evidence(self) -> None:
+        entry = next(
+            item
+            for item in self.payloads["json_object_types"]["entries"]
+            if item["type"] == "effect_on_condition"
+        )
+        fields = {
+            field["name"]: field
+            for field in entry["field_contract"]["fields"]
+        }
+        self.assertTrue(fields["id"]["required"])
+        self.assertTrue(fields["required_event"]["required"])
+        self.assertFalse(fields["global"]["required"])
+        self.assertEqual(fields["id"]["requiredness_evidence"], "mandatory")
+
+    def test_examples_resolve_to_tracked_json_pointers(self) -> None:
+        tracked = set(git_tracked_files(REPOSITORY_ROOT, "data"))
+        for kind, payload in self.payloads.items():
+            for entry in payload["entries"]:
+                block = entry.get(
+                    "instance_evidence",
+                    entry.get("example_evidence"))
+                for evidence in block["examples"]:
+                    self.assertIn(evidence["path"], tracked)
+                    value = json.loads(
+                        (REPOSITORY_ROOT /
+                         evidence["path"]).read_text(
+                            encoding="utf-8"))
+                    pointer = evidence["pointer"]
+                    resolved = resolve_json_pointer(value, pointer)
+                    key_name = "type" if kind == "json_object_types" else "key"
+                    key = entry[key_name]
+                    if kind == "json_object_types":
+                        self.assertEqual(resolved["type"], key)
+                    else:
+                        token = pointer.rsplit("/", 1)[-1]
+                        token = token.replace("~1", "/").replace("~0", "~")
+                        self.assertTrue(token == key or resolved == key)
+
+    def test_stale_source_and_example_evidence_fail_closed(self) -> None:
+        bad_source = copy.deepcopy(self.payloads)
+        bad_source["json_object_types"]["entries"][0]["registrations"][0][
+            "source"
+        ]["line"] = 1
+        with self.assertRaisesRegex(RuntimeError, "source evidence"):
+            validate_contracts(bad_source)
+
+        bad_example = copy.deepcopy(self.payloads)
+        entry = next(
+            item
+            for item in bad_example["json_object_types"]["entries"]
+            if item["instance_evidence"]["examples"]
+        )
+        entry["instance_evidence"]["examples"][0]["pointer"] = "/999999"
+        with self.assertRaisesRegex(RuntimeError, "JSON Pointer"):
+            validate_contracts(bad_example)
+
+    def test_check_mode_reports_stale_without_writing(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory)
+            stale = write_or_check(self.payloads, output, check=True)
+            self.assertEqual(len(stale), 3)
+            self.assertEqual(list(output.iterdir()), [])
+
+    def test_check_mode_accepts_repository_formatter_whitespace(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory)
+            for kind, filename in OUTPUT_NAMES.items():
+                (output / filename).write_text(
+                    json.dumps(self.payloads[kind], separators=(",", ":")),
+                    encoding="utf-8",
+                )
+            self.assertEqual(
+                write_or_check(self.payloads, output, check=True), [])
+
+    def test_discovery_invokes_git_ls_files(self) -> None:
+        completed = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=b"src/init.cpp\0"
+        )
+        with mock.patch("subprocess.run", return_value=completed) as run:
+            self.assertEqual(
+                git_tracked_files(
+                    Path("/repo"),
+                    "src"),
+                ["src/init.cpp"])
+        command = run.call_args.args[0]
+        self.assertEqual(command[:4], ["git", "ls-files", "-z", "--"])
+        self.assertNotIn("obj-lua", command)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds evidence-backed JSON object-type and EOC condition/effect contract inventories without changing loaders or runtime semantics.

- extracts 190 JSON object types from 191 registered occurrences;
- extracts 275 EOC condition keys and 306 EOC effect keys;
- records source paths, line numbers, registration symbols, and real tracked JSON Pointer examples;
- validates generated inventories against a strict Draft 2020-12 Schema;
- detects registration drift, missing evidence, invalid pointers, duplicate identities, and stale generated output;
- wires generated-file, test-matrix, documentation-impact, and Agent CI metadata.

Program tracker: #558
Stack base: Lua public-contract PR #565.

#### Responsible human

- Responsible human: @LYHGLYTX
- I understand the change and reviewed the final diff: yes
- I own the reported validation, licenses, attribution, and external sources: yes

#### Documentation impact

Creates authoritative machine inputs for later JSON, EOC, and Mod reference documentation. Documentation-impact enforcement remains advisory until the paired CCB-Docs pages and stable default-branch checks are ready.

#### Related CCB-Docs PR

Pending stacked JSON/EOC/Mod documentation PR. It must refresh fingerprints to the final merged source commit before merge.

#### Affected documentation IDs

- `api.json.overview`
- generated JSON object-type reference IDs
- `api.eoc.overview`
- `api.eoc.conditions`
- `api.eoc.effects`
- Mod authoring and complete-example IDs

#### Generated reference impact

Yes:

- `data/reference/json/ccb_json_object_types.json`
- `data/reference/json/ccb_eoc_conditions.json`
- `data/reference/json/ccb_eoc_effects.json`

All three are generator-owned.

#### Runtime/gameplay/save impact

None. No loader, factory, registration, gameplay, balance, runtime semantic, or save-format source is changed.

## Coverage and limitations

- JSON object types: 190
- registration occurrences: 191
- EOC condition syntaxes: 275
- EOC effect syntaxes: 306
- every entry has source evidence and a real tracked JSON Pointer example where detected

This PR does not pretend to provide complete field Schemas. Required/optional fields, parameters, talkers, variables, contexts, and other evidence that cannot be derived completely are explicitly marked `partial` or `unclassified`.

## Validation

Passed on the source commit:

- `python3 tools/json_api/generate_contracts.py --check` (190 / 275 / 306)
- JSON/EOC unit tests: 15/15
- Agent metadata unit tests: 23/23
- focused flake8
- repository JSON formatter for all three generated inventories
- `make -j2 json-check RELEASE=1`
- `git diff --check`

Passed again after stacking on #565:

- generated JSON/EOC `--check`
- JSON/EOC tests: 15/15
- Lua public-contract generated-diff check: 2806 symbols, 0 undocumented
- Agent metadata validation
- Agent tests: 23/23
- `git diff --check`

## Stack

1. #560 contribution/governance
2. #561 registry/inventory
3. #562 classification
4. #565 Lua public contract
5. this PR
6. dependent CCB-Docs JSON/EOC/Mod reference

No auto-merge, Bot approval, CCB-GUIDE, homepage, or game-runtime change is included.

## Commit split

- Previous commit count: 1
- New commit count: 18
- Incremental changed lines: 34924
- Average changed lines: 1940
- Largest atomic commit: see commit log
- Tree-equivalence result: PASS (git diff --exit-code <old-head> <new-head>)
- Previous head: `a038c765568fc47a58ef8c523b2722d416f5f61c`
- New head: `d49367845e6cd725d5ca56d171b610047d64592d`
- Backup bundle: skipped by owner instruction (old head recorded above)
- Validation status: tree-equivalent, chain verified
