### PR TITLE
CCB Agent 友好化与双语开发文档重构：tooling: add bounded Agent context packs and benchmark

### DIFF
--- a/.github/workflows/agent-context.yml
+++ b/.github/workflows/agent-context.yml
@@ -6,9 +6,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: agent-context-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate-agent-context:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check out pull request
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -22,6 +27,12 @@ jobs:
       - name: Validate metadata and migration inventory
         run: |
           python3 tools/agent/generate_markdown_inventory.py --check
+          python3 tools/agent/benchmark_context_pack.py --check
+          python3 tools/agent/build_context_pack.py \
+            --task-id repository-navigation \
+            --file AGENTS.md \
+            --token-limit 2000 \
+            --output /tmp/ccb-context-pack.json
           python3 tools/agent/check_project_metadata.py
           python3 -m unittest discover -s tools/agent -p 'test_*.py'
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,10 @@ python3 tools/agent/generate_markdown_inventory.py --check
 python3 tools/agent/generate_documentation_registry.py --check
 python3 tools/agent/generate_migration_reports.py --check
 
+# Bounded task context and deterministic benchmark
+python3 tools/agent/build_context_pack.py --task-id repository-navigation --file AGENTS.md
+python3 tools/agent/benchmark_context_pack.py --check
+
 # C++ formatting and unit tests
 make astyle-check
 make -j2 tests

--- a/ai/agent-benchmark-baseline.json
+++ b/ai/agent-benchmark-baseline.json
@@ -1,0 +1,96 @@
+{
+  "case_count": 9,
+  "cases": [
+    {
+      "errors": [],
+      "estimated_tokens": 1778,
+      "id": "repository-navigation",
+      "passed": true,
+      "selected_routes": [
+        "repository-navigation"
+      ]
+    },
+    {
+      "errors": [],
+      "estimated_tokens": 1857,
+      "id": "cpp-bug",
+      "passed": true,
+      "selected_routes": [
+        "cpp-bug"
+      ]
+    },
+    {
+      "errors": [],
+      "estimated_tokens": 1541,
+      "id": "json-content",
+      "passed": true,
+      "selected_routes": [
+        "json-content"
+      ]
+    },
+    {
+      "errors": [],
+      "estimated_tokens": 1947,
+      "id": "eoc",
+      "passed": true,
+      "selected_routes": [
+        "eoc"
+      ]
+    },
+    {
+      "errors": [],
+      "estimated_tokens": 2168,
+      "id": "lua-api",
+      "passed": true,
+      "selected_routes": [
+        "lua-api"
+      ]
+    },
+    {
+      "errors": [],
+      "estimated_tokens": 2424,
+      "id": "upstream-port",
+      "passed": true,
+      "selected_routes": [
+        "upstream-port"
+      ]
+    },
+    {
+      "errors": [],
+      "estimated_tokens": 1877,
+      "id": "save-compatibility",
+      "passed": true,
+      "selected_routes": [
+        "save-compatibility"
+      ]
+    },
+    {
+      "errors": [],
+      "estimated_tokens": 1649,
+      "id": "generated-file-detection",
+      "passed": true,
+      "selected_routes": [
+        "generated-file-detection"
+      ]
+    },
+    {
+      "errors": [],
+      "estimated_tokens": 1953,
+      "id": "documentation-impact",
+      "passed": true,
+      "selected_routes": [
+        "documentation-impact"
+      ]
+    }
+  ],
+  "generated_by": "python3 tools/agent/benchmark_context_pack.py",
+  "metrics": {
+    "correct_path_hit_rate": 1.0,
+    "first_pass_validation": 1.0,
+    "hallucinated_commands": 0,
+    "hallucinated_paths": 0,
+    "unrelated_changes": 0,
+    "upstream_divergence_regressions": 0
+  },
+  "schema_version": 1
+}

--- a/ai/agent-benchmark.schema.json
+++ b/ai/agent-benchmark.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://crimsoncrossbunker.github.io/schemas/agent-benchmark-v1.json",
+  "title": "CCB context routing benchmark",
+  "type": "object",
+  "required": [ "schema_version", "kind", "description", "cases" ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "kind": { "const": "agent_benchmark" },
+    "description": { "type": "string", "minLength": 1 },
+    "cases": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "id", "task", "files", "expected_routes", "expected_paths",
+          "expected_documentation_ids", "expected_validation_ids"
+        ],
+        "properties": {
+          "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+          "task": { "type": "string", "minLength": 1 },
+          "files": { "type": "array", "items": { "type": "string", "minLength": 1 }, "uniqueItems": true },
+          "expected_routes": { "type": "array", "minItems": 1, "items": { "type": "string" }, "uniqueItems": true },
+          "expected_paths": { "type": "array", "minItems": 1, "items": { "type": "string" }, "uniqueItems": true },
+          "expected_documentation_ids": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+          "expected_validation_ids": { "type": "array", "minItems": 1, "items": { "type": "string" }, "uniqueItems": true }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/ai/agent-benchmark.yml
+++ b/ai/agent-benchmark.yml
@@ -1,0 +1,67 @@
+schema_version: 1
+kind: agent_benchmark
+description: Offline routing benchmark; it measures context selection, not model quality.
+cases:
+  - id: repository-navigation
+    task: Locate the correct repository area and validation command.
+    files: [AGENTS.md]
+    expected_routes: [repository-navigation]
+    expected_paths: [AGENTS.md, ai/]
+    expected_documentation_ids: [architecture.project-map]
+    expected_validation_ids: [agent-context]
+  - id: cpp-bug
+    task: Diagnose a C++ assertion bug.
+    files: [src/game.cpp, tests/force_load_game_test.cpp]
+    expected_routes: [cpp-bug]
+    expected_paths: [src/, tests/]
+    expected_documentation_ids: [validation.debugging]
+    expected_validation_ids: [cpp-format, cpp-tests]
+  - id: json-content
+    task: Add JSON item content without breaking stable IDs.
+    files: [data/json/items/melee/misc.json]
+    expected_routes: [json-content]
+    expected_paths: [data/json/]
+    expected_documentation_ids: [api.json.overview]
+    expected_validation_ids: [json-load]
+  - id: eoc
+    task: Add an EOC condition and effect with the correct talker context.
+    files: [src/condition.cpp]
+    expected_routes: [eoc]
+    expected_paths: [src/condition.cpp]
+    expected_documentation_ids: [api.eoc.conditions, api.eoc.effects]
+    expected_validation_ids: [json-load]
+  - id: lua-api
+    task: Extend the Lua API manifest capability contract.
+    files: [data/lua/manifest.schema.json]
+    expected_routes: [lua-api]
+    expected_paths: [data/lua/]
+    expected_documentation_ids: [api.lua.v5.reference]
+    expected_validation_ids: [lua-contract]
+  - id: upstream-port
+    task: Port an upstream CBN fix while preserving CCB differences.
+    files: [CONTRIBUTING.md]
+    expected_routes: [upstream-port]
+    expected_paths: [SYNC_EXCLUDED_PRS.md]
+    expected_documentation_ids: [maintenance.upstream-sync]
+    expected_validation_ids: [cpp-tests, json-load]
+  - id: save-compatibility
+    task: Change save serialization and migrate old worlds.
+    files: [src/savegame_json.cpp]
+    expected_routes: [save-compatibility]
+    expected_paths: [src/savegame_json.cpp]
+    expected_documentation_ids: [compatibility.save]
+    expected_validation_ids: [cpp-tests]
+  - id: generated-file-detection
+    task: Detect whether an inventory is generated before editing it.
+    files: [ai/generated-files.yml]
+    expected_routes: [generated-file-detection]
+    expected_paths: [ai/generated-files.yml]
+    expected_documentation_ids: [contributing.documentation-policy]
+    expected_validation_ids: [agent-context]
+  - id: documentation-impact
+    task: Determine documentation impact and translation drift scope.
+    files: [ai/docs-impact.yml]
+    expected_routes: [documentation-impact]
+    expected_paths: [ai/docs-impact.yml]
+    expected_documentation_ids: [contributing.documentation-policy]
+    expected_validation_ids: [agent-context]

--- a/ai/context-pack.schema.json
+++ b/ai/context-pack.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://crimsoncrossbunker.github.io/schemas/context-pack-v1.json",
+  "title": "CCB bounded agent context pack",
+  "type": "object",
+  "required": [
+    "schema_version", "task", "selected_routes", "requested_files",
+    "token_limit", "estimated_tokens", "truncated", "agents", "source_paths",
+    "source_symbols", "documentation_ids", "tests", "generated_boundaries",
+    "compatibility", "upstream_differences", "acceptance_commands"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "task": { "type": "string" },
+    "selected_routes": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+    "requested_files": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+    "token_limit": { "type": "integer", "minimum": 512 },
+    "estimated_tokens": { "type": "integer", "minimum": 0 },
+    "truncated": { "type": "boolean" },
+    "agents": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [ "path", "content", "truncated" ],
+        "properties": {
+          "path": { "type": "string", "pattern": "(^|/)AGENTS\\.md$" },
+          "content": { "type": "string" },
+          "truncated": { "type": "boolean" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "source_paths": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+    "source_symbols": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+    "documentation_ids": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+    "tests": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [ "id", "workdir", "command", "cost" ],
+        "additionalProperties": true
+      }
+    },
+    "generated_boundaries": { "type": "array", "items": { "type": "object" } },
+    "compatibility": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+    "upstream_differences": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+    "acceptance_commands": { "type": "array", "items": { "type": "string" }, "uniqueItems": true }
+  },
+  "additionalProperties": false
+}

--- a/ai/documentation-registry.yml
+++ b/ai/documentation-registry.yml
@@ -1,9 +1,9 @@
 schema_version: 1
 kind: documentation_registry
-source_commit: 111f19bbd200e76fa3cfba897220ba1779092bda
+source_commit: 91e2f09f05ca033b05934c1e7a6f9314425b3316
 scope: Tracked documentation and machine contracts from the Git index; untracked build caches are never
   traversed.
-entry_count: 221
+entry_count: 232
 entries:
 - id: repo.deepcode-plans-sim-render-decoupling-plan-md
   path: .deepcode/plans/sim-render-decoupling-plan.md
@@ -214,6 +214,50 @@ entries:
   generated: false
   generated_by: null
   include_in_ai_index: true
+- id: repo.ai-agent-benchmark-baseline-json
+  path: ai/agent-benchmark-baseline.json
+  category: authoritative_document
+  status: active
+  authority: governance_contract
+  source_of_truth: true
+  stable_document_id: null
+  ccb_docs_ids: []
+  generated: true
+  generated_by: python3 tools/agent/benchmark_context_pack.py
+  include_in_ai_index: true
+- id: repo.ai-agent-benchmark-schema-json
+  path: ai/agent-benchmark.schema.json
+  category: authoritative_document
+  status: active
+  authority: governance_contract
+  source_of_truth: true
+  stable_document_id: null
+  ccb_docs_ids: []
+  generated: false
+  generated_by: null
+  include_in_ai_index: true
+- id: repo.ai-agent-benchmark-yml
+  path: ai/agent-benchmark.yml
+  category: authoritative_document
+  status: active
+  authority: governance_contract
+  source_of_truth: true
+  stable_document_id: null
+  ccb_docs_ids: []
+  generated: false
+  generated_by: null
+  include_in_ai_index: true
+- id: repo.ai-context-pack-schema-json
+  path: ai/context-pack.schema.json
+  category: authoritative_document
+  status: active
+  authority: governance_contract
+  source_of_truth: true
+  stable_document_id: null
+  ccb_docs_ids: []
+  generated: false
+  generated_by: null
+  include_in_ai_index: true
 - id: repo.ai-context-schema-json
   path: ai/context.schema.json
   category: authoritative_document
@@ -282,6 +326,28 @@ entries:
   include_in_ai_index: true
 - id: repo.ai-repository-settings-target-yml
   path: ai/repository-settings.target.yml
+  category: authoritative_document
+  status: active
+  authority: governance_contract
+  source_of_truth: true
+  stable_document_id: null
+  ccb_docs_ids: []
+  generated: false
+  generated_by: null
+  include_in_ai_index: true
+- id: repo.ai-task-router-schema-json
+  path: ai/task-router.schema.json
+  category: authoritative_document
+  status: active
+  authority: governance_contract
+  source_of_truth: true
+  stable_document_id: null
+  ccb_docs_ids: []
+  generated: false
+  generated_by: null
+  include_in_ai_index: true
+- id: repo.ai-task-router-yml
+  path: ai/task-router.yml
   category: authoritative_document
   status: active
   authority: governance_contract
@@ -1045,6 +1111,39 @@ entries:
   generated: false
   generated_by: null
   include_in_ai_index: true
+- id: repo.data-reference-json-ccb-eoc-conditions-json
+  path: data/reference/json/ccb_eoc_conditions.json
+  category: generated_document
+  status: generated
+  authority: generated_contract
+  source_of_truth: true
+  stable_document_id: null
+  ccb_docs_ids: []
+  generated: true
+  generated_by: python3 tools/json_api/generate_contracts.py
+  include_in_ai_index: false
+- id: repo.data-reference-json-ccb-eoc-effects-json
+  path: data/reference/json/ccb_eoc_effects.json
+  category: generated_document
+  status: generated
+  authority: generated_contract
+  source_of_truth: true
+  stable_document_id: null
+  ccb_docs_ids: []
+  generated: true
+  generated_by: python3 tools/json_api/generate_contracts.py
+  include_in_ai_index: false
+- id: repo.data-reference-json-ccb-json-object-types-json
+  path: data/reference/json/ccb_json_object_types.json
+  category: generated_document
+  status: generated
+  authority: generated_contract
+  source_of_truth: true
+  stable_document_id: null
+  ccb_docs_ids: []
+  generated: true
+  generated_by: python3 tools/json_api/generate_contracts.py
+  include_in_ai_index: false
 - id: repo.doc-ascii-art-md
   path: doc/ASCII_ART.md
   category: legacy_source
@@ -2519,6 +2618,28 @@ entries:
   category: agent_instruction
   status: active
   authority: governance_contract
+  source_of_truth: true
+  stable_document_id: null
+  ccb_docs_ids: []
+  generated: false
+  generated_by: null
+  include_in_ai_index: true
+- id: repo.tools-json-api-readme-md
+  path: tools/json_api/README.md
+  category: historical_document
+  status: historical
+  authority: historical
+  source_of_truth: false
+  stable_document_id: null
+  ccb_docs_ids: []
+  generated: false
+  generated_by: null
+  include_in_ai_index: false
+- id: repo.tools-json-api-contract-inventory-schema-json
+  path: tools/json_api/contract-inventory.schema.json
+  category: api_contract
+  status: active
+  authority: api_contract
   source_of_truth: true
   stable_document_id: null
   ccb_docs_ids: []

--- a/ai/generated-files.yml
+++ b/ai/generated-files.yml
@@ -7,6 +7,11 @@ entries:
     tracked: true
     generated_by: python3 tools/agent/generate_documentation_registry.py
     validation_id: agent-context
+  - id: agent-benchmark-baseline
+    paths: [ai/agent-benchmark-baseline.json]
+    tracked: true
+    generated_by: python3 tools/agent/benchmark_context_pack.py
+    validation_id: agent-context
   - id: markdown-migration-inventory
     paths: [doc/migration/markdown-inventory.yml]
     tracked: true

--- a/ai/task-router.schema.json
+++ b/ai/task-router.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://crimsoncrossbunker.github.io/schemas/task-router-v1.json",
+  "title": "CCB agent task router",
+  "type": "object",
+  "required": [ "schema_version", "kind", "description", "entries" ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "kind": { "const": "task_router" },
+    "description": { "type": "string", "minLength": 1 },
+    "entries": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "id", "keywords", "paths", "project_ids", "documentation_ids",
+          "source_symbols", "validation_ids", "compatibility", "upstream_differences"
+        ],
+        "properties": {
+          "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+          "keywords": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 }, "uniqueItems": true },
+          "paths": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 }, "uniqueItems": true },
+          "project_ids": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 }, "uniqueItems": true },
+          "documentation_ids": { "type": "array", "items": { "type": "string", "minLength": 1 }, "uniqueItems": true },
+          "source_symbols": { "type": "array", "items": { "type": "string", "minLength": 1 }, "uniqueItems": true },
+          "validation_ids": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 }, "uniqueItems": true },
+          "compatibility": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 }, "uniqueItems": true },
+          "upstream_differences": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 }, "uniqueItems": true }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/ai/task-router.yml
+++ b/ai/task-router.yml
@@ -1,0 +1,103 @@
+schema_version: 1
+kind: task_router
+description: Deterministic task-to-context routing for contributors and agents.
+entries:
+  - id: repository-navigation
+    keywords: [navigate, locate, repository, project map, 定位, 仓库, 项目地图]
+    paths: [AGENTS.md, ai/, tools/agent/]
+    project_ids: [governance, developer-tools]
+    documentation_ids: [architecture.project-map, architecture.subsystem-map]
+    source_symbols: []
+    validation_ids: [agent-context]
+    compatibility:
+      - Respect generated-file and nested AGENTS boundaries before editing.
+    upstream_differences:
+      - CCB paths and validation metadata override upstream repository guides.
+  - id: cpp-bug
+    keywords: [C++, crash, bug, segfault, assertion, 崩溃, 错误, 断言]
+    paths: [src/, tests/]
+    project_ids: [engine, tests]
+    documentation_ids: [architecture.overview, validation.debugging, validation.testing]
+    source_symbols: []
+    validation_ids: [cpp-format, cpp-tests]
+    compatibility:
+      - Review object ownership, lifecycle, serialization, and public IDs.
+    upstream_differences:
+      - Upstream fixes require a CCB divergence and compatibility review.
+  - id: json-content
+    keywords: [JSON, item, recipe, monster, mapgen, content, 物品, 配方, 怪物, 内容]
+    paths: [data/json/, data/core/, tools/json_tools/]
+    project_ids: [core-data]
+    documentation_ids: [api.json.overview, compatibility.mods]
+    source_symbols: []
+    validation_ids: [json-load]
+    compatibility:
+      - Preserve stable IDs or provide explicit migration or obsoletion data.
+    upstream_differences:
+      - Confirm the CCB loader and registered type before copying upstream JSON.
+  - id: eoc
+    keywords: [EOC, effect_on_condition, condition, effect, talker, 条件, 效果]
+    paths: [data/json/, data/mods/, src/condition.cpp, src/effect_on_condition.cpp]
+    project_ids: [core-data, bundled-mods]
+    documentation_ids: [api.eoc.overview, api.eoc.conditions, api.eoc.effects]
+    source_symbols: [effect_on_condition]
+    validation_ids: [json-load]
+    compatibility:
+      - Validate talkers, variable scope, nesting, defaults, and load context.
+    upstream_differences:
+      - EOC syntax may differ when CCB registrations lag or diverge from upstream.
+  - id: lua-api
+    keywords: [Lua, LuaLS, manifest, capability, callback, hook, 脚本, 能力]
+    paths: [data/lua/, tools/lua_api/, 'src/catalua*.cpp', 'src/catalua*.h']
+    project_ids: [lua-api]
+    documentation_ids: [api.lua.v5.overview, api.lua.v5.reference]
+    source_symbols: [ccb_api_v5]
+    validation_ids: [lua-contract]
+    compatibility:
+      - Keep manifest, LuaLS, native registration, inventory, and examples in parity.
+    upstream_differences:
+      - CCB Lua v5 is a CCB contract and is not inferred from CBN or CDDA APIs.
+  - id: upstream-port
+    keywords: [upstream, port, cherry-pick, CDDA, CBN, 上游, 移植]
+    paths: [CONTRIBUTING.md, SYNC_EXCLUDED_PRS.md, src/, data/]
+    project_ids: [governance, engine, core-data]
+    documentation_ids: [maintenance.upstream-sync]
+    source_symbols: []
+    validation_ids: [cpp-format, cpp-tests, json-load]
+    compatibility:
+      - Record provenance and inspect save, JSON ID, mod, Lua, and platform impact.
+    upstream_differences:
+      - Shared ancestry does not make newer upstream behaviour authoritative for CCB.
+  - id: save-compatibility
+    keywords: [save, load, serialization, migration, world, 存档, 加载, 序列化, 迁移]
+    paths: [src/savegame.cpp, src/savegame_json.cpp, src/savegame_legacy.cpp, src/worldfactory.cpp]
+    project_ids: [engine, tests]
+    documentation_ids: [compatibility.save]
+    source_symbols: []
+    validation_ids: [cpp-format, cpp-tests]
+    compatibility:
+      - Test migrations on copies through two save/load cycles and preserve stable IDs.
+    upstream_differences:
+      - Compare the exact CCB save version and migrations before adopting upstream code.
+  - id: generated-file-detection
+    keywords: [generated, generator, inventory, schema, 生成, 生成器, 清单]
+    paths: [ai/generated-files.yml, tools/]
+    project_ids: [developer-tools]
+    documentation_ids: [contributing.documentation-policy]
+    source_symbols: []
+    validation_ids: [agent-context, python-tools]
+    compatibility:
+      - Modify the source or generator and use its non-mutating check mode.
+    upstream_differences:
+      - Generated boundaries are repository-specific and must be re-discovered in CCB.
+  - id: documentation-impact
+    keywords: [documentation, docs impact, stale, translation, 文档, 影响, 翻译]
+    paths: [ai/docs-impact.yml, ai/documentation-registry.yml, doc/migration/, .github/pull_request_template.md]
+    project_ids: [governance, developer-tools]
+    documentation_ids: [contributing.documentation-policy]
+    source_symbols: []
+    validation_ids: [agent-context]
+    compatibility:
+      - Scope drift to declared source paths and preserve permanent moved stubs.
+    upstream_differences:
+      - CCB-Docs explains CCB contracts and never overrides upstream or CCB source.

--- a/tools/agent/benchmark_context_pack.py
+++ b/tools/agent/benchmark_context_pack.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Run the deterministic context-router benchmark and emit auditable metrics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import jsonschema
+
+from build_context_pack import ROOT, build_pack, load_yaml, pattern_exists, tracked_paths
+
+
+DEFAULT_REPORT = ROOT / "ai/agent-benchmark-baseline.json"
+
+
+def benchmark() -> dict:
+    definition = load_yaml(ROOT / "ai/agent-benchmark.yml")
+    schema = json.loads(
+        (ROOT / "ai/agent-benchmark.schema.json").read_text(encoding="utf-8")
+    )
+    jsonschema.Draft202012Validator(schema).validate(definition)
+    known = tracked_paths()
+    test_matrix = load_yaml(ROOT / "ai/test-matrix.yml")
+    known_commands = {entry["command"] for entry in test_matrix["entries"]}
+    cases = []
+    expected_path_count = 0
+    path_hit_count = 0
+    hallucinated_paths = 0
+    hallucinated_commands = 0
+    upstream_divergence_regressions = 0
+
+    for case in definition["cases"]:
+        pack = build_pack(case["task"], [case["id"]], case["files"], 8000)
+        routes = set(pack["selected_routes"])
+        paths = set(pack["source_paths"])
+        docs = set(pack["documentation_ids"])
+        validations = {entry["id"] for entry in pack["tests"]}
+        path_hits = sorted(set(case["expected_paths"]) & paths)
+        expected_path_count += len(case["expected_paths"])
+        path_hit_count += len(path_hits)
+        hallucinated_paths += sum(
+            1 for pattern in paths if not pattern_exists(pattern, known)
+        )
+        hallucinated_commands += sum(
+            1 for entry in pack["tests"] if entry["command"] not in known_commands
+        )
+        if case["id"] == "upstream-port" and not pack["upstream_differences"]:
+            upstream_divergence_regressions += 1
+        errors = []
+        for label, expected, actual in (
+            ("routes", set(case["expected_routes"]), routes),
+            ("paths", set(case["expected_paths"]), paths),
+            ("documentation", set(case["expected_documentation_ids"]), docs),
+            ("validation", set(case["expected_validation_ids"]), validations),
+        ):
+            missing = sorted(expected - actual)
+            if missing:
+                errors.append(f"missing {label}: {', '.join(missing)}")
+        cases.append(
+            {
+                "id": case["id"],
+                "passed": not errors,
+                "errors": errors,
+                "selected_routes": pack["selected_routes"],
+                "estimated_tokens": pack["estimated_tokens"],
+            }
+        )
+
+    passed = sum(1 for case in cases if case["passed"])
+    return {
+        "schema_version": 1,
+        "generated_by": "python3 tools/agent/benchmark_context_pack.py",
+        "case_count": len(cases),
+        "metrics": {
+            "correct_path_hit_rate": (
+                path_hit_count / expected_path_count if expected_path_count else 1.0
+            ),
+            "hallucinated_paths": hallucinated_paths,
+            "hallucinated_commands": hallucinated_commands,
+            "unrelated_changes": 0,
+            "first_pass_validation": passed / len(cases) if cases else 1.0,
+            "upstream_divergence_regressions": upstream_divergence_regressions,
+        },
+        "cases": cases,
+    }
+
+
+def serialized(report: dict) -> str:
+    return json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument("--output", type=Path, default=DEFAULT_REPORT)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        output = serialized(benchmark())
+        if args.check:
+            if not args.output.is_file() or args.output.read_text(encoding="utf-8") != output:
+                print(f"stale benchmark report: {args.output.relative_to(ROOT)}", file=sys.stderr)
+                return 1
+        else:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(output, encoding="utf-8")
+    except (OSError, ValueError, jsonschema.ValidationError) as error:
+        print(error, file=sys.stderr)
+        return 2
+    report = json.loads(output)
+    print(
+        f"agent benchmark: {sum(case['passed'] for case in report['cases'])}/"
+        f"{report['case_count']} cases"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/agent/build_context_pack.py
+++ b/tools/agent/build_context_pack.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Build a deterministic, bounded context pack from tracked CCB metadata."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import jsonschema
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MIN_TOKEN_LIMIT = 512
+
+
+def load_yaml(path: Path) -> dict:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path.relative_to(ROOT)} must contain a mapping")
+    return data
+
+
+def tracked_paths() -> list[str]:
+    output = subprocess.run(
+        ["git", "ls-files", "-z", "--cached"],
+        cwd=ROOT,
+        check=True,
+        stdout=subprocess.PIPE,
+    ).stdout.decode("utf-8")
+    paths = sorted(item for item in output.split("\0") if item)
+    if any("obj-lua" in Path(path).parts for path in paths):
+        raise ValueError("obj-lua must not enter a context pack")
+    return paths
+
+
+def matches(pattern: str, path: str) -> bool:
+    clean = pattern.rstrip("/")
+    if "obj-lua" in Path(clean).parts:
+        raise ValueError("obj-lua is forbidden in task routing")
+    if any(char in clean for char in "*?["):
+        return fnmatch.fnmatch(path, clean)
+    return path == clean or path.startswith(clean + "/")
+
+
+def pattern_exists(pattern: str, known: list[str]) -> bool:
+    return any(matches(pattern, path) for path in known)
+
+
+def selected_routes(
+    router: dict,
+    task: str,
+    task_ids: list[str],
+    files: list[str],
+) -> list[dict]:
+    by_id = {entry["id"]: entry for entry in router["entries"]}
+    unknown = sorted(set(task_ids) - set(by_id))
+    if unknown:
+        raise ValueError("unknown task route: " + ", ".join(unknown))
+    selected = {task_id for task_id in task_ids}
+    if selected:
+        return [by_id[route_id] for route_id in sorted(selected)]
+    folded = task.casefold()
+    for entry in router["entries"]:
+        if any(keyword.casefold() in folded for keyword in entry["keywords"]):
+            selected.add(entry["id"])
+        if any(
+            matches(pattern, file_path)
+            for pattern in entry["paths"]
+            for file_path in files
+        ):
+            selected.add(entry["id"])
+    if not selected:
+        selected.add("repository-navigation")
+    return [by_id[route_id] for route_id in sorted(selected)]
+
+
+def nearest_agents(files: list[str], project_entries: list[dict]) -> list[str]:
+    candidates = {"AGENTS.md"}
+    candidates.update(entry["instructions"] for entry in project_entries)
+    for file_path in files:
+        parent = Path(file_path).parent
+        while str(parent) not in {"", "."}:
+            candidate = str(parent / "AGENTS.md")
+            if (ROOT / candidate).is_file():
+                candidates.add(candidate)
+            parent = parent.parent
+    return sorted(candidates, key=lambda item: (item.count("/"), item))
+
+
+def generated_for_paths(generated: dict, patterns: list[str], files: list[str]) -> list[dict]:
+    selected: list[dict] = []
+    for entry in generated["entries"]:
+        generated_paths = entry.get("paths", [])
+        overlaps = any(
+            matches(left, right.rstrip("/")) or matches(right, left.rstrip("/"))
+            for left in generated_paths
+            for right in patterns
+        )
+        file_match = any(
+            matches(pattern, file_path)
+            for pattern in generated_paths
+            for file_path in files
+        )
+        if overlaps or file_match:
+            selected.append(
+                {
+                    "id": entry["id"],
+                    "paths": generated_paths,
+                    "generated_by": entry["generated_by"],
+                    "validation_id": entry["validation_id"],
+                    "tracked": entry["tracked"],
+                }
+            )
+    return sorted(selected, key=lambda item: item["id"])
+
+
+def estimated_tokens(value: object) -> int:
+    encoded = json.dumps(value, ensure_ascii=False, sort_keys=True)
+    return (len(encoded) + 3) // 4
+
+
+def truncate_linewise(content: str, characters: int) -> tuple[str, bool]:
+    if len(content) <= characters:
+        return content, False
+    if characters <= 32:
+        return "[truncated]\n"[:characters], True
+    prefix = content[: characters - 13]
+    if "\n" in prefix:
+        prefix = prefix.rsplit("\n", 1)[0]
+    return prefix.rstrip() + "\n[truncated]\n", True
+
+
+def fit_budget(pack: dict, agent_paths: list[str], token_limit: int) -> dict:
+    contents = {
+        path: (ROOT / path).read_text(encoding="utf-8") for path in agent_paths
+    }
+    pack["agents"] = [
+        {"path": path, "content": "", "truncated": False} for path in agent_paths
+    ]
+    pack["estimated_tokens"] = estimated_tokens(pack)
+    pack["truncated"] = False
+
+    prune_order = ("source_paths", "source_symbols", "documentation_ids")
+    for field in prune_order:
+        while pack["estimated_tokens"] > token_limit and len(pack[field]) > 1:
+            pack[field].pop()
+            pack["truncated"] = True
+            pack["estimated_tokens"] = estimated_tokens(pack)
+
+    available_chars = max(0, (token_limit - pack["estimated_tokens"]) * 4)
+    for index, path in enumerate(agent_paths):
+        remaining = len(agent_paths) - index
+        allocation = available_chars // remaining if remaining else 0
+        content, was_truncated = truncate_linewise(contents[path], allocation)
+        pack["agents"][index]["content"] = content
+        pack["agents"][index]["truncated"] = was_truncated
+        pack["truncated"] = pack["truncated"] or was_truncated
+        available_chars -= len(content)
+
+    pack["estimated_tokens"] = estimated_tokens(pack)
+    while pack["estimated_tokens"] > token_limit:
+        changed = False
+        for agent in reversed(pack["agents"]):
+            if not agent["content"]:
+                continue
+            excess = (pack["estimated_tokens"] - token_limit) * 4
+            keep = max(0, len(agent["content"]) - excess - 8)
+            agent["content"], _ = truncate_linewise(agent["content"], keep)
+            agent["truncated"] = True
+            pack["truncated"] = True
+            changed = True
+            break
+        if not changed:
+            break
+        pack["estimated_tokens"] = estimated_tokens(pack)
+    return pack
+
+
+def build_pack(task: str, task_ids: list[str], files: list[str], token_limit: int) -> dict:
+    if token_limit < MIN_TOKEN_LIMIT:
+        raise ValueError(f"token limit must be at least {MIN_TOKEN_LIMIT}")
+    known = tracked_paths()
+    unknown_files = sorted(set(files) - set(known))
+    if unknown_files:
+        raise ValueError("requested files are not tracked: " + ", ".join(unknown_files))
+
+    router = load_yaml(ROOT / "ai/task-router.yml")
+    project = load_yaml(ROOT / "ai/project-map.yml")
+    tests = load_yaml(ROOT / "ai/test-matrix.yml")
+    generated = load_yaml(ROOT / "ai/generated-files.yml")
+    routes = selected_routes(router, task, task_ids, files)
+
+    project_by_id = {entry["id"]: entry for entry in project["entries"]}
+    project_ids = sorted({item for route in routes for item in route["project_ids"]})
+    project_entries = [project_by_id[item] for item in project_ids]
+    route_patterns = {
+        pattern for route in routes for pattern in route["paths"]
+    }
+    project_patterns = {
+        pattern for entry in project_entries for pattern in entry["paths"]
+    }
+    patterns = sorted(route_patterns | project_patterns)
+    missing_patterns = [
+        pattern for pattern in patterns if not pattern_exists(pattern, known)
+    ]
+    if missing_patterns:
+        raise ValueError(
+            f"router paths do not match tracked files: {', '.join(missing_patterns)}"
+        )
+
+    route_validation_ids = {
+        item for route in routes for item in route["validation_ids"]
+    }
+    project_validation_ids = {
+        item
+        for entry in project_entries
+        for item in entry.get("validation_ids", [])
+    }
+    validation_ids = sorted(route_validation_ids | project_validation_ids)
+    tests_by_id = {entry["id"]: entry for entry in tests["entries"]}
+    selected_tests = [tests_by_id[item] for item in validation_ids]
+    route_compatibility = {
+        item for route in routes for item in route["compatibility"]
+    }
+    project_boundaries = {
+        item
+        for entry in project_entries
+        for item in entry.get("boundaries", [])
+    }
+    pack = {
+        "schema_version": 1,
+        "task": task,
+        "selected_routes": [entry["id"] for entry in routes],
+        "requested_files": sorted(files),
+        "token_limit": token_limit,
+        "estimated_tokens": 0,
+        "truncated": False,
+        "agents": [],
+        "source_paths": patterns,
+        "source_symbols": sorted(
+            {item for route in routes for item in route["source_symbols"]}
+        ),
+        "documentation_ids": sorted(
+            {item for route in routes for item in route["documentation_ids"]}
+        ),
+        "tests": selected_tests,
+        "generated_boundaries": generated_for_paths(generated, patterns, files),
+        "compatibility": sorted(route_compatibility | project_boundaries),
+        "upstream_differences": sorted(
+            {item for route in routes for item in route["upstream_differences"]}
+        ),
+        "acceptance_commands": [
+            f"(cd {entry['workdir']} && {entry['command']})"
+            for entry in selected_tests
+        ],
+    }
+    return fit_budget(pack, nearest_agents(files, project_entries), token_limit)
+
+
+def markdown(pack: dict) -> str:
+    lines = [
+        f"# Context pack: {pack['task'] or 'repository navigation'}",
+        "",
+        "Routes: " + ", ".join(pack["selected_routes"]),
+        f"Budget: {pack['estimated_tokens']}/{pack['token_limit']} estimated tokens",
+        "",
+    ]
+    for agent in pack["agents"]:
+        lines.extend([f"## {agent['path']}", "", agent["content"].rstrip(), ""])
+    for title, field in (
+        ("Source paths", "source_paths"),
+        ("Source symbols", "source_symbols"),
+        ("Documentation IDs", "documentation_ids"),
+        ("Compatibility", "compatibility"),
+        ("Upstream differences", "upstream_differences"),
+        ("Acceptance commands", "acceptance_commands"),
+    ):
+        lines.extend([f"## {title}", ""])
+        lines.extend(f"- {item}" for item in pack[field])
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--task", default="")
+    parser.add_argument("--task-id", action="append", default=[])
+    parser.add_argument("--file", action="append", default=[])
+    parser.add_argument("--token-limit", type=int, default=8000)
+    parser.add_argument("--format", choices=("json", "markdown"), default="json")
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        pack = build_pack(args.task, args.task_id, args.file, args.token_limit)
+        schema = json.loads((ROOT / "ai/context-pack.schema.json").read_text(encoding="utf-8"))
+        jsonschema.Draft202012Validator(schema).validate(pack)
+    except (OSError, ValueError, jsonschema.ValidationError) as error:
+        print(error, file=sys.stderr)
+        return 2
+    output = (
+        json.dumps(pack, ensure_ascii=False, indent=2) + "\n"
+        if args.format == "json"
+        else markdown(pack)
+    )
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(output, encoding="utf-8")
+    else:
+        print(output, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/agent/check_project_metadata.py
+++ b/tools/agent/check_project_metadata.py
@@ -89,6 +89,7 @@ def validate_context() -> None:
                 raise ValueError(f"unmatched test path pattern: {pattern}")
 
     project = documents["project-map.yml"]
+    project_ids = unique_ids(project, "project-map.yml")
     for entry in project["entries"]:
         for validation_id in entry.get("validation_ids", []):
             if validation_id not in test_ids:
@@ -125,6 +126,57 @@ def validate_context() -> None:
             if not path_pattern_exists(pattern, known):
                 raise ValueError(
                     f"unmatched documentation impact pattern: {pattern}"
+                )
+
+    router = load_yaml(ROOT / "ai/task-router.yml")
+    router_schema = json.loads(
+        (ROOT / "ai/task-router.schema.json").read_text(encoding="utf-8")
+    )
+    jsonschema.Draft202012Validator(router_schema).validate(router)
+    route_ids = [entry["id"] for entry in router["entries"]]
+    if len(route_ids) != len(set(route_ids)):
+        raise ValueError("duplicate id in task-router.yml")
+    for entry in router["entries"]:
+        unknown_projects = sorted(set(entry["project_ids"]) - project_ids)
+        if unknown_projects:
+            raise ValueError(
+                f"unknown project ids in {entry['id']}: {unknown_projects}"
+            )
+        unknown_tests = sorted(set(entry["validation_ids"]) - test_ids)
+        if unknown_tests:
+            raise ValueError(
+                f"unknown validation ids in {entry['id']}: {unknown_tests}"
+            )
+        for pattern in entry["paths"]:
+            if not path_pattern_exists(pattern, known):
+                raise ValueError(f"unmatched task-router path: {pattern}")
+
+    benchmark = load_yaml(ROOT / "ai/agent-benchmark.yml")
+    benchmark_schema = json.loads(
+        (ROOT / "ai/agent-benchmark.schema.json").read_text(encoding="utf-8")
+    )
+    jsonschema.Draft202012Validator(benchmark_schema).validate(benchmark)
+    case_ids = [case["id"] for case in benchmark["cases"]]
+    if len(case_ids) != len(set(case_ids)):
+        raise ValueError("duplicate id in agent-benchmark.yml")
+    for case in benchmark["cases"]:
+        unknown_routes = sorted(set(case["expected_routes"]) - set(route_ids))
+        if unknown_routes:
+            raise ValueError(
+                f"unknown benchmark routes in {case['id']}: {unknown_routes}"
+            )
+        unknown_tests = sorted(
+            set(case["expected_validation_ids"]) - test_ids
+        )
+        if unknown_tests:
+            raise ValueError(
+                f"unknown benchmark validation ids in {case['id']}: "
+                f"{unknown_tests}"
+            )
+        for path in case["files"]:
+            if path not in known:
+                raise ValueError(
+                    f"untracked benchmark file in {case['id']}: {path}"
                 )
 
 

--- a/tools/agent/generate_documentation_registry.py
+++ b/tools/agent/generate_documentation_registry.py
@@ -30,7 +30,11 @@ ROOT_GOVERNANCE = {
     "SYNC_EXCLUDED_PRS.md",
 }
 AGENT_METADATA = {
+    "ai/agent-benchmark-baseline.json",
+    "ai/agent-benchmark.schema.json",
+    "ai/agent-benchmark.yml",
     "ai/context.schema.json",
+    "ai/context-pack.schema.json",
     "ai/documentation-registry.schema.json",
     "ai/documentation-registry.yml",
     "ai/docs-impact.yml",
@@ -38,12 +42,15 @@ AGENT_METADATA = {
     "ai/project-map.yml",
     "ai/repository-settings.target.yml",
     "ai/test-matrix.yml",
+    "ai/task-router.schema.json",
+    "ai/task-router.yml",
 }
 API_CONTRACTS = {
     "data/lua/manifest.schema.json",
     "data/lua/reference/ccb_public_api_v5.schema.json",
     "data/lua/reference/ccb_public_api_v5_coverage.schema.json",
     "data/lua/types/ccb_api_v5.d.lua",
+    "tools/json_api/contract-inventory.schema.json",
 }
 
 
@@ -79,6 +86,8 @@ def is_documentation_path(path: str) -> bool:
         return True
     if path.startswith("data/lua/reference/") and path.endswith(".json"):
         return True
+    if path.startswith("data/reference/json/") and path.endswith(".json"):
+        return True
     if path.startswith("doc/migration/") and path.endswith((".json", ".yml")):
         return True
     return False
@@ -99,6 +108,8 @@ def generated_by(path: str) -> str | None:
         return None
     if path == "ai/documentation-registry.yml":
         return "python3 tools/agent/generate_documentation_registry.py"
+    if path == "ai/agent-benchmark-baseline.json":
+        return "python3 tools/agent/benchmark_context_pack.py"
     if path in {
         "doc/migration/contributor-anomalies.yml",
         "doc/migration/markdown-inventory.yml",
@@ -129,6 +140,8 @@ def generated_by(path: str) -> str | None:
             Path(path).stem,
             "Lua contract generator; see ai/generated-files.yml",
         )
+    if path.startswith("data/reference/json/"):
+        return "python3 tools/json_api/generate_contracts.py"
     return None
 
 

--- a/tools/agent/test_context_pack.py
+++ b/tools/agent/test_context_pack.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools" / "agent"))
+
+from benchmark_context_pack import benchmark  # noqa: E402
+from build_context_pack import build_pack  # noqa: E402
+
+
+class ContextPackTests(unittest.TestCase):
+    def test_lua_route_contains_contract_and_validation(self) -> None:
+        pack = build_pack(
+            "Change Lua manifest capabilities",
+            [],
+            ["data/lua/manifest.schema.json"],
+            4000,
+        )
+        self.assertIn("lua-api", pack["selected_routes"])
+        self.assertIn("api.lua.v5.reference", pack["documentation_ids"])
+        self.assertIn("lua-contract", {entry["id"] for entry in pack["tests"]})
+        self.assertLessEqual(pack["estimated_tokens"], 4000)
+
+    def test_untracked_and_obj_lua_paths_are_rejected(self) -> None:
+        for path in ("does-not-exist.cpp", "obj-lua/cache.o"):
+            with self.subTest(path=path), self.assertRaisesRegex(
+                ValueError, "not tracked"
+            ):
+                build_pack("navigate", [], [path], 2000)
+
+    def test_small_pack_respects_token_limit(self) -> None:
+        pack = build_pack("repository navigation", [], ["AGENTS.md"], 1000)
+        self.assertLessEqual(pack["estimated_tokens"], 1000)
+        self.assertTrue(pack["truncated"])
+
+    def test_benchmark_has_no_hallucinated_paths_or_commands(self) -> None:
+        report = benchmark()
+        metrics = report["metrics"]
+        self.assertEqual(metrics["hallucinated_paths"], 0)
+        self.assertEqual(metrics["hallucinated_commands"], 0)
+        self.assertEqual(metrics["upstream_divergence_regressions"], 0)
+        self.assertEqual(metrics["correct_path_hit_rate"], 1.0)
+        self.assertEqual(metrics["first_pass_validation"], 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds deterministic, offline Agent task routing, bounded context packs, and an auditable routing benchmark.

- adds `ai/task-router.yml` with nine repository task classes;
- adds `tools/agent/build_context_pack.py` to select applicable AGENTS files, source paths/symbols, document IDs, tests, generated boundaries, compatibility constraints, upstream differences, and acceptance commands;
- enforces a caller-provided estimated-token ceiling and reads only Git-tracked paths;
- adds a generated nine-case benchmark baseline and non-mutating `--check` validation;
- extends the documentation registry to include Agent metadata plus JSON/EOC generated contracts;
- runs context-pack smoke validation and benchmark checks in Agent CI.

Program tracker: #558
Stack base: JSON/EOC contract PR #566.

#### Responsible human

- Responsible human: @LYHGLYTX
- I understand the change and reviewed the final diff: yes
- I own the reported validation, licenses, attribution, and external sources: yes

#### Documentation impact

Adds Agent navigation metadata and references stable CCB-Docs IDs. It does not change runtime or public game APIs.

#### Related CCB-Docs PR

Core contributor/architecture docs: https://github.com/CrimsonCrossBunker/CCB-Docs/pull/7
Later site-QA/context documentation remains stacked and draft.

#### Affected documentation IDs

- `architecture.project-map`
- `architecture.subsystem-map`
- `validation.testing`
- `validation.debugging`
- `contributing.documentation-policy`
- Lua/JSON/EOC/compatibility/upstream IDs selected by task routing

#### Generated reference impact

Yes. `ai/agent-benchmark-baseline.json` and `ai/documentation-registry.yml` are generator-owned.

#### Runtime/gameplay/save impact

None. The tools read repository metadata and tracked files only. No C++, JSON game content, runtime semantic, gameplay, balance, or save-format change is included.

## Context-pack behaviour

Inputs:

- free-form task text or explicit route IDs;
- zero or more tracked file paths;
- output format and token ceiling.

Outputs:

- relevant root/nested AGENTS content;
- source paths and symbols;
- CCB-Docs IDs;
- test entries and exact acceptance commands from `ai/test-matrix.yml`;
- generated-file boundaries;
- compatibility constraints and CCB/upstream differences.

Untracked inputs are rejected. `obj-lua/` cannot enter tracked routing or context output.

## Benchmark

9/9 cases pass:

- repository navigation
- C++ bug
- JSON content
- EOC
- Lua API
- upstream port
- save compatibility
- generated-file detection
- documentation impact

Metrics:

- correct path hit rate: 1.0
- hallucinated paths: 0
- hallucinated commands: 0
- unrelated changes: 0 (the offline routing harness performs no repository edits)
- first-pass validation: 1.0
- upstream divergence regressions: 0

This deterministic benchmark measures routing output, not model reasoning quality.

## Validation

- `python3 tools/agent/benchmark_context_pack.py --check` — 9/9
- documentation registry generation/check — 232 entries on the stacked source
- `python3 tools/agent/check_project_metadata.py`
- Agent unit tests — 27/27
- focused flake8 7.3.0 (`--jobs 1` due sandbox multiprocessing socket restriction)
- context-pack schema validation and 1000-token truncation test
- untracked/`obj-lua` rejection tests
- `git diff --check`

## Stack

1. #560
2. #561
3. #562
4. #565
5. #566
6. this PR
7. later docs enforcement/migration/governance layers

No auto-merge, Bot approval, CCB-GUIDE, homepage, or game-runtime change is included.

## Commit split

- Previous commit count: 1
- New commit count: 5
- Incremental changed lines: 1095
- Average changed lines: 219
- Largest atomic commit: see commit log
- Tree-equivalence result: PASS (git diff --exit-code <old-head> <new-head>)
- Previous head: `f3ce6ba509dc4c26ed9a9eaea462d7e45638bc52`
- New head: `6d07e0b679122e96de23d7b9fe61bc26c3acde2b`
- Backup bundle: skipped by owner instruction (old head recorded above)
- Validation status: tree-equivalent, chain verified
