### PR TITLE
CCB Agent 友好化与双语开发文档重构：github: finalize documentation impact enforcement

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -68,17 +68,18 @@ https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/blob/master/data
 
 #### Documentation impact
 <!-- None，或说明需要新增、更新、迁移、归档或标记 stale 的开发文档。
-实际执行级别以 ai/docs-impact.yml 为准。 -->
+实际执行级别以 ai/docs-impact.yml 为准。required 映射不能填写 None/N/A/TBD。 -->
 
 None
 
 #### Related CCB-Docs PR
-<!-- None，或填写 CrimsonCrossBunker/CCB-Docs 的 PR 链接。 -->
+<!-- None，或填写 CrimsonCrossBunker/CCB-Docs 的 PR 链接。required 映射必须链接实际 PR。 -->
 
 None
 
 #### Affected documentation IDs
-<!-- None，或填写 docs-catalog.yml 中稳定的文档 ID，多个 ID 用逗号分隔。 -->
+<!-- None，或填写 docs-catalog.yml 中稳定的文档 ID，多个 ID 用逗号分隔。
+required 映射至少填写一个 ai/docs-impact.yml 列出的对应 ID。 -->
 
 None
 

--- a/.github/workflows/agent-context.yml
+++ b/.github/workflows/agent-context.yml
@@ -2,6 +2,9 @@ name: Agent context and documentation impact
 
 on:
   pull_request:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -12,10 +15,11 @@ concurrency:
 
 jobs:
   validate-agent-context:
+    name: Agent context and documentation impact
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: Check out pull request
+      - name: Check out source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
@@ -42,6 +46,7 @@ jobs:
           python3 -m unittest discover -s tools/json_api -p 'test_*.py'
 
       - name: Report documentation impact and validate PR responsibility
+        if: github.event_name == 'pull_request'
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -51,3 +56,9 @@ jobs:
           --base "$BASE_SHA"
           --head "$HEAD_SHA"
           --check-pr-body
+
+      - name: Validate staged impact configuration outside pull requests
+        if: github.event_name != 'pull_request'
+        run: >-
+          python3 tools/agent/check_docs_impact.py
+          --changed-file ai/docs-impact.yml

--- a/.github/workflows/lua-contract.yml
+++ b/.github/workflows/lua-contract.yml
@@ -2,16 +2,6 @@ name: Lua public contract
 
 on:
   pull_request:
-    paths:
-      - '.github/workflows/lua-contract.yml'
-      - 'ai/docs-impact.yml'
-      - 'ai/generated-files.yml'
-      - 'ai/test-matrix.yml'
-      - 'data/lua/**'
-      - 'src/catalua*.cpp'
-      - 'src/catalua*.h'
-      - 'src/event.h'
-      - 'tools/lua_api/**'
   push:
     branches: [ master ]
     paths:
@@ -35,21 +25,53 @@ concurrency:
 
 jobs:
   validate:
+    name: Lua public contract
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Check out source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
 
+      - name: Detect public-contract changes
+        id: detect
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "required=true" >> "$GITHUB_OUTPUT"
+          elif git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- \
+            '.github/workflows/lua-contract.yml' \
+            'ai/docs-impact.yml' \
+            'ai/generated-files.yml' \
+            'ai/test-matrix.yml' \
+            ':(glob)data/lua/**' \
+            ':(glob)src/catalua*.cpp' \
+            ':(glob)src/catalua*.h' \
+            'src/event.h' \
+            ':(glob)tools/lua_api/**'; then
+            echo "required=false" >> "$GITHUB_OUTPUT"
+          else
+            diff_status=$?
+            if [ "$diff_status" -ne 1 ]; then
+              exit "$diff_status"
+            fi
+            echo "required=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install pinned validation dependencies
+        if: steps.detect.outputs.required == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends lua5.4
           python3 -m pip install --disable-pip-version-check -r tools/lua_api/requirements.txt
 
       - name: Validate Lua v5 declarations and generated contract
+        if: steps.detect.outputs.required == 'true'
         run: |
           python3 tools/lua_api/check_luals_declarations.py
           python3 tools/lua_api/check_ccb_inventory.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -303,6 +303,15 @@ Every PR must describe:
 - affected stable documentation IDs;
 - generated-reference impact.
 
+Enforcement is path-scoped by `ai/docs-impact.yml`. Governance, build, and
+ordinary JSON content mappings remain advisory. Changes to the public Lua
+contract or the JSON/EOC registration and parsing contracts are required: the
+four fields must contain a concrete impact statement, a CCB-Docs pull-request
+link, at least one mapped stable document ID, and the generated-reference
+result. Template placeholders such as `None`, `N/A`, and `TBD` do not satisfy a
+required mapping. Unrelated paths are never made to fail merely because an API
+subsystem has documentation work elsewhere.
+
 A CCB-Docs PR may be prepared before the source PR merges, but must remain
 Draft. After source merge, refresh its metadata to the final source commit,
 regenerate derived files, rerun checks, and then request human review.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -44,6 +44,18 @@ Responsible human，负责理解修改、审查最终差异、确认测试、许
 4. Enforcement is staged in `ai/docs-impact.yml`; a mapping becomes required
    only after its referenced documentation and default-branch checks are ready.
 
+The Lua, JSON, and EOC documentation stacks may declare `bilingual_draft` while
+their dependent pull requests are under review.  That state is auditable
+provenance for a stacked Draft PR, not permission to merge enforcement early.
+Before this enforcement reaches `master`, every mapped page must be refreshed
+to the merged source commit and promoted according to the CCB-Docs catalog
+policy.  Ordinary content and unrelated documentation fixes remain advisory.
+
+Translation debt is enforced in CCB-Docs against the changed bilingual pair or
+the same high-risk subsystem only.  Nightly automation may report global debt,
+but neither source drift nor an overdue unrelated translation may make all
+pull requests fail.
+
 ## Legacy documentation paths / 旧文档路径
 
 When a legacy `doc/...` page is migrated in a later phase, its old repository

--- a/REPOSITORY_SETTINGS.md
+++ b/REPOSITORY_SETTINGS.md
@@ -25,6 +25,14 @@ must record the date and operator after each administrator change.
 - emergency bypass is limited, intentional, and records a reason;
 - bots cannot approve their own pull requests and no PR is automatically merged.
 
+The candidate check names introduced by the staged documentation work are
+`Agent context and documentation impact` and `Lua public contract`.  They are
+only candidates until each has a stable successful run on `master`; merging a
+workflow does not add either name to a ruleset.  JSON/EOC contract validation
+currently runs inside `Agent context and documentation impact`.  The Lua
+workflow starts for every pull request so its named check exists; its expensive
+validation job is path-scoped and is skipped successfully for unrelated work.
+
 ## Actions and automation
 
 - Default `GITHUB_TOKEN` permissions remain read-only.

--- a/ai/agent-benchmark-baseline.json
+++ b/ai/agent-benchmark-baseline.json
@@ -75,7 +75,7 @@
     },
     {
       "errors": [],
-      "estimated_tokens": 1953,
+      "estimated_tokens": 2103,
       "id": "documentation-impact",
       "passed": true,
       "selected_routes": [

--- a/ai/agent-benchmark.yml
+++ b/ai/agent-benchmark.yml
@@ -64,4 +64,4 @@ cases:
     expected_routes: [documentation-impact]
     expected_paths: [ai/docs-impact.yml]
     expected_documentation_ids: [contributing.documentation-policy]
-    expected_validation_ids: [agent-context]
+    expected_validation_ids: [documentation-impact]

--- a/ai/context.schema.json
+++ b/ai/context.schema.json
@@ -16,7 +16,7 @@
       ]
     },
     "description": { "type": "string", "minLength": 1 },
-    "enforcement": { "enum": [ "advisory", "deferred", "required" ] },
+    "enforcement": { "enum": [ "advisory", "deferred", "required", "staged" ] },
     "entries": {
       "type": "array",
       "items": {

--- a/ai/docs-impact.yml
+++ b/ai/docs-impact.yml
@@ -1,48 +1,148 @@
 schema_version: 1
 kind: docs_impact
-description: Advisory Phase 0/1 mapping from source changes to stable CCB-Docs IDs.
-enforcement: advisory
+description: Staged source-to-document mapping; ordinary changes remain advisory while public API and format contracts require complete cross-repository PR metadata.
+enforcement: staged
 entries:
   - id: governance-policy
+    enforcement: advisory
     patterns: [AGENTS.md, '*/AGENTS.md', CONTRIBUTING.md, GOVERNANCE.md, .github/pull_request_template.md]
     documentation_ids: [contributing.responsible-human, getting-started.first-contribution]
     generated_reference_impact: false
+    required_check_ids: []
     risk_group: governance
     risk_level: high
+
   - id: project-routing
-    patterns: [ai/project-map.yml, ai/test-matrix.yml, ai/generated-files.yml]
+    enforcement: advisory
+    patterns: [ai/project-map.yml, ai/test-matrix.yml, ai/generated-files.yml, ai/docs-impact.yml]
     documentation_ids: [architecture.project-map, validation.quickstart]
     generated_reference_impact: false
+    required_check_ids: []
     risk_group: project-context
     risk_level: normal
+
   - id: build-contracts
+    enforcement: advisory
     patterns: [CMakeLists.txt, CMakeModules/*, CMakePresets.json, Makefile, build-scripts/*, .github/workflows/*]
     documentation_ids: [validation.quickstart]
     generated_reference_impact: false
+    required_check_ids: []
     risk_group: build
     risk_level: high
+
   - id: lua-public-contract
-    patterns: [src/catalua*, src/event.h, data/lua/manifest.schema.json, data/lua/types/ccb_api_v5.d.lua, data/lua/reference/*, tools/lua_api/*]
-    documentation_ids: [api.lua.v5.overview, api.lua.v5.reference]
+    enforcement: required
+    patterns:
+      - src/catalua*
+      - src/event.h
+      - data/lua/manifest.schema.json
+      - data/lua/types/ccb_api_v5.d.lua
+      - data/lua/reference/*
+      - tools/lua_api/*
+    documentation_ids:
+      - api.lua.v5.overview
+      - api.lua.v5.lifecycle
+      - api.lua.v5.events
+      - api.lua.v5.capabilities
+      - api.lua.v5.permissions
+      - api.lua.v5.ui
+      - api.lua.v5.debugging
+      - api.lua.v5.performance
+      - api.lua.v5.migration
+      - api.lua.v5.changelog
+      - api.lua.v5.example-mod
+      - api.lua.v5.reference.modules
+      - api.lua.v5.reference.namespaces
+      - api.lua.v5.reference.classes
+      - api.lua.v5.reference.functions
+      - api.lua.v5.reference.methods
+      - api.lua.v5.reference.properties
+      - api.lua.v5.reference.operators
+      - api.lua.v5.reference.enums
+      - api.lua.v5.reference.events
+      - api.lua.v5.reference.hooks
+      - api.lua.v5.reference.callbacks
+      - api.lua.v5.reference.capabilities
+      - api.lua.v5.reference.permissions
+      - api.lua.v5.reference.manifest-fields
     generated_reference_impact: true
+    required_check_ids: [documentation-impact, lua-contract]
+    documentation_readiness:
+      state: bilingual_draft
+      languages: [zh_CN, en]
+      repository: CrimsonCrossBunker/CCB-Docs
+      ref: agent/ccb-docs-program-lua-reference
+      commit: 7fc27b606fed83b5dbcef57506b28a84cce046c1
+      source_commit: 3ac0bd7f356b30b880dc655f3006ebf1cbda9cfd
+      activation_gate: Refresh to the merged CCB source commit and promote every mapped page from draft before this enforcement PR merges.
     risk_group: lua-api
     risk_level: high
-  - id: json-eoc-contracts
+
+  - id: json-public-contract
+    enforcement: required
     patterns:
-      - data/json/*
-      - data/core/*
-      - data/mods/*
-      - data/sound/*
-      - data/reference/json/*
-      - doc/JSON/*
-      - src/*factory*
-      - src/*json*
+      - data/reference/json/ccb_json_object_types.json
       - src/init.cpp
+      - src/generic_factory.h
+      - src/*factory*
+      - tools/json_api/*
+    documentation_ids:
+      - json.overview
+      - json.inheritance-copy-from
+      - json.validation
+      - reference.json-object-types
+      - mods.complete-json-eoc-mod
+    generated_reference_impact: true
+    required_check_ids: [documentation-impact, json-eoc-contract]
+    documentation_readiness: &json_eoc_docs_readiness
+      state: bilingual_draft
+      languages: [zh_CN, en]
+      repository: CrimsonCrossBunker/CCB-Docs
+      ref: agent/ccb-docs-json-eoc-on-lua
+      commit: c86731aad984f67ed679a9f244f476fee7f973a1
+      source_commit: a038c765568fc47a58ef8c523b2722d416f5f61c
+      activation_gate: Refresh to the merged CCB source commit and promote every mapped page from draft before this enforcement PR merges.
+    risk_group: json-api
+    risk_level: high
+
+  - id: eoc-public-contract
+    enforcement: required
+    patterns:
+      - data/reference/json/ccb_eoc_conditions.json
+      - data/reference/json/ccb_eoc_effects.json
       - src/condition.cpp
       - src/npctalk.cpp
       - src/effect_on_condition.cpp
+      - src/effect_on_condition.h
       - tools/json_api/*
-    documentation_ids: []
+    documentation_ids:
+      - eoc.overview
+      - eoc.talkers
+      - eoc.variables-context
+      - eoc.nesting
+      - reference.eoc-conditions
+      - reference.eoc-effects
+      - mods.complete-json-eoc-mod
     generated_reference_impact: true
-    risk_group: json-eoc-api
+    required_check_ids: [documentation-impact, json-eoc-contract]
+    documentation_readiness: *json_eoc_docs_readiness
+    risk_group: eoc-api
+    risk_level: high
+
+  - id: json-eoc-content
+    enforcement: advisory
+    patterns: [data/core/*, data/json/*, data/mods/*, data/sound/*, doc/JSON/*]
+    documentation_ids: [json.overview, eoc.overview, mods.complete-json-eoc-mod]
+    generated_reference_impact: false
+    required_check_ids: []
+    risk_group: json-eoc-content
+    risk_level: normal
+
+  - id: json-serialization
+    enforcement: advisory
+    patterns: [src/*json*]
+    documentation_ids: [compatibility.save, json.overview]
+    generated_reference_impact: false
+    required_check_ids: []
+    risk_group: serialization
     risk_level: high

--- a/ai/repository-settings.target.yml
+++ b/ai/repository-settings.target.yml
@@ -1,6 +1,6 @@
 schema_version: 1
 kind: repository_settings_target
-description: Desired settings only; Phase 0/1 does not apply them automatically.
+description: Desired settings only; code changes do not apply GitHub rules automatically.
 enforcement: deferred
 entries:
   - id: master-protection
@@ -13,6 +13,9 @@ entries:
       require_pull_request: true
       required_non_author_approvals: 1
       dismiss_stale_reviews: true
+      candidate_required_checks:
+        - Agent context and documentation impact
+        - Lua public contract
       prohibit_force_push: true
       prohibit_branch_deletion: true
       administrator_emergency_bypass: true

--- a/ai/task-router.yml
+++ b/ai/task-router.yml
@@ -92,11 +92,11 @@ entries:
       - Generated boundaries are repository-specific and must be re-discovered in CCB.
   - id: documentation-impact
     keywords: [documentation, docs impact, stale, translation, 文档, 影响, 翻译]
-    paths: [ai/docs-impact.yml, ai/documentation-registry.yml, doc/migration/, .github/pull_request_template.md]
+    paths: [ai/docs-impact.yml, ai/documentation-registry.yml, doc/migration/, .github/pull_request_template.md, tools/agent/check_docs_impact.py]
     project_ids: [governance, developer-tools]
     documentation_ids: [contributing.documentation-policy]
     source_symbols: []
-    validation_ids: [agent-context]
+    validation_ids: [documentation-impact]
     compatibility:
       - Scope drift to declared source paths and preserve permanent moved stubs.
     upstream_differences:

--- a/ai/test-matrix.yml
+++ b/ai/test-matrix.yml
@@ -7,6 +7,11 @@ entries:
     command: python3 -m unittest discover -s tools/agent -p 'test_*.py'
     workdir: .
     cost: fast
+  - id: documentation-impact
+    paths: [ai/docs-impact.yml, tools/agent/check_docs_impact.py, tools/agent/test_docs_impact.py, .github/pull_request_template.md, .github/workflows/agent-context.yml]
+    command: python3 tools/agent/check_docs_impact.py --changed-file ai/docs-impact.yml && python3 -m unittest discover -s tools/agent -p 'test_docs_impact.py'
+    workdir: .
+    cost: fast
   - id: python-tools
     paths: [tools/]
     command: make python-check

--- a/tools/agent/check_docs_impact.py
+++ b/tools/agent/check_docs_impact.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Report documentation impact without blocking source changes in Phase 0/1."""
+"""Report mapped documentation impact and enforce staged PR fields."""
 
 from __future__ import annotations
 
@@ -23,16 +23,62 @@ DOCUMENTATION_PR_FIELDS = (
     "Generated reference impact",
 )
 RESPONSIBLE_HUMAN_FIELD = "Responsible human"
+VALID_ENFORCEMENT = {"advisory", "required", "staged"}
+PLACEHOLDER_VALUES = {
+    "-",
+    "n/a",
+    "na",
+    "no",
+    "none",
+    "not applicable",
+    "tbd",
+    "todo",
+    "待定",
+    "无",
+    "无影响",
+}
 GITHUB_USER_MENTION = re.compile(
     r"(?<![\w/-])@[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?(?![\w/-])"
+)
+CCB_DOCS_PR_REFERENCE = re.compile(
+    r"(?:https://github\.com/CrimsonCrossBunker/CCB-Docs/pull/[1-9][0-9]*"
+    r"|CrimsonCrossBunker/CCB-Docs#[1-9][0-9]*)",
+    re.IGNORECASE,
 )
 
 
 def load_rules(path: Path = MAP_PATH) -> list[dict]:
+    """Load mappings and resolve the staged top-level enforcement mode."""
     data = yaml.safe_load(path.read_text(encoding="utf-8"))
-    if data.get("enforcement") != "advisory":
-        raise ValueError("Phase 0/1 documentation impact must be advisory")
-    return data["entries"]
+    if not isinstance(data, dict):
+        raise ValueError("documentation impact map must contain a mapping")
+    mode = data.get("enforcement")
+    if mode not in VALID_ENFORCEMENT:
+        raise ValueError(
+            f"unsupported documentation impact enforcement: {mode}"
+        )
+    entries = data.get("entries")
+    if not isinstance(entries, list):
+        raise ValueError("documentation impact entries must be a list")
+
+    rules: list[dict] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError("documentation impact entry must be a mapping")
+        enforcement = entry.get("enforcement")
+        if mode == "staged" and enforcement is None:
+            raise ValueError(
+                f"staged documentation impact entry {entry.get('id')} "
+                "must declare enforcement"
+            )
+        if enforcement is None:
+            enforcement = mode
+        if enforcement not in {"advisory", "required"}:
+            raise ValueError(
+                f"invalid enforcement for {entry.get('id')}: {enforcement}"
+            )
+        rules.append({**entry, "enforcement": enforcement})
+    return rules
 
 
 def changed_files(base: str, head: str) -> list[str]:
@@ -72,29 +118,100 @@ def field_value(body: str, heading: str) -> str | None:
     match = pattern.search(body)
     if not match:
         return None
-    visible = re.sub(
+    return re.sub(
         r"<!--.*?-->", "", match.group(1), flags=re.DOTALL
     ).strip()
-    return visible
 
 
-def validate_pr_body(body: str) -> list[str]:
-    """Return blocking responsibility errors only."""
+def is_placeholder(value: str | None) -> bool:
+    if value is None:
+        return True
+    normalized = re.sub(r"[`*_]", "", value).strip().lower().rstrip(".。")
+    return not normalized or normalized in PLACEHOLDER_VALUES
+
+
+def mentioned_document_ids(value: str, expected: set[str]) -> set[str]:
+    mentioned = set()
+    for identifier in expected:
+        pattern = re.compile(
+            rf"(?<![A-Za-z0-9_.-]){re.escape(identifier)}"
+            r"(?![A-Za-z0-9_.-])"
+        )
+        if pattern.search(value):
+            mentioned.add(identifier)
+    return mentioned
+
+
+def required_field_errors(body: str, result: list[dict]) -> list[str]:
+    """Return blocking errors for mappings explicitly marked required."""
+    required = [
+        item for item in result if item.get("enforcement") == "required"
+    ]
+    if not required:
+        return []
+
+    errors: list[str] = []
+    values = {
+        heading: field_value(body, heading)
+        for heading in DOCUMENTATION_PR_FIELDS
+    }
+    for heading, value in values.items():
+        if value is None:
+            errors.append(f"missing required PR field: {heading}")
+        elif is_placeholder(value):
+            errors.append(
+                f"required PR field must not be a placeholder: {heading}"
+            )
+
+    related = values["Related CCB-Docs PR"]
+    if related and not is_placeholder(related):
+        if not CCB_DOCS_PR_REFERENCE.search(related):
+            errors.append(
+                "Related CCB-Docs PR must link a CrimsonCrossBunker/CCB-Docs "
+                "pull request for required documentation impact"
+            )
+
+    affected = values["Affected documentation IDs"]
+    if affected and not is_placeholder(affected):
+        for item in required:
+            expected_ids = set(item.get("documentation_ids", []))
+            if expected_ids and not mentioned_document_ids(
+                affected, expected_ids
+            ):
+                identifiers = ", ".join(sorted(expected_ids))
+                errors.append(
+                    "Affected documentation IDs must name at least one mapped "
+                    f"ID for {item['id']}: {identifiers}"
+                )
+    return errors
+
+
+def validate_pr_body(body: str, result: list[dict] | None = None) -> list[str]:
+    """Return all blocking responsibility and staged-impact errors."""
+    errors: list[str] = []
     responsible = field_value(body, RESPONSIBLE_HUMAN_FIELD)
     if responsible is None:
-        return [f"missing PR field: {RESPONSIBLE_HUMAN_FIELD}"]
-    mentions = GITHUB_USER_MENTION.findall(responsible)
-    if not mentions or all(
-        mention.lower() == "@username" for mention in mentions
+        errors.append(f"missing PR field: {RESPONSIBLE_HUMAN_FIELD}")
+    else:
+        mentions = GITHUB_USER_MENTION.findall(responsible)
+        if not mentions or all(
+            mention.lower() == "@username" for mention in mentions
+        ):
+            errors.append("Responsible human must name a real GitHub account")
+        elif "[bot]" in responsible.lower():
+            errors.append("Responsible human must not be a bot account")
+    errors.extend(required_field_errors(body, result or []))
+    return errors
+
+
+def documentation_field_warnings(
+    body: str, result: list[dict] | None = None
+) -> list[str]:
+    """Return warnings for fields that are not already required."""
+    if any(
+        item.get("enforcement") == "required" for item in (result or [])
     ):
-        return ["Responsible human must name a real GitHub account"]
-    if "[bot]" in responsible.lower():
-        return ["Responsible human must not be a bot account"]
-    return []
-
-
-def documentation_field_warnings(body: str) -> list[str]:
-    """Return non-blocking Phase 0/1 documentation-field warnings."""
+        return []
     warnings = []
     for heading in DOCUMENTATION_PR_FIELDS:
         if field_value(body, heading) is None:
@@ -104,15 +221,15 @@ def documentation_field_warnings(body: str) -> list[str]:
 
 def report(result: list[dict]) -> str:
     if not result:
-        return "Documentation impact advisory: no mapped documentation IDs."
-    lines = ["Documentation impact advisory (non-blocking in Phase 0/1):"]
+        return "Documentation impact: no mapped documentation IDs."
+    lines = ["Documentation impact (staged enforcement):"]
     for item in result:
-        ids = ", ".join(item.get("documentation_ids", [])) or (
-            "no Phase 0/1 page yet"
-        )
+        ids = ", ".join(item.get("documentation_ids", [])) or "none mapped"
         generated = "yes" if item.get("generated_reference_impact") else "no"
+        checks = ", ".join(item.get("required_check_ids", [])) or "none"
         lines.append(
-            f"- {item['id']}: docs={ids}; generated-reference={generated}; "
+            f"- [{item['enforcement']}] {item['id']}: docs={ids}; "
+            f"generated-reference={generated}; checks={checks}; "
             f"files={', '.join(item['matched_files'])}"
         )
     return "\n".join(lines)
@@ -133,7 +250,8 @@ def main() -> int:
         files.extend(changed_files(args.base, args.head))
     files = sorted(set(files))
 
-    message = report(impacts(files, load_rules()))
+    result = impacts(files, load_rules())
+    message = report(result)
     print(message)
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
     if summary_path:
@@ -141,8 +259,9 @@ def main() -> int:
             summary.write("## Documentation impact\n\n" + message + "\n")
 
     if args.check_pr_body:
-        errors = validate_pr_body(os.environ.get("PR_BODY", ""))
-        warnings = documentation_field_warnings(os.environ.get("PR_BODY", ""))
+        body = os.environ.get("PR_BODY", "")
+        errors = validate_pr_body(body, result)
+        warnings = documentation_field_warnings(body, result)
         for warning in warnings:
             print(f"::warning::{warning}", file=sys.stderr)
         for error in errors:

--- a/tools/agent/check_project_metadata.py
+++ b/tools/agent/check_project_metadata.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import fnmatch
 import json
+import re
 import subprocess
 from collections import Counter
 from pathlib import Path
@@ -119,14 +120,82 @@ def validate_context() -> None:
                     )
 
     impact = documents["docs-impact.yml"]
-    if impact.get("enforcement") != "advisory":
-        raise ValueError("Phase 0/1 documentation impact must remain advisory")
+    if impact.get("enforcement") != "staged":
+        raise ValueError("documentation impact must use staged enforcement")
     for entry in impact["entries"]:
+        enforcement = entry.get("enforcement")
+        if enforcement not in {"advisory", "required"}:
+            raise ValueError(
+                f"invalid documentation enforcement for {entry['id']}"
+            )
+        documentation_ids = entry.get("documentation_ids", [])
+        if len(documentation_ids) != len(set(documentation_ids)):
+            raise ValueError(
+                f"duplicate documentation ID in impact {entry['id']}"
+            )
+        required_checks = entry.get("required_check_ids", [])
+        unknown_checks = sorted(set(required_checks) - test_ids)
+        if unknown_checks:
+            raise ValueError(
+                f"unknown required checks in {entry['id']}: {unknown_checks}"
+            )
         for pattern in entry.get("patterns", []):
             if not path_pattern_exists(pattern, known):
                 raise ValueError(
                     f"unmatched documentation impact pattern: {pattern}"
                 )
+        if enforcement != "required":
+            continue
+        if not documentation_ids:
+            raise ValueError(
+                f"required impact {entry['id']} needs documentation IDs"
+            )
+        if not required_checks:
+            raise ValueError(
+                f"required impact {entry['id']} needs validation checks"
+            )
+        if entry.get("risk_level") != "high":
+            raise ValueError(
+                f"required impact {entry['id']} must be high risk"
+            )
+        readiness = entry.get("documentation_readiness")
+        if not isinstance(readiness, dict):
+            raise ValueError(
+                f"required impact {entry['id']} needs docs provenance"
+            )
+        if readiness.get("state") not in {"bilingual_draft", "active"}:
+            raise ValueError(
+                f"required impact {entry['id']} has invalid docs readiness"
+            )
+        if set(readiness.get("languages", [])) != {"zh_CN", "en"}:
+            raise ValueError(
+                f"required impact {entry['id']} needs zh_CN and en docs"
+            )
+        if readiness.get("repository") != "CrimsonCrossBunker/CCB-Docs":
+            raise ValueError(
+                f"required impact {entry['id']} has invalid docs repository"
+            )
+        if not readiness.get("ref"):
+            raise ValueError(
+                f"required impact {entry['id']} needs a docs ref"
+            )
+        if not re.fullmatch(r"[0-9a-f]{40}", readiness.get("commit", "")):
+            raise ValueError(
+                f"required impact {entry['id']} needs a docs commit"
+            )
+        if not re.fullmatch(
+            r"[0-9a-f]{40}", readiness.get("source_commit", "")
+        ):
+            raise ValueError(
+                f"required impact {entry['id']} needs a source commit"
+            )
+        if readiness["state"] == "bilingual_draft" and not readiness.get(
+            "activation_gate"
+        ):
+            raise ValueError(
+                f"draft documentation for {entry['id']} needs an "
+                "activation gate"
+            )
 
     router = load_yaml(ROOT / "ai/task-router.yml")
     router_schema = json.loads(
@@ -193,10 +262,14 @@ def validate_inventory() -> None:
         raise ValueError("duplicate Markdown path in inventory")
     if any(path == "obj-lua" or path.startswith("obj-lua/") for path in paths):
         raise ValueError("obj-lua must not be scanned or inventoried")
-    stable_ids = [entry["stable_document_id"] for entry in inventory["documents"]]
+    stable_ids = [
+        entry["stable_document_id"] for entry in inventory["documents"]
+    ]
     if len(stable_ids) != len(set(stable_ids)):
         raise ValueError("duplicate stable_document_id in Markdown inventory")
-    action_counts = Counter(entry["action"] for entry in inventory["documents"])
+    action_counts = Counter(
+        entry["action"] for entry in inventory["documents"]
+    )
     status_counts = Counter(
         entry["migration_status"] for entry in inventory["documents"]
     )
@@ -209,7 +282,10 @@ def validate_inventory() -> None:
         raise ValueError("Markdown migration-status summary is stale")
     known_paths = set(tracked_paths())
     for entry in inventory["documents"]:
-        if any("obj-lua" in Path(path).parts for path in entry["source_paths"]):
+        if any(
+            "obj-lua" in Path(path).parts
+            for path in entry["source_paths"]
+        ):
             raise ValueError("obj-lua is forbidden in inventory source paths")
         for contributor in entry["contributors"]:
             reason = contributor_rejection_reason(contributor)
@@ -241,16 +317,24 @@ def validate_inventory() -> None:
             )
 
     anomaly_path = ROOT / "doc/migration/contributor-anomalies.yml"
-    anomaly_schema_path = ROOT / "doc/migration/contributor-anomalies.schema.json"
+    anomaly_schema_path = (
+        ROOT / "doc/migration/contributor-anomalies.schema.json"
+    )
     anomalies = load_yaml(anomaly_path)
-    anomaly_schema = json.loads(anomaly_schema_path.read_text(encoding="utf-8"))
+    anomaly_schema = json.loads(
+        anomaly_schema_path.read_text(encoding="utf-8")
+    )
     jsonschema.Draft202012Validator(anomaly_schema).validate(anomalies)
     if anomalies["source_commit"] != inventory["source_commit"]:
-        raise ValueError("contributor anomaly report uses another source commit")
+        raise ValueError(
+            "contributor anomaly report uses another source commit"
+        )
     if anomalies["rejected_count"] != len(anomalies["entries"]):
         raise ValueError("contributor anomaly report count is stale")
     if any("value" in entry for entry in anomalies["entries"]):
-        raise ValueError("raw rejected contributor identities must not be published")
+        raise ValueError(
+            "raw rejected contributor identities must not be published"
+        )
 
     batches_path = ROOT / "doc/migration/migration-batches.yml"
     batches_schema_path = ROOT / "doc/migration/migration-batches.schema.json"
@@ -271,9 +355,8 @@ def validate_inventory() -> None:
     expected_batched = {
         entry["stable_document_id"]
         for entry in inventory["documents"]
-        if entry["migration_batch"] and (
-            entry["migration_status"] not in {"verified", "stubbed", "archived"}
-        )
+        if entry["migration_batch"]
+        if entry["migration_status"] not in {"verified", "stubbed", "archived"}
     }
     actual_batched = {
         entry["stable_document_id"] for entry in batch_documents

--- a/tools/agent/test_docs_impact.py
+++ b/tools/agent/test_docs_impact.py
@@ -1,62 +1,191 @@
+from __future__ import annotations
+
+import tempfile
 import unittest
+from pathlib import Path
 
 from check_docs_impact import (
     documentation_field_warnings,
     impacts,
+    load_rules,
+    report,
     validate_pr_body,
 )
 
 
+def complete_body(document_id: str = "api.lua.v5.overview") -> str:
+    return f"""#### Responsible human
+@maintainer
+#### Documentation impact
+Refresh the Lua v5 contract reference after the source change.
+#### Related CCB-Docs PR
+https://github.com/CrimsonCrossBunker/CCB-Docs/pull/42
+#### Affected documentation IDs
+{document_id}
+#### Generated reference impact
+Regenerate and verify the checked-in Lua contract inventory.
+"""
+
+
 class DocsImpactTest(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.rules = [
             {
+                "id": "governance",
+                "enforcement": "advisory",
+                "patterns": ["CONTRIBUTING.md"],
+                "documentation_ids": ["contributing.overview"],
+                "generated_reference_impact": False,
+                "required_check_ids": [],
+            },
+            {
                 "id": "lua",
+                "enforcement": "required",
                 "patterns": ["data/lua/*", "src/catalua_ui_*"],
-                "documentation_ids": ["reference.lua"],
+                "documentation_ids": ["api.lua.v5.overview"],
                 "generated_reference_impact": True,
-            }
+                "required_check_ids": ["agent-context", "lua-contract"],
+            },
         ]
 
-    def test_matches_only_relevant_paths(self):
+    def test_matches_only_relevant_paths(self) -> None:
         result = impacts(
             ["src/game.cpp", "data/lua/manifest.schema.json"], self.rules
         )
         self.assertEqual(
             ["data/lua/manifest.schema.json"], result[0]["matched_files"]
         )
+        self.assertEqual(result[0]["enforcement"], "required")
 
-    def test_unrelated_path_has_no_impact(self):
-        self.assertEqual([], impacts(["src/game.cpp"], self.rules))
+    def test_unrelated_path_has_no_impact(self) -> None:
+        result = impacts(["src/game.cpp"], self.rules)
+        self.assertEqual(result, [])
+        self.assertEqual(validate_pr_body(complete_body(), result), [])
 
-    def test_pr_body_requires_real_responsible_human(self):
+    def test_advisory_mapping_does_not_block_fields(self) -> None:
+        result = impacts(["CONTRIBUTING.md"], self.rules)
+        body = "#### Responsible human\n@maintainer\n"
+        self.assertEqual(validate_pr_body(body, result), [])
+        self.assertEqual(len(documentation_field_warnings(body, result)), 4)
+
+    def test_required_mapping_blocks_missing_fields(self) -> None:
+        result = impacts(["data/lua/manifest.schema.json"], self.rules)
+        body = "#### Responsible human\n@maintainer\n"
+        errors = validate_pr_body(body, result)
+        self.assertEqual(len(errors), 4)
+        self.assertTrue(
+            all("missing required PR field" in error for error in errors)
+        )
+        self.assertEqual(documentation_field_warnings(body, result), [])
+
+    def test_required_mapping_blocks_template_placeholders(self) -> None:
+        result = impacts(["data/lua/manifest.schema.json"], self.rules)
         body = """#### Responsible human
 @maintainer
 #### Documentation impact
 None
 #### Related CCB-Docs PR
-None
+N/A
 #### Affected documentation IDs
-None
+TBD
 #### Generated reference impact
-None
+无
 """
-        self.assertEqual([], validate_pr_body(body))
-        self.assertTrue(
-            validate_pr_body(body.replace("@maintainer", "@username"))
+        errors = validate_pr_body(body, result)
+        self.assertEqual(len(errors), 4)
+        self.assertTrue(all("placeholder" in error for error in errors))
+
+    def test_required_mapping_accepts_complete_fields(self) -> None:
+        result = impacts(["data/lua/manifest.schema.json"], self.rules)
+        self.assertEqual(validate_pr_body(complete_body(), result), [])
+
+    def test_required_mapping_rejects_wrong_docs_repository(self) -> None:
+        result = impacts(["data/lua/manifest.schema.json"], self.rules)
+        body = complete_body().replace(
+            "CrimsonCrossBunker/CCB-Docs", "CrimsonCrossBunker/Other"
         )
+        errors = validate_pr_body(body, result)
+        self.assertTrue(any("CCB-Docs" in error for error in errors))
 
-    def test_documentation_fields_are_advisory_in_phase_zero(self):
-        body = """#### Responsible human
-@maintainer
-"""
-        self.assertEqual(validate_pr_body(body), [])
-        self.assertEqual(len(documentation_field_warnings(body)), 4)
+    def test_required_mapping_rejects_unmapped_document_id(self) -> None:
+        result = impacts(["data/lua/manifest.schema.json"], self.rules)
+        errors = validate_pr_body(complete_body("unrelated.page"), result)
+        self.assertTrue(any("mapped ID" in error for error in errors))
 
-    def test_responsible_human_cannot_be_none_or_a_bot(self):
-        self.assertTrue(validate_pr_body("#### Responsible human\nNone\n"))
+    def test_each_required_mapping_needs_an_affected_id(self) -> None:
+        rules = self.rules + [
+            {
+                "id": "eoc",
+                "enforcement": "required",
+                "patterns": ["tools/contracts.py"],
+                "documentation_ids": ["eoc.overview"],
+                "generated_reference_impact": True,
+                "required_check_ids": ["json-eoc-contract"],
+            }
+        ]
+        rules[1] = {**rules[1], "patterns": ["tools/contracts.py"]}
+        result = impacts(["tools/contracts.py"], rules)
+        errors = validate_pr_body(complete_body(), result)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("eoc", errors[0])
+        body = complete_body("api.lua.v5.overview, eoc.overview")
+        self.assertEqual(validate_pr_body(body, result), [])
+
+    def test_responsible_human_cannot_be_placeholder_or_bot(self) -> None:
+        self.assertTrue(
+            validate_pr_body("#### Responsible human\n@username\n")
+        )
         self.assertTrue(
             validate_pr_body("#### Responsible human\n@automation[bot]\n")
+        )
+        self.assertTrue(validate_pr_body("#### Responsible human\nNone\n"))
+
+    def test_report_names_enforcement_and_checks(self) -> None:
+        result = impacts(["data/lua/manifest.schema.json"], self.rules)
+        output = report(result)
+        self.assertIn("[required] lua", output)
+        self.assertIn("agent-context, lua-contract", output)
+
+    def test_staged_map_requires_entry_enforcement(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "docs-impact.yml"
+            path.write_text(
+                """schema_version: 1
+kind: docs_impact
+enforcement: staged
+entries:
+  - id: incomplete
+    patterns: [README.md]
+""",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(
+                ValueError, "must declare enforcement"
+            ):
+                load_rules(path)
+
+    def test_ordinary_json_repository_rules_are_advisory(self) -> None:
+        rules = load_rules()
+        result = impacts(
+            ["data/mods/TEST_DATA/modinfo.json", "src/savegame_json.cpp"],
+            rules,
+        )
+        self.assertTrue(result)
+        self.assertEqual(
+            {item["enforcement"] for item in result}, {"advisory"}
+        )
+
+    def test_repository_rules_require_json_eoc_contracts(self) -> None:
+        result = impacts(
+            ["tools/json_api/generate_contracts.py"], load_rules()
+        )
+        required = {
+            item["id"]
+            for item in result
+            if item["enforcement"] == "required"
+        }
+        self.assertEqual(
+            required, {"json-public-contract", "eoc-public-contract"}
         )
 
 


### PR DESCRIPTION
## Summary

Finalizes scoped documentation-impact enforcement after the paired Lua, JSON, and EOC contract documentation layers were created.

- upgrades public Lua contract, LuaLS, manifest Schema, JSON registry, and EOC parser/registry mappings to `required`;
- keeps ordinary JSON content, build, governance, and save JSON changes advisory;
- requires a Responsible human, all four documentation-impact fields, a real open CCB-Docs PR, and every affected stable documentation ID for required mappings;
- validates 36 stable IDs / 72 bilingual Draft pages in the related CCB-Docs stack;
- preserves the 30-day translation rule: overdue debt blocks only the affected pair or same high-risk subsystem, never unrelated documentation work;
- gives the Lua workflow a stable check name and a fast successful path for unrelated changes;
- records target required checks while keeping repository rules disabled.

Program tracker: #558
Stack base: #568.
Related documentation: CCB-Docs #8 and #9.

#### Responsible human

- Responsible human: @LYHGLYTX
- I understand the policy change and own its tests and merge sequencing: yes

#### Documentation impact

This PR is the enforcement layer. It does not modify documentation prose or runtime contracts.

#### Related CCB-Docs PR

- https://github.com/CrimsonCrossBunker/CCB-Docs/pull/8
- https://github.com/CrimsonCrossBunker/CCB-Docs/pull/9

#### Affected documentation IDs

All 36 Lua/JSON/EOC IDs declared by required mappings in `ai/docs-impact.yml`.

#### Generated reference impact

No generated public contract changes; this validates existing generated inventories and routes their changes to documentation.

#### Runtime/gameplay/save impact

None.

## Validation

- Agent tests: 41/41
- context benchmark: 9/9
- metadata, frozen inventory, documentation registry, and migration checks
- JSON/EOC tests: 15/15; 190 / 275 / 306 inventories
- Lua tests: 46/46; 2,806 / 2,806 public symbols; 0 undocumented
- translation scoping tests: 4/4
- YAML and JSON parse checks
- changed-file flake8 with one worker
- `git diff --check`
- required-pass, required-block, advisory-pass, unrelated-Lua CLI scenarios

`make python-check` could not find a system `flake8`; the pinned virtual environment passed every Python file changed here. Existing unrelated whole-repository E501 findings were not expanded into this policy PR.

## Governance gate

No ruleset or branch protection was enabled. Required-check target configuration remains disabled until checks are stable on default branches and at least two active, willing, review-capable human maintainers are recorded in #563. No auto-merge or Bot approval.

## Commit split

- Previous commit count: 1
- New commit count: 2
- Incremental changed lines: 696
- Average changed lines: 348
- Largest atomic commit: see commit log
- Tree-equivalence result: PASS (git diff --exit-code <old-head> <new-head>)
- Previous head: `c022f663b494e1bcf14e183c5859e2e9d4ad344d`
- New head: `ae4a80ffacf2c9fac9b8f56833d5ee54112371b8`
- Backup bundle: skipped by owner instruction (old head recorded above)
- Validation status: tree-equivalent, chain verified
