### PR TITLE
CCB Agent 友好化与双语开发文档重构：tooling: reconcile cross-repository documentation IDs

### DIFF
--- a/ai/agent-benchmark-baseline.json
+++ b/ai/agent-benchmark-baseline.json
@@ -21,7 +21,7 @@
     },
     {
       "errors": [],
-      "estimated_tokens": 1541,
+      "estimated_tokens": 1540,
       "id": "json-content",
       "passed": true,
       "selected_routes": [
@@ -30,7 +30,7 @@
     },
     {
       "errors": [],
-      "estimated_tokens": 1947,
+      "estimated_tokens": 1949,
       "id": "eoc",
       "passed": true,
       "selected_routes": [
@@ -39,7 +39,7 @@
     },
     {
       "errors": [],
-      "estimated_tokens": 2168,
+      "estimated_tokens": 2170,
       "id": "lua-api",
       "passed": true,
       "selected_routes": [

--- a/ai/agent-benchmark.yml
+++ b/ai/agent-benchmark.yml
@@ -21,21 +21,21 @@ cases:
     files: [data/json/items/melee/misc.json]
     expected_routes: [json-content]
     expected_paths: [data/json/]
-    expected_documentation_ids: [api.json.overview]
+    expected_documentation_ids: [json.overview]
     expected_validation_ids: [json-load]
   - id: eoc
     task: Add an EOC condition and effect with the correct talker context.
     files: [src/condition.cpp]
     expected_routes: [eoc]
     expected_paths: [src/condition.cpp]
-    expected_documentation_ids: [api.eoc.conditions, api.eoc.effects]
+    expected_documentation_ids: [reference.eoc-conditions, reference.eoc-effects]
     expected_validation_ids: [json-load]
   - id: lua-api
     task: Extend the Lua API manifest capability contract.
     files: [data/lua/manifest.schema.json]
     expected_routes: [lua-api]
     expected_paths: [data/lua/]
-    expected_documentation_ids: [api.lua.v5.reference]
+    expected_documentation_ids: [api.lua.v5.reference.modules]
     expected_validation_ids: [lua-contract]
   - id: upstream-port
     task: Port an upstream CBN fix while preserving CCB differences.

--- a/ai/documentation-registry.yml
+++ b/ai/documentation-registry.yml
@@ -1,6 +1,6 @@
 schema_version: 1
 kind: documentation_registry
-source_commit: 16bdf7a04a31e9ddb0733a00ee88685ec22e520d
+source_commit: af96b9d149fa7b269bb2c6ed5f51c8e126321204
 scope: Tracked documentation and machine contracts from the Git index; untracked build caches are never
   traversed.
 entry_count: 233
@@ -420,7 +420,7 @@ entries:
   source_of_truth: false
   stable_document_id: legacy.data-json-loading-order
   ccb_docs_ids:
-  - legacy.data-json-loading-order
+  - json.loading-order
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -465,7 +465,7 @@ entries:
   source_of_truth: false
   stable_document_id: lua.v5.overview
   ccb_docs_ids:
-  - lua.v5.overview
+  - api.lua.v5.overview
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -477,7 +477,7 @@ entries:
   source_of_truth: false
   stable_document_id: lua.v5.example-mod
   ccb_docs_ids:
-  - lua.v5.example-mod
+  - api.lua.v5.example-mod
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -897,7 +897,7 @@ entries:
   source_of_truth: false
   stable_document_id: mods.aftershock-exoplanet.lore.cyberpunk-future
   ccb_docs_ids:
-  - mods.aftershock-exoplanet.lore.cyberpunk-future
+  - mods.aftershock-exoplanet.lore.organizations
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1186,7 +1186,7 @@ entries:
   source_of_truth: false
   stable_document_id: contributing.developer-faq
   ccb_docs_ids:
-  - contributing.developer-faq
+  - how-to.common-tasks
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1234,7 +1234,7 @@ entries:
   source_of_truth: false
   stable_document_id: getting-started.how-you-can-help
   ccb_docs_ids:
-  - getting-started.how-you-can-help
+  - getting-started.first-contribution
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1474,7 +1474,7 @@ entries:
   source_of_truth: false
   stable_document_id: legacy.doc-json-json-loading-order
   ccb_docs_ids:
-  - legacy.doc-json-json-loading-order
+  - json.loading-order
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1510,7 +1510,7 @@ entries:
   source_of_truth: false
   stable_document_id: tutorial.mapgen-roofs
   ccb_docs_ids:
-  - tutorial.mapgen-roofs
+  - tutorial.mapgen-beginner
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1570,7 +1570,7 @@ entries:
   source_of_truth: false
   stable_document_id: json.map-smashing
   ccb_docs_ids:
-  - json.map-smashing
+  - json.terrain-and-furniture
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1858,7 +1858,7 @@ entries:
   source_of_truth: false
   stable_document_id: cpp-activities
   ccb_docs_ids:
-  - cpp-activities
+  - cpp.activities
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1870,7 +1870,7 @@ entries:
   source_of_truth: false
   stable_document_id: legacy.doc-release-diff
   ccb_docs_ids:
-  - legacy.doc-release-diff
+  - maintenance.releases
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -1882,7 +1882,7 @@ entries:
   source_of_truth: false
   stable_document_id: legacy.doc-release-process
   ccb_docs_ids:
-  - legacy.doc-release-process
+  - maintenance.releases
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -2002,7 +2002,7 @@ entries:
   source_of_truth: false
   stable_document_id: legacy.doc-c-compiling-cmake-vcpkg
   ccb_docs_ids:
-  - legacy.doc-c-compiling-cmake-vcpkg
+  - build-windows-msvc
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -2086,7 +2086,7 @@ entries:
   source_of_truth: false
   stable_document_id: build-overview
   ccb_docs_ids:
-  - build-overview
+  - build.overview
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -2182,7 +2182,7 @@ entries:
   source_of_truth: false
   stable_document_id: legacy.doc-design-balance-lore-game-balance
   ccb_docs_ids:
-  - legacy.doc-design-balance-lore-game-balance
+  - design-balance
   generated: false
   generated_by: null
   include_in_ai_index: true
@@ -2510,7 +2510,7 @@ entries:
   source_of_truth: false
   stable_document_id: legacy.lang-notes-readme-all-translators
   ccb_docs_ids:
-  - legacy.lang-notes-readme-all-translators
+  - translation-guide
   generated: false
   generated_by: null
   include_in_ai_index: true

--- a/ai/task-router.yml
+++ b/ai/task-router.yml
@@ -28,7 +28,7 @@ entries:
     keywords: [JSON, item, recipe, monster, mapgen, content, 物品, 配方, 怪物, 内容]
     paths: [data/json/, data/core/, tools/json_tools/]
     project_ids: [core-data]
-    documentation_ids: [api.json.overview, compatibility.mods]
+    documentation_ids: [json.overview, compatibility.mods]
     source_symbols: []
     validation_ids: [json-load]
     compatibility:
@@ -39,7 +39,7 @@ entries:
     keywords: [EOC, effect_on_condition, condition, effect, talker, 条件, 效果]
     paths: [data/json/, data/mods/, src/condition.cpp, src/effect_on_condition.cpp]
     project_ids: [core-data, bundled-mods]
-    documentation_ids: [api.eoc.overview, api.eoc.conditions, api.eoc.effects]
+    documentation_ids: [eoc.overview, reference.eoc-conditions, reference.eoc-effects]
     source_symbols: [effect_on_condition]
     validation_ids: [json-load]
     compatibility:
@@ -50,7 +50,7 @@ entries:
     keywords: [Lua, LuaLS, manifest, capability, callback, hook, 脚本, 能力]
     paths: [data/lua/, tools/lua_api/, 'src/catalua*.cpp', 'src/catalua*.h']
     project_ids: [lua-api]
-    documentation_ids: [api.lua.v5.overview, api.lua.v5.reference]
+    documentation_ids: [api.lua.v5.overview, api.lua.v5.reference.modules]
     source_symbols: [ccb_api_v5]
     validation_ids: [lua-contract]
     compatibility:

--- a/doc/migration/markdown-inventory.yml
+++ b/doc/migration/markdown-inventory.yml
@@ -350,7 +350,7 @@ documents:
   last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
   ccb_specificity: ccb_specific
   upstream_relation: ccb_native_lua_v5_contract
-  merge_target: null
+  merge_target: api.lua.v5.overview
   source_paths:
   - data/lua/README.md
   - data/lua/manifest.schema.json
@@ -392,7 +392,7 @@ documents:
   last_applicable_commit: 5f23722ff28c5cc552baa0422b32b1f10fd890fa
   ccb_specificity: ccb_specific
   upstream_relation: ccb_native_lua_v5_example
-  merge_target: null
+  merge_target: api.lua.v5.example-mod
   source_paths:
   - data/lua/examples/api_v5_mod/README.md
   - data/lua/examples/api_v5_mod/lua/main.lua
@@ -4541,7 +4541,7 @@ documents:
   license: CC-BY-SA-3.0
   action: migrate_rewrite
   archive_reason: null
-  replacement: cpp-activities
+  replacement: cpp.activities
   migration_status: stubbed
   history_strategy: evaluate_filtered_history
   stable_document_id: cpp-activities
@@ -4550,7 +4550,7 @@ documents:
   last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
   ccb_specificity: mixed
   upstream_relation: upstream_derived_revalidate
-  merge_target: null
+  merge_target: cpp.activities
   source_paths:
   - doc/PLAYER_ACTIVITY.md
   - src/activity_actor.h
@@ -4581,7 +4581,7 @@ documents:
   license: CC-BY-SA-3.0
   action: merge_into
   archive_reason: null
-  replacement: release-maintenance
+  replacement: maintenance.releases
   migration_status: stubbed
   history_strategy: evaluate_filtered_history
   stable_document_id: legacy.doc-release-diff
@@ -4590,7 +4590,7 @@ documents:
   last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
   ccb_specificity: ccb_specific
   upstream_relation: ccb_workflow_replaces_upstream_process
-  merge_target: release-maintenance
+  merge_target: maintenance.releases
   source_paths:
   - doc/RELEASE_DIFF.md
   - .github/workflows/release.yml
@@ -4617,7 +4617,7 @@ documents:
   license: CC-BY-SA-3.0
   action: merge_into
   archive_reason: null
-  replacement: release-maintenance
+  replacement: maintenance.releases
   migration_status: stubbed
   history_strategy: evaluate_filtered_history
   stable_document_id: legacy.doc-release-process
@@ -4626,7 +4626,7 @@ documents:
   last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
   ccb_specificity: ccb_specific
   upstream_relation: ccb_workflow_replaces_upstream_process
-  merge_target: release-maintenance
+  merge_target: maintenance.releases
   source_paths:
   - doc/RELEASE_PROCESS.md
   - .github/workflows/release.yml
@@ -5270,7 +5270,7 @@ documents:
   license: CC-BY-SA-3.0
   action: migrate_rewrite
   archive_reason: null
-  replacement: build-overview
+  replacement: build.overview
   migration_status: stubbed
   history_strategy: evaluate_filtered_history
   stable_document_id: build-overview
@@ -5279,7 +5279,7 @@ documents:
   last_applicable_commit: 7a008bf28d7ee7ebef549514228a0d0b45b7bac4
   ccb_specificity: mixed
   upstream_relation: upstream_derived_with_ccb_extensions
-  merge_target: null
+  merge_target: build.overview
   source_paths:
   - doc/c++/COMPILING.md
   - CMakeLists.txt

--- a/tools/agent/generate_documentation_registry.py
+++ b/tools/agent/generate_documentation_registry.py
@@ -207,7 +207,10 @@ def classify(path: str, legacy: dict[str, dict]) -> dict:
         "keep_in_repo",
         "retain_third_party",
     }:
-        ccb_docs_ids.append(historical["stable_document_id"])
+        target_id = (
+            historical.get("merge_target") or historical["stable_document_id"]
+        )
+        ccb_docs_ids.append(target_id)
     return {
         "id": registry_id(path),
         "path": path,

--- a/tools/agent/generate_markdown_inventory.py
+++ b/tools/agent/generate_markdown_inventory.py
@@ -33,6 +33,16 @@ KEEP_IN_REPO = {
     "SYNC_EXCLUDED_PRS.md",
     "TRANSLATION_CREDITS.md",
 }
+FROZEN_DOCUMENT_COUNT = 175
+TERMINAL_MIGRATION_STATUSES = {"verified", "stubbed", "archived"}
+TARGET_ID_OVERRIDES = {
+    "data/lua/README.md": "api.lua.v5.overview",
+    "data/lua/examples/api_v5_mod/README.md": "api.lua.v5.example-mod",
+    "doc/PLAYER_ACTIVITY.md": "cpp.activities",
+    "doc/RELEASE_DIFF.md": "maintenance.releases",
+    "doc/RELEASE_PROCESS.md": "maintenance.releases",
+    "doc/c++/COMPILING.md": "build.overview",
+}
 
 
 def git(*args: str) -> str:
@@ -192,6 +202,19 @@ def default_record(commit: str, path: str, names: list[object]) -> tuple[dict, l
     return record, anomalies
 
 
+def apply_target_id_override(record: dict) -> None:
+    """Apply a reviewed CCB-Docs ID without replacing the frozen source ID."""
+    target_id = TARGET_ID_OVERRIDES.get(record["original_path"])
+    if target_id is None:
+        return
+    record["merge_target"] = target_id
+    replacement = record.get("replacement")
+    if isinstance(replacement, str) and not replacement.startswith(
+        ("https://", "http://")
+    ):
+        record["replacement"] = target_id
+
+
 def build_inventory(
     commit: str,
     record_snapshot: dict[str, object] | None = None,
@@ -218,6 +241,7 @@ def build_inventory(
                 "log", commit, "--format=%aN", "--", path
             ).splitlines()
             record, anomalies = default_record(commit, path, names)
+        apply_target_id_override(record)
         if anomaly_sink is not None:
             anomaly_sink.extend(
                 {"original_path": path, **anomaly} for anomaly in anomalies
@@ -269,6 +293,57 @@ def inventory_for_check(output: Path) -> tuple[str, dict[str, dict]]:
     )
 
 
+def inventory_for_preservation(output: Path) -> tuple[str, dict[str, dict]]:
+    """Load a complete classified snapshot, refusing any scope change."""
+    if not output.exists():
+        raise FileNotFoundError(f"inventory does not exist: {output}")
+    data = yaml.safe_load(output.read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or not isinstance(data.get("documents"), list):
+        raise ValueError("preserved inventory must contain a documents array")
+    documents = data["documents"]
+    if data.get("document_count") != FROZEN_DOCUMENT_COUNT or len(
+        documents
+    ) != FROZEN_DOCUMENT_COUNT:
+        raise ValueError(
+            f"preserved inventory must contain exactly {FROZEN_DOCUMENT_COUNT} documents"
+        )
+    if data.get("classification_summary", {}).get("review") != 0:
+        raise ValueError("preserved inventory still contains review classifications")
+    if any(entry.get("action") == "review" for entry in documents):
+        raise ValueError("preserved inventory contains a review action")
+    nonterminal = [
+        entry.get("original_path")
+        for entry in documents
+        if entry.get("migration_status") not in TERMINAL_MIGRATION_STATUSES
+    ]
+    if nonterminal:
+        sample = ", ".join(str(path) for path in nonterminal[:3])
+        raise ValueError(
+            f"preserved inventory contains non-terminal classifications: {sample}"
+        )
+
+    commit = resolve_commit(str(data["source_commit"]))
+    recorded_paths = [entry.get("original_path") for entry in documents]
+    if not all(isinstance(path, str) for path in recorded_paths):
+        raise ValueError("preserved inventory contains an invalid original_path")
+    if len(recorded_paths) != len(set(recorded_paths)):
+        raise ValueError("preserved inventory contains duplicate original paths")
+    if any(entry.get("source_commit") != commit for entry in documents):
+        raise ValueError("preserved records do not share the frozen source commit")
+    tracked_paths = tracked_markdown(commit)
+    if set(recorded_paths) != set(tracked_paths):
+        removed = sorted(set(recorded_paths) - set(tracked_paths))
+        added = sorted(set(tracked_paths) - set(recorded_paths))
+        raise ValueError(
+            "refusing to change the frozen classified Markdown scope; "
+            f"removed={removed[:3]}, added={added[:3]}"
+        )
+    return commit, {
+        entry["original_path"]: entry
+        for entry in documents
+    }
+
+
 def render_anomaly_report(commit: str, anomalies: list[dict]) -> str:
     data = {
         "schema_version": 1,
@@ -303,9 +378,12 @@ def main() -> int:
     parser.add_argument(
         "--anomaly-report", type=Path, default=DEFAULT_ANOMALY_REPORT
     )
-    parser.add_argument("--source-commit", default="HEAD")
+    parser.add_argument("--source-commit")
     parser.add_argument("--check", action="store_true")
+    parser.add_argument("--preserve-classification", action="store_true")
     args = parser.parse_args()
+    if args.check and args.preserve_classification:
+        parser.error("--check and --preserve-classification are mutually exclusive")
 
     output = args.output if args.output.is_absolute() else ROOT / args.output
     anomaly_report = (
@@ -315,8 +393,14 @@ def main() -> int:
     )
     if args.check:
         commit, record_snapshot = inventory_for_check(output)
+    elif args.preserve_classification:
+        commit, record_snapshot = inventory_for_preservation(output)
+        if args.source_commit and resolve_commit(args.source_commit) != commit:
+            raise ValueError(
+                "--preserve-classification cannot change the frozen source commit"
+            )
     else:
-        commit = resolve_commit(args.source_commit)
+        commit = resolve_commit(args.source_commit or "HEAD")
         record_snapshot = None
     anomalies: list[dict] = []
     rendered = render(build_inventory(commit, record_snapshot, anomalies))
@@ -332,8 +416,16 @@ def main() -> int:
         print(f"Markdown inventory is current at {commit}")
         return 0
 
+    if args.preserve_classification:
+        validate_anomaly_report(anomaly_report, commit)
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(rendered, encoding="utf-8")
+    if args.preserve_classification:
+        print(
+            "synchronized deterministic inventory fields while preserving "
+            f"{FROZEN_DOCUMENT_COUNT} terminal classifications"
+        )
+        return 0
     anomaly_report.parent.mkdir(parents=True, exist_ok=True)
     anomaly_report.write_text(
         render_anomaly_report(commit, anomalies), encoding="utf-8"

--- a/tools/agent/test_context_pack.py
+++ b/tools/agent/test_context_pack.py
@@ -21,7 +21,7 @@ class ContextPackTests(unittest.TestCase):
             4000,
         )
         self.assertIn("lua-api", pack["selected_routes"])
-        self.assertIn("api.lua.v5.reference", pack["documentation_ids"])
+        self.assertIn("api.lua.v5.reference.modules", pack["documentation_ids"])
         self.assertIn("lua-contract", {entry["id"] for entry in pack["tests"]})
         self.assertLessEqual(pack["estimated_tokens"], 4000)
 

--- a/tools/agent/test_documentation_registry.py
+++ b/tools/agent/test_documentation_registry.py
@@ -51,6 +51,30 @@ class DocumentationRegistryTest(unittest.TestCase):
         self.assertFalse(third_party["include_in_ai_index"])
         self.assertEqual(third_party["status"], "third_party")
 
+    def test_ccb_docs_ids_prefer_reviewed_merge_target(self):
+        legacy = {
+            "doc/merged.md": {
+                "action": "merge_into",
+                "migration_status": "stubbed",
+                "stable_document_id": "legacy.doc-merged",
+                "merge_target": "maintenance.releases",
+                "include_in_ai_index": True,
+            },
+            "doc/direct.md": {
+                "action": "migrate_rewrite",
+                "migration_status": "stubbed",
+                "stable_document_id": "cpp.activities",
+                "merge_target": None,
+                "include_in_ai_index": True,
+            },
+        }
+
+        merged = registry.classify("doc/merged.md", legacy)
+        direct = registry.classify("doc/direct.md", legacy)
+
+        self.assertEqual(merged["ccb_docs_ids"], ["maintenance.releases"])
+        self.assertEqual(direct["ccb_docs_ids"], ["cpp.activities"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/agent/test_markdown_inventory.py
+++ b/tools/agent/test_markdown_inventory.py
@@ -1,3 +1,4 @@
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -11,6 +12,65 @@ ROOT = Path(__file__).resolve().parents[2]
 
 
 class MarkdownInventoryTest(unittest.TestCase):
+    def test_reviewed_target_ids_override_legacy_aliases(self):
+        for path, target_id in inventory.TARGET_ID_OVERRIDES.items():
+            with self.subTest(path=path):
+                record = {
+                    "original_path": path,
+                    "merge_target": None,
+                    "replacement": "old-non-url-id",
+                }
+
+                inventory.apply_target_id_override(record)
+
+                self.assertEqual(record["merge_target"], target_id)
+                self.assertEqual(record["replacement"], target_id)
+
+        record = {
+            "original_path": "data/lua/README.md",
+            "merge_target": None,
+            "replacement": "https://example.invalid/existing/",
+        }
+        inventory.apply_target_id_override(record)
+        self.assertEqual(
+            record["replacement"],
+            "https://example.invalid/existing/",
+        )
+
+    @mock.patch.object(inventory, "resolve_commit", return_value="frozen-commit")
+    @mock.patch.object(inventory, "tracked_markdown")
+    def test_preservation_refuses_a_changed_175_path_scope(
+        self, tracked_markdown, _resolve_commit
+    ):
+        paths = [f"doc/frozen-{index:03}.md" for index in range(175)]
+        documents = [
+            {
+                "original_path": path,
+                "source_commit": "frozen-commit",
+                "action": "migrate_rewrite",
+                "migration_status": "stubbed",
+            }
+            for path in paths
+        ]
+        data = {
+            "source_commit": "frozen-commit",
+            "document_count": 175,
+            "classification_summary": {"review": 0},
+            "documents": documents,
+        }
+        tracked_markdown.return_value = paths[:-1] + ["doc/unclassified-new.md"]
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "inventory.yml"
+            output.write_text(
+                yaml.safe_dump(data, sort_keys=False),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "refusing to change"):
+                inventory.inventory_for_preservation(output)
+
+        tracked_markdown.assert_called_once_with("frozen-commit")
+
     @mock.patch.object(inventory, "git")
     @mock.patch.object(
         inventory,


### PR DESCRIPTION
## Summary

Final cross-repository reconciliation layer for **CCB Agent 友好化与双语开发文档重构**.

Six frozen migration records used historical CCB IDs that did not match the canonical IDs in CCB-Docs. In addition, the generated documentation registry exposed each legacy stable ID instead of the reviewed merge target for merged or rewritten pages.

This PR:

- maps the six reviewed legacy targets to canonical CCB-Docs IDs
- preserves each frozen source document ID and all 175 terminal classifications
- updates non-URL replacement IDs for the affected permanent migration stubs
- makes the documentation registry publish `merge_target` when present
- adds a preservation mode that refuses source-commit, path-scope, review-state, or terminal-state drift
- regenerates the inventory and registry from their generators

No generated file was hand-edited.

## Stack

Base: `agent/ccb-docs-program-governance` (CCB #570).

This PR must merge after #570. It remains Draft and must not be auto-merged.

## Validation

- Agent unit tests: 60/60 passed
- project metadata: passed
- Markdown inventory `--check`: passed
- migration finalizer: 111 permanent-stub paths / 175 terminal records
- migration reports `--check`: passed
- documentation registry `--check`: passed
- flake8 (agent validation environment): passed
- `git diff --check`: passed
- CCB-Docs maintenance coverage against this commit:
  - tracked Markdown: 199/199
  - frozen inventory: 175/175 terminal
  - permanent stubs: 111/111
  - registry/catalog IDs: 111/111
  - migration/catalog mappings: 111/111
  - coverage findings: 0

#### Documentation impact

Reconciles permanent migration metadata and cross-repository document IDs; it does not change game behavior.

#### Related CCB-Docs PR

CrimsonCrossBunker/CCB-Docs#13

#### Affected documentation IDs

- `api.lua.v5.overview`
- `api.lua.v5.example-mod`
- `cpp.activities`
- `maintenance.releases`
- `build.overview`

#### Generated reference impact

Yes. The Markdown inventory and documentation registry are regenerated by their checked-in generators.

#### Responsible human

@LYHGLYTX is the Responsible human and is responsible for understanding the change, reviewing the final diff, test results, licensing and external sources, and answering review questions.

No gameplay, runtime, balance, save-format, CCB-GUIDE, or `obj-lua/` change is included.

## Commit split

- Previous commit count: 1
- New commit count: 3
- Incremental changed lines: 259
- Average changed lines: 86
- Largest atomic commit: see commit log
- Tree-equivalence result: PASS (git diff --exit-code <old-head> <new-head>)
- Previous head: `414e79e73ada674bb2829241dfeb3cbed2e9fd8d`
- New head: `b7e01227bc392188b4aea14a22d2a8374e3b1280`
- Backup bundle: skipped by owner instruction (old head recorded above)
- Validation status: tree-equivalent, chain verified
