### PR TITLE
CCB Agent 友好化与双语开发文档重构：tooling: validate Lua Mod sources in --check-mods

### DIFF
--- a/.github/workflows/lua-contract.yml
+++ b/.github/workflows/lua-contract.yml
@@ -10,6 +10,7 @@ on:
       - 'ai/generated-files.yml'
       - 'ai/test-matrix.yml'
       - 'data/lua/**'
+      - 'src/CMakeLists.txt'
       - 'src/catalua*.cpp'
       - 'src/catalua*.h'
       - 'src/event.h'
@@ -50,6 +51,7 @@ jobs:
             'ai/generated-files.yml' \
             'ai/test-matrix.yml' \
             ':(glob)data/lua/**' \
+            'src/CMakeLists.txt' \
             ':(glob)src/catalua*.cpp' \
             ':(glob)src/catalua*.h' \
             'src/event.h' \
@@ -78,4 +80,5 @@ jobs:
           python3 tools/lua_api/generate_public_contract.py --check
           python3 tools/lua_api/check_public_contract.py
           python3 tools/lua_api/check_examples.py --require-luac
+          python3 tools/lua_api/check_cmake_contract.py
           python3 -m unittest discover -s tools/lua_api -p 'test_*.py'

--- a/.github/workflows/lua-contract.yml
+++ b/.github/workflows/lua-contract.yml
@@ -54,6 +54,7 @@ jobs:
             ':(glob)data/lua/**' \
             'src/CMakeLists.txt' \
             'src/lua/CMakeLists.txt' \
+            'src/main.cpp' \
             ':(glob)src/catalua*.cpp' \
             ':(glob)src/catalua*.h' \
             'src/event.h' \

--- a/.github/workflows/lua-contract.yml
+++ b/.github/workflows/lua-contract.yml
@@ -11,6 +11,7 @@ on:
       - 'ai/test-matrix.yml'
       - 'data/lua/**'
       - 'src/CMakeLists.txt'
+      - 'src/lua/CMakeLists.txt'
       - 'src/catalua*.cpp'
       - 'src/catalua*.h'
       - 'src/event.h'
@@ -52,6 +53,7 @@ jobs:
             'ai/test-matrix.yml' \
             ':(glob)data/lua/**' \
             'src/CMakeLists.txt' \
+            'src/lua/CMakeLists.txt' \
             ':(glob)src/catalua*.cpp' \
             ':(glob)src/catalua*.h' \
             'src/event.h' \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ make -j2 json-check
 # Lua public-contract checks
 python3 tools/lua_api/check_luals_declarations.py
 python3 tools/lua_api/check_coverage.py
+python3 tools/lua_api/check_cmake_contract.py
 
 # CMake configuration (out-of-tree)
 cmake --preset linux-x64

--- a/ai/agent-benchmark-baseline.json
+++ b/ai/agent-benchmark-baseline.json
@@ -39,7 +39,7 @@
     },
     {
       "errors": [],
-      "estimated_tokens": 2218,
+      "estimated_tokens": 2477,
       "id": "lua-api",
       "passed": true,
       "selected_routes": [

--- a/ai/agent-benchmark-baseline.json
+++ b/ai/agent-benchmark-baseline.json
@@ -3,7 +3,7 @@
   "cases": [
     {
       "errors": [],
-      "estimated_tokens": 1996,
+      "estimated_tokens": 2008,
       "id": "repository-navigation",
       "passed": true,
       "selected_routes": [
@@ -48,7 +48,7 @@
     },
     {
       "errors": [],
-      "estimated_tokens": 2642,
+      "estimated_tokens": 2654,
       "id": "upstream-port",
       "passed": true,
       "selected_routes": [
@@ -75,7 +75,7 @@
     },
     {
       "errors": [],
-      "estimated_tokens": 2321,
+      "estimated_tokens": 2333,
       "id": "documentation-impact",
       "passed": true,
       "selected_routes": [

--- a/ai/agent-benchmark-baseline.json
+++ b/ai/agent-benchmark-baseline.json
@@ -12,7 +12,7 @@
     },
     {
       "errors": [],
-      "estimated_tokens": 1857,
+      "estimated_tokens": 1869,
       "id": "cpp-bug",
       "passed": true,
       "selected_routes": [
@@ -21,7 +21,7 @@
     },
     {
       "errors": [],
-      "estimated_tokens": 1540,
+      "estimated_tokens": 1552,
       "id": "json-content",
       "passed": true,
       "selected_routes": [
@@ -30,7 +30,7 @@
     },
     {
       "errors": [],
-      "estimated_tokens": 1949,
+      "estimated_tokens": 1961,
       "id": "eoc",
       "passed": true,
       "selected_routes": [
@@ -39,7 +39,7 @@
     },
     {
       "errors": [],
-      "estimated_tokens": 2170,
+      "estimated_tokens": 2218,
       "id": "lua-api",
       "passed": true,
       "selected_routes": [
@@ -57,7 +57,7 @@
     },
     {
       "errors": [],
-      "estimated_tokens": 1877,
+      "estimated_tokens": 1889,
       "id": "save-compatibility",
       "passed": true,
       "selected_routes": [
@@ -66,7 +66,7 @@
     },
     {
       "errors": [],
-      "estimated_tokens": 1649,
+      "estimated_tokens": 1660,
       "id": "generated-file-detection",
       "passed": true,
       "selected_routes": [

--- a/ai/agent-benchmark.yml
+++ b/ai/agent-benchmark.yml
@@ -31,10 +31,10 @@ cases:
     expected_documentation_ids: [reference.eoc-conditions, reference.eoc-effects]
     expected_validation_ids: [json-load]
   - id: lua-api
-    task: Extend the Lua API manifest capability contract.
-    files: [data/lua/manifest.schema.json]
+    task: Extend the Lua API contract and keep headless Mod validation working.
+    files: [data/lua/manifest.schema.json, src/main.cpp]
     expected_routes: [lua-api]
-    expected_paths: [data/lua/]
+    expected_paths: [data/lua/, src/main.cpp, src/game_io.cpp]
     expected_documentation_ids: [api.lua.v5.reference.modules]
     expected_validation_ids: [lua-contract]
   - id: upstream-port

--- a/ai/project-map.yml
+++ b/ai/project-map.yml
@@ -18,12 +18,12 @@ entries:
     boundaries:
       - Preserve stable IDs or provide explicit migration data.
   - id: lua-api
-    paths: [data/lua/, tools/lua_api/, 'src/catalua_ui_*.cpp', 'src/catalua_ui_*.h']
+    paths: [data/lua/, tools/lua_api/, src/main.cpp, src/game_io.cpp, 'src/catalua_ui*.cpp', 'src/catalua_ui*.h']
     purpose: Versioned Lua runtime, declarations, registrations, and coverage inventories.
     instructions: data/lua/AGENTS.md
     validation_ids: [lua-contract]
     boundaries:
-      - Schema, LuaLS declarations, native registrations, and generated inventories are authoritative.
+      - Schema, LuaLS declarations, native registrations, generated inventories, and runtime validation tests are authoritative.
   - id: bundled-mods
     paths: [data/mods/]
     purpose: Mods shipped and validated with CCB.
@@ -77,4 +77,4 @@ entries:
     boundaries:
       - Every PR names a Responsible human.
       - Tracked targets never prove that an administrator setting is active.
-      - One Responsible human is sufficient; do not enable an approval gate that locks the sole maintainer's own pull requests.
+      - Do not enable non-author approval without two confirmed human reviewers.

--- a/ai/project-map.yml
+++ b/ai/project-map.yml
@@ -77,4 +77,4 @@ entries:
     boundaries:
       - Every PR names a Responsible human.
       - Tracked targets never prove that an administrator setting is active.
-      - Do not enable non-author approval without two confirmed human reviewers.
+      - One Responsible human is sufficient; do not enable an approval gate that locks the sole maintainer's own pull requests.

--- a/ai/task-router.yml
+++ b/ai/task-router.yml
@@ -48,13 +48,13 @@ entries:
       - EOC syntax may differ when CCB registrations lag or diverge from upstream.
   - id: lua-api
     keywords: [Lua, LuaLS, manifest, capability, callback, hook, 脚本, 能力]
-    paths: [data/lua/, tools/lua_api/, 'src/catalua*.cpp', 'src/catalua*.h']
+    paths: [data/lua/, tools/lua_api/, src/main.cpp, src/game_io.cpp, 'src/catalua*.cpp', 'src/catalua*.h']
     project_ids: [lua-api]
     documentation_ids: [api.lua.v5.overview, api.lua.v5.reference.modules]
     source_symbols: [ccb_api_v5]
     validation_ids: [lua-contract]
     compatibility:
-      - Keep manifest, LuaLS, native registration, inventory, and examples in parity.
+      - Keep manifest, LuaLS, native registration, inventory, examples, and runtime validation in parity.
     upstream_differences:
       - CCB Lua v5 is a CCB contract and is not inferred from CBN or CDDA APIs.
   - id: upstream-port

--- a/ai/test-matrix.yml
+++ b/ai/test-matrix.yml
@@ -62,7 +62,7 @@ entries:
     workdir: .
     cost: medium
   - id: lua-contract
-    paths: [src/CMakeLists.txt, 'src/catalua*.cpp', 'src/catalua*.h', src/event.h, data/lua/, tools/lua_api/]
+    paths: [src/CMakeLists.txt, src/lua/CMakeLists.txt, 'src/catalua*.cpp', 'src/catalua*.h', src/event.h, data/lua/, tools/lua_api/]
     command: python3 tools/lua_api/check_luals_declarations.py && python3 tools/lua_api/check_ccb_inventory.py && python3 tools/lua_api/generate_public_contract.py --check && python3 tools/lua_api/check_public_contract.py && python3 tools/lua_api/check_examples.py && python3 tools/lua_api/check_cmake_contract.py && python3 -m unittest discover -s tools/lua_api -p 'test_*.py'
     workdir: .
     cost: fast

--- a/ai/test-matrix.yml
+++ b/ai/test-matrix.yml
@@ -62,7 +62,7 @@ entries:
     workdir: .
     cost: medium
   - id: lua-contract
-    paths: [src/CMakeLists.txt, src/lua/CMakeLists.txt, 'src/catalua*.cpp', 'src/catalua*.h', src/event.h, data/lua/, tools/lua_api/]
+    paths: [src/CMakeLists.txt, src/lua/CMakeLists.txt, src/main.cpp, 'src/catalua*.cpp', 'src/catalua*.h', src/event.h, data/lua/, tools/lua_api/]
     command: python3 tools/lua_api/check_luals_declarations.py && python3 tools/lua_api/check_ccb_inventory.py && python3 tools/lua_api/generate_public_contract.py --check && python3 tools/lua_api/check_public_contract.py && python3 tools/lua_api/check_examples.py && python3 tools/lua_api/check_cmake_contract.py && python3 -m unittest discover -s tools/lua_api -p 'test_*.py'
     workdir: .
     cost: fast

--- a/ai/test-matrix.yml
+++ b/ai/test-matrix.yml
@@ -62,8 +62,8 @@ entries:
     workdir: .
     cost: medium
   - id: lua-contract
-    paths: ['src/catalua*.cpp', 'src/catalua*.h', src/event.h, data/lua/, tools/lua_api/]
-    command: python3 tools/lua_api/check_luals_declarations.py && python3 tools/lua_api/check_ccb_inventory.py && python3 tools/lua_api/generate_public_contract.py --check && python3 tools/lua_api/check_public_contract.py && python3 tools/lua_api/check_examples.py && python3 -m unittest discover -s tools/lua_api -p 'test_*.py'
+    paths: [src/CMakeLists.txt, 'src/catalua*.cpp', 'src/catalua*.h', src/event.h, data/lua/, tools/lua_api/]
+    command: python3 tools/lua_api/check_luals_declarations.py && python3 tools/lua_api/check_ccb_inventory.py && python3 tools/lua_api/generate_public_contract.py --check && python3 tools/lua_api/check_public_contract.py && python3 tools/lua_api/check_examples.py && python3 tools/lua_api/check_cmake_contract.py && python3 -m unittest discover -s tools/lua_api -p 'test_*.py'
     workdir: .
     cost: fast
   - id: cmake-configure

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,16 +13,6 @@ function(configure_lua_ui TARGET)
     endif()
 endfunction()
 
-# Object-library usage requirements do not reliably place Lua's static archive
-# after the final executable objects on every CMake generator.  Link the Lua
-# runtime explicitly at each executable boundary while keeping Lua-disabled
-# builds free of the dependency.
-function(link_lua_ui_runtime TARGET)
-    if (CATA_ENABLE_LUA_UI)
-        target_link_libraries(${TARGET} PRIVATE liblua)
-    endif()
-endfunction()
-
 # Tracy profiler interface.  When TRACY=ON (root CMakeLists.txt), this carries
 # the tracy include path and libTracyClient link to every -common object lib.
 # When TRACY=OFF the target is not created and these lines are inert.
@@ -162,7 +152,6 @@ if (TILES)
     add_dependencies(cataclysm-tiles-common get_version)
 
     target_link_libraries(cataclysm-tiles PRIVATE cataclysm-tiles-common)
-    link_lua_ui_runtime(cataclysm-tiles)
     target_compile_definitions(cataclysm-tiles-common PUBLIC TILES )
     if(NOT "${CMAKE_EXPORT_COMPILE_COMMANDS}")
         target_precompile_headers(cataclysm-tiles-common PUBLIC
@@ -365,7 +354,6 @@ if (CURSES)
 
     add_dependencies(cataclysm-common get_version)
     target_link_libraries(cataclysm PRIVATE cataclysm-common)
-    link_lua_ui_runtime(cataclysm)
 
     if (LOCALIZE)
         target_include_directories(cataclysm-common PUBLIC
@@ -444,7 +432,6 @@ if (HEADLESS)
 
     add_dependencies(cataclysm-common get_version)
     target_link_libraries(cataclysm PRIVATE cataclysm-common)
-    link_lua_ui_runtime(cataclysm)
 
     if (LOCALIZE)
         target_include_directories(cataclysm-common PUBLIC

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,16 @@ function(configure_lua_ui TARGET)
     endif()
 endfunction()
 
+# Object-library usage requirements do not reliably place Lua's static archive
+# after the final executable objects on every CMake generator.  Link the Lua
+# runtime explicitly at each executable boundary while keeping Lua-disabled
+# builds free of the dependency.
+function(link_lua_ui_runtime TARGET)
+    if (CATA_ENABLE_LUA_UI)
+        target_link_libraries(${TARGET} PRIVATE liblua)
+    endif()
+endfunction()
+
 # Tracy profiler interface.  When TRACY=ON (root CMakeLists.txt), this carries
 # the tracy include path and libTracyClient link to every -common object lib.
 # When TRACY=OFF the target is not created and these lines are inert.
@@ -152,6 +162,7 @@ if (TILES)
     add_dependencies(cataclysm-tiles-common get_version)
 
     target_link_libraries(cataclysm-tiles PRIVATE cataclysm-tiles-common)
+    link_lua_ui_runtime(cataclysm-tiles)
     target_compile_definitions(cataclysm-tiles-common PUBLIC TILES )
     if(NOT "${CMAKE_EXPORT_COMPILE_COMMANDS}")
         target_precompile_headers(cataclysm-tiles-common PUBLIC
@@ -354,6 +365,7 @@ if (CURSES)
 
     add_dependencies(cataclysm-common get_version)
     target_link_libraries(cataclysm PRIVATE cataclysm-common)
+    link_lua_ui_runtime(cataclysm)
 
     if (LOCALIZE)
         target_include_directories(cataclysm-common PUBLIC
@@ -432,6 +444,7 @@ if (HEADLESS)
 
     add_dependencies(cataclysm-common get_version)
     target_link_libraries(cataclysm PRIVATE cataclysm-common)
+    link_lua_ui_runtime(cataclysm)
 
     if (LOCALIZE)
         target_include_directories(cataclysm-common PUBLIC

--- a/src/catalua_ui.cpp
+++ b/src/catalua_ui.cpp
@@ -4204,6 +4204,48 @@ std::vector<script_source> active_script_sources()
     return sources;
 }
 
+std::vector<script_source> explicit_mod_script_sources(
+    const std::vector<std::string> &mod_ids )
+{
+    std::vector<script_source> sources;
+    const fs::path built_in_root = fs::u8path( PATH_INFO::datadir() ) / "lua";
+    sources.push_back( script_source{
+        load_source_manifest( built_in_root, "builtin", true, true ), built_in_root,
+        built_in_root / "main.lua"
+    } );
+
+    std::set<std::string> seen = { "builtin" };
+    for( const std::string &id : mod_ids ) {
+        if( !seen.insert( id ).second ) {
+            continue;
+        }
+        const mod_id mod( id );
+        if( !mod.is_valid() ) {
+            throw std::runtime_error( "Unknown Lua Mod source: " + id );
+        }
+        const fs::path root = mod->path.get_unrelative_path() / "lua";
+        const fs::path entry = root / "main.lua";
+        if( !file_exist( entry.string() ) ) {
+            continue;
+        }
+        sources.push_back( script_source{
+            load_source_manifest( root, id, false, false ), root, entry
+        } );
+    }
+
+    std::vector<script_manifest> manifests;
+    manifests.reserve( sources.size() );
+    for( const script_source &source : sources ) {
+        if( !file_exist( source.entry.string() ) ) {
+            throw std::runtime_error( "Lua source '" + source.manifest.id +
+                                      "' is missing main.lua" );
+        }
+        manifests.push_back( source.manifest );
+    }
+    validate_script_manifests( manifests );
+    return sources;
+}
+
 cata_path persistent_state_path()
 {
     return PATH_INFO::player_base_save_path() + ".lua_ui.json";
@@ -6265,6 +6307,30 @@ bool reload_scripts( std::string &error )
         record_runtime_error( "UI profile reload failed", profile_error );
     }
     return reloaded;
+}
+
+bool validate_mod_scripts( const std::vector<std::string> &mod_ids,
+                           std::string &error )
+{
+    try {
+        runtime_state validation;
+        validation.generation = 1;
+        validation.world_generation = 1;
+        validation.sources = explicit_mod_script_sources( mod_ids );
+        if( validation.sources.size() == 1 ) {
+            error.clear();
+            return true;
+        }
+        initialize_state( validation );
+        for( std::size_t index = 0; index < validation.sources.size(); ++index ) {
+            run_script( validation, validation.sources[index].entry, index );
+        }
+        error.clear();
+        return true;
+    } catch( const std::exception &exception ) {
+        error = exception.what();
+        return false;
+    }
 }
 
 void on_turn()

--- a/src/catalua_ui.h
+++ b/src/catalua_ui.h
@@ -196,6 +196,13 @@ bool is_safe_module_name( std::string_view name );
 // failed reload leaves the previous runtime active.
 bool reload_scripts( std::string &error );
 
+// In Lua-enabled builds, parse manifests and execute the top-level scripts for
+// explicit Mods in a separate, non-active Lua runtime state.  Top-level APIs
+// execute normally, but --check-mods never subscribes callbacks, dispatches
+// lifecycle events, or commits script state.  Builds without Lua skip this.
+bool validate_mod_scripts( const std::vector<std::string> &mod_ids,
+                           std::string &error );
+
 // Run deterministic due callbacks once after the game turn advances.
 void on_turn();
 

--- a/src/catalua_ui_disabled.cpp
+++ b/src/catalua_ui_disabled.cpp
@@ -36,6 +36,13 @@ bool reload_scripts( std::string &error )
     return false;
 }
 
+bool validate_mod_scripts( const std::vector<std::string> &, std::string &error )
+{
+    // A build without Lua has no script runtime to validate.
+    error.clear();
+    return true;
+}
+
 void on_turn()
 {
 }

--- a/src/game_io.cpp
+++ b/src/game_io.cpp
@@ -128,6 +128,7 @@ void game::load_static_data()
 bool game::check_mod_data( const std::vector<mod_id> &opts )
 {
     dependency_tree &tree = world_generator->get_mod_manager().get_tree();
+    bool data_valid = true;
 
     // deduplicated list of mods to check
     std::set<mod_id> check( opts.begin(), opts.end() );
@@ -154,6 +155,7 @@ bool game::check_mod_data( const std::vector<mod_id> &opts )
             DynamicDataLoader::get_instance().finalize_loaded_data();
         } catch( const std::exception &err ) {
             std::cerr << "Error loading data from json: " << err.what() << std::endl;
+            data_valid = false;
         }
 
         std::string world_name = world_generator->active_world->world_name;
@@ -185,6 +187,7 @@ bool game::check_mod_data( const std::vector<mod_id> &opts )
 
         std::cout << "Checking mod " << mod.name() << " [" << mod.ident.str() << "]" << std::endl;
 
+        bool mod_valid = true;
         try {
             load_core_data();
 
@@ -198,8 +201,26 @@ bool game::check_mod_data( const std::vector<mod_id> &opts )
             // Load mod itself
             load_data_from_dir( mod.path, mod.ident.str() );
             DynamicDataLoader::get_instance().finalize_loaded_data();
+
+            std::vector<std::string> lua_mod_ids;
+            lua_mod_ids.reserve( dep_vector.size() + 1 );
+            std::set<std::string> seen_lua_mod_ids;
+            for( const mod_id &dep : dep_vector ) {
+                if( seen_lua_mod_ids.insert( dep.str() ).second ) {
+                    lua_mod_ids.push_back( dep.str() );
+                }
+            }
+            if( seen_lua_mod_ids.insert( mod.ident.str() ).second ) {
+                lua_mod_ids.push_back( mod.ident.str() );
+            }
+            std::string lua_error;
+            if( !cata::lua_ui::validate_mod_scripts( lua_mod_ids, lua_error ) ) {
+                std::cerr << "Error loading Lua Mod scripts: " << lua_error << std::endl;
+                mod_valid = false;
+            }
         } catch( const std::exception &err ) {
             std::cerr << "Error loading data: " << err.what() << std::endl;
+            mod_valid = false;
         }
 
         std::string world_name = world_generator->active_world->world_name;
@@ -207,8 +228,11 @@ bool game::check_mod_data( const std::vector<mod_id> &opts )
 
         MAPBUFFER.clear();
         overmap_buffer.clear();
+        if( !mod_valid ) {
+            return false;
+        }
     }
-    return true;
+    return data_valid;
 }
 
 bool game::is_core_data_loaded() const

--- a/src/lua/CMakeLists.txt
+++ b/src/lua/CMakeLists.txt
@@ -34,6 +34,13 @@ set(LUA_SOURCE_NAMES
 list(TRANSFORM LUA_SOURCE_NAMES
     PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/"
     OUTPUT_VARIABLE LUA_SOURCES)
+
+# Make compiles the bundled Lua .c sources as C++.  sol2 and the native Lua
+# bridge therefore reference C++-mangled lua_* symbols; keep CMake on the same
+# ABI so every generator links the same runtime contract.
+set_source_files_properties(${LUA_SOURCES}
+    PROPERTIES LANGUAGE CXX)
+
 file(GLOB LUA_HEADERS CONFIGURE_DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/*.h
     ${CMAKE_CURRENT_SOURCE_DIR}/*.hpp)
@@ -42,8 +49,8 @@ file(GLOB LUA_HEADERS CONFIGURE_DEPENDS
 add_library(liblua ${LUA_SOURCES} ${LUA_HEADERS})
 target_include_directories(liblua SYSTEM PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-# Lua is third-party C code.  Keep its diagnostics isolated from the game's
-# warning-as-error policy while still compiling it with the platform C compiler.
+# Lua is third-party code.  Keep its diagnostics isolated from the game's
+# warning-as-error policy while compiling it with the required C++ ABI.
 if(MSVC)
     target_compile_options(liblua PRIVATE /w)
 else()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -344,7 +344,7 @@ cli_opts parse_commandline( int argc, const char **argv )
             },
             {
                 "--check-mods", "[mod…]",
-                "Checks the json files belonging to given CDDA mod and exits",
+                "Checks Mod data and, in Lua-enabled builds, top-level Lua scripts, then exits",
                 section_default,
                 1,
                 [&result]( int n, const char **params ) -> int {
@@ -1080,8 +1080,10 @@ int main( int argc, const char *argv[] )
 #endif
 
 #if !defined(TILES)
-    get_options().init();
-    get_options().load();
+    if( !cli.check_mods ) {
+        get_options().init();
+        get_options().load();
+    }
 #endif
 
     // in test mode don't initialize curses to avoid escape sequences being inserted into output stream

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1080,8 +1080,10 @@ int main( int argc, const char *argv[] )
 #endif
 
 #if !defined(TILES)
-    get_options().init();
-    get_options().load();
+    if( !cli.check_mods ) {
+        get_options().init();
+        get_options().load();
+    }
 #endif
 
     // in test mode don't initialize curses to avoid escape sequences being inserted into output stream

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1080,10 +1080,8 @@ int main( int argc, const char *argv[] )
 #endif
 
 #if !defined(TILES)
-    if( !cli.check_mods ) {
-        get_options().init();
-        get_options().load();
-    }
+    get_options().init();
+    get_options().load();
 #endif
 
     // in test mode don't initialize curses to avoid escape sequences being inserted into output stream

--- a/tests/catalua_ui_disabled_test.cpp
+++ b/tests/catalua_ui_disabled_test.cpp
@@ -17,6 +17,10 @@ TEST_CASE( "disabled_lua_ui_build_has_an_inert_facade", "[lua][ui][build]" )
     CHECK_FALSE( cata::lua_ui::reload_scripts( error ) );
     CHECK_FALSE( error.empty() );
 
+    error = "stale";
+    CHECK( cata::lua_ui::validate_mod_scripts( { "ignored_without_lua" }, error ) );
+    CHECK( error.empty() );
+
     const cata::lua_ui::runtime_status status = cata::lua_ui::status();
     CHECK_FALSE( status.loaded );
     CHECK_FALSE( status.last_error.empty() );

--- a/tests/catalua_ui_test.cpp
+++ b/tests/catalua_ui_test.cpp
@@ -50,6 +50,7 @@
 #include "martialarts.h"
 #include "mission.h"
 #include "monster.h"
+#include "mod_manager.h"
 #include "npc.h"
 #include "overmapbuffer.h"
 #include "panels.h"
@@ -424,6 +425,105 @@ class scoped_lua_user_module
     private:
         fs::path path_;
         std::optional<std::string> previous_;
+};
+
+class scoped_lua_test_mod
+{
+    public:
+        scoped_lua_test_mod( std::string id, const std::string &source ) :
+            id_( std::move( id ) ),
+            root_( PATH_INFO::user_moddir_path().get_unrelative_path() / id_ ) {
+            if( fs::exists( root_ ) ) {
+                throw std::runtime_error( "Refusing to replace existing Lua test Mod: " +
+                                          root_.string() );
+            }
+            std::error_code error;
+            fs::create_directories( root_ / "lua", error );
+            if( error ) {
+                throw std::runtime_error( "Unable to create Lua test Mod: " + error.message() );
+            }
+            active_ = true;
+            try {
+                write_file( root_ / "modinfo.json",
+                            "[{\"type\":\"MOD_INFO\",\"id\":\"" + id_ +
+                            "\",\"name\":\"Lua validation test\",\"authors\":[\"CCB tests\"],"
+                            "\"description\":\"Execution-sensitive Lua validation fixture\","
+                            "\"category\":\"content\",\"dependencies\":[\"dda\"]}]" );
+                write_file( root_ / "lua" / "manifest.json",
+                            "{\"id\":\"" + id_ +
+                            "\",\"version\":\"1.0.0\",\"api_version\":5,"
+                            "\"capabilities\":[],\"dependencies\":[\"builtin\"]}" );
+                write( source );
+                world_generator->get_mod_manager().refresh_mod_list();
+            } catch( ... ) {
+                try {
+                    std::string ignored;
+                    cleanup( ignored );
+                } catch( ... ) {
+                    // Preserve the construction failure.  The test user directory is disposable.
+                }
+                throw;
+            }
+        }
+
+        scoped_lua_test_mod( const scoped_lua_test_mod & ) = delete;
+        scoped_lua_test_mod &operator=( const scoped_lua_test_mod & ) = delete;
+
+        ~scoped_lua_test_mod() noexcept {
+            try {
+                std::string ignored;
+                cleanup( ignored );
+            } catch( ... ) {
+                // A test fixture destructor must not terminate the test process.
+            }
+        }
+
+        void write( const std::string &source ) const {
+            write_file( root_ / "lua" / "main.lua", source );
+        }
+
+        const std::string &id() const {
+            return id_;
+        }
+
+        bool cleanup( std::string &error ) {
+            if( !active_ ) {
+                error.clear();
+                return true;
+            }
+            std::error_code filesystem_error;
+            fs::remove_all( root_, filesystem_error );
+            if( filesystem_error ) {
+                error = "Unable to remove Lua test Mod: " + filesystem_error.message();
+                return false;
+            }
+            try {
+                world_generator->get_mod_manager().refresh_mod_list();
+            } catch( const std::exception &exception ) {
+                error = "Unable to refresh Mods after Lua validation test: " +
+                        std::string( exception.what() );
+                return false;
+            } catch( ... ) {
+                error = "Unable to refresh Mods after Lua validation test";
+                return false;
+            }
+            active_ = false;
+            error.clear();
+            return true;
+        }
+
+    private:
+        static void write_file( const fs::path &path, const std::string &contents ) {
+            std::ofstream output( path, std::ios::binary | std::ios::trunc );
+            output << contents;
+            if( !output ) {
+                throw std::runtime_error( "Unable to write Lua test Mod file: " + path.string() );
+            }
+        }
+
+        std::string id_;
+        fs::path root_;
+        bool active_ = false;
 };
 
 class scoped_calendar_turn
@@ -9096,6 +9196,32 @@ return true
                          "return string.rep('x', 40 * 1024 * 1024)", 1000, error ) );
         CHECK_FALSE( error.empty() );
     }
+}
+
+TEST_CASE( "lua_mod_validation_executes_registered_sources_without_activation",
+           "[lua][ui][mod][integration]" )
+{
+    cata::lua_ui::shutdown();
+    scoped_lua_test_mod test_mod( "ccb_lua_validation_test",
+                                  "error(\"validation execution sentinel\")\n" );
+    std::string error;
+    REQUIRE( mod_id( test_mod.id() ).is_valid() );
+    CHECK_FALSE( cata::lua_ui::validate_mod_scripts( { test_mod.id() }, error ) );
+    CHECK( error.find( "validation execution sentinel" ) != std::string::npos );
+    CHECK_FALSE( cata::lua_ui::status().loaded );
+
+    test_mod.write( "return true\n" );
+    CHECK( cata::lua_ui::validate_mod_scripts( { test_mod.id() }, error ) );
+    CHECK( error.empty() );
+    CHECK_FALSE( cata::lua_ui::status().loaded );
+
+    CHECK_FALSE( cata::lua_ui::validate_mod_scripts( { "invalid_lua_mod" }, error ) );
+    CHECK( error.find( "Unknown Lua Mod source" ) != std::string::npos );
+    CHECK_FALSE( cata::lua_ui::status().loaded );
+
+    std::string cleanup_error;
+    CHECK( test_mod.cleanup( cleanup_error ) );
+    CHECK( cleanup_error.empty() );
 }
 
 TEST_CASE( "bundled_lua_ui_script_registers_api_v4", "[lua][ui][integration]" )

--- a/tools/agent/test_context_pack.py
+++ b/tools/agent/test_context_pack.py
@@ -23,6 +23,8 @@ class ContextPackTests(unittest.TestCase):
         self.assertIn("lua-api", pack["selected_routes"])
         self.assertIn("api.lua.v5.reference.modules", pack["documentation_ids"])
         self.assertIn("lua-contract", {entry["id"] for entry in pack["tests"]})
+        self.assertIn("src/main.cpp", pack["source_paths"])
+        self.assertIn("src/game_io.cpp", pack["source_paths"])
         self.assertLessEqual(pack["estimated_tokens"], 4000)
 
     def test_untracked_and_obj_lua_paths_are_rejected(self) -> None:

--- a/tools/lua_api/README.md
+++ b/tools/lua_api/README.md
@@ -29,10 +29,11 @@ python3 tools/lua_api/check_cmake_contract.py
 python3 -m unittest discover -s tools/lua_api -p 'test_*.py'
 ```
 
-`check_cmake_contract.py` protects the final executable link boundary for all
-three CMake backends. Lua-disabled builds remain dependency-free; Lua-enabled
-tiles, curses, and headless executables must explicitly link the bundled Lua
-archive after their object libraries so static-link order cannot drop it.
+`check_cmake_contract.py` keeps bundled Lua on the same ABI in Make and CMake.
+Make compiles the bundled `.c` sources as C++, so CMake must also apply
+`LANGUAGE CXX`; otherwise sol2 and the native bridge request C++-mangled
+`lua_*` symbols from a C ABI archive. The checker also preserves `libsol`
+propagation through `configure_lua_ui` while Lua-disabled builds remain inert.
 
 Generated JSON must not be edited by hand. The coverage file distinguishes
 100% inventory coverage from CCB-Docs publication coverage; the latter stays

--- a/tools/lua_api/README.md
+++ b/tools/lua_api/README.md
@@ -25,8 +25,14 @@ tools/format/json_formatter.cgi data/lua/reference/ccb_public_api_v5_coverage.js
 python3 tools/lua_api/generate_public_contract.py --check
 python3 tools/lua_api/check_public_contract.py
 python3 tools/lua_api/check_examples.py --require-luac
+python3 tools/lua_api/check_cmake_contract.py
 python3 -m unittest discover -s tools/lua_api -p 'test_*.py'
 ```
+
+`check_cmake_contract.py` protects the final executable link boundary for all
+three CMake backends. Lua-disabled builds remain dependency-free; Lua-enabled
+tiles, curses, and headless executables must explicitly link the bundled Lua
+archive after their object libraries so static-link order cannot drop it.
 
 Generated JSON must not be edited by hand. The coverage file distinguishes
 100% inventory coverage from CCB-Docs publication coverage; the latter stays

--- a/tools/lua_api/README.md
+++ b/tools/lua_api/README.md
@@ -34,6 +34,9 @@ Make compiles the bundled `.c` sources as C++, so CMake must also apply
 `LANGUAGE CXX`; otherwise sol2 and the native bridge request C++-mangled
 `lua_*` symbols from a C ABI archive. The checker also preserves `libsol`
 propagation through `configure_lua_ui` while Lua-disabled builds remain inert.
+It also prevents headless `--check-mods` from initializing options twice.  A
+second initialization retains option-group registrations while clearing their
+options, emits `D_ERROR`, and makes an otherwise successful validation exit 1.
 
 Generated JSON must not be edited by hand. The coverage file distinguishes
 100% inventory coverage from CCB-Docs publication coverage; the latter stays

--- a/tools/lua_api/check_cmake_contract.py
+++ b/tools/lua_api/check_cmake_contract.py
@@ -1,51 +1,58 @@
 #!/usr/bin/env python3
-"""Validate the Lua-enabled CMake executable-link contract."""
+"""Validate the Lua-enabled CMake ABI and propagated-link contract."""
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[2]
-CMAKE_PATH = ROOT / "src" / "CMakeLists.txt"
+ENGINE_CMAKE_PATH = ROOT / "src" / "CMakeLists.txt"
+LUA_CMAKE_PATH = ROOT / "src" / "lua" / "CMakeLists.txt"
 
 
-def validate_cmake_contract(source: str) -> list[str]:
-    """Return actionable errors for a broken Lua executable link contract."""
+def validate_cmake_contract(engine_source: str, lua_source: str) -> list[str]:
+    """Return actionable errors for a broken bundled-Lua CMake contract."""
     errors: list[str] = []
-    match = re.search(
-        r"function\(link_lua_ui_runtime TARGET\)(.*?)endfunction\(\)",
-        source,
-        flags=re.DOTALL,
-    )
-    if match is None:
-        return ["src/CMakeLists.txt: missing link_lua_ui_runtime helper"]
+    signature = "function(configure_lua_ui TARGET)"
+    start = engine_source.find(signature)
+    if start == -1:
+        errors.append("src/CMakeLists.txt: missing configure_lua_ui helper")
+    else:
+        end = engine_source.find("endfunction()", start)
+        if end == -1:
+            errors.append("src/CMakeLists.txt: configure_lua_ui is unterminated")
+        else:
+            helper = engine_source[start:end]
+            if "if (CATA_ENABLE_LUA_UI)" not in helper:
+                errors.append("src/CMakeLists.txt: Lua linking must remain optional")
+            if "target_link_libraries(${TARGET} PUBLIC libsol)" not in helper:
+                errors.append(
+                    "src/CMakeLists.txt: configure_lua_ui must propagate libsol"
+                )
 
-    helper = match.group(1)
-    if "if (CATA_ENABLE_LUA_UI)" not in helper:
-        errors.append("src/CMakeLists.txt: Lua executable linking must remain optional")
-    if "target_link_libraries(${TARGET} PRIVATE liblua)" not in helper:
-        errors.append("src/CMakeLists.txt: final executables must link liblua explicitly")
-
-    tiles_calls = source.count("link_lua_ui_runtime(cataclysm-tiles)")
-    curses_and_headless_calls = source.count("link_lua_ui_runtime(cataclysm)")
-    if tiles_calls != 1:
-        errors.append("src/CMakeLists.txt: tiles needs exactly one Lua runtime link")
-    if curses_and_headless_calls != 2:
+    normalized_lua = " ".join(lua_source.split())
+    if (
+        "set_source_files_properties(${LUA_SOURCES} "
+        "PROPERTIES LANGUAGE CXX)"
+        not in normalized_lua
+    ):
         errors.append(
-            "src/CMakeLists.txt: curses and headless both need a Lua runtime link"
+            "src/lua/CMakeLists.txt: bundled Lua sources must use LANGUAGE CXX"
         )
     return errors
 
 
 def main() -> int:
-    errors = validate_cmake_contract(CMAKE_PATH.read_text(encoding="utf-8"))
+    errors = validate_cmake_contract(
+        ENGINE_CMAKE_PATH.read_text(encoding="utf-8"),
+        LUA_CMAKE_PATH.read_text(encoding="utf-8"),
+    )
     if errors:
         for error in errors:
             print(error)
         return 1
-    print("Lua-enabled CMake executable link contract passed")
+    print("Lua-enabled CMake ABI and propagated-link contract passed")
     return 0
 
 

--- a/tools/lua_api/check_cmake_contract.py
+++ b/tools/lua_api/check_cmake_contract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate the Lua-enabled CMake ABI and propagated-link contract."""
+"""Validate Lua-enabled build and ``--check-mods`` runtime contracts."""
 
 from __future__ import annotations
 
@@ -9,10 +9,13 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 ENGINE_CMAKE_PATH = ROOT / "src" / "CMakeLists.txt"
 LUA_CMAKE_PATH = ROOT / "src" / "lua" / "CMakeLists.txt"
+MAIN_PATH = ROOT / "src" / "main.cpp"
 
 
-def validate_cmake_contract(engine_source: str, lua_source: str) -> list[str]:
-    """Return actionable errors for a broken bundled-Lua CMake contract."""
+def validate_cmake_contract(
+    engine_source: str, lua_source: str, main_source: str
+) -> list[str]:
+    """Return actionable errors for broken bundled-Lua build/runtime contracts."""
     errors: list[str] = []
     signature = "function(configure_lua_ui TARGET)"
     start = engine_source.find(signature)
@@ -40,6 +43,24 @@ def validate_cmake_contract(engine_source: str, lua_source: str) -> list[str]:
         errors.append(
             "src/lua/CMakeLists.txt: bundled Lua sources must use LANGUAGE CXX"
         )
+
+    normalized_main = " ".join(main_source.split())
+    headless_init = (
+        "#if !defined(TILES) if( !cli.check_mods ) { "
+        "get_options().init(); get_options().load(); } #endif"
+    )
+    check_mods_init = (
+        "else if( cli.check_mods ) { get_options().init(); "
+        "get_options().load(); }"
+    )
+    if headless_init not in normalized_main:
+        errors.append(
+            "src/main.cpp: headless option initialization must skip --check-mods"
+        )
+    if check_mods_init not in normalized_main:
+        errors.append(
+            "src/main.cpp: --check-mods must initialize options exactly once"
+        )
     return errors
 
 
@@ -47,12 +68,13 @@ def main() -> int:
     errors = validate_cmake_contract(
         ENGINE_CMAKE_PATH.read_text(encoding="utf-8"),
         LUA_CMAKE_PATH.read_text(encoding="utf-8"),
+        MAIN_PATH.read_text(encoding="utf-8"),
     )
     if errors:
         for error in errors:
             print(error)
         return 1
-    print("Lua-enabled CMake ABI and propagated-link contract passed")
+    print("Lua-enabled build and --check-mods runtime contracts passed")
     return 0
 
 

--- a/tools/lua_api/check_cmake_contract.py
+++ b/tools/lua_api/check_cmake_contract.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Validate the Lua-enabled CMake executable-link contract."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CMAKE_PATH = ROOT / "src" / "CMakeLists.txt"
+
+
+def validate_cmake_contract(source: str) -> list[str]:
+    """Return actionable errors for a broken Lua executable link contract."""
+    errors: list[str] = []
+    match = re.search(
+        r"function\(link_lua_ui_runtime TARGET\)(.*?)endfunction\(\)",
+        source,
+        flags=re.DOTALL,
+    )
+    if match is None:
+        return ["src/CMakeLists.txt: missing link_lua_ui_runtime helper"]
+
+    helper = match.group(1)
+    if "if (CATA_ENABLE_LUA_UI)" not in helper:
+        errors.append("src/CMakeLists.txt: Lua executable linking must remain optional")
+    if "target_link_libraries(${TARGET} PRIVATE liblua)" not in helper:
+        errors.append("src/CMakeLists.txt: final executables must link liblua explicitly")
+
+    tiles_calls = source.count("link_lua_ui_runtime(cataclysm-tiles)")
+    curses_and_headless_calls = source.count("link_lua_ui_runtime(cataclysm)")
+    if tiles_calls != 1:
+        errors.append("src/CMakeLists.txt: tiles needs exactly one Lua runtime link")
+    if curses_and_headless_calls != 2:
+        errors.append(
+            "src/CMakeLists.txt: curses and headless both need a Lua runtime link"
+        )
+    return errors
+
+
+def main() -> int:
+    errors = validate_cmake_contract(CMAKE_PATH.read_text(encoding="utf-8"))
+    if errors:
+        for error in errors:
+            print(error)
+        return 1
+    print("Lua-enabled CMake executable link contract passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lua_api/test_check_cmake_contract.py
+++ b/tools/lua_api/test_check_cmake_contract.py
@@ -6,12 +6,14 @@ try:
     from .check_cmake_contract import (
         ENGINE_CMAKE_PATH,
         LUA_CMAKE_PATH,
+        MAIN_PATH,
         validate_cmake_contract,
     )
 except ImportError:
     from check_cmake_contract import (
         ENGINE_CMAKE_PATH,
         LUA_CMAKE_PATH,
+        MAIN_PATH,
         validate_cmake_contract,
     )
 
@@ -21,10 +23,14 @@ class CMakeContractTests(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.engine_source = ENGINE_CMAKE_PATH.read_text(encoding="utf-8")
         cls.lua_source = LUA_CMAKE_PATH.read_text(encoding="utf-8")
+        cls.main_source = MAIN_PATH.read_text(encoding="utf-8")
 
     def test_checked_in_contract_is_complete(self) -> None:
         self.assertEqual(
-            validate_cmake_contract(self.engine_source, self.lua_source), []
+            validate_cmake_contract(
+                self.engine_source, self.lua_source, self.main_source
+            ),
+            [],
         )
 
     def test_c_abi_for_bundled_lua_is_rejected(self) -> None:
@@ -32,7 +38,9 @@ class CMakeContractTests(unittest.TestCase):
             "PROPERTIES LANGUAGE CXX", "PROPERTIES LANGUAGE C"
         )
         self.assertNotEqual(lua_source, self.lua_source)
-        errors = validate_cmake_contract(self.engine_source, lua_source)
+        errors = validate_cmake_contract(
+            self.engine_source, lua_source, self.main_source
+        )
         self.assertTrue(any("LANGUAGE CXX" in error for error in errors), errors)
 
     def test_missing_libsol_propagation_is_rejected(self) -> None:
@@ -41,8 +49,28 @@ class CMakeContractTests(unittest.TestCase):
             "target_link_libraries(${TARGET} PUBLIC third-party)",
         )
         self.assertNotEqual(engine_source, self.engine_source)
-        errors = validate_cmake_contract(engine_source, self.lua_source)
+        errors = validate_cmake_contract(
+            engine_source, self.lua_source, self.main_source
+        )
         self.assertTrue(any("propagate libsol" in error for error in errors), errors)
+
+    def test_duplicate_headless_check_mods_initialization_is_rejected(self) -> None:
+        main_source = self.main_source.replace(
+            """    if( !cli.check_mods ) {
+        get_options().init();
+        get_options().load();
+    }
+""",
+            """    get_options().init();
+    get_options().load();
+""",
+            1,
+        )
+        self.assertNotEqual(main_source, self.main_source)
+        errors = validate_cmake_contract(
+            self.engine_source, self.lua_source, main_source
+        )
+        self.assertTrue(any("skip --check-mods" in error for error in errors), errors)
 
 
 if __name__ == "__main__":

--- a/tools/lua_api/test_check_cmake_contract.py
+++ b/tools/lua_api/test_check_cmake_contract.py
@@ -3,34 +3,46 @@ from __future__ import annotations
 import unittest
 
 try:
-    from .check_cmake_contract import CMAKE_PATH, validate_cmake_contract
+    from .check_cmake_contract import (
+        ENGINE_CMAKE_PATH,
+        LUA_CMAKE_PATH,
+        validate_cmake_contract,
+    )
 except ImportError:
-    from check_cmake_contract import CMAKE_PATH, validate_cmake_contract
+    from check_cmake_contract import (
+        ENGINE_CMAKE_PATH,
+        LUA_CMAKE_PATH,
+        validate_cmake_contract,
+    )
 
 
 class CMakeContractTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
-        cls.source = CMAKE_PATH.read_text(encoding="utf-8")
+        cls.engine_source = ENGINE_CMAKE_PATH.read_text(encoding="utf-8")
+        cls.lua_source = LUA_CMAKE_PATH.read_text(encoding="utf-8")
 
     def test_checked_in_contract_is_complete(self) -> None:
-        self.assertEqual(validate_cmake_contract(self.source), [])
-
-    def test_missing_final_lua_archive_is_rejected(self) -> None:
-        source = self.source.replace(
-            "target_link_libraries(${TARGET} PRIVATE liblua)",
-            "target_link_libraries(${TARGET} PRIVATE libsol)",
+        self.assertEqual(
+            validate_cmake_contract(self.engine_source, self.lua_source), []
         )
-        errors = validate_cmake_contract(source)
-        self.assertTrue(any("link liblua explicitly" in error for error in errors), errors)
 
-    def test_missing_headless_executable_link_is_rejected(self) -> None:
-        prefix, separator, suffix = self.source.rpartition(
-            "    link_lua_ui_runtime(cataclysm)\n"
+    def test_c_abi_for_bundled_lua_is_rejected(self) -> None:
+        lua_source = self.lua_source.replace(
+            "PROPERTIES LANGUAGE CXX", "PROPERTIES LANGUAGE C"
         )
-        self.assertTrue(separator)
-        errors = validate_cmake_contract(prefix + suffix)
-        self.assertTrue(any("curses and headless" in error for error in errors), errors)
+        self.assertNotEqual(lua_source, self.lua_source)
+        errors = validate_cmake_contract(self.engine_source, lua_source)
+        self.assertTrue(any("LANGUAGE CXX" in error for error in errors), errors)
+
+    def test_missing_libsol_propagation_is_rejected(self) -> None:
+        engine_source = self.engine_source.replace(
+            "target_link_libraries(${TARGET} PUBLIC libsol)",
+            "target_link_libraries(${TARGET} PUBLIC third-party)",
+        )
+        self.assertNotEqual(engine_source, self.engine_source)
+        errors = validate_cmake_contract(engine_source, self.lua_source)
+        self.assertTrue(any("propagate libsol" in error for error in errors), errors)
 
 
 if __name__ == "__main__":

--- a/tools/lua_api/test_check_cmake_contract.py
+++ b/tools/lua_api/test_check_cmake_contract.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import unittest
+
+try:
+    from .check_cmake_contract import CMAKE_PATH, validate_cmake_contract
+except ImportError:
+    from check_cmake_contract import CMAKE_PATH, validate_cmake_contract
+
+
+class CMakeContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.source = CMAKE_PATH.read_text(encoding="utf-8")
+
+    def test_checked_in_contract_is_complete(self) -> None:
+        self.assertEqual(validate_cmake_contract(self.source), [])
+
+    def test_missing_final_lua_archive_is_rejected(self) -> None:
+        source = self.source.replace(
+            "target_link_libraries(${TARGET} PRIVATE liblua)",
+            "target_link_libraries(${TARGET} PRIVATE libsol)",
+        )
+        errors = validate_cmake_contract(source)
+        self.assertTrue(any("link liblua explicitly" in error for error in errors), errors)
+
+    def test_missing_headless_executable_link_is_rejected(self) -> None:
+        prefix, separator, suffix = self.source.rpartition(
+            "    link_lua_ui_runtime(cataclysm)\n"
+        )
+        self.assertTrue(separator)
+        errors = validate_cmake_contract(prefix + suffix)
+        self.assertTrue(any("curses and headless" in error for error in errors), errors)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes the executable example-validation gap for **CCB Agent 友好化与双语开发文档重构**.

- makes `--check-mods` validate Lua manifests and execute selected Mods' top-level `main.lua` files in Lua-enabled builds;
- uses an isolated, non-active Lua runtime state and does not subscribe callbacks, dispatch lifecycle events, persist Lua state, or change normal gameplay;
- makes JSON or Lua validation failures return a failing CLI status;
- aligns bundled Lua's CMake ABI with Make by compiling the bundled `.c` sources as C++;
- fixes headless `--check-mods` option initialization so it occurs exactly once;
- adds focused enabled/disabled Lua tests, an execution sentinel, build/runtime contract checks, and Agent routing.

Stack base: #571. Related documentation: CrimsonCrossBunker/CCB-Docs#13 and #14.

## Root causes fixed

1. CMake previously compiled bundled Lua as C while Make compiled it as C++, so sol2/native code requested C++-mangled `lua_*` symbols from a C ABI archive. Commit `413db137` aligns the ABI and allows the headless executable to link.
2. In non-TILES builds, `--check-mods` initialized options once in the headless block and again in its test-mode branch. The second initialization retained option groups, emitted repeated `D_ERROR` messages, set `error_observed`, and forced exit 1 even after both Mods passed. Commit `bee42cfc` skips the first initialization for `--check-mods`.

The earlier missing-`config/` hypothesis was rejected by the captured `debug.log`; it is not the root cause.

#### Responsible human

@LYHGLYTX is the sole Responsible human and owns the final diff, validation evidence, licenses, sources, and review answers.

#### Documentation impact

Executable Lua/JSON Mod validation only; no gameplay, balance, save-format, or public Lua API contract change.

#### Related CCB-Docs PR

CrimsonCrossBunker/CCB-Docs#13 and #14.

#### Affected documentation IDs

- `api.lua.v5.example-mod`
- `mods.complete-json-eoc-mod`
- `validation.testing`

#### Generated reference impact

Generated Lua API inventories are unchanged. No gameplay, balance, public Lua API, or save-format contract changes.

## Validation

Passed locally or on the committed branch:

- focused build/runtime contract checker;
- 4 contract-checker regression tests;
- Lua public contract CI;
- astyle CI;
- Agent benchmark 9/9;
- 4 focused Agent context tests;
- Agent metadata validation;
- `git diff --check`;
- CCB-Docs #13 Runtime [30747908694](https://github.com/CrimsonCrossBunker/CCB-Docs/actions/runs/30747908694): passed;
- CCB-Docs #14 Runtime [30747923493](https://github.com/CrimsonCrossBunker/CCB-Docs/actions/runs/30747923493): passed.

The real headless example-Mod runs passed on CCB-Docs #13 and #14 against `bee42cfc3bdf1162974f6dcc655aef03a7aa605d`. This Draft must not be auto-merged.

## Commit split

- Previous commit count: 1
- New commit count: 6
- Incremental changed lines: 469
- Average changed lines: 78
- Largest atomic commit: see commit log
- Tree-equivalence result: PASS (git diff --exit-code <old-head> <new-head>)
- Previous head: `630aaefbe1d5c5d4b5e16c166e077650f07acac2`
- New head: `5973195f5333233d70894915e61081fbf57caf1c`
- Backup bundle: skipped by owner instruction (old head recorded above)
- Validation status: tree-equivalent, chain verified
