### PR TITLE
Allow EOC and Lua to manipulate unabsorbed calories and vitamins in the gut

### DIFF
--- a/data/lua/README.md
+++ b/data/lua/README.md
@@ -467,7 +467,7 @@ file gives every method's exact parameters and result type.
 | `game.skills` | skill definitions and character levels/training | bounded level, exercise, training and practice updates |
 | `game.proficiencies` | definitions, categories and learning progress | grant/remove/practice/set progress |
 | `game.vitamins` / `game.addictions` | definitions and character pools/state | bounded pool, exposure and withdrawal updates |
-| `game.needs` | hunger, thirst, calories, sleep and health | checked set/modify/reset operations |
+| `game.needs` | hunger, thirst, calories, gut nutrients awaiting absorption, sleep and health | checked set/modify/reset operations |
 | `game.martial_arts` | style definitions, known and selected state | learn/remove/select/trigger and hand policy |
 | `game.vehicles` | prototypes, live state, lift, parts and fuels | rename, cruise/stop/tracking and part enablement |
 | `game.npcs` | class catalogue and live NPC snapshots | rename, attitude and opinion updates |

--- a/data/lua/types/ccb_api_v5.d.lua
+++ b/data/lua/types/ccb_api_v5.d.lua
@@ -3342,6 +3342,10 @@ function CcbAddictionsApi.run_effect(handle, id) end
 ---@field sleepiness? integer
 ---@field sleep_deprivation? integer
 
+---@class CcbGutVitaminSnapshot
+---@field id GameId
+---@field amount integer
+
 ---@class CcbSleepAdjustments
 ---@field daily? TimeDuration
 ---@field continuous? TimeDuration
@@ -3381,6 +3385,37 @@ function CcbNeedsApi.set_calories(handle, kcal) end
 ---@param ignore_weariness? boolean
 ---@return CcbResult
 function CcbNeedsApi.modify_calories(handle, delta, ignore_weariness) end
+
+---@param handle GameHandle
+---@return CcbResult
+function CcbNeedsApi.get_gut_calories(handle) end
+
+---@param handle GameHandle
+---@param kcal integer
+---@return CcbResult
+function CcbNeedsApi.set_gut_calories(handle, kcal) end
+
+---@param handle GameHandle
+---@param delta integer
+---@return CcbResult
+function CcbNeedsApi.modify_gut_calories(handle, delta) end
+
+---@param handle GameHandle
+---@param id GameId
+---@return CcbResult
+function CcbNeedsApi.get_gut_vitamin(handle, id) end
+
+---@param handle GameHandle
+---@param id GameId
+---@param amount integer
+---@return CcbResult
+function CcbNeedsApi.set_gut_vitamin(handle, id, amount) end
+
+---@param handle GameHandle
+---@param id GameId
+---@param delta integer
+---@return CcbResult
+function CcbNeedsApi.modify_gut_vitamin(handle, id, delta) end
 
 ---@param handle GameHandle
 ---@param adjustments CcbSleepAdjustments

--- a/doc/JSON/NPCs.md
+++ b/doc/JSON/NPCs.md
@@ -1553,6 +1553,9 @@ _some functions support array arguments or kwargs, denoted with square brackets 
 | gender() |  ✅  |  ✅  | u, n | Character's current gender. (Boolean value currently. Value is 1/true for male, 0/false for female).<br/><br/>Examples:<br/>`"condition: { "math": [ " u_gender() == 1 " ] }`<br/>`{ "math": [ "u_gender() = 0" ] }` |
 | enchant_val( `s` / `v` ) |  ✅  |  ❌  | u, n | Returns the final result of a custom enchantment attribute. It requires two arguments: the first is the custom attribute key, and the second is the default value for the attribute. Ultimately, it returns the result after adjusting the default value for the enchantment attribute.<br/><br/>Examples:<br/>`{ "math": [ " _my_attr = u_enchant_val('my_attr', 100) " ] }`<br/>Returns `(100 + Σadd) × (1 + Σmultiply)`. |
 
+| gut_calories() | ✅ | ✅ | u, n | Return or set calories currently held in the character's guts and awaiting absorption.  This is separate from stored calories; assigning it does not immediately change body calories, hunger, or digestion timing.  Values below zero are clamped to zero.  This function can only be used with a character talker.<br/><br/>Example:<br/>`{ "math": [ "u_gut_calories() += 250" ] }` |
+| gut_vitamin(`s`/`v`) | ✅ | ✅ | u, n | Return or set the amount of a vitamin currently held in the character's guts and awaiting absorption.  Argument is a valid vitamin ID.  This does not immediately alter the character's vitamin pool; normal digestion absorbs it later.  Values at or below zero remove the vitamin from the gut pool.  This function can only be used with a character talker.<br/><br/>Example:<br/>`{ "math": [ "u_gut_vitamin('vitC') += 24" ] }` |
+
 #### List of Character and item aspects
 These can be read or written to with `val()`.
 

--- a/src/catalua_ui_needs.cpp
+++ b/src/catalua_ui_needs.cpp
@@ -7,12 +7,14 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "catalua_bindings_values.h"
 #include "catalua_game_handle.h"
 #include "character.h"
 #include "creature.h"
+#include "vitamin.h"
 
 namespace cata::lua_ui
 {
@@ -22,6 +24,7 @@ namespace
 
 constexpr int maximum_need_magnitude = 1000000;
 constexpr int maximum_stored_kcal = 2000000;
+constexpr int maximum_gut_vitamin = 1000000000;
 constexpr std::int64_t maximum_sleep_adjustment_turns = 31622400;
 
 Character *resolve_character(
@@ -298,6 +301,188 @@ sol::table modify_calories(
     value["before"] = std::move( before );
     value["after"] =
         snapshot_needs( state, *character );
+    return make_game_value_result(
+               state, sol::make_object( state, std::move( value ) ) );
+}
+
+void require_vitamin_id(
+    const script_game_id &id, const std::string_view api_name )
+{
+    if( id.kind() != "vitamin" || !id.is_valid() ) {
+        throw std::invalid_argument(
+            std::string( api_name ) +
+            " requires a valid GameId<vitamin>" );
+    }
+}
+
+sol::table snapshot_gut_vitamin(
+    sol::state_view lua, const Character &character,
+    const vitamin_id &id )
+{
+    sol::table result = lua.create_table();
+    result["id"] = script_game_id( "vitamin", id.str() );
+    result["amount"] = character.guts.get_vitamin( id );
+    return result;
+}
+
+sol::table get_gut_calories(
+    sol::this_state lua, const game_handle &handle,
+    const std::size_t runtime_generation,
+    const std::size_t world_generation )
+{
+    sol::state_view state( lua );
+    std::optional<game_handle_error> error;
+    Character *character = resolve_character(
+                               handle, runtime_generation,
+                               world_generation, error );
+    if( character == nullptr ) {
+        return make_game_error_result( state, *error );
+    }
+    return make_game_value_result(
+               state, sol::make_object(
+                   state, character->guts.get_calories() ) );
+}
+
+sol::table set_gut_calories(
+    sol::this_state lua, const game_handle &handle,
+    const int requested_kcal,
+    const std::size_t runtime_generation,
+    const std::size_t world_generation )
+{
+    if( requested_kcal < 0 || requested_kcal > maximum_stored_kcal ) {
+        throw std::invalid_argument(
+            "game.needs.set_gut_calories kcal must be within 0..2000000" );
+    }
+    sol::state_view state( lua );
+    std::optional<game_handle_error> error;
+    Character *character = resolve_character(
+                               handle, runtime_generation,
+                               world_generation, error );
+    if( character == nullptr ) {
+        return make_game_error_result( state, *error );
+    }
+    const int before = character->guts.get_calories();
+    character->guts.mod_calories( requested_kcal - before );
+    sol::table value = state.create_table();
+    value["requested"] = requested_kcal;
+    value["before"] = before;
+    value["after"] = character->guts.get_calories();
+    return make_game_value_result(
+               state, sol::make_object( state, std::move( value ) ) );
+}
+
+sol::table modify_gut_calories(
+    sol::this_state lua, const game_handle &handle,
+    const int requested_delta,
+    const std::size_t runtime_generation,
+    const std::size_t world_generation )
+{
+    if( requested_delta < -maximum_need_magnitude ||
+        requested_delta > maximum_need_magnitude ) {
+        throw std::invalid_argument(
+            "game.needs.modify_gut_calories delta must be within -1000000..1000000" );
+    }
+    sol::state_view state( lua );
+    std::optional<game_handle_error> error;
+    Character *character = resolve_character(
+                               handle, runtime_generation,
+                               world_generation, error );
+    if( character == nullptr ) {
+        return make_game_error_result( state, *error );
+    }
+    const int before = character->guts.get_calories();
+    character->guts.mod_calories( requested_delta );
+    const int after = character->guts.get_calories();
+    sol::table value = state.create_table();
+    value["requested_delta"] = requested_delta;
+    value["applied_delta"] = after - before;
+    value["before"] = before;
+    value["after"] = after;
+    return make_game_value_result(
+               state, sol::make_object( state, std::move( value ) ) );
+}
+
+sol::table get_gut_vitamin(
+    sol::this_state lua, const game_handle &handle,
+    const script_game_id &id,
+    const std::size_t runtime_generation,
+    const std::size_t world_generation )
+{
+    require_vitamin_id( id, "game.needs.get_gut_vitamin" );
+    sol::state_view state( lua );
+    std::optional<game_handle_error> error;
+    Character *character = resolve_character(
+                               handle, runtime_generation,
+                               world_generation, error );
+    if( character == nullptr ) {
+        return make_game_error_result( state, *error );
+    }
+    return make_game_value_result(
+               state, sol::make_object(
+                   state, snapshot_gut_vitamin(
+                       state, *character, vitamin_id( id.value() ) ) ) );
+}
+
+sol::table set_gut_vitamin(
+    sol::this_state lua, const game_handle &handle,
+    const script_game_id &id, const int requested_amount,
+    const std::size_t runtime_generation,
+    const std::size_t world_generation )
+{
+    require_vitamin_id( id, "game.needs.set_gut_vitamin" );
+    if( requested_amount < 0 || requested_amount > maximum_gut_vitamin ) {
+        throw std::invalid_argument(
+            "game.needs.set_gut_vitamin amount must be within 0..1000000000" );
+    }
+    sol::state_view state( lua );
+    std::optional<game_handle_error> error;
+    Character *character = resolve_character(
+                               handle, runtime_generation,
+                               world_generation, error );
+    if( character == nullptr ) {
+        return make_game_error_result( state, *error );
+    }
+    const vitamin_id vitamin( id.value() );
+    sol::table before = snapshot_gut_vitamin( state, *character, vitamin );
+    character->guts.set_vitamin( vitamin, requested_amount );
+    sol::table value = state.create_table();
+    value["requested"] = requested_amount;
+    value["before"] = std::move( before );
+    value["after"] = snapshot_gut_vitamin( state, *character, vitamin );
+    return make_game_value_result(
+               state, sol::make_object( state, std::move( value ) ) );
+}
+
+sol::table modify_gut_vitamin(
+    sol::this_state lua, const game_handle &handle,
+    const script_game_id &id, const int requested_delta,
+    const std::size_t runtime_generation,
+    const std::size_t world_generation )
+{
+    require_vitamin_id( id, "game.needs.modify_gut_vitamin" );
+    if( requested_delta < -maximum_gut_vitamin ||
+        requested_delta > maximum_gut_vitamin ) {
+        throw std::invalid_argument(
+            "game.needs.modify_gut_vitamin delta must be within -1000000000..1000000000" );
+    }
+    sol::state_view state( lua );
+    std::optional<game_handle_error> error;
+    Character *character = resolve_character(
+                               handle, runtime_generation,
+                               world_generation, error );
+    if( character == nullptr ) {
+        return make_game_error_result( state, *error );
+    }
+    const vitamin_id vitamin( id.value() );
+    const int before_amount = character->guts.get_vitamin( vitamin );
+    sol::table before = snapshot_gut_vitamin( state, *character, vitamin );
+    character->guts.mod_vitamin( vitamin, requested_delta );
+    const int after_amount = character->guts.get_vitamin( vitamin );
+    sol::table value = state.create_table();
+    value["requested_delta"] = requested_delta;
+    value["applied_delta"] = after_amount - before_amount;
+    value["before"] = std::move( before );
+    value["after"] = snapshot_gut_vitamin( state, *character, vitamin );
     return make_game_value_result(
                state, sol::make_object( state, std::move( value ) ) );
 }
@@ -669,6 +854,68 @@ void install_need_api(
         return modify_calories(
                    lua_state, handle, delta,
                    ignore_weariness.value_or( false ),
+                   current_runtime_generation(),
+                   current_world_generation() );
+    } );
+    needs.set_function(
+        "get_gut_calories",
+        [current_runtime_generation, current_world_generation, require_read](
+    sol::this_state lua_state, const game_handle & handle ) {
+        require_read();
+        return get_gut_calories(
+                   lua_state, handle,
+                   current_runtime_generation(),
+                   current_world_generation() );
+    } );
+    needs.set_function(
+        "set_gut_calories",
+        [current_runtime_generation, current_world_generation, require_write](
+    sol::this_state lua_state, const game_handle & handle, const int kcal ) {
+        require_write();
+        return set_gut_calories(
+                   lua_state, handle, kcal,
+                   current_runtime_generation(),
+                   current_world_generation() );
+    } );
+    needs.set_function(
+        "modify_gut_calories",
+        [current_runtime_generation, current_world_generation, require_write](
+    sol::this_state lua_state, const game_handle & handle, const int delta ) {
+        require_write();
+        return modify_gut_calories(
+                   lua_state, handle, delta,
+                   current_runtime_generation(),
+                   current_world_generation() );
+    } );
+    needs.set_function(
+        "get_gut_vitamin",
+        [current_runtime_generation, current_world_generation, require_read](
+    sol::this_state lua_state, const game_handle & handle, const script_game_id & id ) {
+        require_read();
+        return get_gut_vitamin(
+                   lua_state, handle, id,
+                   current_runtime_generation(),
+                   current_world_generation() );
+    } );
+    needs.set_function(
+        "set_gut_vitamin",
+        [current_runtime_generation, current_world_generation, require_write](
+    sol::this_state lua_state, const game_handle & handle, const script_game_id & id,
+    const int amount ) {
+        require_write();
+        return set_gut_vitamin(
+                   lua_state, handle, id, amount,
+                   current_runtime_generation(),
+                   current_world_generation() );
+    } );
+    needs.set_function(
+        "modify_gut_vitamin",
+        [current_runtime_generation, current_world_generation, require_write](
+    sol::this_state lua_state, const game_handle & handle, const script_game_id & id,
+    const int delta ) {
+        require_write();
+        return modify_gut_vitamin(
+                   lua_state, handle, id, delta,
                    current_runtime_generation(),
                    current_world_generation() );
     } );

--- a/src/catalua_ui_needs.cpp
+++ b/src/catalua_ui_needs.cpp
@@ -24,7 +24,6 @@ namespace
 
 constexpr int maximum_need_magnitude = 1000000;
 constexpr int maximum_stored_kcal = 2000000;
-constexpr int maximum_gut_vitamin = 1000000000;
 constexpr std::int64_t maximum_sleep_adjustment_turns = 31622400;
 
 Character *resolve_character(
@@ -349,9 +348,9 @@ sol::table set_gut_calories(
     const std::size_t runtime_generation,
     const std::size_t world_generation )
 {
-    if( requested_kcal < 0 || requested_kcal > maximum_stored_kcal ) {
+    if( requested_kcal < 0 ) {
         throw std::invalid_argument(
-            "game.needs.set_gut_calories kcal must be within 0..2000000" );
+            "game.needs.set_gut_calories kcal cannot be negative" );
     }
     sol::state_view state( lua );
     std::optional<game_handle_error> error;
@@ -377,11 +376,6 @@ sol::table modify_gut_calories(
     const std::size_t runtime_generation,
     const std::size_t world_generation )
 {
-    if( requested_delta < -maximum_need_magnitude ||
-        requested_delta > maximum_need_magnitude ) {
-        throw std::invalid_argument(
-            "game.needs.modify_gut_calories delta must be within -1000000..1000000" );
-    }
     sol::state_view state( lua );
     std::optional<game_handle_error> error;
     Character *character = resolve_character(
@@ -430,9 +424,9 @@ sol::table set_gut_vitamin(
     const std::size_t world_generation )
 {
     require_vitamin_id( id, "game.needs.set_gut_vitamin" );
-    if( requested_amount < 0 || requested_amount > maximum_gut_vitamin ) {
+    if( requested_amount < 0 ) {
         throw std::invalid_argument(
-            "game.needs.set_gut_vitamin amount must be within 0..1000000000" );
+            "game.needs.set_gut_vitamin amount cannot be negative" );
     }
     sol::state_view state( lua );
     std::optional<game_handle_error> error;
@@ -460,11 +454,6 @@ sol::table modify_gut_vitamin(
     const std::size_t world_generation )
 {
     require_vitamin_id( id, "game.needs.modify_gut_vitamin" );
-    if( requested_delta < -maximum_gut_vitamin ||
-        requested_delta > maximum_gut_vitamin ) {
-        throw std::invalid_argument(
-            "game.needs.modify_gut_vitamin delta must be within -1000000000..1000000000" );
-    }
     sol::state_view state( lua );
     std::optional<game_handle_error> error;
     Character *character = resolve_character(

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <functional>
 #include <list>
+#include <limits>
 #include <memory>
 #include <numeric>
 #include <optional>
@@ -1890,7 +1891,9 @@ void gut_calories_ass( double val, dialogue &d, char scope,
                        diag_kwargs const & /* kwargs */ )
 {
     if( Character *const chr = d.actor( is_beta( scope ) )->get_character() ) {
-        const int difference = val - chr->guts.get_calories();
+        const int desired = static_cast<int>( std::clamp( val, 0.0,
+                            static_cast<double>( std::numeric_limits<int>::max() ) ) );
+        const int difference = desired - chr->guts.get_calories();
         chr->guts.mod_calories( difference );
         return;
     }

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -1875,6 +1875,61 @@ void calories_ass( double val, dialogue &d, char scope,
     d.actor( is_beta( scope ) )->mod_stored_kcal( difference, ignore_weariness );
 }
 
+double gut_calories_eval( const_dialogue const &d, char scope,
+                          std::vector<diag_value> const & /* params */,
+                          diag_kwargs const & /* kwargs */ )
+{
+    if( const Character *const chr = d.const_actor( is_beta( scope ) )->get_const_character() ) {
+        return chr->guts.get_calories();
+    }
+    throw math::runtime_error( "For gut_calories(), talker is not character" );
+}
+
+void gut_calories_ass( double val, dialogue &d, char scope,
+                       std::vector<diag_value> const & /* params */,
+                       diag_kwargs const & /* kwargs */ )
+{
+    if( Character *const chr = d.actor( is_beta( scope ) )->get_character() ) {
+        constexpr int maximum_gut_calories = 2000000;
+        const int desired = static_cast<int>( clamp( val, 0.0,
+                            static_cast<double>( maximum_gut_calories ) ) );
+        chr->guts.mod_calories( desired - chr->guts.get_calories() );
+        return;
+    }
+    throw math::runtime_error( "For gut_calories(), talker is not character" );
+}
+
+double gut_vitamin_eval( const_dialogue const &d, char scope,
+                         std::vector<diag_value> const &params,
+                         diag_kwargs const & /* kwargs */ )
+{
+    const vitamin_id vit( params[0].str( d ) );
+    if( !vit.is_valid() ) {
+        throw math::runtime_error( "Invalid vitamin for gut_vitamin()" );
+    }
+    if( const Character *const chr = d.const_actor( is_beta( scope ) )->get_const_character() ) {
+        return chr->guts.get_vitamin( vit );
+    }
+    throw math::runtime_error( "For gut_vitamin(), talker is not character" );
+}
+
+void gut_vitamin_ass( double val, dialogue &d, char scope,
+                      std::vector<diag_value> const &params,
+                      diag_kwargs const & /* kwargs */ )
+{
+    const vitamin_id vit( params[0].str( d ) );
+    if( !vit.is_valid() ) {
+        throw math::runtime_error( "Invalid vitamin for gut_vitamin()" );
+    }
+    if( Character *const chr = d.actor( is_beta( scope ) )->get_character() ) {
+        constexpr int maximum_gut_vitamin = 1000000000;
+        chr->guts.set_vitamin( vit, static_cast<int>( clamp( val, 0.0,
+                               static_cast<double>( maximum_gut_vitamin ) ) ) );
+        return;
+    }
+    throw math::runtime_error( "For gut_vitamin(), talker is not character" );
+}
+
 double weight_eval( const_dialogue const &d, char scope,
                     std::vector<diag_value> const & /* params */, diag_kwargs const & /* kwargs */ )
 {
@@ -2102,6 +2157,8 @@ std::map<std::string_view, dialogue_func> const dialogue_funcs{
     { "vision_range", { "un", 0, vision_range_eval } },
     { "vitamin", { "un", 1, vitamin_eval, vitamin_ass } },
     { "calories", { "un", 0, calories_eval, calories_ass, { "format", "dont_affect_weariness" } } },
+    { "gut_calories", { "un", 0, gut_calories_eval, gut_calories_ass } },
+    { "gut_vitamin", { "un", 1, gut_vitamin_eval, gut_vitamin_ass } },
     { "weight", { "un", 0, weight_eval } },
     { "volume", { "un", 0, volume_eval } },
     { "warmth", { "un", 1, warmth_eval } },

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -1890,10 +1890,8 @@ void gut_calories_ass( double val, dialogue &d, char scope,
                        diag_kwargs const & /* kwargs */ )
 {
     if( Character *const chr = d.actor( is_beta( scope ) )->get_character() ) {
-        constexpr int maximum_gut_calories = 2000000;
-        const int desired = static_cast<int>( clamp( val, 0.0,
-                            static_cast<double>( maximum_gut_calories ) ) );
-        chr->guts.mod_calories( desired - chr->guts.get_calories() );
+        const int difference = val - chr->guts.get_calories();
+        chr->guts.mod_calories( difference );
         return;
     }
     throw math::runtime_error( "For gut_calories(), talker is not character" );
@@ -1922,9 +1920,7 @@ void gut_vitamin_ass( double val, dialogue &d, char scope,
         throw math::runtime_error( "Invalid vitamin for gut_vitamin()" );
     }
     if( Character *const chr = d.actor( is_beta( scope ) )->get_character() ) {
-        constexpr int maximum_gut_vitamin = 1000000000;
-        chr->guts.set_vitamin( vit, static_cast<int>( clamp( val, 0.0,
-                               static_cast<double>( maximum_gut_vitamin ) ) ) );
+        chr->guts.set_vitamin( vit, val );
         return;
     }
     throw math::runtime_error( "For gut_vitamin(), talker is not character" );

--- a/src/stomach.cpp
+++ b/src/stomach.cpp
@@ -478,11 +478,12 @@ stomach_digest_rates stomach_contents::get_digest_rates( const needs_rates &meta
 
 void stomach_contents::mod_calories( int kcal )
 {
-    if( -kcal >= nutr.kcal() ) {
+    const int64_t calories = static_cast<int64_t>( kcal ) * 1000;
+    if( calories <= -nutr.calories ) {
         nutr.calories = 0;
         return;
     }
-    nutr.calories += kcal * 1000;
+    nutr.calories += calories;
 }
 
 void stomach_contents::set_vitamin( const vitamin_id &vit, int units )

--- a/src/stomach.cpp
+++ b/src/stomach.cpp
@@ -479,11 +479,13 @@ stomach_digest_rates stomach_contents::get_digest_rates( const needs_rates &meta
 void stomach_contents::mod_calories( int kcal )
 {
     const int64_t calories = static_cast<int64_t>( kcal ) * 1000;
+    const int64_t maximum_calories = static_cast<int64_t>( std::numeric_limits<int>::max() ) * 1000;
+    nutr.calories = std::min( nutr.calories, maximum_calories );
     if( calories <= -nutr.calories ) {
         nutr.calories = 0;
         return;
     }
-    nutr.calories += calories;
+    nutr.calories = std::min( nutr.calories, maximum_calories - calories ) + calories;
 }
 
 void stomach_contents::set_vitamin( const vitamin_id &vit, int units )

--- a/src/stomach.cpp
+++ b/src/stomach.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <memory>
 #include <ostream>
 #include <string>
@@ -484,6 +485,22 @@ void stomach_contents::mod_calories( int kcal )
     nutr.calories += kcal * 1000;
 }
 
+void stomach_contents::set_vitamin( const vitamin_id &vit, int units )
+{
+    if( units <= 0 ) {
+        nutr.remove_vitamin( vit );
+        return;
+    }
+    nutr.set_vitamin( vit, units );
+}
+
+void stomach_contents::mod_vitamin( const vitamin_id &vit, int units )
+{
+    const int64_t adjusted = static_cast<int64_t>( nutr.get_vitamin( vit ) ) + units;
+    set_vitamin( vit, static_cast<int>( std::clamp<int64_t>( adjusted, 0,
+                 std::numeric_limits<int>::max() ) ) );
+}
+
 void stomach_contents::mod_nutr( int nutr )
 {
     // nutr is legacy type code, this function simply converts old nutrition to new kcal
@@ -514,6 +531,11 @@ void stomach_contents::mod_contents( const units::volume &vol )
 int stomach_contents::get_calories() const
 {
     return nutr.kcal();
+}
+
+int stomach_contents::get_vitamin( const vitamin_id &vit ) const
+{
+    return nutr.get_vitamin( vit );
 }
 
 units::volume stomach_contents::get_water() const

--- a/src/stomach.h
+++ b/src/stomach.h
@@ -187,10 +187,13 @@ class stomach_contents
         units::volume contains() const;
 
         int get_calories() const;
+        int get_vitamin( const vitamin_id &vit ) const;
         units::volume get_water() const;
 
         // changes calorie amount
         void mod_calories( int kcal );
+        void set_vitamin( const vitamin_id &vit, int units );
+        void mod_vitamin( const vitamin_id &vit, int units );
 
         // changes calorie amount based on old nutr value
         void mod_nutr( int nutr );

--- a/tests/catalua_ui_test.cpp
+++ b/tests/catalua_ui_test.cpp
@@ -3035,6 +3035,11 @@ assert(modified_calories.ok == true)
 assert(modified_calories.value.applied_delta == -25)
 assert(modified_calories.value.after == 75)
 
+local capped_calories = game.needs.modify_gut_calories(avatar, 2147483647)
+assert(capped_calories.ok == true)
+assert(capped_calories.value.applied_delta == 2147483572)
+assert(capped_calories.value.after == 2147483647)
+
 local vitamin = game.needs.get_gut_vitamin(avatar, vit_c)
 assert(vitamin.ok == true)
 assert(vitamin.value.id == vit_c)
@@ -3060,9 +3065,9 @@ end) == false)
     std::string error;
     REQUIRE( cata::lua_ui::reload_scripts( error ) );
     CHECK( error.empty() );
-    CHECK( player.guts.get_calories() == 75 );
+    CHECK( player.guts.get_calories() == std::numeric_limits<int>::max() );
     CHECK( player.guts.get_vitamin( vitamin_c ) == 15 );
-    player.guts.mod_calories( original_calories - 75 );
+    player.guts.mod_calories( original_calories - std::numeric_limits<int>::max() );
     player.guts.set_vitamin( vitamin_c, original_vitamin );
 }
 

--- a/tests/catalua_ui_test.cpp
+++ b/tests/catalua_ui_test.cpp
@@ -79,7 +79,6 @@
 #include <iterator>
 #include <list>
 #include <limits>
-#include <list>
 #include <map>
 #include <memory>
 #include <optional>
@@ -94,6 +93,9 @@ namespace
 {
 
 namespace fs = std::filesystem;
+
+static const efftype_id effect_cold( "cold" );
+static const efftype_id effect_downed( "downed" );
 
 class mutation_event_subscriber final : public event_subscriber
 {
@@ -303,8 +305,9 @@ class recording_ui_renderer final : public cata::lua_ui::script_ui_renderer
 class scoped_lua_user_script
 {
     public:
-        scoped_lua_user_script() : path_( fs::u8path( PATH_INFO::config_dir() ) / "lua" / "main.lua" ),
-            manifest_path_( path_.parent_path() / "manifest.json" ) {
+        scoped_lua_user_script() : path_( fs::u8path( PATH_INFO::config_dir() ) /
+                                          fs::u8path( "lua" ) / fs::u8path( "main.lua" ) ),
+            manifest_path_( path_.parent_path() / fs::u8path( "manifest.json" ) ) {
             std::error_code error;
             fs::create_directories( path_.parent_path(), error );
             if( error ) {
@@ -383,7 +386,7 @@ class scoped_lua_user_module
 {
     public:
         explicit scoped_lua_user_module( const fs::path &relative_path ) :
-            path_( fs::u8path( PATH_INFO::config_dir() ) / "lua" / relative_path ) {
+            path_( fs::u8path( PATH_INFO::config_dir() ) / fs::u8path( "lua" ) / relative_path ) {
             std::error_code error;
             fs::create_directories( path_.parent_path(), error );
             if( error ) {
@@ -488,7 +491,7 @@ class scoped_weather_state
             weather_.windspeed_override =
                 windspeed_override_;
             weather_.weather_override =
-                weather_override_;
+                weather_override_; // NOLINT(cata-tests-must-restore-global-state)
             weather_.nextweather = nextweather_;
             weather_.temperature_cache =
                 std::move( temperature_cache_ );
@@ -923,8 +926,8 @@ TEST_CASE( "lua_v4_modules_are_source_scoped_and_dependency_gated",
     using cata::lua_ui::script_module_resolver;
     using cata::lua_ui::script_module_source;
 
-    const fs::path builtin_root = fs::u8path( PATH_INFO::datadir() ) / "lua";
-    const fs::path empty_root = fs::u8path( PATH_INFO::config_dir() ) / "lua";
+    const fs::path builtin_root = fs::u8path( PATH_INFO::datadir() ) / fs::u8path( "lua" );
+    const fs::path empty_root = fs::u8path( PATH_INFO::config_dir() ) / fs::u8path( "lua" );
 
     script_manifest builtin;
     builtin.id = "builtin";
@@ -2033,7 +2036,7 @@ assert(game.effects.has(avatar, downed).value == false)
     std::string error;
     REQUIRE( cata::lua_ui::reload_scripts( error ) );
     CHECK( error.empty() );
-    CHECK_FALSE( get_avatar().has_effect( efftype_id( "downed" ) ) );
+    CHECK_FALSE( get_avatar().has_effect( effect_downed ) );
 
     script.write_manifest( R"json({
         "id": "user",
@@ -2050,19 +2053,18 @@ game.effects.add(
 )lua" );
     CHECK_FALSE( cata::lua_ui::reload_scripts( error ) );
     CHECK( error.find( "game.write" ) != std::string::npos );
-    CHECK_FALSE( get_avatar().has_effect( efftype_id( "downed" ) ) );
+    CHECK_FALSE( get_avatar().has_effect( effect_downed ) );
 }
 
 TEST_CASE( "lua_v5_effect_updates_notify_the_owning_creature",
            "[lua][bindings][effects][integration][regression]" )
 {
     avatar &player = get_avatar();
-    const efftype_id cold( "cold" );
     const bodypart_id torso = bodypart_str_id( "torso" ).id();
-    player.remove_effect( cold, torso );
+    player.remove_effect( effect_cold, torso );
     player.clear_morale();
-    on_out_of_scope cleanup( [&player, &cold, &torso]() {
-        player.remove_effect( cold, torso );
+    on_out_of_scope cleanup( [&player, &torso]() {
+        player.remove_effect( effect_cold, torso );
         player.clear_morale();
         player.reset_bonuses();
         player.process_effects();

--- a/tests/catalua_ui_test.cpp
+++ b/tests/catalua_ui_test.cpp
@@ -3021,6 +3021,10 @@ local calories = game.needs.get_gut_calories(avatar)
 assert(calories.ok == true)
 assert(math.type(calories.value) == "integer")
 
+local large_calories = game.needs.set_gut_calories(avatar, 2000001)
+assert(large_calories.ok == true)
+assert(large_calories.value.after == 2000001)
+
 local assigned_calories = game.needs.set_gut_calories(avatar, 100)
 assert(assigned_calories.ok == true)
 assert(assigned_calories.value.before == calories.value)
@@ -3049,7 +3053,7 @@ assert(pcall(function()
     game.needs.get_gut_vitamin(avatar, game.types.id("item", "rock"))
 end) == false)
 assert(pcall(function()
-    game.needs.set_gut_calories(avatar, 2000001)
+    game.needs.set_gut_calories(avatar, -1)
 end) == false)
 )lua" );
 

--- a/tests/catalua_ui_test.cpp
+++ b/tests/catalua_ui_test.cpp
@@ -2997,6 +2997,71 @@ end) == false)
         original_sleep_deprivation );
 }
 
+TEST_CASE( "lua_v5_gut_nutrients_are_generation_safe_and_bounded",
+           "[lua][bindings][needs][gut][integration]" )
+{
+    avatar &player = get_avatar();
+    const vitamin_id vitamin_c( "vitC" );
+    const int original_calories = player.guts.get_calories();
+    const int original_vitamin = player.guts.get_vitamin( vitamin_c );
+
+    scoped_lua_user_script script;
+    script.write_manifest( R"json({
+        "id": "user",
+        "version": "5.0.0",
+        "api_version": 5,
+        "capabilities": [ "game.read", "game.write" ],
+        "dependencies": [ "builtin" ]
+    })json" );
+    script.write( R"lua(
+local avatar = game.characters.avatar()
+local vit_c = game.types.id("vitamin", "vitC")
+
+local calories = game.needs.get_gut_calories(avatar)
+assert(calories.ok == true)
+assert(math.type(calories.value) == "integer")
+
+local assigned_calories = game.needs.set_gut_calories(avatar, 100)
+assert(assigned_calories.ok == true)
+assert(assigned_calories.value.before == calories.value)
+assert(assigned_calories.value.after == 100)
+
+local modified_calories = game.needs.modify_gut_calories(avatar, -25)
+assert(modified_calories.ok == true)
+assert(modified_calories.value.applied_delta == -25)
+assert(modified_calories.value.after == 75)
+
+local vitamin = game.needs.get_gut_vitamin(avatar, vit_c)
+assert(vitamin.ok == true)
+assert(vitamin.value.id == vit_c)
+assert(math.type(vitamin.value.amount) == "integer")
+
+local assigned_vitamin = game.needs.set_gut_vitamin(avatar, vit_c, 20)
+assert(assigned_vitamin.ok == true)
+assert(assigned_vitamin.value.after.amount == 20)
+
+local modified_vitamin = game.needs.modify_gut_vitamin(avatar, vit_c, -5)
+assert(modified_vitamin.ok == true)
+assert(modified_vitamin.value.applied_delta == -5)
+assert(modified_vitamin.value.after.amount == 15)
+
+assert(pcall(function()
+    game.needs.get_gut_vitamin(avatar, game.types.id("item", "rock"))
+end) == false)
+assert(pcall(function()
+    game.needs.set_gut_calories(avatar, 2000001)
+end) == false)
+)lua" );
+
+    std::string error;
+    REQUIRE( cata::lua_ui::reload_scripts( error ) );
+    CHECK( error.empty() );
+    CHECK( player.guts.get_calories() == 75 );
+    CHECK( player.guts.get_vitamin( vitamin_c ) == 15 );
+    player.guts.mod_calories( original_calories - 75 );
+    player.guts.set_vitamin( vitamin_c, original_vitamin );
+}
+
 TEST_CASE( "lua_v5_calorie_sleep_and_health_services_use_native_rules",
            "[lua][bindings][needs][health][integration]" )
 {

--- a/tests/math_parser_test.cpp
+++ b/tests/math_parser_test.cpp
@@ -2,6 +2,7 @@
 #include <clocale>
 #include <cmath>
 #include <functional>
+#include <limits>
 #include <locale>
 #include <memory>
 #include <stdexcept>
@@ -387,6 +388,9 @@ TEST_CASE( "math_parser_dialogue_integration", "[math_parser]" )
     CHECK( get_avatar().guts.get_calories() == 100 );
     CHECK( testexp.parse( "u_gut_calories()" ) );
     CHECK( testexp.eval( d ) == Approx( 100 ) );
+    CHECK( testexp.parse( "u_gut_calories() = 2147483648" ) );
+    testexp.eval( d );
+    CHECK( get_avatar().guts.get_calories() == std::numeric_limits<int>::max() );
     CHECK( testexp.parse( "n_gut_calories() = 200" ) );
     testexp.eval( d );
     CHECK( dude.guts.get_calories() == 200 );
@@ -398,7 +402,8 @@ TEST_CASE( "math_parser_dialogue_integration", "[math_parser]" )
     CHECK( testexp.parse( "n_gut_vitamin('vitC') = 24" ) );
     testexp.eval( d );
     CHECK( dude.guts.get_vitamin( vit_c ) == 24 );
-    get_avatar().guts.mod_calories( original_avatar_gut_calories - 100 );
+    get_avatar().guts.mod_calories( original_avatar_gut_calories -
+                                    std::numeric_limits<int>::max() );
     dude.guts.mod_calories( original_npc_gut_calories - 200 );
     get_avatar().guts.set_vitamin( vit_c, original_avatar_gut_vitamin );
     dude.guts.set_vitamin( vit_c, original_npc_gut_vitamin );

--- a/tests/math_parser_test.cpp
+++ b/tests/math_parser_test.cpp
@@ -377,6 +377,32 @@ TEST_CASE( "math_parser_dialogue_integration", "[math_parser]" )
     CHECK( testexp.parse( "u_val('stamina')" ) );
     CHECK( testexp.eval( d ) == get_avatar().get_stamina() );
 
+    const vitamin_id vit_c( "vitC" );
+    const int original_avatar_gut_calories = get_avatar().guts.get_calories();
+    const int original_npc_gut_calories = dude.guts.get_calories();
+    const int original_avatar_gut_vitamin = get_avatar().guts.get_vitamin( vit_c );
+    const int original_npc_gut_vitamin = dude.guts.get_vitamin( vit_c );
+    CHECK( testexp.parse( "u_gut_calories() = 100" ) );
+    testexp.eval( d );
+    CHECK( get_avatar().guts.get_calories() == 100 );
+    CHECK( testexp.parse( "u_gut_calories()" ) );
+    CHECK( testexp.eval( d ) == Approx( 100 ) );
+    CHECK( testexp.parse( "n_gut_calories() = 200" ) );
+    testexp.eval( d );
+    CHECK( dude.guts.get_calories() == 200 );
+    CHECK( testexp.parse( "u_gut_vitamin('vitC') = 12" ) );
+    testexp.eval( d );
+    CHECK( get_avatar().guts.get_vitamin( vit_c ) == 12 );
+    CHECK( testexp.parse( "u_gut_vitamin('vitC')" ) );
+    CHECK( testexp.eval( d ) == Approx( 12 ) );
+    CHECK( testexp.parse( "n_gut_vitamin('vitC') = 24" ) );
+    testexp.eval( d );
+    CHECK( dude.guts.get_vitamin( vit_c ) == 24 );
+    get_avatar().guts.mod_calories( original_avatar_gut_calories - 100 );
+    dude.guts.mod_calories( original_npc_gut_calories - 200 );
+    get_avatar().guts.set_vitamin( vit_c, original_avatar_gut_vitamin );
+    dude.guts.set_vitamin( vit_c, original_npc_gut_vitamin );
+
     // units test
     CHECK( testexp.parse( "time('1 m')" ) );
     CHECK( testexp.eval( d ) == 60 );


### PR DESCRIPTION
#### Summary
Features "Expose gut calories and vitamins to EOC and Lua"

#### Purpose of change
Add more interfaces, as mentioned in issue #44.

The current digestion system is entirely hardcoded and cannot be manipulated externally, with only a few enchantments being able to influence it. After this PR, external interfaces will be able to manipulate the nutrients waiting to be absorbed in the gut, allowing parts of the digestion process to be simulated externally.

This also helps alleviate cases where certain metabolism rates are reduced to zero by enchantments, causing the digestion code to effectively stop running while direct calorie consumption continues, eventually leading to starvation despite no longer needing to eat. This is mainly relevant to some mechanics in Mind Over Matter.

#### Describe the solution
Register the following interfaces:

- EOC math:
  - `u_gut_calories()` / `n_gut_calories()`
  - `u_gut_vitamin('vitC')` / `n_gut_vitamin('vitC')`
- Lua:
  - `game.needs.get_gut_calories`
  - `game.needs.set_gut_calories`
  - `game.needs.modify_gut_calories`
  - `game.needs.get_gut_vitamin`
  - `game.needs.set_gut_vitamin`
  - `game.needs.modify_gut_vitamin`

Example usage:

EOC:
```json
{ "math": [ "u_gut_calories() += 250" ] }
{ "math": [ "u_gut_vitamin('vitC') += 24" ] }
{ "condition": { "math": [ "u_gut_calories() >= 500" ] } }
```

Lua:
```lua
local avatar = game.characters.avatar()

local calories = game.needs.modify_gut_calories( avatar, 250 )
local vitamin = game.needs.modify_gut_vitamin( avatar, "vitC", 24 )
assert( calories.ok and vitamin.ok )

local pending = game.needs.get_gut_vitamin( avatar, "vitC" )
assert( pending.ok )
-- pending.value.id == "vitC"
-- pending.value.amount == 24
```

#### Additional context
Someone asked why support EOC is needed when Lua is already present. This is because Lua is currently not fully supported in environments where this functionality is widely used, especially since the `processed_eocs` continuous processing interface in bionic/mutation does not currently support it. Secondly, `math` is actually an implementation shared by both EOC and NPC, not just a feature that supports EOC alone. Although EOC is a very unconventional declarative syntax, math is not EOC-only, and we cannot completely reject anything that might be tied to old features just because there are other implementations.