### PR TITLE
Rationalize superalloy item pricing

### DIFF
--- a/data/json/items/vehicle/plating.json
+++ b/data/json/items/vehicle/plating.json
@@ -64,8 +64,8 @@
     "material": [ "superalloy" ],
     "volume": "6 L",
     "category": "veh_parts",
-    "price": "185 USD",
-    "price_postapoc": "5 USD",
+    "price": "5 kUSD",
+    "price_postapoc": "75 USD",
     "qualities": [ [ "COOK", 1 ] ],
     "use_action": [ "HEAT_SOLID_ITEMS" ],
     "melee_damage": { "bash": 6 }
@@ -81,7 +81,7 @@
     "material": [ "superalloy" ],
     "volume": "500 ml",
     "category": "veh_parts",
-    "price": "85 USD",
+    "price": "350 USD",
     "price_postapoc": "5 USD",
     "qualities": [ [ "COOK", 1 ] ],
     "use_action": [ "HEAT_SOLID_ITEMS" ]

--- a/data/mods/FuturismCataclysmLegacy/items/vehicle/frames.json
+++ b/data/mods/FuturismCataclysmLegacy/items/vehicle/frames.json
@@ -6,6 +6,8 @@
     "name": { "str": "superalloy frame" },
     "description": "A large, reinforced superalloy frame, used in advanced vehicle construction.  Other vehicle components can be mounted on it, and it can be attached to other frames to increase the vehicle's size.  Its performance is exceptionally high for its low weight.",
     "weight": "36800 g",
-    "material": [ "superalloy" ]
+    "material": [ "superalloy" ],
+    "price": "15 kUSD",
+    "price_postapoc": "225 USD"
   }
 ]


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Players reported that the pricing of superalloy vehicle part items is a complete mess. They are all either directly `copy-from` other part items or arbitrarily written by DDA, without considering the material costs or manufacturing difficulty at all. In some cases, disassembling the finished item into its components can even make it worth more than the finished item itself.

#### Describe the solution
Adjusted the pricing chain for superalloy items:

- `superalloy sheet`: pre-Cataclysm price 85 → 350 USD, equivalent to the nanomaterial and metal cost required by the superalloy forge ported from C:BN.
- `superalloy plating`: 185 → 5,000 USD; post-Cataclysm price 5 → 75 USD, matching its material cost and manufacturing difficulty.
- `superalloy frame` (FCL): no longer directly inherits the 120 USD/ 2.5 USD price of the heavy-duty frame by mistake, changed to 15 kUSD / 225 USD.