### PR TITLE
Now ordinary zombies should no longer be able to suffocate characters wearing power armor

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -4118,6 +4118,13 @@
   },
   {
     "type": "effect_type",
+    "id": "crowd_crushed",
+    "name": [ "Crowd crushed" ],
+    "desc": [ "You are being crushed by a crowd." ],
+    "max_duration": "2 turns"
+  },
+  {
+    "type": "effect_type",
     "id": "grabbing",
     "name": [ "Grabbing" ],
     "desc": [ "Grabbing another creature and holding them in place." ],

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -1266,8 +1266,7 @@
       {
         "encumbrance": 37,
         "coverage": 100,
-        "covers": [ "head", "eyes", "mouth", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-        "specifically_covers": [ "torso_neck" ]
+        "covers": [ "head", "eyes", "mouth", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
       }
     ]
   },

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -1266,7 +1266,8 @@
       {
         "encumbrance": 37,
         "coverage": 100,
-        "covers": [ "head", "eyes", "mouth", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+        "covers": [ "head", "eyes", "mouth", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+        "specifically_covers": [ "torso_neck" ]
       }
     ]
   },

--- a/data/mods/TEST_DATA/monsters.json
+++ b/data/mods/TEST_DATA/monsters.json
@@ -447,6 +447,14 @@
     "flags": [ "SEES", "HEARS", "NO_BREATHE", "PUSH_MON", "GROUP_BASH" ]
   },
   {
+    "id": "mon_debug_group_bash_no_damage",
+    "type": "MONSTER",
+    "copy-from": "mon_debug_memory",
+    "name": { "str": "harmless memory", "str_pl": "harmless memories" },
+    "melee_dice": 0,
+    "melee_dice_sides": 0
+  },
+  {
     "id": "mon_test_weakpoint_mon",
     "type": "MONSTER",
     "copy-from": "mon_test_zombie_cop",

--- a/src/character.h
+++ b/src/character.h
@@ -1312,10 +1312,11 @@ class Character : public Creature, public visitable
         const weakpoint *absorb_hit( const weakpoint_attack &attack, const bodypart_id &bp,
                                      damage_instance &dam, const weakpoint &wp = weakpoint() ) override;
         /** Runs through all bionics and armor on a specific sub-body part without damaging the character. */
-        void absorb_hit( const sub_bodypart_id &sbp, damage_instance &dam );
+        void absorb_hit( const sub_bodypart_id &sbp, damage_instance &dam,
+                         bool allow_torso_neck_fallback = false );
     protected:
         void absorb_damage( const bodypart_id &bp, const std::optional<sub_bodypart_id> &sbp,
-                            damage_instance &dam );
+                            damage_instance &dam, bool allow_torso_neck_fallback = false );
         float generic_weakpoint_skill( skill_id skill_1, skill_id skill_2,
                                        limb_score_id limb_score_1, limb_score_id limb_score_2 ) const;
     public:

--- a/src/character.h
+++ b/src/character.h
@@ -1311,7 +1311,11 @@ class Character : public Creature, public visitable
         /** Runs through all bionics and armor on a part and reduces damage through their armor_absorb */
         const weakpoint *absorb_hit( const weakpoint_attack &attack, const bodypart_id &bp,
                                      damage_instance &dam, const weakpoint &wp = weakpoint() ) override;
+        /** Runs through all bionics and armor on a specific sub-body part without damaging the character. */
+        void absorb_hit( const sub_bodypart_id &sbp, damage_instance &dam );
     protected:
+        void absorb_damage( const bodypart_id &bp, const std::optional<sub_bodypart_id> &sbp,
+                            damage_instance &dam );
         float generic_weakpoint_skill( skill_id skill_1, skill_id skill_2,
                                        limb_score_id limb_score_1, limb_score_id limb_score_2 ) const;
     public:

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -143,6 +143,18 @@ void destroyed_armor_msg( Character &who, const std::string &pre_damage_name )
 const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart_id &bp,
                                         damage_instance &dam, const weakpoint & )
 {
+    absorb_damage( bp, std::nullopt, dam );
+    return nullptr;
+}
+
+void Character::absorb_hit( const sub_bodypart_id &sbp, damage_instance &dam )
+{
+    absorb_damage( sbp->parent.id(), sbp, dam );
+}
+
+void Character::absorb_damage( const bodypart_id &bp, const std::optional<sub_bodypart_id> &sbp,
+                               damage_instance &dam )
+{
     std::list<item> worn_remains;
     bool armor_destroyed = false;
 
@@ -194,7 +206,7 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
 
         adjust_taken_damage_by_enchantments( elem );
 
-        worn.absorb_damage( *this, elem, bp, worn_remains, armor_destroyed );
+        worn.absorb_damage( *this, elem, bp, worn_remains, armor_destroyed, sbp );
 
         passive_absorb_hit( bp, elem );
 
@@ -208,7 +220,6 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
     if( armor_destroyed ) {
         drop_invalid_inventory();
     }
-    return nullptr;
 }
 
 void Character::armor_use_power_when_hit( damage_unit &du, item &armor ) const

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -147,13 +147,14 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
     return nullptr;
 }
 
-void Character::absorb_hit( const sub_bodypart_id &sbp, damage_instance &dam )
+void Character::absorb_hit( const sub_bodypart_id &sbp, damage_instance &dam,
+                            bool allow_torso_neck_fallback )
 {
-    absorb_damage( sbp->parent.id(), sbp, dam );
+    absorb_damage( sbp->parent.id(), sbp, dam, allow_torso_neck_fallback );
 }
 
 void Character::absorb_damage( const bodypart_id &bp, const std::optional<sub_bodypart_id> &sbp,
-                               damage_instance &dam )
+                               damage_instance &dam, bool allow_torso_neck_fallback )
 {
     std::list<item> worn_remains;
     bool armor_destroyed = false;
@@ -206,7 +207,8 @@ void Character::absorb_damage( const bodypart_id &bp, const std::optional<sub_bo
 
         adjust_taken_damage_by_enchantments( elem );
 
-        worn.absorb_damage( *this, elem, bp, worn_remains, armor_destroyed, sbp );
+        worn.absorb_damage( *this, elem, bp, worn_remains, armor_destroyed, sbp,
+                            allow_torso_neck_fallback );
 
         passive_absorb_hit( bp, elem );
 

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -74,6 +74,8 @@ static const material_id material_wool( "wool" );
 
 static const sub_bodypart_str_id sub_body_part_foot_sole_l( "foot_sole_l" );
 static const sub_bodypart_str_id sub_body_part_foot_sole_r( "foot_sole_r" );
+static const sub_bodypart_str_id sub_body_part_torso_neck( "torso_neck" );
+static const sub_bodypart_str_id sub_body_part_torso_upper( "torso_upper" );
 
 static const trait_id trait_ANTENNAE( "ANTENNAE" );
 static const trait_id trait_ANTLERS( "ANTLERS" );
@@ -1865,7 +1867,8 @@ item &outfit::front()
 
 void outfit::absorb_damage( Character &guy, damage_unit &elem, bodypart_id bp,
                             std::list<item> &worn_remains, bool &armor_destroyed,
-                            const std::optional<sub_bodypart_id> &forced_sbp )
+                            const std::optional<sub_bodypart_id> &forced_sbp,
+                            bool allow_torso_neck_fallback )
 {
     const map &here = get_map();
 
@@ -1913,13 +1916,19 @@ void outfit::absorb_damage( Character &guy, damage_unit &elem, bodypart_id bp,
         }
 
         if( !destroy ) {
+            const bool use_torso_upper = allow_torso_neck_fallback &&
+                                         sbp == sub_body_part_torso_neck.id() && !armor.covers( sbp ) &&
+                                         armor.covers( body_part_torso ) &&
+                                         ( armor.covers( body_part_head ) || armor.covers( body_part_mouth ) );
+            const sub_bodypart_id armor_sbp = use_torso_upper ?
+                                                sub_body_part_torso_upper.id() : sbp;
             // if the armor location has ablative armor apply that first
             if( armor.is_ablative() ) {
-                guy.ablative_armor_absorb( elem, armor, sbp, roll );
+                guy.ablative_armor_absorb( elem, armor, armor_sbp, roll );
             }
 
             // if not already destroyed to an armor absorb
-            destroy = guy.armor_absorb( elem, armor, bp, sbp, roll );
+            destroy = guy.armor_absorb( elem, armor, bp, armor_sbp, roll );
             // for the torso we also need to consider if it hits anything hanging off the character or their neck
             if( secondary_sbp != sub_bodypart_id() && !destroy ) {
                 destroy = guy.armor_absorb( elem, armor, bp, secondary_sbp, roll );

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1864,14 +1864,17 @@ item &outfit::front()
 }
 
 void outfit::absorb_damage( Character &guy, damage_unit &elem, bodypart_id bp,
-                            std::list<item> &worn_remains, bool &armor_destroyed )
+                            std::list<item> &worn_remains, bool &armor_destroyed,
+                            const std::optional<sub_bodypart_id> &forced_sbp )
 {
     const map &here = get_map();
 
     sub_bodypart_id sbp;
     sub_bodypart_id secondary_sbp;
-    // if this body part has sub part locations roll one
-    if( !bp->sub_parts.empty() ) {
+    if( forced_sbp ) {
+        sbp = *forced_sbp;
+    } else if( !bp->sub_parts.empty() ) {
+        // if this body part has sub part locations roll one
         sbp = bp->random_sub_part( false );
         // the torso and legs has a second layer of hanging body parts
         secondary_sbp = bp->random_sub_part( true );

--- a/src/character_attire.h
+++ b/src/character_attire.h
@@ -194,7 +194,8 @@ class outfit
         void insert_item_at_index( const item &clothing, int index );
         void check_and_recover_morale( player_morale &test_morale ) const;
         void absorb_damage( Character &guy, damage_unit &elem, bodypart_id bp,
-                            std::list<item> &worn_remains, bool &armor_destroyed );
+                            std::list<item> &worn_remains, bool &armor_destroyed,
+                            const std::optional<sub_bodypart_id> &forced_sbp = std::nullopt );
         /** Draws the UI and handles player input for the armor re-ordering window */
         void sort_armor( Character &guy );
         /*

--- a/src/character_attire.h
+++ b/src/character_attire.h
@@ -195,7 +195,8 @@ class outfit
         void check_and_recover_morale( player_morale &test_morale ) const;
         void absorb_damage( Character &guy, damage_unit &elem, bodypart_id bp,
                             std::list<item> &worn_remains, bool &armor_destroyed,
-                            const std::optional<sub_bodypart_id> &forced_sbp = std::nullopt );
+                            const std::optional<sub_bodypart_id> &forced_sbp = std::nullopt,
+                            bool allow_torso_neck_fallback = false );
         /** Draws the UI and handles player input for the armor re-ordering window */
         void sort_armor( Character &guy );
         /*

--- a/src/character_health.cpp
+++ b/src/character_health.cpp
@@ -127,6 +127,7 @@ static const efftype_id effect_bite( "bite" );
 static const efftype_id effect_chafing( "chafing" );
 static const efftype_id effect_common_cold( "common_cold" );
 static const efftype_id effect_cough_suppress( "cough_suppress" );
+static const efftype_id effect_crowd_crushed( "crowd_crushed" );
 static const efftype_id effect_deaf( "deaf" );
 static const efftype_id effect_disinfected( "disinfected" );
 static const efftype_id effect_disrupted_sleep( "disrupted_sleep" );
@@ -262,7 +263,8 @@ std::string enum_to_string<blood_type>( blood_type data )
 bool Character::can_recover_oxygen() const
 {
     return get_limb_score( limb_score_breathing ) > 0.5f && !is_underwater() &&
-           !has_effect_with_flag( json_flag_GRAB ) && !( has_bionic( bio_synlungs ) &&
+           !( has_effect_with_flag( json_flag_GRAB ) && has_effect( effect_crowd_crushed ) ) &&
+           !( has_bionic( bio_synlungs ) &&
                    !has_active_bionic( bio_synlungs ) );
 }
 

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -142,6 +142,7 @@ json_flag_SUNBURN_SUPERNATURAL_REDUCTION( "SUNBURN_SUPERNATURAL_REDUCTION" );
 
 static const damage_type_id damage_bash( "bash" );
 static const sub_bodypart_str_id sub_body_part_torso_upper( "torso_upper" );
+static const sub_bodypart_str_id sub_body_part_torso_neck( "torso_neck" );
 
 static const morale_type morale_feeling_bad( "morale_feeling_bad" );
 static const morale_type morale_feeling_good( "morale_feeling_good" );
@@ -417,14 +418,16 @@ void suffer::while_grabbed( Character &you )
             pressure_absorbed = false;
         }
     };
-    const auto absorb_sub_bodypart_pressure = [&]( const sub_bodypart_id & sbp, float pressure_amount ) {
+    const auto absorb_sub_bodypart_pressure = [&]( const sub_bodypart_id & sbp, float pressure_amount,
+    bool allow_torso_neck_fallback = false ) {
         damage_instance pressure( damage_bash, pressure_amount );
-        you.absorb_hit( sbp, pressure );
+        you.absorb_hit( sbp, pressure, allow_torso_neck_fallback );
         if( pressure.total_damage() > 0.0f ) {
             pressure_absorbed = false;
         }
     };
-    absorb_sub_bodypart_pressure( sub_body_part_torso_upper.id(), pressure_per_part * 2 );
+    absorb_sub_bodypart_pressure( sub_body_part_torso_upper.id(), pressure_per_part );
+    absorb_sub_bodypart_pressure( sub_body_part_torso_neck.id(), pressure_per_part, true );
     absorb_bodypart_pressure( body_part_mouth.id(), pressure_per_part );
     absorb_bodypart_pressure( body_part_eyes.id(), pressure_per_part );
 

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -141,6 +141,7 @@ static const json_character_flag
 json_flag_SUNBURN_SUPERNATURAL_REDUCTION( "SUNBURN_SUPERNATURAL_REDUCTION" );
 
 static const damage_type_id damage_bash( "bash" );
+static const sub_bodypart_str_id sub_body_part_torso_neck( "torso_neck" );
 
 static const morale_type morale_feeling_bad( "morale_feeling_bad" );
 static const morale_type morale_feeling_good( "morale_feeling_good" );
@@ -407,17 +408,26 @@ void suffer::while_grabbed( Character &you )
         crowd_pressure += impassable_ter * std::max( 1, crowd_pressure / ( crowd - impassable_ter ) );
     }
 
-    const std::array<bodypart_id, 3> breathing_parts = { body_part_torso.id(), body_part_mouth.id(),
-        body_part_eyes.id() };
-    const float pressure_per_part = static_cast<float>( crowd_pressure ) / breathing_parts.size();
+    const float pressure_per_part = static_cast<float>( crowd_pressure ) / 4;
     bool pressure_absorbed = true;
-    for( const bodypart_id &bp : breathing_parts ) {
+    const auto absorb_bodypart_pressure = [&]( const bodypart_id & bp ) {
         damage_instance pressure( damage_bash, pressure_per_part );
         you.absorb_hit( weakpoint_attack(), bp, pressure );
         if( pressure.total_damage() > 0.0f ) {
             pressure_absorbed = false;
         }
-    }
+    };
+    const auto absorb_sub_bodypart_pressure = [&]( const sub_bodypart_id & sbp ) {
+        damage_instance pressure( damage_bash, pressure_per_part );
+        you.absorb_hit( sbp, pressure );
+        if( pressure.total_damage() > 0.0f ) {
+            pressure_absorbed = false;
+        }
+    };
+    absorb_bodypart_pressure( body_part_torso.id() );
+    absorb_sub_bodypart_pressure( sub_body_part_torso_neck.id() );
+    absorb_bodypart_pressure( body_part_mouth.id() );
+    absorb_bodypart_pressure( body_part_eyes.id() );
 
     if( pressure_absorbed ) {
         return;

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -141,6 +141,7 @@ static const json_character_flag
 json_flag_SUNBURN_SUPERNATURAL_REDUCTION( "SUNBURN_SUPERNATURAL_REDUCTION" );
 
 static const damage_type_id damage_bash( "bash" );
+static const sub_bodypart_str_id sub_body_part_torso_upper( "torso_upper" );
 static const sub_bodypart_str_id sub_body_part_torso_neck( "torso_neck" );
 
 static const morale_type morale_feeling_bad( "morale_feeling_bad" );
@@ -424,7 +425,7 @@ void suffer::while_grabbed( Character &you )
             pressure_absorbed = false;
         }
     };
-    absorb_bodypart_pressure( body_part_torso.id() );
+    absorb_sub_bodypart_pressure( sub_body_part_torso_upper.id() );
     absorb_sub_bodypart_pressure( sub_body_part_torso_neck.id() );
     absorb_bodypart_pressure( body_part_mouth.id() );
     absorb_bodypart_pressure( body_part_eyes.id() );

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -378,7 +378,7 @@ void suffer::while_grabbed( Character &you )
             crowd++;
             const int bash_damage = static_cast<int>( mon->type->melee_damage.type_damage( damage_bash ) ) +
                                     mon->type->melee_dice * mon->type->melee_sides;
-            crowd_pressure += std::max( 1, bash_damage );
+            crowd_pressure += std::max( 0, bash_damage );
             add_msg_debug( debugmode::DF_CHARACTER, "Crowd pressure check: monster %s found, crowd size %d",
                            mon->name(), crowd );
         }

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -141,7 +141,6 @@ static const json_character_flag
 json_flag_SUNBURN_SUPERNATURAL_REDUCTION( "SUNBURN_SUPERNATURAL_REDUCTION" );
 
 static const damage_type_id damage_bash( "bash" );
-static const bodypart_str_id body_part_neck( "neck" );
 
 static const morale_type morale_feeling_bad( "morale_feeling_bad" );
 static const morale_type morale_feeling_good( "morale_feeling_good" );
@@ -408,8 +407,8 @@ void suffer::while_grabbed( Character &you )
         crowd_pressure += impassable_ter * std::max( 1, crowd_pressure / ( crowd - impassable_ter ) );
     }
 
-    const std::array<bodypart_id, 4> breathing_parts = { body_part_torso.id(), body_part_neck.id(),
-        body_part_mouth.id(), body_part_eyes.id() };
+    const std::array<bodypart_id, 3> breathing_parts = { body_part_torso.id(), body_part_mouth.id(),
+        body_part_eyes.id() };
     const float pressure_per_part = static_cast<float>( crowd_pressure ) / breathing_parts.size();
     bool pressure_absorbed = true;
     for( const bodypart_id &bp : breathing_parts ) {

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -364,7 +364,7 @@ void suffer::while_grabbed( Character &you )
     map &here = get_map();
     creature_tracker &creatures = get_creature_tracker();
     int crowd = 0;
-    int crowd_pressure = 0;
+    float crowd_pressure = 0.0f;
     int impassable_ter = 0;
     // This looks scary, but it's really just casting the enum to an integer. So medium size characters == 3.
     int your_size = static_cast<std::underlying_type_t<creature_size>>( you.get_size() );
@@ -376,9 +376,9 @@ void suffer::while_grabbed( Character &you )
         const monster *const mon = creatures.creature_at<monster>( dest );
         if( mon && mon->has_flag( mon_flag_GROUP_BASH ) ) {
             crowd++;
-            const int bash_damage = static_cast<int>( mon->type->melee_damage.type_damage( damage_bash ) ) +
-                                    mon->type->melee_dice * mon->type->melee_sides;
-            crowd_pressure += std::max( 0, bash_damage );
+            const float bash_damage = mon->type->melee_damage.type_damage( damage_bash ) +
+                                      mon->type->melee_dice * mon->type->melee_sides;
+            crowd_pressure += std::max( 0.0f, bash_damage );
             add_msg_debug( debugmode::DF_CHARACTER, "Crowd pressure check: monster %s found, crowd size %d",
                            mon->name(), crowd );
         }
@@ -406,10 +406,11 @@ void suffer::while_grabbed( Character &you )
     if( impassable_ter ) {
         you.add_msg_if_player( m_bad, _( "You're crushed against the walls!" ) );
         crowd += impassable_ter;
-        crowd_pressure += impassable_ter * std::max( 1, crowd_pressure / ( crowd - impassable_ter ) );
+        crowd_pressure += impassable_ter * std::max( 1.0f,
+                          crowd_pressure / ( crowd - impassable_ter ) );
     }
 
-    const float pressure_per_part = static_cast<float>( crowd_pressure ) / 4;
+    const float pressure_per_part = crowd_pressure / 4;
     bool pressure_absorbed = true;
     const auto absorb_bodypart_pressure = [&]( const bodypart_id & bp, float pressure_amount ) {
         damage_instance pressure( damage_bash, pressure_amount );

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -142,7 +142,6 @@ json_flag_SUNBURN_SUPERNATURAL_REDUCTION( "SUNBURN_SUPERNATURAL_REDUCTION" );
 
 static const damage_type_id damage_bash( "bash" );
 static const sub_bodypart_str_id sub_body_part_torso_upper( "torso_upper" );
-static const sub_bodypart_str_id sub_body_part_torso_neck( "torso_neck" );
 
 static const morale_type morale_feeling_bad( "morale_feeling_bad" );
 static const morale_type morale_feeling_good( "morale_feeling_good" );
@@ -411,24 +410,23 @@ void suffer::while_grabbed( Character &you )
 
     const float pressure_per_part = static_cast<float>( crowd_pressure ) / 4;
     bool pressure_absorbed = true;
-    const auto absorb_bodypart_pressure = [&]( const bodypart_id & bp ) {
-        damage_instance pressure( damage_bash, pressure_per_part );
+    const auto absorb_bodypart_pressure = [&]( const bodypart_id & bp, float pressure_amount ) {
+        damage_instance pressure( damage_bash, pressure_amount );
         you.absorb_hit( weakpoint_attack(), bp, pressure );
         if( pressure.total_damage() > 0.0f ) {
             pressure_absorbed = false;
         }
     };
-    const auto absorb_sub_bodypart_pressure = [&]( const sub_bodypart_id & sbp ) {
-        damage_instance pressure( damage_bash, pressure_per_part );
+    const auto absorb_sub_bodypart_pressure = [&]( const sub_bodypart_id & sbp, float pressure_amount ) {
+        damage_instance pressure( damage_bash, pressure_amount );
         you.absorb_hit( sbp, pressure );
         if( pressure.total_damage() > 0.0f ) {
             pressure_absorbed = false;
         }
     };
-    absorb_sub_bodypart_pressure( sub_body_part_torso_upper.id() );
-    absorb_sub_bodypart_pressure( sub_body_part_torso_neck.id() );
-    absorb_bodypart_pressure( body_part_mouth.id() );
-    absorb_bodypart_pressure( body_part_eyes.id() );
+    absorb_sub_bodypart_pressure( sub_body_part_torso_upper.id(), pressure_per_part * 2 );
+    absorb_bodypart_pressure( body_part_mouth.id(), pressure_per_part );
+    absorb_bodypart_pressure( body_part_eyes.id(), pressure_per_part );
 
     if( pressure_absorbed ) {
         return;

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -27,6 +27,7 @@
 #include "creature.h"
 #include "creature_tracker.h"
 #include "debug.h"
+#include "damage.h"
 #include "dialogue.h"
 #include "effect.h"
 #include "effect_on_condition.h"
@@ -84,6 +85,7 @@ static const efftype_id effect_adrenaline( "adrenaline" );
 static const efftype_id effect_asthma( "asthma" );
 static const efftype_id effect_blind( "blind" );
 static const efftype_id effect_cig( "cig" );
+static const efftype_id effect_crowd_crushed( "crowd_crushed" );
 static const efftype_id effect_datura( "datura" );
 static const efftype_id effect_deaf( "deaf" );
 static const efftype_id effect_disabled( "disabled" );
@@ -137,6 +139,9 @@ static const json_character_flag json_flag_SUNBURN( "SUNBURN" );
 static const json_character_flag json_flag_SUNBURN_SUPERNATURAL( "SUNBURN_SUPERNATURAL" );
 static const json_character_flag
 json_flag_SUNBURN_SUPERNATURAL_REDUCTION( "SUNBURN_SUPERNATURAL_REDUCTION" );
+
+static const damage_type_id damage_bash( "bash" );
+static const bodypart_str_id body_part_neck( "neck" );
 
 static const morale_type morale_feeling_bad( "morale_feeling_bad" );
 static const morale_type morale_feeling_good( "morale_feeling_good" );
@@ -358,6 +363,7 @@ void suffer::while_grabbed( Character &you )
     map &here = get_map();
     creature_tracker &creatures = get_creature_tracker();
     int crowd = 0;
+    int crowd_pressure = 0;
     int impassable_ter = 0;
     // This looks scary, but it's really just casting the enum to an integer. So medium size characters == 3.
     int your_size = static_cast<std::underlying_type_t<creature_size>>( you.get_size() );
@@ -369,6 +375,9 @@ void suffer::while_grabbed( Character &you )
         const monster *const mon = creatures.creature_at<monster>( dest );
         if( mon && mon->has_flag( mon_flag_GROUP_BASH ) ) {
             crowd++;
+            const int bash_damage = static_cast<int>( mon->type->melee_damage.type_damage( damage_bash ) ) +
+                                    mon->type->melee_dice * mon->type->melee_sides;
+            crowd_pressure += std::max( 1, bash_damage );
             add_msg_debug( debugmode::DF_CHARACTER, "Crowd pressure check: monster %s found, crowd size %d",
                            mon->name(), crowd );
         }
@@ -379,6 +388,8 @@ void suffer::while_grabbed( Character &you )
 
     add_msg_debug( debugmode::DF_CHARACTER,
                    "Crowd pressure sum: character size requires %d grabbers, found %d ", crush_grabs_req, crowd );
+
+    you.remove_effect( effect_crowd_crushed );
 
     // if we aren't near enough monsters with GROUP_BASH we won't suffocate
     if( crowd < crush_grabs_req ) {
@@ -394,7 +405,26 @@ void suffer::while_grabbed( Character &you )
     if( impassable_ter ) {
         you.add_msg_if_player( m_bad, _( "You're crushed against the walls!" ) );
         crowd += impassable_ter;
+        crowd_pressure += impassable_ter * std::max( 1, crowd_pressure / ( crowd - impassable_ter ) );
     }
+
+    const std::array<bodypart_id, 4> breathing_parts = { body_part_torso.id(), body_part_neck.id(),
+        body_part_mouth.id(), body_part_eyes.id() };
+    const float pressure_per_part = static_cast<float>( crowd_pressure ) / breathing_parts.size();
+    bool pressure_absorbed = true;
+    for( const bodypart_id &bp : breathing_parts ) {
+        damage_instance pressure( damage_bash, pressure_per_part );
+        you.absorb_hit( weakpoint_attack(), bp, pressure );
+        if( pressure.total_damage() > 0.0f ) {
+            pressure_absorbed = false;
+        }
+    }
+
+    if( pressure_absorbed ) {
+        return;
+    }
+
+    you.add_effect( effect_crowd_crushed, 2_turns );
 
     if( crowd == crush_grabs_req ) {
         // only a chance to lose breath at minimum grabs

--- a/tests/char_suffer_test.cpp
+++ b/tests/char_suffer_test.cpp
@@ -29,7 +29,6 @@ static const efftype_id effect_crowd_crushed( "crowd_crushed" );
 
 static const damage_type_id damage_bash( "bash" );
 static const sub_bodypart_str_id sub_body_part_torso_upper( "torso_upper" );
-static const sub_bodypart_str_id sub_body_part_torso_neck( "torso_neck" );
 
 static const itype_id itype_test_hazmat_suit( "test_hazmat_suit" );
 static const itype_id itype_test_longshirt( "test_longshirt" );
@@ -497,16 +496,6 @@ TEST_CASE( "suffering_from_asphyxiation", "[char][suffer][oxygen][grab]" )
                 test_suffer( dummy, 3_turns, true );
                 CHECK( dummy.oxygen == 15 );
                 CHECK_FALSE( dummy.has_effect( effect_crowd_crushed ) );
-            }
-        }
-
-        WHEN( "their torso neck is protected by armor" ) {
-            REQUIRE( dummy.wear_item( item( itype_test_hazmat_suit ), false ).has_value() );
-            damage_instance pressure( damage_bash, 1 );
-            dummy.absorb_hit( sub_body_part_torso_neck.id(), pressure );
-
-            THEN( "the pressure is absorbed without harming the character" ) {
-                CHECK( pressure.total_damage() == 0.0f );
             }
         }
 

--- a/tests/char_suffer_test.cpp
+++ b/tests/char_suffer_test.cpp
@@ -10,6 +10,7 @@
 #include "character.h"
 #include "coordinates.h"
 #include "creature.h"
+#include "damage.h"
 #include "flag.h"
 #include "game.h"
 #include "item.h"
@@ -25,6 +26,9 @@
 
 static const efftype_id effect_grabbed( "grabbed" );
 static const efftype_id effect_crowd_crushed( "crowd_crushed" );
+
+static const damage_type_id damage_bash( "bash" );
+static const sub_bodypart_str_id sub_body_part_torso_neck( "torso_neck" );
 
 static const itype_id itype_test_hazmat_suit( "test_hazmat_suit" );
 static const itype_id itype_test_longshirt( "test_longshirt" );
@@ -492,6 +496,16 @@ TEST_CASE( "suffering_from_asphyxiation", "[char][suffer][oxygen][grab]" )
                 test_suffer( dummy, 3_turns, true );
                 CHECK( dummy.oxygen == 15 );
                 CHECK_FALSE( dummy.has_effect( effect_crowd_crushed ) );
+            }
+        }
+
+        WHEN( "their torso neck is protected by armor" ) {
+            REQUIRE( dummy.wear_item( item( itype_test_hazmat_suit ), false ).has_value() );
+            damage_instance pressure( damage_bash, 1 );
+            dummy.absorb_hit( sub_body_part_torso_neck.id(), pressure );
+
+            THEN( "the pressure is absorbed without harming the character" ) {
+                CHECK( pressure.total_damage() == 0.0f );
             }
         }
 

--- a/tests/char_suffer_test.cpp
+++ b/tests/char_suffer_test.cpp
@@ -566,4 +566,17 @@ TEST_CASE( "suffering_from_asphyxiation", "[char][suffer][oxygen][grab]" )
             }
         }
     }
+
+    GIVEN( "character is grabbed by a harmless crowd" ) {
+        spawn_test_monster( "mon_debug_group_bash_no_damage", dummy.pos_bub() + tripoint::east );
+        spawn_test_monster( "mon_debug_group_bash_no_damage", dummy.pos_bub() + tripoint::west );
+        dummy.add_effect( effect_grabbed, 20_turns, body_part_torso, false, 2, true );
+        dummy.oxygen = 0;
+
+        THEN( "they recover oxygen" ) {
+            test_suffer( dummy, 3_turns, true );
+            CHECK( dummy.oxygen == 15 );
+            CHECK_FALSE( dummy.has_effect( effect_crowd_crushed ) );
+        }
+    }
 }

--- a/tests/char_suffer_test.cpp
+++ b/tests/char_suffer_test.cpp
@@ -24,6 +24,7 @@
 #include "weather_type.h"
 
 static const efftype_id effect_grabbed( "grabbed" );
+static const efftype_id effect_crowd_crushed( "crowd_crushed" );
 
 static const itype_id itype_test_hazmat_suit( "test_hazmat_suit" );
 static const itype_id itype_test_longshirt( "test_longshirt" );
@@ -480,6 +481,28 @@ TEST_CASE( "suffering_from_asphyxiation", "[char][suffer][oxygen][grab]" )
             THEN( "they lose 0 or 1 oxygen per turn" ) {
                 test_suffer( dummy, 10_turns, true );
                 CHECK( dummy.oxygen == Approx( 41 ).margin( 5 ) );
+            }
+        }
+
+        WHEN( "their breathing parts are protected by armor" ) {
+            REQUIRE( dummy.wear_item( item( itype_test_hazmat_suit ), false ).has_value() );
+            dummy.oxygen = 0;
+
+            THEN( "they recover oxygen instead of suffocating" ) {
+                test_suffer( dummy, 3_turns, true );
+                CHECK( dummy.oxygen == 15 );
+                CHECK_FALSE( dummy.has_effect( effect_crowd_crushed ) );
+            }
+        }
+
+        WHEN( "crowd pressure is not a direct body attack" ) {
+            spawn_test_monster( "mon_debug_memory", dummy.pos_bub() + tripoint::north );
+            spawn_test_monster( "mon_debug_memory", dummy.pos_bub() + tripoint::south );
+            const int torso_hp = dummy.get_part_hp_cur( body_part_torso );
+
+            THEN( "it does not cause immediate torso damage" ) {
+                test_suffer( dummy, 1_turn );
+                CHECK( dummy.get_part_hp_cur( body_part_torso ) == torso_hp );
             }
         }
 

--- a/tests/char_suffer_test.cpp
+++ b/tests/char_suffer_test.cpp
@@ -501,7 +501,7 @@ TEST_CASE( "suffering_from_asphyxiation", "[char][suffer][oxygen][grab]" )
             const int torso_hp = dummy.get_part_hp_cur( body_part_torso );
 
             THEN( "it does not cause immediate torso damage" ) {
-                test_suffer( dummy, 1_turn );
+                test_suffer( dummy, 1_turns );
                 CHECK( dummy.get_part_hp_cur( body_part_torso ) == torso_hp );
             }
         }

--- a/tests/char_suffer_test.cpp
+++ b/tests/char_suffer_test.cpp
@@ -28,6 +28,7 @@ static const efftype_id effect_grabbed( "grabbed" );
 static const efftype_id effect_crowd_crushed( "crowd_crushed" );
 
 static const damage_type_id damage_bash( "bash" );
+static const sub_bodypart_str_id sub_body_part_torso_upper( "torso_upper" );
 static const sub_bodypart_str_id sub_body_part_torso_neck( "torso_neck" );
 
 static const itype_id itype_test_hazmat_suit( "test_hazmat_suit" );
@@ -503,6 +504,16 @@ TEST_CASE( "suffering_from_asphyxiation", "[char][suffer][oxygen][grab]" )
             REQUIRE( dummy.wear_item( item( itype_test_hazmat_suit ), false ).has_value() );
             damage_instance pressure( damage_bash, 1 );
             dummy.absorb_hit( sub_body_part_torso_neck.id(), pressure );
+
+            THEN( "the pressure is absorbed without harming the character" ) {
+                CHECK( pressure.total_damage() == 0.0f );
+            }
+        }
+
+        WHEN( "their upper torso is protected by armor" ) {
+            REQUIRE( dummy.wear_item( item( itype_test_hazmat_suit ), false ).has_value() );
+            damage_instance pressure( damage_bash, 1 );
+            dummy.absorb_hit( sub_body_part_torso_upper.id(), pressure );
 
             THEN( "the pressure is absorbed without harming the character" ) {
                 CHECK( pressure.total_damage() == 0.0f );


### PR DESCRIPTION
#### Summary

Bugfixes "Fix horde pressure ignoring vital body part armor and causing suffocation"

#### Purpose of change

Players have frequently reported cases where characters wearing full-body power armor are grabbed and suffocated to death, which is unreasonable and unrealistic. After checking the code, I found that the cause is that when the player is grabbed and there are multiple `GROUP_BASH` monsters nearby, the original logic unconditionally reduces oxygen. Even if the torso, neck, mouth, and eyes are all covered by effective armor, and the monsters should theoretically be unable to prevent the player from breathing, the character can still suffocate.

#### Describe the solution

Distributed horde pressure to the upper torso, neck, and face, and reused the existing armor absorption pipeline (meaning it is still protected by armor defense and durability, CBM, mutations, enchantments, and other existing logic). The pressure is calculated as virtual damage, and only when any of the vital body parts has unabsorbed pressure will oxygen recovery be prevented and the original oxygen reduction and hypoxia damage logic be applied.