### PR TITLE
延长真菌孢子花的FUNGUS_HAZE特殊攻击间隔

### DIFF
--- a/data/json/monsters/fungus.json
+++ b/data/json/monsters/fungus.json
@@ -28,7 +28,7 @@
     ],
     "luminance": 40,
     "harvest": "exempt",
-    "special_attacks": [ [ "FUNGUS_HAZE", 25 ] ],
+    "special_attacks": [ [ "FUNGUS_HAZE", 40 ] ],
     "death_function": { "corpse_type": "NO_CORPSE", "effect": { "id": "death_fungus", "hit_self": true } },
     "flags": [ "HEARS", "GOODHEARING", "NOHEAD", "POISON", "IMMOBILE", "NO_BREATHE" ],
     "armor": { "bash": 4, "cut": 4, "bullet": 3, "electric": 4 }


### PR DESCRIPTION
把真菌孢子花的FUNGUS_HAZE特殊攻击间隔从25秒提升40秒，降低其在现实气泡内的扩张与复制速度