### PR TITLE
Fire can now burn other fields instead of only furniture and terrain

### DIFF
--- a/data/json/fields/debris.json
+++ b/data/json/fields/debris.json
@@ -131,6 +131,7 @@
     "mopsafe": true,
     "moppable": true,
     "percent_spread": 75,
+    "fire_reaction": { "degrade_at": 2, "clear_at": 3, "interval": "30 seconds" },
     "half_life": "6 hours",
     "phase": "gas",
     "has_fume": true,
@@ -145,7 +146,6 @@
         "sym": "%",
         "color": "light_gray",
         "transparent": true,
-        "dangerous": true,
         "concentration": 1
       }
     ],

--- a/data/mods/TEST_DATA/fields.json
+++ b/data/mods/TEST_DATA/fields.json
@@ -100,6 +100,18 @@
     "looks_like": "fd_fog"
   },
   {
+    "id": "fd_test_fire_reaction",
+    "type": "field_type",
+    "intensity_levels": [
+      { "name": "test fire reaction", "sym": "1" },
+      { "name": "test fire reaction", "sym": "2" },
+      { "name": "test fire reaction", "sym": "3" }
+    ],
+    "fire_reaction": { "degrade_at": 2, "clear_at": 3, "interval": "1 turns" },
+    "half_life": "1 hours",
+    "phase": "solid"
+  },
+  {
     "id": "test_fd_migration_new_id",
     "type": "field_type",
     "intensity_levels": [ { "name": "migrated" } ]

--- a/data/mods/TEST_DATA/fields.json
+++ b/data/mods/TEST_DATA/fields.json
@@ -112,6 +112,18 @@
     "phase": "solid"
   },
   {
+    "id": "fd_test_fire_reaction_source",
+    "type": "field_type",
+    "intensity_levels": [
+      { "name": "test fire source", "sym": "1" },
+      { "name": "test fire source", "sym": "2" },
+      { "name": "test fire source", "sym": "3" }
+    ],
+    "has_fire": true,
+    "half_life": "1 hours",
+    "phase": "solid"
+  },
+  {
     "id": "test_fd_migration_new_id",
     "type": "field_type",
     "intensity_levels": [ { "name": "migrated" } ]

--- a/doc/JSON/JSON_INFO.md
+++ b/doc/JSON/JSON_INFO.md
@@ -4586,6 +4586,11 @@ Fields can exist on top of terrain/furniture, and support different intensity le
     "is_splattering": true, // If splatters of this field should bloody vehicle parts
     "dirty_transparency_cache": true, // Should the transparency cache be recalculated when the field is modified (used for nontransparent, spreading fields)
     "has_fire": false, // Is this field a kind of fire (for immunity, monster avoidance and similar checks)
+    "fire_reaction": { // Optional; omitted keeps the legacy behavior
+      "degrade_at": 2, // Periodic intensity-loss threshold; 0 disables degradation
+      "clear_at": 3, // Immediate-removal threshold; 0 disables immediate removal
+      "interval": "30 seconds" // Interval between degradation attempts; defaults to 1 minute
+    },
     "has_acid": false, // See has_fire
     "has_elec": false, // See has_fire
     "has_fume": false, // See has_fire, non-breathing monsters are immune to this field
@@ -4619,6 +4624,13 @@ Fields can exist on top of terrain/furniture, and support different intensity le
     "indestructible": true // Field cannot be bashed or destroyed, but may still expire over time.  Useful when combined with the bash field because it can allow fields to prevent bashing terrain but not be destructible.
   }
 ```
+
+`fire_reaction` is optional.  `degrade_at` and `clear_at` are integer thresholds from 0 to 3;
+0 disables the corresponding behavior.  Immediate clearing takes precedence over degradation.  A
+field with `has_fire` ignores `fire_reaction`, preventing fire fields from reacting to themselves.
+`clear_at` must be greater than `degrade_at` when both are nonzero.  For example, use
+`"degrade_at": 1, "clear_at": 3` to degrade in small or medium fires and clear immediately in a
+large fire.
 
 ## Emits
 Defines field emissions 

--- a/doc/JSON/JSON_INFO.md
+++ b/doc/JSON/JSON_INFO.md
@@ -4585,8 +4585,8 @@ Fields can exist on top of terrain/furniture, and support different intensity le
     "gas_absorption_factor": "80m", // Length a full 100 charge gas mask filter will last in this gas. Will be divided by the concentration of the gas, and should be 80m for concentration 1 toxic gas or similar. The worst gas should still be kept out for 20 minutes in a concentration 4 thick gas.
     "is_splattering": true, // If splatters of this field should bloody vehicle parts
     "dirty_transparency_cache": true, // Should the transparency cache be recalculated when the field is modified (used for nontransparent, spreading fields)
-    "has_fire": false, // Is this field a kind of fire (for immunity, monster avoidance and similar checks)
-    "fire_reaction": { // Optional; omitted keeps the legacy behavior
+    "has_fire": false, // Is this field a kind of fire (for immunity, monster avoidance and similar checks); true ignores fire_reaction
+    "fire_reaction": { // Optional; omitted keeps the legacy behavior; ignored when has_fire is true
       "degrade_at": 2, // Periodic intensity-loss threshold; 0 disables degradation
       "clear_at": 3, // Immediate-removal threshold; 0 disables immediate removal
       "interval": "30 seconds" // Interval between degradation attempts; defaults to 1 minute
@@ -4627,7 +4627,7 @@ Fields can exist on top of terrain/furniture, and support different intensity le
 
 `fire_reaction` is optional.  `degrade_at` and `clear_at` are integer thresholds from 0 to 3;
 0 disables the corresponding behavior.  Immediate clearing takes precedence over degradation.  A
-field with `has_fire` ignores `fire_reaction`, preventing fire fields from reacting to themselves.
+field with `has_fire: true` ignores `fire_reaction`, preventing fire fields from reacting to themselves.
 `clear_at` must be greater than `degrade_at` when both are nonzero.  For example, use
 `"degrade_at": 1, "clear_at": 3` to degrade in small or medium fires and clear immediately in a
 large fire.

--- a/src/field_type.cpp
+++ b/src/field_type.cpp
@@ -302,6 +302,12 @@ void field_type::load( const JsonObject &jo, std::string_view )
     optional( jo, was_loaded, "is_splattering", is_splattering, false );
     optional( jo, was_loaded, "dirty_transparency_cache", dirty_transparency_cache, false );
     optional( jo, was_loaded, "has_fire", has_fire, false );
+    if( jo.has_object( "fire_reaction" ) ) {
+        JsonObject jfr = jo.get_object( "fire_reaction" );
+        optional( jfr, was_loaded, "degrade_at", fire_reaction.degrade_at, 0 );
+        optional( jfr, was_loaded, "clear_at", fire_reaction.clear_at, 0 );
+        optional( jfr, was_loaded, "interval", fire_reaction.interval, 1_minutes );
+    }
     optional( jo, was_loaded, "has_acid", has_acid, false );
     optional( jo, was_loaded, "has_elec", has_elec, false );
     optional( jo, was_loaded, "has_fume", has_fume, false );
@@ -371,6 +377,23 @@ void field_type::finalize()
 
 void field_type::check() const
 {
+    if( fire_reaction.degrade_at < 0 || fire_reaction.degrade_at > 3 ||
+        fire_reaction.clear_at < 0 || fire_reaction.clear_at > 3 ) {
+        debugmsg( "Field type %s has fire reaction thresholds outside the range 0 to 3.",
+                  id.c_str() );
+    }
+    if( fire_reaction.degrade_at > 0 && fire_reaction.interval <= 0_turns ) {
+        debugmsg( "Field type %s has a non-positive fire reaction interval.", id.c_str() );
+    }
+    if( fire_reaction.degrade_at > 0 && fire_reaction.clear_at > 0 &&
+        fire_reaction.clear_at <= fire_reaction.degrade_at ) {
+        debugmsg( "Field type %s clears at or below its fire reaction degrade threshold.", id.c_str() );
+    }
+    if( has_fire && ( fire_reaction.degrade_at > 0 || fire_reaction.clear_at > 0 ) ) {
+        debugmsg( "Field type %s has both has_fire and fire_reaction; the reaction is ignored.",
+                  id.c_str() );
+    }
+
     int i = 0;
     for( const field_intensity_level &intensity_level : intensity_levels ) {
         i++;

--- a/src/field_type.h
+++ b/src/field_type.h
@@ -204,6 +204,11 @@ struct field_type {
         bool is_splattering = false;
         bool dirty_transparency_cache = false;
         bool has_fire = false;
+        struct fire_reaction_data {
+            int degrade_at = 0;
+            int clear_at = 0;
+            time_duration interval = 1_minutes;
+        } fire_reaction;
         bool has_acid = false;
         bool has_elec = false;
         bool has_fume = false;

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -979,6 +979,22 @@ void field_processor_fd_fire( const tripoint_bub_ms &p, field_entry &cur, field_
     const ter_t &ter = map_tile.get_ter_t();
     const furn_t &frn = map_tile.get_furn_t();
 
+    const int fire_intensity = cur.get_field_intensity();
+    for( const std::pair<const field_type_id, field_entry> &entry : map_tile.get_field() ) {
+        const field_type &other_type = entry.first.obj();
+        const field_type::fire_reaction_data &reaction = other_type.fire_reaction;
+        if( other_type.has_fire ) {
+            continue;
+        }
+        if( reaction.clear_at > 0 && fire_intensity >= reaction.clear_at ) {
+            here.remove_field( p, entry.first );
+        } else if( reaction.degrade_at > 0 && reaction.interval > 0_turns &&
+                   fire_intensity >= reaction.degrade_at &&
+                   calendar::once_every( reaction.interval ) ) {
+            here.mod_field_intensity( p, entry.first, -1 );
+        }
+    }
+
     // We've got ter/furn cached, so let's use that
     const bool is_sealed = ter_furn_has_flag( ter, frn, ter_furn_flag::TFLAG_SEALED ) &&
                            !ter_furn_has_flag( ter, frn, ter_furn_flag::TFLAG_ALLOW_FIELD_EFFECT );

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -961,6 +961,26 @@ static void field_processor_fd_fungicidal_gas( const tripoint_bub_ms &p, field_e
     }
 }
 
+static void process_field_fire_reactions( const tripoint_bub_ms &p, field_entry &cur,
+        field_proc_data &pd )
+{
+    const int fire_intensity = cur.get_field_intensity();
+    for( const std::pair<const field_type_id, field_entry> &entry : pd.map_tile.get_field() ) {
+        const field_type &other_type = entry.first.obj();
+        const field_type::fire_reaction_data &reaction = other_type.fire_reaction;
+        if( other_type.has_fire ) {
+            continue;
+        }
+        if( reaction.clear_at > 0 && fire_intensity >= reaction.clear_at ) {
+            pd.here.remove_field( p, entry.first );
+        } else if( reaction.degrade_at > 0 && reaction.interval > 0_turns &&
+                   fire_intensity >= reaction.degrade_at &&
+                   calendar::once_every( reaction.interval ) ) {
+            pd.here.mod_field_intensity( p, entry.first, -1 );
+        }
+    }
+}
+
 void field_processor_fd_fire( const tripoint_bub_ms &p, field_entry &cur, field_proc_data &pd )
 {
     const field_type_id fd_fire = ::fd_fire;
@@ -978,22 +998,6 @@ void field_processor_fd_fire( const tripoint_bub_ms &p, field_entry &cur, field_
                                          sheltered );
     const ter_t &ter = map_tile.get_ter_t();
     const furn_t &frn = map_tile.get_furn_t();
-
-    const int fire_intensity = cur.get_field_intensity();
-    for( const std::pair<const field_type_id, field_entry> &entry : map_tile.get_field() ) {
-        const field_type &other_type = entry.first.obj();
-        const field_type::fire_reaction_data &reaction = other_type.fire_reaction;
-        if( other_type.has_fire ) {
-            continue;
-        }
-        if( reaction.clear_at > 0 && fire_intensity >= reaction.clear_at ) {
-            here.remove_field( p, entry.first );
-        } else if( reaction.degrade_at > 0 && reaction.interval > 0_turns &&
-                   fire_intensity >= reaction.degrade_at &&
-                   calendar::once_every( reaction.interval ) ) {
-            here.mod_field_intensity( p, entry.first, -1 );
-        }
-    }
 
     // We've got ter/furn cached, so let's use that
     const bool is_sealed = ter_furn_has_flag( ter, frn, ter_furn_flag::TFLAG_SEALED ) &&
@@ -1152,6 +1156,7 @@ void field_processor_fd_fire( const tripoint_bub_ms &p, field_entry &cur, field_
                     }
                     fire_there->set_field_intensity( new_intensity );
                 }
+                process_field_fire_reactions( p, cur, pd );
                 return;
             }
         }
@@ -1459,6 +1464,8 @@ void field_processor_fd_fire( const tripoint_bub_ms &p, field_entry &cur, field_
     if( adjacent_fires < 5 && rng( 0, 4 - adjacent_fires ) ) {
         here.create_hot_air( p, cur.get_field_intensity() );
     }
+
+    process_field_fire_reactions( p, cur, pd );
 }
 
 static void field_processor_fd_last_known( const tripoint_bub_ms &p, field_entry &cur,

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -961,7 +961,7 @@ static void field_processor_fd_fungicidal_gas( const tripoint_bub_ms &p, field_e
     }
 }
 
-static void process_field_fire_reactions( const tripoint_bub_ms &p, field_entry &cur,
+static void field_processor_fire_reactions( const tripoint_bub_ms &p, field_entry &cur,
         field_proc_data &pd )
 {
     const int fire_intensity = cur.get_field_intensity();
@@ -1156,7 +1156,6 @@ void field_processor_fd_fire( const tripoint_bub_ms &p, field_entry &cur, field_
                     }
                     fire_there->set_field_intensity( new_intensity );
                 }
-                process_field_fire_reactions( p, cur, pd );
                 return;
             }
         }
@@ -1465,7 +1464,6 @@ void field_processor_fd_fire( const tripoint_bub_ms &p, field_entry &cur, field_
         here.create_hot_air( p, cur.get_field_intensity() );
     }
 
-    process_field_fire_reactions( p, cur, pd );
 }
 
 static void field_processor_fd_last_known( const tripoint_bub_ms &p, field_entry &cur,
@@ -2349,6 +2347,9 @@ std::vector<FieldProcessorPtr> map_field_processing::processors_for_type( const 
     }
     if( ft.id == fd_last_known ) {
         processors.push_back( &field_processor_fd_last_known );
+    }
+    if( ft.has_fire ) {
+        processors.push_back( &field_processor_fire_reactions );
     }
 
     return processors;

--- a/tests/field_test.cpp
+++ b/tests/field_test.cpp
@@ -24,6 +24,8 @@
 static const efftype_id effect_test_rash( "test_rash" );
 
 static const field_type_str_id field_fd_acid( "fd_acid" );
+static const field_type_str_id field_fd_fungal_splinters( "fd_fungal_splinters" );
+static const field_type_str_id field_fd_spores( "fd_spores" );
 static const field_type_str_id field_fd_test( "fd_test" );
 static const field_type_str_id field_fd_test_fire_reaction( "fd_test_fire_reaction" );
 
@@ -196,6 +198,19 @@ TEST_CASE( "field fire reaction", "[field]" )
     m.process_fields();
 
     reaction_field = m.get_field( p, field_fd_test_fire_reaction );
+    CHECK( ( !reaction_field || !reaction_field->is_field_alive() ) );
+
+    CHECK( field_fd_spores->fire_reaction.degrade_at == 2 );
+    CHECK( field_fd_spores->fire_reaction.clear_at == 3 );
+    CHECK( field_fd_spores->fire_reaction.interval == 30_seconds );
+    CHECK( field_fd_fungal_splinters->fire_reaction.clear_at == 1 );
+
+    m.remove_field( p, fd_fire );
+    m.add_field( p, fd_fire, 1, 1_turns );
+    m.add_field( p, field_fd_fungal_splinters, 1, 1_turns );
+    m.process_fields();
+
+    reaction_field = m.get_field( p, field_fd_fungal_splinters );
     CHECK( ( !reaction_field || !reaction_field->is_field_alive() ) );
 
     fields_test_cleanup();

--- a/tests/field_test.cpp
+++ b/tests/field_test.cpp
@@ -26,6 +26,7 @@ static const efftype_id effect_test_rash( "test_rash" );
 static const field_type_str_id field_fd_acid( "fd_acid" );
 static const field_type_str_id field_fd_test( "fd_test" );
 static const field_type_str_id field_fd_test_fire_reaction( "fd_test_fire_reaction" );
+static const field_type_str_id field_fd_test_fire_reaction_source( "fd_test_fire_reaction_source" );
 
 static const itype_id itype_test_2x4( "test_2x4" );
 static const itype_id itype_test_hazmat_hat( "test_hazmat_hat" );
@@ -196,6 +197,14 @@ TEST_CASE( "field fire reaction", "[field]" )
     m.process_fields();
 
     reaction_field = m.get_field( p, field_fd_test_fire_reaction );
+    CHECK( ( !reaction_field || !reaction_field->is_field_alive() ) );
+
+    const tripoint_bub_ms other_p{ 34, 33, 0 };
+    m.add_field( other_p, field_fd_test_fire_reaction_source, 3, 1_turns );
+    m.add_field( other_p, field_fd_test_fire_reaction, 1, 1_turns );
+    m.process_fields();
+
+    reaction_field = m.get_field( other_p, field_fd_test_fire_reaction );
     CHECK( ( !reaction_field || !reaction_field->is_field_alive() ) );
 
     fields_test_cleanup();

--- a/tests/field_test.cpp
+++ b/tests/field_test.cpp
@@ -25,6 +25,7 @@ static const efftype_id effect_test_rash( "test_rash" );
 
 static const field_type_str_id field_fd_acid( "fd_acid" );
 static const field_type_str_id field_fd_test( "fd_test" );
+static const field_type_str_id field_fd_test_fire_reaction( "fd_test_fire_reaction" );
 
 static const itype_id itype_test_2x4( "test_2x4" );
 static const itype_id itype_test_hazmat_hat( "test_hazmat_hat" );
@@ -170,6 +171,34 @@ static void fields_test_cleanup()
 {
     calendar::turn = fields_test_time_before();
     clear_map_without_vision();
+}
+
+TEST_CASE( "field fire reaction", "[field]" )
+{
+    fields_test_setup();
+
+    const tripoint_bub_ms p{ 33, 33, 0 };
+    map &m = get_map();
+
+    REQUIRE( field_fd_test_fire_reaction->fire_reaction.degrade_at == 2 );
+    REQUIRE( field_fd_test_fire_reaction->fire_reaction.clear_at == 3 );
+    REQUIRE( field_fd_test_fire_reaction->fire_reaction.interval == 1_turns );
+
+    m.add_field( p, fd_fire, 2, 1_turns );
+    m.add_field( p, field_fd_test_fire_reaction, 2, 1_turns );
+    m.process_fields();
+
+    field_entry *reaction_field = m.get_field( p, field_fd_test_fire_reaction );
+    REQUIRE( reaction_field );
+    CHECK( reaction_field->get_field_intensity() == 1 );
+
+    m.mod_field_intensity( p, fd_fire, 1 );
+    m.process_fields();
+
+    reaction_field = m.get_field( p, field_fd_test_fire_reaction );
+    CHECK( ( !reaction_field || !reaction_field->is_field_alive() ) );
+
+    fields_test_cleanup();
 }
 
 TEST_CASE( "fd_acid_falls_down", "[field]" )

--- a/tests/field_test.cpp
+++ b/tests/field_test.cpp
@@ -24,8 +24,6 @@
 static const efftype_id effect_test_rash( "test_rash" );
 
 static const field_type_str_id field_fd_acid( "fd_acid" );
-static const field_type_str_id field_fd_fungal_splinters( "fd_fungal_splinters" );
-static const field_type_str_id field_fd_spores( "fd_spores" );
 static const field_type_str_id field_fd_test( "fd_test" );
 static const field_type_str_id field_fd_test_fire_reaction( "fd_test_fire_reaction" );
 
@@ -198,19 +196,6 @@ TEST_CASE( "field fire reaction", "[field]" )
     m.process_fields();
 
     reaction_field = m.get_field( p, field_fd_test_fire_reaction );
-    CHECK( ( !reaction_field || !reaction_field->is_field_alive() ) );
-
-    CHECK( field_fd_spores->fire_reaction.degrade_at == 2 );
-    CHECK( field_fd_spores->fire_reaction.clear_at == 3 );
-    CHECK( field_fd_spores->fire_reaction.interval == 30_seconds );
-    CHECK( field_fd_fungal_splinters->fire_reaction.clear_at == 1 );
-
-    m.remove_field( p, fd_fire );
-    m.add_field( p, fd_fire, 1, 1_turns );
-    m.add_field( p, field_fd_fungal_splinters, 1, 1_turns );
-    m.process_fields();
-
-    reaction_field = m.get_field( p, field_fd_fungal_splinters );
     CHECK( ( !reaction_field || !reaction_field->is_field_alive() ) );
 
     fields_test_cleanup();


### PR DESCRIPTION
#### Summary
Features "Implement interactions between `field_processor_fd_fire` and other fields"

#### Purpose of change
This originated from a player report that burning down a fungal infestation leaves `spore dust` behind for a long time. Simply approaching it still triggers the "dangerous tile" prompt, leading players to suspect that using fire to clear fungal infestations is actually ineffective.

After reading the relevant code, I found that fungal creatures leave behind `fd_spores` and `fd_fungal_splinters` upon death. The former is indeed hazardous, while the latter is currently only marked as `dangerous` without defining any actual effect or having any corresponding hardcoded handling. As a result, it triggers the "dangerous terrain" confirmation, but under the current implementation it neither infects nor causes any damage.

Further investigation revealed that fire and both of these are fields. Fire is represented by `fd_fire`, and all three share the same `"type": "field_type"`. As a result, fire has no interaction with any other fields at all. I think it is worthwhile to add a dedicated field property to define how a field reacts to low-intensity fire or, more generally, how it interacts with fire.

#### Describe the solution
Implemented the `fire_reaction` data structure:

```json
"fire_reaction": { // Optional; omitted keeps the legacy behavior; ignored when has_fire is true
  "degrade_at": 2, // Periodic intensity-loss threshold; 0 disables degradation
  "clear_at": 3, // Immediate-removal threshold; 0 disables immediate removal
  "interval": "30 seconds" // Interval between degradation attempts; defaults to 1 minute
}
```

Also configured `fd_spores` with `"fire_reaction": { "degrade_at": 2, "clear_at": 3, "interval": "30 seconds" }`, and removed the ineffective `dangerous` definition from `fd_fungal_splinters`.