### PR TITLE
fix: 删除世界时同时移除残留存档目录

### DIFF
--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -2381,13 +2381,26 @@ void main_menu::world_tab( const std::string &worldname )
 
     auto clear_world = [this, &worldname]( bool do_delete ) {
         // NOLINTNEXTLINE(cata-use-localized-sorting)
-        if( last_world_pos > 0 && worldname <= world_generator->all_worldnames()[last_world_pos] ) {
-            last_world_pos--;
-        }
-        world_generator->delete_world( worldname, do_delete );
+        const bool shift_last_world_pos = last_world_pos > 0 &&
+                                          worldname <= world_generator->all_worldnames()[last_world_pos];
+
+        // Release save and map resources before removing the directory.  Windows
+        // will otherwise keep the world folder alive while one of these resources
+        // still has an open handle inside it.
         savegames.clear();
         MAPBUFFER.clear();
         overmap_buffer.clear();
+        if( !world_generator->delete_world( worldname, do_delete ) ) {
+            if( do_delete ) {
+                popup( _( "Unable to delete world \"%s\".  Some files or its folder could not be "
+                          "removed.  Close programs using the save directory, check its permissions, "
+                          "and try again." ), worldname );
+            }
+            return;
+        }
+        if( shift_last_world_pos ) {
+            last_world_pos--;
+        }
         if( do_delete ) {
             sel2 = 0; // reset to create world selection
         }

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -10,6 +10,7 @@
 #include <iterator>
 #include <memory>
 #include <set>
+#include <system_error>
 #include <unordered_map>
 #include <utility>
 
@@ -3757,15 +3758,89 @@ static bool isForbidden( const cata_path &candidate )
            || candidate_path.extension().generic_u8string() == ".dict";
 }
 
-void worldfactory::delete_world( const std::string &worldname, const bool delete_folder )
+static void make_world_tree_writable( const std::filesystem::path &worldpath )
 {
+    std::error_code ec;
+    std::filesystem::permissions( worldpath, std::filesystem::perms::owner_all,
+                                  std::filesystem::perm_options::add, ec );
+
+    std::filesystem::recursive_directory_iterator iter(
+        worldpath, std::filesystem::directory_options::skip_permission_denied, ec );
+    const std::filesystem::recursive_directory_iterator end;
+    while( iter != end ) {
+        const std::filesystem::path entry_path = iter->path();
+        std::error_code status_ec;
+        const std::filesystem::file_status status = iter->symlink_status( status_ec );
+        if( !status_ec && !std::filesystem::is_symlink( status ) ) {
+            const std::filesystem::perms permissions = std::filesystem::is_directory( status ) ?
+                    std::filesystem::perms::owner_all : std::filesystem::perms::owner_write;
+            std::error_code permissions_ec;
+            std::filesystem::permissions( entry_path, permissions,
+                                          std::filesystem::perm_options::add, permissions_ec );
+        }
+        iter.increment( ec );
+        if( ec ) {
+            ec.clear();
+        }
+    }
+}
+
+static bool remove_world_directory( const std::filesystem::path &worldpath,
+                                    std::error_code &result_error )
+{
+    std::error_code remove_error;
+    std::filesystem::remove_all( worldpath, remove_error );
+
+    std::error_code exists_error;
+    bool directory_remains = std::filesystem::exists( worldpath, exists_error );
+    if( !directory_remains && !exists_error ) {
+        return true;
+    }
+
+    // Windows refuses to delete read-only files.  A failed remove_all may also
+    // leave only the now-empty world directory behind, so make any remaining
+    // entries writable and retry the complete operation.
+    make_world_tree_writable( worldpath );
+    remove_error.clear();
+    std::filesystem::remove_all( worldpath, remove_error );
+
+    exists_error.clear();
+    directory_remains = std::filesystem::exists( worldpath, exists_error );
+    if( !directory_remains && !exists_error ) {
+        return true;
+    }
+
+    if( exists_error ) {
+        result_error = exists_error;
+    } else if( remove_error ) {
+        result_error = remove_error;
+    } else {
+        result_error = std::make_error_code( std::errc::directory_not_empty );
+    }
+    return false;
+}
+
+bool worldfactory::delete_world( const std::string &worldname, const bool delete_folder )
+{
+    if( !has_world( worldname ) ) {
+        DebugLog( D_ERROR, D_MAIN ) << "Unable to delete unknown world '" << worldname << "'";
+        return false;
+    }
+
     cata_path worldpath = get_world( worldname )->folder_path();
     std::set<std::filesystem::path> directory_paths;
 
     if( delete_folder ) {
-        std::filesystem::remove_all( worldpath.get_unrelative_path() );
+        const std::filesystem::path unrelative_worldpath = worldpath.get_unrelative_path();
+        std::error_code ec;
+        if( !remove_world_directory( unrelative_worldpath, ec ) ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Unable to delete world directory ['"
+                                        << unrelative_worldpath.generic_u8string() << "']: "
+                                        << ec.message();
+            return false;
+        }
         remove_world( worldname );
-        return;
+        return true;
     }
 
     // Clear out everything except options and mods and compression dictionaries.
@@ -3795,4 +3870,5 @@ void worldfactory::delete_world( const std::string &worldname, const bool delete
         remove_directory( *it );
     }
     get_world( worldname )->world_saves.clear();
+    return true;
 }

--- a/src/worldfactory.h
+++ b/src/worldfactory.h
@@ -147,8 +147,10 @@ class worldfactory
          * @param delete_folder If true: delete all the files and directories of the given
          * world folder. Else just avoid deleting the config files and the directory
          * itself.
+         * @return True when the requested operation completed.  When deleting the
+         * world, success means its directory no longer exists.
          */
-        void delete_world( const std::string &worldname, bool delete_folder );
+        bool delete_world( const std::string &worldname, bool delete_folder );
 
         static std::map<size_t, inclusive_rectangle<point>> draw_worldgen_tabs( const catacurses::window &w,
                 size_t current );

--- a/tests/worldfactory_test.cpp
+++ b/tests/worldfactory_test.cpp
@@ -1,7 +1,13 @@
+#include <filesystem>
+#include <fstream>
 #include <memory>
 #include <string>
+#include <system_error>
+#include <vector>
 
 #include "cata_catch.h"
+#include "cata_scope_helpers.h"
+#include "filesystem.h"
 #include "worldfactory.h"
 
 TEST_CASE( "world_create_timestamp" )
@@ -14,4 +20,51 @@ TEST_CASE( "world_create_timestamp" )
         CHECK( ch >= '0' );
         CHECK( ch <= '9' );
     }
+}
+
+TEST_CASE( "delete_world_removes_read_only_directory_tree" )
+{
+    const std::string world_name = "Delete World 测试";
+    const std::vector<mod_id> mods;
+    REQUIRE_FALSE( world_generator->has_world( world_name ) );
+
+    WORLD *world = world_generator->make_new_world( world_name, mods );
+    REQUIRE( world != nullptr );
+    const std::filesystem::path world_path = world->folder_path().get_unrelative_path();
+    const std::filesystem::path nested_path = world_path / "read_only";
+    const std::filesystem::path marker_path = nested_path / "marker.txt";
+
+    on_out_of_scope cleanup( [&]() {
+        std::error_code ec;
+        std::filesystem::permissions( nested_path, std::filesystem::perms::owner_all,
+                                      std::filesystem::perm_options::add, ec );
+        std::filesystem::permissions( marker_path, std::filesystem::perms::owner_write,
+                                      std::filesystem::perm_options::add, ec );
+        if( world_generator->has_world( world_name ) ) {
+            world_generator->delete_world( world_name, true );
+        } else {
+            std::filesystem::remove_all( world_path, ec );
+        }
+    } );
+
+    REQUIRE( assure_dir_exist( nested_path ) );
+    {
+        std::ofstream marker( marker_path );
+        REQUIRE( marker.is_open() );
+        marker << "world deletion regression test";
+    }
+
+    std::error_code ec;
+    std::filesystem::permissions( marker_path, std::filesystem::perms::owner_read,
+                                  std::filesystem::perm_options::replace, ec );
+    REQUIRE_FALSE( ec );
+    std::filesystem::permissions( nested_path,
+                                  std::filesystem::perms::owner_read |
+                                  std::filesystem::perms::owner_exec,
+                                  std::filesystem::perm_options::replace, ec );
+    REQUIRE_FALSE( ec );
+
+    CHECK( world_generator->delete_world( world_name, true ) );
+    CHECK_FALSE( std::filesystem::exists( world_path ) );
+    CHECK_FALSE( world_generator->has_world( world_name ) );
 }


### PR DESCRIPTION
#### Summary

Bugfixes "修复游戏内删除世界后空存档文件夹残留的问题"

#### Responsible human

@LYHGLYTX

#### Purpose of change

玩家在 Windows 上从世界管理菜单删除世界后，存档内容会消失，但世界根目录可能残留。残留目录会让删除结果看起来无效，并可能在仍有世界配置文件时再次出现在世界列表中。

复现方式：

1. 创建并保存一个世界。
2. 在世界管理菜单选择“删除世界”。
3. 查看存档目录和世界列表。
4. 删除前若有仍被游戏占用或只读的存档资源，目录可能残留。

#### Describe the solution

- 在文件系统删除前释放存档列表、地图缓存和大地图缓存，避免 Windows 文件句柄阻止删除根目录。
- 将 `worldfactory::delete_world` 改为返回成功状态。
- 使用不抛异常的 `remove_all`，删除后明确检查世界根目录是否仍存在。
- 首次删除失败时，只对世界目录内非符号链接的剩余项目恢复所有者写权限并重试，覆盖 Windows 只读文件和“内容已删但根目录残留”的情况。
- 只有确认目录消失后才从内存世界注册表移除世界。
- 最终仍失败时记录完整路径和系统错误，并在菜单中向玩家显示可操作的错误提示。
- 新增 Unicode 世界名、嵌套目录和只读文件的聚焦回归测试。

#### Describe alternatives you've considered

只在现有 `remove_all` 后调用一次 `remove_directory` 无法解决游戏自身文件句柄或只读文件导致的失败，也仍然会静默忽略错误，因此没有采用。

#### Testing

已运行并通过：

- `astyle --options=.astylerc --dry-run -X -Q --ascii src/main_menu.cpp src/worldfactory.cpp src/worldfactory.h tests/worldfactory_test.cpp`
- `make -j6 CATA_ENABLE_LUA_UI=0 PCH=0 obj/worldfactory.o obj/main_menu.o`
- `g++ -std=c++17 ... -c tests/worldfactory_test.cpp -o /tmp/ccb-worldfactory_test.o`
- `git diff --check`

`make -j6 CATA_ENABLE_LUA_UI=0 astyle-check` 仍报告 16 个远端基线文件需要格式化；本 PR 修改的 4 个文件不在报告中。

完整测试二进制未在本机重新链接；请由 PR CI 运行新增 Catch2 用例 `delete_world_removes_read_only_directory_tree` 及平台构建。

#### Documentation impact

None

#### Related CCB-Docs PR

None

#### Affected documentation IDs

None

#### Generated reference impact

None

#### Additional context

该修复不修改游戏玩法、存档格式或运行时数据契约。