### PR TITLE
fix(input): forward Enter/Escape when ImGui consumes them in text widgets

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -3218,7 +3218,7 @@ void inventory_selector::refresh_window()
 }
 
 std::pair< bool, std::string > inventory_selector::query_string( const std::string &val,
-        bool end_with_toggle )
+        bool end_with_toggle, bool live_filter )
 {
     spopup = std::make_unique<string_input_popup>();
     spopup->max_length( 256 )
@@ -3241,6 +3241,12 @@ std::pair< bool, std::string > inventory_selector::query_string( const std::stri
     do {
         ui_manager::redraw();
         spopup->query_string( /*loop=*/false );
+        if( live_filter && !spopup->canceled() && spopup->text() != filter ) {
+            set_filter( spopup->text() );
+            if( ui.lock() ) {
+                ui.lock()->mark_resize();
+            }
+        }
     } while( !spopup->confirmed() && !spopup->canceled() );
 
     std::string rval;
@@ -3255,7 +3261,8 @@ std::pair< bool, std::string > inventory_selector::query_string( const std::stri
 
 void inventory_selector::query_set_filter()
 {
-    std::pair< bool, std::string > query = query_string( filter );
+    std::pair< bool, std::string > query = query_string(
+            filter, /*end_with_toggle=*/false, /*live_filter=*/true );
     if( query.first ) {
         set_filter( query.second );
     }

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -772,7 +772,8 @@ class inventory_selector
          * @param val The default value to have set in the query prompt.
          * @return A tuple of a bool and string, bool is true if user confirmed.
          */
-        std::pair< bool, std::string > query_string( const std::string &val, bool end_with_toggle = false );
+        std::pair< bool, std::string > query_string( const std::string &val, bool end_with_toggle = false,
+                bool live_filter = false );
         /** Query the user for a filter and apply it. */
         void query_set_filter();
         /** Query the user for a count and return it. */

--- a/src/lua/CMakeLists.txt
+++ b/src/lua/CMakeLists.txt
@@ -40,6 +40,10 @@ file(GLOB LUA_HEADERS CONFIGURE_DEPENDS
 
 # Add both sources and headers to the library (headers for IDE visibility)
 add_library(liblua ${LUA_SOURCES} ${LUA_HEADERS})
+# sol is configured (via src/sol/config.hpp, SOL_USE_CXX_LUA) to reference
+# Lua symbols with C++ linkage, so the Lua sources must be compiled as C++
+# too, or linking fails with undefined Lua references on CMake builds.
+set_source_files_properties(${LUA_SOURCES} PROPERTIES LANGUAGE CXX)
 target_include_directories(liblua SYSTEM PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Lua is third-party C code.  Keep its diagnostics isolated from the game's

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -6416,10 +6416,27 @@ static void CheckMessages()
             // context so the widget redraws, but do not also resolve the same
             // keystroke through gameplay/menu bindings (for example, typing
             // 'a' in a name field must not invoke CHANGE_AGE).
-            last_input = input_event();
-            last_input.type = input_event_t::timeout;
-            text_refresh = true;
-            ui_manager::redraw_invalidated();
+            //
+            // Enter and Escape are exceptions: ImGui consumes them to commit
+            // or dismiss the focused text widget, so without forwarding the
+            // game would require a second press of the same key to confirm or
+            // cancel the surrounding input loop.
+            const bool commit_or_cancel =
+                ev.type == CATA_KEYDOWN &&
+                ( GetKeysym( ev ).sym == SDLK_RETURN ||
+                  GetKeysym( ev ).sym == SDLK_RETURN2 ||
+                  GetKeysym( ev ).sym == SDLK_KP_ENTER ||
+                  GetKeysym( ev ).sym == SDLK_ESCAPE );
+            if( commit_or_cancel ) {
+                const int lc = sdl_keysym_to_curses( GetKeysym( ev ) );
+                last_input = input_event( lc, input_event_t::keyboard_char );
+                text_refresh = true;
+            } else {
+                last_input = input_event();
+                last_input.type = input_event_t::timeout;
+                text_refresh = true;
+                ui_manager::redraw_invalidated();
+            }
         } else if( IsWindowEvent( ev ) ) {
             switch( GetWindowEventID( ev ) ) {
 #if defined(__ANDROID__)


### PR DESCRIPTION
#### Summary
Bugfixes "修复 ImGui 文本输入框(搜索/筛选)输入后需按两次回车才生效的问题"

#### Responsible human

@LYHGLYTX

#### Purpose of change

Windows 与 Linux 的 tiles 版本中,所有走 ImGui 输入框的搜索/筛选功能(制作台搜索、按键绑定菜单过滤、调试控制台 omnibox、角色创建输入框等)在输入文字后都需要按两次 Enter 才能确认,与输入法无关,稳定复现。

根因:CCB 在 `src/sdltiles.cpp` 的事件分发中加入了 `imgui_owns_text_event` 机制——当 ImGui 输入框激活(`io.WantTextInput` 为 true)时,所有键盘事件被 ImGui 抢占,游戏输入循环只收到 timeout。ImGui 消费 Enter 用于提交文本并失焦,但游戏感知不到,必须再按一次 Enter 才轮到游戏处理。

#### Describe the solution

- `src/sdltiles.cpp`:在 `imgui_owns_text_event` 分支中,将 Enter(Escape 同理)的 KEYDOWN 以 `keyboard_char` 事件转发给游戏,使输入循环在第一次按键时立即收到 `TEXT.CONFIRM` / `TEXT.QUIT`。ImGui 已消费该键用于提交/取消输入框,转发不会造成重复动作。
- `src/inventory_ui.cpp/h`:物品栏搜索框改为实时过滤(live_filter),输入即应用,Enter 仅负责关闭输入框。
- `src/lua/CMakeLists.txt`:修复 CMake 构建链接失败——`src/sol/config.hpp` 在 CMAKE 构建下定义 `SOL_USE_CXX_LUA`,sol 以 C++ 链接引用 Lua 符号,但 Lua 源文件此前按 C 编译,导致链接时大量 undefined reference。将 Lua 源文件改为按 C++ 编译以匹配。

#### Describe alternatives you've considered

- 在 `string_input_popup_imgui` 内部检测 `IsItemDeactivatedAfterEdit` 确认 Enter:只能修复制作台搜索,其他 ImGui 输入框(键位菜单、调试控制台等)仍有同样问题,故采用统一的事件转发方案。
- 依赖 `io.WantTextInput` 的实时状态:该值滞后一帧且可能残留,不可靠。

#### Testing

- 本机 Linux 使用 CMake + SDL3 配置 `-DTILES=ON -DSOUND=ON` 完整构建 `cataclysm-tiles` 成功(链接通过,仅余 `tmpnam` 警告)。
- `astyle --options=.astylerc --dry-run` 对全部改动文件检查通过。
- 未做交互式按键实测,建议审阅者/维护者在 Windows 或 Linux tiles 版中验证:制作台搜索输入文字后按一次 Enter 即生效,再按 Enter 或 ESC 关闭/取消。

#### Documentation impact

None

#### Related CCB-Docs PR

None

#### Affected documentation IDs

None

#### Generated reference impact

None

#### Additional context

该问题同时影响 Windows 与 Linux 的 tiles 构建,与操作系统输入法无关。CCB 的 curses 版物品栏搜索不受影响(不走 ImGui 事件路径);本次实时过滤改动同时覆盖了物品栏搜索。
