### PR TITLE
Attempt to fix the Android Lua library build failure preventing experimental releases

### DIFF
--- a/android/app/jni/CMakeLists.txt
+++ b/android/app/jni/CMakeLists.txt
@@ -151,6 +151,7 @@ target_compile_definitions(
           USE_SDL3
           CCB_ANDROID_NEW_UI=$<BOOL:${CCB_ANDROID_NEW_UI}>
           CATA_ENABLE_LUA_UI=$<BOOL:${CATA_ENABLE_LUA_UI}>
+          CMAKE
           BACKTRACE
           LOCALIZE
           ZSTD_STATIC_LINKING_ONLY


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The Android Lua library is already compiled with the C++ ABI, but the Android target does not define `CMAKE`, causing sol2 to continue referencing Lua symbols with the C ABI. This results in the linker reporting a large number of `undefined symbol: lua_*` errors.

Example log:

```text
Building CXX object lua/CMakeFiles/liblua.dir/lapi.c.o
ld.lld: error: undefined symbol: luaL_loadbufferx
did you mean to declare ... as extern "C"?
```

Desktop CMake enables `SOL_USE_CXX_LUA` through `add_definitions(-DCMAKE)` in the top-level configuration. The Android CMake configuration is missing this definition.

#### Describe the solution
Add `CMAKE` to the compile definitions of `main` in `android/app/jni/CMakeLists.txt`, so that sol2 on Android uses the same C++ ABI as `liblua`.

#### Additional context
Will it win?