### PR TITLE
fcl_plating_alloy_fcl-plating_alloy_aapc-mg

### DIFF
--- a/data/mods/FuturismCataclysmLegacy/vehicles/superalloy_military_vehicles.json
+++ b/data/mods/FuturismCataclysmLegacy/vehicles/superalloy_military_vehicles.json
@@ -108,7 +108,7 @@
     ]
   },
   {
-    "id": "fcl_plating_alloy_fcl-plating_alloy_aapc-mg",
+    "id": "fcl-plating_alloy_aapc-mg",
     "color_palette": "military_standard",
     "type": "vehicle",
     "name": "Mechanized Infantry Carrier",

--- a/data/mods/FuturismCataclysmLegacy/vehicles/superalloy_military_vehicles.json
+++ b/data/mods/FuturismCataclysmLegacy/vehicles/superalloy_military_vehicles.json
@@ -108,7 +108,7 @@
     ]
   },
   {
-    "id": "fcl-plating_alloy_aapc-mg",
+    "id": "fcl_plating_alloy_aapc-mg",
     "color_palette": "military_standard",
     "type": "vehicle",
     "name": "Mechanized Infantry Carrier",


### PR DESCRIPTION
修复 #585 中未知原因导致的 fcl_plating_alloy_aapc-mg 载具id 前缀重复（我猜又是不小心点到GitHub Copilot自动补全导致的×）