### PR TITLE
Fix solid hydrogen canister (`plasma`) spawning in the CVD machin reward room

### DIFF
--- a/data/json/mapgen/microlab/microlab_distorted_special.json
+++ b/data/json/mapgen/microlab/microlab_distorted_special.json
@@ -154,7 +154,7 @@
       "palettes": [ "microlab" ],
       "furniture": { "K": "f_rack", "C": "f_machinery_electronic", "A": "f_machinery_heavy" },
       "terrain": { "G": "t_card_science", "`": "t_cvdmachine", "/": "t_cvdbody" },
-      "item": { "r": { "item": "nanomaterial" }, "K": { "item": "plasma", "repeat": [ 25, 75 ] } },
+      "item": { "r": { "item": "nanomaterial" }, "K": { "item": "plasma", "repeat": [ 1, 3 ] } },
       "monster": { "T": { "monster": "mon_turret_rifle", "spawn_data": { "ammo": [ { "ammo_id": "556", "qty": [ 30, 90 ] } ] } } },
       "place_monsters": [ { "monster": "GROUP_LAB", "chance": 2, "x": [ 2, 21 ], "y": [ 2, 21 ], "repeat": [ 1, 5 ] } ],
       "place_monster": [ { "monster": "mon_mech_lifter", "x": 17, "y": 13, "chance": 75 } ]

--- a/data/json/mapgen/microlab/microlab_special_tiles.json
+++ b/data/json/mapgen/microlab/microlab_special_tiles.json
@@ -448,7 +448,7 @@
       "palettes": [ "microlab" ],
       "furniture": { "K": "f_rack", "C": "f_machinery_electronic", "A": "f_machinery_heavy" },
       "terrain": { "G": "t_card_science", "`": "t_cvdmachine", "/": "t_cvdbody" },
-      "item": { "r": { "item": "nanomaterial" }, "K": { "item": "plasma", "repeat": [ 25, 75 ] } },
+      "item": { "r": { "item": "nanomaterial" }, "K": { "item": "plasma", "repeat": [ 1, 3 ] } },
       "monster": { "T": { "monster": "mon_turret_rifle", "spawn_data": { "ammo": [ { "ammo_id": "556", "qty": [ 30, 90 ] } ] } } },
       "place_monsters": [ { "monster": "GROUP_LAB", "chance": 2, "x": [ 2, 21 ], "y": [ 2, 21 ], "repeat": [ 1, 5 ] } ],
       "place_monster": [ { "monster": "mon_mech_lifter", "x": 17, "y": 13, "chance": 75 } ]

--- a/data/mods/FuturismCataclysmLegacy/mapgen/microlab/microlab_special_tiles.json
+++ b/data/mods/FuturismCataclysmLegacy/mapgen/microlab/microlab_special_tiles.json
@@ -78,7 +78,7 @@
       "palettes": [ "microlab" ],
       "furniture": { "K": "f_rack", "C": "f_machinery_electronic", "A": "f_machinery_heavy" },
       "terrain": { "G": "t_card_science", "`": "t_cvdmachine", "/": "t_cvdbody" },
-      "item": { "r": { "item": "nanomaterial" }, "K": { "item": "plasma", "repeat": [ 25, 75 ] } },
+      "item": { "r": { "item": "nanomaterial" }, "K": { "item": "plasma", "repeat": [ 1, 3 ] } },
       "monster": { "T": { "monster": "mon_turret_rifle", "spawn_data": { "ammo": [ { "ammo_id": "556", "qty": [ 30, 90 ] } ] } } },
       "place_monsters": [ { "monster": "GROUP_LAB", "chance": 2, "x": [ 2, 21 ], "y": [ 2, 21 ], "repeat": [ 1, 5 ] } ],
       "place_monster": [ { "monster": "mon_mech_lifter", "x": 17, "y": 13, "chance": 75 } ]


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The upstream C:DDA branch removed the stack size data for nanomaterial, but the solid hydrogen spawn in the CVD machin laboratory reward room variant was still based on the data from the nanofabricator reward room. As a result, it incorrectly generated a much larger quantity than intended.

#### Describe the solution

Scale the original `repeat` value proportionally according to the stack configuration defined for `plasma` in its JSON data.