### PR TITLE
修復experimental release title格式會被啟動器項目截斷的問題

### DIFF
--- a/.github/workflows/release-android-bundle.yaml
+++ b/.github/workflows/release-android-bundle.yaml
@@ -33,7 +33,7 @@ jobs:
         id: vars
         run: |
           timestamp=$(TZ=Asia/Shanghai date "+%Y-%m-%d-%H%M")
-          title_time=$(TZ=Asia/Shanghai date "+%Y-%m-%d %H:%M")
+          title_time=$(TZ=Asia/Shanghai date "+%Y-%m-%d_%H:%M")
           echo "timestamp=$timestamp" >> $GITHUB_OUTPUT
           echo "tag_name=android-aab-$timestamp" >> $GITHUB_OUTPUT
           echo "release_name=Android AAB $title_time" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         id: meta
         run: |
           time=$(TZ=Asia/Shanghai /bin/date "+%Y-%m-%d-%H%M")
-          title_time=$(TZ=Asia/Shanghai /bin/date "+%Y-%m-%d %H:%M")
+          title_time=$(TZ=Asia/Shanghai /bin/date "+%Y-%m-%d_%H:%M")
           echo "time=$time" >> $GITHUB_OUTPUT
           echo "tag_name=${time}" >> $GITHUB_OUTPUT
           echo "release_name=Experimental ${title_time}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
自從 #343 更改並簡化了實驗發行版的標籤與標題後，啟動器項目的“縮短測試版發佈名稱”選項就會錯誤截斷實驗版版本號：
<img width="356" height="198" alt="image" src="https://github.com/user-attachments/assets/329a3c81-a84b-472e-93ad-97239829592b" />
這是因為原先experimental release title的title_time參數的時間日期格式為`%Y-%m-%d %H:%M`，在日期與當日時間中間存在一個空格導致了截斷。
現在試著把空格換成下劃線。