### PR TITLE
Add Lua dialogue API support

### DIFF
--- a/data/lua/README.md
+++ b/data/lua/README.md
@@ -172,6 +172,7 @@ capabilities are:
 - `game.actions`
 - `game.actions.dangerous`
 - `game.callbacks`
+- `game.dialogue`
 - `game.hooks`
 - `game.read`
 - `game.write`
@@ -186,7 +187,7 @@ capabilities are:
 - `ui.pages`
 
 The dangerous-action, module-import, registry, scheduler, and service
-capabilities require API v4. `game.callbacks`, `game.hooks`, and `game.write`
+capabilities require API v4. `game.callbacks`, `game.dialogue`, `game.hooks`, and `game.write`
 require API v5. `game.actions.dangerous` requires `game.actions`;
 `game.write` requires `game.read`; `game.hooks` requires `events`; and
 `game.callbacks` requires `game.read`. Unknown capabilities, an incompatible

--- a/data/lua/manifest.schema.json
+++ b/data/lua/manifest.schema.json
@@ -39,6 +39,7 @@
           "game.actions",
           "game.actions.dangerous",
           "game.callbacks",
+          "game.dialogue",
           "game.hooks",
           "game.read",
           "game.write",
@@ -78,7 +79,7 @@
     },
     {
       "if": {
-        "properties": { "capabilities": { "contains": { "enum": [ "game.callbacks", "game.hooks", "game.write" ] } } },
+        "properties": { "capabilities": { "contains": { "enum": [ "game.callbacks", "game.dialogue", "game.hooks", "game.write" ] } } },
         "required": [ "capabilities" ]
       },
       "then": { "properties": { "api_version": { "minimum": 5 } } }

--- a/data/lua/reference/ccb_public_api_v5.json
+++ b/data/lua/reference/ccb_public_api_v5.json
@@ -37,7 +37,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3098,
+          "line": 3708,
           "authority": "native registration"
         }
       ],
@@ -53,12 +53,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3108,
+          "line": 3718,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1058,
+          "line": 1059,
           "authority": "LuaLS declaration"
         }
       ],
@@ -74,12 +74,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3117,
+          "line": 3727,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1061,
+          "line": 1062,
           "authority": "LuaLS declaration"
         }
       ],
@@ -97,7 +97,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3265,
+          "line": 3875,
           "authority": "native registration"
         }
       ],
@@ -113,7 +113,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3355,
+          "line": 3986,
           "authority": "native registration"
         }
       ],
@@ -145,7 +145,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3442,
+          "line": 4073,
           "authority": "native registration"
         }
       ],
@@ -209,7 +209,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3570,
+          "line": 4234,
           "authority": "native registration"
         }
       ],
@@ -337,12 +337,28 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4088,
+          "line": 4752,
           "authority": "native registration"
         }
       ],
       "documentation": {
         "id": "api.lua.v5.generated.namespace.game.diagnostics",
+        "status": "generated-contract-source"
+      }
+    },
+    {
+      "id": "game.dialogue",
+      "kind": "child",
+      "class": "CcbDialogueApi",
+      "sources": [
+        {
+          "path": "src/catalua_ui.cpp",
+          "line": 4105,
+          "authority": "native registration"
+        }
+      ],
+      "documentation": {
+        "id": "api.lua.v5.generated.namespace.game.dialogue",
         "status": "generated-contract-source"
       }
     },
@@ -433,7 +449,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3363,
+          "line": 3994,
           "authority": "native registration"
         }
       ],
@@ -465,7 +481,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3545,
+          "line": 4209,
           "authority": "native registration"
         }
       ],
@@ -529,7 +545,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3590,
+          "line": 4254,
           "authority": "native registration"
         }
       ],
@@ -609,7 +625,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3419,
+          "line": 4050,
           "authority": "native registration"
         }
       ],
@@ -769,7 +785,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3481,
+          "line": 4145,
           "authority": "native registration"
         }
       ],
@@ -1041,7 +1057,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3107,
+          "line": 3717,
           "authority": "native registration"
         }
       ],
@@ -1073,7 +1089,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3121,
+          "line": 3731,
           "authority": "native registration"
         }
       ],
@@ -1089,7 +1105,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3140,
+          "line": 3750,
           "authority": "native registration"
         }
       ],
@@ -1105,7 +1121,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3443,
+          "line": 4107,
           "authority": "native registration"
         }
       ],
@@ -1121,7 +1137,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4097,
+          "line": 4761,
           "authority": "native registration"
         }
       ],
@@ -1137,7 +1153,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4114,
+          "line": 4778,
           "authority": "native registration"
         }
       ],
@@ -1153,7 +1169,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4150,
+          "line": 4814,
           "authority": "native registration"
         }
       ],
@@ -1169,7 +1185,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4132,
+          "line": 4796,
           "authority": "native registration"
         }
       ],
@@ -1185,7 +1201,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3248,
+          "line": 3858,
           "authority": "native registration"
         }
       ],
@@ -1208,7 +1224,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3629,
+              "line": 3702,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1224,7 +1240,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3630,
+              "line": 3703,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1240,7 +1256,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3631,
+              "line": 3704,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1256,7 +1272,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3632,
+              "line": 3705,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1272,7 +1288,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3633,
+              "line": 3706,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1288,7 +1304,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3634,
+              "line": 3707,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1304,7 +1320,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3635,
+              "line": 3708,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1320,7 +1336,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3636,
+              "line": 3709,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1336,7 +1352,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3637,
+              "line": 3710,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1352,7 +1368,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3638,
+              "line": 3711,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1365,7 +1381,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3628,
+          "line": 3701,
           "authority": "LuaLS declaration"
         }
       ],
@@ -1386,7 +1402,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3650,
+              "line": 3723,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1402,7 +1418,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3651,
+              "line": 3724,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1418,7 +1434,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3652,
+              "line": 3725,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1434,7 +1450,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3653,
+              "line": 3726,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1447,7 +1463,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3649,
+          "line": 3722,
           "authority": "LuaLS declaration"
         }
       ],
@@ -1468,7 +1484,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3641,
+              "line": 3714,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1484,7 +1500,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3642,
+              "line": 3715,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1500,7 +1516,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3643,
+              "line": 3716,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1516,7 +1532,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3644,
+              "line": 3717,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1532,7 +1548,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3645,
+              "line": 3718,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1548,7 +1564,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3646,
+              "line": 3719,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1564,7 +1580,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3647,
+              "line": 3720,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1577,7 +1593,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3640,
+          "line": 3713,
           "authority": "LuaLS declaration"
         }
       ],
@@ -1598,7 +1614,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3623,
+              "line": 3696,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1614,7 +1630,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3624,
+              "line": 3697,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1630,7 +1646,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3625,
+              "line": 3698,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1646,7 +1662,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3626,
+              "line": 3699,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1659,7 +1675,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3622,
+          "line": 3695,
           "authority": "LuaLS declaration"
         }
       ],
@@ -1676,7 +1692,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3655,
+          "line": 3728,
           "authority": "LuaLS declaration"
         }
       ],
@@ -1697,7 +1713,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1319,
+              "line": 1320,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1713,7 +1729,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1320,
+              "line": 1321,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1729,7 +1745,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1321,
+              "line": 1322,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1745,7 +1761,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1322,
+              "line": 1323,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1761,7 +1777,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1323,
+              "line": 1324,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1774,7 +1790,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1318,
+          "line": 1319,
           "authority": "LuaLS declaration"
         }
       ],
@@ -1795,7 +1811,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1363,
+              "line": 1364,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1811,7 +1827,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1364,
+              "line": 1365,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1827,7 +1843,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1365,
+              "line": 1366,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1840,7 +1856,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1362,
+          "line": 1363,
           "authority": "LuaLS declaration"
         }
       ],
@@ -1857,7 +1873,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1411,
+          "line": 1412,
           "authority": "LuaLS declaration"
         }
       ],
@@ -1878,7 +1894,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1392,
+              "line": 1393,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1894,7 +1910,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1393,
+              "line": 1394,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1910,7 +1926,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1394,
+              "line": 1395,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1926,7 +1942,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1395,
+              "line": 1396,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1939,7 +1955,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1391,
+          "line": 1392,
           "authority": "LuaLS declaration"
         }
       ],
@@ -1960,7 +1976,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1398,
+              "line": 1399,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1976,7 +1992,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1399,
+              "line": 1400,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1992,7 +2008,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1400,
+              "line": 1401,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2008,7 +2024,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1401,
+              "line": 1402,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2024,7 +2040,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1402,
+              "line": 1403,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2040,7 +2056,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1403,
+              "line": 1404,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2053,7 +2069,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1397,
+          "line": 1398,
           "authority": "LuaLS declaration"
         }
       ],
@@ -2074,7 +2090,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1406,
+              "line": 1407,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2090,7 +2106,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1407,
+              "line": 1408,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2106,7 +2122,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1408,
+              "line": 1409,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2122,7 +2138,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1409,
+              "line": 1410,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2135,7 +2151,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1405,
+          "line": 1406,
           "authority": "LuaLS declaration"
         }
       ],
@@ -2156,7 +2172,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1344,
+              "line": 1345,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2172,7 +2188,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1345,
+              "line": 1346,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2188,7 +2204,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1346,
+              "line": 1347,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2204,7 +2220,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1347,
+              "line": 1348,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2220,7 +2236,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1348,
+              "line": 1349,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2236,7 +2252,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1349,
+              "line": 1350,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2252,7 +2268,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1350,
+              "line": 1351,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2265,7 +2281,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1343,
+          "line": 1344,
           "authority": "LuaLS declaration"
         }
       ],
@@ -2286,7 +2302,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 643,
+              "line": 644,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2302,7 +2318,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 644,
+              "line": 645,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2318,7 +2334,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 645,
+              "line": 646,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2331,7 +2347,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 642,
+          "line": 643,
           "authority": "LuaLS declaration"
         }
       ],
@@ -2352,7 +2368,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1353,
+              "line": 1354,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2368,7 +2384,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1354,
+              "line": 1355,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2384,7 +2400,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1355,
+              "line": 1356,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2400,7 +2416,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1356,
+              "line": 1357,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2416,7 +2432,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1357,
+              "line": 1358,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2429,7 +2445,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1352,
+          "line": 1353,
           "authority": "LuaLS declaration"
         }
       ],
@@ -2450,7 +2466,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1296,
+              "line": 1297,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2466,7 +2482,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1297,
+              "line": 1298,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2482,7 +2498,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1298,
+              "line": 1299,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2498,7 +2514,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1299,
+              "line": 1300,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2514,7 +2530,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1300,
+              "line": 1301,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2530,7 +2546,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1301,
+              "line": 1302,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2546,7 +2562,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1302,
+              "line": 1303,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2562,7 +2578,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1303,
+              "line": 1304,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2578,7 +2594,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1304,
+              "line": 1305,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2594,7 +2610,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1305,
+              "line": 1306,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2607,7 +2623,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1295,
+          "line": 1296,
           "authority": "LuaLS declaration"
         }
       ],
@@ -2628,7 +2644,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3273,
+              "line": 3346,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2644,7 +2660,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3274,
+              "line": 3347,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2657,7 +2673,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3272,
+          "line": 3345,
           "authority": "LuaLS declaration"
         }
       ],
@@ -2678,7 +2694,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3253,
+              "line": 3326,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2694,7 +2710,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3254,
+              "line": 3327,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2710,7 +2726,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3255,
+              "line": 3328,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2726,7 +2742,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3256,
+              "line": 3329,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2742,7 +2758,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3257,
+              "line": 3330,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2758,7 +2774,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3258,
+              "line": 3331,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2774,7 +2790,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3259,
+              "line": 3332,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2787,7 +2803,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3252,
+          "line": 3325,
           "authority": "LuaLS declaration"
         }
       ],
@@ -2808,7 +2824,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3262,
+              "line": 3335,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2824,7 +2840,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3263,
+              "line": 3336,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2840,7 +2856,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3264,
+              "line": 3337,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2856,7 +2872,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3265,
+              "line": 3338,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2872,7 +2888,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3266,
+              "line": 3339,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2888,7 +2904,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3267,
+              "line": 3340,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2904,7 +2920,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3268,
+              "line": 3341,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2920,7 +2936,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3269,
+              "line": 3342,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2936,7 +2952,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3270,
+              "line": 3343,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2949,7 +2965,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3261,
+          "line": 3334,
           "authority": "LuaLS declaration"
         }
       ],
@@ -2966,7 +2982,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3276,
+          "line": 3349,
           "authority": "LuaLS declaration"
         }
       ],
@@ -2987,7 +3003,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1967,
+              "line": 2040,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3003,7 +3019,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1968,
+              "line": 2041,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3019,7 +3035,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1969,
+              "line": 2042,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3035,7 +3051,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1970,
+              "line": 2043,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3048,7 +3064,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1966,
+          "line": 2039,
           "authority": "LuaLS declaration"
         }
       ],
@@ -3069,7 +3085,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1784,
+              "line": 1857,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3085,7 +3101,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1785,
+              "line": 1858,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3101,7 +3117,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1786,
+              "line": 1859,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3117,7 +3133,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1787,
+              "line": 1860,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3133,7 +3149,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1788,
+              "line": 1861,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3146,7 +3162,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1783,
+          "line": 1856,
           "authority": "LuaLS declaration"
         }
       ],
@@ -3167,7 +3183,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2203,
+              "line": 2276,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3183,7 +3199,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2204,
+              "line": 2277,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3199,7 +3215,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2205,
+              "line": 2278,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3212,7 +3228,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2202,
+          "line": 2275,
           "authority": "LuaLS declaration"
         }
       ],
@@ -3233,7 +3249,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1269,
+              "line": 1270,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3249,7 +3265,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1270,
+              "line": 1271,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3265,7 +3281,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1271,
+              "line": 1272,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3281,7 +3297,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1272,
+              "line": 1273,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3297,7 +3313,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1273,
+              "line": 1274,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3313,7 +3329,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1274,
+              "line": 1275,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3329,7 +3345,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1275,
+              "line": 1276,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3345,7 +3361,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1276,
+              "line": 1277,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3361,7 +3377,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1277,
+              "line": 1278,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3377,7 +3393,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1278,
+              "line": 1279,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3393,7 +3409,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1279,
+              "line": 1280,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3406,7 +3422,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1268,
+          "line": 1269,
           "authority": "LuaLS declaration"
         }
       ],
@@ -3423,7 +3439,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2207,
+          "line": 2280,
           "authority": "LuaLS declaration"
         }
       ],
@@ -3444,7 +3460,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1230,
+              "line": 1231,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3460,7 +3476,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1231,
+              "line": 1232,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3476,7 +3492,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1232,
+              "line": 1233,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3492,7 +3508,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1233,
+              "line": 1234,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3508,7 +3524,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1234,
+              "line": 1235,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3521,7 +3537,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1229,
+          "line": 1230,
           "authority": "LuaLS declaration"
         }
       ],
@@ -3542,7 +3558,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 361,
+              "line": 362,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3558,7 +3574,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 362,
+              "line": 363,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3574,7 +3590,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 363,
+              "line": 364,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3590,7 +3606,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 364,
+              "line": 365,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3606,7 +3622,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 365,
+              "line": 366,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3622,7 +3638,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 366,
+              "line": 367,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3638,7 +3654,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 367,
+              "line": 368,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3654,7 +3670,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 368,
+              "line": 369,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3670,7 +3686,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 369,
+              "line": 370,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3686,7 +3702,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 370,
+              "line": 371,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3702,7 +3718,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 371,
+              "line": 372,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3718,7 +3734,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 372,
+              "line": 373,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3734,7 +3750,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 373,
+              "line": 374,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3750,7 +3766,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 374,
+              "line": 375,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3766,7 +3782,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 375,
+              "line": 376,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3782,7 +3798,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 376,
+              "line": 377,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3798,7 +3814,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 377,
+              "line": 378,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3814,7 +3830,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 378,
+              "line": 379,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3830,7 +3846,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 379,
+              "line": 380,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3846,7 +3862,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 380,
+              "line": 381,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3862,7 +3878,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 381,
+              "line": 382,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3878,7 +3894,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 382,
+              "line": 383,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3894,7 +3910,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 383,
+              "line": 384,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3910,7 +3926,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 384,
+              "line": 385,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3923,7 +3939,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 360,
+          "line": 361,
           "authority": "LuaLS declaration"
         }
       ],
@@ -3944,7 +3960,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 355,
+              "line": 356,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3960,7 +3976,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 356,
+              "line": 357,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3976,7 +3992,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 357,
+              "line": 358,
               "authority": "LuaLS declaration"
             }
           ],
@@ -3992,7 +4008,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 358,
+              "line": 359,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4005,7 +4021,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 354,
+          "line": 355,
           "authority": "LuaLS declaration"
         }
       ],
@@ -4026,7 +4042,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 387,
+              "line": 388,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4042,7 +4058,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 388,
+              "line": 389,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4058,7 +4074,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 389,
+              "line": 390,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4074,7 +4090,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 390,
+              "line": 391,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4090,7 +4106,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 391,
+              "line": 392,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4106,7 +4122,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 392,
+              "line": 393,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4122,7 +4138,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 393,
+              "line": 394,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4138,7 +4154,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 394,
+              "line": 395,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4154,7 +4170,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 395,
+              "line": 396,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4170,7 +4186,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 396,
+              "line": 397,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4186,7 +4202,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 397,
+              "line": 398,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4199,7 +4215,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 386,
+          "line": 387,
           "authority": "LuaLS declaration"
         }
       ],
@@ -4220,7 +4236,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1546,
+              "line": 1588,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4236,7 +4252,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1547,
+              "line": 1589,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4252,7 +4268,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1548,
+              "line": 1590,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4268,7 +4284,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1549,
+              "line": 1591,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4284,7 +4300,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1550,
+              "line": 1592,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4300,7 +4316,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1551,
+              "line": 1593,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4316,7 +4332,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1552,
+              "line": 1594,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4332,7 +4348,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1553,
+              "line": 1595,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4348,7 +4364,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1554,
+              "line": 1596,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4364,7 +4380,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1555,
+              "line": 1597,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4380,7 +4396,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1556,
+              "line": 1598,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4396,7 +4412,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1557,
+              "line": 1599,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4412,7 +4428,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1558,
+              "line": 1600,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4428,7 +4444,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1559,
+              "line": 1601,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4444,7 +4460,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1560,
+              "line": 1602,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4460,7 +4476,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1561,
+              "line": 1603,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4476,7 +4492,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1562,
+              "line": 1604,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4492,7 +4508,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1563,
+              "line": 1605,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4508,7 +4524,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1564,
+              "line": 1606,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4524,7 +4540,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1565,
+              "line": 1607,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4540,7 +4556,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1566,
+              "line": 1608,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4556,7 +4572,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1567,
+              "line": 1609,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4572,7 +4588,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1568,
+              "line": 1610,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4588,7 +4604,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1569,
+              "line": 1611,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4604,7 +4620,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1570,
+              "line": 1612,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4620,7 +4636,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1571,
+              "line": 1613,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4636,7 +4652,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1572,
+              "line": 1614,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4652,7 +4668,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1573,
+              "line": 1615,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4668,7 +4684,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1574,
+              "line": 1616,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4684,7 +4700,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1575,
+              "line": 1617,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4700,7 +4716,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1576,
+              "line": 1618,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4716,7 +4732,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1577,
+              "line": 1619,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4732,7 +4748,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1578,
+              "line": 1620,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4748,7 +4764,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1579,
+              "line": 1621,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4764,7 +4780,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1580,
+              "line": 1622,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4780,7 +4796,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1581,
+              "line": 1623,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4796,7 +4812,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1582,
+              "line": 1624,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4812,7 +4828,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1583,
+              "line": 1625,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4825,7 +4841,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1545,
+          "line": 1587,
           "authority": "LuaLS declaration"
         }
       ],
@@ -4846,7 +4862,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1592,
+              "line": 1634,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4862,7 +4878,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1593,
+              "line": 1635,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4878,7 +4894,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1594,
+              "line": 1636,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4891,7 +4907,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1591,
+          "line": 1633,
           "authority": "LuaLS declaration"
         }
       ],
@@ -4912,7 +4928,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1597,
+              "line": 1639,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4928,7 +4944,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1598,
+              "line": 1640,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4944,7 +4960,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1599,
+              "line": 1641,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4960,7 +4976,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1600,
+              "line": 1642,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4976,7 +4992,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1601,
+              "line": 1643,
               "authority": "LuaLS declaration"
             }
           ],
@@ -4992,7 +5008,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1602,
+              "line": 1644,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5008,7 +5024,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1603,
+              "line": 1645,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5024,7 +5040,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1604,
+              "line": 1646,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5037,7 +5053,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1596,
+          "line": 1638,
           "authority": "LuaLS declaration"
         }
       ],
@@ -5058,7 +5074,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1586,
+              "line": 1628,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5074,7 +5090,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1587,
+              "line": 1629,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5090,7 +5106,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1588,
+              "line": 1630,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5106,7 +5122,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1589,
+              "line": 1631,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5119,7 +5135,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1585,
+          "line": 1627,
           "authority": "LuaLS declaration"
         }
       ],
@@ -5136,7 +5152,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1606,
+          "line": 1648,
           "authority": "LuaLS declaration"
         }
       ],
@@ -5157,7 +5173,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4130,
+              "line": 4203,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5170,7 +5186,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4129,
+          "line": 4202,
           "authority": "LuaLS declaration"
         }
       ],
@@ -5191,7 +5207,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4133,
+              "line": 4206,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5207,7 +5223,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4134,
+              "line": 4207,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5223,7 +5239,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4135,
+              "line": 4208,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5239,7 +5255,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4136,
+              "line": 4209,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5255,7 +5271,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4137,
+              "line": 4210,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5271,7 +5287,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4138,
+              "line": 4211,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5287,7 +5303,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4139,
+              "line": 4212,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5303,7 +5319,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4140,
+              "line": 4213,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5319,7 +5335,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4141,
+              "line": 4214,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5335,7 +5351,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4142,
+              "line": 4215,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5351,7 +5367,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4143,
+              "line": 4216,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5367,7 +5383,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4144,
+              "line": 4217,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5383,7 +5399,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4145,
+              "line": 4218,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5396,7 +5412,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4132,
+          "line": 4205,
           "authority": "LuaLS declaration"
         }
       ],
@@ -5413,7 +5429,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4147,
+          "line": 4220,
           "authority": "LuaLS declaration"
         }
       ],
@@ -5434,7 +5450,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2083,
+              "line": 2156,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5450,7 +5466,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2084,
+              "line": 2157,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5466,7 +5482,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2085,
+              "line": 2158,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5482,7 +5498,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2086,
+              "line": 2159,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5498,7 +5514,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2087,
+              "line": 2160,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5514,7 +5530,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2088,
+              "line": 2161,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5530,7 +5546,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2089,
+              "line": 2162,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5546,7 +5562,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2090,
+              "line": 2163,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5562,7 +5578,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2091,
+              "line": 2164,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5578,7 +5594,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2092,
+              "line": 2165,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5591,7 +5607,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2082,
+          "line": 2155,
           "authority": "LuaLS declaration"
         }
       ],
@@ -5608,7 +5624,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2112,
+          "line": 2185,
           "authority": "LuaLS declaration"
         }
       ],
@@ -5625,7 +5641,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1942,
+          "line": 2015,
           "authority": "LuaLS declaration"
         }
       ],
@@ -5646,7 +5662,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1939,
+              "line": 2012,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5662,7 +5678,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1940,
+              "line": 2013,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5675,7 +5691,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1938,
+          "line": 2011,
           "authority": "LuaLS declaration"
         }
       ],
@@ -5696,7 +5712,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 451,
+              "line": 452,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5712,7 +5728,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 452,
+              "line": 453,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5728,7 +5744,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 453,
+              "line": 454,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5744,7 +5760,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 454,
+              "line": 455,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5760,7 +5776,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 455,
+              "line": 456,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5776,7 +5792,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 456,
+              "line": 457,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5792,7 +5808,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 457,
+              "line": 458,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5808,7 +5824,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 458,
+              "line": 459,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5824,7 +5840,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 459,
+              "line": 460,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5840,7 +5856,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 460,
+              "line": 461,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5856,7 +5872,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 461,
+              "line": 462,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5872,7 +5888,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 462,
+              "line": 463,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5888,7 +5904,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 463,
+              "line": 464,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5904,7 +5920,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 464,
+              "line": 465,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5920,7 +5936,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 465,
+              "line": 466,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5936,7 +5952,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 466,
+              "line": 467,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5952,7 +5968,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 467,
+              "line": 468,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5968,7 +5984,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 468,
+              "line": 469,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5984,7 +6000,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 469,
+              "line": 470,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6000,7 +6016,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 470,
+              "line": 471,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6016,7 +6032,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 471,
+              "line": 472,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6032,7 +6048,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 472,
+              "line": 473,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6048,7 +6064,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 473,
+              "line": 474,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6064,7 +6080,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 474,
+              "line": 475,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6080,7 +6096,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 475,
+              "line": 476,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6096,7 +6112,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 476,
+              "line": 477,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6112,7 +6128,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 477,
+              "line": 478,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6128,7 +6144,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 478,
+              "line": 479,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6144,7 +6160,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 479,
+              "line": 480,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6160,7 +6176,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 480,
+              "line": 481,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6176,7 +6192,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 481,
+              "line": 482,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6192,7 +6208,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 482,
+              "line": 483,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6208,7 +6224,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 483,
+              "line": 484,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6224,7 +6240,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 484,
+              "line": 485,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6240,7 +6256,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 485,
+              "line": 486,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6256,7 +6272,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 486,
+              "line": 487,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6272,7 +6288,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 487,
+              "line": 488,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6285,7 +6301,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 450,
+          "line": 451,
           "authority": "LuaLS declaration"
         }
       ],
@@ -6306,7 +6322,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2701,
+              "line": 2774,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6322,7 +6338,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2702,
+              "line": 2775,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6335,7 +6351,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2700,
+          "line": 2773,
           "authority": "LuaLS declaration"
         }
       ],
@@ -6352,7 +6368,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2704,
+          "line": 2777,
           "authority": "LuaLS declaration"
         }
       ],
@@ -6373,7 +6389,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1308,
+              "line": 1309,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6389,7 +6405,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1309,
+              "line": 1310,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6405,7 +6421,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1310,
+              "line": 1311,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6421,7 +6437,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1311,
+              "line": 1312,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6437,7 +6453,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1312,
+              "line": 1313,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6453,7 +6469,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1313,
+              "line": 1314,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6469,7 +6485,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1314,
+              "line": 1315,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6485,7 +6501,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1315,
+              "line": 1316,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6501,7 +6517,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1316,
+              "line": 1317,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6514,7 +6530,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1307,
+          "line": 1308,
           "authority": "LuaLS declaration"
         }
       ],
@@ -6531,7 +6547,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2094,
+          "line": 2167,
           "authority": "LuaLS declaration"
         }
       ],
@@ -6552,7 +6568,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4338,
+              "line": 4411,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6568,7 +6584,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4339,
+              "line": 4412,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6584,7 +6600,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4340,
+              "line": 4413,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6600,7 +6616,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4341,
+              "line": 4414,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6616,7 +6632,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4342,
+              "line": 4415,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6632,7 +6648,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4343,
+              "line": 4416,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6648,7 +6664,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4344,
+              "line": 4417,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6664,7 +6680,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4345,
+              "line": 4418,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6680,7 +6696,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4346,
+              "line": 4419,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6696,7 +6712,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4347,
+              "line": 4420,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6712,7 +6728,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4348,
+              "line": 4421,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6728,7 +6744,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4349,
+              "line": 4422,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6744,7 +6760,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4350,
+              "line": 4423,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6760,7 +6776,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4351,
+              "line": 4424,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6773,7 +6789,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4337,
+          "line": 4410,
           "authority": "LuaLS declaration"
         }
       ],
@@ -6794,7 +6810,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3000,
+              "line": 3073,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6807,7 +6823,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2999,
+          "line": 3072,
           "authority": "LuaLS declaration"
         }
       ],
@@ -6824,7 +6840,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1814,
+          "line": 1887,
           "authority": "LuaLS declaration"
         }
       ],
@@ -6845,7 +6861,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1791,
+              "line": 1864,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6861,7 +6877,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1792,
+              "line": 1865,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6877,7 +6893,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1793,
+              "line": 1866,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6893,7 +6909,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1794,
+              "line": 1867,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6909,7 +6925,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1795,
+              "line": 1868,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6925,7 +6941,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1796,
+              "line": 1869,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6941,7 +6957,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1797,
+              "line": 1870,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6954,7 +6970,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1790,
+          "line": 1863,
           "authority": "LuaLS declaration"
         }
       ],
@@ -6975,7 +6991,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1841,
+              "line": 1914,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6991,7 +7007,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1842,
+              "line": 1915,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7007,7 +7023,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1843,
+              "line": 1916,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7023,7 +7039,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1844,
+              "line": 1917,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7039,7 +7055,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1845,
+              "line": 1918,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7055,7 +7071,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1846,
+              "line": 1919,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7071,7 +7087,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1847,
+              "line": 1920,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7084,7 +7100,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1840,
+          "line": 1913,
           "authority": "LuaLS declaration"
         }
       ],
@@ -7101,7 +7117,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1906,
+          "line": 1979,
           "authority": "LuaLS declaration"
         }
       ],
@@ -7122,7 +7138,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1869,
+              "line": 1942,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7138,7 +7154,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1870,
+              "line": 1943,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7154,7 +7170,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1871,
+              "line": 1944,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7170,7 +7186,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1872,
+              "line": 1945,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7186,7 +7202,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1873,
+              "line": 1946,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7202,7 +7218,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1874,
+              "line": 1947,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7218,7 +7234,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1875,
+              "line": 1948,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7234,7 +7250,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1876,
+              "line": 1949,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7250,7 +7266,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1877,
+              "line": 1950,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7266,7 +7282,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1878,
+              "line": 1951,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7279,7 +7295,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1868,
+          "line": 1941,
           "authority": "LuaLS declaration"
         }
       ],
@@ -7300,7 +7316,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1850,
+              "line": 1923,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7316,7 +7332,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1851,
+              "line": 1924,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7332,7 +7348,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1852,
+              "line": 1925,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7348,7 +7364,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1853,
+              "line": 1926,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7364,7 +7380,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1854,
+              "line": 1927,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7377,7 +7393,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1849,
+          "line": 1922,
           "authority": "LuaLS declaration"
         }
       ],
@@ -7398,7 +7414,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1864,
+              "line": 1937,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7414,7 +7430,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1865,
+              "line": 1938,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7430,7 +7446,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1866,
+              "line": 1939,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7443,7 +7459,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1863,
+          "line": 1936,
           "authority": "LuaLS declaration"
         }
       ],
@@ -7464,7 +7480,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1857,
+              "line": 1930,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7480,7 +7496,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1858,
+              "line": 1931,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7496,7 +7512,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1859,
+              "line": 1932,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7512,7 +7528,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1860,
+              "line": 1933,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7528,7 +7544,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1861,
+              "line": 1934,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7541,7 +7557,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1856,
+          "line": 1929,
           "authority": "LuaLS declaration"
         }
       ],
@@ -7562,7 +7578,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1897,
+              "line": 1970,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7578,7 +7594,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1898,
+              "line": 1971,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7594,7 +7610,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1899,
+              "line": 1972,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7610,7 +7626,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1900,
+              "line": 1973,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7626,7 +7642,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1901,
+              "line": 1974,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7642,7 +7658,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1902,
+              "line": 1975,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7658,7 +7674,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1903,
+              "line": 1976,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7674,7 +7690,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1904,
+              "line": 1977,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7687,7 +7703,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1896,
+          "line": 1969,
           "authority": "LuaLS declaration"
         }
       ],
@@ -7708,7 +7724,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1881,
+              "line": 1954,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7724,7 +7740,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1882,
+              "line": 1955,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7740,7 +7756,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1883,
+              "line": 1956,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7756,7 +7772,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1884,
+              "line": 1957,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7772,7 +7788,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1885,
+              "line": 1958,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7788,7 +7804,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1886,
+              "line": 1959,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7804,7 +7820,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1887,
+              "line": 1960,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7820,7 +7836,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1888,
+              "line": 1961,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7836,7 +7852,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1889,
+              "line": 1962,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7852,7 +7868,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1890,
+              "line": 1963,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7868,7 +7884,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1891,
+              "line": 1964,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7884,7 +7900,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1892,
+              "line": 1965,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7900,7 +7916,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1893,
+              "line": 1966,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7916,7 +7932,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1894,
+              "line": 1967,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7929,12 +7945,373 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1880,
+          "line": 1953,
           "authority": "LuaLS declaration"
         }
       ],
       "documentation": {
         "id": "api.lua.v5.generated.class.CcbDiagnosticsSource",
+        "status": "generated-contract-source"
+      }
+    },
+    {
+      "id": "CcbDialogueApi",
+      "kind": "record",
+      "declaration": "",
+      "fields": [],
+      "sources": [
+        {
+          "path": "data/lua/types/ccb_api_v5.d.lua",
+          "line": 1457,
+          "authority": "LuaLS declaration"
+        }
+      ],
+      "documentation": {
+        "id": "api.lua.v5.generated.class.CcbDialogueApi",
+        "status": "generated-contract-source"
+      }
+    },
+    {
+      "id": "CcbDialogueExtensionDescriptor",
+      "kind": "record",
+      "declaration": "",
+      "fields": [
+        {
+          "name": "id",
+          "optional": false,
+          "declaration": "string",
+          "sources": [
+            {
+              "path": "data/lua/types/ccb_api_v5.d.lua",
+              "line": 1443,
+              "authority": "LuaLS declaration"
+            }
+          ],
+          "documentation": {
+            "id": "api.lua.v5.generated.property.CcbDialogueExtensionDescriptor.id",
+            "status": "generated-contract-source"
+          }
+        },
+        {
+          "name": "insert_before_standard_exits",
+          "optional": true,
+          "declaration": "boolean",
+          "sources": [
+            {
+              "path": "data/lua/types/ccb_api_v5.d.lua",
+              "line": 1444,
+              "authority": "LuaLS declaration"
+            }
+          ],
+          "documentation": {
+            "id": "api.lua.v5.generated.property.CcbDialogueExtensionDescriptor.insert_before_standard_exits",
+            "status": "generated-contract-source"
+          }
+        },
+        {
+          "name": "responses",
+          "optional": false,
+          "declaration": "CcbDialogueResponses",
+          "sources": [
+            {
+              "path": "data/lua/types/ccb_api_v5.d.lua",
+              "line": 1445,
+              "authority": "LuaLS declaration"
+            }
+          ],
+          "documentation": {
+            "id": "api.lua.v5.generated.property.CcbDialogueExtensionDescriptor.responses",
+            "status": "generated-contract-source"
+          }
+        }
+      ],
+      "sources": [
+        {
+          "path": "data/lua/types/ccb_api_v5.d.lua",
+          "line": 1442,
+          "authority": "LuaLS declaration"
+        }
+      ],
+      "documentation": {
+        "id": "api.lua.v5.generated.class.CcbDialogueExtensionDescriptor",
+        "status": "generated-contract-source"
+      }
+    },
+    {
+      "id": "CcbDialogueLimits",
+      "kind": "record",
+      "declaration": "",
+      "fields": [
+        {
+          "name": "topics",
+          "optional": false,
+          "declaration": "integer",
+          "sources": [
+            {
+              "path": "data/lua/types/ccb_api_v5.d.lua",
+              "line": 1448,
+              "authority": "LuaLS declaration"
+            }
+          ],
+          "documentation": {
+            "id": "api.lua.v5.generated.property.CcbDialogueLimits.topics",
+            "status": "generated-contract-source"
+          }
+        },
+        {
+          "name": "topics_per_source",
+          "optional": false,
+          "declaration": "integer",
+          "sources": [
+            {
+              "path": "data/lua/types/ccb_api_v5.d.lua",
+              "line": 1449,
+              "authority": "LuaLS declaration"
+            }
+          ],
+          "documentation": {
+            "id": "api.lua.v5.generated.property.CcbDialogueLimits.topics_per_source",
+            "status": "generated-contract-source"
+          }
+        },
+        {
+          "name": "extensions",
+          "optional": false,
+          "declaration": "integer",
+          "sources": [
+            {
+              "path": "data/lua/types/ccb_api_v5.d.lua",
+              "line": 1450,
+              "authority": "LuaLS declaration"
+            }
+          ],
+          "documentation": {
+            "id": "api.lua.v5.generated.property.CcbDialogueLimits.extensions",
+            "status": "generated-contract-source"
+          }
+        },
+        {
+          "name": "extensions_per_source",
+          "optional": false,
+          "declaration": "integer",
+          "sources": [
+            {
+              "path": "data/lua/types/ccb_api_v5.d.lua",
+              "line": 1451,
+              "authority": "LuaLS declaration"
+            }
+          ],
+          "documentation": {
+            "id": "api.lua.v5.generated.property.CcbDialogueLimits.extensions_per_source",
+            "status": "generated-contract-source"
+          }
+        },
+        {
+          "name": "responses_per_topic",
+          "optional": false,
+          "declaration": "integer",
+          "sources": [
+            {
+              "path": "data/lua/types/ccb_api_v5.d.lua",
+              "line": 1452,
+              "authority": "LuaLS declaration"
+            }
+          ],
+          "documentation": {
+            "id": "api.lua.v5.generated.property.CcbDialogueLimits.responses_per_topic",
+            "status": "generated-contract-source"
+          }
+        },
+        {
+          "name": "id_bytes",
+          "optional": false,
+          "declaration": "integer",
+          "sources": [
+            {
+              "path": "data/lua/types/ccb_api_v5.d.lua",
+              "line": 1453,
+              "authority": "LuaLS declaration"
+            }
+          ],
+          "documentation": {
+            "id": "api.lua.v5.generated.property.CcbDialogueLimits.id_bytes",
+            "status": "generated-contract-source"
+          }
+        },
+        {
+          "name": "text_bytes",
+          "optional": false,
+          "declaration": "integer",
+          "sources": [
+            {
+              "path": "data/lua/types/ccb_api_v5.d.lua",
+              "line": 1454,
+              "authority": "LuaLS declaration"
+            }
+          ],
+          "documentation": {
+            "id": "api.lua.v5.generated.property.CcbDialogueLimits.text_bytes",
+            "status": "generated-contract-source"
+          }
+        },
+        {
+          "name": "callback_instructions",
+          "optional": false,
+          "declaration": "integer",
+          "sources": [
+            {
+              "path": "data/lua/types/ccb_api_v5.d.lua",
+              "line": 1455,
+              "authority": "LuaLS declaration"
+            }
+          ],
+          "documentation": {
+            "id": "api.lua.v5.generated.property.CcbDialogueLimits.callback_instructions",
+            "status": "generated-contract-source"
+          }
+        }
+      ],
+      "sources": [
+        {
+          "path": "data/lua/types/ccb_api_v5.d.lua",
+          "line": 1447,
+          "authority": "LuaLS declaration"
+        }
+      ],
+      "documentation": {
+        "id": "api.lua.v5.generated.class.CcbDialogueLimits",
+        "status": "generated-contract-source"
+      }
+    },
+    {
+      "id": "CcbDialogueResponseDescriptor",
+      "kind": "record",
+      "declaration": "",
+      "fields": [
+        {
+          "name": "text",
+          "optional": false,
+          "declaration": "string",
+          "sources": [
+            {
+              "path": "data/lua/types/ccb_api_v5.d.lua",
+              "line": 1431,
+              "authority": "LuaLS declaration"
+            }
+          ],
+          "documentation": {
+            "id": "api.lua.v5.generated.property.CcbDialogueResponseDescriptor.text",
+            "status": "generated-contract-source"
+          }
+        },
+        {
+          "name": "topic",
+          "optional": true,
+          "declaration": "string",
+          "sources": [
+            {
+              "path": "data/lua/types/ccb_api_v5.d.lua",
+              "line": 1432,
+              "authority": "LuaLS declaration"
+            }
+          ],
+          "documentation": {
+            "id": "api.lua.v5.generated.property.CcbDialogueResponseDescriptor.topic",
+            "status": "generated-contract-source"
+          }
+        },
+        {
+          "name": "on_select",
+          "optional": true,
+          "declaration": "fun(context: ScriptDialogueContext): string|table|nil",
+          "sources": [
+            {
+              "path": "data/lua/types/ccb_api_v5.d.lua",
+              "line": 1433,
+              "authority": "LuaLS declaration"
+            }
+          ],
+          "documentation": {
+            "id": "api.lua.v5.generated.property.CcbDialogueResponseDescriptor.on_select",
+            "status": "generated-contract-source"
+          }
+        }
+      ],
+      "sources": [
+        {
+          "path": "data/lua/types/ccb_api_v5.d.lua",
+          "line": 1430,
+          "authority": "LuaLS declaration"
+        }
+      ],
+      "documentation": {
+        "id": "api.lua.v5.generated.class.CcbDialogueResponseDescriptor",
+        "status": "generated-contract-source"
+      }
+    },
+    {
+      "id": "CcbDialogueTopicDescriptor",
+      "kind": "record",
+      "declaration": "",
+      "fields": [
+        {
+          "name": "id",
+          "optional": false,
+          "declaration": "string",
+          "sources": [
+            {
+              "path": "data/lua/types/ccb_api_v5.d.lua",
+              "line": 1438,
+              "authority": "LuaLS declaration"
+            }
+          ],
+          "documentation": {
+            "id": "api.lua.v5.generated.property.CcbDialogueTopicDescriptor.id",
+            "status": "generated-contract-source"
+          }
+        },
+        {
+          "name": "dynamic_line",
+          "optional": false,
+          "declaration": "string|fun(context: ScriptDialogueContext): string",
+          "sources": [
+            {
+              "path": "data/lua/types/ccb_api_v5.d.lua",
+              "line": 1439,
+              "authority": "LuaLS declaration"
+            }
+          ],
+          "documentation": {
+            "id": "api.lua.v5.generated.property.CcbDialogueTopicDescriptor.dynamic_line",
+            "status": "generated-contract-source"
+          }
+        },
+        {
+          "name": "responses",
+          "optional": false,
+          "declaration": "CcbDialogueResponses",
+          "sources": [
+            {
+              "path": "data/lua/types/ccb_api_v5.d.lua",
+              "line": 1440,
+              "authority": "LuaLS declaration"
+            }
+          ],
+          "documentation": {
+            "id": "api.lua.v5.generated.property.CcbDialogueTopicDescriptor.responses",
+            "status": "generated-contract-source"
+          }
+        }
+      ],
+      "sources": [
+        {
+          "path": "data/lua/types/ccb_api_v5.d.lua",
+          "line": 1437,
+          "authority": "LuaLS declaration"
+        }
+      ],
+      "documentation": {
+        "id": "api.lua.v5.generated.class.CcbDialogueTopicDescriptor",
         "status": "generated-contract-source"
       }
     },
@@ -7950,7 +8327,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2148,
+              "line": 2221,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7966,7 +8343,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2149,
+              "line": 2222,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7982,7 +8359,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2150,
+              "line": 2223,
               "authority": "LuaLS declaration"
             }
           ],
@@ -7998,7 +8375,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2151,
+              "line": 2224,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8011,7 +8388,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2147,
+          "line": 2220,
           "authority": "LuaLS declaration"
         }
       ],
@@ -8032,7 +8409,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1237,
+              "line": 1238,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8048,7 +8425,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1238,
+              "line": 1239,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8064,7 +8441,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1239,
+              "line": 1240,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8080,7 +8457,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1240,
+              "line": 1241,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8096,7 +8473,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1241,
+              "line": 1242,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8112,7 +8489,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1242,
+              "line": 1243,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8128,7 +8505,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1243,
+              "line": 1244,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8141,7 +8518,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1236,
+          "line": 1237,
           "authority": "LuaLS declaration"
         }
       ],
@@ -8162,7 +8539,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2154,
+              "line": 2227,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8178,7 +8555,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2155,
+              "line": 2228,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8194,7 +8571,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2156,
+              "line": 2229,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8210,7 +8587,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2157,
+              "line": 2230,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8223,7 +8600,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2153,
+          "line": 2226,
           "authority": "LuaLS declaration"
         }
       ],
@@ -8240,7 +8617,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2159,
+          "line": 2232,
           "authority": "LuaLS declaration"
         }
       ],
@@ -8261,7 +8638,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 545,
+              "line": 546,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8277,7 +8654,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 546,
+              "line": 547,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8293,7 +8670,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 547,
+              "line": 548,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8309,7 +8686,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 548,
+              "line": 549,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8325,7 +8702,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 549,
+              "line": 550,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8341,7 +8718,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 550,
+              "line": 551,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8354,7 +8731,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 544,
+          "line": 545,
           "authority": "LuaLS declaration"
         }
       ],
@@ -8375,7 +8752,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 553,
+              "line": 554,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8391,7 +8768,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 554,
+              "line": 555,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8407,7 +8784,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 555,
+              "line": 556,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8423,7 +8800,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 556,
+              "line": 557,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8439,7 +8816,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 557,
+              "line": 558,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8455,7 +8832,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 558,
+              "line": 559,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8471,7 +8848,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 559,
+              "line": 560,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8484,7 +8861,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 552,
+          "line": 553,
           "authority": "LuaLS declaration"
         }
       ],
@@ -8501,7 +8878,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 561,
+          "line": 562,
           "authority": "LuaLS declaration"
         }
       ],
@@ -8522,7 +8899,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3530,
+              "line": 3603,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8538,7 +8915,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3531,
+              "line": 3604,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8554,7 +8931,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3532,
+              "line": 3605,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8570,7 +8947,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3533,
+              "line": 3606,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8586,7 +8963,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3534,
+              "line": 3607,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8602,7 +8979,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3535,
+              "line": 3608,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8618,7 +8995,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3536,
+              "line": 3609,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8634,7 +9011,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3537,
+              "line": 3610,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8650,7 +9027,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3538,
+              "line": 3611,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8666,7 +9043,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3539,
+              "line": 3612,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8679,7 +9056,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3529,
+          "line": 3602,
           "authority": "LuaLS declaration"
         }
       ],
@@ -8700,7 +9077,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3547,
+              "line": 3620,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8716,7 +9093,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3548,
+              "line": 3621,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8732,7 +9109,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3549,
+              "line": 3622,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8748,7 +9125,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3550,
+              "line": 3623,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8761,7 +9138,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3546,
+          "line": 3619,
           "authority": "LuaLS declaration"
         }
       ],
@@ -8782,7 +9159,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3542,
+              "line": 3615,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8798,7 +9175,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3543,
+              "line": 3616,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8814,7 +9191,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3544,
+              "line": 3617,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8827,7 +9204,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3541,
+          "line": 3614,
           "authority": "LuaLS declaration"
         }
       ],
@@ -8848,7 +9225,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3526,
+              "line": 3599,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8864,7 +9241,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3527,
+              "line": 3600,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8877,7 +9254,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3525,
+          "line": 3598,
           "authority": "LuaLS declaration"
         }
       ],
@@ -8894,7 +9271,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3552,
+          "line": 3625,
           "authority": "LuaLS declaration"
         }
       ],
@@ -8915,7 +9292,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 302,
+              "line": 303,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8931,7 +9308,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 303,
+              "line": 304,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8944,7 +9321,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 301,
+          "line": 302,
           "authority": "LuaLS declaration"
         }
       ],
@@ -8965,7 +9342,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 922,
+              "line": 923,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8981,7 +9358,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 923,
+              "line": 924,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8997,7 +9374,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 924,
+              "line": 925,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9013,7 +9390,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 925,
+              "line": 926,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9026,7 +9403,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 921,
+          "line": 922,
           "authority": "LuaLS declaration"
         }
       ],
@@ -9047,7 +9424,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 918,
+              "line": 919,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9063,7 +9440,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 919,
+              "line": 920,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9076,7 +9453,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 917,
+          "line": 918,
           "authority": "LuaLS declaration"
         }
       ],
@@ -9093,7 +9470,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 942,
+          "line": 943,
           "authority": "LuaLS declaration"
         }
       ],
@@ -9114,7 +9491,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4016,
+              "line": 4089,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9130,7 +9507,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4017,
+              "line": 4090,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9146,7 +9523,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4018,
+              "line": 4091,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9162,7 +9539,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4019,
+              "line": 4092,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9175,7 +9552,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4015,
+          "line": 4088,
           "authority": "LuaLS declaration"
         }
       ],
@@ -9196,7 +9573,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4046,
+              "line": 4119,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9212,7 +9589,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4047,
+              "line": 4120,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9225,7 +9602,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4045,
+          "line": 4118,
           "authority": "LuaLS declaration"
         }
       ],
@@ -9246,7 +9623,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4050,
+              "line": 4123,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9262,7 +9639,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4051,
+              "line": 4124,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9278,7 +9655,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4052,
+              "line": 4125,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9294,7 +9671,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4053,
+              "line": 4126,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9310,7 +9687,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4054,
+              "line": 4127,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9326,7 +9703,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4055,
+              "line": 4128,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9342,7 +9719,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4056,
+              "line": 4129,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9358,7 +9735,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4057,
+              "line": 4130,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9371,7 +9748,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4049,
+          "line": 4122,
           "authority": "LuaLS declaration"
         }
       ],
@@ -9392,7 +9769,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4001,
+              "line": 4074,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9408,7 +9785,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4002,
+              "line": 4075,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9424,7 +9801,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4003,
+              "line": 4076,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9440,7 +9817,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4004,
+              "line": 4077,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9456,7 +9833,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4005,
+              "line": 4078,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9469,7 +9846,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4000,
+          "line": 4073,
           "authority": "LuaLS declaration"
         }
       ],
@@ -9490,7 +9867,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4036,
+              "line": 4109,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9506,7 +9883,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4037,
+              "line": 4110,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9522,7 +9899,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4038,
+              "line": 4111,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9535,7 +9912,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4035,
+          "line": 4108,
           "authority": "LuaLS declaration"
         }
       ],
@@ -9556,7 +9933,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4041,
+              "line": 4114,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9572,7 +9949,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4042,
+              "line": 4115,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9588,7 +9965,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4043,
+              "line": 4116,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9601,7 +9978,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4040,
+          "line": 4113,
           "authority": "LuaLS declaration"
         }
       ],
@@ -9622,7 +9999,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4008,
+              "line": 4081,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9638,7 +10015,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4009,
+              "line": 4082,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9654,7 +10031,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4010,
+              "line": 4083,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9670,7 +10047,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4011,
+              "line": 4084,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9686,7 +10063,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4012,
+              "line": 4085,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9702,7 +10079,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4013,
+              "line": 4086,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9715,7 +10092,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4007,
+          "line": 4080,
           "authority": "LuaLS declaration"
         }
       ],
@@ -9736,7 +10113,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4022,
+              "line": 4095,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9752,7 +10129,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4023,
+              "line": 4096,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9768,7 +10145,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4024,
+              "line": 4097,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9784,7 +10161,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4025,
+              "line": 4098,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9800,7 +10177,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4026,
+              "line": 4099,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9816,7 +10193,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4027,
+              "line": 4100,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9832,7 +10209,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4028,
+              "line": 4101,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9848,7 +10225,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4029,
+              "line": 4102,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9864,7 +10241,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4030,
+              "line": 4103,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9880,7 +10257,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4031,
+              "line": 4104,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9896,7 +10273,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4032,
+              "line": 4105,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9912,7 +10289,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4033,
+              "line": 4106,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9925,7 +10302,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4021,
+          "line": 4094,
           "authority": "LuaLS declaration"
         }
       ],
@@ -9942,7 +10319,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4059,
+          "line": 4132,
           "authority": "LuaLS declaration"
         }
       ],
@@ -9959,7 +10336,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2050,
+          "line": 2123,
           "authority": "LuaLS declaration"
         }
       ],
@@ -9976,7 +10353,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1367,
+          "line": 1368,
           "authority": "LuaLS declaration"
         }
       ],
@@ -9997,7 +10374,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4474,
+              "line": 4547,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10013,7 +10390,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4475,
+              "line": 4548,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10029,7 +10406,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4476,
+              "line": 4549,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10045,7 +10422,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4477,
+              "line": 4550,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10061,12 +10438,28 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4478,
+              "line": 4551,
               "authority": "LuaLS declaration"
             }
           ],
           "documentation": {
             "id": "api.lua.v5.generated.property.CcbGameApi.addictions",
+            "status": "generated-contract-source"
+          }
+        },
+        {
+          "name": "dialogue",
+          "optional": false,
+          "declaration": "CcbDialogueApi",
+          "sources": [
+            {
+              "path": "data/lua/types/ccb_api_v5.d.lua",
+              "line": 4552,
+              "authority": "LuaLS declaration"
+            }
+          ],
+          "documentation": {
+            "id": "api.lua.v5.generated.property.CcbGameApi.dialogue",
             "status": "generated-contract-source"
           }
         },
@@ -10077,7 +10470,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4479,
+              "line": 4553,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10093,7 +10486,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4480,
+              "line": 4554,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10109,7 +10502,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4481,
+              "line": 4555,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10125,7 +10518,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4482,
+              "line": 4556,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10141,7 +10534,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4483,
+              "line": 4557,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10157,7 +10550,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4484,
+              "line": 4558,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10173,7 +10566,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4485,
+              "line": 4559,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10189,7 +10582,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4486,
+              "line": 4560,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10205,7 +10598,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4487,
+              "line": 4561,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10221,7 +10614,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4488,
+              "line": 4562,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10237,7 +10630,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4489,
+              "line": 4563,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10253,7 +10646,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4490,
+              "line": 4564,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10269,7 +10662,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4491,
+              "line": 4565,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10285,7 +10678,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4492,
+              "line": 4566,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10301,7 +10694,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4493,
+              "line": 4567,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10317,7 +10710,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4494,
+              "line": 4568,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10333,7 +10726,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4495,
+              "line": 4569,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10349,7 +10742,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4496,
+              "line": 4570,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10365,7 +10758,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4497,
+              "line": 4571,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10381,7 +10774,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4498,
+              "line": 4572,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10397,7 +10790,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4499,
+              "line": 4573,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10413,7 +10806,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4500,
+              "line": 4574,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10429,7 +10822,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4501,
+              "line": 4575,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10445,7 +10838,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4502,
+              "line": 4576,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10461,7 +10854,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4503,
+              "line": 4577,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10477,7 +10870,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4504,
+              "line": 4578,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10493,7 +10886,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4505,
+              "line": 4579,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10509,7 +10902,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4506,
+              "line": 4580,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10525,7 +10918,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4507,
+              "line": 4581,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10541,7 +10934,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4508,
+              "line": 4582,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10557,7 +10950,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4509,
+              "line": 4583,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10573,7 +10966,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4510,
+              "line": 4584,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10589,7 +10982,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4511,
+              "line": 4585,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10605,7 +10998,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4512,
+              "line": 4586,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10621,7 +11014,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4513,
+              "line": 4587,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10637,7 +11030,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4514,
+              "line": 4588,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10653,7 +11046,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4515,
+              "line": 4589,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10669,7 +11062,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4516,
+              "line": 4590,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10685,7 +11078,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4517,
+              "line": 4591,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10701,7 +11094,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4518,
+              "line": 4592,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10717,7 +11110,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4519,
+              "line": 4593,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10733,7 +11126,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4520,
+              "line": 4594,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10749,7 +11142,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4521,
+              "line": 4595,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10765,7 +11158,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4522,
+              "line": 4596,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10781,7 +11174,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4523,
+              "line": 4597,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10797,7 +11190,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4524,
+              "line": 4598,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10813,7 +11206,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4525,
+              "line": 4599,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10829,7 +11222,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4526,
+              "line": 4600,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10845,7 +11238,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4527,
+              "line": 4601,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10861,7 +11254,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4528,
+              "line": 4602,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10877,7 +11270,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4529,
+              "line": 4603,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10893,7 +11286,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4530,
+              "line": 4604,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10906,7 +11299,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4473,
+          "line": 4546,
           "authority": "LuaLS declaration"
         }
       ],
@@ -10927,7 +11320,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2344,
+              "line": 2417,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10940,7 +11333,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2343,
+          "line": 2416,
           "authority": "LuaLS declaration"
         }
       ],
@@ -10961,7 +11354,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3343,
+              "line": 3416,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10977,7 +11370,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3344,
+              "line": 3417,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10990,7 +11383,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3342,
+          "line": 3415,
           "authority": "LuaLS declaration"
         }
       ],
@@ -11011,7 +11404,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2033,
+              "line": 2106,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11027,7 +11420,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2034,
+              "line": 2107,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11040,7 +11433,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2032,
+          "line": 2105,
           "authority": "LuaLS declaration"
         }
       ],
@@ -11061,7 +11454,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 294,
+              "line": 295,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11077,7 +11470,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 295,
+              "line": 296,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11093,7 +11486,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 296,
+              "line": 297,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11109,7 +11502,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 297,
+              "line": 298,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11125,7 +11518,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 298,
+              "line": 299,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11141,7 +11534,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 299,
+              "line": 300,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11154,7 +11547,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 293,
+          "line": 294,
           "authority": "LuaLS declaration"
         }
       ],
@@ -11171,7 +11564,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3596,
+          "line": 3669,
           "authority": "LuaLS declaration"
         }
       ],
@@ -11188,7 +11581,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 607,
+          "line": 608,
           "authority": "LuaLS declaration"
         }
       ],
@@ -11209,7 +11602,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3351,
+              "line": 3424,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11225,7 +11618,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3352,
+              "line": 3425,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11238,7 +11631,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3350,
+          "line": 3423,
           "authority": "LuaLS declaration"
         }
       ],
@@ -11259,7 +11652,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3355,
+              "line": 3428,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11275,7 +11668,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3356,
+              "line": 3429,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11288,7 +11681,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3354,
+          "line": 3427,
           "authority": "LuaLS declaration"
         }
       ],
@@ -11309,7 +11702,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1507,
+              "line": 1549,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11325,7 +11718,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1508,
+              "line": 1550,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11341,7 +11734,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1509,
+              "line": 1551,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11357,7 +11750,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1510,
+              "line": 1552,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11373,7 +11766,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1511,
+              "line": 1553,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11389,7 +11782,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1512,
+              "line": 1554,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11405,7 +11798,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1513,
+              "line": 1555,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11418,7 +11811,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1506,
+          "line": 1548,
           "authority": "LuaLS declaration"
         }
       ],
@@ -11439,7 +11832,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1495,
+              "line": 1537,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11455,7 +11848,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1496,
+              "line": 1538,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11468,7 +11861,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1494,
+          "line": 1536,
           "authority": "LuaLS declaration"
         }
       ],
@@ -11489,7 +11882,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1516,
+              "line": 1558,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11505,7 +11898,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1517,
+              "line": 1559,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11518,7 +11911,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1515,
+          "line": 1557,
           "authority": "LuaLS declaration"
         }
       ],
@@ -11539,7 +11932,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1499,
+              "line": 1541,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11555,7 +11948,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1500,
+              "line": 1542,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11571,7 +11964,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1501,
+              "line": 1543,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11587,7 +11980,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1502,
+              "line": 1544,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11603,7 +11996,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1503,
+              "line": 1545,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11619,7 +12012,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1504,
+              "line": 1546,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11632,7 +12025,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1498,
+          "line": 1540,
           "authority": "LuaLS declaration"
         }
       ],
@@ -11649,7 +12042,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1522,
+          "line": 1564,
           "authority": "LuaLS declaration"
         }
       ],
@@ -11670,7 +12063,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2892,
+              "line": 2965,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11686,7 +12079,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2893,
+              "line": 2966,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11702,7 +12095,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2894,
+              "line": 2967,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11718,7 +12111,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2895,
+              "line": 2968,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11731,7 +12124,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2891,
+          "line": 2964,
           "authority": "LuaLS declaration"
         }
       ],
@@ -11748,7 +12141,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2915,
+          "line": 2988,
           "authority": "LuaLS declaration"
         }
       ],
@@ -11765,7 +12158,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1106,
+          "line": 1107,
           "authority": "LuaLS declaration"
         }
       ],
@@ -11786,7 +12179,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1326,
+              "line": 1327,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11802,7 +12195,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1327,
+              "line": 1328,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11818,7 +12211,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1328,
+              "line": 1329,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11834,7 +12227,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1329,
+              "line": 1330,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11850,7 +12243,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1330,
+              "line": 1331,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11866,7 +12259,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1331,
+              "line": 1332,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11879,7 +12272,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1325,
+          "line": 1326,
           "authority": "LuaLS declaration"
         }
       ],
@@ -11896,7 +12289,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2346,
+          "line": 2419,
           "authority": "LuaLS declaration"
         }
       ],
@@ -11917,7 +12310,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2337,
+              "line": 2410,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11933,7 +12326,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2338,
+              "line": 2411,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11949,7 +12342,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2339,
+              "line": 2412,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11965,7 +12358,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2340,
+              "line": 2413,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11981,7 +12374,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2341,
+              "line": 2414,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11994,7 +12387,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2336,
+          "line": 2409,
           "authority": "LuaLS declaration"
         }
       ],
@@ -12015,7 +12408,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2267,
+              "line": 2340,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12031,7 +12424,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2268,
+              "line": 2341,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12044,7 +12437,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2266,
+          "line": 2339,
           "authority": "LuaLS declaration"
         }
       ],
@@ -12061,7 +12454,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2264,
+          "line": 2337,
           "authority": "LuaLS declaration"
         }
       ],
@@ -12082,7 +12475,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1216,
+              "line": 1217,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12098,7 +12491,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1217,
+              "line": 1218,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12114,7 +12507,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1218,
+              "line": 1219,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12130,7 +12523,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1219,
+              "line": 1220,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12146,7 +12539,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1220,
+              "line": 1221,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12162,7 +12555,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1221,
+              "line": 1222,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12178,7 +12571,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1222,
+              "line": 1223,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12194,7 +12587,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1223,
+              "line": 1224,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12210,7 +12603,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1224,
+              "line": 1225,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12226,7 +12619,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1225,
+              "line": 1226,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12242,7 +12635,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1226,
+              "line": 1227,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12258,7 +12651,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1227,
+              "line": 1228,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12271,7 +12664,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1215,
+          "line": 1216,
           "authority": "LuaLS declaration"
         }
       ],
@@ -12292,7 +12685,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2271,
+              "line": 2344,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12308,7 +12701,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2272,
+              "line": 2345,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12324,7 +12717,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2273,
+              "line": 2346,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12337,7 +12730,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2270,
+          "line": 2343,
           "authority": "LuaLS declaration"
         }
       ],
@@ -12354,7 +12747,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2275,
+          "line": 2348,
           "authority": "LuaLS declaration"
         }
       ],
@@ -12375,7 +12768,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2446,
+              "line": 2519,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12391,7 +12784,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2447,
+              "line": 2520,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12407,7 +12800,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2448,
+              "line": 2521,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12420,7 +12813,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2445,
+          "line": 2518,
           "authority": "LuaLS declaration"
         }
       ],
@@ -12441,7 +12834,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2898,
+              "line": 2971,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12457,7 +12850,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2899,
+              "line": 2972,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12473,7 +12866,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2900,
+              "line": 2973,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12486,7 +12879,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2897,
+          "line": 2970,
           "authority": "LuaLS declaration"
         }
       ],
@@ -12507,7 +12900,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2903,
+              "line": 2976,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12523,7 +12916,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2904,
+              "line": 2977,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12539,7 +12932,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2905,
+              "line": 2978,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12555,7 +12948,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2906,
+              "line": 2979,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12571,7 +12964,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2907,
+              "line": 2980,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12587,7 +12980,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2908,
+              "line": 2981,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12603,7 +12996,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2909,
+              "line": 2982,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12616,7 +13009,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2902,
+          "line": 2975,
           "authority": "LuaLS declaration"
         }
       ],
@@ -12637,7 +13030,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2912,
+              "line": 2985,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12653,7 +13046,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2913,
+              "line": 2986,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12666,7 +13059,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2911,
+          "line": 2984,
           "authority": "LuaLS declaration"
         }
       ],
@@ -12687,7 +13080,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3583,
+              "line": 3656,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12703,7 +13096,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3584,
+              "line": 3657,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12719,7 +13112,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3585,
+              "line": 3658,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12735,7 +13128,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3586,
+              "line": 3659,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12751,7 +13144,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3587,
+              "line": 3660,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12767,7 +13160,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3588,
+              "line": 3661,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12783,7 +13176,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3589,
+              "line": 3662,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12799,7 +13192,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3590,
+              "line": 3663,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12815,7 +13208,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3591,
+              "line": 3664,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12831,7 +13224,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3592,
+              "line": 3665,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12847,7 +13240,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3593,
+              "line": 3666,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12863,7 +13256,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3594,
+              "line": 3667,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12876,7 +13269,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3582,
+          "line": 3655,
           "authority": "LuaLS declaration"
         }
       ],
@@ -12893,7 +13286,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1768,
+          "line": 1841,
           "authority": "LuaLS declaration"
         }
       ],
@@ -12914,7 +13307,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1750,
+              "line": 1823,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12930,7 +13323,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1751,
+              "line": 1824,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12946,7 +13339,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1752,
+              "line": 1825,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12959,7 +13352,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1749,
+          "line": 1822,
           "authority": "LuaLS declaration"
         }
       ],
@@ -12980,7 +13373,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1755,
+              "line": 1828,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12996,7 +13389,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1756,
+              "line": 1829,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13012,7 +13405,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1757,
+              "line": 1830,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13028,7 +13421,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1758,
+              "line": 1831,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13044,7 +13437,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1759,
+              "line": 1832,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13060,7 +13453,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1760,
+              "line": 1833,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13076,7 +13469,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1761,
+              "line": 1834,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13092,7 +13485,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1762,
+              "line": 1835,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13108,7 +13501,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1763,
+              "line": 1836,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13124,7 +13517,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1764,
+              "line": 1837,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13140,7 +13533,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1765,
+              "line": 1838,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13156,7 +13549,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1766,
+              "line": 1839,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13169,7 +13562,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1754,
+          "line": 1827,
           "authority": "LuaLS declaration"
         }
       ],
@@ -13190,7 +13583,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3438,
+              "line": 3511,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13206,7 +13599,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3439,
+              "line": 3512,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13222,7 +13615,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3440,
+              "line": 3513,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13238,7 +13631,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3441,
+              "line": 3514,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13254,7 +13647,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3442,
+              "line": 3515,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13270,7 +13663,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3443,
+              "line": 3516,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13286,7 +13679,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3444,
+              "line": 3517,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13302,7 +13695,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3445,
+              "line": 3518,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13318,7 +13711,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3446,
+              "line": 3519,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13334,7 +13727,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3447,
+              "line": 3520,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13350,7 +13743,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3448,
+              "line": 3521,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13366,7 +13759,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3449,
+              "line": 3522,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13382,7 +13775,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3450,
+              "line": 3523,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13398,7 +13791,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3451,
+              "line": 3524,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13414,7 +13807,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3452,
+              "line": 3525,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13430,7 +13823,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3453,
+              "line": 3526,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13446,7 +13839,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3454,
+              "line": 3527,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13462,7 +13855,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3455,
+              "line": 3528,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13475,7 +13868,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3437,
+          "line": 3510,
           "authority": "LuaLS declaration"
         }
       ],
@@ -13496,7 +13889,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3470,
+              "line": 3543,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13509,7 +13902,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3469,
+          "line": 3542,
           "authority": "LuaLS declaration"
         }
       ],
@@ -13530,7 +13923,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3458,
+              "line": 3531,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13546,7 +13939,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3459,
+              "line": 3532,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13562,7 +13955,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3460,
+              "line": 3533,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13578,7 +13971,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3461,
+              "line": 3534,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13594,7 +13987,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3462,
+              "line": 3535,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13610,7 +14003,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3463,
+              "line": 3536,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13626,7 +14019,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3464,
+              "line": 3537,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13642,7 +14035,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3465,
+              "line": 3538,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13658,7 +14051,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3466,
+              "line": 3539,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13674,7 +14067,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3467,
+              "line": 3540,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13687,7 +14080,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3457,
+          "line": 3530,
           "authority": "LuaLS declaration"
         }
       ],
@@ -13704,7 +14097,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3472,
+          "line": 3545,
           "authority": "LuaLS declaration"
         }
       ],
@@ -13725,7 +14118,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1917,
+              "line": 1990,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13741,7 +14134,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1918,
+              "line": 1991,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13754,7 +14147,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1916,
+          "line": 1989,
           "authority": "LuaLS declaration"
         }
       ],
@@ -13775,7 +14168,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1921,
+              "line": 1994,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13791,7 +14184,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1922,
+              "line": 1995,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13807,7 +14200,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1923,
+              "line": 1996,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13823,7 +14216,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1924,
+              "line": 1997,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13839,7 +14232,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1925,
+              "line": 1998,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13852,7 +14245,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1920,
+          "line": 1993,
           "authority": "LuaLS declaration"
         }
       ],
@@ -13869,7 +14262,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1927,
+          "line": 2000,
           "authority": "LuaLS declaration"
         }
       ],
@@ -13890,7 +14283,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2558,
+              "line": 2631,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13906,7 +14299,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2559,
+              "line": 2632,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13919,7 +14312,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2557,
+          "line": 2630,
           "authority": "LuaLS declaration"
         }
       ],
@@ -13940,7 +14333,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1282,
+              "line": 1283,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13956,7 +14349,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1283,
+              "line": 1284,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13972,7 +14365,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1284,
+              "line": 1285,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13988,7 +14381,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1285,
+              "line": 1286,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14004,7 +14397,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1286,
+              "line": 1287,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14020,7 +14413,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1287,
+              "line": 1288,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14036,7 +14429,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1288,
+              "line": 1289,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14052,7 +14445,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1289,
+              "line": 1290,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14068,7 +14461,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1290,
+              "line": 1291,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14084,7 +14477,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1291,
+              "line": 1292,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14100,7 +14493,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1292,
+              "line": 1293,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14116,7 +14509,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1293,
+              "line": 1294,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14129,7 +14522,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1281,
+          "line": 1282,
           "authority": "LuaLS declaration"
         }
       ],
@@ -14146,7 +14539,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2561,
+          "line": 2634,
           "authority": "LuaLS declaration"
         }
       ],
@@ -14163,7 +14556,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1052,
+          "line": 1053,
           "authority": "LuaLS declaration"
         }
       ],
@@ -14184,7 +14577,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1180,
+              "line": 1181,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14200,7 +14593,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1181,
+              "line": 1182,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14216,7 +14609,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1182,
+              "line": 1183,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14232,7 +14625,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1183,
+              "line": 1184,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14248,7 +14641,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1184,
+              "line": 1185,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14264,7 +14657,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1185,
+              "line": 1186,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14280,7 +14673,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1186,
+              "line": 1187,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14293,7 +14686,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1179,
+          "line": 1180,
           "authority": "LuaLS declaration"
         }
       ],
@@ -14314,7 +14707,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1189,
+              "line": 1190,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14330,7 +14723,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1190,
+              "line": 1191,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14346,7 +14739,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1191,
+              "line": 1192,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14362,7 +14755,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1192,
+              "line": 1193,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14375,7 +14768,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1188,
+          "line": 1189,
           "authority": "LuaLS declaration"
         }
       ],
@@ -14396,7 +14789,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2393,
+              "line": 2466,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14412,7 +14805,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2394,
+              "line": 2467,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14425,7 +14818,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2392,
+          "line": 2465,
           "authority": "LuaLS declaration"
         }
       ],
@@ -14446,7 +14839,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1258,
+              "line": 1259,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14462,7 +14855,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1259,
+              "line": 1260,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14478,7 +14871,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1260,
+              "line": 1261,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14494,7 +14887,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1261,
+              "line": 1262,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14510,7 +14903,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1262,
+              "line": 1263,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14526,7 +14919,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1263,
+              "line": 1264,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14542,7 +14935,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1264,
+              "line": 1265,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14558,7 +14951,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1265,
+              "line": 1266,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14574,7 +14967,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1266,
+              "line": 1267,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14587,7 +14980,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1257,
+          "line": 1258,
           "authority": "LuaLS declaration"
         }
       ],
@@ -14604,7 +14997,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2396,
+          "line": 2469,
           "authority": "LuaLS declaration"
         }
       ],
@@ -14625,7 +15018,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 933,
+              "line": 934,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14641,7 +15034,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 934,
+              "line": 935,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14657,7 +15050,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 935,
+              "line": 936,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14673,7 +15066,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 936,
+              "line": 937,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14686,7 +15079,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 932,
+          "line": 933,
           "authority": "LuaLS declaration"
         }
       ],
@@ -14707,7 +15100,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 928,
+              "line": 929,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14723,7 +15116,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 929,
+              "line": 930,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14739,7 +15132,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 930,
+              "line": 931,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14752,7 +15145,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 927,
+          "line": 928,
           "authority": "LuaLS declaration"
         }
       ],
@@ -14769,7 +15162,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 974,
+          "line": 975,
           "authority": "LuaLS declaration"
         }
       ],
@@ -14790,7 +15183,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3720,
+              "line": 3793,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14806,7 +15199,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3721,
+              "line": 3794,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14822,7 +15215,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3722,
+              "line": 3795,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14838,7 +15231,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3723,
+              "line": 3796,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14854,7 +15247,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3724,
+              "line": 3797,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14870,7 +15263,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3725,
+              "line": 3798,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14883,7 +15276,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3719,
+          "line": 3792,
           "authority": "LuaLS declaration"
         }
       ],
@@ -14904,7 +15297,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3003,
+              "line": 3076,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14920,7 +15313,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3004,
+              "line": 3077,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14936,7 +15329,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3005,
+              "line": 3078,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14952,7 +15345,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3006,
+              "line": 3079,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14968,7 +15361,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3007,
+              "line": 3080,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14984,7 +15377,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3008,
+              "line": 3081,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15000,7 +15393,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3009,
+              "line": 3082,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15016,7 +15409,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3010,
+              "line": 3083,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15032,7 +15425,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3011,
+              "line": 3084,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15048,7 +15441,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3012,
+              "line": 3085,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15061,7 +15454,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3002,
+          "line": 3075,
           "authority": "LuaLS declaration"
         }
       ],
@@ -15082,7 +15475,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3015,
+              "line": 3088,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15098,7 +15491,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3016,
+              "line": 3089,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15114,7 +15507,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3017,
+              "line": 3090,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15130,7 +15523,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3018,
+              "line": 3091,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15146,7 +15539,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3019,
+              "line": 3092,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15162,7 +15555,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3020,
+              "line": 3093,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15178,7 +15571,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3021,
+              "line": 3094,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15194,7 +15587,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3022,
+              "line": 3095,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15210,7 +15603,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3023,
+              "line": 3096,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15226,7 +15619,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3024,
+              "line": 3097,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15242,7 +15635,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3025,
+              "line": 3098,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15258,7 +15651,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3026,
+              "line": 3099,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15274,7 +15667,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3027,
+              "line": 3100,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15290,7 +15683,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3028,
+              "line": 3101,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15306,7 +15699,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3029,
+              "line": 3102,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15322,7 +15715,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3030,
+              "line": 3103,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15338,7 +15731,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3031,
+              "line": 3104,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15351,7 +15744,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3014,
+          "line": 3087,
           "authority": "LuaLS declaration"
         }
       ],
@@ -15372,7 +15765,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2076,
+              "line": 2149,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15388,7 +15781,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2077,
+              "line": 2150,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15404,7 +15797,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2078,
+              "line": 2151,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15420,7 +15813,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2079,
+              "line": 2152,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15436,7 +15829,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2080,
+              "line": 2153,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15449,7 +15842,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2075,
+          "line": 2148,
           "authority": "LuaLS declaration"
         }
       ],
@@ -15470,7 +15863,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3337,
+              "line": 3410,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15486,7 +15879,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3338,
+              "line": 3411,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15502,7 +15895,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3339,
+              "line": 3412,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15518,7 +15911,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3340,
+              "line": 3413,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15531,7 +15924,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3336,
+          "line": 3409,
           "authority": "LuaLS declaration"
         }
       ],
@@ -15548,7 +15941,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3358,
+          "line": 3431,
           "authority": "LuaLS declaration"
         }
       ],
@@ -15569,7 +15962,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3320,
+              "line": 3393,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15585,7 +15978,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3321,
+              "line": 3394,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15601,7 +15994,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3322,
+              "line": 3395,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15617,7 +16010,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3323,
+              "line": 3396,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15633,7 +16026,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3324,
+              "line": 3397,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15649,7 +16042,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3325,
+              "line": 3398,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15665,7 +16058,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3326,
+              "line": 3399,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15681,7 +16074,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3327,
+              "line": 3400,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15697,7 +16090,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3328,
+              "line": 3401,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15713,7 +16106,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3329,
+              "line": 3402,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15729,7 +16122,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3330,
+              "line": 3403,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15745,7 +16138,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3331,
+              "line": 3404,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15761,7 +16154,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3332,
+              "line": 3405,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15777,7 +16170,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3333,
+              "line": 3406,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15793,7 +16186,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3334,
+              "line": 3407,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15806,7 +16199,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3319,
+          "line": 3392,
           "authority": "LuaLS declaration"
         }
       ],
@@ -15827,7 +16220,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3909,
+              "line": 3982,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15843,7 +16236,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3910,
+              "line": 3983,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15859,7 +16252,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3911,
+              "line": 3984,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15875,7 +16268,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3912,
+              "line": 3985,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15891,7 +16284,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3913,
+              "line": 3986,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15907,7 +16300,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3914,
+              "line": 3987,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15923,7 +16316,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3915,
+              "line": 3988,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15939,7 +16332,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3916,
+              "line": 3989,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15955,7 +16348,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3917,
+              "line": 3990,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15971,7 +16364,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3918,
+              "line": 3991,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15987,7 +16380,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3919,
+              "line": 3992,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16000,7 +16393,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3908,
+          "line": 3981,
           "authority": "LuaLS declaration"
         }
       ],
@@ -16021,7 +16414,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3922,
+              "line": 3995,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16037,7 +16430,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3923,
+              "line": 3996,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16053,7 +16446,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3924,
+              "line": 3997,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16069,7 +16462,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3925,
+              "line": 3998,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16085,7 +16478,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3926,
+              "line": 3999,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16101,7 +16494,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3927,
+              "line": 4000,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16114,7 +16507,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3921,
+          "line": 3994,
           "authority": "LuaLS declaration"
         }
       ],
@@ -16135,7 +16528,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3959,
+              "line": 4032,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16151,7 +16544,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3960,
+              "line": 4033,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16167,7 +16560,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3961,
+              "line": 4034,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16183,7 +16576,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3962,
+              "line": 4035,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16199,7 +16592,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3963,
+              "line": 4036,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16215,7 +16608,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3964,
+              "line": 4037,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16228,7 +16621,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3958,
+          "line": 4031,
           "authority": "LuaLS declaration"
         }
       ],
@@ -16249,7 +16642,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3930,
+              "line": 4003,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16265,7 +16658,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3931,
+              "line": 4004,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16281,7 +16674,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3932,
+              "line": 4005,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16297,7 +16690,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3933,
+              "line": 4006,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16313,7 +16706,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3934,
+              "line": 4007,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16329,7 +16722,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3935,
+              "line": 4008,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16345,7 +16738,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3936,
+              "line": 4009,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16361,7 +16754,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3937,
+              "line": 4010,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16377,7 +16770,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3938,
+              "line": 4011,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16393,7 +16786,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3939,
+              "line": 4012,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16409,7 +16802,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3940,
+              "line": 4013,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16425,7 +16818,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3941,
+              "line": 4014,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16441,7 +16834,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3942,
+              "line": 4015,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16457,7 +16850,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3943,
+              "line": 4016,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16473,7 +16866,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3944,
+              "line": 4017,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16489,7 +16882,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3945,
+              "line": 4018,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16505,7 +16898,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3946,
+              "line": 4019,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16521,7 +16914,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3947,
+              "line": 4020,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16537,7 +16930,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3948,
+              "line": 4021,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16553,7 +16946,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3949,
+              "line": 4022,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16569,7 +16962,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3950,
+              "line": 4023,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16585,7 +16978,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3951,
+              "line": 4024,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16601,7 +16994,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3952,
+              "line": 4025,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16617,7 +17010,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3953,
+              "line": 4026,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16633,7 +17026,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3954,
+              "line": 4027,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16649,7 +17042,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3955,
+              "line": 4028,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16665,7 +17058,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3956,
+              "line": 4029,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16678,7 +17071,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3929,
+          "line": 4002,
           "authority": "LuaLS declaration"
         }
       ],
@@ -16695,7 +17088,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3966,
+          "line": 4039,
           "authority": "LuaLS declaration"
         }
       ],
@@ -16712,7 +17105,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2805,
+          "line": 2878,
           "authority": "LuaLS declaration"
         }
       ],
@@ -16733,7 +17126,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2797,
+              "line": 2870,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16749,7 +17142,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2798,
+              "line": 2871,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16765,7 +17158,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2799,
+              "line": 2872,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16781,7 +17174,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2800,
+              "line": 2873,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16797,7 +17190,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2801,
+              "line": 2874,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16813,7 +17206,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2802,
+              "line": 2875,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16829,7 +17222,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2803,
+              "line": 2876,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16842,7 +17235,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2796,
+          "line": 2869,
           "authority": "LuaLS declaration"
         }
       ],
@@ -16863,7 +17256,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2791,
+              "line": 2864,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16879,7 +17272,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2792,
+              "line": 2865,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16892,7 +17285,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2790,
+          "line": 2863,
           "authority": "LuaLS declaration"
         }
       ],
@@ -16913,7 +17306,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 614,
+              "line": 615,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16929,7 +17322,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 615,
+              "line": 616,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16945,7 +17338,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 616,
+              "line": 617,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16961,7 +17354,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 617,
+              "line": 618,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16974,7 +17367,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 613,
+          "line": 614,
           "authority": "LuaLS declaration"
         }
       ],
@@ -16995,7 +17388,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2199,
+              "line": 2272,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17011,7 +17404,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2200,
+              "line": 2273,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17024,7 +17417,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2198,
+          "line": 2271,
           "authority": "LuaLS declaration"
         }
       ],
@@ -17045,7 +17438,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1153,
+              "line": 1154,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17061,7 +17454,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1154,
+              "line": 1155,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17077,7 +17470,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1155,
+              "line": 1156,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17093,7 +17486,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1156,
+              "line": 1157,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17109,7 +17502,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1157,
+              "line": 1158,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17125,7 +17518,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1158,
+              "line": 1159,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17141,7 +17534,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1159,
+              "line": 1160,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17157,7 +17550,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1160,
+              "line": 1161,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17173,7 +17566,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1161,
+              "line": 1162,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17189,7 +17582,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1162,
+              "line": 1163,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17205,7 +17598,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1163,
+              "line": 1164,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17221,7 +17614,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1164,
+              "line": 1165,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17237,7 +17630,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1165,
+              "line": 1166,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17253,7 +17646,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1166,
+              "line": 1167,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17269,7 +17662,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1167,
+              "line": 1168,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17285,7 +17678,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1168,
+              "line": 1169,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17301,7 +17694,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1169,
+              "line": 1170,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17317,7 +17710,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1170,
+              "line": 1171,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17333,7 +17726,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1171,
+              "line": 1172,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17349,7 +17742,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1172,
+              "line": 1173,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17365,7 +17758,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1173,
+              "line": 1174,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17381,7 +17774,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1174,
+              "line": 1175,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17397,7 +17790,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1175,
+              "line": 1176,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17413,7 +17806,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1176,
+              "line": 1177,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17429,7 +17822,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1177,
+              "line": 1178,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17442,7 +17835,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1152,
+          "line": 1153,
           "authority": "LuaLS declaration"
         }
       ],
@@ -17459,7 +17852,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3135,
+          "line": 3208,
           "authority": "LuaLS declaration"
         }
       ],
@@ -17480,7 +17873,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3095,
+              "line": 3168,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17496,7 +17889,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3096,
+              "line": 3169,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17512,7 +17905,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3097,
+              "line": 3170,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17525,7 +17918,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3094,
+          "line": 3167,
           "authority": "LuaLS declaration"
         }
       ],
@@ -17546,7 +17939,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3100,
+              "line": 3173,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17562,7 +17955,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3101,
+              "line": 3174,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17578,7 +17971,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3102,
+              "line": 3175,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17594,7 +17987,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3103,
+              "line": 3176,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17610,7 +18003,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3104,
+              "line": 3177,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17626,7 +18019,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3105,
+              "line": 3178,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17642,7 +18035,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3106,
+              "line": 3179,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17658,7 +18051,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3107,
+              "line": 3180,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17674,7 +18067,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3108,
+              "line": 3181,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17690,7 +18083,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3109,
+              "line": 3182,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17706,7 +18099,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3110,
+              "line": 3183,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17722,7 +18115,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3111,
+              "line": 3184,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17738,7 +18131,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3112,
+              "line": 3185,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17751,7 +18144,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3099,
+          "line": 3172,
           "authority": "LuaLS declaration"
         }
       ],
@@ -17772,7 +18165,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3132,
+              "line": 3205,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17788,7 +18181,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3133,
+              "line": 3206,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17801,7 +18194,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3131,
+          "line": 3204,
           "authority": "LuaLS declaration"
         }
       ],
@@ -17822,7 +18215,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3127,
+              "line": 3200,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17838,7 +18231,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3128,
+              "line": 3201,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17854,7 +18247,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3129,
+              "line": 3202,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17867,7 +18260,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3126,
+          "line": 3199,
           "authority": "LuaLS declaration"
         }
       ],
@@ -17888,7 +18281,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3115,
+              "line": 3188,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17904,7 +18297,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3116,
+              "line": 3189,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17920,7 +18313,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3117,
+              "line": 3190,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17936,7 +18329,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3118,
+              "line": 3191,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17952,7 +18345,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3119,
+              "line": 3192,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17968,7 +18361,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3120,
+              "line": 3193,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17984,7 +18377,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3121,
+              "line": 3194,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18000,7 +18393,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3122,
+              "line": 3195,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18016,7 +18409,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3123,
+              "line": 3196,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18032,7 +18425,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3124,
+              "line": 3197,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18045,7 +18438,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3114,
+          "line": 3187,
           "authority": "LuaLS declaration"
         }
       ],
@@ -18066,7 +18459,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1334,
+              "line": 1335,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18082,7 +18475,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1335,
+              "line": 1336,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18098,7 +18491,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1336,
+              "line": 1337,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18114,7 +18507,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1337,
+              "line": 1338,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18130,7 +18523,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1338,
+              "line": 1339,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18146,7 +18539,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1339,
+              "line": 1340,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18162,7 +18555,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1340,
+              "line": 1341,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18178,7 +18571,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1341,
+              "line": 1342,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18191,7 +18584,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1333,
+          "line": 1334,
           "authority": "LuaLS declaration"
         }
       ],
@@ -18212,7 +18605,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 637,
+              "line": 638,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18228,7 +18621,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 638,
+              "line": 639,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18244,7 +18637,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 639,
+              "line": 640,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18260,7 +18653,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 640,
+              "line": 641,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18273,7 +18666,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 636,
+          "line": 637,
           "authority": "LuaLS declaration"
         }
       ],
@@ -18290,7 +18683,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1948,
+          "line": 2021,
           "authority": "LuaLS declaration"
         }
       ],
@@ -18311,7 +18704,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2635,
+              "line": 2708,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18327,7 +18720,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2636,
+              "line": 2709,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18343,7 +18736,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2637,
+              "line": 2710,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18359,7 +18752,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2638,
+              "line": 2711,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18375,7 +18768,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2639,
+              "line": 2712,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18391,7 +18784,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2640,
+              "line": 2713,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18407,7 +18800,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2641,
+              "line": 2714,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18420,7 +18813,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2634,
+          "line": 2707,
           "authority": "LuaLS declaration"
         }
       ],
@@ -18437,7 +18830,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2643,
+          "line": 2716,
           "authority": "LuaLS declaration"
         }
       ],
@@ -18454,7 +18847,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1087,
+          "line": 1088,
           "authority": "LuaLS declaration"
         }
       ],
@@ -18475,7 +18868,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1074,
+              "line": 1075,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18491,7 +18884,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1075,
+              "line": 1076,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18504,7 +18897,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1073,
+          "line": 1074,
           "authority": "LuaLS declaration"
         }
       ],
@@ -18525,7 +18918,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1070,
+              "line": 1071,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18541,7 +18934,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1071,
+              "line": 1072,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18554,7 +18947,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1069,
+          "line": 1070,
           "authority": "LuaLS declaration"
         }
       ],
@@ -18575,7 +18968,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1064,
+              "line": 1065,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18591,7 +18984,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1065,
+              "line": 1066,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18607,7 +19000,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1066,
+              "line": 1067,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18623,7 +19016,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1067,
+              "line": 1068,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18636,7 +19029,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1063,
+          "line": 1064,
           "authority": "LuaLS declaration"
         }
       ],
@@ -18657,7 +19050,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1078,
+              "line": 1079,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18673,7 +19066,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1079,
+              "line": 1080,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18689,7 +19082,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1080,
+              "line": 1081,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18705,7 +19098,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1081,
+              "line": 1082,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18721,7 +19114,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1082,
+              "line": 1083,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18737,7 +19130,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1083,
+              "line": 1084,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18753,7 +19146,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1084,
+              "line": 1085,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18769,7 +19162,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1085,
+              "line": 1086,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18782,7 +19175,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1077,
+          "line": 1078,
           "authority": "LuaLS declaration"
         }
       ],
@@ -18799,7 +19192,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2064,
+          "line": 2137,
           "authority": "LuaLS declaration"
         }
       ],
@@ -18820,7 +19213,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2678,
+              "line": 2751,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18833,7 +19226,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2677,
+          "line": 2750,
           "authority": "LuaLS declaration"
         }
       ],
@@ -18850,7 +19243,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2680,
+          "line": 2753,
           "authority": "LuaLS declaration"
         }
       ],
@@ -18871,7 +19264,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 306,
+              "line": 307,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18887,7 +19280,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 307,
+              "line": 308,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18903,7 +19296,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 308,
+              "line": 309,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18916,7 +19309,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 305,
+          "line": 306,
           "authority": "LuaLS declaration"
         }
       ],
@@ -18937,7 +19330,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4455,
+              "line": 4528,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18953,7 +19346,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4456,
+              "line": 4529,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18969,7 +19362,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4457,
+              "line": 4530,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18985,7 +19378,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4458,
+              "line": 4531,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19001,7 +19394,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4459,
+              "line": 4532,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19017,7 +19410,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4460,
+              "line": 4533,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19033,7 +19426,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4461,
+              "line": 4534,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19049,7 +19442,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4462,
+              "line": 4535,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19065,7 +19458,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4463,
+              "line": 4536,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19081,7 +19474,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4464,
+              "line": 4537,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19097,7 +19490,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4465,
+              "line": 4538,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19113,7 +19506,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4466,
+              "line": 4539,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19129,7 +19522,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4467,
+              "line": 4540,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19145,7 +19538,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4468,
+              "line": 4541,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19161,7 +19554,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4469,
+              "line": 4542,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19177,7 +19570,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4470,
+              "line": 4543,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19193,7 +19586,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4471,
+              "line": 4544,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19206,7 +19599,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4454,
+          "line": 4527,
           "authority": "LuaLS declaration"
         }
       ],
@@ -19223,7 +19616,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 999,
+          "line": 1000,
           "authority": "LuaLS declaration"
         }
       ],
@@ -19244,7 +19637,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 588,
+              "line": 589,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19260,7 +19653,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 589,
+              "line": 590,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19276,7 +19669,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 590,
+              "line": 591,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19292,7 +19685,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 591,
+              "line": 592,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19308,7 +19701,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 592,
+              "line": 593,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19324,7 +19717,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 593,
+              "line": 594,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19337,7 +19730,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 587,
+          "line": 588,
           "authority": "LuaLS declaration"
         }
       ],
@@ -19358,7 +19751,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1020,
+              "line": 1021,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19374,7 +19767,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1021,
+              "line": 1022,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19387,7 +19780,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1019,
+          "line": 1020,
           "authority": "LuaLS declaration"
         }
       ],
@@ -19408,7 +19801,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1024,
+              "line": 1025,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19424,7 +19817,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1025,
+              "line": 1026,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19440,7 +19833,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1026,
+              "line": 1027,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19456,7 +19849,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1027,
+              "line": 1028,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19469,7 +19862,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1023,
+          "line": 1024,
           "authority": "LuaLS declaration"
         }
       ],
@@ -19486,7 +19879,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1029,
+          "line": 1030,
           "authority": "LuaLS declaration"
         }
       ],
@@ -19503,7 +19896,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1467,
+          "line": 1509,
           "authority": "LuaLS declaration"
         }
       ],
@@ -19524,7 +19917,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1459,
+              "line": 1501,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19540,7 +19933,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1460,
+              "line": 1502,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19556,7 +19949,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1461,
+              "line": 1503,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19572,7 +19965,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1462,
+              "line": 1504,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19588,7 +19981,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1463,
+              "line": 1505,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19604,7 +19997,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1464,
+              "line": 1506,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19620,7 +20013,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1465,
+              "line": 1507,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19633,7 +20026,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1458,
+          "line": 1500,
           "authority": "LuaLS declaration"
         }
       ],
@@ -19654,7 +20047,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1430,
+              "line": 1472,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19670,7 +20063,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1431,
+              "line": 1473,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19683,7 +20076,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1429,
+          "line": 1471,
           "authority": "LuaLS declaration"
         }
       ],
@@ -19704,7 +20097,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1436,
+              "line": 1478,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19720,7 +20113,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1437,
+              "line": 1479,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19736,7 +20129,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1438,
+              "line": 1480,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19752,7 +20145,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1439,
+              "line": 1481,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19768,7 +20161,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1440,
+              "line": 1482,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19784,7 +20177,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1441,
+              "line": 1483,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19800,7 +20193,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1442,
+              "line": 1484,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19816,7 +20209,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1443,
+              "line": 1485,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19832,7 +20225,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1444,
+              "line": 1486,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19845,7 +20238,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1435,
+          "line": 1477,
           "authority": "LuaLS declaration"
         }
       ],
@@ -19866,7 +20259,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1447,
+              "line": 1489,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19882,7 +20275,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1448,
+              "line": 1490,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19898,7 +20291,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1449,
+              "line": 1491,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19914,7 +20307,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1450,
+              "line": 1492,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19930,7 +20323,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1451,
+              "line": 1493,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19946,7 +20339,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1452,
+              "line": 1494,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19962,7 +20355,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1453,
+              "line": 1495,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19978,7 +20371,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1454,
+              "line": 1496,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19994,7 +20387,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1455,
+              "line": 1497,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20010,7 +20403,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1456,
+              "line": 1498,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20023,7 +20416,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1446,
+          "line": 1488,
           "authority": "LuaLS declaration"
         }
       ],
@@ -20044,7 +20437,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3046,
+              "line": 3119,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20060,7 +20453,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3047,
+              "line": 3120,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20076,7 +20469,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3048,
+              "line": 3121,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20089,7 +20482,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3045,
+          "line": 3118,
           "authority": "LuaLS declaration"
         }
       ],
@@ -20110,7 +20503,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3034,
+              "line": 3107,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20126,7 +20519,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3035,
+              "line": 3108,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20142,7 +20535,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3036,
+              "line": 3109,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20158,7 +20551,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3037,
+              "line": 3110,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20174,7 +20567,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3038,
+              "line": 3111,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20190,7 +20583,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3039,
+              "line": 3112,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20203,7 +20596,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3033,
+          "line": 3106,
           "authority": "LuaLS declaration"
         }
       ],
@@ -20224,7 +20617,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3042,
+              "line": 3115,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20240,7 +20633,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3043,
+              "line": 3116,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20253,7 +20646,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3041,
+          "line": 3114,
           "authority": "LuaLS declaration"
         }
       ],
@@ -20274,7 +20667,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3051,
+              "line": 3124,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20290,7 +20683,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3052,
+              "line": 3125,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20303,7 +20696,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3050,
+          "line": 3123,
           "authority": "LuaLS declaration"
         }
       ],
@@ -20324,7 +20717,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1246,
+              "line": 1247,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20340,7 +20733,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1247,
+              "line": 1248,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20356,7 +20749,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1248,
+              "line": 1249,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20372,7 +20765,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1249,
+              "line": 1250,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20388,7 +20781,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1250,
+              "line": 1251,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20404,7 +20797,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1251,
+              "line": 1252,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20420,7 +20813,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1252,
+              "line": 1253,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20436,7 +20829,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1253,
+              "line": 1254,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20452,7 +20845,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1254,
+              "line": 1255,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20468,7 +20861,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1255,
+              "line": 1256,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20481,7 +20874,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1245,
+          "line": 1246,
           "authority": "LuaLS declaration"
         }
       ],
@@ -20498,7 +20891,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3054,
+          "line": 3127,
           "authority": "LuaLS declaration"
         }
       ],
@@ -20519,7 +20912,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3347,
+              "line": 3420,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20535,7 +20928,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3348,
+              "line": 3421,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20548,7 +20941,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3346,
+          "line": 3419,
           "authority": "LuaLS declaration"
         }
       ],
@@ -20565,7 +20958,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1972,
+          "line": 2045,
           "authority": "LuaLS declaration"
         }
       ],
@@ -20582,7 +20975,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2036,
+          "line": 2109,
           "authority": "LuaLS declaration"
         }
       ],
@@ -20599,7 +20992,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2450,
+          "line": 2523,
           "authority": "LuaLS declaration"
         }
       ],
@@ -20620,7 +21013,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1148,
+              "line": 1149,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20636,7 +21029,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1149,
+              "line": 1150,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20652,7 +21045,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1150,
+              "line": 1151,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20665,7 +21058,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1147,
+          "line": 1148,
           "authority": "LuaLS declaration"
         }
       ],
@@ -20682,7 +21075,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1134,
+          "line": 1135,
           "authority": "LuaLS declaration"
         }
       ],
@@ -20703,7 +21096,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3694,
+              "line": 3767,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20719,7 +21112,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3695,
+              "line": 3768,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20735,7 +21128,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3696,
+              "line": 3769,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20751,7 +21144,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3697,
+              "line": 3770,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20767,7 +21160,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3698,
+              "line": 3771,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20783,7 +21176,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3699,
+              "line": 3772,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20796,7 +21189,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3693,
+          "line": 3766,
           "authority": "LuaLS declaration"
         }
       ],
@@ -20817,7 +21210,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3709,
+              "line": 3782,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20833,7 +21226,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3710,
+              "line": 3783,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20849,7 +21242,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3711,
+              "line": 3784,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20865,7 +21258,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3712,
+              "line": 3785,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20878,7 +21271,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3708,
+          "line": 3781,
           "authority": "LuaLS declaration"
         }
       ],
@@ -20899,7 +21292,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3715,
+              "line": 3788,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20915,7 +21308,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3716,
+              "line": 3789,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20931,7 +21324,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3717,
+              "line": 3790,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20944,7 +21337,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3714,
+          "line": 3787,
           "authority": "LuaLS declaration"
         }
       ],
@@ -20965,7 +21358,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3702,
+              "line": 3775,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20981,7 +21374,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3703,
+              "line": 3776,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20997,7 +21390,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3704,
+              "line": 3777,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21013,7 +21406,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3705,
+              "line": 3778,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21029,7 +21422,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3706,
+              "line": 3779,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21042,7 +21435,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3701,
+          "line": 3774,
           "authority": "LuaLS declaration"
         }
       ],
@@ -21063,7 +21456,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3688,
+              "line": 3761,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21079,7 +21472,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3689,
+              "line": 3762,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21095,7 +21488,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3690,
+              "line": 3763,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21111,7 +21504,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3691,
+              "line": 3764,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21124,7 +21517,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3687,
+          "line": 3760,
           "authority": "LuaLS declaration"
         }
       ],
@@ -21141,7 +21534,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3727,
+          "line": 3800,
           "authority": "LuaLS declaration"
         }
       ],
@@ -21162,7 +21555,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1991,
+              "line": 2064,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21178,7 +21571,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1992,
+              "line": 2065,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21191,7 +21584,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1990,
+          "line": 2063,
           "authority": "LuaLS declaration"
         }
       ],
@@ -21208,7 +21601,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1994,
+          "line": 2067,
           "authority": "LuaLS declaration"
         }
       ],
@@ -21225,7 +21618,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 351,
+          "line": 352,
           "authority": "LuaLS declaration"
         }
       ],
@@ -21246,7 +21639,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 407,
+              "line": 408,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21262,7 +21655,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 408,
+              "line": 409,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21278,7 +21671,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 409,
+              "line": 410,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21294,7 +21687,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 410,
+              "line": 411,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21307,7 +21700,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 406,
+          "line": 407,
           "authority": "LuaLS declaration"
         }
       ],
@@ -21328,7 +21721,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 400,
+              "line": 401,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21344,7 +21737,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 401,
+              "line": 402,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21360,7 +21753,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 402,
+              "line": 403,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21376,7 +21769,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 403,
+              "line": 404,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21392,7 +21785,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 404,
+              "line": 405,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21405,7 +21798,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 399,
+          "line": 400,
           "authority": "LuaLS declaration"
         }
       ],
@@ -21426,7 +21819,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1195,
+              "line": 1196,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21442,7 +21835,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1196,
+              "line": 1197,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21458,7 +21851,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1197,
+              "line": 1198,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21474,7 +21867,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1198,
+              "line": 1199,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21490,7 +21883,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1199,
+              "line": 1200,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21506,7 +21899,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1200,
+              "line": 1201,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21522,7 +21915,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1201,
+              "line": 1202,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21538,7 +21931,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1202,
+              "line": 1203,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21551,7 +21944,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1194,
+          "line": 1195,
           "authority": "LuaLS declaration"
         }
       ],
@@ -21572,7 +21965,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1800,
+              "line": 1873,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21588,7 +21981,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1801,
+              "line": 1874,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21604,7 +21997,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1802,
+              "line": 1875,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21617,7 +22010,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1799,
+          "line": 1872,
           "authority": "LuaLS declaration"
         }
       ],
@@ -21638,7 +22031,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1805,
+              "line": 1878,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21654,7 +22047,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1806,
+              "line": 1879,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21670,7 +22063,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1807,
+              "line": 1880,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21686,7 +22079,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1808,
+              "line": 1881,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21702,7 +22095,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1809,
+              "line": 1882,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21718,7 +22111,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1810,
+              "line": 1883,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21734,7 +22127,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1811,
+              "line": 1884,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21750,7 +22143,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1812,
+              "line": 1885,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21763,7 +22156,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1804,
+          "line": 1877,
           "authority": "LuaLS declaration"
         }
       ],
@@ -21780,7 +22173,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 324,
+          "line": 325,
           "authority": "LuaLS declaration"
         }
       ],
@@ -21797,7 +22190,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 900,
+          "line": 901,
           "authority": "LuaLS declaration"
         }
       ],
@@ -21814,7 +22207,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 335,
+          "line": 336,
           "authority": "LuaLS declaration"
         }
       ],
@@ -21831,7 +22224,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3603,
+          "line": 3676,
           "authority": "LuaLS declaration"
         }
       ],
@@ -21852,7 +22245,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1962,
+              "line": 2035,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21868,7 +22261,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1963,
+              "line": 2036,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21884,7 +22277,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1964,
+              "line": 2037,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21897,7 +22290,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1961,
+          "line": 2034,
           "authority": "LuaLS declaration"
         }
       ],
@@ -21918,7 +22311,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3797,
+              "line": 3870,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21934,7 +22327,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3798,
+              "line": 3871,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21950,7 +22343,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3799,
+              "line": 3872,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21966,7 +22359,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3800,
+              "line": 3873,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21982,7 +22375,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3801,
+              "line": 3874,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21998,7 +22391,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3802,
+              "line": 3875,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22014,7 +22407,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3803,
+              "line": 3876,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22030,7 +22423,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3804,
+              "line": 3877,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22046,7 +22439,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3805,
+              "line": 3878,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22062,7 +22455,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3806,
+              "line": 3879,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22078,7 +22471,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3807,
+              "line": 3880,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22094,7 +22487,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3808,
+              "line": 3881,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22110,7 +22503,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3809,
+              "line": 3882,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22123,7 +22516,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3796,
+          "line": 3869,
           "authority": "LuaLS declaration"
         }
       ],
@@ -22144,7 +22537,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3782,
+              "line": 3855,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22160,7 +22553,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3783,
+              "line": 3856,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22176,7 +22569,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3784,
+              "line": 3857,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22192,7 +22585,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3785,
+              "line": 3858,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22208,7 +22601,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3786,
+              "line": 3859,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22224,7 +22617,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3787,
+              "line": 3860,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22240,7 +22633,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3788,
+              "line": 3861,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22256,7 +22649,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3789,
+              "line": 3862,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22272,7 +22665,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3790,
+              "line": 3863,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22288,7 +22681,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3791,
+              "line": 3864,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22304,7 +22697,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3792,
+              "line": 3865,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22320,7 +22713,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3793,
+              "line": 3866,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22336,7 +22729,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3794,
+              "line": 3867,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22349,7 +22742,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3781,
+          "line": 3854,
           "authority": "LuaLS declaration"
         }
       ],
@@ -22370,7 +22763,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3826,
+              "line": 3899,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22386,7 +22779,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3827,
+              "line": 3900,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22402,7 +22795,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3828,
+              "line": 3901,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22418,7 +22811,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3829,
+              "line": 3902,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22434,7 +22827,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3830,
+              "line": 3903,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22450,7 +22843,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3831,
+              "line": 3904,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22466,7 +22859,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3832,
+              "line": 3905,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22482,7 +22875,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3833,
+              "line": 3906,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22498,7 +22891,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3834,
+              "line": 3907,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22514,7 +22907,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3835,
+              "line": 3908,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22530,7 +22923,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3836,
+              "line": 3909,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22546,7 +22939,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3837,
+              "line": 3910,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22562,7 +22955,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3838,
+              "line": 3911,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22578,7 +22971,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3839,
+              "line": 3912,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22594,7 +22987,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3840,
+              "line": 3913,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22610,7 +23003,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3841,
+              "line": 3914,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22626,7 +23019,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3842,
+              "line": 3915,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22642,7 +23035,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3843,
+              "line": 3916,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22658,7 +23051,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3844,
+              "line": 3917,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22674,7 +23067,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3845,
+              "line": 3918,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22690,7 +23083,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3846,
+              "line": 3919,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22706,7 +23099,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3847,
+              "line": 3920,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22719,7 +23112,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3825,
+          "line": 3898,
           "authority": "LuaLS declaration"
         }
       ],
@@ -22740,7 +23133,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3850,
+              "line": 3923,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22756,7 +23149,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3851,
+              "line": 3924,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22769,7 +23162,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3849,
+          "line": 3922,
           "authority": "LuaLS declaration"
         }
       ],
@@ -22790,7 +23183,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3773,
+              "line": 3846,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22806,7 +23199,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3774,
+              "line": 3847,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22822,7 +23215,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3775,
+              "line": 3848,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22838,7 +23231,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3776,
+              "line": 3849,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22854,7 +23247,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3777,
+              "line": 3850,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22870,7 +23263,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3778,
+              "line": 3851,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22886,7 +23279,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3779,
+              "line": 3852,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22899,7 +23292,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3772,
+          "line": 3845,
           "authority": "LuaLS declaration"
         }
       ],
@@ -22920,7 +23313,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3812,
+              "line": 3885,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22936,7 +23329,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3813,
+              "line": 3886,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22952,7 +23345,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3814,
+              "line": 3887,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22968,7 +23361,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3815,
+              "line": 3888,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22984,7 +23377,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3816,
+              "line": 3889,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23000,7 +23393,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3817,
+              "line": 3890,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23016,7 +23409,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3818,
+              "line": 3891,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23032,7 +23425,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3819,
+              "line": 3892,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23048,7 +23441,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3820,
+              "line": 3893,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23064,7 +23457,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3821,
+              "line": 3894,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23080,7 +23473,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3822,
+              "line": 3895,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23096,7 +23489,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3823,
+              "line": 3896,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23109,7 +23502,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3811,
+          "line": 3884,
           "authority": "LuaLS declaration"
         }
       ],
@@ -23130,7 +23523,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3854,
+              "line": 3927,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23146,7 +23539,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3855,
+              "line": 3928,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23162,7 +23555,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3856,
+              "line": 3929,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23175,7 +23568,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3853,
+          "line": 3926,
           "authority": "LuaLS declaration"
         }
       ],
@@ -23192,7 +23585,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3858,
+          "line": 3931,
           "authority": "LuaLS declaration"
         }
       ],
@@ -23213,7 +23606,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3188,
+              "line": 3261,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23229,7 +23622,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3189,
+              "line": 3262,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23242,7 +23635,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3187,
+          "line": 3260,
           "authority": "LuaLS declaration"
         }
       ],
@@ -23263,7 +23656,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3192,
+              "line": 3265,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23279,7 +23672,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3193,
+              "line": 3266,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23295,7 +23688,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3194,
+              "line": 3267,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23311,7 +23704,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3195,
+              "line": 3268,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23327,7 +23720,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3196,
+              "line": 3269,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23343,7 +23736,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3197,
+              "line": 3270,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23359,7 +23752,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3198,
+              "line": 3271,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23375,7 +23768,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3199,
+              "line": 3272,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23391,7 +23784,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3200,
+              "line": 3273,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23407,7 +23800,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3201,
+              "line": 3274,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23420,7 +23813,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3191,
+          "line": 3264,
           "authority": "LuaLS declaration"
         }
       ],
@@ -23441,7 +23834,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3204,
+              "line": 3277,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23457,7 +23850,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3205,
+              "line": 3278,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23473,7 +23866,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3206,
+              "line": 3279,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23489,7 +23882,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3207,
+              "line": 3280,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23505,7 +23898,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3208,
+              "line": 3281,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23521,7 +23914,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3209,
+              "line": 3282,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23537,7 +23930,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3210,
+              "line": 3283,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23553,7 +23946,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3211,
+              "line": 3284,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23569,7 +23962,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3212,
+              "line": 3285,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23582,7 +23975,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3203,
+          "line": 3276,
           "authority": "LuaLS declaration"
         }
       ],
@@ -23599,7 +23992,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3214,
+          "line": 3287,
           "authority": "LuaLS declaration"
         }
       ],
@@ -23616,7 +24009,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4406,
+          "line": 4479,
           "authority": "LuaLS declaration"
         }
       ],
@@ -23637,7 +24030,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4383,
+              "line": 4456,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23653,7 +24046,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4384,
+              "line": 4457,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23669,7 +24062,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4385,
+              "line": 4458,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23685,7 +24078,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4386,
+              "line": 4459,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23701,7 +24094,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4387,
+              "line": 4460,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23717,7 +24110,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4388,
+              "line": 4461,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23733,7 +24126,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4389,
+              "line": 4462,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23746,7 +24139,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4382,
+          "line": 4455,
           "authority": "LuaLS declaration"
         }
       ],
@@ -23767,7 +24160,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4376,
+              "line": 4449,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23783,7 +24176,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4377,
+              "line": 4450,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23799,7 +24192,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4378,
+              "line": 4451,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23815,7 +24208,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4379,
+              "line": 4452,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23831,7 +24224,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4380,
+              "line": 4453,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23844,7 +24237,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4375,
+          "line": 4448,
           "authority": "LuaLS declaration"
         }
       ],
@@ -23865,7 +24258,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4358,
+              "line": 4431,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23881,7 +24274,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4359,
+              "line": 4432,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23897,7 +24290,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4360,
+              "line": 4433,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23913,7 +24306,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4361,
+              "line": 4434,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23929,7 +24322,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4362,
+              "line": 4435,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23945,7 +24338,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4363,
+              "line": 4436,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23961,7 +24354,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4364,
+              "line": 4437,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23977,7 +24370,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4365,
+              "line": 4438,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23993,7 +24386,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4366,
+              "line": 4439,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24009,7 +24402,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4367,
+              "line": 4440,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24025,7 +24418,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4368,
+              "line": 4441,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24041,7 +24434,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4369,
+              "line": 4442,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24054,7 +24447,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4357,
+          "line": 4430,
           "authority": "LuaLS declaration"
         }
       ],
@@ -24075,7 +24468,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4398,
+              "line": 4471,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24091,7 +24484,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4399,
+              "line": 4472,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24107,7 +24500,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4400,
+              "line": 4473,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24123,7 +24516,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4401,
+              "line": 4474,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24139,7 +24532,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4402,
+              "line": 4475,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24155,7 +24548,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4403,
+              "line": 4476,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24171,7 +24564,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4404,
+              "line": 4477,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24184,7 +24577,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4397,
+          "line": 4470,
           "authority": "LuaLS declaration"
         }
       ],
@@ -24205,7 +24598,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4372,
+              "line": 4445,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24221,7 +24614,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4373,
+              "line": 4446,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24234,7 +24627,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4371,
+          "line": 4444,
           "authority": "LuaLS declaration"
         }
       ],
@@ -24255,7 +24648,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4320,
+              "line": 4393,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24271,7 +24664,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4321,
+              "line": 4394,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24287,7 +24680,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4322,
+              "line": 4395,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24303,7 +24696,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4323,
+              "line": 4396,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24319,7 +24712,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4324,
+              "line": 4397,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24335,7 +24728,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4325,
+              "line": 4398,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24351,7 +24744,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4326,
+              "line": 4399,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24367,7 +24760,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4327,
+              "line": 4400,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24383,7 +24776,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4328,
+              "line": 4401,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24399,7 +24792,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4329,
+              "line": 4402,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24415,7 +24808,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4330,
+              "line": 4403,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24431,7 +24824,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4331,
+              "line": 4404,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24447,7 +24840,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4332,
+              "line": 4405,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24463,7 +24856,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4333,
+              "line": 4406,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24479,7 +24872,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4334,
+              "line": 4407,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24495,7 +24888,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4335,
+              "line": 4408,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24508,7 +24901,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4319,
+          "line": 4392,
           "authority": "LuaLS declaration"
         }
       ],
@@ -24529,7 +24922,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4354,
+              "line": 4427,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24545,7 +24938,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4355,
+              "line": 4428,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24558,7 +24951,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4353,
+          "line": 4426,
           "authority": "LuaLS declaration"
         }
       ],
@@ -24579,7 +24972,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1205,
+              "line": 1206,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24595,7 +24988,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1206,
+              "line": 1207,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24611,7 +25004,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1207,
+              "line": 1208,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24627,7 +25020,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1208,
+              "line": 1209,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24643,7 +25036,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1209,
+              "line": 1210,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24659,7 +25052,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1210,
+              "line": 1211,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24675,7 +25068,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1211,
+              "line": 1212,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24691,7 +25084,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1212,
+              "line": 1213,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24707,7 +25100,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 1213,
+              "line": 1214,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24720,7 +25113,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1204,
+          "line": 1205,
           "authority": "LuaLS declaration"
         }
       ],
@@ -24741,7 +25134,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4295,
+              "line": 4368,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24757,7 +25150,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4296,
+              "line": 4369,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24773,7 +25166,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4297,
+              "line": 4370,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24789,7 +25182,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4298,
+              "line": 4371,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24805,7 +25198,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4299,
+              "line": 4372,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24821,7 +25214,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4300,
+              "line": 4373,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24837,7 +25230,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4301,
+              "line": 4374,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24853,7 +25246,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4302,
+              "line": 4375,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24869,7 +25262,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4303,
+              "line": 4376,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24885,7 +25278,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4304,
+              "line": 4377,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24901,7 +25294,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4305,
+              "line": 4378,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24917,7 +25310,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4306,
+              "line": 4379,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24933,7 +25326,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4307,
+              "line": 4380,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24949,7 +25342,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4308,
+              "line": 4381,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24965,7 +25358,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4309,
+              "line": 4382,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24981,7 +25374,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4310,
+              "line": 4383,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24997,7 +25390,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4311,
+              "line": 4384,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25013,7 +25406,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4312,
+              "line": 4385,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25029,7 +25422,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4313,
+              "line": 4386,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25045,7 +25438,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4314,
+              "line": 4387,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25061,7 +25454,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4315,
+              "line": 4388,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25077,7 +25470,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4316,
+              "line": 4389,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25093,7 +25486,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4317,
+              "line": 4390,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25106,7 +25499,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4294,
+          "line": 4367,
           "authority": "LuaLS declaration"
         }
       ],
@@ -25127,7 +25520,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4392,
+              "line": 4465,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25143,7 +25536,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4393,
+              "line": 4466,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25159,7 +25552,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4394,
+              "line": 4467,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25175,7 +25568,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4395,
+              "line": 4468,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25188,7 +25581,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4391,
+          "line": 4464,
           "authority": "LuaLS declaration"
         }
       ],
@@ -25205,7 +25598,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2724,
+          "line": 2797,
           "authority": "LuaLS declaration"
         }
       ],
@@ -25226,7 +25619,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2717,
+              "line": 2790,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25242,7 +25635,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2718,
+              "line": 2791,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25258,7 +25651,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2719,
+              "line": 2792,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25274,7 +25667,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2720,
+              "line": 2793,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25287,7 +25680,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2716,
+          "line": 2789,
           "authority": "LuaLS declaration"
         }
       ],
@@ -25308,7 +25701,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2713,
+              "line": 2786,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25324,7 +25717,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2714,
+              "line": 2787,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25337,7 +25730,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2712,
+          "line": 2785,
           "authority": "LuaLS declaration"
         }
       ],
@@ -25354,7 +25747,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2722,
+          "line": 2795,
           "authority": "LuaLS declaration"
         }
       ],
@@ -25375,7 +25768,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4227,
+              "line": 4300,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25391,7 +25784,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4228,
+              "line": 4301,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25407,7 +25800,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4229,
+              "line": 4302,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25423,7 +25816,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4230,
+              "line": 4303,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25439,7 +25832,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4231,
+              "line": 4304,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25455,7 +25848,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4232,
+              "line": 4305,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25471,7 +25864,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4233,
+              "line": 4306,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25487,7 +25880,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4234,
+              "line": 4307,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25500,7 +25893,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4226,
+          "line": 4299,
           "authority": "LuaLS declaration"
         }
       ],
@@ -25521,7 +25914,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4223,
+              "line": 4296,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25537,7 +25930,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4224,
+              "line": 4297,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25550,7 +25943,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4222,
+          "line": 4295,
           "authority": "LuaLS declaration"
         }
       ],
@@ -25571,7 +25964,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4205,
+              "line": 4278,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25587,7 +25980,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4206,
+              "line": 4279,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25603,7 +25996,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4207,
+              "line": 4280,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25619,7 +26012,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4208,
+              "line": 4281,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25635,7 +26028,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4209,
+              "line": 4282,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25651,7 +26044,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4210,
+              "line": 4283,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25667,7 +26060,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4211,
+              "line": 4284,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25683,7 +26076,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4212,
+              "line": 4285,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25699,7 +26092,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4213,
+              "line": 4286,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25715,7 +26108,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4214,
+              "line": 4287,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25731,7 +26124,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4215,
+              "line": 4288,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25747,7 +26140,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4216,
+              "line": 4289,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25763,7 +26156,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4217,
+              "line": 4290,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25779,7 +26172,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4218,
+              "line": 4291,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25795,7 +26188,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4219,
+              "line": 4292,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25811,7 +26204,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4220,
+              "line": 4293,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25824,7 +26217,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4204,
+          "line": 4277,
           "authority": "LuaLS declaration"
         }
       ],
@@ -25845,7 +26238,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4195,
+              "line": 4268,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25861,7 +26254,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4196,
+              "line": 4269,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25877,7 +26270,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4197,
+              "line": 4270,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25893,7 +26286,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4198,
+              "line": 4271,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25909,7 +26302,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4199,
+              "line": 4272,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25925,7 +26318,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4200,
+              "line": 4273,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25941,7 +26334,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4201,
+              "line": 4274,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25957,7 +26350,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4202,
+              "line": 4275,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25970,7 +26363,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4194,
+          "line": 4267,
           "authority": "LuaLS declaration"
         }
       ],
@@ -25987,7 +26380,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4236,
+          "line": 4309,
           "authority": "LuaLS declaration"
         }
       ],
@@ -26008,7 +26401,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 288,
+              "line": 289,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26024,7 +26417,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 289,
+              "line": 290,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26040,7 +26433,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 290,
+              "line": 291,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26058,7 +26451,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 287,
+          "line": 288,
           "authority": "LuaLS declaration"
         }
       ],
@@ -26079,7 +26472,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 312,
+              "line": 313,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26097,7 +26490,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 311,
+          "line": 312,
           "authority": "LuaLS declaration"
         }
       ],
@@ -26118,7 +26511,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 66,
+              "line": 67,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26134,7 +26527,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 67,
+              "line": 68,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26152,7 +26545,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 65,
+          "line": 66,
           "authority": "LuaLS declaration"
         }
       ],
@@ -26173,7 +26566,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2869,
+              "line": 2942,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26189,7 +26582,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2870,
+              "line": 2943,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26205,7 +26598,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2871,
+              "line": 2944,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26221,7 +26614,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2872,
+              "line": 2945,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26239,7 +26632,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2868,
+          "line": 2941,
           "authority": "LuaLS declaration"
         }
       ],
@@ -26260,7 +26653,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2880,
+              "line": 2953,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26276,7 +26669,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2881,
+              "line": 2954,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26292,7 +26685,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2882,
+              "line": 2955,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26308,7 +26701,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2883,
+              "line": 2956,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26326,7 +26719,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2879,
+          "line": 2952,
           "authority": "LuaLS declaration"
         }
       ],
@@ -26347,7 +26740,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2549,
+              "line": 2622,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26363,7 +26756,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2550,
+              "line": 2623,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26379,7 +26772,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2551,
+              "line": 2624,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26397,7 +26790,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2548,
+          "line": 2621,
           "authority": "LuaLS declaration"
         }
       ],
@@ -26418,7 +26811,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 176,
+              "line": 177,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26434,7 +26827,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 177,
+              "line": 178,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26450,7 +26843,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 178,
+              "line": 179,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26466,7 +26859,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 179,
+              "line": 180,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26482,7 +26875,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 180,
+              "line": 181,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26500,12 +26893,34 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 175,
+          "line": 176,
           "authority": "LuaLS declaration"
         }
       ],
       "documentation": {
         "id": "api.lua.v5.generated.class.PointCoord",
+        "status": "generated-contract-source"
+      }
+    },
+    {
+      "id": "ScriptDialogueContext",
+      "kind": "native-usertype",
+      "declaration": "",
+      "fields": [],
+      "sources": [
+        {
+          "path": "src/catalua_ui.cpp",
+          "line": 3965,
+          "authority": "native registration"
+        },
+        {
+          "path": "data/lua/types/ccb_api_v5.d.lua",
+          "line": 1792,
+          "authority": "LuaLS declaration"
+        }
+      ],
+      "documentation": {
+        "id": "api.lua.v5.generated.class.ScriptDialogueContext",
         "status": "generated-contract-source"
       }
     },
@@ -26517,12 +26932,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3320,
+          "line": 3930,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1630,
+          "line": 1672,
           "authority": "LuaLS declaration"
         }
       ],
@@ -26539,12 +26954,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3186,
+          "line": 3796,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 649,
+          "line": 650,
           "authority": "LuaLS declaration"
         }
       ],
@@ -26565,7 +26980,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 620,
+              "line": 621,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26581,7 +26996,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 621,
+              "line": 622,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26597,7 +27012,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 622,
+              "line": 623,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26613,7 +27028,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 623,
+              "line": 624,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26629,7 +27044,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 624,
+              "line": 625,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26645,7 +27060,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 625,
+              "line": 626,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26661,7 +27076,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 626,
+              "line": 627,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26677,7 +27092,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 627,
+              "line": 628,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26693,7 +27108,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 628,
+              "line": 629,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26709,7 +27124,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 629,
+              "line": 630,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26725,7 +27140,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 630,
+              "line": 631,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26741,7 +27156,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 631,
+              "line": 632,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26757,7 +27172,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 632,
+              "line": 633,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26770,12 +27185,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3170,
+          "line": 3780,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 619,
+          "line": 620,
           "authority": "LuaLS declaration"
         }
       ],
@@ -26796,7 +27211,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 107,
+              "line": 108,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26814,7 +27229,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 106,
+          "line": 107,
           "authority": "LuaLS declaration"
         }
       ],
@@ -26835,7 +27250,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 131,
+              "line": 132,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26853,7 +27268,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 130,
+          "line": 131,
           "authority": "LuaLS declaration"
         }
       ],
@@ -26874,7 +27289,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 229,
+              "line": 230,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26890,7 +27305,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 230,
+              "line": 231,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26906,7 +27321,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 231,
+              "line": 232,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26922,7 +27337,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 232,
+              "line": 233,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26938,7 +27353,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 233,
+              "line": 234,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26954,7 +27369,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 234,
+              "line": 235,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26972,7 +27387,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 228,
+          "line": 229,
           "authority": "LuaLS declaration"
         }
       ],
@@ -26993,7 +27408,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 78,
+              "line": 79,
               "authority": "LuaLS declaration"
             }
           ],
@@ -27009,7 +27424,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 79,
+              "line": 80,
               "authority": "LuaLS declaration"
             }
           ],
@@ -27027,7 +27442,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 77,
+          "line": 78,
           "authority": "LuaLS declaration"
         }
       ],
@@ -27048,7 +27463,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4180,
+              "line": 4253,
               "authority": "LuaLS declaration"
             }
           ],
@@ -27064,7 +27479,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4181,
+              "line": 4254,
               "authority": "LuaLS declaration"
             }
           ],
@@ -27080,7 +27495,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4182,
+              "line": 4255,
               "authority": "LuaLS declaration"
             }
           ],
@@ -27096,7 +27511,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4183,
+              "line": 4256,
               "authority": "LuaLS declaration"
             }
           ],
@@ -27112,7 +27527,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4184,
+              "line": 4257,
               "authority": "LuaLS declaration"
             }
           ],
@@ -27128,7 +27543,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4185,
+              "line": 4258,
               "authority": "LuaLS declaration"
             }
           ],
@@ -27146,7 +27561,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4179,
+          "line": 4252,
           "authority": "LuaLS declaration"
         }
       ],
@@ -27188,12 +27603,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3302,
+          "line": 3912,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 967,
+          "line": 968,
           "authority": "LuaLS declaration"
         }
       ],
@@ -27244,12 +27659,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3307,
+          "line": 3917,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 972,
+          "line": 973,
           "authority": "LuaLS declaration"
         }
       ],
@@ -27295,12 +27710,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3299,
+          "line": 3909,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 963,
+          "line": 964,
           "authority": "LuaLS declaration"
         }
       ],
@@ -27346,12 +27761,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3296,
+          "line": 3906,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 960,
+          "line": 961,
           "authority": "LuaLS declaration"
         }
       ],
@@ -27404,12 +27819,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3266,
+          "line": 3876,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 949,
+          "line": 950,
           "authority": "LuaLS declaration"
         }
       ],
@@ -27473,12 +27888,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3281,
+          "line": 3891,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 956,
+          "line": 957,
           "authority": "LuaLS declaration"
         }
       ],
@@ -27529,7 +27944,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3664,
+          "line": 3737,
           "authority": "LuaLS declaration"
         }
       ],
@@ -27580,7 +27995,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3660,
+          "line": 3733,
           "authority": "LuaLS declaration"
         }
       ],
@@ -27631,7 +28046,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3672,
+          "line": 3745,
           "authority": "LuaLS declaration"
         }
       ],
@@ -27682,7 +28097,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3668,
+          "line": 3741,
           "authority": "LuaLS declaration"
         }
       ],
@@ -27738,7 +28153,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3681,
+          "line": 3754,
           "authority": "LuaLS declaration"
         }
       ],
@@ -27789,7 +28204,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3685,
+          "line": 3758,
           "authority": "LuaLS declaration"
         }
       ],
@@ -27840,7 +28255,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3676,
+          "line": 3749,
           "authority": "LuaLS declaration"
         }
       ],
@@ -27880,12 +28295,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3437,
+          "line": 4068,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1427,
+          "line": 1428,
           "authority": "LuaLS declaration"
         }
       ],
@@ -27925,12 +28340,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3432,
+          "line": 4063,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1424,
+          "line": 1425,
           "authority": "LuaLS declaration"
         }
       ],
@@ -27976,12 +28391,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3428,
+          "line": 4059,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1421,
+          "line": 1422,
           "authority": "LuaLS declaration"
         }
       ],
@@ -28032,12 +28447,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3421,
+          "line": 4052,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1417,
+          "line": 1418,
           "authority": "LuaLS declaration"
         }
       ],
@@ -28094,7 +28509,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1382,
+          "line": 1383,
           "authority": "LuaLS declaration"
         }
       ],
@@ -28139,7 +28554,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1389,
+          "line": 1390,
           "authority": "LuaLS declaration"
         }
       ],
@@ -28201,7 +28616,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1373,
+          "line": 1374,
           "authority": "LuaLS declaration"
         }
       ],
@@ -28257,7 +28672,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1378,
+          "line": 1379,
           "authority": "LuaLS declaration"
         }
       ],
@@ -28308,7 +28723,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1386,
+          "line": 1387,
           "authority": "LuaLS declaration"
         }
       ],
@@ -28359,7 +28774,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4593,
+          "line": 4667,
           "authority": "LuaLS declaration"
         }
       ],
@@ -28401,12 +28816,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3989,
+          "line": 4653,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4534,
+          "line": 4608,
           "authority": "LuaLS declaration"
         }
       ],
@@ -28468,7 +28883,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3285,
+          "line": 3358,
           "authority": "LuaLS declaration"
         }
       ],
@@ -28519,7 +28934,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3281,
+          "line": 3354,
           "authority": "LuaLS declaration"
         }
       ],
@@ -28580,7 +28995,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3301,
+          "line": 3374,
           "authority": "LuaLS declaration"
         }
       ],
@@ -28636,7 +29051,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3295,
+          "line": 3368,
           "authority": "LuaLS declaration"
         }
       ],
@@ -28692,7 +29107,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3290,
+          "line": 3363,
           "authority": "LuaLS declaration"
         }
       ],
@@ -28748,7 +29163,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3306,
+          "line": 3379,
           "authority": "LuaLS declaration"
         }
       ],
@@ -28804,7 +29219,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3317,
+          "line": 3390,
           "authority": "LuaLS declaration"
         }
       ],
@@ -28865,7 +29280,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3312,
+          "line": 3385,
           "authority": "LuaLS declaration"
         }
       ],
@@ -28910,7 +29325,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4604,
+          "line": 4678,
           "authority": "LuaLS declaration"
         }
       ],
@@ -28961,7 +29376,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4608,
+          "line": 4682,
           "authority": "LuaLS declaration"
         }
       ],
@@ -29017,7 +29432,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2251,
+          "line": 2324,
           "authority": "LuaLS declaration"
         }
       ],
@@ -29078,7 +29493,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2262,
+          "line": 2335,
           "authority": "LuaLS declaration"
         }
       ],
@@ -29134,7 +29549,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2256,
+          "line": 2329,
           "authority": "LuaLS declaration"
         }
       ],
@@ -29185,7 +29600,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2216,
+          "line": 2289,
           "authority": "LuaLS declaration"
         }
       ],
@@ -29236,7 +29651,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2212,
+          "line": 2285,
           "authority": "LuaLS declaration"
         }
       ],
@@ -29292,7 +29707,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2226,
+          "line": 2299,
           "authority": "LuaLS declaration"
         }
       ],
@@ -29348,7 +29763,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2231,
+          "line": 2304,
           "authority": "LuaLS declaration"
         }
       ],
@@ -29404,7 +29819,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2236,
+          "line": 2309,
           "authority": "LuaLS declaration"
         }
       ],
@@ -29460,7 +29875,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2221,
+          "line": 2294,
           "authority": "LuaLS declaration"
         }
       ],
@@ -29516,7 +29931,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2241,
+          "line": 2314,
           "authority": "LuaLS declaration"
         }
       ],
@@ -29572,7 +29987,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2246,
+          "line": 2319,
           "authority": "LuaLS declaration"
         }
       ],
@@ -29623,7 +30038,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4585,
+          "line": 4659,
           "authority": "LuaLS declaration"
         }
       ],
@@ -29669,12 +30084,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3559,
+          "line": 4223,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1621,
+          "line": 1663,
           "authority": "LuaLS declaration"
         }
       ],
@@ -29714,12 +30129,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3567,
+          "line": 4231,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1627,
+          "line": 1669,
           "authority": "LuaLS declaration"
         }
       ],
@@ -29759,12 +30174,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3564,
+          "line": 4228,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1624,
+          "line": 1666,
           "authority": "LuaLS declaration"
         }
       ],
@@ -29810,12 +30225,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3555,
+          "line": 4219,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1617,
+          "line": 1659,
           "authority": "LuaLS declaration"
         }
       ],
@@ -29871,12 +30286,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3547,
+          "line": 4211,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1613,
+          "line": 1655,
           "authority": "LuaLS declaration"
         }
       ],
@@ -29927,7 +30342,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4161,
+          "line": 4234,
           "authority": "LuaLS declaration"
         }
       ],
@@ -29978,7 +30393,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4152,
+          "line": 4225,
           "authority": "LuaLS declaration"
         }
       ],
@@ -30034,7 +30449,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4157,
+          "line": 4230,
           "authority": "LuaLS declaration"
         }
       ],
@@ -30090,7 +30505,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4166,
+          "line": 4239,
           "authority": "LuaLS declaration"
         }
       ],
@@ -30146,7 +30561,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4176,
+          "line": 4249,
           "authority": "LuaLS declaration"
         }
       ],
@@ -30202,7 +30617,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4171,
+          "line": 4244,
           "authority": "LuaLS declaration"
         }
       ],
@@ -30258,7 +30673,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2134,
+          "line": 2207,
           "authority": "LuaLS declaration"
         }
       ],
@@ -30303,7 +30718,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2116,
+          "line": 2189,
           "authority": "LuaLS declaration"
         }
       ],
@@ -30354,7 +30769,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2125,
+          "line": 2198,
           "authority": "LuaLS declaration"
         }
       ],
@@ -30415,7 +30830,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2140,
+          "line": 2213,
           "authority": "LuaLS declaration"
         }
       ],
@@ -30466,7 +30881,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2129,
+          "line": 2202,
           "authority": "LuaLS declaration"
         }
       ],
@@ -30522,7 +30937,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2145,
+          "line": 2218,
           "authority": "LuaLS declaration"
         }
       ],
@@ -30578,7 +30993,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2121,
+          "line": 2194,
           "authority": "LuaLS declaration"
         }
       ],
@@ -30623,7 +31038,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1946,
+          "line": 2019,
           "authority": "LuaLS declaration"
         }
       ],
@@ -30684,7 +31099,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 542,
+          "line": 543,
           "authority": "LuaLS declaration"
         }
       ],
@@ -30729,7 +31144,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 506,
+          "line": 507,
           "authority": "LuaLS declaration"
         }
       ],
@@ -30790,7 +31205,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 530,
+          "line": 531,
           "authority": "LuaLS declaration"
         }
       ],
@@ -30856,7 +31271,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 495,
+          "line": 496,
           "authority": "LuaLS declaration"
         }
       ],
@@ -30917,7 +31332,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 457,
+          "line": 458,
           "authority": "LuaLS declaration"
         }
       ],
@@ -30973,7 +31388,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 461,
+          "line": 462,
           "authority": "LuaLS declaration"
         }
       ],
@@ -31029,7 +31444,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 459,
+          "line": 460,
           "authority": "LuaLS declaration"
         }
       ],
@@ -31085,7 +31500,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 460,
+          "line": 461,
           "authority": "LuaLS declaration"
         }
       ],
@@ -31141,7 +31556,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 458,
+          "line": 459,
           "authority": "LuaLS declaration"
         }
       ],
@@ -31197,7 +31612,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 468,
+          "line": 469,
           "authority": "LuaLS declaration"
         }
       ],
@@ -31253,7 +31668,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 469,
+          "line": 470,
           "authority": "LuaLS declaration"
         }
       ],
@@ -31309,7 +31724,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 465,
+          "line": 466,
           "authority": "LuaLS declaration"
         }
       ],
@@ -31365,7 +31780,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 467,
+          "line": 468,
           "authority": "LuaLS declaration"
         }
       ],
@@ -31421,7 +31836,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 466,
+          "line": 467,
           "authority": "LuaLS declaration"
         }
       ],
@@ -31477,7 +31892,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 463,
+          "line": 464,
           "authority": "LuaLS declaration"
         }
       ],
@@ -31533,7 +31948,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 464,
+          "line": 465,
           "authority": "LuaLS declaration"
         }
       ],
@@ -31589,7 +32004,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 452,
+          "line": 453,
           "authority": "LuaLS declaration"
         }
       ],
@@ -31645,7 +32060,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 456,
+          "line": 457,
           "authority": "LuaLS declaration"
         }
       ],
@@ -31701,7 +32116,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 454,
+          "line": 455,
           "authority": "LuaLS declaration"
         }
       ],
@@ -31757,7 +32172,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 455,
+          "line": 456,
           "authority": "LuaLS declaration"
         }
       ],
@@ -31813,7 +32228,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 453,
+          "line": 454,
           "authority": "LuaLS declaration"
         }
       ],
@@ -31869,7 +32284,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 462,
+          "line": 463,
           "authority": "LuaLS declaration"
         }
       ],
@@ -31920,7 +32335,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 523,
+          "line": 524,
           "authority": "LuaLS declaration"
         }
       ],
@@ -31976,7 +32391,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 517,
+          "line": 518,
           "authority": "LuaLS declaration"
         }
       ],
@@ -32032,7 +32447,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 512,
+          "line": 513,
           "authority": "LuaLS declaration"
         }
       ],
@@ -32093,7 +32508,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 536,
+          "line": 537,
           "authority": "LuaLS declaration"
         }
       ],
@@ -32164,7 +32579,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 503,
+          "line": 504,
           "authority": "LuaLS declaration"
         }
       ],
@@ -32230,7 +32645,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 475,
+          "line": 476,
           "authority": "LuaLS declaration"
         }
       ],
@@ -32291,7 +32706,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 479,
+          "line": 480,
           "authority": "LuaLS declaration"
         }
       ],
@@ -32352,7 +32767,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 477,
+          "line": 478,
           "authority": "LuaLS declaration"
         }
       ],
@@ -32413,7 +32828,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 478,
+          "line": 479,
           "authority": "LuaLS declaration"
         }
       ],
@@ -32474,7 +32889,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 476,
+          "line": 477,
           "authority": "LuaLS declaration"
         }
       ],
@@ -32535,7 +32950,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 486,
+          "line": 487,
           "authority": "LuaLS declaration"
         }
       ],
@@ -32596,7 +33011,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 487,
+          "line": 488,
           "authority": "LuaLS declaration"
         }
       ],
@@ -32657,7 +33072,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 483,
+          "line": 484,
           "authority": "LuaLS declaration"
         }
       ],
@@ -32718,7 +33133,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 485,
+          "line": 486,
           "authority": "LuaLS declaration"
         }
       ],
@@ -32779,7 +33194,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 484,
+          "line": 485,
           "authority": "LuaLS declaration"
         }
       ],
@@ -32840,7 +33255,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 481,
+          "line": 482,
           "authority": "LuaLS declaration"
         }
       ],
@@ -32901,7 +33316,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 482,
+          "line": 483,
           "authority": "LuaLS declaration"
         }
       ],
@@ -32962,7 +33377,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 470,
+          "line": 471,
           "authority": "LuaLS declaration"
         }
       ],
@@ -33023,7 +33438,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 474,
+          "line": 475,
           "authority": "LuaLS declaration"
         }
       ],
@@ -33084,7 +33499,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 472,
+          "line": 473,
           "authority": "LuaLS declaration"
         }
       ],
@@ -33145,7 +33560,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 473,
+          "line": 474,
           "authority": "LuaLS declaration"
         }
       ],
@@ -33206,7 +33621,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 471,
+          "line": 472,
           "authority": "LuaLS declaration"
         }
       ],
@@ -33267,7 +33682,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 480,
+          "line": 481,
           "authority": "LuaLS declaration"
         }
       ],
@@ -33318,7 +33733,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2710,
+          "line": 2783,
           "authority": "LuaLS declaration"
         }
       ],
@@ -33369,7 +33784,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2110,
+          "line": 2183,
           "authority": "LuaLS declaration"
         }
       ],
@@ -33414,7 +33829,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2098,
+          "line": 2171,
           "authority": "LuaLS declaration"
         }
       ],
@@ -33465,7 +33880,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2106,
+          "line": 2179,
           "authority": "LuaLS declaration"
         }
       ],
@@ -33516,7 +33931,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2102,
+          "line": 2175,
           "authority": "LuaLS declaration"
         }
       ],
@@ -33567,7 +33982,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4577,
+          "line": 4651,
           "authority": "LuaLS declaration"
         }
       ],
@@ -33618,7 +34033,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1822,
+          "line": 1895,
           "authority": "LuaLS declaration"
         }
       ],
@@ -33669,7 +34084,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1826,
+          "line": 1899,
           "authority": "LuaLS declaration"
         }
       ],
@@ -33720,7 +34135,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1830,
+          "line": 1903,
           "authority": "LuaLS declaration"
         }
       ],
@@ -33765,7 +34180,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1818,
+          "line": 1891,
           "authority": "LuaLS declaration"
         }
       ],
@@ -33821,7 +34236,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1835,
+          "line": 1908,
           "authority": "LuaLS declaration"
         }
       ],
@@ -33866,7 +34281,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1838,
+          "line": 1911,
           "authority": "LuaLS declaration"
         }
       ],
@@ -33912,12 +34327,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4079,
+          "line": 4743,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1914,
+          "line": 1987,
           "authority": "LuaLS declaration"
         }
       ],
@@ -33957,12 +34372,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4072,
+          "line": 4736,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1910,
+          "line": 1983,
           "authority": "LuaLS declaration"
         }
       ],
@@ -33974,6 +34389,153 @@
       "examples": [],
       "documentation": {
         "id": "api.lua.v5.generated.function.game.diagnostics.snapshot",
+        "status": "generated-contract-source"
+      }
+    },
+    {
+      "class": "CcbDialogueApi",
+      "name": "extend_topic",
+      "style": "function",
+      "parameters": [
+        {
+          "name": "descriptor",
+          "optional": false,
+          "declaration": "CcbDialogueExtensionDescriptor"
+        }
+      ],
+      "returns": [
+        {
+          "declaration": "integer registration_id"
+        }
+      ],
+      "overloads": [],
+      "errors": {
+        "mode": "lua-error",
+        "message_stability": "not-guaranteed",
+        "conditions": [
+          "capability, validation, lifecycle, or native operation failure"
+        ]
+      },
+      "api_version": 5,
+      "since": "untracked-before-or-at-v5",
+      "deprecated": false,
+      "deprecation_replacement": null,
+      "sources": [
+        {
+          "path": "src/catalua_ui.cpp",
+          "line": 4081,
+          "authority": "native registration"
+        },
+        {
+          "path": "data/lua/types/ccb_api_v5.d.lua",
+          "line": 1466,
+          "authority": "LuaLS declaration"
+        }
+      ],
+      "id": "game.dialogue.extend_topic",
+      "namespace": "game.dialogue",
+      "capabilities": [
+        "game.dialogue"
+      ],
+      "examples": [],
+      "documentation": {
+        "id": "api.lua.v5.generated.function.game.dialogue.extend_topic",
+        "status": "generated-contract-source"
+      }
+    },
+    {
+      "class": "CcbDialogueApi",
+      "name": "limits",
+      "style": "function",
+      "parameters": [],
+      "returns": [
+        {
+          "declaration": "CcbDialogueLimits"
+        }
+      ],
+      "overloads": [],
+      "errors": {
+        "mode": "lua-error",
+        "message_stability": "not-guaranteed",
+        "conditions": [
+          "capability, validation, lifecycle, or native operation failure"
+        ]
+      },
+      "api_version": 5,
+      "since": "untracked-before-or-at-v5",
+      "deprecated": false,
+      "deprecation_replacement": null,
+      "sources": [
+        {
+          "path": "src/catalua_ui.cpp",
+          "line": 4086,
+          "authority": "native registration"
+        },
+        {
+          "path": "data/lua/types/ccb_api_v5.d.lua",
+          "line": 1469,
+          "authority": "LuaLS declaration"
+        }
+      ],
+      "id": "game.dialogue.limits",
+      "namespace": "game.dialogue",
+      "capabilities": [
+        "game.dialogue"
+      ],
+      "examples": [],
+      "documentation": {
+        "id": "api.lua.v5.generated.function.game.dialogue.limits",
+        "status": "generated-contract-source"
+      }
+    },
+    {
+      "class": "CcbDialogueApi",
+      "name": "register_topic",
+      "style": "function",
+      "parameters": [
+        {
+          "name": "descriptor",
+          "optional": false,
+          "declaration": "CcbDialogueTopicDescriptor"
+        }
+      ],
+      "returns": [
+        {
+          "declaration": "integer registration_id"
+        }
+      ],
+      "overloads": [],
+      "errors": {
+        "mode": "lua-error",
+        "message_stability": "not-guaranteed",
+        "conditions": [
+          "capability, validation, lifecycle, or native operation failure"
+        ]
+      },
+      "api_version": 5,
+      "since": "untracked-before-or-at-v5",
+      "deprecated": false,
+      "deprecation_replacement": null,
+      "sources": [
+        {
+          "path": "src/catalua_ui.cpp",
+          "line": 4076,
+          "authority": "native registration"
+        },
+        {
+          "path": "data/lua/types/ccb_api_v5.d.lua",
+          "line": 1462,
+          "authority": "LuaLS declaration"
+        }
+      ],
+      "id": "game.dialogue.register_topic",
+      "namespace": "game.dialogue",
+      "capabilities": [
+        "game.dialogue"
+      ],
+      "examples": [],
+      "documentation": {
+        "id": "api.lua.v5.generated.function.game.dialogue.register_topic",
         "status": "generated-contract-source"
       }
     },
@@ -34028,7 +34590,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2184,
+          "line": 2257,
           "authority": "LuaLS declaration"
         }
       ],
@@ -34089,7 +34651,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2177,
+          "line": 2250,
           "authority": "LuaLS declaration"
         }
       ],
@@ -34150,7 +34712,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2171,
+          "line": 2244,
           "authority": "LuaLS declaration"
         }
       ],
@@ -34206,7 +34768,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2165,
+          "line": 2238,
           "authority": "LuaLS declaration"
         }
       ],
@@ -34267,7 +34829,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2190,
+          "line": 2263,
           "authority": "LuaLS declaration"
         }
       ],
@@ -34328,7 +34890,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2196,
+          "line": 2269,
           "authority": "LuaLS declaration"
         }
       ],
@@ -34379,7 +34941,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4560,
+          "line": 4634,
           "authority": "LuaLS declaration"
         }
       ],
@@ -34430,7 +34992,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 574,
+          "line": 575,
           "authority": "LuaLS declaration"
         }
       ],
@@ -34486,7 +35048,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 585,
+          "line": 586,
           "authority": "LuaLS declaration"
         }
       ],
@@ -34531,7 +35093,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 570,
+          "line": 571,
           "authority": "LuaLS declaration"
         }
       ],
@@ -34587,7 +35149,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 567,
+          "line": 568,
           "authority": "LuaLS declaration"
         }
       ],
@@ -34648,7 +35210,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 580,
+          "line": 581,
           "authority": "LuaLS declaration"
         }
       ],
@@ -34704,7 +35266,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3571,
+          "line": 3644,
           "authority": "LuaLS declaration"
         }
       ],
@@ -34755,7 +35317,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3561,
+          "line": 3634,
           "authority": "LuaLS declaration"
         }
       ],
@@ -34800,7 +35362,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3580,
+          "line": 3653,
           "authority": "LuaLS declaration"
         }
       ],
@@ -34851,7 +35413,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3557,
+          "line": 3630,
           "authority": "LuaLS declaration"
         }
       ],
@@ -34912,7 +35474,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3577,
+          "line": 3650,
           "authority": "LuaLS declaration"
         }
       ],
@@ -34968,7 +35530,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3566,
+          "line": 3639,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35019,7 +35581,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4568,
+          "line": 4642,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35075,7 +35637,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4091,
+          "line": 4164,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35126,7 +35688,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4068,
+          "line": 4141,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35177,7 +35739,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4064,
+          "line": 4137,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35233,7 +35795,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4076,
+          "line": 4149,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35289,7 +35851,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4116,
+          "line": 4189,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35345,7 +35907,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4106,
+          "line": 4179,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35401,7 +35963,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4111,
+          "line": 4184,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35446,7 +36008,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4071,
+          "line": 4144,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35502,7 +36064,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4086,
+          "line": 4159,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35558,7 +36120,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4081,
+          "line": 4154,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35614,7 +36176,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4096,
+          "line": 4169,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35670,7 +36232,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4101,
+          "line": 4174,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35726,7 +36288,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4121,
+          "line": 4194,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35787,7 +36349,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4127,
+          "line": 4200,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35838,7 +36400,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2058,
+          "line": 2131,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35883,7 +36445,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2054,
+          "line": 2127,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35934,7 +36496,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2062,
+          "line": 2135,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35981,12 +36543,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3358,
+          "line": 3989,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3601,
+          "line": 3674,
           "authority": "LuaLS declaration"
         }
       ],
@@ -36031,7 +36593,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 611,
+          "line": 612,
           "authority": "LuaLS declaration"
         }
       ],
@@ -36077,12 +36639,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3534,
+          "line": 4198,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1537,
+          "line": 1579,
           "authority": "LuaLS declaration"
         }
       ],
@@ -36122,12 +36684,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3542,
+          "line": 4206,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1543,
+          "line": 1585,
           "authority": "LuaLS declaration"
         }
       ],
@@ -36167,12 +36729,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3539,
+          "line": 4203,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1540,
+          "line": 1582,
           "authority": "LuaLS declaration"
         }
       ],
@@ -36218,12 +36780,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3531,
+          "line": 4195,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1533,
+          "line": 1575,
           "authority": "LuaLS declaration"
         }
       ],
@@ -36276,12 +36838,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3517,
+          "line": 4181,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1529,
+          "line": 1571,
           "authority": "LuaLS declaration"
         }
       ],
@@ -36332,7 +36894,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2997,
+          "line": 3070,
           "authority": "LuaLS declaration"
         }
       ],
@@ -36393,7 +36955,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2972,
+          "line": 3045,
           "authority": "LuaLS declaration"
         }
       ],
@@ -36449,7 +37011,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2939,
+          "line": 3012,
           "authority": "LuaLS declaration"
         }
       ],
@@ -36505,7 +37067,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2928,
+          "line": 3001,
           "authority": "LuaLS declaration"
         }
       ],
@@ -36556,7 +37118,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2923,
+          "line": 2996,
           "authority": "LuaLS declaration"
         }
       ],
@@ -36612,7 +37174,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2944,
+          "line": 3017,
           "authority": "LuaLS declaration"
         }
       ],
@@ -36663,7 +37225,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2948,
+          "line": 3021,
           "authority": "LuaLS declaration"
         }
       ],
@@ -36714,7 +37276,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2957,
+          "line": 3030,
           "authority": "LuaLS declaration"
         }
       ],
@@ -36770,7 +37332,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2953,
+          "line": 3026,
           "authority": "LuaLS declaration"
         }
       ],
@@ -36815,7 +37377,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2919,
+          "line": 2992,
           "authority": "LuaLS declaration"
         }
       ],
@@ -36876,7 +37438,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2934,
+          "line": 3007,
           "authority": "LuaLS declaration"
         }
       ],
@@ -36927,7 +37489,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2976,
+          "line": 3049,
           "authority": "LuaLS declaration"
         }
       ],
@@ -36978,7 +37540,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2989,
+          "line": 3062,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37034,7 +37596,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2994,
+          "line": 3067,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37090,7 +37652,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2966,
+          "line": 3039,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37141,7 +37703,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2980,
+          "line": 3053,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37192,7 +37754,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2961,
+          "line": 3034,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37248,7 +37810,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2985,
+          "line": 3058,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37304,7 +37866,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2357,
+          "line": 2430,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37370,7 +37932,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2370,
+          "line": 2443,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37426,7 +37988,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2352,
+          "line": 2425,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37487,7 +38049,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2376,
+          "line": 2449,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37548,7 +38110,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2363,
+          "line": 2436,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37599,7 +38161,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2390,
+          "line": 2463,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37655,7 +38217,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2386,
+          "line": 2459,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37711,7 +38273,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2381,
+          "line": 2454,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37762,7 +38324,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4556,
+          "line": 4630,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37818,7 +38380,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4573,
+          "line": 4647,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37874,7 +38436,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2291,
+          "line": 2364,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37930,7 +38492,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2312,
+          "line": 2385,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37986,7 +38548,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2301,
+          "line": 2374,
           "authority": "LuaLS declaration"
         }
       ],
@@ -38042,7 +38604,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2317,
+          "line": 2390,
           "authority": "LuaLS declaration"
         }
       ],
@@ -38098,7 +38660,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2328,
+          "line": 2401,
           "authority": "LuaLS declaration"
         }
       ],
@@ -38154,7 +38716,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2286,
+          "line": 2359,
           "authority": "LuaLS declaration"
         }
       ],
@@ -38215,7 +38777,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2323,
+          "line": 2396,
           "authority": "LuaLS declaration"
         }
       ],
@@ -38276,7 +38838,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2334,
+          "line": 2407,
           "authority": "LuaLS declaration"
         }
       ],
@@ -38337,7 +38899,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2307,
+          "line": 2380,
           "authority": "LuaLS declaration"
         }
       ],
@@ -38393,7 +38955,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2281,
+          "line": 2354,
           "authority": "LuaLS declaration"
         }
       ],
@@ -38449,7 +39011,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2296,
+          "line": 2369,
           "authority": "LuaLS declaration"
         }
       ],
@@ -38489,12 +39051,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3587,
+          "line": 4251,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1781,
+          "line": 1854,
           "authority": "LuaLS declaration"
         }
       ],
@@ -38542,12 +39104,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3584,
+          "line": 4248,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1778,
+          "line": 1851,
           "authority": "LuaLS declaration"
         }
       ],
@@ -38597,12 +39159,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3572,
+          "line": 4236,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1774,
+          "line": 1847,
           "authority": "LuaLS declaration"
         }
       ],
@@ -38655,7 +39217,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3495,
+          "line": 3568,
           "authority": "LuaLS declaration"
         }
       ],
@@ -38706,7 +39268,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3481,
+          "line": 3554,
           "authority": "LuaLS declaration"
         }
       ],
@@ -38757,7 +39319,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3477,
+          "line": 3550,
           "authority": "LuaLS declaration"
         }
       ],
@@ -38813,7 +39375,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3491,
+          "line": 3564,
           "authority": "LuaLS declaration"
         }
       ],
@@ -38869,7 +39431,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3500,
+          "line": 3573,
           "authority": "LuaLS declaration"
         }
       ],
@@ -38925,7 +39487,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3486,
+          "line": 3559,
           "authority": "LuaLS declaration"
         }
       ],
@@ -38981,7 +39543,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3505,
+          "line": 3578,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39037,7 +39599,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3510,
+          "line": 3583,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39093,7 +39655,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3515,
+          "line": 3588,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39149,7 +39711,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3520,
+          "line": 3593,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39201,7 +39763,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1936,
+          "line": 2009,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39252,7 +39814,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1932,
+          "line": 2005,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39303,7 +39865,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2632,
+          "line": 2705,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39354,7 +39916,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2606,
+          "line": 2679,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39405,7 +39967,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2628,
+          "line": 2701,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39461,7 +40023,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2624,
+          "line": 2697,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39506,7 +40068,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2581,
+          "line": 2654,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39557,7 +40119,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2570,
+          "line": 2643,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39608,7 +40170,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2566,
+          "line": 2639,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39659,7 +40221,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2619,
+          "line": 2692,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39710,7 +40272,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2578,
+          "line": 2651,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39766,7 +40328,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2591,
+          "line": 2664,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39817,7 +40379,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2574,
+          "line": 2647,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39873,7 +40435,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2586,
+          "line": 2659,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39929,7 +40491,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2596,
+          "line": 2669,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39990,7 +40552,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2602,
+          "line": 2675,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40041,7 +40603,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2610,
+          "line": 2683,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40097,7 +40659,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2615,
+          "line": 2688,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40148,7 +40710,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4589,
+          "line": 4663,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40193,7 +40755,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4546,
+          "line": 4620,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40244,7 +40806,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2405,
+          "line": 2478,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40295,7 +40857,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2401,
+          "line": 2474,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40351,7 +40913,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2420,
+          "line": 2493,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40412,7 +40974,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2426,
+          "line": 2499,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40468,7 +41030,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2415,
+          "line": 2488,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40524,7 +41086,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2410,
+          "line": 2483,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40580,7 +41142,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2431,
+          "line": 2504,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40641,7 +41203,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2437,
+          "line": 2510,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40702,7 +41264,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2443,
+          "line": 2516,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40753,7 +41315,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4581,
+          "line": 4655,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40799,12 +41361,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3401,
+          "line": 4032,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 992,
+          "line": 993,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40856,12 +41418,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3408,
+          "line": 4039,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 997,
+          "line": 998,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40903,12 +41465,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3396,
+          "line": 4027,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 988,
+          "line": 989,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40955,12 +41517,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3391,
+          "line": 4022,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 985,
+          "line": 986,
           "authority": "LuaLS declaration"
         }
       ],
@@ -41014,12 +41576,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3370,
+          "line": 4001,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 981,
+          "line": 982,
           "authority": "LuaLS declaration"
         }
       ],
@@ -41082,7 +41644,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4598,
+          "line": 4672,
           "authority": "LuaLS declaration"
         }
       ],
@@ -41133,7 +41695,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3363,
+          "line": 3436,
           "authority": "LuaLS declaration"
         }
       ],
@@ -41184,7 +41746,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3388,
+          "line": 3461,
           "authority": "LuaLS declaration"
         }
       ],
@@ -41240,7 +41802,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3403,
+          "line": 3476,
           "authority": "LuaLS declaration"
         }
       ],
@@ -41296,7 +41858,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3373,
+          "line": 3446,
           "authority": "LuaLS declaration"
         }
       ],
@@ -41357,7 +41919,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3384,
+          "line": 3457,
           "authority": "LuaLS declaration"
         }
       ],
@@ -41413,7 +41975,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3398,
+          "line": 3471,
           "authority": "LuaLS declaration"
         }
       ],
@@ -41474,7 +42036,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3415,
+          "line": 3488,
           "authority": "LuaLS declaration"
         }
       ],
@@ -41530,7 +42092,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3435,
+          "line": 3508,
           "authority": "LuaLS declaration"
         }
       ],
@@ -41586,7 +42148,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3420,
+          "line": 3493,
           "authority": "LuaLS declaration"
         }
       ],
@@ -41642,7 +42204,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3425,
+          "line": 3498,
           "authority": "LuaLS declaration"
         }
       ],
@@ -41698,7 +42260,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3368,
+          "line": 3441,
           "authority": "LuaLS declaration"
         }
       ],
@@ -41754,7 +42316,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3378,
+          "line": 3451,
           "authority": "LuaLS declaration"
         }
       ],
@@ -41810,7 +42372,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3393,
+          "line": 3466,
           "authority": "LuaLS declaration"
         }
       ],
@@ -41871,7 +42433,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3409,
+          "line": 3482,
           "authority": "LuaLS declaration"
         }
       ],
@@ -41927,7 +42489,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3430,
+          "line": 3503,
           "authority": "LuaLS declaration"
         }
       ],
@@ -41978,7 +42540,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3975,
+          "line": 4048,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42029,7 +42591,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3971,
+          "line": 4044,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42080,7 +42642,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3983,
+          "line": 4056,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42131,7 +42693,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3979,
+          "line": 4052,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42187,7 +42749,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3998,
+          "line": 4071,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42243,7 +42805,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3988,
+          "line": 4061,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42299,7 +42861,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3993,
+          "line": 4066,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42355,7 +42917,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2823,
+          "line": 2896,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42400,7 +42962,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2809,
+          "line": 2882,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42461,7 +43023,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2834,
+          "line": 2907,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42517,7 +43079,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2828,
+          "line": 2901,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42573,7 +43135,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2865,
+          "line": 2938,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42629,7 +43191,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2818,
+          "line": 2891,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42685,7 +43247,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2849,
+          "line": 2922,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42741,7 +43303,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2854,
+          "line": 2927,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42802,7 +43364,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2860,
+          "line": 2933,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42858,7 +43420,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2844,
+          "line": 2917,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42914,7 +43476,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2839,
+          "line": 2912,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42965,7 +43527,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2813,
+          "line": 2886,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43005,12 +43567,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3993,
+          "line": 4657,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4537,
+          "line": 4611,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43061,7 +43623,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4540,
+          "line": 4614,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43106,7 +43668,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4543,
+          "line": 4617,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43157,7 +43719,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3148,
+          "line": 3221,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43208,7 +43770,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3152,
+          "line": 3225,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43259,7 +43821,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3144,
+          "line": 3217,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43310,7 +43872,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3140,
+          "line": 3213,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43366,7 +43928,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3162,
+          "line": 3235,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43427,7 +43989,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3168,
+          "line": 3241,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43483,7 +44045,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3157,
+          "line": 3230,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43544,7 +44106,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3179,
+          "line": 3252,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43600,7 +44162,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3173,
+          "line": 3246,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43661,7 +44223,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3185,
+          "line": 3258,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43717,7 +44279,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1959,
+          "line": 2032,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43773,7 +44335,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1954,
+          "line": 2027,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43824,7 +44386,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2655,
+          "line": 2728,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43880,7 +44442,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2665,
+          "line": 2738,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43936,7 +44498,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2660,
+          "line": 2733,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43992,7 +44554,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2670,
+          "line": 2743,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44048,7 +44610,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2675,
+          "line": 2748,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44093,7 +44655,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2647,
+          "line": 2720,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44144,7 +44706,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2651,
+          "line": 2724,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44195,7 +44757,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2069,
+          "line": 2142,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44247,7 +44809,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2073,
+          "line": 2146,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44304,7 +44866,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2698,
+          "line": 2771,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44360,7 +44922,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2693,
+          "line": 2766,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44405,7 +44967,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2684,
+          "line": 2757,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44456,7 +45018,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2688,
+          "line": 2761,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44496,12 +45058,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4068,
+          "line": 4732,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4601,
+          "line": 4675,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44550,7 +45112,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 602,
+          "line": 603,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44601,7 +45163,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 598,
+          "line": 599,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44646,7 +45208,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 605,
+          "line": 606,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44686,12 +45248,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3459,
+          "line": 4123,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1483,
+          "line": 1525,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44731,12 +45293,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3473,
+          "line": 4137,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1492,
+          "line": 1534,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44776,12 +45338,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3468,
+          "line": 4132,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1489,
+          "line": 1531,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44821,12 +45383,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3463,
+          "line": 4127,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1486,
+          "line": 1528,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44872,12 +45434,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3455,
+          "line": 4119,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1480,
+          "line": 1522,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44923,12 +45485,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3450,
+          "line": 4114,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1476,
+          "line": 1518,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44974,12 +45536,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3445,
+          "line": 4109,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1472,
+          "line": 1514,
           "authority": "LuaLS declaration"
         }
       ],
@@ -45030,7 +45592,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3063,
+          "line": 3136,
           "authority": "LuaLS declaration"
         }
       ],
@@ -45081,7 +45643,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3059,
+          "line": 3132,
           "authority": "LuaLS declaration"
         }
       ],
@@ -45137,7 +45699,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3073,
+          "line": 3146,
           "authority": "LuaLS declaration"
         }
       ],
@@ -45193,7 +45755,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3068,
+          "line": 3141,
           "authority": "LuaLS declaration"
         }
       ],
@@ -45259,7 +45821,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3092,
+          "line": 3165,
           "authority": "LuaLS declaration"
         }
       ],
@@ -45320,7 +45882,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3079,
+          "line": 3152,
           "authority": "LuaLS declaration"
         }
       ],
@@ -45381,7 +45943,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3085,
+          "line": 3158,
           "authority": "LuaLS declaration"
         }
       ],
@@ -45432,7 +45994,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4564,
+          "line": 4638,
           "authority": "LuaLS declaration"
         }
       ],
@@ -45477,7 +46039,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1988,
+          "line": 2061,
           "authority": "LuaLS declaration"
         }
       ],
@@ -45539,7 +46101,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1979,
+          "line": 2052,
           "authority": "LuaLS declaration"
         }
       ],
@@ -45601,7 +46163,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1985,
+          "line": 2058,
           "authority": "LuaLS declaration"
         }
       ],
@@ -45657,7 +46219,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2048,
+          "line": 2121,
           "authority": "LuaLS declaration"
         }
       ],
@@ -45718,7 +46280,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2043,
+          "line": 2116,
           "authority": "LuaLS declaration"
         }
       ],
@@ -45774,7 +46336,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2479,
+          "line": 2552,
           "authority": "LuaLS declaration"
         }
       ],
@@ -45825,7 +46387,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2459,
+          "line": 2532,
           "authority": "LuaLS declaration"
         }
       ],
@@ -45876,7 +46438,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2455,
+          "line": 2528,
           "authority": "LuaLS declaration"
         }
       ],
@@ -45932,7 +46494,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2490,
+          "line": 2563,
           "authority": "LuaLS declaration"
         }
       ],
@@ -45993,7 +46555,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2502,
+          "line": 2575,
           "authority": "LuaLS declaration"
         }
       ],
@@ -46054,7 +46616,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2514,
+          "line": 2587,
           "authority": "LuaLS declaration"
         }
       ],
@@ -46110,7 +46672,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2474,
+          "line": 2547,
           "authority": "LuaLS declaration"
         }
       ],
@@ -46166,7 +46728,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2469,
+          "line": 2542,
           "authority": "LuaLS declaration"
         }
       ],
@@ -46227,7 +46789,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2485,
+          "line": 2558,
           "authority": "LuaLS declaration"
         }
       ],
@@ -46283,7 +46845,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2464,
+          "line": 2537,
           "authority": "LuaLS declaration"
         }
       ],
@@ -46334,7 +46896,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2518,
+          "line": 2591,
           "authority": "LuaLS declaration"
         }
       ],
@@ -46390,7 +46952,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2528,
+          "line": 2601,
           "authority": "LuaLS declaration"
         }
       ],
@@ -46451,7 +47013,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2545,
+          "line": 2618,
           "authority": "LuaLS declaration"
         }
       ],
@@ -46507,7 +47069,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2533,
+          "line": 2606,
           "authority": "LuaLS declaration"
         }
       ],
@@ -46568,7 +47130,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2496,
+          "line": 2569,
           "authority": "LuaLS declaration"
         }
       ],
@@ -46629,7 +47191,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2539,
+          "line": 2612,
           "authority": "LuaLS declaration"
         }
       ],
@@ -46690,7 +47252,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2508,
+          "line": 2581,
           "authority": "LuaLS declaration"
         }
       ],
@@ -46746,7 +47308,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2523,
+          "line": 2596,
           "authority": "LuaLS declaration"
         }
       ],
@@ -46797,12 +47359,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4061,
+          "line": 4725,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4614,
+          "line": 4688,
           "authority": "LuaLS declaration"
         }
       ],
@@ -46849,12 +47411,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4065,
+          "line": 4729,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4618,
+          "line": 4692,
           "authority": "LuaLS declaration"
         }
       ],
@@ -46905,7 +47467,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3736,
+          "line": 3809,
           "authority": "LuaLS declaration"
         }
       ],
@@ -46956,7 +47518,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3732,
+          "line": 3805,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47012,7 +47574,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3762,
+          "line": 3835,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47063,7 +47625,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3757,
+          "line": 3830,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47114,7 +47676,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3770,
+          "line": 3843,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47165,7 +47727,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3766,
+          "line": 3839,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47221,7 +47783,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3753,
+          "line": 3826,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47272,7 +47834,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3748,
+          "line": 3821,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47323,7 +47885,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3744,
+          "line": 3817,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47374,7 +47936,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3740,
+          "line": 3813,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47430,7 +47992,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2000,
+          "line": 2073,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47501,7 +48063,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2022,
+          "line": 2095,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47572,7 +48134,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2030,
+          "line": 2103,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47633,7 +48195,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2014,
+          "line": 2087,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47689,7 +48251,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2005,
+          "line": 2078,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47734,7 +48296,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2008,
+          "line": 2081,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47790,7 +48352,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 448,
+          "line": 449,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47835,7 +48397,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 416,
+          "line": 417,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47880,7 +48442,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 435,
+          "line": 436,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47936,7 +48498,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 421,
+          "line": 422,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47981,7 +48543,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 438,
+          "line": 439,
           "authority": "LuaLS declaration"
         }
       ],
@@ -48026,7 +48588,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 428,
+          "line": 429,
           "authority": "LuaLS declaration"
         }
       ],
@@ -48083,7 +48645,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 425,
+          "line": 426,
           "authority": "LuaLS declaration"
         }
       ],
@@ -48139,7 +48701,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 443,
+          "line": 444,
           "authority": "LuaLS declaration"
         }
       ],
@@ -48190,7 +48752,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 432,
+          "line": 433,
           "authority": "LuaLS declaration"
         }
       ],
@@ -48241,7 +48803,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 413,
+          "line": 414,
           "authority": "LuaLS declaration"
         }
       ],
@@ -48286,7 +48848,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4549,
+          "line": 4623,
           "authority": "LuaLS declaration"
         }
       ],
@@ -48342,7 +48904,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 330,
+          "line": 331,
           "authority": "LuaLS declaration"
         }
       ],
@@ -48387,7 +48949,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 333,
+          "line": 334,
           "authority": "LuaLS declaration"
         }
       ],
@@ -48432,7 +48994,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 345,
+          "line": 346,
           "authority": "LuaLS declaration"
         }
       ],
@@ -48493,7 +49055,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 342,
+          "line": 343,
           "authority": "LuaLS declaration"
         }
       ],
@@ -48544,7 +49106,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 349,
+          "line": 350,
           "authority": "LuaLS declaration"
         }
       ],
@@ -48600,7 +49162,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3609,
+          "line": 3682,
           "authority": "LuaLS declaration"
         }
       ],
@@ -48656,7 +49218,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3620,
+          "line": 3693,
           "authority": "LuaLS declaration"
         }
       ],
@@ -48717,7 +49279,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3615,
+          "line": 3688,
           "authority": "LuaLS declaration"
         }
       ],
@@ -48768,7 +49330,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3867,
+          "line": 3940,
           "authority": "LuaLS declaration"
         }
       ],
@@ -48819,7 +49381,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3863,
+          "line": 3936,
           "authority": "LuaLS declaration"
         }
       ],
@@ -48870,7 +49432,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3880,
+          "line": 3953,
           "authority": "LuaLS declaration"
         }
       ],
@@ -48921,7 +49483,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3871,
+          "line": 3944,
           "authority": "LuaLS declaration"
         }
       ],
@@ -48977,7 +49539,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3876,
+          "line": 3949,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49033,7 +49595,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3885,
+          "line": 3958,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49089,7 +49651,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3890,
+          "line": 3963,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49150,7 +49712,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3906,
+          "line": 3979,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49206,7 +49768,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3900,
+          "line": 3973,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49262,7 +49824,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3895,
+          "line": 3968,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49313,7 +49875,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3223,
+          "line": 3296,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49364,7 +49926,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3219,
+          "line": 3292,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49420,7 +49982,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3233,
+          "line": 3306,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49476,7 +50038,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3228,
+          "line": 3301,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49537,7 +50099,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3245,
+          "line": 3318,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49593,7 +50155,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3250,
+          "line": 3323,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49654,7 +50216,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3239,
+          "line": 3312,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49699,7 +50261,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4435,
+          "line": 4508,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49744,7 +50306,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4449,
+          "line": 4522,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49789,7 +50351,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4442,
+          "line": 4515,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49834,7 +50396,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4418,
+          "line": 4491,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49891,7 +50453,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4425,
+          "line": 4498,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49936,7 +50498,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4421,
+          "line": 4494,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49981,7 +50543,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4428,
+          "line": 4501,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50026,7 +50588,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4452,
+          "line": 4525,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50077,7 +50639,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4432,
+          "line": 4505,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50128,7 +50690,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4439,
+          "line": 4512,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50179,7 +50741,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4446,
+          "line": 4519,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50230,7 +50792,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4415,
+          "line": 4488,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50281,7 +50843,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4411,
+          "line": 4484,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50326,7 +50888,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4552,
+          "line": 4626,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50371,7 +50933,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2736,
+          "line": 2809,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50437,7 +50999,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2772,
+          "line": 2845,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50493,7 +51055,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2746,
+          "line": 2819,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50549,7 +51111,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2777,
+          "line": 2850,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50605,7 +51167,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2788,
+          "line": 2861,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50661,7 +51223,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2760,
+          "line": 2833,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50717,7 +51279,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2755,
+          "line": 2828,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50773,7 +51335,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2765,
+          "line": 2838,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50834,7 +51396,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2783,
+          "line": 2856,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50890,7 +51452,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2741,
+          "line": 2814,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50941,7 +51503,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2729,
+          "line": 2802,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50992,7 +51554,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2733,
+          "line": 2806,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51043,7 +51605,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2750,
+          "line": 2823,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51099,7 +51661,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4254,
+          "line": 4327,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51155,7 +51717,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4263,
+          "line": 4336,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51206,7 +51768,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4267,
+          "line": 4340,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51257,7 +51819,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4258,
+          "line": 4331,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51308,7 +51870,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4249,
+          "line": 4322,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51359,7 +51921,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4292,
+          "line": 4365,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51415,7 +51977,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4272,
+          "line": 4345,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51471,7 +52033,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4277,
+          "line": 4350,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51532,7 +52094,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4288,
+          "line": 4361,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51588,7 +52150,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4282,
+          "line": 4355,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51639,7 +52201,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4245,
+          "line": 4318,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51690,7 +52252,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4241,
+          "line": 4314,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51741,7 +52303,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1111,
+          "line": 1112,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51795,7 +52357,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1132,
+          "line": 1133,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51854,7 +52416,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1122,
+          "line": 1123,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51918,7 +52480,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1129,
+          "line": 1130,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51972,7 +52534,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1116,
+          "line": 1117,
           "authority": "LuaLS declaration"
         }
       ],
@@ -52021,12 +52583,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3108,
+          "line": 3718,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1058,
+          "line": 1059,
           "authority": "LuaLS declaration"
         }
       ],
@@ -52066,12 +52628,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3117,
+          "line": 3727,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1061,
+          "line": 1062,
           "authority": "LuaLS declaration"
         }
       ],
@@ -52131,7 +52693,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1096,
+          "line": 1097,
           "authority": "LuaLS declaration"
         }
       ],
@@ -52177,7 +52739,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1091,
+          "line": 1092,
           "authority": "LuaLS declaration"
         }
       ],
@@ -52234,7 +52796,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1101,
+          "line": 1102,
           "authority": "LuaLS declaration"
         }
       ],
@@ -52286,7 +52848,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1104,
+          "line": 1105,
           "authority": "LuaLS declaration"
         }
       ],
@@ -52336,7 +52898,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3098,
+          "line": 3708,
           "authority": "native registration"
         }
       ],
@@ -52388,12 +52950,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3122,
+          "line": 3732,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1005,
+          "line": 1006,
           "authority": "LuaLS declaration"
         }
       ],
@@ -52445,12 +53007,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3132,
+          "line": 3742,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1014,
+          "line": 1015,
           "authority": "LuaLS declaration"
         }
       ],
@@ -52501,12 +53063,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3127,
+          "line": 3737,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1010,
+          "line": 1011,
           "authority": "LuaLS declaration"
         }
       ],
@@ -52546,12 +53108,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3135,
+          "line": 3745,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1017,
+          "line": 1018,
           "authority": "LuaLS declaration"
         }
       ],
@@ -52613,12 +53175,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3154,
+          "line": 3764,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1047,
+          "line": 1048,
           "authority": "LuaLS declaration"
         }
       ],
@@ -52677,12 +53239,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3146,
+          "line": 3756,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1041,
+          "line": 1042,
           "authority": "LuaLS declaration"
         }
       ],
@@ -52728,12 +53290,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3166,
+          "line": 3776,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1050,
+          "line": 1051,
           "authority": "LuaLS declaration"
         }
       ],
@@ -52778,12 +53340,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3141,
+          "line": 3751,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1034,
+          "line": 1035,
           "authority": "LuaLS declaration"
         }
       ],
@@ -52829,12 +53391,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3459,
+          "line": 4123,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1483,
+          "line": 1525,
           "authority": "LuaLS declaration"
         }
       ],
@@ -52874,12 +53436,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3473,
+          "line": 4137,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1492,
+          "line": 1534,
           "authority": "LuaLS declaration"
         }
       ],
@@ -52919,12 +53481,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3468,
+          "line": 4132,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1489,
+          "line": 1531,
           "authority": "LuaLS declaration"
         }
       ],
@@ -52964,12 +53526,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3463,
+          "line": 4127,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1486,
+          "line": 1528,
           "authority": "LuaLS declaration"
         }
       ],
@@ -53015,12 +53577,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3455,
+          "line": 4119,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1480,
+          "line": 1522,
           "authority": "LuaLS declaration"
         }
       ],
@@ -53066,12 +53628,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3450,
+          "line": 4114,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1476,
+          "line": 1518,
           "authority": "LuaLS declaration"
         }
       ],
@@ -53123,12 +53685,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3445,
+          "line": 4109,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1472,
+          "line": 1514,
           "authority": "LuaLS declaration"
         }
       ],
@@ -53185,12 +53747,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4099,
+          "line": 4763,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1141,
+          "line": 1142,
           "authority": "LuaLS declaration"
         }
       ],
@@ -53248,12 +53810,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4107,
+          "line": 4771,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1145,
+          "line": 1146,
           "authority": "LuaLS declaration"
         }
       ],
@@ -53315,12 +53877,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4135,
+          "line": 4799,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1141,
+          "line": 1142,
           "authority": "LuaLS declaration"
         }
       ],
@@ -53378,12 +53940,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4143,
+          "line": 4807,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1145,
+          "line": 1146,
           "authority": "LuaLS declaration"
         }
       ],
@@ -53445,12 +54007,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4117,
+          "line": 4781,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1141,
+          "line": 1142,
           "authority": "LuaLS declaration"
         }
       ],
@@ -53497,12 +54059,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4125,
+          "line": 4789,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1145,
+          "line": 1146,
           "authority": "LuaLS declaration"
         }
       ],
@@ -53543,7 +54105,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 913,
+          "line": 914,
           "authority": "LuaLS declaration"
         }
       ],
@@ -53590,7 +54152,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 915,
+          "line": 916,
           "authority": "LuaLS declaration"
         }
       ],
@@ -53642,7 +54204,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 911,
+          "line": 912,
           "authority": "LuaLS declaration"
         }
       ],
@@ -53707,12 +54269,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3249,
+          "line": 3859,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 907,
+          "line": 908,
           "authority": "LuaLS declaration"
         }
       ],
@@ -53770,7 +54332,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 319,
+          "line": 320,
           "authority": "LuaLS declaration"
         }
       ],
@@ -53812,7 +54374,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 316,
+          "line": 317,
           "authority": "LuaLS declaration"
         }
       ],
@@ -53854,7 +54416,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 322,
+          "line": 323,
           "authority": "LuaLS declaration"
         }
       ],
@@ -53896,7 +54458,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 71,
+          "line": 72,
           "authority": "LuaLS declaration"
         }
       ],
@@ -53938,7 +54500,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 74,
+          "line": 75,
           "authority": "LuaLS declaration"
         }
       ],
@@ -53980,7 +54542,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2876,
+          "line": 2949,
           "authority": "LuaLS declaration"
         }
       ],
@@ -54024,7 +54586,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2887,
+          "line": 2960,
           "authority": "LuaLS declaration"
         }
       ],
@@ -54068,7 +54630,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2555,
+          "line": 2628,
           "authority": "LuaLS declaration"
         }
       ],
@@ -54118,7 +54680,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 185,
+          "line": 186,
           "authority": "LuaLS declaration"
         }
       ],
@@ -54166,7 +54728,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 225,
+          "line": 226,
           "authority": "LuaLS declaration"
         }
       ],
@@ -54214,7 +54776,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 221,
+          "line": 222,
           "authority": "LuaLS declaration"
         }
       ],
@@ -54262,7 +54824,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 213,
+          "line": 214,
           "authority": "LuaLS declaration"
         }
       ],
@@ -54310,7 +54872,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 209,
+          "line": 210,
           "authority": "LuaLS declaration"
         }
       ],
@@ -54358,7 +54920,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 205,
+          "line": 206,
           "authority": "LuaLS declaration"
         }
       ],
@@ -54406,7 +54968,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 201,
+          "line": 202,
           "authority": "LuaLS declaration"
         }
       ],
@@ -54454,7 +55016,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 193,
+          "line": 194,
           "authority": "LuaLS declaration"
         }
       ],
@@ -54502,7 +55064,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 217,
+          "line": 218,
           "authority": "LuaLS declaration"
         }
       ],
@@ -54550,7 +55112,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 189,
+          "line": 190,
           "authority": "LuaLS declaration"
         }
       ],
@@ -54598,7 +55160,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 197,
+          "line": 198,
           "authority": "LuaLS declaration"
         }
       ],
@@ -54607,6 +55169,337 @@
       "examples": [],
       "documentation": {
         "id": "api.lua.v5.generated.method.PointCoord.to",
+        "status": "generated-contract-source"
+      }
+    },
+    {
+      "class": "ScriptDialogueContext",
+      "name": "buy_quoted_item",
+      "style": "method",
+      "parameters": [
+        {
+          "name": "prefix",
+          "optional": true,
+          "declaration": "string"
+        }
+      ],
+      "returns": [
+        {
+          "declaration": "boolean"
+        }
+      ],
+      "overloads": [],
+      "errors": {
+        "mode": "lua-error",
+        "message_stability": "not-guaranteed",
+        "conditions": [
+          "capability, validation, lifecycle, or native operation failure"
+        ]
+      },
+      "api_version": 5,
+      "since": "untracked-before-or-at-v5",
+      "deprecated": false,
+      "deprecation_replacement": null,
+      "sources": [
+        {
+          "path": "src/catalua_ui.cpp",
+          "line": 3979,
+          "authority": "native registration"
+        },
+        {
+          "path": "data/lua/types/ccb_api_v5.d.lua",
+          "line": 1820,
+          "authority": "LuaLS declaration"
+        }
+      ],
+      "id": "ScriptDialogueContext.buy_quoted_item",
+      "capabilities": [],
+      "examples": [],
+      "documentation": {
+        "id": "api.lua.v5.generated.method.ScriptDialogueContext.buy_quoted_item",
+        "status": "generated-contract-source"
+      }
+    },
+    {
+      "class": "ScriptDialogueContext",
+      "name": "get",
+      "style": "method",
+      "parameters": [
+        {
+          "name": "key",
+          "optional": false,
+          "declaration": "string"
+        }
+      ],
+      "returns": [
+        {
+          "declaration": "nil|string|number"
+        }
+      ],
+      "overloads": [],
+      "errors": {
+        "mode": "lua-error",
+        "message_stability": "not-guaranteed",
+        "conditions": [
+          "capability, validation, lifecycle, or native operation failure"
+        ]
+      },
+      "api_version": 5,
+      "since": "untracked-before-or-at-v5",
+      "deprecated": false,
+      "deprecation_replacement": null,
+      "sources": [
+        {
+          "path": "src/catalua_ui.cpp",
+          "line": 3969,
+          "authority": "native registration"
+        },
+        {
+          "path": "data/lua/types/ccb_api_v5.d.lua",
+          "line": 1803,
+          "authority": "LuaLS declaration"
+        }
+      ],
+      "id": "ScriptDialogueContext.get",
+      "capabilities": [],
+      "examples": [],
+      "documentation": {
+        "id": "api.lua.v5.generated.method.ScriptDialogueContext.get",
+        "status": "generated-contract-source"
+      }
+    },
+    {
+      "class": "ScriptDialogueContext",
+      "name": "quote_trade_item",
+      "style": "method",
+      "parameters": [
+        {
+          "name": "item_id",
+          "optional": false,
+          "declaration": "string"
+        },
+        {
+          "name": "count",
+          "optional": false,
+          "declaration": "integer"
+        },
+        {
+          "name": "prefix",
+          "optional": true,
+          "declaration": "string"
+        }
+      ],
+      "returns": [
+        {
+          "declaration": "boolean"
+        }
+      ],
+      "overloads": [],
+      "errors": {
+        "mode": "lua-error",
+        "message_stability": "not-guaranteed",
+        "conditions": [
+          "capability, validation, lifecycle, or native operation failure"
+        ]
+      },
+      "api_version": 5,
+      "since": "untracked-before-or-at-v5",
+      "deprecated": false,
+      "deprecation_replacement": null,
+      "sources": [
+        {
+          "path": "src/catalua_ui.cpp",
+          "line": 3972,
+          "authority": "native registration"
+        },
+        {
+          "path": "data/lua/types/ccb_api_v5.d.lua",
+          "line": 1816,
+          "authority": "LuaLS declaration"
+        }
+      ],
+      "id": "ScriptDialogueContext.quote_trade_item",
+      "capabilities": [],
+      "examples": [],
+      "documentation": {
+        "id": "api.lua.v5.generated.method.ScriptDialogueContext.quote_trade_item",
+        "status": "generated-contract-source"
+      }
+    },
+    {
+      "class": "ScriptDialogueContext",
+      "name": "remove",
+      "style": "method",
+      "parameters": [
+        {
+          "name": "key",
+          "optional": false,
+          "declaration": "string"
+        }
+      ],
+      "returns": [],
+      "overloads": [],
+      "errors": {
+        "mode": "lua-error",
+        "message_stability": "not-guaranteed",
+        "conditions": [
+          "capability, validation, lifecycle, or native operation failure"
+        ]
+      },
+      "api_version": 5,
+      "since": "untracked-before-or-at-v5",
+      "deprecated": false,
+      "deprecation_replacement": null,
+      "sources": [
+        {
+          "path": "src/catalua_ui.cpp",
+          "line": 3971,
+          "authority": "native registration"
+        },
+        {
+          "path": "data/lua/types/ccb_api_v5.d.lua",
+          "line": 1810,
+          "authority": "LuaLS declaration"
+        }
+      ],
+      "id": "ScriptDialogueContext.remove",
+      "capabilities": [],
+      "examples": [],
+      "documentation": {
+        "id": "api.lua.v5.generated.method.ScriptDialogueContext.remove",
+        "status": "generated-contract-source"
+      }
+    },
+    {
+      "class": "ScriptDialogueContext",
+      "name": "set",
+      "style": "method",
+      "parameters": [
+        {
+          "name": "key",
+          "optional": false,
+          "declaration": "string"
+        },
+        {
+          "name": "value",
+          "optional": false,
+          "declaration": "nil|string|number|boolean"
+        }
+      ],
+      "returns": [],
+      "overloads": [],
+      "errors": {
+        "mode": "lua-error",
+        "message_stability": "not-guaranteed",
+        "conditions": [
+          "capability, validation, lifecycle, or native operation failure"
+        ]
+      },
+      "api_version": 5,
+      "since": "untracked-before-or-at-v5",
+      "deprecated": false,
+      "deprecation_replacement": null,
+      "sources": [
+        {
+          "path": "src/catalua_ui.cpp",
+          "line": 3970,
+          "authority": "native registration"
+        },
+        {
+          "path": "data/lua/types/ccb_api_v5.d.lua",
+          "line": 1807,
+          "authority": "LuaLS declaration"
+        }
+      ],
+      "id": "ScriptDialogueContext.set",
+      "capabilities": [],
+      "examples": [],
+      "documentation": {
+        "id": "api.lua.v5.generated.method.ScriptDialogueContext.set",
+        "status": "generated-contract-source"
+      }
+    },
+    {
+      "class": "ScriptDialogueContext",
+      "name": "topic",
+      "style": "method",
+      "parameters": [],
+      "returns": [
+        {
+          "declaration": "string"
+        }
+      ],
+      "overloads": [],
+      "errors": {
+        "mode": "lua-error",
+        "message_stability": "not-guaranteed",
+        "conditions": [
+          "capability, validation, lifecycle, or native operation failure"
+        ]
+      },
+      "api_version": 5,
+      "since": "untracked-before-or-at-v5",
+      "deprecated": false,
+      "deprecation_replacement": null,
+      "sources": [
+        {
+          "path": "src/catalua_ui.cpp",
+          "line": 3968,
+          "authority": "native registration"
+        },
+        {
+          "path": "data/lua/types/ccb_api_v5.d.lua",
+          "line": 1799,
+          "authority": "LuaLS declaration"
+        }
+      ],
+      "id": "ScriptDialogueContext.topic",
+      "capabilities": [],
+      "examples": [],
+      "documentation": {
+        "id": "api.lua.v5.generated.method.ScriptDialogueContext.topic",
+        "status": "generated-contract-source"
+      }
+    },
+    {
+      "class": "ScriptDialogueContext",
+      "name": "valid",
+      "style": "method",
+      "parameters": [],
+      "returns": [
+        {
+          "declaration": "boolean"
+        }
+      ],
+      "overloads": [],
+      "errors": {
+        "mode": "lua-error",
+        "message_stability": "not-guaranteed",
+        "conditions": [
+          "capability, validation, lifecycle, or native operation failure"
+        ]
+      },
+      "api_version": 5,
+      "since": "untracked-before-or-at-v5",
+      "deprecated": false,
+      "deprecation_replacement": null,
+      "sources": [
+        {
+          "path": "src/catalua_ui.cpp",
+          "line": 3967,
+          "authority": "native registration"
+        },
+        {
+          "path": "data/lua/types/ccb_api_v5.d.lua",
+          "line": 1796,
+          "authority": "LuaLS declaration"
+        }
+      ],
+      "id": "ScriptDialogueContext.valid",
+      "capabilities": [],
+      "examples": [],
+      "documentation": {
+        "id": "api.lua.v5.generated.method.ScriptDialogueContext.valid",
         "status": "generated-contract-source"
       }
     },
@@ -54635,12 +55528,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3335,
+          "line": 3945,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1670,
+          "line": 1712,
           "authority": "LuaLS declaration"
         }
       ],
@@ -54677,12 +55570,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3336,
+          "line": 3946,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1673,
+          "line": 1715,
           "authority": "LuaLS declaration"
         }
       ],
@@ -54719,12 +55612,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3328,
+          "line": 3938,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1649,
+          "line": 1691,
           "authority": "LuaLS declaration"
         }
       ],
@@ -54757,12 +55650,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3351,
+          "line": 3961,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1739,
+          "line": 1781,
           "authority": "LuaLS declaration"
         }
       ],
@@ -54810,12 +55703,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3346,
+          "line": 3956,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1714,
+          "line": 1756,
           "authority": "LuaLS declaration"
         }
       ],
@@ -54854,12 +55747,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3353,
+          "line": 3963,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1747,
+          "line": 1789,
           "authority": "LuaLS declaration"
         }
       ],
@@ -54902,12 +55795,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3339,
+          "line": 3949,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1684,
+          "line": 1726,
           "authority": "LuaLS declaration"
         }
       ],
@@ -54950,12 +55843,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3337,
+          "line": 3947,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1677,
+          "line": 1719,
           "authority": "LuaLS declaration"
         }
       ],
@@ -54992,12 +55885,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3342,
+          "line": 3952,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1694,
+          "line": 1736,
           "authority": "LuaLS declaration"
         }
       ],
@@ -55034,12 +55927,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3341,
+          "line": 3951,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1691,
+          "line": 1733,
           "authority": "LuaLS declaration"
         }
       ],
@@ -55076,12 +55969,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3326,
+          "line": 3936,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1643,
+          "line": 1685,
           "authority": "LuaLS declaration"
         }
       ],
@@ -55118,12 +56011,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3331,
+          "line": 3941,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1658,
+          "line": 1700,
           "authority": "LuaLS declaration"
         }
       ],
@@ -55172,12 +56065,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3352,
+          "line": 3962,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1744,
+          "line": 1786,
           "authority": "LuaLS declaration"
         }
       ],
@@ -55214,12 +56107,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3327,
+          "line": 3937,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1646,
+          "line": 1688,
           "authority": "LuaLS declaration"
         }
       ],
@@ -55256,12 +56149,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3334,
+          "line": 3944,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1667,
+          "line": 1709,
           "authority": "LuaLS declaration"
         }
       ],
@@ -55298,12 +56191,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3324,
+          "line": 3934,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1640,
+          "line": 1682,
           "authority": "LuaLS declaration"
         }
       ],
@@ -55340,12 +56233,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3323,
+          "line": 3933,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1637,
+          "line": 1679,
           "authority": "LuaLS declaration"
         }
       ],
@@ -55393,12 +56286,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3344,
+          "line": 3954,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1704,
+          "line": 1746,
           "authority": "LuaLS declaration"
         }
       ],
@@ -55446,12 +56339,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3343,
+          "line": 3953,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1699,
+          "line": 1741,
           "authority": "LuaLS declaration"
         }
       ],
@@ -55488,12 +56381,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3332,
+          "line": 3942,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1661,
+          "line": 1703,
           "authority": "LuaLS declaration"
         }
       ],
@@ -55537,12 +56430,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3340,
+          "line": 3950,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1688,
+          "line": 1730,
           "authority": "LuaLS declaration"
         }
       ],
@@ -55595,12 +56488,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3349,
+          "line": 3959,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1731,
+          "line": 1773,
           "authority": "LuaLS declaration"
         }
       ],
@@ -55653,12 +56546,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3348,
+          "line": 3958,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1725,
+          "line": 1767,
           "authority": "LuaLS declaration"
         }
       ],
@@ -55711,12 +56604,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3350,
+          "line": 3960,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1737,
+          "line": 1779,
           "authority": "LuaLS declaration"
         }
       ],
@@ -55753,12 +56646,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3329,
+          "line": 3939,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1652,
+          "line": 1694,
           "authority": "LuaLS declaration"
         }
       ],
@@ -55795,12 +56688,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3333,
+          "line": 3943,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1664,
+          "line": 1706,
           "authority": "LuaLS declaration"
         }
       ],
@@ -55848,12 +56741,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3345,
+          "line": 3955,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1709,
+          "line": 1751,
           "authority": "LuaLS declaration"
         }
       ],
@@ -55901,12 +56794,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3347,
+          "line": 3957,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1719,
+          "line": 1761,
           "authority": "LuaLS declaration"
         }
       ],
@@ -55943,12 +56836,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3322,
+          "line": 3932,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1634,
+          "line": 1676,
           "authority": "LuaLS declaration"
         }
       ],
@@ -55985,12 +56878,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3330,
+          "line": 3940,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1655,
+          "line": 1697,
           "authority": "LuaLS declaration"
         }
       ],
@@ -56027,12 +56920,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3338,
+          "line": 3948,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 1680,
+          "line": 1722,
           "authority": "LuaLS declaration"
         }
       ],
@@ -56090,12 +56983,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3228,
+          "line": 3838,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 834,
+          "line": 835,
           "authority": "LuaLS declaration"
         }
       ],
@@ -56132,12 +57025,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3188,
+          "line": 3798,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 653,
+          "line": 654,
           "authority": "LuaLS declaration"
         }
       ],
@@ -56176,12 +57069,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3196,
+          "line": 3806,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 678,
+          "line": 679,
           "authority": "LuaLS declaration"
         }
       ],
@@ -56224,12 +57117,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3207,
+          "line": 3817,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 711,
+          "line": 712,
           "authority": "LuaLS declaration"
         }
       ],
@@ -56277,12 +57170,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3208,
+          "line": 3818,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 716,
+          "line": 717,
           "authority": "LuaLS declaration"
         }
       ],
@@ -56330,12 +57223,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3211,
+          "line": 3821,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 730,
+          "line": 731,
           "authority": "LuaLS declaration"
         }
       ],
@@ -56388,12 +57281,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3212,
+          "line": 3822,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 736,
+          "line": 737,
           "authority": "LuaLS declaration"
         }
       ],
@@ -56442,12 +57335,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3234,
+          "line": 3844,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 839,
+          "line": 840,
           "authority": "LuaLS declaration"
         }
       ],
@@ -56486,12 +57379,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3197,
+          "line": 3807,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 681,
+          "line": 682,
           "authority": "LuaLS declaration"
         }
       ],
@@ -56528,12 +57421,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3193,
+          "line": 3803,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 669,
+          "line": 670,
           "authority": "LuaLS declaration"
         }
       ],
@@ -56592,12 +57485,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3237,
+          "line": 3847,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 856,
+          "line": 857,
           "authority": "LuaLS declaration"
         }
       ],
@@ -56636,12 +57529,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3195,
+          "line": 3805,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 675,
+          "line": 676,
           "authority": "LuaLS declaration"
         }
       ],
@@ -56689,12 +57582,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3223,
+          "line": 3833,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 804,
+          "line": 805,
           "authority": "LuaLS declaration"
         }
       ],
@@ -56747,12 +57640,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3224,
+          "line": 3834,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 810,
+          "line": 811,
           "authority": "LuaLS declaration"
         }
       ],
@@ -56800,12 +57693,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3221,
+          "line": 3831,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 793,
+          "line": 794,
           "authority": "LuaLS declaration"
         }
       ],
@@ -56858,12 +57751,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3222,
+          "line": 3832,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 799,
+          "line": 800,
           "authority": "LuaLS declaration"
         }
       ],
@@ -56911,12 +57804,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3225,
+          "line": 3835,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 815,
+          "line": 816,
           "authority": "LuaLS declaration"
         }
       ],
@@ -56969,12 +57862,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3226,
+          "line": 3836,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 821,
+          "line": 822,
           "authority": "LuaLS declaration"
         }
       ],
@@ -57011,12 +57904,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3191,
+          "line": 3801,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 663,
+          "line": 664,
           "authority": "LuaLS declaration"
         }
       ],
@@ -57055,12 +57948,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3205,
+          "line": 3815,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 703,
+          "line": 704,
           "authority": "LuaLS declaration"
         }
       ],
@@ -57118,12 +58011,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3243,
+          "line": 3853,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 885,
+          "line": 886,
           "authority": "LuaLS declaration"
         }
       ],
@@ -57156,12 +58049,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3202,
+          "line": 3812,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 696,
+          "line": 697,
           "authority": "LuaLS declaration"
         }
       ],
@@ -57198,12 +58091,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3189,
+          "line": 3799,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 656,
+          "line": 657,
           "authority": "LuaLS declaration"
         }
       ],
@@ -57247,12 +58140,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3206,
+          "line": 3816,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 707,
+          "line": 708,
           "authority": "LuaLS declaration"
         }
       ],
@@ -57305,12 +58198,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3227,
+          "line": 3837,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 827,
+          "line": 828,
           "authority": "LuaLS declaration"
         }
       ],
@@ -57358,12 +58251,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3213,
+          "line": 3823,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 741,
+          "line": 742,
           "authority": "LuaLS declaration"
         }
       ],
@@ -57416,12 +58309,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3214,
+          "line": 3824,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 747,
+          "line": 748,
           "authority": "LuaLS declaration"
         }
       ],
@@ -57454,12 +58347,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3201,
+          "line": 3811,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 695,
+          "line": 696,
           "authority": "LuaLS declaration"
         }
       ],
@@ -57508,12 +58401,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3235,
+          "line": 3845,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 844,
+          "line": 845,
           "authority": "LuaLS declaration"
         }
       ],
@@ -57561,12 +58454,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3215,
+          "line": 3825,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 752,
+          "line": 753,
           "authority": "LuaLS declaration"
         }
       ],
@@ -57619,12 +58512,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3216,
+          "line": 3826,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 758,
+          "line": 759,
           "authority": "LuaLS declaration"
         }
       ],
@@ -57657,12 +58550,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3200,
+          "line": 3810,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 694,
+          "line": 695,
           "authority": "LuaLS declaration"
         }
       ],
@@ -57701,12 +58594,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3204,
+          "line": 3814,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 700,
+          "line": 701,
           "authority": "LuaLS declaration"
         }
       ],
@@ -57764,12 +58657,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3219,
+          "line": 3829,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 780,
+          "line": 781,
           "authority": "LuaLS declaration"
         }
       ],
@@ -57832,12 +58725,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3220,
+          "line": 3830,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 788,
+          "line": 789,
           "authority": "LuaLS declaration"
         }
       ],
@@ -57895,12 +58788,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3217,
+          "line": 3827,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 765,
+          "line": 766,
           "authority": "LuaLS declaration"
         }
       ],
@@ -57963,12 +58856,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3218,
+          "line": 3828,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 773,
+          "line": 774,
           "authority": "LuaLS declaration"
         }
       ],
@@ -58011,12 +58904,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3209,
+          "line": 3819,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 720,
+          "line": 721,
           "authority": "LuaLS declaration"
         }
       ],
@@ -58064,12 +58957,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3210,
+          "line": 3820,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 725,
+          "line": 726,
           "authority": "LuaLS declaration"
         }
       ],
@@ -58102,12 +58995,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3203,
+          "line": 3813,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 697,
+          "line": 698,
           "authority": "LuaLS declaration"
         }
       ],
@@ -58150,12 +59043,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3190,
+          "line": 3800,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 660,
+          "line": 661,
           "authority": "LuaLS declaration"
         }
       ],
@@ -58208,12 +59101,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3241,
+          "line": 3851,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 871,
+          "line": 872,
           "authority": "LuaLS declaration"
         }
       ],
@@ -58262,12 +59155,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3236,
+          "line": 3846,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 849,
+          "line": 850,
           "authority": "LuaLS declaration"
         }
       ],
@@ -58304,12 +59197,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3239,
+          "line": 3849,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 861,
+          "line": 862,
           "authority": "LuaLS declaration"
         }
       ],
@@ -58342,12 +59235,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3238,
+          "line": 3848,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 858,
+          "line": 859,
           "authority": "LuaLS declaration"
         }
       ],
@@ -58391,12 +59284,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3240,
+          "line": 3850,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 865,
+          "line": 866,
           "authority": "LuaLS declaration"
         }
       ],
@@ -58435,12 +59328,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3194,
+          "line": 3804,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 672,
+          "line": 673,
           "authority": "LuaLS declaration"
         }
       ],
@@ -58499,12 +59392,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3198,
+          "line": 3808,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 688,
+          "line": 689,
           "authority": "LuaLS declaration"
         }
       ],
@@ -58548,12 +59441,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3199,
+          "line": 3809,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 692,
+          "line": 693,
           "authority": "LuaLS declaration"
         }
       ],
@@ -58592,12 +59485,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3244,
+          "line": 3854,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 888,
+          "line": 889,
           "authority": "LuaLS declaration"
         }
       ],
@@ -58655,12 +59548,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3242,
+          "line": 3852,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 878,
+          "line": 879,
           "authority": "LuaLS declaration"
         }
       ],
@@ -58697,12 +59590,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3192,
+          "line": 3802,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 666,
+          "line": 667,
           "authority": "LuaLS declaration"
         }
       ],
@@ -58751,12 +59644,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3245,
+          "line": 3855,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 893,
+          "line": 894,
           "authority": "LuaLS declaration"
         }
       ],
@@ -58805,12 +59698,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3246,
+          "line": 3856,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 898,
+          "line": 899,
           "authority": "LuaLS declaration"
         }
       ],
@@ -58858,7 +59751,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 119,
+          "line": 120,
           "authority": "LuaLS declaration"
         }
       ],
@@ -58900,7 +59793,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 115,
+          "line": 116,
           "authority": "LuaLS declaration"
         }
       ],
@@ -58948,7 +59841,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 127,
+          "line": 128,
           "authority": "LuaLS declaration"
         }
       ],
@@ -58996,7 +59889,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 123,
+          "line": 124,
           "authority": "LuaLS declaration"
         }
       ],
@@ -59044,7 +59937,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 112,
+          "line": 113,
           "authority": "LuaLS declaration"
         }
       ],
@@ -59092,7 +59985,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 172,
+          "line": 173,
           "authority": "LuaLS declaration"
         }
       ],
@@ -59134,7 +60027,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 168,
+          "line": 169,
           "authority": "LuaLS declaration"
         }
       ],
@@ -59176,7 +60069,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 141,
+          "line": 142,
           "authority": "LuaLS declaration"
         }
       ],
@@ -59218,7 +60111,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 150,
+          "line": 151,
           "authority": "LuaLS declaration"
         }
       ],
@@ -59260,7 +60153,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 144,
+          "line": 145,
           "authority": "LuaLS declaration"
         }
       ],
@@ -59302,7 +60195,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 153,
+          "line": 154,
           "authority": "LuaLS declaration"
         }
       ],
@@ -59344,7 +60237,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 147,
+          "line": 148,
           "authority": "LuaLS declaration"
         }
       ],
@@ -59386,7 +60279,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 138,
+          "line": 139,
           "authority": "LuaLS declaration"
         }
       ],
@@ -59428,7 +60321,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 162,
+          "line": 163,
           "authority": "LuaLS declaration"
         }
       ],
@@ -59470,7 +60363,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 165,
+          "line": 166,
           "authority": "LuaLS declaration"
         }
       ],
@@ -59512,7 +60405,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 135,
+          "line": 136,
           "authority": "LuaLS declaration"
         }
       ],
@@ -59554,7 +60447,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 156,
+          "line": 157,
           "authority": "LuaLS declaration"
         }
       ],
@@ -59596,7 +60489,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 159,
+          "line": 160,
           "authority": "LuaLS declaration"
         }
       ],
@@ -59646,7 +60539,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 243,
+          "line": 244,
           "authority": "LuaLS declaration"
         }
       ],
@@ -59694,7 +60587,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 284,
+          "line": 285,
           "authority": "LuaLS declaration"
         }
       ],
@@ -59742,7 +60635,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 280,
+          "line": 281,
           "authority": "LuaLS declaration"
         }
       ],
@@ -59790,7 +60683,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 272,
+          "line": 273,
           "authority": "LuaLS declaration"
         }
       ],
@@ -59838,7 +60731,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 268,
+          "line": 269,
           "authority": "LuaLS declaration"
         }
       ],
@@ -59886,7 +60779,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 264,
+          "line": 265,
           "authority": "LuaLS declaration"
         }
       ],
@@ -59934,7 +60827,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 260,
+          "line": 261,
           "authority": "LuaLS declaration"
         }
       ],
@@ -59982,7 +60875,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 252,
+          "line": 253,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60030,7 +60923,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 276,
+          "line": 277,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60080,7 +60973,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 248,
+          "line": 249,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60128,7 +61021,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 256,
+          "line": 257,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60170,7 +61063,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 238,
+          "line": 239,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60218,7 +61111,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 91,
+          "line": 92,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60266,7 +61159,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 103,
+          "line": 104,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60308,7 +61201,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 83,
+          "line": 84,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60356,7 +61249,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 99,
+          "line": 100,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60404,7 +61297,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 95,
+          "line": 96,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60452,7 +61345,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 87,
+          "line": 88,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60494,7 +61387,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4189,
+          "line": 4262,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60536,7 +61429,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4192,
+          "line": 4265,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60562,7 +61455,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 288,
+          "line": 289,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60586,7 +61479,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 289,
+          "line": 290,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60610,7 +61503,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 290,
+          "line": 291,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60634,7 +61527,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 312,
+          "line": 313,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60658,7 +61551,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 66,
+          "line": 67,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60682,7 +61575,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 67,
+          "line": 68,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60706,7 +61599,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2870,
+          "line": 2943,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60730,7 +61623,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2869,
+          "line": 2942,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60754,7 +61647,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2871,
+          "line": 2944,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60778,7 +61671,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2872,
+          "line": 2945,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60802,7 +61695,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2881,
+          "line": 2954,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60826,7 +61719,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2880,
+          "line": 2953,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60850,7 +61743,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2882,
+          "line": 2955,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60874,7 +61767,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2883,
+          "line": 2956,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60898,7 +61791,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2550,
+          "line": 2623,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60922,7 +61815,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2549,
+          "line": 2622,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60946,7 +61839,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2551,
+          "line": 2624,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60970,7 +61863,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 178,
+          "line": 179,
           "authority": "LuaLS declaration"
         }
       ],
@@ -60994,7 +61887,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 179,
+          "line": 180,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61018,7 +61911,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 180,
+          "line": 181,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61042,7 +61935,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 176,
+          "line": 177,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61066,7 +61959,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 177,
+          "line": 178,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61085,12 +61978,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3175,
+          "line": 3785,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 623,
+          "line": 624,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61109,12 +62002,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3174,
+          "line": 3784,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 622,
+          "line": 623,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61133,12 +62026,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3178,
+          "line": 3788,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 626,
+          "line": 627,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61157,12 +62050,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3173,
+          "line": 3783,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 621,
+          "line": 622,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61181,12 +62074,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3181,
+          "line": 3791,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 629,
+          "line": 630,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61205,12 +62098,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3184,
+          "line": 3794,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 632,
+          "line": 633,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61229,12 +62122,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3176,
+          "line": 3786,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 624,
+          "line": 625,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61253,12 +62146,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3180,
+          "line": 3790,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 628,
+          "line": 629,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61277,12 +62170,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3182,
+          "line": 3792,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 630,
+          "line": 631,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61301,12 +62194,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3172,
+          "line": 3782,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 620,
+          "line": 621,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61325,12 +62218,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3179,
+          "line": 3789,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 627,
+          "line": 628,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61349,12 +62242,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3183,
+          "line": 3793,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 631,
+          "line": 632,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61373,12 +62266,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3177,
+          "line": 3787,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 625,
+          "line": 626,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61402,7 +62295,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 107,
+          "line": 108,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61426,7 +62319,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 131,
+          "line": 132,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61450,7 +62343,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 232,
+          "line": 233,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61474,7 +62367,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 233,
+          "line": 234,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61498,7 +62391,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 234,
+          "line": 235,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61522,7 +62415,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 229,
+          "line": 230,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61546,7 +62439,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 230,
+          "line": 231,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61570,7 +62463,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 231,
+          "line": 232,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61594,7 +62487,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 79,
+          "line": 80,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61618,7 +62511,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 78,
+          "line": 79,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61642,7 +62535,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4184,
+          "line": 4257,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61666,7 +62559,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4180,
+          "line": 4253,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61690,7 +62583,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4182,
+          "line": 4255,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61714,7 +62607,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4185,
+          "line": 4258,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61738,7 +62631,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4183,
+          "line": 4256,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61762,7 +62655,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4181,
+          "line": 4254,
           "authority": "LuaLS declaration"
         }
       ],
@@ -73242,7 +74135,7 @@
       }
     },
     {
-      "id": "game.hooks",
+      "id": "game.dialogue",
       "minimum_api_version": 5,
       "sources": [
         {
@@ -73257,6 +74150,26 @@
         }
       ],
       "documentation": {
+        "id": "api.lua.v5.generated.capability.game.dialogue",
+        "status": "generated-contract-source"
+      }
+    },
+    {
+      "id": "game.hooks",
+      "minimum_api_version": 5,
+      "sources": [
+        {
+          "path": "src/catalua_ui_manifest.cpp",
+          "line": 51,
+          "authority": "native capability registry"
+        },
+        {
+          "path": "data/lua/manifest.schema.json",
+          "line": 43,
+          "authority": "manifest Schema"
+        }
+      ],
+      "documentation": {
         "id": "api.lua.v5.generated.capability.game.hooks",
         "status": "generated-contract-source"
       }
@@ -73267,12 +74180,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_manifest.cpp",
-          "line": 51,
+          "line": 52,
           "authority": "native capability registry"
         },
         {
           "path": "data/lua/manifest.schema.json",
-          "line": 43,
+          "line": 44,
           "authority": "manifest Schema"
         }
       ],
@@ -73287,12 +74200,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_manifest.cpp",
-          "line": 52,
+          "line": 53,
           "authority": "native capability registry"
         },
         {
           "path": "data/lua/manifest.schema.json",
-          "line": 44,
+          "line": 45,
           "authority": "manifest Schema"
         }
       ],
@@ -73307,12 +74220,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_manifest.cpp",
-          "line": 53,
+          "line": 54,
           "authority": "native capability registry"
         },
         {
           "path": "data/lua/manifest.schema.json",
-          "line": 45,
+          "line": 46,
           "authority": "manifest Schema"
         }
       ],
@@ -73327,12 +74240,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_manifest.cpp",
-          "line": 54,
+          "line": 55,
           "authority": "native capability registry"
         },
         {
           "path": "data/lua/manifest.schema.json",
-          "line": 46,
+          "line": 47,
           "authority": "manifest Schema"
         }
       ],
@@ -73347,12 +74260,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_manifest.cpp",
-          "line": 55,
+          "line": 56,
           "authority": "native capability registry"
         },
         {
           "path": "data/lua/manifest.schema.json",
-          "line": 47,
+          "line": 48,
           "authority": "manifest Schema"
         }
       ],
@@ -73367,12 +74280,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_manifest.cpp",
-          "line": 56,
+          "line": 57,
           "authority": "native capability registry"
         },
         {
           "path": "data/lua/manifest.schema.json",
-          "line": 48,
+          "line": 49,
           "authority": "manifest Schema"
         }
       ],
@@ -73387,12 +74300,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_manifest.cpp",
-          "line": 57,
+          "line": 58,
           "authority": "native capability registry"
         },
         {
           "path": "data/lua/manifest.schema.json",
-          "line": 49,
+          "line": 50,
           "authority": "manifest Schema"
         }
       ],
@@ -73407,12 +74320,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_manifest.cpp",
-          "line": 58,
+          "line": 59,
           "authority": "native capability registry"
         },
         {
           "path": "data/lua/manifest.schema.json",
-          "line": 50,
+          "line": 51,
           "authority": "manifest Schema"
         }
       ],
@@ -73427,12 +74340,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_manifest.cpp",
-          "line": 59,
+          "line": 60,
           "authority": "native capability registry"
         },
         {
           "path": "data/lua/manifest.schema.json",
-          "line": 51,
+          "line": 52,
           "authority": "manifest Schema"
         }
       ],
@@ -73447,12 +74360,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_manifest.cpp",
-          "line": 60,
+          "line": 61,
           "authority": "native capability registry"
         },
         {
           "path": "data/lua/manifest.schema.json",
-          "line": 52,
+          "line": 53,
           "authority": "manifest Schema"
         }
       ],
@@ -73467,12 +74380,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_manifest.cpp",
-          "line": 61,
+          "line": 62,
           "authority": "native capability registry"
         },
         {
           "path": "data/lua/manifest.schema.json",
-          "line": 53,
+          "line": 54,
           "authority": "manifest Schema"
         }
       ],
@@ -73623,6 +74536,7 @@
             "game.actions",
             "game.actions.dangerous",
             "game.callbacks",
+            "game.dialogue",
             "game.hooks",
             "game.read",
             "game.write",

--- a/data/lua/reference/ccb_public_api_v5_coverage.json
+++ b/data/lua/reference/ccb_public_api_v5_coverage.json
@@ -10,26 +10,26 @@
       "private C++ helpers without a registered Lua access path"
     ]
   },
-  "inventory_sha256": "0311c4337fbd0b327f7fc7aab031c2ead6e86e63bf1eff935878c812b9251908",
+  "inventory_sha256": "6787b734c2d87c72f2744a7953efd2cf738bf4088a220c615a0be683705c1bdf",
   "sections": {
     "modules": 3,
-    "namespaces": 69,
-    "classes": 263,
-    "functions": 489,
-    "methods": 142,
+    "namespaces": 70,
+    "classes": 269,
+    "functions": 492,
+    "methods": 149,
     "properties": 51,
     "operators": 47,
     "enums": 26,
     "events": 113,
     "hooks": 52,
     "callbacks": 38,
-    "capabilities": 16,
+    "capabilities": 17,
     "manifest_fields": 6,
-    "class_fields": 1326,
+    "class_fields": 1344,
     "event_fields": 242
   },
-  "public_symbols": 2832,
-  "documented_symbols": 2832,
+  "public_symbols": 2868,
+  "documented_symbols": 2868,
   "undocumented_symbols": {
     "count": 0,
     "ids": []

--- a/data/lua/types/ccb_api_v5.d.lua
+++ b/data/lua/types/ccb_api_v5.d.lua
@@ -27,6 +27,7 @@
 ---| '"game.actions"'
 ---| '"game.actions.dangerous"'
 ---| '"game.callbacks"'
+---| '"game.dialogue"'
 ---| '"game.hooks"'
 ---| '"game.read"'
 ---| '"game.write"'
@@ -1426,6 +1427,47 @@ function CcbActionMenuApi.list() end
 ---@return CcbActionMenuLimits
 function CcbActionMenuApi.limits() end
 
+---@class CcbDialogueResponseDescriptor
+---@field text string
+---@field topic? string
+---@field on_select? fun(context: ScriptDialogueContext): string|table|nil
+
+---@alias CcbDialogueResponses CcbDialogueResponseDescriptor[]|fun(context: ScriptDialogueContext): CcbDialogueResponseDescriptor[]
+
+---@class CcbDialogueTopicDescriptor
+---@field id string
+---@field dynamic_line string|fun(context: ScriptDialogueContext): string
+---@field responses CcbDialogueResponses
+
+---@class CcbDialogueExtensionDescriptor
+---@field id string
+---@field insert_before_standard_exits? boolean
+---@field responses CcbDialogueResponses
+
+---@class CcbDialogueLimits
+---@field topics integer
+---@field topics_per_source integer
+---@field extensions integer
+---@field extensions_per_source integer
+---@field responses_per_topic integer
+---@field id_bytes integer
+---@field text_bytes integer
+---@field callback_instructions integer
+
+---@class CcbDialogueApi
+local CcbDialogueApi = {}
+
+---@param descriptor CcbDialogueTopicDescriptor
+---@return integer registration_id
+function CcbDialogueApi.register_topic(descriptor) end
+
+---@param descriptor CcbDialogueExtensionDescriptor
+---@return integer registration_id
+function CcbDialogueApi.extend_topic(descriptor) end
+
+---@return CcbDialogueLimits
+function CcbDialogueApi.limits() end
+
 ---@class CcbSidebarLine
 ---@field text string
 ---@field color? string
@@ -1745,6 +1787,37 @@ function ScriptMapgenContext:nest(id, x, y) end
 
 ---@param id string
 function ScriptMapgenContext:generate(id) end
+
+---Callback-scoped NPC dialogue facade.
+---@class ScriptDialogueContext
+local ScriptDialogueContext = {}
+
+---@return boolean
+function ScriptDialogueContext:valid() end
+
+---@return string
+function ScriptDialogueContext:topic() end
+
+---@param key string
+---@return nil|string|number
+function ScriptDialogueContext:get(key) end
+
+---@param key string
+---@param value nil|string|number|boolean
+function ScriptDialogueContext:set(key, value) end
+
+---@param key string
+function ScriptDialogueContext:remove(key) end
+
+---@param item_id string
+---@param count integer
+---@param prefix? string
+---@return boolean
+function ScriptDialogueContext:quote_trade_item(item_id, count, prefix) end
+
+---@param prefix? string
+---@return boolean
+function ScriptDialogueContext:buy_quoted_item(prefix) end
 
 ---@class CcbMapgenHookOptions: CcbHookOptions
 ---@field terrain_ids? string[]
@@ -4476,6 +4549,7 @@ function CcbWeatherApi.refresh() end
 ---@field actions CcbGameActionsApi
 ---@field action_menu CcbActionMenuApi
 ---@field addictions CcbAddictionsApi
+---@field dialogue CcbDialogueApi
 ---@field sidebar CcbSidebarApi
 ---@field types CcbTypesApi
 ---@field units CcbUnitsApi

--- a/src/catalua_ui.cpp
+++ b/src/catalua_ui.cpp
@@ -17,6 +17,7 @@
 #include <set>
 #include <stdexcept>
 #include <string>
+#include <system_error>
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
@@ -83,6 +84,7 @@
 #include "catalua_ui_world_services.h"
 #include "catalua_ui_zones.h"
 #include "debug.h"
+#include "dialogue.h"
 #include "enum_conversions.h"
 #include "event.h"
 #include "event_bus.h"
@@ -98,11 +100,15 @@
 #include "item_location.h"
 #include "json_loader.h"
 #include "messages.h"
+#include "math_parser_diag_value.h"
 #include "mapgendata.h"
 #include "mod_manager.h"
+#include "npc.h"
+#include "npctrade.h"
 #include "output.h"
 #include "panels.h"
 #include "path_info.h"
+#include "popup.h"
 #include "talker.h"
 #include "translations.h"
 #include "thread_pool.h"
@@ -150,6 +156,13 @@ constexpr std::size_t maximum_hook_result_bytes = 512;
 constexpr std::size_t maximum_hook_results_per_handler = 64;
 constexpr std::size_t maximum_hook_results_per_dispatch = 256;
 constexpr std::size_t maximum_hook_result_entry_bytes = 512;
+constexpr std::size_t maximum_dialogue_topics = 256;
+constexpr std::size_t maximum_dialogue_topics_per_source = 64;
+constexpr std::size_t maximum_dialogue_extensions = 256;
+constexpr std::size_t maximum_dialogue_extensions_per_source = 64;
+constexpr std::size_t maximum_dialogue_responses_per_topic = 256;
+constexpr std::size_t maximum_dialogue_id_bytes = 256;
+constexpr std::size_t maximum_dialogue_text_bytes = 4096;
 
 struct memory_tracker {
     std::size_t used = 0;
@@ -340,6 +353,33 @@ struct sidebar_widget_definition {
     std::size_t source_index = 0;
 };
 
+struct dialogue_topic_definition {
+    std::uint64_t registration_id = 0;
+    std::string id;
+    std::optional<std::string> dynamic_line_text;
+    std::optional<sol::protected_function> dynamic_line_callback;
+    sol::object responses;
+    bool enabled = true;
+    std::string error;
+    std::size_t source_index = 0;
+};
+
+struct dialogue_extension_definition {
+    std::uint64_t registration_id = 0;
+    std::string id;
+    bool insert_before_standard_exits = false;
+    sol::object responses;
+    bool enabled = true;
+    std::string error;
+    std::size_t source_index = 0;
+};
+
+struct dialogue_response_callback {
+    std::size_t source_index = 0;
+    std::string topic_id;
+    sol::protected_function callback;
+};
+
 struct script_source {
     script_manifest manifest;
     fs::path root;
@@ -393,6 +433,12 @@ class runtime_state : public event_subscriber
         std::uint64_t next_action_menu_registration_id = 1;
         std::vector<sidebar_widget_definition> sidebar_widgets;
         std::uint64_t next_sidebar_widget_registration_id = 1;
+        std::vector<dialogue_topic_definition> dialogue_topics;
+        std::uint64_t next_dialogue_topic_registration_id = 1;
+        std::vector<dialogue_extension_definition> dialogue_extensions;
+        std::uint64_t next_dialogue_extension_registration_id = 1;
+        std::unordered_map<std::uint64_t, dialogue_response_callback> dialogue_response_callbacks;
+        std::uint64_t next_dialogue_response_callback_id = 1;
         script_event_registry event_registry;
         std::unordered_map<std::uint64_t, sol::protected_function> event_callbacks;
         script_event_registry hook_registry;
@@ -1476,6 +1522,539 @@ sol::table sidebar_limits_to_lua(
                maximum_sidebar_widget_output_bytes,
                "callback_instructions",
                callback_instruction_limit );
+}
+
+bool valid_dialogue_id( const std::string &value )
+{
+    return !value.empty() && value.size() <= maximum_dialogue_id_bytes &&
+           value.find( '\0' ) == std::string::npos;
+}
+
+void require_dialogue_text( const std::string &value,
+                            const std::string_view field )
+{
+    if( value.empty() || value.size() > maximum_dialogue_text_bytes ||
+        value.find( '\0' ) != std::string::npos ) {
+        throw std::invalid_argument(
+            "game.dialogue " + std::string( field ) +
+            " must contain 1 to 4096 non-NUL bytes" );
+    }
+}
+
+class script_dialogue_context
+{
+    public:
+        script_dialogue_context( runtime_state &state, dialogue &d,
+                                 std::string topic_id,
+                                 const bool allow_write )
+            : state_( std::make_shared<context_state>() ) {
+            state_->lua_state = state.lua.lua_state();
+            state_->d = &d;
+            state_->topic_id = std::move( topic_id );
+            state_->allow_write = allow_write;
+        }
+
+        bool valid() const noexcept {
+            return state_ != nullptr && state_->d != nullptr;
+        }
+
+        void invalidate() noexcept {
+            if( state_ != nullptr ) {
+                state_->d = nullptr;
+            }
+        }
+
+        std::string topic() const {
+            return require_state().topic_id;
+        }
+
+        sol::object get( const std::string &key ) const {
+            const dialogue &d = require_state().dialogue_ref();
+            const diag_value *value = d.maybe_get_value( key );
+            sol::state_view lua( require_state().lua_state );
+            if( value == nullptr || value->is_empty() ) {
+                return sol::make_object( lua, sol::lua_nil );
+            }
+            if( value->is_dbl() ) {
+                return sol::make_object( lua, value->dbl() );
+            }
+            if( value->is_str() ) {
+                return sol::make_object( lua, value->str() );
+            }
+            return sol::make_object( lua, value->to_string() );
+        }
+
+        void set( const std::string &key, const sol::object &value ) const {
+            dialogue &d = require_write_state().dialogue_ref();
+            if( value.get_type() == sol::type::nil ) {
+                d.remove_value( key );
+            } else if( value.get_type() == sol::type::number ) {
+                d.set_value( key, value.as<double>() );
+            } else if( value.get_type() == sol::type::string ) {
+                d.set_value( key, value.as<std::string>() );
+            } else if( value.get_type() == sol::type::boolean ) {
+                d.set_value( key, value.as<bool>() ? "true" : "false" );
+            } else {
+                throw std::invalid_argument(
+                    "dialogue context values must be nil, string, number, or boolean" );
+            }
+        }
+
+        void remove( const std::string &key ) const {
+            require_write_state().dialogue_ref().remove_value( key );
+        }
+
+        bool quote_trade_item( const std::string &item_name, const int count,
+                               const std::string &prefix ) const {
+            dialogue &d = require_write_state().dialogue_ref();
+            const auto set_quote = [&d, &prefix]( const std::string & item_id,
+                                                  const std::string & display_name,
+            const int item_count, const int cost ) {
+                d.set_value( prefix + "_item_id", item_id );
+                d.set_value( prefix + "_item_name", display_name );
+                d.set_value( prefix + "_count", item_count );
+                d.set_value( prefix + "_cost", cost );
+            };
+
+            const itype_id item_id( item_name );
+            const int stored_count = count > 0 ? count : 0;
+            Character *buyer = d.actor( false )->get_character();
+            Character *seller = d.actor( true )->get_character();
+            if( npc *seller_npc = d.actor( true )->get_npc() ) {
+                seller = &seller_npc->get_trade_delegate();
+            }
+
+            if( buyer == nullptr || seller == nullptr || count <= 0 || !item_id.is_valid() ) {
+                set_quote( item_name, item_name, stored_count, -1 );
+                return false;
+            }
+
+            item quote_item( item_id, calendar::turn );
+            if( quote_item.count_by_charges() ) {
+                quote_item.charges = count;
+            }
+            const int quoted_cost = npc_trading::trading_price_for_order(
+                                        *buyer, *seller, quote_item, count );
+            set_quote( item_id.str(), item::nname( item_id, count ), count,
+                       quoted_cost > 0 ? quoted_cost : -1 );
+            return quoted_cost > 0;
+        }
+
+        bool buy_quoted_item( const std::string &prefix ) const {
+            dialogue &d = require_write_state().dialogue_ref();
+            const std::string item_name =
+                get_context_string( d, prefix + "_item_id" );
+            const int count = get_context_int( d, prefix + "_count", 1 );
+            const int cost = get_context_int( d, prefix + "_cost", 0 );
+            const itype_id item_id( item_name );
+            if( count <= 0 || cost <= 0 || !item_id.is_valid() ) {
+                return false;
+            }
+            if( !d.actor( true )->buy_from( cost ) ) {
+                popup( _( "You can't afford it!" ) );
+                return false;
+            }
+
+            item new_item( item_id, calendar::turn );
+            if( new_item.count_by_charges() ) {
+                new_item.charges = count;
+                d.actor( false )->i_add_or_drop( new_item );
+            } else {
+                for( int index = 0; index < count; ++index ) {
+                    d.actor( false )->i_add_or_drop( new_item );
+                }
+            }
+            if( d.has_beta && !d.actor( true )->disp_name().empty() ) {
+                if( count == 1 ) {
+                    popup( _( "%1$s gives you a %2$s." ),
+                           d.actor( true )->disp_name(), new_item.tname() );
+                } else {
+                    popup( _( "%1$s gives you %2$d %3$s." ),
+                           d.actor( true )->disp_name(), count,
+                           new_item.tname() );
+                }
+            }
+            return true;
+        }
+
+    private:
+        struct context_state {
+            lua_State *lua_state = nullptr;
+            dialogue *d = nullptr;
+            std::string topic_id;
+            bool allow_write = false;
+
+            dialogue &dialogue_ref() const {
+                return *d;
+            }
+        };
+
+        std::shared_ptr<context_state> state_;
+
+        context_state &require_state() const {
+            if( !valid() ) {
+                throw std::runtime_error(
+                    "Lua dialogue context is no longer valid" );
+            }
+            return *state_;
+        }
+
+        context_state &require_write_state() const {
+            context_state &state = require_state();
+            if( !state.allow_write ) {
+                throw std::runtime_error(
+                    "Lua dialogue mutation requires capability 'game.write'" );
+            }
+            return state;
+        }
+
+        static std::string get_context_string( dialogue &d,
+                                               const std::string &key ) {
+            const diag_value *value = d.maybe_get_value( key );
+            if( value == nullptr || value->is_empty() ) {
+                return {};
+            }
+            if( value->is_str() ) {
+                return value->str();
+            }
+            return value->to_string();
+        }
+
+        static int get_context_int( dialogue &d, const std::string &key,
+                                    const int fallback ) {
+            const diag_value *value = d.maybe_get_value( key );
+            if( value == nullptr || value->is_empty() ) {
+                return fallback;
+            }
+            if( value->is_dbl() ) {
+                return static_cast<int>( value->dbl() );
+            }
+            if( value->is_str() ) {
+                int parsed = fallback;
+                const std::string &text = value->str();
+                const char *begin = text.data();
+                const char *end = begin + text.size();
+                const std::from_chars_result result =
+                    std::from_chars( begin, end, parsed );
+                if( result.ec == std::errc() && result.ptr == end ) {
+                    return parsed;
+                }
+            }
+            return fallback;
+        }
+};
+
+std::shared_ptr<script_dialogue_context> make_dialogue_context(
+    runtime_state &state, dialogue &d, const std::size_t source_index,
+    const std::string &topic_id )
+{
+    if( source_index >= state.sources.size() ) {
+        throw std::runtime_error(
+            "Lua dialogue handler has an invalid source index" );
+    }
+    return std::make_shared<script_dialogue_context>(
+               state, d, topic_id,
+               state.sources[source_index].manifest.has_capability( "game.write" ) );
+}
+
+sol::object evaluate_dialogue_response_source(
+    runtime_state &state, const sol::object &source,
+    const std::shared_ptr<script_dialogue_context> &context,
+    const std::string &label )
+{
+    if( source.get_type() == sol::type::table ) {
+        return source;
+    }
+    sol::protected_function callback = source.as<sol::protected_function>();
+    const auto started = std::chrono::steady_clock::now();
+    const sol::protected_function_result result = callback( context );
+    record_callback_timing( state, label, started );
+    if( !result.valid() ) {
+        const sol::error error = result;
+        throw std::runtime_error( error.what() );
+    }
+    if( result.get_type() != sol::type::table ) {
+        throw std::invalid_argument(
+            label + " must return an array table of response descriptors" );
+    }
+    return result.get<sol::object>();
+}
+
+talk_response lua_dialogue_response_from_table(
+    runtime_state &state, const std::size_t source_index,
+    const std::string &topic_id, const sol::table &descriptor )
+{
+    for( const auto &entry : descriptor ) {
+        if( entry.first.get_type() != sol::type::string ) {
+            continue;
+        }
+        const std::string key = entry.first.as<std::string>();
+        if( key != "text" && key != "topic" && key != "on_select" ) {
+            throw std::invalid_argument(
+                "game.dialogue response received unknown field '" + key + "'" );
+        }
+    }
+
+    const sol::object raw_text = descriptor.raw_get<sol::object>( "text" );
+    if( !raw_text.valid() || raw_text.get_type() != sol::type::string ) {
+        throw std::invalid_argument(
+            "game.dialogue response requires string field 'text'" );
+    }
+    const std::string text = raw_text.as<std::string>();
+    require_dialogue_text( text, "response text" );
+
+    std::string next_topic = "TALK_NONE";
+    const sol::object raw_topic = descriptor.raw_get<sol::object>( "topic" );
+    if( raw_topic.valid() && raw_topic.get_type() != sol::type::nil ) {
+        if( raw_topic.get_type() != sol::type::string ) {
+            throw std::invalid_argument(
+                "game.dialogue response field 'topic' must be a string" );
+        }
+        next_topic = raw_topic.as<std::string>();
+        if( !valid_dialogue_id( next_topic ) ) {
+            throw std::invalid_argument(
+                "game.dialogue response topic has an invalid id" );
+        }
+    }
+
+    talk_response response;
+    response.truetext = no_translation( text );
+    response.truefalse_condition = []( const_dialogue const & ) {
+        return true;
+    };
+    response.success.next_topic = talk_topic( next_topic );
+
+    const sol::object raw_on_select =
+        descriptor.raw_get<sol::object>( "on_select" );
+    if( raw_on_select.valid() && raw_on_select.get_type() != sol::type::nil ) {
+        if( raw_on_select.get_type() != sol::type::function ) {
+            throw std::invalid_argument(
+                "game.dialogue response field 'on_select' must be a function" );
+        }
+        const std::uint64_t callback_id =
+            state.next_dialogue_response_callback_id++;
+        state.dialogue_response_callbacks.emplace(
+            callback_id,
+            dialogue_response_callback {
+                source_index, topic_id,
+                raw_on_select.as<sol::protected_function>()
+            } );
+        response.lua_response_id = callback_id;
+    }
+
+    return response;
+}
+
+std::vector<talk_response> lua_dialogue_responses_from_object(
+    runtime_state &state, const std::size_t source_index,
+    const std::string &topic_id, const sol::object &object )
+{
+    if( object.get_type() != sol::type::table ) {
+        throw std::invalid_argument(
+            "game.dialogue responses must be an array table" );
+    }
+    const sol::table table = object.as<sol::table>();
+    const std::size_t count = table.size();
+    if( count > maximum_dialogue_responses_per_topic ) {
+        throw std::runtime_error(
+            "game.dialogue topic response limit reached" );
+    }
+
+    std::vector<talk_response> result;
+    result.reserve( count );
+    for( std::size_t index = 1; index <= count; ++index ) {
+        const sol::object raw_response = table.raw_get<sol::object>( index );
+        if( !raw_response.valid() ||
+            raw_response.get_type() != sol::type::table ) {
+            throw std::invalid_argument(
+                "game.dialogue responses must contain descriptor tables" );
+        }
+        result.push_back(
+            lua_dialogue_response_from_table(
+                state, source_index, topic_id,
+                raw_response.as<sol::table>() ) );
+    }
+    return result;
+}
+
+void add_lua_dialogue_responses(
+    dialogue &d, const std::vector<talk_response> &responses,
+    const bool insert_before_standard_exits )
+{
+    for( const talk_response &response : responses ) {
+        d.add_gen_response(
+            response, false, true, true, insert_before_standard_exits );
+    }
+}
+
+void disable_dialogue_callback( bool &enabled, std::string &stored_error,
+                                const std::string &context,
+                                const std::string &error )
+{
+    enabled = false;
+    stored_error = error;
+    record_runtime_error( context, stored_error );
+}
+
+std::uint64_t register_dialogue_topic(
+    runtime_state &state, const sol::table &descriptor )
+{
+    require_api_version( state, 5, "game.dialogue.register_topic" );
+    require_capability( state, "game.dialogue" );
+    if( !state.current_source ) {
+        throw std::runtime_error(
+            "game.dialogue.register_topic is outside a Lua source context" );
+    }
+    for( const auto &entry : descriptor ) {
+        if( entry.first.get_type() != sol::type::string ) {
+            throw std::invalid_argument(
+                "game.dialogue.register_topic option keys must be strings" );
+        }
+        const std::string key = entry.first.as<std::string>();
+        if( key != "id" && key != "dynamic_line" && key != "responses" ) {
+            throw std::invalid_argument(
+                "game.dialogue.register_topic received unknown option '" +
+                key + "'" );
+        }
+    }
+
+    dialogue_topic_definition replacement;
+    replacement.id = descriptor.get_or( "id", std::string() );
+    replacement.source_index = *state.current_source;
+    if( !valid_dialogue_id( replacement.id ) ) {
+        throw std::invalid_argument(
+            "game.dialogue.register_topic id must contain 1 to 256 non-NUL bytes" );
+    }
+
+    const sol::object dynamic_line =
+        descriptor.raw_get<sol::object>( "dynamic_line" );
+    if( !dynamic_line.valid() ||
+        dynamic_line.get_type() == sol::type::nil ) {
+        throw std::invalid_argument(
+            "game.dialogue.register_topic requires dynamic_line" );
+    }
+    if( dynamic_line.get_type() == sol::type::string ) {
+        replacement.dynamic_line_text = dynamic_line.as<std::string>();
+        require_dialogue_text(
+            *replacement.dynamic_line_text, "dynamic_line" );
+    } else if( dynamic_line.get_type() == sol::type::function ) {
+        replacement.dynamic_line_callback =
+            dynamic_line.as<sol::protected_function>();
+    } else {
+        throw std::invalid_argument(
+            "game.dialogue.register_topic dynamic_line must be a string or function" );
+    }
+
+    replacement.responses =
+        descriptor.raw_get<sol::object>( "responses" );
+    if( !replacement.responses.valid() ||
+        ( replacement.responses.get_type() != sol::type::table &&
+          replacement.responses.get_type() != sol::type::function ) ) {
+        throw std::invalid_argument(
+            "game.dialogue.register_topic requires table or function responses" );
+    }
+
+    const auto existing = find_definition( state.dialogue_topics, replacement.id );
+    if( existing != state.dialogue_topics.end() ) {
+        replacement.registration_id = existing->registration_id;
+        *existing = std::move( replacement );
+        return existing->registration_id;
+    }
+
+    const std::size_t source_count = std::count_if(
+                                         state.dialogue_topics.begin(),
+                                         state.dialogue_topics.end(),
+    [&replacement]( const dialogue_topic_definition & entry ) {
+        return entry.source_index == replacement.source_index;
+    } );
+    if( state.dialogue_topics.size() >= maximum_dialogue_topics ) {
+        throw std::runtime_error(
+            "game.dialogue runtime topic limit reached" );
+    }
+    if( source_count >= maximum_dialogue_topics_per_source ) {
+        throw std::runtime_error(
+            "game.dialogue source topic limit reached" );
+    }
+    replacement.registration_id =
+        state.next_dialogue_topic_registration_id++;
+    const std::uint64_t result = replacement.registration_id;
+    state.dialogue_topics.emplace_back( std::move( replacement ) );
+    return result;
+}
+
+std::uint64_t extend_dialogue_topic(
+    runtime_state &state, const sol::table &descriptor )
+{
+    require_api_version( state, 5, "game.dialogue.extend_topic" );
+    require_capability( state, "game.dialogue" );
+    if( !state.current_source ) {
+        throw std::runtime_error(
+            "game.dialogue.extend_topic is outside a Lua source context" );
+    }
+    for( const auto &entry : descriptor ) {
+        if( entry.first.get_type() != sol::type::string ) {
+            throw std::invalid_argument(
+                "game.dialogue.extend_topic option keys must be strings" );
+        }
+        const std::string key = entry.first.as<std::string>();
+        if( key != "id" && key != "insert_before_standard_exits" &&
+            key != "responses" ) {
+            throw std::invalid_argument(
+                "game.dialogue.extend_topic received unknown option '" +
+                key + "'" );
+        }
+    }
+
+    dialogue_extension_definition replacement;
+    replacement.id = descriptor.get_or( "id", std::string() );
+    replacement.source_index = *state.current_source;
+    replacement.insert_before_standard_exits =
+        descriptor.get_or( "insert_before_standard_exits", false );
+    if( !valid_dialogue_id( replacement.id ) ) {
+        throw std::invalid_argument(
+            "game.dialogue.extend_topic id must contain 1 to 256 non-NUL bytes" );
+    }
+    replacement.responses =
+        descriptor.raw_get<sol::object>( "responses" );
+    if( !replacement.responses.valid() ||
+        ( replacement.responses.get_type() != sol::type::table &&
+          replacement.responses.get_type() != sol::type::function ) ) {
+        throw std::invalid_argument(
+            "game.dialogue.extend_topic requires table or function responses" );
+    }
+
+    const auto existing = std::find_if(
+                              state.dialogue_extensions.begin(),
+                              state.dialogue_extensions.end(),
+    [&replacement]( const dialogue_extension_definition & entry ) {
+        return entry.id == replacement.id &&
+               entry.source_index == replacement.source_index;
+    } );
+    if( existing != state.dialogue_extensions.end() ) {
+        replacement.registration_id = existing->registration_id;
+        *existing = std::move( replacement );
+        return existing->registration_id;
+    }
+
+    const std::size_t source_count = std::count_if(
+                                         state.dialogue_extensions.begin(),
+                                         state.dialogue_extensions.end(),
+    [&replacement]( const dialogue_extension_definition & entry ) {
+        return entry.source_index == replacement.source_index;
+    } );
+    if( state.dialogue_extensions.size() >= maximum_dialogue_extensions ) {
+        throw std::runtime_error(
+            "game.dialogue runtime extension limit reached" );
+    }
+    if( source_count >= maximum_dialogue_extensions_per_source ) {
+        throw std::runtime_error(
+            "game.dialogue source extension limit reached" );
+    }
+    replacement.registration_id =
+        state.next_dialogue_extension_registration_id++;
+    const std::uint64_t result = replacement.registration_id;
+    state.dialogue_extensions.emplace_back( std::move( replacement ) );
+    return result;
 }
 
 std::string local_custom_event_name( const runtime_state &state,
@@ -2702,6 +3281,9 @@ sol::table lua_runtime_status( sol::this_state lua, const runtime_state &runtime
         runtime.action_menu_entries.size();
     result["sidebar_widgets"] =
         runtime.sidebar_widgets.size();
+    result["dialogue_topics"] = runtime.dialogue_topics.size();
+    result["dialogue_extensions"] =
+        runtime.dialogue_extensions.size();
     result["event_handlers"] = runtime.event_registry.size();
     result["mapgen_handlers"] = runtime.mapgen_registry.size();
     result["sources"] = runtime.sources.size();
@@ -2743,6 +3325,8 @@ struct source_resource_counts {
     std::size_t pages = 0;
     std::size_t action_menu_entries = 0;
     std::size_t sidebar_widgets = 0;
+    std::size_t dialogue_topics = 0;
+    std::size_t dialogue_extensions = 0;
     std::size_t event_handlers = 0;
     std::size_t mapgen_handlers = 0;
     std::size_t scheduled_tasks = 0;
@@ -2769,6 +3353,18 @@ std::vector<source_resource_counts> count_source_resources(
          runtime.sidebar_widgets ) {
         if( entry.source_index < result.size() ) {
             ++result[entry.source_index].sidebar_widgets;
+        }
+    }
+    for( const dialogue_topic_definition &entry :
+         runtime.dialogue_topics ) {
+        if( entry.source_index < result.size() ) {
+            ++result[entry.source_index].dialogue_topics;
+        }
+    }
+    for( const dialogue_extension_definition &entry :
+         runtime.dialogue_extensions ) {
+        if( entry.source_index < result.size() ) {
+            ++result[entry.source_index].dialogue_extensions;
         }
     }
     for( const script_event_subscription &event :
@@ -2866,6 +3462,10 @@ sol::table lua_runtime_diagnostics(
         runtime.action_menu_entries.size();
     resources["sidebar_widgets"] =
         runtime.sidebar_widgets.size();
+    resources["dialogue_topics"] =
+        runtime.dialogue_topics.size();
+    resources["dialogue_extensions"] =
+        runtime.dialogue_extensions.size();
     resources["event_handlers"] = runtime.event_registry.size();
     resources["mapgen_handlers"] = runtime.mapgen_registry.size();
     resources["scheduled_tasks"] = runtime.scheduler.size();
@@ -2905,6 +3505,12 @@ sol::table lua_runtime_diagnostics(
         maximum_sidebar_widgets;
     limits["sidebar_widgets_per_source"] =
         maximum_sidebar_widgets_per_source;
+    limits["dialogue_topics"] = maximum_dialogue_topics;
+    limits["dialogue_topics_per_source"] =
+        maximum_dialogue_topics_per_source;
+    limits["dialogue_extensions"] = maximum_dialogue_extensions;
+    limits["dialogue_extensions_per_source"] =
+        maximum_dialogue_extensions_per_source;
     limits["sidebar_widget_lines"] =
         maximum_sidebar_widget_lines;
     limits["sidebar_widget_output_bytes"] =
@@ -2937,6 +3543,9 @@ sol::table lua_runtime_diagnostics(
             counts.action_menu_entries;
         source["sidebar_widgets"] =
             counts.sidebar_widgets;
+        source["dialogue_topics"] = counts.dialogue_topics;
+        source["dialogue_extensions"] =
+            counts.dialogue_extensions;
         source["event_handlers"] = counts.event_handlers;
         source["mapgen_handlers"] = counts.mapgen_handlers;
         source["scheduled_tasks"] = counts.scheduled_tasks;
@@ -3353,6 +3962,27 @@ void initialize_state( runtime_state &state )
         "nest", &script_mapgen_context::nest,
         "generate", &script_mapgen_context::generate );
 
+    state.lua.new_usertype<script_dialogue_context>(
+        "ScriptDialogueContext", sol::no_constructor,
+        "valid", &script_dialogue_context::valid,
+        "topic", &script_dialogue_context::topic,
+        "get", &script_dialogue_context::get,
+        "set", &script_dialogue_context::set,
+        "remove", &script_dialogue_context::remove,
+        "quote_trade_item",
+    []( const script_dialogue_context & context,
+    const std::string & item_id, const int count,
+    const sol::optional<std::string> &prefix ) {
+        return context.quote_trade_item(
+                   item_id, count, prefix.value_or( "quote" ) );
+    },
+    "buy_quoted_item",
+    []( const script_dialogue_context & context,
+    const sol::optional<std::string> &prefix ) {
+        return context.buy_quoted_item(
+                   prefix.value_or( "quote" ) );
+    } );
+
     sol::table game = state.lua.create_named_table( "game" );
     game["api_version"] = api_version;
     sol::table handlers = state.lua.create_table();
@@ -3441,6 +4071,39 @@ void initialize_state( runtime_state &state )
         return action_menu_limits_to_lua( state, lua );
     } );
     game["action_menu"] = std::move( action_menu );
+
+    sol::table dialogue = state.lua.create_table();
+    dialogue.set_function(
+        "register_topic",
+    [&state]( const sol::table & descriptor ) {
+        return register_dialogue_topic( state, descriptor );
+    } );
+    dialogue.set_function(
+        "extend_topic",
+    [&state]( const sol::table & descriptor ) {
+        return extend_dialogue_topic( state, descriptor );
+    } );
+    dialogue.set_function(
+        "limits",
+    [&state]( sol::this_state lua ) {
+        require_api_version( state, 5, "game.dialogue.limits" );
+        require_capability( state, "game.dialogue" );
+        sol::state_view lua_state( lua );
+        return lua_state.create_table_with(
+                   "topics", maximum_dialogue_topics,
+                   "topics_per_source", maximum_dialogue_topics_per_source,
+                   "extensions", maximum_dialogue_extensions,
+                   "extensions_per_source",
+                   maximum_dialogue_extensions_per_source,
+                   "responses_per_topic",
+                   maximum_dialogue_responses_per_topic,
+                   "id_bytes", maximum_dialogue_id_bytes,
+                   "text_bytes", maximum_dialogue_text_bytes,
+                   "callback_instructions",
+                   callback_instruction_limit );
+    } );
+    game["dialogue"] = std::move( dialogue );
+
     sol::table sidebar =
         state.lua.create_named_table( "sidebar" );
     sidebar.set_function(
@@ -6209,6 +6872,262 @@ native_hook_result dispatch_native_dialogue_hook(
         } );
     }
     return dispatch_native_hook_result( name, payload );
+}
+
+void clear_dialogue_response_callbacks()
+{
+    if( active_state ) {
+        active_state->dialogue_response_callbacks.clear();
+    }
+}
+
+std::optional<std::string> dialogue_dynamic_line(
+    dialogue &d, const talk_topic &topic )
+{
+    if( !active_state ) {
+        return std::nullopt;
+    }
+    runtime_state &state = *active_state;
+    const auto found = find_definition( state.dialogue_topics, topic.id );
+    if( found == state.dialogue_topics.end() || !found->enabled ) {
+        return std::nullopt;
+    }
+    if( found->source_index >= state.sources.size() ) {
+        found->enabled = false;
+        found->error = "Lua dialogue topic has an invalid source index";
+        record_runtime_error(
+            "Lua dialogue topic '" + found->id + "'", found->error );
+        return std::nullopt;
+    }
+    if( found->dynamic_line_text ) {
+        return *found->dynamic_line_text;
+    }
+    if( !found->dynamic_line_callback ) {
+        return std::nullopt;
+    }
+
+    const std::shared_ptr<script_dialogue_context> context =
+        make_dialogue_context(
+            state, d, found->source_index, topic.id );
+    on_out_of_scope invalidate_context( [context]() {
+        context->invalidate();
+    } );
+    try {
+        source_scope source( state, found->source_index );
+        instruction_guard guard(
+            state.lua.lua_state(), callback_instruction_limit );
+        const auto started = std::chrono::steady_clock::now();
+        const sol::protected_function_result result =
+            ( *found->dynamic_line_callback )( context );
+        context->invalidate();
+        record_callback_timing(
+            state, "dialogue dynamic_line '" + found->id + "'", started );
+        if( !result.valid() ) {
+            const sol::error error = result;
+            disable_dialogue_callback(
+                found->enabled, found->error,
+                "Lua dialogue topic '" + found->id + "'", error.what() );
+            return std::nullopt;
+        }
+        if( result.get_type() != sol::type::string ) {
+            throw std::invalid_argument(
+                "Lua dialogue dynamic_line callback must return a string" );
+        }
+        std::string line = result.get<std::string>();
+        require_dialogue_text( line, "dynamic_line" );
+        return line;
+    } catch( const std::exception &exception ) {
+        disable_dialogue_callback(
+            found->enabled, found->error,
+            "Lua dialogue topic '" + found->id + "'", exception.what() );
+        return std::nullopt;
+    }
+}
+
+bool gen_lua_dialogue_responses(
+    dialogue &d, const talk_topic &topic )
+{
+    if( !active_state ) {
+        return false;
+    }
+    runtime_state &state = *active_state;
+    const auto found = find_definition( state.dialogue_topics, topic.id );
+    if( found == state.dialogue_topics.end() || !found->enabled ) {
+        return false;
+    }
+    if( found->source_index >= state.sources.size() ) {
+        found->enabled = false;
+        found->error = "Lua dialogue topic has an invalid source index";
+        record_runtime_error(
+            "Lua dialogue topic '" + found->id + "'", found->error );
+        return false;
+    }
+    const std::shared_ptr<script_dialogue_context> context =
+        make_dialogue_context(
+            state, d, found->source_index, topic.id );
+    on_out_of_scope invalidate_context( [context]() {
+        context->invalidate();
+    } );
+    try {
+        source_scope source( state, found->source_index );
+        instruction_guard guard(
+            state.lua.lua_state(), callback_instruction_limit );
+        const sol::object responses_object =
+            evaluate_dialogue_response_source(
+                state, found->responses, context,
+                "dialogue responses '" + found->id + "'" );
+        std::vector<talk_response> responses =
+            lua_dialogue_responses_from_object(
+                state, found->source_index, found->id,
+                responses_object );
+        context->invalidate();
+        add_lua_dialogue_responses( d, responses, false );
+        return true;
+    } catch( const std::exception &exception ) {
+        disable_dialogue_callback(
+            found->enabled, found->error,
+            "Lua dialogue topic '" + found->id + "'", exception.what() );
+        return false;
+    }
+}
+
+void extend_lua_dialogue_responses(
+    dialogue &d, const talk_topic &topic )
+{
+    if( !active_state ) {
+        return;
+    }
+    runtime_state &state = *active_state;
+    for( dialogue_extension_definition &extension :
+         state.dialogue_extensions ) {
+        if( extension.id != topic.id || !extension.enabled ) {
+            continue;
+        }
+        if( extension.source_index >= state.sources.size() ) {
+            extension.enabled = false;
+            extension.error =
+                "Lua dialogue extension has an invalid source index";
+            record_runtime_error(
+                "Lua dialogue extension '" + extension.id + "'",
+                extension.error );
+            continue;
+        }
+        const std::shared_ptr<script_dialogue_context> context =
+            make_dialogue_context(
+                state, d, extension.source_index, topic.id );
+        on_out_of_scope invalidate_context( [context]() {
+            context->invalidate();
+        } );
+        try {
+            source_scope source( state, extension.source_index );
+            instruction_guard guard(
+                state.lua.lua_state(), callback_instruction_limit );
+            const sol::object responses_object =
+                evaluate_dialogue_response_source(
+                    state, extension.responses, context,
+                    "dialogue extension '" + extension.id + "'" );
+            std::vector<talk_response> responses =
+                lua_dialogue_responses_from_object(
+                    state, extension.source_index, extension.id,
+                    responses_object );
+            context->invalidate();
+            add_lua_dialogue_responses(
+                d, responses,
+                extension.insert_before_standard_exits );
+        } catch( const std::exception &exception ) {
+            disable_dialogue_callback(
+                extension.enabled, extension.error,
+                "Lua dialogue extension '" + extension.id + "'",
+                exception.what() );
+        }
+    }
+}
+
+talk_topic apply_lua_dialogue_response(
+    dialogue &d, const std::uint64_t response_id,
+    const talk_topic &fallback )
+{
+    if( !active_state ) {
+        return fallback;
+    }
+    runtime_state &state = *active_state;
+    const auto found =
+        state.dialogue_response_callbacks.find( response_id );
+    if( found == state.dialogue_response_callbacks.end() ) {
+        return fallback;
+    }
+
+    dialogue_response_callback callback = found->second;
+    state.dialogue_response_callbacks.erase( found );
+    if( callback.source_index >= state.sources.size() ) {
+        record_runtime_error(
+            "Lua dialogue on_select '" + callback.topic_id + "'",
+            "Lua dialogue response has an invalid source index" );
+        return fallback;
+    }
+    const std::shared_ptr<script_dialogue_context> context =
+        make_dialogue_context(
+            state, d, callback.source_index, callback.topic_id );
+    on_out_of_scope invalidate_context( [context]() {
+        context->invalidate();
+    } );
+    try {
+        source_scope source( state, callback.source_index );
+        instruction_guard guard(
+            state.lua.lua_state(), callback_instruction_limit );
+        const auto started = std::chrono::steady_clock::now();
+        const sol::protected_function_result result =
+            callback.callback( context );
+        context->invalidate();
+        record_callback_timing(
+            state, "dialogue on_select '" + callback.topic_id + "'",
+            started );
+        if( !result.valid() ) {
+            const sol::error error = result;
+            record_runtime_error(
+                "Lua dialogue on_select '" + callback.topic_id + "'",
+                error.what() );
+            return fallback;
+        }
+        if( result.return_count() == 0 ||
+            result.get_type() == sol::type::nil ) {
+            return fallback;
+        }
+        if( result.get_type() == sol::type::string ) {
+            const std::string next_topic = result.get<std::string>();
+            if( valid_dialogue_id( next_topic ) ) {
+                return talk_topic( next_topic );
+            }
+            throw std::invalid_argument(
+                "Lua dialogue on_select returned an invalid topic id" );
+        }
+        if( result.get_type() == sol::type::table ) {
+            const sol::table table = result.get<sol::table>();
+            const sol::object raw_topic =
+                table.raw_get<sol::object>( "topic" );
+            if( raw_topic.valid() &&
+                raw_topic.get_type() != sol::type::nil ) {
+                if( raw_topic.get_type() != sol::type::string ) {
+                    throw std::invalid_argument(
+                        "Lua dialogue on_select result topic must be a string" );
+                }
+                const std::string next_topic = raw_topic.as<std::string>();
+                if( valid_dialogue_id( next_topic ) ) {
+                    return talk_topic( next_topic );
+                }
+                throw std::invalid_argument(
+                    "Lua dialogue on_select returned an invalid topic id" );
+            }
+            return fallback;
+        }
+        throw std::invalid_argument(
+            "Lua dialogue on_select must return nil, a string, or a table" );
+    } catch( const std::exception &exception ) {
+        record_runtime_error(
+            "Lua dialogue on_select '" + callback.topic_id + "'",
+            exception.what() );
+        return fallback;
+    }
 }
 
 bool begin_native_npc_interaction(

--- a/src/catalua_ui.h
+++ b/src/catalua_ui.h
@@ -17,6 +17,8 @@ class Creature;
 class const_talker;
 class item;
 class mapgendata;
+struct dialogue;
+struct talk_topic;
 
 namespace cata::lua_ui
 {
@@ -163,6 +165,15 @@ native_hook_result dispatch_native_dialogue_hook(
     std::string_view name, const const_talker &alpha,
     const const_talker &beta, std::string_view topic,
     std::optional<std::string_view> option = std::nullopt );
+void clear_dialogue_response_callbacks();
+std::optional<std::string> dialogue_dynamic_line(
+    dialogue &d, const talk_topic &topic );
+bool gen_lua_dialogue_responses(
+    dialogue &d, const talk_topic &topic );
+void extend_lua_dialogue_responses(
+    dialogue &d, const talk_topic &topic );
+talk_topic apply_lua_dialogue_response(
+    dialogue &d, std::uint64_t response_id, const talk_topic &fallback );
 bool begin_native_npc_interaction(
     const Character &avatar, const Character &npc );
 bool allow_native_monster_interaction(

--- a/src/catalua_ui_disabled.cpp
+++ b/src/catalua_ui_disabled.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "catalua_ui_actions.h"
+#include "dialogue.h"
 
 namespace cata::lua_ui
 {
@@ -97,6 +98,33 @@ native_hook_result dispatch_native_dialogue_hook(
     std::string_view, std::optional<std::string_view> )
 {
     return {};
+}
+
+void clear_dialogue_response_callbacks()
+{
+}
+
+std::optional<std::string> dialogue_dynamic_line(
+    dialogue &, const talk_topic & )
+{
+    return std::nullopt;
+}
+
+bool gen_lua_dialogue_responses(
+    dialogue &, const talk_topic & )
+{
+    return false;
+}
+
+void extend_lua_dialogue_responses(
+    dialogue &, const talk_topic & )
+{
+}
+
+talk_topic apply_lua_dialogue_response(
+    dialogue &, std::uint64_t, const talk_topic &fallback )
+{
+    return fallback;
 }
 
 bool begin_native_npc_interaction(

--- a/src/catalua_ui_manifest.cpp
+++ b/src/catalua_ui_manifest.cpp
@@ -47,6 +47,7 @@ const std::set<std::string> &supported_script_capabilities()
         "game.actions",
         "game.actions.dangerous",
         "game.callbacks",
+        "game.dialogue",
         "game.hooks",
         "game.read",
         "game.write",
@@ -75,6 +76,7 @@ int capability_minimum_api_version( const std::string_view capability )
     };
     static const std::set<std::string> version_five = {
         "game.callbacks",
+        "game.dialogue",
         "game.hooks",
         "game.write"
     };
@@ -185,6 +187,7 @@ script_manifest default_script_manifest( const std::string &id, bool allow_actio
     if( !allow_actions ) {
         result.capabilities.erase( "game.actions" );
         result.capabilities.erase( "game.callbacks" );
+        result.capabilities.erase( "game.dialogue" );
         result.capabilities.erase( "game.hooks" );
         result.capabilities.erase( "game.write" );
     }

--- a/src/dialogue.h
+++ b/src/dialogue.h
@@ -2,8 +2,10 @@
 #ifndef CATA_SRC_DIALOGUE_H
 #define CATA_SRC_DIALOGUE_H
 
+#include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
 #include <type_traits>
@@ -205,6 +207,7 @@ struct talk_response {
 
     talk_effect_t success;
     talk_effect_t failure;
+    std::optional<std::uint64_t> lua_response_id;
 
     talk_data create_option_line( dialogue &d, const input_event &hotkey,
                                   bool is_computer = false );
@@ -312,7 +315,7 @@ struct dialogue: public const_dialogue {
 
         // add an already-generated response to this dialogue's responses
         void add_gen_response( const talk_response &resp, bool insert_front, bool condition_exists = true,
-                               bool condition_result = true );
+                               bool condition_result = true, bool insert_before_standard_exits = false );
 
         void add_topic( const std::string &topic );
         void add_topic( const talk_topic &topic );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1784,6 +1784,11 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic )
 
     // For compatibility
     const std::string &topic = the_topic.id;
+    if( std::optional<std::string> lua_line =
+            cata::lua_ui::dialogue_dynamic_line( *this, the_topic ) ) {
+        return *lua_line;
+    }
+
     const auto iter = json_talk_topics.find( topic );
     if( iter != json_talk_topics.end() ) {
         std::string line = iter->second.get_dynamic_line( *this );
@@ -2055,14 +2060,21 @@ void dialogue::gen_responses( const talk_topic &the_topic )
     responses.clear();
     response_condition_exists.clear();
     response_condition_eval.clear();
+    cata::lua_ui::clear_dialogue_response_callbacks();
+
+    if( cata::lua_ui::gen_lua_dialogue_responses( *this, the_topic ) ) {
+        return;
+    }
 
     const auto iter = json_talk_topics.find( the_topic.id );
     if( iter != json_talk_topics.end() ) {
         json_talk_topic &jtt = iter->second;
         if( jtt.gen_responses( *this ) ) {
+            cata::lua_ui::extend_lua_dialogue_responses( *this, the_topic );
             return;
         }
     }
+    cata::lua_ui::extend_lua_dialogue_responses( *this, the_topic );
 
     Character &player_character = get_player_character();
     if( the_topic.id == "TALK_MISSION_LIST" ) {
@@ -2737,15 +2749,34 @@ void parse_tags( std::string &phrase, const_talker const &u, const_talker const 
 }
 
 void dialogue::add_gen_response( const talk_response &resp, bool insert_front,
-                                 bool condition_exists, bool condition_result )
+                                 bool condition_exists, bool condition_result,
+                                 bool insert_before_standard_exits )
 {
     if( insert_front ) {
         responses.insert( responses.begin(), resp );
+        response_condition_exists.insert( response_condition_exists.begin(), condition_exists );
+        response_condition_eval.insert( response_condition_eval.begin(), condition_result );
+    } else if( insert_before_standard_exits ) {
+        std::size_t dec_count = 0;
+        if( !responses.empty() &&
+            responses.back().success.next_topic.id == "TALK_DONE" ) {
+            dec_count = 1;
+        }
+        if( responses.size() >= 2 &&
+            responses[ responses.size() - 2 ].success.next_topic.id == "TALK_NONE" ) {
+            dec_count = 2;
+        }
+        const std::size_t position = responses.size() - dec_count;
+        responses.insert( responses.begin() + position, resp );
+        response_condition_exists.insert(
+            response_condition_exists.begin() + position, condition_exists );
+        response_condition_eval.insert(
+            response_condition_eval.begin() + position, condition_result );
     } else {
         responses.push_back( resp );
+        response_condition_exists.emplace_back( condition_exists );
+        response_condition_eval.emplace_back( condition_result );
     }
-    response_condition_exists.emplace_back( condition_exists );
-    response_condition_eval.emplace_back( condition_result );
 }
 
 void dialogue::add_topic( const std::string &topic_id )
@@ -3199,6 +3230,10 @@ talk_topic dialogue::opt( dialogue_window &d_win, const talk_topic &topic )
     const bool success = chosen.trial.roll( *this );
     talk_effect_t const &effects = success ? chosen.success : chosen.failure;
     talk_topic ret_topic =  effects.apply( *this );
+    if( chosen.lua_response_id ) {
+        ret_topic = cata::lua_ui::apply_lua_dialogue_response(
+                        *this, *chosen.lua_response_id, ret_topic );
+    }
     talk_effect_t::update_missions( *this );
     return ret_topic;
 }

--- a/tests/catalua_ui_test.cpp
+++ b/tests/catalua_ui_test.cpp
@@ -30,6 +30,7 @@
 #include "clzones.h"
 #include "creature_tracker.h"
 #include "damage.h"
+#include "dialogue.h"
 #include "effect.h"
 #include "event_bus.h"
 #include "event_subscriber.h"
@@ -970,7 +971,8 @@ TEST_CASE( "lua_script_manifests_validate_versions_capabilities_and_dependencies
     const script_manifest v5 = read_script_manifest( json_loader::from_string( R"json({
         "id": "v5", "version": "5", "api_version": 5,
         "capabilities": [
-            "events", "game.callbacks", "game.hooks", "game.read", "game.write"
+            "events", "game.callbacks", "game.dialogue", "game.hooks",
+            "game.read", "game.write"
         ],
         "dependencies": []
     })json" ) );
@@ -1015,6 +1017,7 @@ TEST_CASE( "lua_script_manifests_validate_versions_capabilities_and_dependencies
         "capabilities": [ "game.read", "game.write" ], "dependencies": []
     })json" ) ) );
     CHECK( capability_minimum_api_version( "scheduler" ) == 4 );
+    CHECK( capability_minimum_api_version( "game.dialogue" ) == 5 );
     CHECK( capability_minimum_api_version( "game.write" ) == 5 );
     CHECK( capability_minimum_api_version( "game.read" ) == minimum_api_version );
 }
@@ -12338,6 +12341,185 @@ assert(state.character.get(
     "native_interaction.elevator", 0) == 1)
 )lua" );
     REQUIRE( reload_scripts( error ) );
+}
+
+TEST_CASE( "lua_v5_dialogue_topics_extend_json_without_replacing_it",
+           "[lua][dialogue][integration]" )
+{
+    using namespace cata::lua_ui;
+
+    JsonObject base_topic = json_loader::from_string( R"json({
+        "id": "TALK_LUA_DIALOGUE_BASE",
+        "type": "talk_topic",
+        "dynamic_line": "Base JSON line.",
+        "responses": [
+            { "text": "Original JSON response.", "topic": "TALK_NONE" },
+            { "text": "<end_talking_leave>", "topic": "TALK_DONE" }
+        ]
+    })json" );
+    load_talk_topic( base_topic, "lua dialogue test" );
+
+    clear_avatar();
+    clear_map_without_vision();
+    avatar &player = get_avatar();
+    map &here = get_map();
+    player.setpos( here, tripoint_bub_ms( 30, 30, 0 ) );
+    standard_npc test_npc(
+        "Lua dialogue NPC",
+        player.pos_bub( here ) + tripoint_rel_ms::east * 2 );
+
+    scoped_lua_user_script script;
+    script.write_manifest( R"json({
+        "id": "user",
+        "version": "5.0.0",
+        "api_version": 5,
+        "capabilities": [ "game.dialogue", "game.read", "game.write" ],
+        "dependencies": [ "builtin" ]
+    })json" );
+    script.write( R"lua(
+game.dialogue.extend_topic({
+    id = "TALK_LUA_DIALOGUE_BASE",
+    insert_before_standard_exits = true,
+    responses = function(ctx)
+        assert(ctx:valid())
+        assert(ctx:topic() == "TALK_LUA_DIALOGUE_BASE")
+        return {
+            {
+                text = "Lua extension response.",
+                topic = "TALK_LUA_DIALOGUE_TOPIC"
+            }
+        }
+    end
+})
+
+game.dialogue.register_topic({
+    id = "TALK_LUA_DIALOGUE_TOPIC",
+    dynamic_line = function(ctx)
+        ctx:set("lua_dialogue_seen", "yes")
+        return "Lua generated line " .. ctx:get("lua_dialogue_seen")
+    end,
+    responses = function(ctx)
+        assert(ctx:get("lua_dialogue_seen") == "yes")
+        assert(ctx:quote_trade_item("bottle_glass", 2, "lua_quote"))
+        assert(ctx:get("lua_quote_item_id") == "bottle_glass")
+        assert(ctx:get("lua_quote_count") == 2)
+        assert(tonumber(ctx:get("lua_quote_cost")) > 0)
+        return {
+            {
+                text = "Lua generated response.",
+                topic = "TALK_DONE",
+                on_select = function(ctx)
+                    ctx:set("manual_item_id", "bottle_glass")
+                    ctx:set("manual_count", 1)
+                    ctx:set("manual_cost", 0)
+                    assert(not ctx:buy_quoted_item("manual"))
+                    ctx:set("lua_dialogue_choice", "picked")
+                    return { topic = "TALK_LUA_DIALOGUE_AFTER_SELECT" }
+                end
+            }
+        }
+    end
+})
+)lua" );
+
+    std::string error;
+    REQUIRE( reload_scripts( error ) );
+
+    dialogue base_dialogue( get_talker_for( player ), get_talker_for( test_npc ) );
+    const talk_topic base_topic_id( "TALK_LUA_DIALOGUE_BASE" );
+    CHECK( base_dialogue.dynamic_line( base_topic_id ) == "Base JSON line." );
+    base_dialogue.gen_responses( base_topic_id );
+    REQUIRE( base_dialogue.responses.size() == 3 );
+    CHECK( base_dialogue.responses[0].success.next_topic.id == "TALK_NONE" );
+    CHECK( base_dialogue.responses[1].success.next_topic.id == "TALK_LUA_DIALOGUE_TOPIC" );
+    CHECK( base_dialogue.responses[2].success.next_topic.id == "TALK_DONE" );
+
+    dialogue lua_dialogue( get_talker_for( player ), get_talker_for( test_npc ) );
+    const talk_topic lua_topic_id( "TALK_LUA_DIALOGUE_TOPIC" );
+    CHECK( lua_dialogue.dynamic_line( lua_topic_id ) == "Lua generated line yes" );
+    lua_dialogue.gen_responses( lua_topic_id );
+    REQUIRE( lua_dialogue.responses.size() == 1 );
+    talk_response &response = lua_dialogue.responses.front();
+    response.create_option_line( lua_dialogue, input_event() );
+    CHECK( response.text == "Lua generated response." );
+    REQUIRE( response.lua_response_id.has_value() );
+    talk_topic next_topic = response.success.apply( lua_dialogue );
+    next_topic = apply_lua_dialogue_response(
+                     lua_dialogue, *response.lua_response_id, next_topic );
+    CHECK( next_topic.id == "TALK_LUA_DIALOGUE_AFTER_SELECT" );
+    CHECK( lua_dialogue.get_value( "lua_dialogue_choice" ).str() == "picked" );
+
+    script.write_manifest( R"json({
+        "id": "user",
+        "version": "5.0.0",
+        "api_version": 5,
+        "capabilities": [ "game.dialogue" ],
+        "dependencies": [ "builtin" ]
+    })json" );
+    script.write( R"lua(
+game.dialogue.register_topic({
+    id = "TALK_LUA_DIALOGUE_READONLY",
+    dynamic_line = "Read-only Lua dialogue.",
+    responses = {
+        {
+            text = "Try forbidden writes.",
+            topic = "TALK_DONE",
+            on_select = function(ctx)
+                assert(not pcall(function()
+                    ctx:set("lua_dialogue_forbidden_set", "bad")
+                end))
+                assert(not pcall(function()
+                    ctx:remove("lua_dialogue_existing")
+                end))
+                assert(not pcall(function()
+                    ctx:quote_trade_item("bottle_glass", 2, "lua_forbidden_quote")
+                end))
+                return "TALK_LUA_DIALOGUE_READONLY_DONE"
+            end
+        }
+    }
+})
+)lua" );
+    REQUIRE( reload_scripts( error ) );
+
+    dialogue readonly_dialogue(
+        get_talker_for( player ), get_talker_for( test_npc ) );
+    readonly_dialogue.set_value( "lua_dialogue_existing", "keep" );
+    const talk_topic readonly_topic_id( "TALK_LUA_DIALOGUE_READONLY" );
+    CHECK( readonly_dialogue.dynamic_line( readonly_topic_id ) ==
+           "Read-only Lua dialogue." );
+    readonly_dialogue.gen_responses( readonly_topic_id );
+    REQUIRE( readonly_dialogue.responses.size() == 1 );
+    talk_response &readonly_response = readonly_dialogue.responses.front();
+    REQUIRE( readonly_response.lua_response_id.has_value() );
+    talk_topic readonly_next = readonly_response.success.apply( readonly_dialogue );
+    readonly_next = apply_lua_dialogue_response(
+                        readonly_dialogue, *readonly_response.lua_response_id,
+                        readonly_next );
+    CHECK( readonly_next.id == "TALK_LUA_DIALOGUE_READONLY_DONE" );
+    CHECK_FALSE( readonly_dialogue.maybe_get_value(
+                     "lua_dialogue_forbidden_set" ) );
+    CHECK( readonly_dialogue.get_value(
+               "lua_dialogue_existing" ).str() == "keep" );
+    CHECK_FALSE( readonly_dialogue.maybe_get_value(
+                     "lua_forbidden_quote_cost" ) );
+
+    script.write_manifest( R"json({
+        "id": "user",
+        "version": "5.0.0",
+        "api_version": 5,
+        "capabilities": [],
+        "dependencies": [ "builtin" ]
+    })json" );
+    script.write( R"lua(
+game.dialogue.register_topic({
+    id = "TALK_LUA_DIALOGUE_FORBIDDEN",
+    dynamic_line = "Forbidden.",
+    responses = {}
+})
+)lua" );
+    CHECK_FALSE( reload_scripts( error ) );
+    CHECK( error.find( "game.dialogue" ) != std::string::npos );
 }
 
 TEST_CASE( "lua_v5_craft_and_explosion_hooks_run_at_native_boundaries",

--- a/tools/lua_api/README.md
+++ b/tools/lua_api/README.md
@@ -115,8 +115,8 @@ subsystem, which CCB does not contain.  Coordinate conversion, action-menu
 entries, native sidebar widgets, and bounded diagnostics all have CCB
 equivalents and must not be classified as exceptions.
 
-`check_luals_declarations.py` compares the API v5 LuaLS file to all 438 native
-methods across 66 registered tables, the 55 tables attached to `game`, all 15
+`check_luals_declarations.py` compares the API v5 LuaLS file to all 447 native
+methods across 67 registered tables, the 56 tables attached to `game`, all 16
 native usertypes, and all 36 generated coordinate factories. It rejects an
 unmapped newly registered table, verifies every `game.*` field's API class,
 checks that each stub's parameter annotations match its callable signature,

--- a/tools/lua_api/check_luals_declarations.py
+++ b/tools/lua_api/check_luals_declarations.py
@@ -29,6 +29,7 @@ TABLE_CLASSES = {
     "creatures": "CcbCreaturesApi",
     "definitions": "CcbDefinitionsApi",
     "diagnostics": "CcbDiagnosticsApi",
+    "dialogue": "CcbDialogueApi",
     "effects": "CcbEffectsApi",
     "enum_api": "CcbEnumsApi",
     "eocs": "CcbEocsApi",

--- a/tools/lua_api/check_public_contract.py
+++ b/tools/lua_api/check_public_contract.py
@@ -199,17 +199,17 @@ def validate_contract(contract: dict[str, object]) -> dict[str, int]:
     counts = {section: len(values) for section, values in seen.items()}
     expected_counts = {
         "modules": 3,
-        "namespaces": 69,
-        "classes": 263,
-        "functions": 489,
-        "methods": 142,
+        "namespaces": 70,
+        "classes": 269,
+        "functions": 492,
+        "methods": 149,
         "properties": 51,
         "operators": 47,
         "enums": 26,
         "events": 113,
         "hooks": 52,
         "callbacks": 38,
-        "capabilities": 16,
+        "capabilities": 17,
         "manifest_fields": 6,
     }
     if counts != expected_counts:

--- a/tools/lua_api/generate_public_contract.py
+++ b/tools/lua_api/generate_public_contract.py
@@ -69,6 +69,7 @@ NAMESPACE_CAPABILITIES = {
     "game.actions": ["game.actions"],
     "game.callbacks": ["game.callbacks"],
     "game.definitions": ["registry.read"],
+    "game.dialogue": ["game.dialogue"],
     "game.handlers": ["game.write"],
     "game.hooks": ["game.hooks"],
     "game.mapgen": ["events", "game.hooks", "game.read"],
@@ -418,8 +419,8 @@ def parse_luals(path: Path = DECLARATIONS) -> dict[str, object]:
             ],
         }
 
-    if len(classes) != 263:
-        raise RuntimeError(f"expected 263 LuaLS classes, found {len(classes)}")
+    if len(classes) != 269:
+        raise RuntimeError(f"expected 269 LuaLS classes, found {len(classes)}")
     result = {"classes": classes, "functions": functions, "contents": contents}
     validate_confirmed_declaration_contracts(result)
     return result
@@ -943,9 +944,9 @@ def parse_usertypes(
             f"native/LuaLS usertype method parity failed; "
             f"declaration-only={extra}, native-only={missing}"
         )
-    if len(usertype_names) != 15:
+    if len(usertype_names) != 16:
         raise RuntimeError(
-            f"expected 15 native usertypes, found {len(usertype_names)}")
+            f"expected 16 native usertypes, found {len(usertype_names)}")
     return (
         sorted(methods, key=lambda entry: str(entry["id"])),
         sorted(properties, key=lambda entry: str(entry["id"])),

--- a/tools/lua_api/test_check_luals_declarations.py
+++ b/tools/lua_api/test_check_luals_declarations.py
@@ -35,10 +35,10 @@ class LuaLsDeclarationTest(unittest.TestCase):
 
     def test_committed_declarations_cover_the_native_surface(self) -> None:
         result = check(DECLARATIONS)
-        self.assertEqual(result["tables"], 67)
-        self.assertEqual(result["methods"], 445)
-        self.assertEqual(result["game_tables"], 56)
-        self.assertEqual(result["usertypes"], 15)
+        self.assertEqual(result["tables"], 68)
+        self.assertEqual(result["methods"], 448)
+        self.assertEqual(result["game_tables"], 57)
+        self.assertEqual(result["usertypes"], 16)
         self.assertEqual(result["coordinate_factories"], 36)
 
     def test_unmapped_registered_table_is_rejected(self) -> None:

--- a/tools/lua_api/test_check_public_contract.py
+++ b/tools/lua_api/test_check_public_contract.py
@@ -35,8 +35,8 @@ class PublicContractCheckTest(unittest.TestCase):
 
     def test_checked_contract_matches_all_authorities(self) -> None:
         summary = check(DEFAULT_OUTPUT, DEFAULT_COVERAGE)
-        self.assertEqual(summary["functions"], 488)
-        self.assertEqual(summary["methods"], 142)
+        self.assertEqual(summary["functions"], 492)
+        self.assertEqual(summary["methods"], 149)
         self.assertEqual(summary["events"], 113)
 
     def test_stale_inventory_is_rejected(self) -> None:

--- a/tools/lua_api/test_generate_public_contract.py
+++ b/tools/lua_api/test_generate_public_contract.py
@@ -58,17 +58,17 @@ class PublicContractGeneratorTest(unittest.TestCase):
             section_counts(self.contract),
             {
                 "modules": 3,
-                "namespaces": 69,
-                "classes": 263,
-                "functions": 489,
-                "methods": 142,
+                "namespaces": 70,
+                "classes": 269,
+                "functions": 492,
+                "methods": 149,
                 "properties": 51,
                 "operators": 47,
                 "enums": 26,
                 "events": 113,
                 "hooks": 52,
                 "callbacks": 38,
-                "capabilities": 16,
+                "capabilities": 17,
                 "manifest_fields": 6,
             },
         )
@@ -78,8 +78,8 @@ class PublicContractGeneratorTest(unittest.TestCase):
         )
 
     def test_inventory_coverage_is_exactly_complete(self) -> None:
-        self.assertEqual(self.coverage["public_symbols"], 2832)
-        self.assertEqual(self.coverage["documented_symbols"], 2832)
+        self.assertEqual(self.coverage["public_symbols"], 2868)
+        self.assertEqual(self.coverage["documented_symbols"], 2868)
         self.assertEqual(
             self.coverage["undocumented_symbols"],
             {"count": 0, "ids": []},


### PR DESCRIPTION

<!-- 使用说明：在下面每个「#### 标题」下填写与你的 PR 相关的信息。
请保留这些标题。像这样的注释可以安全删除。

如果你是在 GitHub 网页界面发起这个 PR，可以用「preview（预览）」按钮查看 PR 对他人显示的样子。

PR 提交准则：
- 让你的改动只聚焦于一个具体的问题或变更，外加为实现它所必需的最小相关改动。
- 一个经验法则：大多数 PR 的改动应少于 500 行。
- 你可以另开 PR 来拆分一次较大的预期改动；如果不确定怎么拆，尽管问。我们很乐意与你协作，并建议合并你 PR 的最佳方式。
-->

#### Summary
<!-- #### 概述 -->
- Add the game.dialogue Lua API v5 for registering Lua talk topics and extending existing JSON topics.
- Expose a controlled ScriptDialogueContext for dialogue context values, trade quotes, and quoted-item purchases.
- Update the Lua manifest schema, LuaLS declarations, generated public API inventory, and related contract tests.

<!-- 这一节应当只有一行，请编辑上面那一行。
1. 把「分类」替换为下列具体分类之一：Features、Content、Interface、Mods、Balance、Bugfixes、Performance、Infrastructure、Build、I18N。
2. 把引号内的文字替换为对你改动的简要描述。
如果你不希望生成更新日志条目，把整行替换为单独一个词「None」（不带引号）。
示例：
1. None
2. Bugfixes "修复长矛无法锁定不同楼层敌人的问题"
3. Interface "在制作界面显示制作失败几率"
分类含义详见：
https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/blob/master/doc/CHANGELOG_GUIDELINES.md
合并后，你的概述会被加入项目更新日志：
https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/blob/master/data/changelog.txt -->

#### Responsible human
<!-- #### 责任人 -->

@username

<!-- 每个 PR 必须指定一名真实的人类责任人。AI 工具或模型无需披露，但责任人
必须理解修改、审查最终 diff、确认测试与许可证/外部来源，并回答审阅问题。 -->

#### Purpose of change
<!-- #### 变更目的 -->
- Allow mods such as AmmoOrder to migrate NPC dialogue logic from JSON to Lua.
- Let Lua add an AmmoOrder entry to Jay's existing gunsmith service menu without replacing the original JSON dialogue.

<!-- 用几句话描述你做这次改动的原因。
如果它与某个已有 issue 相关，可以用「#」加 GitHub issue 编号来关联，例如 #1234。

【重要】当你的 PR 能完全解决某个 issue 时，必须使用 [GitHub 的英文关闭关键字](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
才能在 PR 合并后自动关闭该 issue，例如：Fixes #1234。
只能用以下英文关键词（后面紧跟「#编号」）：
  close / closes / closed
  fix / fixes / fixed
  resolve / resolves / resolved
注意：中文「修复 #1234」不会触发自动关闭，GitHub 只识别上述英文关键词。

如果没有相关 issue，请在这里说明你要解决的问题、特性或其他关注点。如果这是一个 bug 修复，请附上复现原始 bug 的步骤，以便你的修复可以被验证。 -->


#### Describe the solution
<!-- #### 解决方案描述 -->
- Hook Lua topic and extension handling into dialogue dynamic-line generation, response generation, and selected-response execution.
- Append Lua extension responses to JSON topics, optionally before standard exit responses, while falling back to JSON behavior on Lua callback errors.
- Reuse existing NPC trade quote and purchase behavior through bounded dialogue-context helpers, with no-op stubs for non-Lua builds.
<!-- 这个特性是如何工作的，或者这个 bug 是怎么被修复的？方案越易于理解，就越快能被合并。 -->

#### Describe alternatives you've considered
<!-- #### 你考虑过的替代方案 -->

<!-- 说明你为解决同一问题考虑过的其他方案、不同思路或可能性。 -->

#### Testing
<!-- #### 测试 -->

<!-- 描述你采取了哪些步骤来测试这个 PR 是否修复了 bug 或添加了特性，以及你做了哪些测试以确保没有引入回归问题。也请为审阅者和维护者提供测试建议。参见 TESTING_YOUR_CHANGES.md -->

#### Documentation impact
<!-- None，或说明需要新增、更新、迁移、归档或标记 stale 的开发文档。
实际执行级别以 ai/docs-impact.yml 为准。required 映射不能填写 None/N/A/TBD。 -->

None

#### Related CCB-Docs PR
<!-- None，或填写 CrimsonCrossBunker/CCB-Docs 的 PR 链接。required 映射必须链接实际 PR。 -->

None

#### Affected documentation IDs
<!-- None，或填写 docs-catalog.yml 中稳定的文档 ID，多个 ID 用逗号分隔。
required 映射至少填写一个 ai/docs-impact.yml 列出的对应 ID。 -->

None

#### Generated reference impact
<!-- None，或说明 Schema、LuaLS、注册信息或生成清单是否需要刷新。 -->

None

#### Additional context
<!-- #### 补充说明 -->

<!-- 在此添加关于这个特性或 bug 修复的其他背景信息（例如原型图、概念验证或截图）。 -->


<!--README: Cataclysm: Cleanwater Bomb (CCB) 以 Creative Commons Attribution ShareAlike 3.0 许可证发布。
游戏的代码与内容可自由用于任何目的的使用、修改和再分发。
通过为本项目做贡献，你即同意该许可证的条款，并同意你所做的任何贡献也将受同一许可证覆盖。
详见 http://creativecommons.org/licenses/by-sa/3.0/ 。 -->
