### PR TITLE
Absit Invidia work bettetr

### DIFF
--- a/data/mods/BombasticPerks/perkdata/absit_invidia.json
+++ b/data/mods/BombasticPerks/perkdata/absit_invidia.json
@@ -21,6 +21,14 @@
     "extend": { "flags": [ "ANTI_EVIL_EYE_GEAR" ] }
   },
   {
+    "id": "small_relic",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "copy-from": "small_relic",
+    "name": { "str": "small relic" },
+    "extend": { "flags": [ "ANTI_EVIL_EYE_GEAR" ] }
+  },
+  {
     "type": "effect_on_condition",
     "id": "EOC_PERK_ABSIT_INVIDIA_HOLY_SYMBOL",
     "eoc_type": "EVENT",

--- a/data/mods/Xedra_Evolved/mod_interactions/bombastic_perks/perks/perk_data/absit_invidia.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/bombastic_perks/perks/perk_data/absit_invidia.json
@@ -1,0 +1,29 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PERK_ABSIT_INVIDIA_HOLY_SYMBOL",
+    "eoc_type": "EVENT",
+    "required_event": "character_gains_effect",
+    "condition": {
+      "and": [
+        { "u_has_trait": "perk_absit_invidia" },
+        { "compare_string": [ "effect_evil_eye", { "context_val": "effect" } ] },
+        { "u_has_worn_with_flag": "ANTI_EVIL_EYE_GEAR" }
+      ]
+    },
+    "effect": [ { "u_lose_effect": "effect_evil_eye" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PERK_ABSIT_INVIDIA_SALT",
+    "condition": { "u_has_trait": "perk_absit_invidia" },
+    "effect": [
+      { "u_lose_effect": "effect_evil_eye" },
+      {
+        "u_message": "You toss the salt over your shoulder and mutter under your breath the words that you remember from your childhood.",
+        "type": "mixed"
+      }
+    ],
+    "false_effect": [ { "u_message": "You toss the salt over your shoulder.  Hey, any luck you can get, right?", "type": "mixed" } ]
+  }
+]


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Adjusting the performance of Bombastic Perks' Absit Invidia trait

#### Describe the solution
 - small relic alos has ANTI_EVIL_EYE_GEAR flag, so it can also protect against flaming eye.
 - Absit Invidia also work on Xedra Evolved's flaming eye special attacks