### PR TITLE
fix(consumption): 修复含 cast_spell 使用效果的药剂不消耗的问题（魔力药剂可无限使用）

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1969,7 +1969,18 @@ static bool consume_med( item &target, Character &you )
     if( target.type->has_use() ) {
         amount_used = target.type->invoke( &you, target, you.pos_bub() ).value_or( 0 );
         if( amount_used <= 0 ) {
-            return false;
+            // cast_spell 类 use_action（如魔力药剂）通过注册施法活动来延迟物品消耗，
+            // 并返回 0 表示"未立即消耗"。若此处直接返回 false，对 MED 类物品
+            // （is_food() 为 false）eat() 也会失败，consume 返回 NONE，物品不会被移除；
+            // 施法完成时 Character::i_rem 只能移除角色身上的物品，物品位于地面、
+            // 车辆或其他容器时残留并报 "did not found item ... to remove it!"，
+            // 表现为药剂不消耗、可反复使用。施法活动确实已注册时视为"已使用"，
+            // 由 consume 流程从实际位置移除物品；施法完成时 item_location 已失效，
+            // 不会再重复移除。
+            static const activity_id ACT_SPELLCASTING( "ACT_SPELLCASTING" );
+            if( you.activity.id() != ACT_SPELLCASTING ) {
+                return false;
+            }
         }
     }
 


### PR DESCRIPTION
## 问题现象

魔力药剂（Magiclysm `mana_potion` 等）**喝了不消耗**，同时弹出报错：

```
DEBUG : did not found item 魔力药剂[...] to remove it!
REPORTING FUNCTION : i_rem
SOURCE FILE : src/character_inventory.cpp LINE 566
```

效果正常生效（魔力恢复），但药剂残留在原地，可以反复使用。

## 根因

1. 魔力药剂的 `use_action` 是 `cast_spell`（喝下 → 施放 `potion_recover_mana`），并带有 `SINGLE_USE` flag（上游 #87324/#87460 引入）。
2. `cast_spell_actor::use` 会**注册施法活动**并返回 `0`，语义是"物品消耗延迟到施法活动完成"（`iuse_actor.cpp:3039`）。
3. `consume_med` 把返回值 `0` 视为"使用失败"直接返回 `false`（`consumption.cpp:1970-1973`）。
4. 随后 `eat()` 也失败：MED 类物品的 `is_food()` 返回 `false`（`item.cpp:3197-3204`，仅 `FOOD`/`DRINK` 为 true）。
5. 于是 `Character::consume` 返回 `NONE`，**物品不会被移除**。
6. 施法完成后，`spellcasting_activity_actor::finish` 因 `SINGLE_USE` 调用 `Character::i_rem( it )`（`activity_actor.cpp:3001`），但 `i_rem` **只能移除角色身上的物品**（`visitable.cpp:701` 仅搜索 inv/worn/weapon）。物品位于地面、车辆或其他容器时找不到 → 报错 + 残留。

> 上游曾修过急救物品的同款问题（#57494 → #57538 "First aid item deletion fix"），但 `cast_spell` 施法路径未做同样处理，`SINGLE_USE` 引入后魔力药剂踩中同一坑。

## 修复方案

`consume_med` 中 `invoke` 返回 `0` 时，检查施法活动（`ACT_SPELLCASTING`）是否**确实已注册**：

- 已注册 → 视为"已使用"，`consume` 走 `ALL` 分支，由 `loc.remove_item()` 从**实际位置**移除药剂（物品在背包/容器/地面均正确处理）。
- 施法完成时 `item_location` 的 `safe_reference` 已失效，`spellcasting_activity_actor::finish` 不会再重复移除，报错消失。
- 未注册（如 `need_worn`/`need_wielding` 检查失败等）→ 维持原行为返回 `false`。

## 行为变化

喝下药剂立即消耗（即使施法失败也不再保留），与普通药品"喝下去就没了"的直觉一致，同时杜绝无限使用。

## 验证

- `consumption.cpp` 使用项目完整编译参数通过语法编译检查（GCC 16 环境下仅存在与本次改动无关的预存 `-Wsfinae-incomplete` 警告）。