### PR TITLE
fix(ci): 修复 Auto request review 权限与 analyze-text-changes base 步骤

### DIFF
--- a/.github/workflows/request-review.yml
+++ b/.github/workflows/request-review.yml
@@ -12,6 +12,11 @@ concurrency:
   cancel-in-progress: true
 
 
+permissions:
+  contents: read
+  pull-requests: write
+
+
 jobs:
   auto-request-review:
     # Do not spam reviewer with PRs in forks. If fork owners wish to alert

--- a/.github/workflows/text-changes-analyzer.yml
+++ b/.github/workflows/text-changes-analyzer.yml
@@ -47,6 +47,12 @@ jobs:
         with:
           ref: ${{ steps.get-commit-hash.outputs.base_commit }}
           persist-credentials: false
+      - name: "Use PR's update_pot.sh for base pot generation"
+        # base 分支可能带有过期的 update_pot.sh（如遗漏的 schema 排除），
+        # 用 PR 分支的脚本生成 base.pot（内容仍来自 base 数据，语义不变）。
+        run: |
+          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-head
+          git checkout pr-head -- lang/update_pot.sh
       - name: "Generate translation template on base commit"
         run: |
           rm -f lang/po/cataclysm-dda.pot


### PR DESCRIPTION
## 修复内容

### 1. `request-review.yml`（Auto request review）
`qrox/auto-request-review` 需要请求 PR review 的权限，但 workflow 未声明 `permissions`，导致 GitHub 返回 `Resource not accessible by integration`。添加：

```yaml
permissions:
  contents: read
  pull-requests: write
```

### 2. `text-changes-analyzer.yml`（analyze-text-changes）
base 步骤会 checkout 到 `master` 并运行**master 上可能过期的 `lang/update_pot.sh`**（例如遗漏 `data/lua/reference/*.schema.json` 的排除），导致 pot 生成失败。修复：base checkout 后，先从 PR 分支取 `lang/update_pot.sh` 再生成 base.pot——脚本只是工具，**内容仍来自 base 数据，diff 语义不变**。

## 背景

这两个失败都是 master 上的预存问题（与本 PR 同步内容无关），单独修复并合入 master 后，`#598`（上游同步 PR）的 CI 即可全绿。