### PR TITLE
Fix the compilation failure caused by the Lua-related changes in #598

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4655,7 +4655,7 @@ bool Character::invoke_item( item *used, const tripoint_bub_ms &pt,
         { "tick", false },
         {
             "position", cata::lua_ui::native_callback_point {
-                "bub_ms", pt.x(), pt.y(), pt.z()
+                "bub_ms", tripoint_rel_ms( pt.x(), pt.y(), pt.z() )
             }
         }
     };
@@ -4733,7 +4733,7 @@ bool Character::invoke_item( item *used, const std::string &method, const tripoi
         { "tick", false },
         {
             "position", cata::lua_ui::native_callback_point {
-                "bub_ms", pt.x(), pt.y(), pt.z()
+                "bub_ms", tripoint_rel_ms( pt.x(), pt.y(), pt.z() )
             }
         }
     };

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -585,7 +585,7 @@ void _make_explosion( map *m, const Creature *source, const tripoint_bub_ms &p,
             {
                 "position",
                 cata::lua_ui::native_callback_point {
-                    "abs_ms", position.x(), position.y(), position.z()
+                    "abs_ms", tripoint_rel_ms( position.x(), position.y(), position.z() )
                 }
             },
             { "power", static_cast<double>( ex.power ) },

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5231,7 +5231,7 @@ bool item::on_drop( const tripoint_bub_ms &pos, map &m )
         { "item", static_cast<const item *>( this ) },
         {
             "position", cata::lua_ui::native_callback_point {
-                "bub_ms", pos.x(), pos.y(), pos.z()
+                "bub_ms", tripoint_rel_ms( pos.x(), pos.y(), pos.z() )
             }
         }
     } ) ) {

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -2130,7 +2130,7 @@ void spell_effect::lua( const spell &sp, Creature &caster, const tripoint_bub_ms
     cata::lua_ui::invoke_lua_call( *call, "spell", {
         { "caster", &caster },
         { "spell", cata::lua_ui::native_callback_id{ "spell", sp.id().str() } },
-        { "target", cata::lua_ui::native_callback_point{ "bubble", target.x(), target.y(), target.z() } }
+        { "target", cata::lua_ui::native_callback_point{ "bubble", tripoint_rel_ms( target.x(), target.y(), target.z() ) } }
     } );
 }
 

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -2085,12 +2085,12 @@ bool monster::move_to( const tripoint_bub_ms &p, bool force, bool step_on_critte
             { "monster", static_cast<const Creature *>( this ) },
             {
                 "from", cata::lua_ui::native_callback_point {
-                    "bub_ms", pos.x(), pos.y(), pos.z()
+                    "bub_ms", tripoint_rel_ms( pos.x(), pos.y(), pos.z() )
                 }
             },
             {
                 "to", cata::lua_ui::native_callback_point {
-                    "bub_ms", p.x(), p.y(), p.z()
+                    "bub_ms", tripoint_rel_ms( p.x(), p.y(), p.z() )
                 }
             },
             { "force", force }

--- a/src/trap.cpp
+++ b/src/trap.cpp
@@ -350,7 +350,7 @@ void trap::trigger( const tripoint_bub_ms &pos, Creature *creature,
         },
         {
             "position", cata::lua_ui::native_callback_point {
-                "bub_ms", pos.x(), pos.y(), pos.z()
+                "bub_ms", tripoint_rel_ms( pos.x(), pos.y(), pos.z() )
             }
         }
     };


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

The Experimental Release GitHub Action failed completely, and the cause was traced to the Lua-related changes introduced by PR #598.

```text
error C2440: '<function-style-cast>': cannot convert from 'initializer list'
to 'cata::lua_ui::native_callback_point'
```

```text
cannot convert from 'int' to 'tripoint_rel_ms'
too many initializers
```

It appears that one of the parameters of `cata::lua_ui::native_callback_point` is supposed to receive a `coords::coord_point_ob<tripoint, ...>`, but instead of constructing it with `tripoint_rel_ms`, three `int` values were passed directly.

| File | Line |
| ------------------------ | ---------- |
| `magic_spell_effect.cpp` | 2133 |
| `monmove.cpp` | 2087, 2092 |
| `trap.cpp` | 352 |
| `character.cpp` | 4657, 4735 |
| `explosion.cpp` | 587 |
| `item.cpp` | 5233 |

#### Describe the solution

Use `tripoint_rel_ms(x, y, z)`.