### PR TITLE
Allow configuring multifunction mining tools with JACKHAMMER use_action

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -1795,6 +1795,11 @@
     "type": "json_flag"
   },
   {
+    "id": "MULTI_DRILL",
+    "//": "A jackhammer that can mine and destroy walls",
+    "type": "json_flag"
+  },
+  {
     "id": "MUNDANE",
     "//": "For items that have relic data but aren't actually magic",
     "info": "This item is designed to have special effects",

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2173,9 +2173,11 @@ activity_reason_info multi_mine_activity_actor::multi_activity_can_do( Character
     if( !here.has_flag( ter_furn_flag::TFLAG_MINEABLE, src_loc ) ) {
         return activity_reason_info::fail( do_activity_reason::NO_ZONE );
     }
-    std::vector<item *> mining_inv = you.items_with( [&you]( const item & itm ) {
+    const bool is_wall_mining = here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_WALL, src_loc );
+    std::vector<item *> mining_inv = you.items_with( [&you, is_wall_mining]( const item & itm ) {
         return ( itm.has_flag( flag_DIG_TOOL ) && !itm.type->can_use( "JACKHAMMER" ) ) ||
-               ( itm.type->can_use( "JACKHAMMER" ) && itm.ammo_sufficient( &you ) );
+               ( itm.type->can_use( "JACKHAMMER" ) && itm.ammo_sufficient( &you ) &&
+               ( !is_wall_mining || itm.has_flag( flag_MULTI_DRILL ) ) );
     } );
     if( mining_inv.empty() ) {
         return activity_reason_info::fail( do_activity_reason::NEEDS_MINING );
@@ -3441,8 +3443,9 @@ static bool mine_activity( Character &you, const tripoint_bub_ms &src_loc )
     // If we don't then our iteration will preferentially select the (powered) jackhammer and always fail in subsequent calls to dig_tool(). Very troublesome!
     const bool is_wall_mining = here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_WALL, src_loc );
     std::vector<item *> mining_inv = you.items_with( [&you, is_wall_mining]( const item & itm ) {
-        return ( itm.has_flag( flag_DIG_TOOL ) && !itm.type->can_use( "JACKHAMMER" ) ) ||
-               ( !is_wall_mining && ( itm.type->can_use( "JACKHAMMER" ) && itm.ammo_sufficient( &you ) ) );
+        return ( itm.has_flag( flag_DIG_TOOL ) && !itm.type->can_use( "JACKHAMMER" ) ) || 
+               ( itm.type->can_use( "JACKHAMMER" ) && itm.ammo_sufficient( &you ) &&
+               ( !is_wall_mining || itm.has_flag( flag_MULTI_DRILL ) ) );
     } );
     // All other failure conditions are handled in subsequent calls to dig_tool() with specific messaging for the player. This is just an early short circuit.
     if( mining_inv.empty() ) {

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -205,6 +205,7 @@ const flag_id flag_MODULE_HOLDER( "MODULE_HOLDER" );
 const flag_id flag_MORPHIC( "MORPHIC" );
 const flag_id flag_MOUNTED_GUN( "MOUNTED_GUN" );
 const flag_id flag_MOUSE( "MOUSE" );
+const flag_id flag_MULTI_DRILL( "MULTI_DRILL" );
 const flag_id flag_MUNDANE( "MUNDANE" );
 const flag_id flag_MUSHY( "MUSHY" );
 const flag_id flag_MUTE( "MUTE" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -252,6 +252,7 @@ extern const flag_id flag_MODULE_HOLDER;
 extern const flag_id flag_MORPHIC;
 extern const flag_id flag_MOUNTED_GUN;
 extern const flag_id flag_MOUSE;
+extern const flag_id flag_MULTI_DRILL;
 extern const flag_id flag_MUNDANE;
 extern const flag_id flag_MUSHY;
 extern const flag_id flag_MWS_PORTAL_STORM_DATA;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

As described in PR #602, the blanket C++ hardcoded logic introduced by RenechCDDA that prohibits any tool with JACKHAMMER functionality from destroying walls has caused several secondary issues. For example, it permanently prevents the addition of multifunction mining tools in the future, and causes `mine_activity` and `multi_activity_can_do` to use inconsistent logic when determining whether a tool can perform mining.

#### Describe the solution

Added a new JSON flag `MULTI_DRILL`, meaning "a jackhammer that can mine and destroy walls".

Modified the logic in `activity_item_handling.cpp` to unify the checks performed by `mine_activity` and `multi_activity_can_do`, and changed the `!is_wall_mining` condition (the variable used in the JACKHAMMER branch to determine whether the target is wall demolition) to `( !is_wall_mining || itm.has_flag( flag_MULTI_DRILL ) )`. When the `MULTI_DRILL` flag is present, the tool is allowed to operate even if the target is a wall.

For now, only the code support has been added. No actual tool currently uses this flag.