### PR TITLE
fix(main-menu): 清除切换菜单后残留的子菜单像素

### DIFF
--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -772,6 +772,14 @@ void main_menu::print_menu( const catacurses::window &w_open, int iSel, const po
 {
     main_menu_button_map.clear();
 
+    // w_open is a centered window that may not cover the whole terminal, and
+    // the submenu window is destroyed right after display_sub_menu() returns.
+    // Clear the entire screen first so stale pixels from a previous submenu
+    // (e.g. the tall New Game list) cannot linger outside w_open when the
+    // selection switches to another menu.
+    catacurses::erase();
+    wnoutrefresh( catacurses::stdscr );
+
     // Clear Lines
     werase( w_open );
 


### PR DESCRIPTION
#### Summary
Bugfixes "修复主菜单子菜单切换后残留(如'新角色/预设角色'字样只消失一半)"

#### Responsible human
@LYHGLYTX

#### Purpose of change
主菜单中选中「新游戏」时弹出的子菜单(新角色/预设角色/随机角色等),在切换到其他菜单(设置/其他等)后只消失一半,屏幕上仍残留"新角色""预设角色"等字样。

复现步骤:
1. 进入主菜单,选中「新游戏」(New Game),显示子菜单
2. 按 ←/→ 切换到其他菜单(如 Settings / Other)
3. 观察到 New Game 子菜单部分内容残留在屏幕上,只有一半被刷新

#### Describe the solution
根因有三层:
- `w_open` 是居中窗口,不覆盖整个终端(`init_windows` 中 `p0 = (TERMX-total_w)/2, (TERMY-total_h)/2`),大终端下两侧和顶部有留白
- 子菜单窗口 `w_sub` 是 `display_sub_menu` 的局部变量,函数返回即销毁;SDL curses 直接绘制,销毁后其像素不会自动清除,`draw_window` 清行也只清该窗口自身宽度范围
- `background_pane` 的清屏回调只在被 invalidate 时执行,而 `ui_manager::redraw()` 每帧只 invalidate 栈顶 UI,`stdscr` 不会每帧清屏

New Game 子菜单(第一个按钮 + 最高的子菜单)窗口被 clamp 到终端边界而非 `w_open` 边界,会向左超出 `w_open`;切换菜单后超出部分没有任何窗口覆盖,形成残留。

修复:在 `print_menu` 重绘开头先 `catacurses::erase(); wnoutrefresh( catacurses::stdscr );` 全屏清除,再绘制 `w_open` 与子菜单。该写法与 `background_pane` 既有清屏实现一致(`ui_manager.cpp`)。

#### Describe alternatives you've considered
- 仅清除旧子菜单矩形区域:需要跟踪上一次子菜单的位置/尺寸,状态管理更复杂,且首帧与 resize 边界情况多
- 将子菜单窗口 clamp 到 `w_open` 边界:会改变子菜单与按钮的对齐布局(此前提交专门对齐过),且 w_open 较小时仍可能超界
- 每帧 invalidate background_pane:改动全局 UI 调度逻辑,影响面过大

#### Testing
- `src/main_menu.cpp` 在 TUI (`build/`) 与 TILES (`build-tiles/`) 两个构建目录均单独编译通过
- 完整链接验证受限于分支既有问题:`character.cpp`/`explosion.cpp` 的 Lua `native_callback` 编译错误在本次改动前已存在(stash 后完整构建同样失败),与本次修改无关
- 建议人工验证:主菜单切到「新游戏」再切到「设置/其他」,确认子菜单无残留

#### Documentation impact
None

#### Related CCB-Docs PR
None

#### Affected documentation IDs
None

#### Generated reference impact
None

#### Additional context
无