### PR TITLE
fix(input): 边缘滚动按实际渲染缓冲区计算边界

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2591,13 +2591,25 @@ std::pair<tripoint_rel_ms, tripoint_rel_ms> game::mouse_edge_scrolling( input_co
     }
     const input_event event = ctxt.get_raw_input();
     if( event.type == input_event_t::mouse ) {
-        const point_rel_ms threshold( projected_window_width() / 100, projected_window_height() / 100 );
+        // event.mouse_pos is in display_buffer coordinates, whose size follows
+        // the actual window and can be smaller than the configured
+        // TERMINAL_X/Y (e.g. a window narrower than requested).  Comparing
+        // against the configured projected size would make the right/bottom
+        // edge unreachable, so measure against the real buffer.
+        int buffer_width = 0;
+        int buffer_height = 0;
+        get_display_buffer_dims( &buffer_width, &buffer_height );
+        if( buffer_width <= 0 || buffer_height <= 0 ) {
+            buffer_width = projected_window_width();
+            buffer_height = projected_window_height();
+        }
+        const point_rel_ms threshold( buffer_width / 100, buffer_height / 100 );
         if( event.mouse_pos.x <= threshold.x() ) {
             ret.first.x() -= speed;
             if( iso ) {
                 ret.first.y() -= speed;
             }
-        } else if( event.mouse_pos.x >= projected_window_width() - threshold.x() ) {
+        } else if( event.mouse_pos.x >= buffer_width - threshold.x() ) {
             ret.first.x() += speed;
             if( iso ) {
                 ret.first.y() += speed;
@@ -2608,7 +2620,7 @@ std::pair<tripoint_rel_ms, tripoint_rel_ms> game::mouse_edge_scrolling( input_co
             if( iso ) {
                 ret.first.x() += speed;
             }
-        } else if( event.mouse_pos.y >= projected_window_height() - threshold.y() ) {
+        } else if( event.mouse_pos.y >= buffer_height - threshold.y() ) {
             ret.first.y() += speed;
             if( iso ) {
                 ret.first.x() -= speed;


### PR DESCRIPTION
## 问题

大地图模式下鼠标移到右边缘不滚动(上/下/左正常)。

## 根因

本仓库将鼠标事件坐标统一转换为 display_buffer 坐标(提交 304330f137d 引入),其范围是实际窗口对应的渲染缓冲区(TERMINAL_WIDTH × fontwidth),可能小于配置的 TERMINAL_X/Y(例如窗口比配置窄、被显示器/窗口管理器限制、Android 按实际屏幕决定)。

而 game::mouse_edge_scrolling 仍用 projected_window_width()/projected_window_height()(配置值)判断边缘:

- 左/上:坐标从 0 开始,阈值小,正常触发
- 右(窗口变窄时还有下):要求 mouse_pos >= 配置宽度 - 1%,但鼠标坐标最大只有实际缓冲区宽度,永远达不到 → 边缘滚动失效

## 修复

改用 get_display_buffer_dims() 获取实际渲染缓冲区尺寸作为边缘判断基准(缓冲区不可用时回退到 projected 尺寸),同时修复地形模式共用同一函数的边缘滚动。
