### PR TITLE
fix(input): 边缘滚动在 ImGui 面板捕获鼠标时仍可工作

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2590,12 +2590,19 @@ std::pair<tripoint_rel_ms, tripoint_rel_ms> game::mouse_edge_scrolling( input_co
         last_mouse_edge_scroll = now;
     }
     const input_event event = ctxt.get_raw_input();
-    if( event.type == input_event_t::mouse ) {
+    if( event.type == input_event_t::mouse || event.type == input_event_t::timeout ) {
         // event.mouse_pos is in display_buffer coordinates, whose size follows
         // the actual window and can be smaller than the configured
         // TERMINAL_X/Y (e.g. a window narrower than requested).  Comparing
         // against the configured projected size would make the right/bottom
         // edge unreachable, so measure against the real buffer.
+        //
+        // The input loop re-samples the cursor into mouse_pos every frame,
+        // including for timeout events, so evaluate the edge test on the
+        // sampled position for both event kinds.  This keeps edge scrolling
+        // working while an overlay panel (e.g. the ImGui overmap sidebar)
+        // captures mouse motion events: the game only sees timeouts then, and
+        // reusing the last motion vector would leave it stuck at zero.
         int buffer_width = 0;
         int buffer_height = 0;
         get_display_buffer_dims( &buffer_width, &buffer_height );
@@ -2627,8 +2634,6 @@ std::pair<tripoint_rel_ms, tripoint_rel_ms> game::mouse_edge_scrolling( input_co
             }
         }
         ret.second = ret.first;
-    } else if( event.type == input_event_t::timeout ) {
-        ret.first = ret.second;
     }
 #endif
     return ret;


### PR DESCRIPTION
## 问题

大地图界面鼠标移到右边缘无法滚动(上/下/左正常)。#605 修复后主世界已正常,但大地图仍失效。

## 根因

大地图侧栏是 ImGui 窗口(`OVERMAP_SIDEBAR`,覆盖屏幕右侧约 1/3)。鼠标移入侧栏后 `cataimgui::client::want_capture_mouse()` 为 true,sdltiles 的 MOUSEMOTION 分支被跳过,不再产生 mouse 移动事件,游戏只能收到 timeout。

原 `game::mouse_edge_scrolling` 对 timeout 事件仅复用上次鼠标向量(`ret.first = ret.second`),而上次 mouse 事件发生在鼠标进入侧栏前(不在边缘),向量恒为零 → 永不滚动。坐标采样(`event.mouse_pos`)每帧都在更新,但 timeout 分支从不使用它。

## 修复

timeout 事件与 mouse 事件走同一条边缘判断路径(基于每帧重新采样的 `event.mouse_pos`),而不是复用旧向量。鼠标停在侧栏内任意边缘位置即可持续滚动。

## 关联

补充 #605(边缘阈值按实际渲染缓冲区计算)未覆盖的 ImGui 捕获鼠标场景。两个修复互补,均需保留。