### PR TITLE
fix(mod): 读档时自动给予 status_by_skill 加成效果

### DIFF
--- a/data/mods/status_by_skill/begin.json
+++ b/data/mods/status_by_skill/begin.json
@@ -1,0 +1,17 @@
+[
+    {
+        "//":"进入存档自动给予效果",
+        "type": "effect_on_condition",
+        "id": "begin_status_enhancement",
+       
+        "eoc_type": "EVENT",
+        "required_event":"game_begin",
+    
+        "effect":
+        [
+            { "u_add_effect": "skill_status_buff", "duration": "PERMANENT" }
+        ]
+    
+    }
+    
+]


### PR DESCRIPTION
## 变更内容

为 `status_by_skill` 模组新增 `begin.json`:

- 在 `game_begin`(读档)事件时自动给玩家添加 `skill_status_buff` 效果(永久)
- 与 `modinfo.json` 中已有的 `game_start`(新开局)事件互补,修复读档后技能状态加成丢失的问题

## 测试

- `begin.json` 通过 JSON 语法校验
- 在 data/mods/status_by_skill/ 下与现有 jmath.json、modinfo.json 共存