### PR TITLE
fix(options): EDGE_SCROLL 默认改为关闭(Disabled)

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2722,7 +2722,7 @@ void options_manager::add_options_interface()
             { 30, to_translation( "Normal" ) },
             { 10, to_translation( "Fast" ) },
         },
-        30, 30, COPT_CURSES_HIDE );
+        -1, -1, COPT_CURSES_HIDE );
         get_option( "EDGE_SCROLL" ).setPrerequisite( "ENABLE_MOUSE" );
     } );
 


### PR DESCRIPTION
将界面-鼠标和手柄中的边缘滚动(EDGE_SCROLL)默认值从 30(Normal)改为 -1(Disabled):新玩家/重置默认时默认关闭边缘滚动,已有存档的用户设置不受影响。