### PR TITLE
fix(android): 旧 UI 恢复像素小地图绘制

### DIFF
--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -4256,11 +4256,13 @@ void cata_cursesport::curses_drawwindow( const catacurses::window &w )
         // Special font for the terrain window
         update = draw_window( overmap_font, w, force_full );
     } else if( g && w == g->w_pixel_minimap && pixel_minimap_option ) {
-#if defined(__ANDROID__)
-        // Android's HUD publishes an explicit screen-space rectangle and draws
-        // its minimap during refresh_display().  The curses window remains the
-        // 1x1 placeholder created by game::init_ui(); rendering it here leaves a
-        // tiny duplicate minimap at the upper-left corner of the game surface.
+#if defined(__ANDROID__) && defined(CCB_ANDROID_NEW_UI) && CCB_ANDROID_NEW_UI
+        // Only the new Android UI publishes an explicit screen-space rectangle
+        // and draws its minimap during refresh_display().  The curses window
+        // remains the 1x1 placeholder created by game::init_ui(); rendering it
+        // here would leave a tiny duplicate minimap at the upper-left corner
+        // of the game surface.  Legacy Android UI builds still use the curses
+        // path below, exactly like the desktop version.
 #else
         // ensure the space the minimap covers is "dirtied".
         // this is necessary when it's the only part of the sidebar being drawn


### PR DESCRIPTION
提交 f4520a3ac15 为修复新 UI 的重复小地图,在 curses_drawwindow 用 #if defined(__ANDROID__) 无条件跳过小地图绘制,误伤了旧 UI(CCB_ANDROID_NEW_UI=OFF)构建:旧 UI 没有新 UI 的 HUD 矩形机制,导致小地图完全消失。本修复把条件收紧为仅新 UI 构建(#if defined(__ANDROID__) && defined(CCB_ANDROID_NEW_UI) && CCB_ANDROID_NEW_UI,与 android_ui_mode.h 的 is_new_ui_build() 一致),旧 UI 恢复与 PC 相同的 curses 小地图绘制。新 UI 与 PC 行为不变。