### PR TITLE
Document the Lua-first Platform v1 direction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,9 @@ rules and does not replace this file.
 ## Sources of truth / 权威来源
 
 - Runtime behaviour: C++/Java/Lua source and tests in this repository.
-- JSON/Lua/API contracts: schemas, LuaLS declarations, registrations, and
-  checked-in generated inventories.
+- JSON/Lua/API contracts: schemas, LuaLS declarations, registrations,
+  checked-in generated inventories, and the accepted Lua-first architecture
+  contract plus its checked roadmap.
 - Build and validation: GitHub Actions, CMake, Makefile, Gradle, and repository
   validation scripts.
 - Contribution and governance: this file, `CONTRIBUTING.md`, and
@@ -21,7 +22,8 @@ rules and does not replace this file.
   contract merely to match prose.
 
 - 运行时行为以本仓库源码和测试为准。
-- JSON、Lua 与 API 契约以 Schema、LuaLS 声明、注册信息及生成清单为准。
+- JSON、Lua 与 API 契约以 Schema、LuaLS 声明、注册信息、生成清单，以及已接受的
+  Lua-first 架构合同与受检路线图为准。
 - 构建和验证以 CI、CMake、Makefile、Gradle 与仓库验证脚本为准。
 - 贡献和治理以本文件、`CONTRIBUTING.md`、`GOVERNANCE.md` 为准。
 - CCB-Docs 负责解释和导航；与源码契约冲突时应标记文档过期并修正文档。
@@ -40,7 +42,10 @@ rules and does not replace this file.
 | `doc/` | Legacy developer documentation awaiting classified migration | this file |
 
 The machine-readable map is `ai/project-map.yml`; validation routing is in
-`ai/test-matrix.yml`.
+`ai/test-matrix.yml`.  The long-term pure-Lua authoring direction is defined
+by `data/lua/LUA_FIRST_PLATFORM.md`, with implementation status in
+`ai/lua-first-roadmap.yml`; it is independent of the currently shipped Lua
+API v5 contract.
 
 ## Modification boundaries / 修改边界
 

--- a/ai/docs-impact.yml
+++ b/ai/docs-impact.yml
@@ -91,6 +91,21 @@ entries:
     risk_group: lua-api
     risk_level: high
 
+  - id: lua-first-platform
+    enforcement: advisory
+    patterns:
+      - data/lua/LUA_FIRST_PLATFORM.md
+      - ai/lua-first-roadmap.yml
+      - ai/lua-first-roadmap.schema.json
+    documentation_ids:
+      - architecture.lua-first-platform
+      - architecture.lua-first-roadmap
+      - architecture.lua-first-glossary
+    generated_reference_impact: false
+    required_check_ids: [agent-context]
+    risk_group: lua-platform
+    risk_level: high
+
   - id: json-public-contract
     enforcement: required
     patterns:

--- a/ai/documentation-registry.schema.json
+++ b/ai/documentation-registry.schema.json
@@ -65,6 +65,7 @@
           "authority": {
             "enum": [
               "governance_contract",
+              "architecture_contract",
               "api_contract",
               "build_contract",
               "generated_contract",

--- a/ai/documentation-registry.yml
+++ b/ai/documentation-registry.yml
@@ -1,9 +1,9 @@
 schema_version: 1
 kind: documentation_registry
-source_commit: af96b9d149fa7b269bb2c6ed5f51c8e126321204
+source_commit: aae884c958bc3ac2c23bbf840b22deadade4a2ec
 scope: Tracked documentation and machine contracts from the Git index; untracked build caches are never
   traversed.
-entry_count: 233
+entry_count: 236
 entries:
 - id: repo.deepcode-plans-sim-render-decoupling-plan-md
   path: .deepcode/plans/sim-render-decoupling-plan.md
@@ -313,6 +313,30 @@ entries:
   generated: false
   generated_by: null
   include_in_ai_index: true
+- id: repo.ai-lua-first-roadmap-schema-json
+  path: ai/lua-first-roadmap.schema.json
+  category: authoritative_document
+  status: active
+  authority: governance_contract
+  source_of_truth: true
+  stable_document_id: null
+  ccb_docs_ids:
+  - architecture.lua-first-roadmap
+  generated: false
+  generated_by: null
+  include_in_ai_index: true
+- id: repo.ai-lua-first-roadmap-yml
+  path: ai/lua-first-roadmap.yml
+  category: authoritative_document
+  status: active
+  authority: governance_contract
+  source_of_truth: true
+  stable_document_id: null
+  ccb_docs_ids:
+  - architecture.lua-first-roadmap
+  generated: false
+  generated_by: null
+  include_in_ai_index: true
 - id: repo.ai-project-map-yml
   path: ai/project-map.yml
   category: authoritative_document
@@ -454,6 +478,19 @@ entries:
   source_of_truth: true
   stable_document_id: null
   ccb_docs_ids: []
+  generated: false
+  generated_by: null
+  include_in_ai_index: true
+- id: repo.data-lua-lua-first-platform-md
+  path: data/lua/LUA_FIRST_PLATFORM.md
+  category: authoritative_document
+  status: active
+  authority: architecture_contract
+  source_of_truth: true
+  stable_document_id: null
+  ccb_docs_ids:
+  - architecture.lua-first-platform
+  - architecture.lua-first-glossary
   generated: false
   generated_by: null
   include_in_ai_index: true

--- a/ai/lua-first-roadmap.schema.json
+++ b/ai/lua-first-roadmap.schema.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://crimsoncrossbunker.github.io/schemas/lua-first-roadmap-v1.json",
+  "title": "CCB Lua-first Platform roadmap",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "kind",
+    "direction_status",
+    "platform_version",
+    "authority_path",
+    "current_contract",
+    "target",
+    "legacy_inventories",
+    "status_definitions",
+    "milestones",
+    "capabilities"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "kind": { "const": "lua_first_roadmap" },
+    "direction_status": { "enum": [ "proposal", "accepted", "retired" ] },
+    "platform_version": { "type": "integer", "minimum": 1 },
+    "authority_path": { "type": "string", "minLength": 1 },
+    "current_contract": { "type": "string", "minLength": 1 },
+    "target": { "type": "string", "minLength": 1 },
+    "legacy_inventories": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [ "id", "path", "selector", "entry_count" ],
+        "properties": {
+          "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+          "path": { "type": "string", "minLength": 1 },
+          "selector": { "type": "string", "minLength": 1 },
+          "entry_count": { "type": "integer", "minimum": 0 }
+        },
+        "additionalProperties": false
+      }
+    },
+    "status_definitions": {
+      "type": "object",
+      "required": [ "milestone", "capability", "legacy_dependency" ],
+      "properties": {
+        "milestone": { "const": [ "planned", "in_progress", "complete", "blocked" ] },
+        "capability": { "const": [ "absent", "legacy_only", "partial", "available" ] },
+        "legacy_dependency": { "const": [ "none", "private_adapter", "public_legacy" ] }
+      },
+      "additionalProperties": false
+    },
+    "milestones": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [ "id", "title", "status", "depends_on", "exit_criteria", "evidence" ],
+        "properties": {
+          "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+          "title": { "type": "string", "minLength": 1 },
+          "status": { "enum": [ "planned", "in_progress", "complete", "blocked" ] },
+          "depends_on": {
+            "type": "array",
+            "items": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+            "uniqueItems": true
+          },
+          "exit_criteria": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "evidence": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 },
+            "uniqueItems": true
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "capabilities": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "id", "phase", "status", "legacy_dependency", "target_surface",
+          "evidence", "next_actions"
+        ],
+        "properties": {
+          "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+          "phase": { "type": "string", "minLength": 1 },
+          "status": { "enum": [ "absent", "legacy_only", "partial", "available" ] },
+          "legacy_dependency": { "enum": [ "none", "private_adapter", "public_legacy" ] },
+          "target_surface": { "type": "string", "minLength": 1 },
+          "evidence": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 },
+            "uniqueItems": true
+          },
+          "next_actions": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 1 }
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/ai/lua-first-roadmap.yml
+++ b/ai/lua-first-roadmap.yml
@@ -1,0 +1,185 @@
+schema_version: 1
+kind: lua_first_roadmap
+direction_status: accepted
+platform_version: 1
+authority_path: data/lua/LUA_FIRST_PLATFORM.md
+current_contract: Lua API v5
+target: Pure-Lua authoring for CCB core content and Mods without public JSON or EOC dependencies.
+legacy_inventories:
+  - id: json-object-types
+    path: data/reference/json/ccb_json_object_types.json
+    selector: type
+    entry_count: 190
+  - id: eoc-conditions
+    path: data/reference/json/ccb_eoc_conditions.json
+    selector: key
+    entry_count: 275
+  - id: eoc-effects
+    path: data/reference/json/ccb_eoc_effects.json
+    selector: key
+    entry_count: 310
+status_definitions:
+  milestone: [planned, in_progress, complete, blocked]
+  capability: [absent, legacy_only, partial, available]
+  legacy_dependency: [none, private_adapter, public_legacy]
+milestones:
+  - id: documentation-foundation
+    title: Authoritative design, Agent routing, and checked roadmap
+    status: complete
+    depends_on: []
+    exit_criteria:
+      - The source repository has an authoritative Lua-first architecture document.
+      - The roadmap is schema-checked and routed to contributors and agents.
+      - CCB-Docs has paired Chinese and English explanatory pages.
+    evidence:
+      - data/lua/LUA_FIRST_PLATFORM.md
+      - ai/lua-first-roadmap.yml
+      - data/lua/AGENTS.md
+  - id: zero-config-discovery
+    title: Root main.lua discovery and optional native mod.lua metadata
+    status: planned
+    depends_on: [documentation-foundation]
+    exit_criteria:
+      - A directory containing only main.lua is discoverable as a Mod.
+      - No lua subdirectory, manifest.json, or modinfo.json is required.
+      - Optional mod.lua resolves dependencies before content loading.
+    evidence: []
+  - id: native-content-transaction
+    title: Pre-finalize native content objects and transactional commit
+    status: planned
+    depends_on: [zero-config-discovery]
+    exit_criteria:
+      - Platform content runs before global data finalization.
+      - Exported native references reject stale owners and generations.
+      - Private legacy adapters are inventoried and not publicly callable.
+    evidence: []
+  - id: item-recipe-use-slice
+    title: Zero-JSON/EOC item, recipe, and Lua use behaviour
+    status: planned
+    depends_on: [native-content-transaction]
+    exit_criteria:
+      - The example Mod loads with no JSON or EOC files.
+      - The item and recipe preserve stable ids through save/load.
+      - A named Lua handler produces an observable in-game result.
+    evidence: []
+  - id: behaviour-services
+    title: Events, hooks, callbacks, persistent tasks, state, and shared domain services
+    status: planned
+    depends_on: [item-recipe-use-slice]
+    exit_criteria:
+      - EOC handler logic is mapped to shared services rather than key-shaped bindings.
+      - Named tasks resume from serializable data after save/load.
+      - Workflows can be authored as Lua libraries over the primitive APIs.
+    evidence: []
+  - id: static-domain-coverage
+    title: Complete author-facing static content coverage
+    status: planned
+    depends_on: [behaviour-services]
+    exit_criteria:
+      - Every checked JSON/EOC entry has a reviewed replacement disposition.
+      - Every supported domain has native registration, tests, declarations, and documentation.
+      - No available Platform capability publicly requires a legacy parser.
+    evidence: []
+  - id: core-and-bundled-migration
+    title: Migrate core and bundled content and freeze covered legacy authoring
+    status: planned
+    depends_on: [static-domain-coverage]
+    exit_criteria:
+      - Targeted core and bundled content is Lua-authored with stable ids.
+      - Migration tools emit native-object Lua skeletons and explicit TODOs.
+      - New JSON/EOC features are frozen only in domains with complete replacements.
+    evidence: []
+  - id: legacy-removal-window
+    title: Complete deprecation window and allow legacy author-interface removal
+    status: planned
+    depends_on: [core-and-bundled-migration]
+    exit_criteria:
+      - At least two stable releases and at least twelve months have elapsed.
+      - Save migrations and copied-world tests cover retained stable ids.
+      - The compatibility layer can be removed without bundled-content dependencies.
+    evidence: []
+capabilities:
+  - id: mod-discovery
+    phase: discovery
+    status: absent
+    legacy_dependency: public_legacy
+    target_surface: Root main.lua with optional native mod.lua metadata
+    evidence: [src/mod_manager.cpp]
+    next_actions:
+      - Add Platform discovery beside legacy modinfo.json scanning.
+      - Define deterministic defaults and hybrid metadata conflict errors.
+  - id: trusted-standard-library
+    phase: bootstrap
+    status: legacy_only
+    legacy_dependency: none
+    target_surface: Complete Lua 5.4 standard libraries and native package loading
+    evidence: [src/catalua_ui.cpp, src/lua/lua.h]
+    next_actions:
+      - Introduce a separately versioned Platform state without v5 capability filtering.
+      - Add user-visible trust warnings for installed and enabled Platform Mods.
+  - id: static-native-content
+    phase: content
+    status: absent
+    legacy_dependency: public_legacy
+    target_surface: ccb.content with exported native definition objects
+    evidence: [src/init.cpp, src/game_io.cpp]
+    next_actions:
+      - Add a pre-finalize Platform execution phase and staging registry.
+      - Define add, replace, edit, commit, and static fingerprint semantics.
+  - id: native-object-surface
+    phase: bindings
+    status: partial
+    legacy_dependency: none
+    target_surface: All bindable public members of explicitly exported native types
+    evidence: [src/catalua_bindings_values.cpp, data/lua/types/ccb_api_v5.d.lua]
+    next_actions:
+      - Add an export-root inventory and report every unbindable public member.
+      - Add owner and generation checks to borrowed native references.
+  - id: runtime-events-hooks-callbacks
+    phase: runtime
+    status: partial
+    legacy_dependency: none
+    target_surface: Typed events, synchronous hooks, and definition callbacks
+    evidence: [src/catalua_ui.cpp, data/lua/reference/ccb_public_api_v5.json]
+    next_actions:
+      - Define Platform-native callback arguments instead of snapshots and talker aliases.
+      - Preserve stable handler ids across runtime reloads.
+  - id: persistent-tasks-and-state
+    phase: runtime
+    status: partial
+    legacy_dependency: none
+    target_surface: Named tasks and serializable character/world state
+    evidence: [src/catalua_ui.cpp, src/catalua_ui_state.cpp]
+    next_actions:
+      - Persist mod id, handler id, due time, owner, payload, and payload version.
+      - Specify missing-handler, overdue-task, and migration outcomes.
+  - id: shared-domain-services
+    phase: runtime
+    status: absent
+    legacy_dependency: public_legacy
+    target_surface: Game-domain services shared by Platform and legacy adapters
+    evidence: [src/condition.cpp, src/npctalk.cpp, src/effect_on_condition.cpp]
+    next_actions:
+      - Classify existing handlers by underlying query or mutation service.
+      - Extract the item, recipe, morale, mission, character, and map vertical slice first.
+  - id: developer-templates
+    phase: tooling
+    status: absent
+    legacy_dependency: none
+    target_surface: Minimal and complete templates plus create_lua_mod.py
+    evidence: [tools/lua_api/README.md]
+    next_actions:
+      - Ship executable templates with the item-recipe-use vertical slice.
+      - Generate no JSON and never overwrite an existing non-empty target.
+  - id: replacement-audit
+    phase: migration
+    status: absent
+    legacy_dependency: private_adapter
+    target_surface: Exact JSON/EOC-to-domain replacement ledger
+    evidence:
+      - data/reference/json/ccb_json_object_types.json
+      - data/reference/json/ccb_eoc_conditions.json
+      - data/reference/json/ccb_eoc_effects.json
+    next_actions:
+      - Create a checked selector ledger covering every inventory entry exactly once.
+      - Record target domain, shared service, status, and source-backed evidence.

--- a/ai/project-map.yml
+++ b/ai/project-map.yml
@@ -24,6 +24,16 @@ entries:
     validation_ids: [lua-contract]
     boundaries:
       - Schema, LuaLS declarations, native registrations, generated inventories, and runtime validation tests are authoritative.
+      - Lua API v5 describes shipped behaviour and is separate from the planned Lua-first Platform v1.
+  - id: lua-first-platform
+    paths: [data/lua/LUA_FIRST_PLATFORM.md, ai/lua-first-roadmap.yml, ai/lua-first-roadmap.schema.json]
+    purpose: Accepted pure-Lua authoring architecture, replacement boundary, and checked implementation roadmap.
+    instructions: data/lua/AGENTS.md
+    validation_ids: [agent-context]
+    boundaries:
+      - The architecture contract defines target design; source and tests alone prove a capability is available.
+      - Public Platform APIs use native domain objects and services rather than exposing JSON loaders or EOC-key-shaped wrappers.
+      - Core serialization such as saves, settings, caches, and generated inventories may remain JSON internally.
   - id: bundled-mods
     paths: [data/mods/]
     purpose: Mods shipped and validated with CCB.

--- a/ai/task-router.yml
+++ b/ai/task-router.yml
@@ -57,6 +57,18 @@ entries:
       - Keep manifest, LuaLS, native registration, inventory, examples, and runtime validation in parity.
     upstream_differences:
       - CCB Lua v5 is a CCB contract and is not inferred from CBN or CDDA APIs.
+  - id: lua-first-platform
+    keywords: [Lua-first, Platform v1, pure Lua, main.lua, mod.lua, zero-config, JSON replacement, EOC replacement, 纯 Lua, 零配置, 替代 JSON, 替代 EOC]
+    paths: [data/lua/LUA_FIRST_PLATFORM.md, ai/lua-first-roadmap.yml, ai/lua-first-roadmap.schema.json, data/lua/, tools/lua_api/, src/]
+    project_ids: [lua-first-platform, lua-api, engine, developer-tools]
+    documentation_ids: [architecture.lua-first-platform, architecture.lua-first-roadmap, architecture.lua-first-glossary]
+    source_symbols: []
+    validation_ids: [agent-context, lua-contract]
+    compatibility:
+      - Treat roadmap status as planning data; only matching runtime source and tests establish implemented behaviour.
+      - Preserve stable content ids, saves, and hybrid Mod compatibility during incremental migration.
+    upstream_differences:
+      - Platform v1 is a CCB-native architecture and must not be inferred from Lua v5, CBN, CDDA, JSON keys, or EOC keys.
   - id: upstream-port
     keywords: [upstream, port, cherry-pick, CDDA, CBN, 上游, 移植]
     paths: [CONTRIBUTING.md, SYNC_EXCLUDED_PRS.md, src/, data/]

--- a/data/lua/AGENTS.md
+++ b/data/lua/AGENTS.md
@@ -1,13 +1,25 @@
 # `data/lua/` agent instructions
 
-This subtree contains the built-in runtime entry point, manifest schema,
-examples, reference inventories, and LuaLS declarations for the public Lua API.
+This subtree contains two distinct contracts:
+
+- the implemented Lua API v5 runtime, manifest, examples, inventories, and
+  LuaLS declarations; and
+- `LUA_FIRST_PLATFORM.md`, the accepted Platform v1 architecture for future
+  pure-Lua core and Mod authoring.  Its implementation status is tracked in
+  `ai/lua-first-roadmap.yml`.
 
 - `manifest.schema.json`, `types/ccb_api_v5.d.lua`, native registrations, and
-  generated inventories are authoritative API contracts.
+  generated inventories are authoritative for the currently shipped v5 API.
+- `LUA_FIRST_PLATFORM.md` is authoritative for Platform v1 design decisions;
+  do not present a roadmap item as implemented without matching source and
+  tests.
 - Never hand-edit generated reference inventories; run their named generator.
-- New code targets API v5 and declares the minimum capabilities it uses.
+- Maintenance of existing v5 code keeps declaring the minimum capabilities it
+  uses.  New Platform code follows the separately versioned Platform contract
+  and does not expose JSON loaders or EOC-key-shaped APIs.
 - Keep examples runnable and synchronized with declarations.
+- Platform Mods must not require a `lua/` subdirectory or author-maintained
+  JSON manifest.  Templates may recommend structure but may not require it.
 
 Validation:
 
@@ -15,6 +27,7 @@ Validation:
 python3 tools/lua_api/check_luals_declarations.py
 python3 tools/lua_api/check_coverage.py
 python3 -m unittest discover -s tools/lua_api -p 'test_*.py'
+python3 tools/agent/check_project_metadata.py
 ```
 
 CCB-Docs 只能解释这些契约；与本目录声明或注册冲突时，应更新并标记文档，

--- a/data/lua/LUA_FIRST_PLATFORM.md
+++ b/data/lua/LUA_FIRST_PLATFORM.md
@@ -1,0 +1,263 @@
+# CCB Lua-first Platform v1 / CCB Lua 优先平台 v1
+
+Status: accepted long-term architecture; implementation is tracked in
+`ai/lua-first-roadmap.yml`.
+
+状态：已接受的长期架构方向；实际实现进度以 `ai/lua-first-roadmap.yml` 为准。
+
+## Purpose / 目标
+
+Lua-first Platform v1 is the target authoring model for CCB core content and
+Mods.  It is intended to let an author define metadata, items, recipes,
+vehicles, creatures, world generation, dialogue, missions, UI, and runtime
+behaviour without authoring JSON or EOC.
+
+Platform v1 is not a spelling change for JSON or EOC.  Lua code should use
+functions, modules, native objects, normal control flow, composition, named
+tasks, and persistent state.  New public APIs must be shaped around the game
+domain, not around legacy parser keys.
+
+Lua-first Platform v1 是 CCB 核心内容与 Mod 的目标创作模型。最终作者应能在不编写
+JSON 或 EOC 的情况下定义 Mod 元数据、物品、配方、载具、怪物、地图生成、对话、
+任务、UI 与运行时行为。
+
+Platform v1 不是把 JSON/EOC 换一种拼写。Lua 应使用函数、模块、原生对象、普通控制
+流、组合、命名任务和持久状态；公共 API 应围绕游戏领域设计，而不是复刻旧解析器键。
+
+## Current boundary / 当前边界
+
+The current implemented contract is Lua API v5.  It starts after JSON data is
+finalized and primarily queries or controls objects already defined by C++ and
+JSON.  It remains supported while Platform v1 is built, but it must not be
+described as if Lua-first static content already exists.
+
+The checked inventories currently contain 190 JSON top-level object types,
+275 canonical EOC condition keys, and 310 canonical EOC effect keys.  These
+inventories are migration denominators, not a list of Lua APIs to reproduce.
+
+当前已实现的契约是 Lua API v5。它在 JSON 数据 finalize 之后启动，主要查询或控制由
+C++/JSON 已经定义的对象。Platform v1 建设期间继续支持 v5，但不得把尚未实现的静态
+Lua 内容能力写成现状。
+
+当前受检清单包含 190 个 JSON 顶层类型、275 个规范 EOC condition 键和 310 个规范
+EOC effect 键。它们是迁移分母，不是要逐项复制的 Lua API 清单。
+
+## Zero-configuration discovery / 零配置发现
+
+A minimal Platform v1 Mod has one required convention: a `main.lua` at the Mod
+root.  No `lua/` directory, `manifest.json`, or `modinfo.json` is required.
+
+```text
+my_mod/
+└── main.lua
+```
+
+Defaults are derived without configuration:
+
+- the directory name is the Mod id and display name;
+- dependencies are empty;
+- the platform version is 1;
+- `main.lua` is the content and runtime registration entry point.
+
+Subdirectories such as `content/`, `runtime/`, `lib/`, and `tests/` are author
+choices.  Templates may recommend them, but the loader must not require them.
+Local `require` searches the Mod root for `?.lua` and `?/init.lua`; trusted
+scripts may further change `package.path`.
+
+最小 Platform v1 Mod 只约定根目录存在 `main.lua`。不强制 `lua/` 目录，也不需要
+`manifest.json` 或 `modinfo.json`。目录名默认同时作为 Mod ID 与显示名，依赖默认为
+空，Platform 版本默认为 1。`content/`、`runtime/`、`lib/`、`tests/` 等目录只属于
+作者的组织选择，模板可以推荐，引擎不能强制。
+
+### Optional `mod.lua` / 可选高级元数据
+
+An advanced Mod may add root `mod.lua`.  It returns a native
+`ccb.ModDefinition` and may override the stable id, display name, version,
+dependencies, core flag, or entry point.  The entry point defaults to
+`main.lua` and must remain inside the packaged Mod root.
+
+The Mod manager executes `mod.lua` while scanning installed Mods.  Platform v1
+is therefore a trusted in-process extension system: placing a Mod in a scanned
+directory may execute code before the player enables it.  User-facing Mod
+screens and documentation must state this prominently.
+
+高级 Mod 可以增加根目录 `mod.lua`，返回原生 `ccb.ModDefinition`，用于覆盖稳定 ID、
+显示名、版本、依赖、核心 Mod 标记或入口路径。扫描安装目录时就会执行 `mod.lua`。
+因此 Platform v1 是可信的进程内扩展系统：把 Mod 放进扫描目录本身就可能执行代码，
+不必等到玩家启用。Mod UI 与文档必须醒目说明这一点。
+
+## Trust model / 信任模型
+
+Platform v1 opens the complete bundled Lua 5.4 standard libraries, including
+`io`, `os`, `debug`, coroutines, dynamic loading, and normal package support.
+It does not use the v5 capability sandbox.  An enabled or discovered Platform
+Mod runs with the game process privileges and can read files, start processes,
+or load native code where the host platform permits it.
+
+This choice maximizes extension power but removes an untrusted distribution
+boundary.  The official API still defines portable behaviour; host-specific
+I/O, processes, native modules, and side effects cannot be rolled back and may
+not work on every platform.
+
+Platform v1 开放捆绑 Lua 5.4 的完整标准库，包括 `io`、`os`、`debug`、协程、动态
+加载和普通 package 支持，不沿用 v5 capability 沙箱。脚本与游戏进程权限相同；这种
+选择换取最大扩展能力，但不再提供“不可信 Mod”安全边界。文件、进程和原生模块副作用
+无法事务回滚，也不保证跨平台可用。
+
+## Loading lifecycle / 加载生命周期
+
+The target lifecycle is:
+
+1. Discover a root `main.lua` or optional `mod.lua`.
+2. Resolve metadata and dependency order.
+3. Begin one data-load transaction.
+4. Load legacy JSON for a hybrid Mod, when present.
+5. Execute the Platform entry and stage native content definitions.
+6. Commit staged definitions and run normal global finalization.
+7. Make registered runtime handlers active after `world_ready`.
+
+Top-level code may create content and register handlers.  Access to live map,
+character, or world state is invalid until the world is ready.  A failed data
+load never enters a playable partially finalized state, although trusted
+external side effects cannot be undone.
+
+Runtime hot reload executes the entry in a candidate state.  If the static
+content fingerprint is unchanged, runtime registrations can be swapped.  If
+content changed, the reload reports `requires_full_data_reload` rather than
+mutating finalized registries in place.
+
+目标生命周期依次为：发现入口、解析依赖、开始数据事务、按需加载旧 JSON、执行 Lua
+并暂存原生定义、提交并统一 finalize、最后在 `world_ready` 后激活运行时 handler。
+顶层代码可以创建内容和注册回调，但世界就绪前不能访问实时地图或角色。静态内容指纹
+改变时拒绝局部热重载，并要求完整数据重载。
+
+## Native object model / 原生对象模型
+
+Platform-exported C++ types expose every bindable public field, method, and
+operator.  Private and protected members retain normal C++ access rules.
+Exported types are explicit; JSON loaders, EOC parsers, and other legacy
+infrastructure are not export roots.
+
+Native references carry an owner and generation check.  Access after object
+destruction, world replacement, content commit, or runtime replacement raises
+a Lua error instead of dereferencing a stale pointer.  Native modules loaded
+by a trusted Mod can bypass this boundary and are outside the compatibility
+guarantee.
+
+Static definitions are real native staging objects.  The target content API
+provides explicit `add`, `replace`, and transactional `edit` operations.
+Duplicate ids are errors unless replacement or editing is requested.  Normal
+Lua functions, loops, modules, constructors, and cloning replace JSON
+`copy-from` and inheritance syntax.
+
+Platform 导出的 C++ 类型公开全部可绑定的 public 字段、方法与运算符；private 和
+protected 仍遵守 C++ 规则。原生引用带 owner/代次检查，owner 消失、世界切换、内容
+提交或 runtime 替换后访问会抛 Lua 错误。静态定义使用真实的原生 staging 对象，
+通过显式 `add`、`replace`、事务性 `edit` 提交；普通 Lua 组合取代 JSON `copy-from`。
+
+## Behaviour instead of EOC / 用 Lua 行为取代 EOC
+
+Platform v1 uses a small set of orthogonal primitives:
+
+- native object methods and domain services for validated mutations;
+- ordinary Lua expressions and query methods for conditions;
+- typed events for observations;
+- synchronous hooks for decisions, vetoes, or transformations;
+- named handlers for definition-owned callbacks;
+- named persistent tasks for delayed or recurring work;
+- serializable character/world state for durable data;
+- Lua libraries built on these primitives for workflows and state machines.
+
+An EOC parser handler should be traced to the underlying game operation.  That
+operation is extracted into a shared C++ service used by both the legacy EOC
+adapter and the Lua binding.  Platform v1 must not publish one Lua function per
+EOC key, `run_eoc`, alpha/beta aliases, or a recurrence DSL.
+
+Platform v1 使用少量正交原语：原生对象方法与领域 service、普通 Lua 条件、类型化
+event、同步 Hook、命名 handler、命名持久任务、可序列化角色/世界状态，以及在其上
+编写的 workflow/state-machine 库。EOC handler 应追踪到背后的通用游戏操作，抽成旧
+EOC 适配层与 Lua binding 共用的 C++ service，而不是逐键复制 Lua API。
+
+## Persistent execution / 持久执行
+
+Closures, coroutine stacks, userdata, and native references are not serialized.
+A durable task stores only stable data:
+
+```text
+mod_id + handler_id + due + owner + payload
+```
+
+Reload resolves `handler_id` against the new Mod state.  Missing handlers,
+invalid owners, incompatible payload versions, and overdue tasks must produce
+bounded diagnostics and a documented discard or migration result.  Session
+coroutines remain useful but do not survive save/load.
+
+闭包、协程调用栈、userdata 和原生引用不序列化。持久任务只保存稳定的 Mod ID、
+handler ID、到期时间、owner 与 payload；重载后在新 Mod state 中重新绑定函数。
+
+## Internal reuse and replacement boundary / 内部复用与替换边界
+
+An early domain may privately adapt staged native definitions to the existing
+loader and finalization pipeline.  This is an implementation shortcut, not a
+public contract.  Every such dependency is recorded in the roadmap and is
+replaced by a domain registrar or service over time.
+
+The long-term replacement target covers author-facing core and Mod content.
+Save files, settings, localization caches, generated inventories, and other
+engine-owned serialization may continue to use JSON internally.  Removing
+those formats does not increase Lua authoring power and is not a Platform goal.
+
+早期领域可以在内部把暂存定义适配到现有 loader/finalize 管线，但这只是私有实现捷径，
+必须在路线图记录并逐域替换。长期目标覆盖作者面对的核心与 Mod 内容；存档、设置、翻译
+缓存和生成清单等引擎内部序列化不在替换目标内。
+
+## Migration and removal gates / 迁移与移除门槛
+
+Legacy JSON/EOC authoring is not frozen merely because this document exists.
+A domain freezes only after its Platform replacement, tooling, tests, and
+documentation are usable.  Removal requires all of the following:
+
+- every checked JSON/EOC inventory entry is mapped to a Platform domain,
+  shared service, migration, or reviewed not-applicable result;
+- core and bundled content targeted for removal has migrated while preserving
+  stable ids and save compatibility;
+- a JSON/EOC-to-Lua extraction tool produces idiomatic native-object skeletons
+  and explicit TODOs instead of `run_eoc` wrappers;
+- a complete zero-JSON/EOC example Mod passes discovery, load, save, reload,
+  and gameplay tests;
+- the deprecation window has lasted at least two stable releases and at least
+  twelve months, with both conditions satisfied.
+
+本文存在并不代表立即冻结旧作者接口。只有某个领域的 Platform 替代、工具、测试和
+文档可用后，才冻结该领域的新 JSON/EOC 能力。最终移除必须同时满足完整映射、核心与
+捆绑内容迁移、存档兼容、迁移工具、端到端纯 Lua Mod，以及至少两个稳定版且十二个月
+的弃用窗口。
+
+## First vertical slice and templates / 首个纵向样板与模板
+
+The first executable slice is one zero-JSON/EOC Mod that defines an item, its
+recipe, and a Lua use behaviour.  It must exercise discovery, native content,
+cross-id references, a named handler, persistent state, save/load, and an
+observable in-game result.
+
+Developer tooling will provide `minimal` and `complete` templates plus a
+scaffolding command.  Generated Mods contain no JSON and no required `lua/`
+directory.  The complete template may recommend `content/`, `runtime/`, and
+`tests/`, but generated files become author-owned and are never overwritten by
+template updates.
+
+首个可执行样板固定为“物品 + 配方 + Lua 使用行为”的零 JSON/EOC Mod。开发工具将
+提供 minimal、complete 模板和脚手架命令；生成结果不包含 JSON，也不强制 `lua/`
+目录。模板只推荐组织方式，生成后文件完全归作者所有，工具不得覆盖其修改。
+
+## Maintenance rule / 维护规则
+
+Any change to Platform discovery, lifecycle, exported native surface,
+persistence, legacy dependency, or milestone status updates this document or
+`ai/lua-first-roadmap.yml` and names the affected CCB-Docs ids.  Runtime source
+and tests remain authoritative for implemented behaviour; planned entries must
+never be presented as shipped API.
+
+Platform 的发现、生命周期、原生导出、持久化、旧接口依赖或阶段状态变化时，必须同步
+更新本文或 `ai/lua-first-roadmap.yml`，并注明受影响的 CCB-Docs 文档 ID。运行时源码
+和测试始终决定已实现行为；计划项不得冒充已发布 API。

--- a/tools/agent/check_project_metadata.py
+++ b/tools/agent/check_project_metadata.py
@@ -25,6 +25,8 @@ CONTEXT_FILES = (
     ROOT / "ai/generated-files.yml",
     ROOT / "ai/docs-impact.yml",
 )
+LUA_FIRST_ROADMAP = ROOT / "ai/lua-first-roadmap.yml"
+LUA_FIRST_ROADMAP_SCHEMA = ROOT / "ai/lua-first-roadmap.schema.json"
 
 
 def load_yaml(path: Path) -> dict:
@@ -63,6 +65,106 @@ def unique_ids(data: dict, label: str) -> set[str]:
     if len(ids) != len(set(ids)):
         raise ValueError(f"duplicate id in {label}")
     return set(ids)
+
+
+def validate_lua_first_roadmap(roadmap: dict | None = None) -> None:
+    """Validate the Lua-first plan without treating planned APIs as shipped."""
+    if roadmap is None:
+        roadmap = load_yaml(LUA_FIRST_ROADMAP)
+    schema = json.loads(LUA_FIRST_ROADMAP_SCHEMA.read_text(encoding="utf-8"))
+    jsonschema.Draft202012Validator(schema).validate(roadmap)
+
+    authority = ROOT / roadmap["authority_path"]
+    if not authority.is_file():
+        raise ValueError(
+            f"missing Lua-first authority: {roadmap['authority_path']}"
+        )
+
+    inventory_ids = [entry["id"] for entry in roadmap["legacy_inventories"]]
+    if len(inventory_ids) != len(set(inventory_ids)):
+        raise ValueError("duplicate legacy inventory id in Lua-first roadmap")
+    for inventory in roadmap["legacy_inventories"]:
+        inventory_path = ROOT / inventory["path"]
+        data = json.loads(inventory_path.read_text(encoding="utf-8"))
+        entries = data.get("entries")
+        if not isinstance(entries, list):
+            raise ValueError(
+                f"Lua-first inventory has no entries: {inventory['path']}"
+            )
+        if inventory["entry_count"] != len(entries):
+            raise ValueError(
+                f"Lua-first inventory count is stale for {inventory['id']}"
+            )
+        selector = inventory["selector"]
+        if any(selector not in entry for entry in entries):
+            raise ValueError(
+                f"Lua-first inventory selector {selector} is missing in "
+                f"{inventory['id']}"
+            )
+
+    milestones = roadmap["milestones"]
+    milestone_ids = [milestone["id"] for milestone in milestones]
+    if len(milestone_ids) != len(set(milestone_ids)):
+        raise ValueError("duplicate milestone id in Lua-first roadmap")
+    known_milestones = set(milestone_ids)
+    dependencies = {
+        milestone["id"]: set(milestone["depends_on"])
+        for milestone in milestones
+    }
+    for milestone in milestones:
+        unknown = sorted(
+            dependencies[milestone["id"]] - known_milestones
+        )
+        if unknown:
+            raise ValueError(
+                f"unknown Lua-first milestone dependencies in "
+                f"{milestone['id']}: {unknown}"
+            )
+        if milestone["status"] == "complete" and not milestone["evidence"]:
+            raise ValueError(
+                f"complete Lua-first milestone needs evidence: "
+                f"{milestone['id']}"
+            )
+        missing_evidence = sorted(
+            path
+            for path in milestone["evidence"]
+            if not (ROOT / path).exists()
+        )
+        if missing_evidence:
+            raise ValueError(
+                f"missing Lua-first milestone evidence in {milestone['id']}: "
+                f"{missing_evidence}"
+            )
+
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(milestone_id: str) -> None:
+        if milestone_id in visiting:
+            raise ValueError("cycle in Lua-first milestone dependencies")
+        if milestone_id in visited:
+            return
+        visiting.add(milestone_id)
+        for dependency in dependencies[milestone_id]:
+            visit(dependency)
+        visiting.remove(milestone_id)
+        visited.add(milestone_id)
+
+    for milestone_id in milestone_ids:
+        visit(milestone_id)
+
+    capability_ids = [item["id"] for item in roadmap["capabilities"]]
+    if len(capability_ids) != len(set(capability_ids)):
+        raise ValueError("duplicate capability id in Lua-first roadmap")
+    for capability in roadmap["capabilities"]:
+        if (
+            capability["status"] == "available"
+            and capability["legacy_dependency"] == "public_legacy"
+        ):
+            raise ValueError(
+                f"available Lua-first capability exposes public legacy "
+                f"dependency: {capability['id']}"
+            )
 
 
 def validate_context() -> None:
@@ -408,6 +510,7 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.parse_args()
     validate_context()
+    validate_lua_first_roadmap()
     validate_inventory()
     validate_documentation_registry()
     validate_repository_settings()

--- a/tools/agent/generate_documentation_registry.py
+++ b/tools/agent/generate_documentation_registry.py
@@ -39,6 +39,8 @@ AGENT_METADATA = {
     "ai/documentation-registry.yml",
     "ai/docs-impact.yml",
     "ai/generated-files.yml",
+    "ai/lua-first-roadmap.schema.json",
+    "ai/lua-first-roadmap.yml",
     "ai/project-map.yml",
     "ai/repository-settings.target.schema.json",
     "ai/repository-settings.target.yml",
@@ -52,6 +54,17 @@ API_CONTRACTS = {
     "data/lua/reference/ccb_public_api_v5_coverage.schema.json",
     "data/lua/types/ccb_api_v5.d.lua",
     "tools/json_api/contract-inventory.schema.json",
+}
+ARCHITECTURE_CONTRACTS = {
+    "data/lua/LUA_FIRST_PLATFORM.md",
+}
+CCB_DOCS_IDS = {
+    "data/lua/LUA_FIRST_PLATFORM.md": [
+        "architecture.lua-first-platform",
+        "architecture.lua-first-glossary",
+    ],
+    "ai/lua-first-roadmap.yml": ["architecture.lua-first-roadmap"],
+    "ai/lua-first-roadmap.schema.json": ["architecture.lua-first-roadmap"],
 }
 
 
@@ -159,6 +172,11 @@ def classify(path: str, legacy: dict[str, dict]) -> dict:
         status = "active"
         authority = "governance_contract"
         source_of_truth = True
+    elif path in ARCHITECTURE_CONTRACTS:
+        category = "authoritative_document"
+        status = "active"
+        authority = "architecture_contract"
+        source_of_truth = True
     elif path in API_CONTRACTS:
         category = "api_contract"
         status = "active"
@@ -211,6 +229,7 @@ def classify(path: str, legacy: dict[str, dict]) -> dict:
             historical.get("merge_target") or historical["stable_document_id"]
         )
         ccb_docs_ids.append(target_id)
+    ccb_docs_ids.extend(CCB_DOCS_IDS.get(path, []))
     return {
         "id": registry_id(path),
         "path": path,

--- a/tools/agent/test_project_metadata.py
+++ b/tools/agent/test_project_metadata.py
@@ -10,6 +10,7 @@ from check_project_metadata import (
     validate_context,
     validate_documentation_registry,
     validate_inventory,
+    validate_lua_first_roadmap,
     validate_repository_settings,
 )
 
@@ -63,6 +64,29 @@ class ProjectMetadataTest(unittest.TestCase):
 
     def test_inventory_is_valid(self):
         validate_inventory()
+
+    def test_lua_first_roadmap_is_valid(self):
+        validate_lua_first_roadmap()
+
+    def test_lua_first_roadmap_rejects_dependency_cycles(self):
+        path = ROOT / "ai/lua-first-roadmap.yml"
+        roadmap = yaml.safe_load(path.read_text(encoding="utf-8"))
+        roadmap = copy.deepcopy(roadmap)
+        roadmap["milestones"][0]["depends_on"] = [
+            roadmap["milestones"][-1]["id"]
+        ]
+
+        with self.assertRaisesRegex(ValueError, "cycle"):
+            validate_lua_first_roadmap(roadmap)
+
+    def test_available_lua_first_capability_cannot_require_public_legacy(self):
+        path = ROOT / "ai/lua-first-roadmap.yml"
+        roadmap = yaml.safe_load(path.read_text(encoding="utf-8"))
+        roadmap = copy.deepcopy(roadmap)
+        roadmap["capabilities"][0]["status"] = "available"
+
+        with self.assertRaisesRegex(ValueError, "public legacy"):
+            validate_lua_first_roadmap(roadmap)
 
     def test_documentation_registry_is_valid(self):
         validate_documentation_registry()


### PR DESCRIPTION
#### Summary

Infrastructure "Document the Lua-first Platform v1 direction"

#### Responsible human

@LYHGLYTX

#### Purpose of change

CCB needs a durable architecture and checked migration plan for making Lua the primary authoring language for core content and Mods, instead of merely wrapping JSON and EOC concepts.

This PR records the agreed design before runtime implementation begins. It distinguishes the planned Platform v1 from the currently shipped Lua API v5 and prevents planned capabilities from being described as available.

#### Describe the solution

- Add an authoritative bilingual-in-place Lua-first Platform contract.
- Define zero-configuration root `main.lua` discovery, optional native `mod.lua`, the trusted execution model, native object ownership, lifecycle, tasks/state, migration gates, and developer templates.
- Add a schema-checked roadmap tied to the generated JSON/EOC inventory denominators.
- Route contributors and agents through the new contract and CCB-Docs IDs.
- Add metadata validation for inventory counts, unique IDs, dependency graphs, evidence, and public legacy dependencies.
- Regenerate the tracked documentation registry.

This is architecture and planning only; it does not claim that Platform v1 runtime APIs are implemented.

#### Describe alternatives you've considered

Keeping the direction only in discussion would leave future implementation without stable boundaries. Extending Lua API v5 by publishing JSON loaders or one wrapper per EOC key would retain the legacy authoring model and is explicitly outside this design.

#### Testing

- `python3 -m unittest discover -s tools/agent -p 'test_*.py'` — 64 tests passed.
- `python3 tools/agent/check_project_metadata.py` — passed.
- `python3 tools/agent/generate_documentation_registry.py --check` — passed.
- Lua v5 contract matrix from `ai/test-matrix.yml` — 50 tests passed; declarations, inventories, public contract, examples, and CMake/runtime contracts passed.

C++ build and gameplay tests were not run because this PR changes documentation and Python metadata validation only.

#### Documentation impact

Adds paired Chinese and English CCB-Docs architecture pages for the Platform contract, roadmap, and learning glossary. They remain draft and excluded from navigation, search, and AI indexes until this source PR merges and their source commit is refreshed.

#### Related CCB-Docs PR

https://github.com/CrimsonCrossBunker/CCB-Docs/pull/35

#### Affected documentation IDs

architecture.lua-first-platform, architecture.lua-first-roadmap, architecture.lua-first-glossary

#### Generated reference impact

Regenerates `ai/documentation-registry.yml` only. Lua v5 and JSON/EOC generated API inventories are unchanged.

#### Additional context

Platform v1 intentionally does not require a `lua/` subdirectory, `manifest.json`, or `modinfo.json`. A minimal future Mod is a directory containing only root `main.lua`.