### PR TITLE
feat: 大地图支持 Z 轴显示；fix: 驾驶飞艇下降不再误触绳梯

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -3685,6 +3685,23 @@ bool cata_tiles::draw_sprite_at(
         ret = sprite_tex->render_copy_ex( renderer, &destination, 0, nullptr, SDL_FLIP_NONE );
     }
 
+    // Shape-exact gray overlay: blend the sprite's own silhouette over it so
+    // the gray effect never tints neighboring sprites that overflow this tile.
+    if( pending_gray_overlay_ ) {
+        if( const texture *silhouette = tileset_ptr->get_silhouette_tile( sprite_index ) ) {
+            const SDL_Color ov = *pending_gray_overlay_;
+            const std::shared_ptr<SDL_Texture> &tex = silhouette->get_texture_ptr();
+            SetTextureBlendMode( tex, SDL_BLENDMODE_BLEND );
+            SetTextureColorMod( tex, ov.r, ov.g, ov.b );
+            SetTextureAlphaMod( tex, ov.a );
+            silhouette->render_copy_ex( renderer, &destination, render_angle, nullptr,
+                                        render_flip );
+            SetTextureAlphaMod( tex, 255 );
+            SetTextureColorMod( tex, 255, 255, 255 );
+            SetTextureBlendMode( tex, SDL_BLENDMODE_NONE );
+        }
+    }
+
     printErrorIf( ret != 0, "SDL_RenderCopyEx() failed" );
 #if SDL_MAJOR_VERSION >= 3
     // variant_pass unbinds on frame-end flush; nothing to do per-sprite.

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -1204,6 +1204,10 @@ class cata_tiles
         // part sprite gets recolored with the part's paint color; nullopt
         // otherwise. Consumed when building tile_render_params.
         std::optional<RGBColor> pending_part_tint_ = std::nullopt;
+        // Shape-exact gray overlay applied to the next drawn sprite (overmap ground
+        // shown through open air); set by draw_om around the draw call so multitile
+        // and fallback sprites inherit it, then cleared.
+        std::optional<SDL_Color> pending_gray_overlay_ = std::nullopt;
 
         // Per-draw caches rebuilt once per draw() from g->all_creatures(). Let the
         // critter layers skip the per-tile creature_at hash lookup for the ~all

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -3472,6 +3472,18 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                     break;
                 }
 
+                // While piloting an aircraft, "descend" means fly down rather
+                // than climb a vehicle ladder mounted on the same tile.  Mirror
+                // the ACTION_MOVE_UP ordering: aircraft control wins over the
+                // ladder, and ladder climbing remains available on foot.
+                if( has_vehicle_control( player_character ) ) {
+                    const optional_vpart_position vp = here.veh_at( player_character.pos_bub() );
+                    if( vp && vp->vehicle().is_aircraft( here ) ) {
+                        pldrive( tripoint_rel_ms::below );
+                        break;
+                    }
+                }
+
                 const tripoint_bub_ms pos = player_character.pos_bub();
                 const bool has_vehicle_ladder = here.has_vehicle_ladder_at( pos );
                 if( const std::optional<tripoint_bub_ms> ladder_dest =
@@ -3487,14 +3499,6 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                     }
                     vertical_move( ladder_dest->z() - pos.z(), true );
                     break;
-                }
-
-                if( has_vehicle_control( player_character ) ) {
-                    const optional_vpart_position vp = here.veh_at( player_character.pos_bub() );
-                    if( vp && vp->vehicle().is_aircraft( here ) ) {
-                        pldrive( tripoint_rel_ms::below );
-                        break;
-                    }
                 }
 
                 if( has_vehicle_ladder ) {

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -690,7 +690,7 @@ static void draw_city_labels( const catacurses::window &w, const tripoint_abs_om
             continue;   // right under the cursor.
         }
 
-        if( !overmap_buffer.seen_more_than( tripoint_abs_omt( city_pos, center.z() ),
+        if( !overmap_buffer.seen_more_than( tripoint_abs_omt( city_pos, 0 ),
                                             om_vision_level::outlines ) ) {
             continue;   // haven't seen it.
         }
@@ -730,7 +730,7 @@ static void draw_camp_labels( const catacurses::window &w, const tripoint_abs_om
             continue;   // right under the cursor.
         }
 
-        if( !overmap_buffer.seen_more_than( tripoint_abs_omt( camp_pos, center.z() ),
+        if( !overmap_buffer.seen_more_than( tripoint_abs_omt( camp_pos, 0 ),
                                             om_vision_level::outlines ) ) {
             continue;   // haven't seen it.
         }
@@ -1187,7 +1187,7 @@ static void draw_ascii( const catacurses::window &w, overmap_draw_data_t &data )
         }
     }
 
-    if( cursor_pos.z() == 0 && uistate.overmap_show_city_labels ) {
+    if( uistate.overmap_show_city_labels ) {
         draw_city_labels( w, cursor_pos );
         draw_camp_labels( w, cursor_pos );
     }

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1187,7 +1187,7 @@ static void draw_ascii( const catacurses::window &w, overmap_draw_data_t &data )
         }
     }
 
-    if( uistate.overmap_show_city_labels ) {
+    if( cursor_pos.z() >= 0 && uistate.overmap_show_city_labels ) {
         draw_city_labels( w, cursor_pos );
         draw_camp_labels( w, cursor_pos );
     }

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3561,15 +3561,24 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
             const tripoint_abs_omt omp = origin + point( col, row );
 
             const om_vision_level vision = overmap_buffer.seen( omp );
-            const bool los = overmap_buffer.seen_more_than( omp, om_vision_level::details ) &&
-                             ( you.overmap_los( omp, sight_points ) || uistate.overmap_debug_mongroup ||
-                               you.has_trait( trait_DEBUG_CLAIRVOYANCE ) );
+            // Hordes and mongroups live on the ground level, so marker
+            // visibility is evaluated at z=0 to keep them on higher z-levels.
+            const tripoint_abs_omt ground_omp( omp.xy(), 0 );
+            const bool los =
+                overmap_buffer.seen_more_than( ground_omp, om_vision_level::details ) &&
+                ( you.overmap_los( ground_omp, sight_points ) ||
+                  uistate.overmap_debug_mongroup ||
+                  you.has_trait( trait_DEBUG_CLAIRVOYANCE ) );
             // the full string from the ter_id including _north etc.
             std::string id;
             TILE_CATEGORY category = TILE_CATEGORY::OVERMAP_TERRAIN;
             int rotation = 0;
             int subtile = -1;
             map_extra_id mx;
+            // Set when an empty tile (see_cost: all_clear) draws the first seen
+            // non-open-air OMT below it; holds the z distance from the observed
+            // layer so the sprite can be grayed by depth.
+            int ground_z_offset = 0;
 
             if( viewing_weather ) {
                 const tripoint_abs_omt omp_sky( omp.xy(), OVERMAP_HEIGHT );
@@ -3589,13 +3598,52 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                 if( !is_omt ) {
                     category = TILE_CATEGORY::OVERMAP_VISION_LEVEL;
                 }
+
+                // P2 plan B: show the first seen non-open-air OMT below empty tiles
+                // (see_cost: all_clear), grayed by depth below the observed layer.
+                // Trade-off: only applies to already-seen tiles; unseen tiles below
+                // are not drilled through to avoid showing never-seen terrain.
+                if( overmap_buffer.ter( omp )->can_see_down_through() ) {
+                    for( int z = omp.z() - 1; z >= -OVERMAP_DEPTH; --z ) {
+                        const tripoint_abs_omt lower( omp.xy(), z );
+                        if( overmap_buffer.seen( lower ) == om_vision_level::unseen ) {
+                            break;
+                        }
+                        if( !overmap_buffer.ter( lower )->can_see_down_through() ) {
+                            const std::pair<std::string, bool> lower_info =
+                                get_omt_id_rotation_and_subtile( lower, rotation, subtile );
+                            id = lower_info.first;
+                            is_omt = lower_info.second;
+                            if( !is_omt ) {
+                                category = TILE_CATEGORY::OVERMAP_VISION_LEVEL;
+                            } else {
+                                category = TILE_CATEGORY::OVERMAP_TERRAIN;
+                            }
+                            ground_z_offset = omp.z() - z;
+                            break;
+                        }
+                    }
+                }
             }
 
+            // Drilled-through tiles keep the original sprite colors and get a
+            // shape-exact overlay blended over the sprite's own silhouette.
+            // Following the CBN overmap-transparency scheme, the overlay alpha
+            // grows linearly with depth and caps at 192 (min(192, 20*(n+1))),
+            // so the original colors are never fully covered: depth 1 = 40,
+            // each further layer +20, capped at 192 toward white (255,255,255).
+            const bool drilled = ground_z_offset > 0;
             const lit_level ll = overmap_buffer.is_explored( omp ) ? lit_level::LOW : lit_level::LIT;
+            if( drilled ) {
+                const Uint8 blend_alpha = static_cast<Uint8>( std::min(
+                                             192, 20 * ( ground_z_offset + 1 ) ) );
+                pending_gray_overlay_ = SDL_Color{ 255, 255, 255, blend_alpha };
+            }
             // light level is now used for choosing between grayscale filter and normal lit tiles.
             draw_from_id_string( id, category,
                                  category == TILE_CATEGORY::OVERMAP_TERRAIN ? "overmap_terrain" : "",
                                  omp, subtile, rotation, ll, false, height_3d );
+            pending_gray_overlay_ = std::nullopt;
             if( !mx.is_empty() && mx->visibility != map_extra_visibility::none ) {
                 draw_from_id_string( mx.str(), TILE_CATEGORY::MAP_EXTRA, "map_extra", omp,
                                      0, 0, ll, false );
@@ -3611,13 +3659,13 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
             if( vision != om_vision_level::unseen ) {
                 if( draw_overlays && uistate.overmap_debug_mongroup ) {
                     std::vector<std::unordered_map<tripoint_abs_ms, horde_entity>*> hordes = overmap_buffer.hordes_at(
-                                omp );
+                                ground_omp );
                     if( !hordes.empty() ) {
                         draw_from_id_string( "mon_zombie", omp, 0, 0, lit_level::LIT, false );
                     }
                 }
                 if( showhordes && los ) {
-                    const int horde_size = overmap_buffer.get_horde_size( omp,
+                    const int horde_size = overmap_buffer.get_horde_size( ground_omp,
                                            horde_map_flavors::active | horde_map_flavors::idle );
                     if( horde_size >= HORDE_VISIBILITY_SIZE ) {
                         // Scale down the range of horde population, which can be 1-576 to a range of 1-10
@@ -3831,8 +3879,11 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
         for( const city_reference &city : overmap_buffer.get_cities_near(
                  project_to<coords::sm>( center_pos ), radius ) ) {
             const tripoint_abs_omt city_center = project_to<coords::omt>( city.abs_sm_pos );
+            // Labels are ground-level data; test screen containment in xy by
+            // projecting the label position onto the viewed z-level.
+            const tripoint_abs_omt city_on_view( city_center.xy(), overmap_area.p_min.z() );
             if( overmap_buffer.seen_more_than( city_center, om_vision_level::outlines ) &&
-                overmap_area.contains( city_center ) ) {
+                overmap_area.contains( city_on_view ) ) {
                 label_bg( city.abs_sm_pos, city.city->name );
             }
         }
@@ -3840,8 +3891,10 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
         for( const camp_reference &camp : overmap_buffer.get_camps_near(
                  project_to<coords::sm>( center_pos ), radius ) ) {
             const tripoint_abs_omt camp_center = project_to<coords::omt>( camp.abs_sm_pos );
+            // Same xy-only containment as cities (labels are ground-level).
+            const tripoint_abs_omt camp_on_view( camp_center.xy(), overmap_area.p_min.z() );
             if( overmap_buffer.seen_more_than( camp_center, om_vision_level::outlines ) &&
-                overmap_area.contains( camp_center ) ) {
+                overmap_area.contains( camp_on_view ) ) {
                 label_bg( camp.abs_sm_pos, camp.camp->camp_name() );
             }
         }


### PR DESCRIPTION
#### Summary
Features "大地图支持 Z 轴显示；驾驶飞艇时下降不再误触绳梯"

#### Responsible human
@QSln

#### Purpose of change
1. 大地图（overmap）tiles 模式此前不支持在 Z 轴上查看各层地形：空置地块（open_air）显示为空白，高层看不到下方地面，城市/营地名称与尸潮标记也不在高 z 层显示。
2. 驾驶位与三节绳梯位于同一载具格时，驾驶飞艇按"下降"会被判定为爬绳梯（移出载具并沿梯子下爬）；期望驾驶时下降/上升只作用于飞艇。

#### Describe the solution
1. 大地图支持 Z 轴显示：tiles 模式下空置地块显示其正下方第一个已见非透视线地面 OMT，按深度做 shape-exact 白色叠加（alpha=min(192,20×(深度+1))）区分层次；城市/营地名称与尸潮标记在高 z 层同样显示。参考 CBN draw_om_tile_recursively 方案。
2. 梯子：ACTION_MOVE_DOWN 中把"有驾驶权且为飞行载具 → 飞艇下降"的判断移到载具梯子判定之前，与 ACTION_MOVE_UP 顺序对齐；下车后爬梯不受影响。

#### Describe alternatives you've considered
1. overmap：只对已见区域下钻，不钻透未见过地形以避免泄露未探索内容。
2. 梯子：禁止绳梯与驾驶位同格安装（限制建造自由）、或 in_vehicle 时跳过全部梯子（改变所有带梯载具行为），均未采用。

#### Testing
- 构建：Release x64（MSVC + vcpkg，/target:Cataclysm-vcpkg-static）成功产出 cataclysm-tiles.exe；
- 进游戏手动实测：
  - 大地图 Z 轴显示：空置地块显示下方已见地面并随深度变灰；城市/营地名称与尸潮在高 z 层正常显示；ASCII 模式与 3D 视野无回归（另一对话实测通过）。
  - 梯子：驾驶位+绳梯同格飞艇按下降 → 下降飞艇而非爬梯；下车后按下降 → 正常爬梯；上升行为无回归。用户实测通过。
- 单元测试：未运行——本机旧 MSVC 14.33 无法编译 tests 目标（C2280），由 CI 执行。

#### Documentation impact
None（无）

#### Related CCB-Docs PR
None（无）

#### Affected documentation IDs
None（无）

#### Generated reference impact
None（无）

#### Additional context
- 大地图 Z 轴显示：src/cata_tiles.cpp/.h、src/overmap_ui.cpp、src/sdltiles.cpp，参考 CBN。
- 梯子修复：handle_action.cpp 一处顺序调整。