### PR TITLE
fix: prevent spell recast from bypassing requirements

### DIFF
--- a/data/mods/TEST_DATA/magic.json
+++ b/data/mods/TEST_DATA/magic.json
@@ -1,5 +1,10 @@
 [
   {
+    "id": "test_components",
+    "type": "requirement",
+    "components": [ [ [ "test_rag", 1 ] ] ]
+  },
+  {
     "id": "test_eoc_spell",
     "type": "SPELL",
     "name": "Mana Bolt",

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2980,6 +2980,24 @@ void spellcasting_activity_actor::finish( player_activity &act, Character &who )
                 return;
             }
 
+            // Components are normally checked when casting starts.  Check
+            // again before consuming them so an interrupted or restored
+            // activity can never cast without materials or reach the item
+            // selection code with no valid choice.
+            if( spell_being_cast.has_components() ) {
+                who.invalidate_crafting_inventory();
+            }
+            if( !spell_being_cast.has_required_components( who ) ) {
+                who.add_msg_if_player( game_message_params{ m_bad, gmf_bypass_cooldown },
+                                       _( "You no longer have the components to cast %s." ),
+                                       spell_being_cast.name() );
+                get_event_bus().send<event_type::spellcasting_finish>( who.getID(), false, sp,
+                        spell_being_cast.spell_class(), spell_being_cast.get_difficulty( who ),
+                        spell_being_cast.energy_cost( who ), spell_being_cast.casting_time( who ),
+                        spell_being_cast.damage( who ) );
+                return;
+            }
+
             if( spell_being_cast.has_flag( spell_flag::VERBAL ) && !who.has_flag( json_flag_SILENT_SPELL ) ) {
                 sounds::sound( who.pos_bub(), who.get_shout_volume() / 2, sounds::sound_t::speech,
                                _( "cast a spell" ),

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2228,6 +2228,22 @@ bool Character::cast_spell( spell &sp, bool fake_spell,
         return false;
     }
 
+    // The spell menu disables powers that cannot currently be cast, but other
+    // entry points (notably recasting the last spell) bypass that menu.
+    if( sp.has_components() ) {
+        invalidate_crafting_inventory();
+    }
+    if( !sp.can_cast( *this ) ) {
+        if( !sp.has_required_components( *this ) ) {
+            add_msg( game_message_params{ m_bad, gmf_bypass_cooldown },
+                     _( "You don't have the components to cast %s." ), sp.name() );
+        } else {
+            add_msg( game_message_params{ m_bad, gmf_bypass_cooldown },
+                     _( "You cannot cast %s right now." ), sp.name() );
+        }
+        return false;
+    }
+
     std::optional<int> fake_spell_level;
     if( fake_spell ) {
         fake_spell_level = sp.get_level();

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1119,9 +1119,7 @@ bool spell::can_cast( const Character &guy ) const
         return false;
     }
 
-    if( !type->spell_components.is_empty() &&
-        !type->spell_components->can_make_with_inventory( guy.crafting_inventory( guy.pos_bub(), 0, false ),
-                return_true<item> ) ) {
+    if( !has_required_components( guy ) ) {
         return false;
     }
 
@@ -1246,6 +1244,13 @@ const requirement_data &spell::components() const
 bool spell::has_components() const
 {
     return !type->spell_components.is_empty();
+}
+
+bool spell::has_required_components( const Character &guy ) const
+{
+    return !has_components() ||
+           type->spell_components->can_make_with_inventory(
+               guy.crafting_inventory( guy.pos_bub(), 0, false ), return_true<item> );
 }
 
 std::string spell::name() const

--- a/src/magic.h
+++ b/src/magic.h
@@ -600,6 +600,7 @@ class spell
         // the requirement data for spell components. includes tools, items, and qualities.
         const requirement_data &components() const;
         bool has_components() const;
+        bool has_required_components( const Character &guy ) const;
         // can the Character cast this spell?
         bool can_cast( const Character &guy ) const;
         bool can_cast( const Character &guy, std::map<magic_type_id, bool> &success_tracker );

--- a/tests/magic_spell_test.cpp
+++ b/tests/magic_spell_test.cpp
@@ -1,13 +1,17 @@
 #include <memory>
+#include <optional>
 #include <string>
 
+#include "activity_actor_definitions.h"
 #include "avatar.h"
 #include "cata_catch.h"
 #include "coordinates.h"
 #include "creature.h"
 #include "creature_tracker.h"
+#include "debug.h"
 #include "dialogue_helpers.h"
 #include "game.h"
+#include "item.h"
 #include "json_loader.h"
 #include "magic.h"
 #include "magic_type.h"
@@ -22,8 +26,10 @@
 #include "type_id.h"
 
 static const spell_id spell_test_spell_box( "test_spell_box" );
+static const spell_id spell_test_spell_json( "test_spell_json" );
 static const spell_id spell_test_spell_tp_ghost( "test_spell_tp_ghost" );
 static const spell_id spell_test_spell_tp_mummy( "test_spell_tp_mummy" );
+static const itype_id itype_test_rag( "test_rag" );
 
 // Magic Spell tests
 // -----------------
@@ -114,6 +120,42 @@ TEST_CASE( "spell_level", "[magic][spell][level]" )
             }
         }
     }
+}
+
+TEST_CASE( "spell_cast_checks_components_at_start_and_finish", "[magic][spell][components]" )
+{
+    avatar &caster = get_avatar();
+    clear_character( caster );
+    clear_map_without_vision();
+    caster.magic->set_mana( caster.magic->max_mana( caster ) );
+    caster.magic->learn_spell( spell_test_spell_json, caster, true );
+
+    spell &component_spell = caster.magic->get_spell( spell_test_spell_json );
+    REQUIRE( component_spell.has_components() );
+    REQUIRE_FALSE( component_spell.has_required_components( caster ) );
+
+    CHECK_FALSE( caster.cast_spell( component_spell, false, std::nullopt ) );
+    CHECK( caster.activity.is_null() );
+
+    caster.i_add( item( itype_test_rag ) );
+    REQUIRE( component_spell.has_required_components( caster ) );
+    CHECK( caster.cast_spell( component_spell, false, std::nullopt ) );
+    CHECK_FALSE( caster.activity.is_null() );
+    caster.cancel_activity();
+
+    caster.remove_items_with( []( const item & it ) {
+        return it.typeId() == itype_test_rag;
+    } );
+    caster.remove_weapon();
+    REQUIRE_FALSE( caster.has_amount( itype_test_rag, 1 ) );
+    caster.assign_activity( spellcasting_activity_actor(
+                                time_duration::from_moves<int>( 1 ), component_spell.id(), caster.pos_abs(),
+                                std::nullopt, true, true ) );
+    const std::string debug_message = capture_debugmsg_during( [&caster]() {
+        process_activity( caster );
+    } );
+    CHECK( debug_message.empty() );
+    CHECK( caster.activity.is_null() );
 }
 
 static int char_to_invlet( char c )
@@ -944,4 +986,3 @@ TEST_CASE( "spell_lua_effect_copy_from_inheritance", "[magic][spell][lua]" )
     CHECK( reclassified.effect_name == "attack" );
     CHECK( !reclassified.lua_effect.has_value() );
 }
-


### PR DESCRIPTION
#### Summary

Bugfixes "修复使用上次超能力可绕过施法材料与条件的问题"

#### Responsible human

@LYHGLYTX

#### Purpose of change

需要梦渣等材料的超能力在正常施放一次后，可以通过“使用上次超能力”快捷键绕过材料检查。材料已经耗尽时，施放仍会开始，并在结算阶段弹出：

`Attempted a recipe with no available components!`

这会让玩家绕过原本的施放条件，并可能继续触发能力效果。

#### Describe the solution

- 让普通施放、快捷重放及其他施放入口统一检查当前材料和施放条件。
- 开始施放前刷新材料需求，避免沿用旧状态。
- 施放完成时再次检查；如果期间材料已经消失，则安全终止，不消耗不存在的材料，也不产生技能效果。
- 添加回归测试，覆盖开始施放时缺少材料以及结算前材料消失的情况。

#### Describe alternatives you've considered

只在“使用上次超能力”按键处理中增加一次检查，无法覆盖其他直接开始施法的入口，也无法处理施放过程中材料被移除的情况，因此检查放在统一施法入口和结算阶段。

#### Testing

- 材料施法回归测试：10 assertions，1 test case。
- 其他非 Lua 法术测试：199 assertions，12 test cases。
- JSON 测试：242 assertions，19 test cases。
- SDL2 图形发布版完整编译通过。
- `./waterfix-cataclysm-tiles --jsonverify`
- `git diff --check origin/agent/finite-water-bodies...HEAD`
- 手工复测步骤：正常释放一次需要梦渣的能力，耗尽材料，再按“使用上次超能力”；现在会立即拒绝，不消耗时间、不生效，也不再弹出调试错误。
- 完整 `[magic][spell]` 集合中的既有 Lua 脚本法术测试因测试数据缺少 `valid_targets` 失败；排除 `[lua]` 后其余法术测试全部通过，该失败与本 PR 无关。

#### Documentation impact

None

#### Related CCB-Docs PR

None

#### Affected documentation IDs

None

#### Generated reference impact

None。本改动未更改 Schema、LuaLS、注册信息或生成清单。

#### Additional context

本 PR 仅含提交 `4ef0c3a3a5b`，共修改 6 个相关文件。由于有限水体 PR #612 尚未合并，当前 PR 以 `agent/finite-water-bodies` 为目标分支；#612 合并后可改为 `master` 或重新变基。