### PR TITLE
Infrastructure: add transactional native registry foundations

### DIFF
--- a/src/activity_type.cpp
+++ b/src/activity_type.cpp
@@ -19,6 +19,24 @@
 // activity_type functions
 static std::map< activity_id, activity_type > activity_type_all;
 
+std::optional<activity_type> cata::lua_platform::detail::activity_type_registry_get(
+    const activity_id &id )
+{
+    const auto found = activity_type_all.find( id );
+    return found == activity_type_all.end() ? std::nullopt :
+           std::optional<activity_type>( found->second );
+}
+
+void cata::lua_platform::detail::activity_type_registry_set( const activity_type &value )
+{
+    activity_type_all[value.id()] = value;
+}
+
+void cata::lua_platform::detail::activity_type_registry_erase( const activity_id &id )
+{
+    activity_type_all.erase( id );
+}
+
 /** @relates string_id */
 template<>
 const activity_type &string_id<activity_type>::obj() const

--- a/src/activity_type.h
+++ b/src/activity_type.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_ACTIVITY_TYPE_H
 
 #include <set>
+#include <optional>
 #include <string>
 
 #include "game_constants.h"
@@ -15,6 +16,11 @@ class activity_type;
 class player_activity;
 enum class distraction_type : int;
 template <typename T> struct enum_traits;
+
+namespace cata::lua_platform
+{
+class content_transaction;
+}
 
 /** @relates string_id */
 template<>
@@ -36,6 +42,7 @@ struct enum_traits<based_on_type> {
 class activity_type
 {
     private:
+        friend class cata::lua_platform::content_transaction;
         bool was_loaded = false;
 
         activity_id id_;
@@ -111,5 +118,12 @@ class activity_type
         static void check_consistency();
         static void reset();
 };
+
+namespace cata::lua_platform::detail
+{
+std::optional<activity_type> activity_type_registry_get( const activity_id &id );
+void activity_type_registry_set( const activity_type &value );
+void activity_type_registry_erase( const activity_id &id );
+} // namespace cata::lua_platform::detail
 
 #endif // CATA_SRC_ACTIVITY_TYPE_H

--- a/src/addiction.cpp
+++ b/src/addiction.cpp
@@ -9,6 +9,8 @@
 #include <utility>
 
 #include "calendar.h"
+#include "catalua_platform_content.h"
+#include "catalua_platform_runtime.h"
 #include "character.h"
 #include "creature.h"
 #include "debug.h"
@@ -37,6 +39,11 @@ namespace
 generic_factory<add_type> add_type_factory( "addiction" );
 
 } // namespace
+
+generic_factory<add_type> &cata::lua_platform::detail::addiction_type_registry()
+{
+    return add_type_factory;
+}
 
 /** @relates string_id */
 template<>
@@ -347,6 +354,11 @@ static const std::map<std::string, std::function<bool( Character &, addiction & 
 
 bool addiction::run_effect( Character &u )
 {
+    if( const std::optional<bool> lua_result =
+            cata::lua_platform::invoke_addiction_type_handler(
+                type.str(), u, intensity, to_turns<std::int64_t>( sated ) ) ) {
+        return *lua_result;
+    }
     bool ret = false;
     if( !type->get_effect().is_null() ) {
         dialogue d( get_talker_for( u ), nullptr );
@@ -375,6 +387,9 @@ void add_type::load( const JsonObject &jo, std::string_view )
 void add_type::check_add_types()
 {
     for( const add_type &add : add_type::get_all() ) {
+        if( add._lua_policy ) {
+            continue;
+        }
         if( add._effect.is_null() == add._builtin.empty() ) {
             debugmsg( "addiction_type \"%s\" defines %s effect_on_condition %s builtin.  Addictions must define either field, but not both.",
                       add.id.c_str(), add._builtin.empty() ? "neither" : "both", add._builtin.empty() ? "or" : "and" );

--- a/src/addiction.h
+++ b/src/addiction.h
@@ -13,6 +13,12 @@
 class Character;
 class JsonObject;
 class JsonOut;
+template<typename T> class generic_factory;
+
+namespace cata::lua_platform
+{
+class content_transaction;
+}
 
 struct add_type {
     private:
@@ -22,6 +28,7 @@ struct add_type {
         morale_type _craving_morale;
         effect_on_condition_id _effect;
         std::string _builtin;
+        bool _lua_policy = false;
     public:
         addiction_id id;
         bool was_loaded = false;
@@ -54,6 +61,8 @@ struct add_type {
         const std::string &get_builtin() const {
             return _builtin;
         }
+    private:
+        friend class cata::lua_platform::content_transaction;
 };
 
 class addiction

--- a/src/ascii_art.cpp
+++ b/src/ascii_art.cpp
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "catacharset.h"
+#include "catalua_platform_content.h"
 #include "debug.h"
 #include "generic_factory.h"
 #include "output.h"
@@ -13,6 +14,11 @@ namespace
 {
 generic_factory<ascii_art> ascii_art_factory( "ascii_art" );
 } // namespace
+
+generic_factory<ascii_art> &cata::lua_platform::detail::ascii_art_registry()
+{
+    return ascii_art_factory;
+}
 
 template<>
 const ascii_art &string_id<ascii_art>::obj() const
@@ -52,4 +58,3 @@ void ascii_art::reset()
 {
     ascii_art_factory.reset();
 }
-

--- a/src/event_statistics.cpp
+++ b/src/event_statistics.cpp
@@ -11,6 +11,7 @@
 
 #include "cata_assert.h"
 #include "cata_variant.h"
+#include "catalua_platform_content.h"
 #include "debug.h"
 #include "enum_conversions.h"
 #include "enums.h"
@@ -58,6 +59,11 @@ generic_factory<event_statistic> event_statistic_factory( "event_statistic" );
 generic_factory<score> score_factory( "score" );
 
 } // namespace
+
+generic_factory<score> &cata::lua_platform::detail::score_registry()
+{
+    return score_factory;
+}
 
 template<>
 const event_transformation &string_id<event_transformation>::obj() const

--- a/src/event_statistics.h
+++ b/src/event_statistics.h
@@ -20,6 +20,13 @@ class stats_tracker;
 class stats_tracker_state;
 enum class cata_variant_type : int;
 enum class monotonically : int;
+template<typename T>
+class generic_factory;
+
+namespace cata::lua_platform
+{
+class content_transaction;
+}
 
 using event_fields_type = std::unordered_map<std::string, cata_variant_type>;
 
@@ -118,6 +125,7 @@ class score
         std::vector<std::pair<string_id<score>, mod_id>> src;
         bool was_loaded = false;
     private:
+        friend class cata::lua_platform::content_transaction;
         translation description_;
         string_id<event_statistic> stat_;
 };

--- a/src/fault.cpp
+++ b/src/fault.cpp
@@ -3,6 +3,7 @@
 #include <utility>
 #include <vector>
 
+#include "catalua_platform_content.h"
 #include "debug.h"
 #include "flexbuffer_json.h"
 #include "generic_factory.h"
@@ -24,6 +25,11 @@ std::multimap<fault_fix_id, std::pair<std::string, int>> reqs_temp_storage;
 std::map<std::string, std::vector<fault_id>> faults_by_type;
 
 } // namespace
+
+generic_factory<fault_group> &cata::lua_platform::detail::fault_group_registry()
+{
+    return fault_group_factory;
+}
 
 std::vector<fault_id> faults::all_of_type( const std::string &type )
 {
@@ -73,6 +79,7 @@ void faults::reset()
 {
     fault_factory.reset();
     fault_fixes_factory.reset();
+    fault_group_factory.reset();
     faults_by_type.clear();
 }
 
@@ -80,6 +87,7 @@ void faults::finalize()
 {
     fault_factory.finalize();
     fault_fixes_factory.finalize();
+    fault_group_factory.finalize();
 
     for( const fault &f : fault_factory.get_all() ) {
         if( !f.type().empty() ) {

--- a/src/fault.h
+++ b/src/fault.h
@@ -22,6 +22,11 @@ class JsonObject;
 class item;
 template <typename T> class generic_factory;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+}
+
 namespace faults
 {
 void load_fault( const JsonObject &jo, const std::string &src );
@@ -142,6 +147,7 @@ class fault_group
         void load( const JsonObject &jo, std::string_view );
         bool was_loaded = false;
         friend class generic_factory<fault_group>;
+        friend class cata::lua_platform::content_transaction;
         weighted_int_list<fault_id> fault_weighted_list;
 };
 

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -1,6 +1,7 @@
 #include "flag.h"
 
 #include "debug.h"
+#include "catalua_platform_content.h"
 #include "generic_factory.h"
 #include "type_id.h"
 
@@ -402,6 +403,11 @@ namespace
 {
 generic_factory<json_flag> json_flags_all( "json_flags" );
 } // namespace
+
+generic_factory<json_flag> &cata::lua_platform::detail::json_flag_registry()
+{
+    return json_flags_all;
+}
 
 /** @relates string_id */
 template<>

--- a/src/flag.h
+++ b/src/flag.h
@@ -16,6 +16,11 @@
 class JsonObject;
 template <typename T> class generic_factory;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+} // namespace cata::lua_platform
+
 // Bit positions for the flags that drive item::stacks_with.
 // Reload-safe: positions are compile-time constants, not int_ids.
 enum class hot_flag_bit : uint64_t {
@@ -457,6 +462,7 @@ class json_flag
 {
         friend class DynamicDataLoader;
         friend class generic_factory<json_flag>;
+        friend class cata::lua_platform::content_transaction;
 
     public:
         // used by generic_factory

--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -425,6 +425,55 @@ class generic_factory
             return result;
         }
 
+        /**
+         * Restore a transaction snapshot without reporting it as a duplicate
+         * definition.  An existing object keeps its concrete registry index;
+         * a missing object is appended as a last-resort recovery path.
+         */
+        T &restore( const T &obj ) {
+            inc_version();
+            const auto iter = map.find( obj.id );
+            if( iter != map.end() ) {
+                T &result = list[iter->second.to_i()];
+                result = obj;
+                result.id.set_cid_version( iter->second.to_i(), version );
+                return result;
+            }
+
+            const int_id<T> cid( list.size() );
+            list.push_back( obj );
+            T &result = list.back();
+            result.id.set_cid_version( cid.to_i(), version );
+            map[result.id] = cid;
+            return result;
+        }
+
+        /**
+         * Remove one concrete object without resetting the complete factory.
+         *
+         * This is primarily useful for transactional native registrars.  It
+         * deliberately does not inspect or mutate deferred JSON or abstract
+         * definitions: callers may only erase an id already present in the
+         * concrete registry.  Cached string_id conversions are invalidated and
+         * rebuilt after the vector compacts.
+         */
+        bool erase( const string_id<T> &id ) {
+            const auto iter = map.find( id );
+            if( iter == map.end() ) {
+                return false;
+            }
+
+            list.erase( list.begin() + iter->second.to_i() );
+            map.clear();
+            inc_version();
+            for( std::size_t index = 0; index < list.size(); ++index ) {
+                const int_id<T> cid( index );
+                list[index].id.set_cid_version( cid.to_i(), version );
+                map[list[index].id] = cid;
+            }
+            return true;
+        }
+
         /** Finalize all entries (derived classes should chain to this method) */
         virtual void finalize() {
             DynamicDataLoader::get_instance().load_deferred( deferred );

--- a/src/hsv_color.cpp
+++ b/src/hsv_color.cpp
@@ -13,6 +13,7 @@
 #include <sstream>
 #include <vector>
 
+#include "catalua_platform_content.h"
 #include "debug.h"
 #include "rng.h"
 #include "string_formatter.h"
@@ -24,6 +25,60 @@
 
 static std::unordered_map<RGBColor, std::string> named_colors = {};
 static std::unordered_map<RGBColor, std::string> similar_name_cache = {};
+
+std::vector<cata::lua_platform::detail::named_color_native_definition>
+cata::lua_platform::detail::named_color_registry_snapshot()
+{
+    std::vector<named_color_native_definition> result;
+    result.reserve( named_colors.size() );
+    for( const auto &[color, name] : named_colors ) {
+        result.push_back( { name, color.r, color.g, color.b, color.a } );
+    }
+    return result;
+}
+
+bool cata::lua_platform::detail::named_color_registry_contains( const std::string &name )
+{
+    return std::any_of( named_colors.begin(), named_colors.end(),
+    [&name]( const auto & entry ) {
+        return entry.second == name;
+    } );
+}
+
+bool cata::lua_platform::detail::named_color_registry_color_in_use(
+    const named_color_native_definition &value, const std::string &except_name )
+{
+    const auto found = named_colors.find( RGBColor{
+        value.red, value.green, value.blue, value.alpha
+    } );
+    return found != named_colors.end() && found->second != except_name;
+}
+
+void cata::lua_platform::detail::named_color_registry_set(
+    const named_color_native_definition &value )
+{
+    for( auto it = named_colors.begin(); it != named_colors.end(); ) {
+        if( it->second == value.name ) {
+            it = named_colors.erase( it );
+        } else {
+            ++it;
+        }
+    }
+    named_colors.insert_or_assign(
+        RGBColor{ value.red, value.green, value.blue, value.alpha }, value.name );
+    similar_name_cache.clear();
+}
+
+void cata::lua_platform::detail::named_color_registry_restore(
+    const std::vector<named_color_native_definition> &snapshot )
+{
+    named_colors.clear();
+    for( const named_color_native_definition &value : snapshot ) {
+        named_colors.emplace(
+            RGBColor{ value.red, value.green, value.blue, value.alpha }, value.name );
+    }
+    similar_name_cache.clear();
+}
 
 void RGBColor::load_named_color( const JsonObject &jo, std::string_view )
 {

--- a/src/item_category.cpp
+++ b/src/item_category.cpp
@@ -1,5 +1,6 @@
 #include "item_category.h"
 
+#include "catalua_platform_content.h"
 #include "generic_factory.h"
 #include "item.h"
 
@@ -7,6 +8,11 @@ namespace
 {
 generic_factory<item_category> item_category_factory( "item_category" );
 } // namespace
+
+generic_factory<item_category> &cata::lua_platform::detail::item_category_registry()
+{
+    return item_category_factory;
+}
 
 template<>
 const item_category &string_id<item_category>::obj() const

--- a/src/item_category.h
+++ b/src/item_category.h
@@ -16,6 +16,11 @@
 class JsonObject;
 class item;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+} // namespace cata::lua_platform
+
 // this is a helper struct with rules for picking a zone
 struct zone_priority_data {
     bool was_loaded = false;
@@ -35,6 +40,7 @@ struct zone_priority_data {
  */
 class item_category
 {
+        friend class cata::lua_platform::content_transaction;
     private:
         /** Name of category for displaying to the user */
         translation name_header_; // in inventory UI headers etc
@@ -110,4 +116,3 @@ struct item_category_spawn_rates {
 };
 
 #endif // CATA_SRC_ITEM_CATEGORY_H
-

--- a/src/magic_type.cpp
+++ b/src/magic_type.cpp
@@ -1,5 +1,6 @@
 #include "magic_type.h"
 
+#include "catalua_platform_content.h"
 #include "debug.h"
 #include "effect_on_condition.h"
 #include "flexbuffer_json.h"
@@ -14,6 +15,11 @@ namespace
 {
 generic_factory<magic_type> magic_type_factory( "magic_type" );
 } // namespace
+
+generic_factory<magic_type> &cata::lua_platform::detail::magic_type_registry()
+{
+    return magic_type_factory;
+}
 
 template<>
 const magic_type &string_id<magic_type>::obj() const

--- a/src/mood_face.cpp
+++ b/src/mood_face.cpp
@@ -4,6 +4,7 @@
 #include <optional>
 
 #include "avatar.h"
+#include "catalua_platform_content.h"
 #include "generic_factory.h"
 #include "mutation.h"
 #include "options.h"
@@ -15,6 +16,11 @@ namespace
 {
 generic_factory<mood_face> mood_face_factory( "mood_face" );
 } // namespace
+
+generic_factory<mood_face> &cata::lua_platform::detail::mood_face_registry()
+{
+    return mood_face_factory;
+}
 
 template<>
 const mood_face &mood_face_id::obj() const

--- a/src/mood_face.h
+++ b/src/mood_face.h
@@ -14,6 +14,11 @@ class mood_face_value;
 template<typename T>
 class generic_factory;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+} // namespace cata::lua_platform
+
 class mood_face
 {
     public:
@@ -36,6 +41,7 @@ class mood_face
     private:
         friend class generic_factory<mood_face>;
         friend struct mod_tracker;
+        friend class cata::lua_platform::content_transaction;
 
         mood_face_id id;
         std::vector<std::pair<mood_face_id, mod_id>> src;
@@ -61,6 +67,7 @@ class mood_face_value
         }
 
     private:
+        friend class cata::lua_platform::content_transaction;
         int value_ = 0;
         std::string face_;
 };

--- a/src/morale_types.cpp
+++ b/src/morale_types.cpp
@@ -1,5 +1,6 @@
 #include "morale_types.h"
 
+#include "catalua_platform_content.h"
 #include "generic_factory.h"
 #include "itype.h"
 #include "string_formatter.h"
@@ -10,6 +11,11 @@ namespace
 generic_factory<morale_type_data> morale_data( "morale type" );
 
 } // namespace
+
+generic_factory<morale_type_data> &cata::lua_platform::detail::morale_type_registry()
+{
+    return morale_data;
+}
 
 template<>
 const morale_type_data &morale_type::obj() const

--- a/src/morale_types.h
+++ b/src/morale_types.h
@@ -13,8 +13,14 @@
 class JsonObject;
 struct itype;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+} // namespace cata::lua_platform
+
 class morale_type_data
 {
+        friend class cata::lua_platform::content_transaction;
     private:
         bool permanent = false;
         // May contain '%s' format string

--- a/src/move_mode.cpp
+++ b/src/move_mode.cpp
@@ -6,6 +6,7 @@
 #include <unordered_map>
 
 #include "debug.h"
+#include "catalua_platform_content.h"
 #include "flexbuffer_json.h"
 #include "generic_factory.h"
 #include "translations.h"
@@ -21,6 +22,11 @@ namespace
 {
 generic_factory<move_mode> move_mode_factory( "move_mode" );
 } // namespace
+
+generic_factory<move_mode> &cata::lua_platform::detail::movement_mode_registry()
+{
+    return move_mode_factory;
+}
 
 template<>
 const move_mode &move_mode_id::obj() const
@@ -97,7 +103,13 @@ void move_mode::finalize()
 
 void move_mode::finalize_all()
 {
+    cata::lua_platform::detail::refresh_movement_mode_registry();
+}
+
+void cata::lua_platform::detail::refresh_movement_mode_registry()
+{
     move_mode_factory.finalize();
+    move_modes_sorted.clear();
     for( const move_mode &mode : move_mode_factory.get_all() ) {
         move_modes_sorted.emplace_back( mode.ident() );
     }

--- a/src/move_mode.h
+++ b/src/move_mode.h
@@ -18,6 +18,11 @@ class JsonObject;
 template<typename T>
 class generic_factory;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+}
+
 enum class steed_type : int {
     NONE,
     ANIMAL,
@@ -37,6 +42,7 @@ class move_mode
 
         friend class generic_factory<move_mode>;
         friend struct mod_tracker;
+        friend class cata::lua_platform::content_transaction;
 
         bool was_loaded = false;
         move_mode_id id;

--- a/src/profession_group.cpp
+++ b/src/profession_group.cpp
@@ -1,5 +1,6 @@
 #include "profession_group.h"
 
+#include "catalua_platform_content.h"
 #include "debug.h"
 #include "generic_factory.h"
 
@@ -9,6 +10,11 @@ namespace
 {
 generic_factory<profession_group> profession_group_factory( "profession_group" );
 } // namespace
+
+generic_factory<profession_group> &cata::lua_platform::detail::profession_group_registry()
+{
+    return profession_group_factory;
+}
 
 template<>
 const profession_group &string_id<profession_group>::obj() const

--- a/src/profession_group.h
+++ b/src/profession_group.h
@@ -9,6 +9,13 @@
 #include "type_id.h"
 
 class JsonObject;
+template<typename T>
+class generic_factory;
+
+namespace cata::lua_platform
+{
+class content_transaction;
+}
 
 struct profession_group {
 
@@ -24,6 +31,8 @@ struct profession_group {
         profession_group_id id;
 
     private:
+        friend class generic_factory<profession_group>;
+        friend class cata::lua_platform::content_transaction;
         std::vector<profession_id> profession_list;
 
 };

--- a/src/rotatable_symbols.cpp
+++ b/src/rotatable_symbols.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "catacharset.h"
+#include "catalua_platform_content.h"
 #include "flexbuffer_json.h"
 #include "generic_factory.h"
 #include "string_formatter.h"
@@ -31,6 +32,64 @@ struct rotatable_symbol {
 std::vector<rotatable_symbol> symbols;
 
 } // anonymous namespace
+
+std::vector<cata::lua_platform::detail::rotatable_symbol_native_entry>
+cata::lua_platform::detail::rotatable_symbol_registry_snapshot()
+{
+    std::vector<rotatable_symbol_native_entry> result;
+    result.reserve( symbols.size() );
+    for( const rotatable_symbol &entry : symbols ) {
+        result.push_back( { entry.symbol, entry.rotated_symbol } );
+    }
+    return result;
+}
+
+std::vector<std::uint32_t> cata::lua_platform::detail::rotatable_symbol_registry_group(
+    const std::uint32_t symbol )
+{
+    const auto found = std::lower_bound( symbols.begin(), symbols.end(), symbol );
+    if( found == symbols.end() || found->symbol != symbol ) {
+        return {};
+    }
+    std::vector<std::uint32_t> result = { found->symbol };
+    result.insert( result.end(), found->rotated_symbol.begin(), found->rotated_symbol.end() );
+    std::sort( result.begin(), result.end() );
+    result.erase( std::unique( result.begin(), result.end() ), result.end() );
+    return result;
+}
+
+void cata::lua_platform::detail::rotatable_symbol_registry_set(
+    const std::vector<std::uint32_t> &tuple )
+{
+    rotatable_symbol temporary;
+    for( auto iter = tuple.cbegin(); iter != tuple.cend(); ++iter ) {
+        const auto found = std::lower_bound( symbols.begin(), symbols.end(), *iter );
+        rotatable_symbol &entry = found != symbols.end() && found->symbol == *iter ?
+                                  *found : temporary;
+        entry.symbol = *iter;
+        auto rotation = iter;
+        for( std::uint32_t &value : entry.rotated_symbol ) {
+            if( ++rotation == tuple.cend() ) {
+                rotation = tuple.cbegin();
+            }
+            value = *rotation;
+        }
+        if( found == symbols.end() || found->symbol != *iter ) {
+            symbols.insert( found, entry );
+        }
+    }
+}
+
+void cata::lua_platform::detail::rotatable_symbol_registry_restore(
+    const std::vector<rotatable_symbol_native_entry> &snapshot )
+{
+    symbols.clear();
+    symbols.reserve( snapshot.size() );
+    for( const rotatable_symbol_native_entry &entry : snapshot ) {
+        symbols.push_back( { entry.symbol, entry.rotations } );
+    }
+    std::sort( symbols.begin(), symbols.end() );
+}
 
 namespace rotatable_symbols
 {

--- a/src/speed_description.cpp
+++ b/src/speed_description.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 
+#include "catalua_platform_content.h"
 #include "flexbuffer_json.h"
 #include "generic_factory.h"
 
@@ -9,6 +10,11 @@ namespace
 {
 generic_factory<speed_description> speed_description_factory( "speed_description" );
 } // namespace
+
+generic_factory<speed_description> &cata::lua_platform::detail::speed_description_registry()
+{
+    return speed_description_factory;
+}
 
 template<>
 const speed_description &speed_description_id::obj() const

--- a/src/speed_description.h
+++ b/src/speed_description.h
@@ -15,6 +15,11 @@ class speed_description_value;
 template<typename T>
 class generic_factory;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+} // namespace cata::lua_platform
+
 class speed_description
 {
     public:
@@ -33,6 +38,7 @@ class speed_description
     private:
         friend class generic_factory<speed_description>;
         friend struct mod_tracker;
+        friend class cata::lua_platform::content_transaction;
 
         speed_description_id id;
         std::vector<std::pair<speed_description_id, mod_id>> src;
@@ -59,6 +65,7 @@ class speed_description_value
         }
 
     private:
+        friend class cata::lua_platform::content_transaction;
         double value_ = 0.00;
         std::vector<translation> descriptions_;
 };

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -9,6 +9,7 @@
 #include "bodypart.h"
 #include "calendar.h"
 #include "cata_variant.h"
+#include "catalua_platform_content.h"
 #include "character.h"
 #include "city.h"
 #include "clzones.h"
@@ -59,6 +60,11 @@ namespace
 {
 generic_factory<start_location> all_start_locations( "start locations" );
 } // namespace
+
+generic_factory<start_location> &cata::lua_platform::detail::start_location_registry()
+{
+    return all_start_locations;
+}
 
 /** @relates string_id */
 template<>

--- a/src/start_location.h
+++ b/src/start_location.h
@@ -21,6 +21,12 @@ class avatar;
 class tinymap;
 enum class ot_match_type : int;
 struct city;
+template<typename T> class generic_factory;
+
+namespace cata::lua_platform
+{
+class content_transaction;
+}
 
 struct start_location_placement_constraints {
     numeric_interval<int> city_size;
@@ -110,6 +116,7 @@ class start_location
         /** @returns whether the start location at specified tripoint can belong to the specified city. */
         bool can_belong_to_city( const tripoint_om_omt &p, const city &cit ) const;
     private:
+        friend class cata::lua_platform::content_transaction;
         translation _name;
         std::vector<omt_types_parameters> _locations;
         std::set<std::string> _flags;

--- a/src/vehicle_part_location.cpp
+++ b/src/vehicle_part_location.cpp
@@ -1,5 +1,6 @@
 #include "vehicle_part_location.h"
 
+#include "catalua_platform_content.h"
 #include "generic_factory.h"
 
 class JsonObject;
@@ -19,6 +20,12 @@ namespace
 generic_factory<vpart_location> vehicle_part_location_factory( "vehicle_part_location" );
 
 } // namespace
+
+generic_factory<vpart_location> &
+cata::lua_platform::detail::vehicle_part_location_registry()
+{
+    return vehicle_part_location_factory;
+}
 
 /** @relates string_id */
 template<>

--- a/src/weather_type.cpp
+++ b/src/weather_type.cpp
@@ -1,6 +1,7 @@
 #include "weather_type.h"
 
 #include "condition.h"
+#include "catalua_platform_content.h"
 #include "debug.h"
 #include "flexbuffer_json.h"
 #include "generic_factory.h"
@@ -9,6 +10,11 @@ namespace
 {
 generic_factory<weather_type> weather_type_factory( "weather_type" );
 } // namespace
+
+generic_factory<weather_type> &cata::lua_platform::detail::weather_type_registry()
+{
+    return weather_type_factory;
+}
 
 namespace io
 {


### PR DESCRIPTION
#### Summary

Infrastructure "Add transactional native registry foundations"

#### Responsible human

@LYHGLYTX

#### Purpose of change

Lua-first native content needs reversible factory operations and stable registry access before the Platform runtime can stage, finalize, retain, and roll back definitions without calling JSON loaders.

#### Describe the solution

Expose the bounded native registry and factory foundations used by later Lua-first content layers. This layer contains 31 focused file-level commits and is intentionally limited to reusable native primitives.

#### Describe alternatives you've considered

Publishing JSON loaders or EOC-shaped wrappers would preserve the legacy authoring model. Keeping all 49,000 added lines in one PR would make ownership and rollback review impractical.

#### Testing

Not run by explicit user direction. This is a draft, `implemented_unverified` stack layer; compilation, tests, formatters, `git diff --check`, and all validation/check commands remain pending approval.

#### Documentation impact

Introduces native contracts explained by the final documentation layer in this stack.

#### Related CCB-Docs PR

https://github.com/CrimsonCrossBunker/CCB-Docs/pull/35

#### Affected documentation IDs

architecture.lua-first-platform, architecture.lua-first-roadmap, architecture.lua-first-glossary

#### Generated reference impact

None in this layer; LuaLS and replacement-ledger artifacts are isolated in later stack layers.

#### Additional context

Stack layer 1/14. Base: `agent/lua-first-platform-docs` (PR #615). Do not merge out of order.

| Layer | PR | Commits | Scope |
| --- | --- | ---: | --- |
| 1/14 | [#619](https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/pull/619) | 31 | Infrastructure: add transactional native registry foundations |
| 2/14 | [#620](https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/pull/620) | 26 | Infrastructure: expose native item and crafting catalogs |
| 3/14 | [#621](https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/pull/621) | 27 | Infrastructure: expose native world and presentation catalogs |
| 4/14 | [#622](https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/pull/622) | 38 | Infrastructure: expose native creature and character catalogs |
| 5/14 | [#623](https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/pull/623) | 12 | Features: add the native Lua-first Platform runtime |
| 6/14 | [#624](https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/pull/624) | 4 | Infrastructure: declare the Lua-first Platform contract |
| 7/14 | [#625](https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/pull/625) | 1 | Infrastructure: cover the Lua-first Platform runtime |
| 8/14 | [#626](https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/pull/626) | 14 | Features: integrate zero-configuration Lua Mod discovery |
| 9/14 | [#627](https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/pull/627) | 11 | Mods: add pure Lua authoring templates and example Mod |
| 10/14 | [#628](https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/pull/628) | 1 | Infrastructure: add the native Lua-first migration extractor |
| 11/14 | [#629](https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/pull/629) | 1 | Infrastructure: cover native Lua-first extraction |
| 12/14 | [#630](https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/pull/630) | 5 | Infrastructure: add exact replacement-ledger tooling |
| 13/14 | [#631](https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/pull/631) | 1 | Infrastructure: inventory Lua-first replacement coverage |
| 14/14 | [#632](https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/pull/632) | 10 | Infrastructure: document and route the Lua-first Platform |
