### PR TITLE
Infrastructure: expose native item and crafting catalogs

### DIFF
--- a/src/ammo.cpp
+++ b/src/ammo.cpp
@@ -12,13 +12,13 @@
 namespace
 {
 using ammo_map_t = std::unordered_map<ammotype, ammunition_type>;
+} //namespace
 
-ammo_map_t &all_ammunition_types()
+ammunition_type::registry_type &ammunition_type::registry()
 {
-    static ammo_map_t the_map;
+    static registry_type the_map;
     return the_map;
 }
-} //namespace
 
 ammunition_type::ammunition_type() : name_( no_translation( "null" ) )
 {
@@ -26,7 +26,7 @@ ammunition_type::ammunition_type() : name_( no_translation( "null" ) )
 
 void ammunition_type::load_ammunition_type( const JsonObject &jsobj )
 {
-    ammunition_type &res = all_ammunition_types()[ ammotype( jsobj.get_string( "id" ) ) ];
+    ammunition_type &res = registry()[ ammotype( jsobj.get_string( "id" ) ) ];
     jsobj.read( "name", res.name_ );
     jsobj.read( "default", res.default_ammotype_, true );
 }
@@ -35,14 +35,14 @@ void ammunition_type::load_ammunition_type( const JsonObject &jsobj )
 template<>
 bool string_id<ammunition_type>::is_valid() const
 {
-    return all_ammunition_types().count( *this ) > 0;
+    return ammunition_type::registry().count( *this ) > 0;
 }
 
 /** @relates string_id */
 template<>
 const ammunition_type &string_id<ammunition_type>::obj() const
 {
-    const ammo_map_t &the_map = all_ammunition_types();
+    const ammo_map_t &the_map = ammunition_type::registry();
 
     const auto it = the_map.find( *this );
     if( it != the_map.end() ) {
@@ -56,12 +56,12 @@ const ammunition_type &string_id<ammunition_type>::obj() const
 
 void ammunition_type::reset()
 {
-    all_ammunition_types().clear();
+    registry().clear();
 }
 
 void ammunition_type::check_consistency()
 {
-    for( const auto &ammo : all_ammunition_types() ) {
+    for( const auto &ammo : registry() ) {
         const auto &id = ammo.first;
         const itype_id &at = ammo.second.default_ammotype_;
 

--- a/src/ammo.h
+++ b/src/ammo.h
@@ -3,15 +3,23 @@
 #define CATA_SRC_AMMO_H
 
 #include <string>
+#include <unordered_map>
 
 #include "translation.h"
 #include "type_id.h"
 
 class JsonObject;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+} // namespace cata::lua_platform
+
 class ammunition_type
 {
         friend class DynamicDataLoader;
+        friend class cata::lua_platform::content_transaction;
+        template<typename T> friend class string_id;
     public:
         ammunition_type();
 
@@ -22,8 +30,12 @@ class ammunition_type
         }
 
     private:
+        using registry_type = std::unordered_map<ammotype, ammunition_type>;
+
         translation name_;
         itype_id default_ammotype_;
+
+        static registry_type &registry();
 
         static void load_ammunition_type( const JsonObject &jsobj );
         static void reset();

--- a/src/clothing_mod.cpp
+++ b/src/clothing_mod.cpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <utility>
 
+#include "catalua_platform_content.h"
 #include "debug.h"
 #include "enum_conversions.h"
 #include "flexbuffer_json.h"
@@ -19,6 +20,16 @@ generic_factory<clothing_mod> all_clothing_mods( "clothing mods" );
 } // namespace
 
 static std::map<clothing_mod_type, std::vector<clothing_mod>> clothing_mods_by_type;
+
+generic_factory<clothing_mod> &cata::lua_platform::detail::clothing_mod_registry()
+{
+    return all_clothing_mods;
+}
+
+void cata::lua_platform::detail::refresh_clothing_mod_registry_cache()
+{
+    clothing_mods_by_type.clear();
+}
 
 /** @relates string_id */
 template<>

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -22,6 +22,7 @@
 
 #include "calendar.h"
 #include "cata_imgui.h"
+#include "catalua_platform_content.h"
 #include "cata_utility.h"
 #include "catacharset.h"
 #include "character.h"
@@ -84,6 +85,11 @@ namespace
 generic_factory<crafting_category> craft_cat_list( "recipe_category" );
 
 } // namespace
+
+generic_factory<crafting_category> &cata::lua_platform::detail::crafting_category_registry()
+{
+    return craft_cat_list;
+}
 
 template<>
 const crafting_category &string_id<crafting_category>::obj() const

--- a/src/harvest.cpp
+++ b/src/harvest.cpp
@@ -6,6 +6,7 @@
 #include <optional>
 #include <string>
 
+#include "catalua_platform_content.h"
 #include "debug.h"
 #include "flexbuffer_json.h"
 #include "generic_factory.h"
@@ -26,6 +27,16 @@ namespace
 generic_factory<harvest_drop_type> harvest_drop_type_factory( "harvest_drop_type" );
 generic_factory<harvest_list> harvest_list_factory( "harvest_list" );
 } //namespace
+
+generic_factory<harvest_drop_type> &cata::lua_platform::detail::harvest_drop_type_registry()
+{
+    return harvest_drop_type_factory;
+}
+
+generic_factory<harvest_list> &cata::lua_platform::detail::harvest_list_registry()
+{
+    return harvest_list_factory;
+}
 
 /** @relates string_id */
 template<>

--- a/src/harvest.h
+++ b/src/harvest.h
@@ -17,6 +17,11 @@ template <typename T> class generic_factory;
 
 using butchery_requirements_id = string_id<butchery_requirements>;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+} // namespace cata::lua_platform
+
 class harvest_drop_type
 {
     public:
@@ -67,6 +72,7 @@ class harvest_drop_type
         std::string msg_dissect_fail;
         friend class generic_factory<harvest_drop_type>;
         friend struct mod_tracker;
+        friend class cata::lua_platform::content_transaction;
 };
 
 // Could be reused for butchery
@@ -157,6 +163,8 @@ class harvest_list
         std::set<std::string> names_;
         translation message_;
         butchery_requirements_id butchery_requirements_;
+
+        friend class cata::lua_platform::content_transaction;
 
 };
 

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1649,9 +1649,14 @@ void Item_factory::finalize()
             continue;
         }
         const itype_id &result = rec.result();
-        auto it = find_template_list_mod( result );
-        if( it.has_value() ) {
-            it->get().recipes.push_back( p.first );
+        auto runtime = m_runtimes.find( result );
+        if( runtime != m_runtimes.end() ) {
+            runtime->second->recipes.push_back( p.first );
+        } else {
+            auto it = find_template_list_mod( result );
+            if( it.has_value() ) {
+                it->get().recipes.push_back( p.first );
+            }
         }
     }
 }
@@ -3097,14 +3102,14 @@ const itype *Item_factory::find_template( const itype_id &id ) const
 {
     cata_assert( frozen );
 
-    auto found = find_template_list_const( id );
-    if( found.has_value() ) {
-        return &found->get();
-    }
-
     auto rt = m_runtimes.find( id );
     if( rt != m_runtimes.end() ) {
         return rt->second.get();
+    }
+
+    auto found = find_template_list_const( id );
+    if( found.has_value() ) {
+        return &found->get();
     }
 
     //If we didn't find the item maybe it is a building instead!
@@ -5426,7 +5431,9 @@ const std::vector<const itype *> &Item_factory::all() const
         templates_all_cache.reserve( item_factory.get_all().size() + m_runtimes.size() );
 
         for( const itype &e : item_factory.get_all() ) {
-            templates_all_cache.push_back( &e );
+            if( m_runtimes.count( e.id ) == 0 ) {
+                templates_all_cache.push_back( &e );
+            }
         }
         for( const auto &e : m_runtimes ) {
             templates_all_cache.push_back( e.second.get() );

--- a/src/item_factory.h
+++ b/src/item_factory.h
@@ -31,6 +31,11 @@ namespace cata
 template <typename T> class value_ptr;
 }  // namespace cata
 
+namespace cata::lua_platform
+{
+class content_transaction;
+} // namespace cata::lua_platform
+
 /**
  * Blacklists are an old way to remove items from the game.
  * It doesn't change at runtime.
@@ -96,6 +101,7 @@ class Item_factory
 {
         friend class generic_factory<itype>;
         friend struct itype;
+        friend class cata::lua_platform::content_transaction;
     public:
         generic_factory<itype> item_factory = generic_factory<itype>( "ITEM" );
 

--- a/src/item_info.cpp
+++ b/src/item_info.cpp
@@ -28,6 +28,7 @@
 #include "bodygraph.h"
 #include "bodypart.h"
 #include "calendar.h"
+#include "catalua_platform_runtime.h"
 #include "cata_utility.h"
 #include "character.h"
 #include "character_martial_arts.h"
@@ -300,12 +301,18 @@ void item::basic_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
 
             // only ever do the effect for a snippet the first time you see it
             if( !get_avatar().has_seen_snippet( snip_id ) ) {
-                // Have looked at the item so call the on examine EOC for the snippet
-                const std::optional<talk_effect_t> examine_effect = SNIPPET.get_EOC_by_id( snip_id );
-                if( examine_effect.has_value() ) {
-                    // activate the effect
-                    dialogue d( get_talker_for( get_avatar() ), nullptr );
-                    examine_effect.value().apply( d );
+                // Lua-first snippets dispatch their named policy directly and
+                // never store an EOC.  Legacy snippets retain their old path.
+                const bool lua_first_snippet =
+                    cata::lua_platform::invoke_snippet_examine_handler(
+                        snip_id.str(), typeId().str(), get_avatar() );
+                if( !lua_first_snippet ) {
+                    const std::optional<talk_effect_t> examine_effect =
+                        SNIPPET.get_EOC_by_id( snip_id );
+                    if( examine_effect.has_value() ) {
+                        dialogue d( get_talker_for( get_avatar() ), nullptr );
+                        examine_effect.value().apply( d );
+                    }
                 }
 
                 //note that you have seen the snippet

--- a/src/itype.h
+++ b/src/itype.h
@@ -50,6 +50,11 @@ class Trait_group;
 class map;
 template <typename E> struct enum_traits;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+} // namespace cata::lua_platform
+
 class gun_modifier_data
 {
     private:
@@ -1414,6 +1419,7 @@ struct item_melee_damage {
 struct itype {
         friend class Item_factory;
         friend struct mod_tracker;
+        friend class cata::lua_platform::content_transaction;
 
         using FlagsSetType = cata::flat_set<flag_id>;
 

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -7,6 +7,7 @@
 #include <unordered_map>
 
 #include "debug.h"
+#include "catalua_platform_content.h"
 #include "flexbuffer_json.h"
 #include "generic_factory.h"
 #include "item.h"
@@ -19,6 +20,11 @@ namespace
 generic_factory<material_type> material_data( "material" );
 
 } // namespace
+
+generic_factory<material_type> &cata::lua_platform::detail::material_registry()
+{
+    return material_data;
+}
 
 /** @relates string_id */
 template<>

--- a/src/material.h
+++ b/src/material.h
@@ -21,6 +21,11 @@ class JsonObject;
 class material_type;
 template <typename T> struct enum_traits;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+} // namespace cata::lua_platform
+
 using mat_burn_products = std::vector<std::pair<itype_id, float>>;
 using material_list = std::vector<material_type>;
 using material_id_list = std::vector<material_id>;
@@ -70,6 +75,8 @@ struct fuel_data {
 
 class material_type
 {
+        friend class cata::lua_platform::content_transaction;
+
     public:
         material_id id;
         std::vector<std::pair<material_id, mod_id>> src;

--- a/src/proficiency.cpp
+++ b/src/proficiency.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "debug.h"
+#include "catalua_platform_content.h"
 #include "flexbuffer_json.h"
 #include "generic_factory.h"
 #include "json.h"
@@ -24,6 +25,16 @@ namespace
 generic_factory<proficiency> proficiency_factory( "proficiency" );
 generic_factory<proficiency_category> proficiency_category_factory( "proficiency category" );
 } // namespace
+
+generic_factory<proficiency_category> &cata::lua_platform::detail::proficiency_category_registry()
+{
+    return proficiency_category_factory;
+}
+
+generic_factory<proficiency> &cata::lua_platform::detail::proficiency_registry()
+{
+    return proficiency_factory;
+}
 
 template<>
 const proficiency &proficiency_id::obj() const

--- a/src/proficiency.h
+++ b/src/proficiency.h
@@ -25,6 +25,11 @@ template<typename E> struct enum_traits;
 template<typename T>
 class generic_factory;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+} // namespace cata::lua_platform
+
 enum class proficiency_bonus_type : int {
     strength,
     dexterity,
@@ -63,6 +68,7 @@ class proficiency
 {
         friend class generic_factory<proficiency>;
         friend struct mod_tracker;
+        friend class cata::lua_platform::content_transaction;
 
         proficiency_id id;
         proficiency_category_id _category;

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -33,6 +33,11 @@ class read_only_visitable;
 class recipe;
 template <typename E> struct enum_traits;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+} // namespace cata::lua_platform
+
 enum class recipe_filter_flags : int {
     none = 0,
     no_rotten = 1,
@@ -159,6 +164,7 @@ class recipe
 {
         friend class recipe_dictionary;
         friend struct mod_tracker;
+        friend class cata::lua_platform::content_transaction;
 
     private:
         itype_id result_ = itype_id::NULL_ID();

--- a/src/recipe_dictionary.h
+++ b/src/recipe_dictionary.h
@@ -22,10 +22,16 @@ class JsonObject;
 class JsonOut;
 class Character;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+} // namespace cata::lua_platform
+
 class recipe_dictionary
 {
         friend class Item_factory; // allow removal of blacklisted recipes
         friend recipe_id;
+        friend class cata::lua_platform::content_transaction;
 
     public:
         /** Returns all recipes that can be automatically learned */

--- a/src/recipe_groups.cpp
+++ b/src/recipe_groups.cpp
@@ -1,5 +1,7 @@
 #include "recipe_groups.h"
 
+#include <algorithm>
+#include <cctype>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -48,6 +50,97 @@ struct recipe_group_data {
 generic_factory<recipe_group_data> recipe_groups_data( "recipe group type" );
 
 } // namespace
+
+bool cata::lua_platform::detail::recipe_group_exists( const std::string_view id )
+{
+    return recipe_groups_data.is_valid( group_id( std::string( id ) ) );
+}
+
+std::optional<cata::lua_platform::detail::recipe_group_native_definition>
+cata::lua_platform::detail::recipe_group_get( const std::string_view id )
+{
+    const group_id key{ std::string( id ) };
+    if( !recipe_groups_data.is_valid( key ) ) {
+        return std::nullopt;
+    }
+    const recipe_group_data &source = recipe_groups_data.obj( key );
+    recipe_group_native_definition result;
+    result.id = source.id.str();
+    result.building_type = source.building_type;
+    for( const auto &[source_id, source_mod] : source.src ) {
+        result.sources.emplace_back( source_id.str(), source_mod );
+    }
+    for( const auto &[recipe_key, description] : source.recipes ) {
+        recipe_group_recipe_definition recipe_entry;
+        recipe_entry.id = recipe_key.str();
+        recipe_entry.description = description;
+        const auto terrain_entries = source.om_terrains.find( recipe_key );
+        if( terrain_entries != source.om_terrains.end() ) {
+            for( const omt_types_parameters &terrain : terrain_entries->second ) {
+                recipe_group_terrain_definition terrain_entry;
+                terrain_entry.overmap_terrain = terrain.omt;
+                terrain_entry.match_type = io::enum_to_string( terrain.omt_type );
+                for( const auto &[parameter, values] : terrain.parameters ) {
+                    terrain_entry.parameters[parameter].insert( values.begin(), values.end() );
+                }
+                recipe_entry.overmap_terrains.push_back( std::move( terrain_entry ) );
+            }
+        }
+        result.recipes.push_back( std::move( recipe_entry ) );
+    }
+    return result;
+}
+
+void cata::lua_platform::detail::recipe_group_set(
+    const recipe_group_native_definition &definition )
+{
+    const auto match_type = []( std::string value ) {
+        std::transform( value.begin(), value.end(), value.begin(), []( const unsigned char byte ) {
+            return static_cast<char>( std::toupper( byte ) );
+        } );
+        if( value == "EXACT" ) {
+            return ot_match_type::exact;
+        }
+        if( value == "SUBTYPE" ) {
+            return ot_match_type::subtype;
+        }
+        if( value == "PREFIX" ) {
+            return ot_match_type::prefix;
+        }
+        if( value == "CONTAINS" ) {
+            return ot_match_type::contains;
+        }
+        return ot_match_type::type;
+    };
+
+    recipe_group_data native;
+    native.id = group_id( definition.id );
+    native.building_type = definition.building_type;
+    native.was_loaded = true;
+    for( const auto &[source_id, source_mod] : definition.sources ) {
+        native.src.emplace_back( group_id( source_id ), source_mod );
+    }
+    for( const recipe_group_recipe_definition &recipe_entry : definition.recipes ) {
+        const recipe_id recipe_key( recipe_entry.id );
+        native.recipes[recipe_key] = recipe_entry.description;
+        for( const recipe_group_terrain_definition &terrain_entry :
+             recipe_entry.overmap_terrains ) {
+            omt_types_parameters terrain;
+            terrain.omt = terrain_entry.overmap_terrain;
+            terrain.omt_type = match_type( terrain_entry.match_type );
+            for( const auto &[parameter, values] : terrain_entry.parameters ) {
+                terrain.parameters[parameter].insert( values.begin(), values.end() );
+            }
+            native.om_terrains[recipe_key].push_back( std::move( terrain ) );
+        }
+    }
+    recipe_groups_data.insert( native );
+}
+
+void cata::lua_platform::detail::recipe_group_erase( const std::string_view id )
+{
+    recipe_groups_data.erase( group_id( std::string( id ) ) );
+}
 
 void recipe_group_data::load( const JsonObject &jo, std::string_view )
 {

--- a/src/recipe_groups.h
+++ b/src/recipe_groups.h
@@ -5,8 +5,12 @@
 #include <cstddef>
 #include <map>
 #include <optional>
+#include <set>
 #include <string>
+#include <string_view>
+#include <vector>
 
+#include "translation.h"
 #include "type_id.h"
 
 class JsonObject;
@@ -29,5 +33,34 @@ std::map<recipe_id, translation> get_recipes_by_id( const std::string &id, const
         const std::optional<mapgen_arguments> *maybe_args, size_t limit = 0 );
 std::string get_building_of_recipe( const std::string &recipe );
 } // namespace recipe_group
+
+namespace cata::lua_platform::detail
+{
+
+struct recipe_group_terrain_definition {
+    std::string overmap_terrain;
+    std::string match_type = "TYPE";
+    std::map<std::string, std::set<std::string>> parameters;
+};
+
+struct recipe_group_recipe_definition {
+    std::string id;
+    translation description;
+    std::vector<recipe_group_terrain_definition> overmap_terrains;
+};
+
+struct recipe_group_native_definition {
+    std::string id;
+    std::string building_type = "NONE";
+    std::vector<std::pair<std::string, mod_id>> sources;
+    std::vector<recipe_group_recipe_definition> recipes;
+};
+
+bool recipe_group_exists( std::string_view id );
+std::optional<recipe_group_native_definition> recipe_group_get( std::string_view id );
+void recipe_group_set( const recipe_group_native_definition &definition );
+void recipe_group_erase( std::string_view id );
+
+} // namespace cata::lua_platform::detail
 
 #endif // CATA_SRC_RECIPE_GROUPS_H

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -16,6 +16,7 @@
 
 #include "cata_assert.h"
 #include "cata_utility.h"
+#include "catalua_platform_content.h"
 #include "character.h"
 #include "color.h"
 #include "coordinates.h"
@@ -64,6 +65,11 @@ static const trait_id trait_DEBUG_HS( "DEBUG_HS" );
 
 static std::map<requirement_id, requirement_data> requirements_all;
 
+std::map<requirement_id, requirement_data> &requirement_data::registry()
+{
+    return requirements_all;
+}
+
 static bool a_satisfies_b( const quality_requirement &a, const quality_requirement &b );
 static bool a_satisfies_b( const std::vector<quality_requirement> &a,
                            const std::vector<quality_requirement> &b );
@@ -102,6 +108,11 @@ namespace
 {
 generic_factory<quality> quality_factory( "tool quality" );
 } // namespace
+
+generic_factory<quality> &cata::lua_platform::detail::tool_quality_registry()
+{
+    return quality_factory;
+}
 
 void quality::reset()
 {

--- a/src/requirements.h
+++ b/src/requirements.h
@@ -29,6 +29,11 @@ class nc_color;
 class read_only_visitable;
 template <typename E> struct enum_traits;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+} // namespace cata::lua_platform
+
 enum class available_status : int {
     a_true = +1, // yes, it's available
     a_false = -1, // no, it's not available
@@ -212,6 +217,7 @@ struct requirement_data {
         // @see vpart_info::check
         // TODO: remove once all parts specify installation requirements directly
         friend class vpart_info;
+        friend class cata::lua_platform::content_transaction;
 
         using alter_tool_comp_vector = std::vector<std::vector<tool_comp> >;
         using alter_quali_req_vector = std::vector<std::vector<quality_requirement> >;
@@ -401,6 +407,8 @@ struct requirement_data {
         uint64_t make_hash() const;
 
     private:
+        static std::map<requirement_id, requirement_data> &registry();
+
         requirement_id id_ = requirement_id::NULL_ID(); // NOLINT(cata-serialize)
         translation name_; // NOLINT(cata-serialize)
 

--- a/src/skill.h
+++ b/src/skill.h
@@ -21,6 +21,11 @@ class JsonOut;
 class item;
 class recipe;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+} // namespace cata::lua_platform
+
 struct time_info_t {
     // Absolute floor on the time taken to attack.
     int min_time = 50;
@@ -33,6 +38,7 @@ struct time_info_t {
 class Skill
 {
         friend class string_id<Skill>;
+        friend class cata::lua_platform::content_transaction;
         skill_id _ident;
 
         translation _name;
@@ -298,6 +304,7 @@ class SkillLevelMap : public std::map<skill_id, SkillLevel>
 class SkillDisplayType
 {
         friend class string_id<SkillDisplayType>;
+        friend class cata::lua_platform::content_transaction;
         skill_displayType_id _ident;
         translation _display_string;
     public:

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -14,6 +14,7 @@
 #include "ammo.h"
 #include "cata_assert.h"
 #include "catacharset.h"
+#include "catalua_platform_content.h"
 #include "character.h"
 #include "clzones.h"
 #include "color.h"
@@ -1725,6 +1726,45 @@ static std::vector<vpart_category> vpart_categories_all;
 const std::vector<vpart_category> &vpart_category::all()
 {
     return vpart_categories_all;
+}
+
+const vpart_category *cata::lua_platform::detail::vehicle_part_category_registry_find(
+    const std::string &id )
+{
+    const auto found = std::find_if( vpart_categories_all.begin(), vpart_categories_all.end(),
+    [&id]( const vpart_category & value ) {
+        return value.get_id() == id;
+    } );
+    return found == vpart_categories_all.end() ? nullptr : &*found;
+}
+
+void cata::lua_platform::detail::vehicle_part_category_registry_set(
+    const vpart_category &value )
+{
+    const auto found = std::find_if( vpart_categories_all.begin(), vpart_categories_all.end(),
+    [&value]( const vpart_category & existing ) {
+        return existing.get_id() == value.get_id();
+    } );
+    if( found == vpart_categories_all.end() ) {
+        vpart_categories_all.push_back( value );
+    } else {
+        *found = value;
+    }
+}
+
+void cata::lua_platform::detail::vehicle_part_category_registry_erase(
+    const std::string &id )
+{
+    vpart_categories_all.erase(
+        std::remove_if( vpart_categories_all.begin(), vpart_categories_all.end(),
+    [&id]( const vpart_category & value ) {
+        return value.get_id() == id;
+    } ), vpart_categories_all.end() );
+}
+
+void cata::lua_platform::detail::vehicle_part_category_registry_finalize()
+{
+    vpart_category::finalize_all();
 }
 
 void vpart_category::load_all( const JsonObject &jo )

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -28,6 +28,12 @@
 
 class Character;
 class JsonObject;
+
+namespace cata::lua_platform
+{
+class content_transaction;
+} // namespace cata::lua_platform
+
 class JsonOut;
 class JsonValue;
 class vehicle;
@@ -261,6 +267,7 @@ class vpart_category
         }
 
     private:
+        friend class cata::lua_platform::content_transaction;
         std::string id_;
         translation name_;
         translation short_name_;

--- a/src/vehicle_group.cpp
+++ b/src/vehicle_group.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <utility>
 
+#include "catalua_platform_content.h"
 #include "coordinates.h"
 #include "debug.h"
 #include "enums.h"
@@ -22,6 +23,24 @@ static const vgroup_id VehicleGroup_parkinglot( "parkinglot" );
 std::unordered_map<vgroup_id, VehicleGroup> vgroups;
 static std::unordered_map<vplacement_id, VehiclePlacement> vplacements;
 static std::unordered_map<vspawn_id, VehicleSpawn> vspawns;
+
+const VehicleGroup *cata::lua_platform::detail::vehicle_group_registry_find(
+    const std::string &id )
+{
+    const auto found = vgroups.find( vgroup_id( id ) );
+    return found == vgroups.end() ? nullptr : &found->second;
+}
+
+void cata::lua_platform::detail::vehicle_group_registry_set(
+    const std::string &id, const VehicleGroup &value )
+{
+    vgroups[vgroup_id( id )] = value;
+}
+
+void cata::lua_platform::detail::vehicle_group_registry_erase( const std::string &id )
+{
+    vgroups.erase( vgroup_id( id ) );
+}
 
 /** @relates string_id */
 template<>

--- a/src/vitamin.cpp
+++ b/src/vitamin.cpp
@@ -1,6 +1,7 @@
 #include "vitamin.h"
 
 #include "calendar.h"
+#include "catalua_platform_content.h"
 #include "debug.h"
 #include "enum_conversions.h"
 #include "flexbuffer_json.h"
@@ -15,6 +16,11 @@ namespace
 generic_factory<vitamin> vitamin_factory( "vitamin" );
 
 } // namespace
+
+generic_factory<vitamin> &cata::lua_platform::detail::vitamin_registry()
+{
+    return vitamin_factory;
+}
 
 /** @relates string_id */
 template<>

--- a/src/vitamin.h
+++ b/src/vitamin.h
@@ -18,6 +18,11 @@ class JsonObject;
 template <typename T> struct enum_traits;
 template <typename T> class generic_factory;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+} // namespace cata::lua_platform
+
 enum class vitamin_type : int {
     VITAMIN,
     TOXIN,
@@ -34,6 +39,7 @@ struct enum_traits<vitamin_type> {
 class vitamin
 {
         friend class generic_factory<vitamin>;
+        friend class cata::lua_platform::content_transaction;
 
     public:
         vitamin_id id;


### PR DESCRIPTION
#### Summary

Infrastructure "Expose native item and crafting catalogs"

#### Responsible human

@LYHGLYTX

#### Purpose of change

Lua-first Item, Recipe, Requirement, harvest, material, proficiency, ammunition, and vehicle definitions need native catalog access before the runtime can apply them transactionally.

#### Describe the solution

Expose bounded native catalog operations for items and crafting dependencies while preserving existing engine ownership and validation. This layer contains 26 focused file-level commits.

#### Describe alternatives you've considered

Publishing JSON loaders or EOC-shaped wrappers would preserve the legacy authoring model. Keeping all 49,000 added lines in one PR would make ownership, dependency, and rollback review impractical.

#### Testing

Not run by explicit user direction. This is a draft, `implemented_unverified` stack layer; compilation, tests, formatters, `git diff --check`, and all validation/check commands remain pending approval.

#### Documentation impact

Introduces or supports native contracts documented by stack layer 14.

#### Related CCB-Docs PR

https://github.com/CrimsonCrossBunker/CCB-Docs/pull/35

#### Affected documentation IDs

architecture.lua-first-platform, architecture.lua-first-roadmap, architecture.lua-first-glossary

#### Generated reference impact

None in this layer; later layers update LuaLS declarations and exact replacement references.

#### Additional context

Stack layer 2/14. Base: `agent/lua-first-stack-01-registry-foundation` (PR #619). Previous: https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/pull/619. Next: `agent/lua-first-stack-03-world-content-catalogs`. Do not merge out of order.
