### PR TITLE
Infrastructure: expose native world and presentation catalogs

### DIFF
--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -20,6 +20,7 @@
 #include "debug.h"
 #include "field_type.h"
 #include "flexbuffer_json.h"
+#include "catalua_platform_content.h"
 #include "generic_factory.h"
 #include "iexamine.h"
 #include "input_popup.h"
@@ -138,6 +139,11 @@ namespace
 {
 generic_factory<zone_type> zone_type_factory( "zone_type" );
 } // namespace
+
+generic_factory<zone_type> &cata::lua_platform::detail::zone_type_registry()
+{
+    return zone_type_factory;
+}
 
 template<>
 const zone_type &string_id<zone_type>::obj() const

--- a/src/clzones.h
+++ b/src/clzones.h
@@ -41,6 +41,11 @@ class talker;
 class const_talker;
 struct construction;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+}
+
 inline const faction_id your_fac( "your_followers" );
 const std::string type_fac_hash_str = "__FAC__";
 
@@ -49,6 +54,7 @@ extern const std::vector<zone_type_id> ignorable_zone_types;
 class zone_type
 {
     private:
+        friend class cata::lua_platform::content_transaction;
         translation name_;
         translation desc_;
         field_type_str_id field_;

--- a/src/construction_category.cpp
+++ b/src/construction_category.cpp
@@ -1,5 +1,6 @@
 #include "construction_category.h"
 
+#include "catalua_platform_content.h"
 #include "generic_factory.h"
 
 namespace
@@ -8,6 +9,12 @@ namespace
 generic_factory<construction_category> all_construction_categories( "construction categories" );
 
 } // namespace
+
+generic_factory<construction_category> &
+cata::lua_platform::detail::construction_category_registry()
+{
+    return all_construction_categories;
+}
 
 /** @relates string_id */
 template<>

--- a/src/construction_category.h
+++ b/src/construction_category.h
@@ -13,6 +13,11 @@
 
 class JsonObject;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+} // namespace cata::lua_platform
+
 struct construction_category {
         void load( const JsonObject &jo, std::string_view src );
 
@@ -26,6 +31,7 @@ struct construction_category {
         static size_t count();
 
     private:
+        friend class cata::lua_platform::content_transaction;
         translation _name;
 };
 

--- a/src/construction_group.cpp
+++ b/src/construction_group.cpp
@@ -1,5 +1,6 @@
 #include "construction_group.h"
 
+#include "catalua_platform_content.h"
 #include "generic_factory.h"
 
 namespace
@@ -8,6 +9,12 @@ namespace
 generic_factory<construction_group> all_construction_groups( "construction groups" );
 
 } // namespace
+
+generic_factory<construction_group> &
+cata::lua_platform::detail::construction_group_registry()
+{
+    return all_construction_groups;
+}
 
 /** @relates string_id */
 template<>

--- a/src/construction_group.h
+++ b/src/construction_group.h
@@ -13,6 +13,11 @@
 
 class JsonObject;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+} // namespace cata::lua_platform
+
 struct construction_group {
         void load( const JsonObject &jo, std::string_view src );
 
@@ -25,6 +30,7 @@ struct construction_group {
         static size_t count();
 
     private:
+        friend class cata::lua_platform::content_transaction;
         translation _name;
 };
 

--- a/src/emit.cpp
+++ b/src/emit.cpp
@@ -3,10 +3,27 @@
 #include <map>
 #include <utility>
 
+#include "catalua_platform_content.h"
 #include "debug.h"
 #include "generic_factory.h"
 
 static std::map<emit_id, emit> emits_all;
+
+const emit *cata::lua_platform::detail::emission_registry_find( const std::string &id )
+{
+    const auto found = emits_all.find( emit_id( id ) );
+    return found == emits_all.end() ? nullptr : &found->second;
+}
+
+void cata::lua_platform::detail::emission_registry_set( const emit &value )
+{
+    emits_all[value.id()] = value;
+}
+
+void cata::lua_platform::detail::emission_registry_erase( const std::string &id )
+{
+    emits_all.erase( emit_id( id ) );
+}
 
 /** @relates string_id */
 template<>

--- a/src/emit.h
+++ b/src/emit.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_EMIT_H
 
 #include <map>
+#include <optional>
 #include <string>
 
 #include "dialogue_helpers.h"
@@ -10,6 +11,11 @@
 
 class JsonObject;
 struct const_dialogue;
+
+namespace cata::lua_platform
+{
+class content_transaction;
+} // namespace cata::lua_platform
 
 class emit
 {
@@ -28,21 +34,33 @@ class emit
 
         /** Type of field to emit @see emit::is_valid */
         field_type_id field( const_dialogue const &d ) const {
+            if( native_profile_ ) {
+                return native_profile_->field.id();
+            }
             return field_type_id( field_.evaluate( d ) );
         }
 
         /** Intensity of output fields, range [1..maximum_intensity] */
         int intensity( const_dialogue const &d ) const {
+            if( native_profile_ ) {
+                return native_profile_->intensity;
+            }
             return intensity_.evaluate( d );
         }
 
         /** Units of field to generate per turn subject to @ref chance */
         int qty( const_dialogue const &d ) const {
+            if( native_profile_ ) {
+                return native_profile_->quantity;
+            }
             return qty_.evaluate( d );
         }
 
         /** Chance to emit each turn, range [1..100] */
         int chance( const_dialogue const &d ) const {
+            if( native_profile_ ) {
+                return native_profile_->chance;
+            }
             return chance_.evaluate( d );
         }
 
@@ -62,11 +80,21 @@ class emit
         static void reset();
 
     private:
+        struct native_profile {
+            field_type_str_id field;
+            int intensity = 1;
+            int quantity = 1;
+            int chance = 100;
+        };
+
         emit_id id_;
         str_or_var field_;
         dbl_or_var intensity_;
         dbl_or_var qty_;
         dbl_or_var chance_;
+        std::optional<native_profile> native_profile_;
+
+        friend class cata::lua_platform::content_transaction;
 };
 
 #endif // CATA_SRC_EMIT_H

--- a/src/end_screen.cpp
+++ b/src/end_screen.cpp
@@ -5,6 +5,8 @@
 #include "avatar.h"
 #include "ascii_art.h"
 #include "cata_imgui.h"
+#include "catalua_platform_content.h"
+#include "catalua_platform_runtime.h"
 #include "condition.h"
 #include "dialogue.h"
 #include "end_screen.h"
@@ -24,6 +26,11 @@ namespace
 {
 generic_factory<end_screen> end_screen_factory( "end_screen" );
 } // namespace
+
+generic_factory<end_screen> &cata::lua_platform::detail::end_screen_registry()
+{
+    return end_screen_factory;
+}
 
 template<>
 const end_screen &string_id<end_screen>::obj()const
@@ -95,7 +102,11 @@ void end_screen_ui_impl::draw_controls()
     } );
 
     for( const end_screen &e_screen : sorted_screens ) {
-        if( e_screen.condition( d ) ) {
+        const std::optional<bool> platform_condition =
+            cata::lua_platform::invoke_end_screen_handler( e_screen.id.str(), u );
+        const bool matches = platform_condition ? *platform_condition :
+                             e_screen.condition( d );
+        if( matches ) {
             art = e_screen.picture_id;
             if( !e_screen.added_info.empty() ) {
                 added_info = e_screen.added_info;

--- a/src/help.cpp
+++ b/src/help.cpp
@@ -238,6 +238,14 @@ void help::reset_instance()
     current_order_start = 0;
     current_src = "";
     help_texts.clear();
+    platform_help_topic_orders.clear();
+}
+
+std::optional<int> help::platform_topic_order( const std::string &id ) const
+{
+    const auto found = platform_help_topic_orders.find( id );
+    return found == platform_help_topic_orders.end() ? std::nullopt :
+           std::optional<int>( found->second );
 }
 
 void help::load_object( const JsonObject &jo, const std::string &src )

--- a/src/help.h
+++ b/src/help.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_HELP_H
 
 #include <map>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -13,6 +14,11 @@
 
 class JsonObject;
 struct input_event;
+
+namespace cata::lua_platform
+{
+class content_transaction;
+}
 
 namespace catacurses
 {
@@ -25,7 +31,9 @@ class help
         static void load( const JsonObject &jo, const std::string &src );
         static void reset();
         void display_help() const;
+        std::optional<int> platform_topic_order( const std::string &id ) const;
     private:
+        friend class cata::lua_platform::content_transaction;
         void load_object( const JsonObject &jo, const std::string &src );
         void reset_instance();
         std::map<int, inclusive_rectangle<point>> draw_menu( const catacurses::window &win,
@@ -37,6 +45,7 @@ class help
         int current_order_start = 0;
         std::string current_src;
         std::map<int, std::pair<translation, std::vector<translation>>> help_texts;
+        std::map<std::string, int> platform_help_topic_orders;
 };
 
 help &get_help();

--- a/src/map_accessories.cpp
+++ b/src/map_accessories.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 
+#include "catalua_platform_content.h"
 #include "damage.h"
 #include "debug.h"
 #include "generic_factory.h"
@@ -10,6 +11,11 @@ namespace
 {
 generic_factory<bash_damage_profile> damage_profile_factory( "bash_damage_profile" );
 } // namespace
+
+generic_factory<bash_damage_profile> &cata::lua_platform::detail::bash_damage_profile_registry()
+{
+    return damage_profile_factory;
+}
 
 // boilerplate
 void bash_damage_profile::load_all( const JsonObject &jo, const std::string &src )

--- a/src/map_accessories.h
+++ b/src/map_accessories.h
@@ -15,10 +15,16 @@ class generic_factory;
 
 class JsonObject;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+} // namespace cata::lua_platform
+
 class bash_damage_profile
 {
         friend class generic_factory<bash_damage_profile>;
         friend struct mod_tracker;
+        friend class cata::lua_platform::content_transaction;
 
         bool was_loaded = false;
         bash_damage_profile_id id;

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -19,6 +19,7 @@
 #include "bodypart.h"
 #include "calendar.h"
 #include "cata_utility.h"
+#include "catalua_platform_runtime.h"
 #include "character.h"
 #include "coordinates.h"
 #include "creature.h"
@@ -2184,10 +2185,19 @@ void map::emit_field( const tripoint_bub_ms &pos, const emit_id &src, float mul 
     }
 
     dialogue d( get_talker_for( get_avatar() ), nullptr );
-    const float chance = src->chance( d ) * mul;
+    const field_type_id fallback_field = src->field( d );
+    const cata::lua_platform::emission_profile fallback = {
+        fallback_field.id().str(), src->intensity( d ), src->qty( d ), src->chance( d )
+    };
+    const cata::lua_platform::emission_profile profile =
+        cata::lua_platform::invoke_emission_profile_handler(
+            src.str(), pos, fallback ).value_or( fallback );
+    const float chance = profile.chance * mul;
     if( x_in_y( chance, 100 ) ) {
-        const int qty = chance > 100.0f ? roll_remainder( src->qty( d ) * chance / 100.0f ) : src->qty( d );
-        propagate_field( pos, src->field( d ), qty, src->intensity( d ) );
+        const int qty = chance > 100.0f ?
+                        roll_remainder( profile.quantity * chance / 100.0f ) :
+                        profile.quantity;
+        propagate_field( pos, field_type_id( profile.field ), qty, profile.intensity );
     }
 }
 

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -11,6 +11,7 @@
 #include "avatar.h"
 #include "calendar.h"
 #include "character.h"
+#include "catalua_platform_content.h"
 #include "color.h"
 #include "debug.h"
 #include "effect_on_condition.h"
@@ -350,6 +351,32 @@ std::string enum_to_string<ter_furn_flag>( ter_furn_flag data )
 } // namespace io
 
 static std::unordered_map<std::string, connect_group> ter_connects_map;
+
+const connect_group *cata::lua_platform::detail::connect_group_registry_find(
+    const std::string &id )
+{
+    const auto found = ter_connects_map.find( id );
+    return found == ter_connects_map.end() ? nullptr : &found->second;
+}
+
+std::size_t cata::lua_platform::detail::connect_group_registry_size()
+{
+    return ter_connects_map.size();
+}
+
+void cata::lua_platform::detail::connect_group_registry_set( const connect_group &value )
+{
+    connect_group replacement = value;
+    const auto found = ter_connects_map.find( value.id.str() );
+    replacement.index = found == ter_connects_map.end() ?
+                        static_cast<int>( ter_connects_map.size() ) : found->second.index;
+    ter_connects_map[value.id.str()] = std::move( replacement );
+}
+
+void cata::lua_platform::detail::connect_group_registry_erase( const std::string &id )
+{
+    ter_connects_map.erase( id );
+}
 
 /** @relates string_id */
 template<>

--- a/src/omdata.h
+++ b/src/omdata.h
@@ -49,6 +49,11 @@ struct mutable_overmap_placement_rule_remainder;
 template <typename E> struct enum_traits;
 template <typename T> class generic_factory;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+}
+
 using join_map = std::unordered_map<cube_direction, mutable_overmap_terrain_join>;
 using overmap_land_use_code_id = string_id<overmap_land_use_code>;
 class overmap;
@@ -399,6 +404,7 @@ class oter_vision
     private:
         friend class generic_factory<oter_vision>;
         friend struct mod_tracker;
+        friend class cata::lua_platform::content_transaction;
         oter_vision_id id;
         std::vector<std::pair<oter_vision_id, mod_id>> src;
         bool was_loaded = false;

--- a/src/overmap_location.cpp
+++ b/src/overmap_location.cpp
@@ -4,6 +4,7 @@
 #include <unordered_map>
 #include <utility>
 
+#include "catalua_platform_content.h"
 #include "debug.h"
 #include "enum_conversions.h"
 #include "flexbuffer_json.h"
@@ -17,6 +18,11 @@ namespace
 generic_factory<overmap_location> locations( "overmap location" );
 
 } // namespace
+
+generic_factory<overmap_location> &cata::lua_platform::detail::overmap_location_registry()
+{
+    return locations;
+}
 
 template<>
 bool string_id<overmap_location>::is_valid() const

--- a/src/overmap_location.h
+++ b/src/overmap_location.h
@@ -13,6 +13,11 @@
 class JsonObject;
 struct oter_t;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+}
+
 struct overmap_location {
     public:
         using TerrColType = cata::flat_set<oter_type_str_id>;
@@ -35,6 +40,7 @@ struct overmap_location {
         bool was_loaded = false;
 
     private:
+        friend class cata::lua_platform::content_transaction;
         TerrColType terrains;
         std::vector<std::string> flags;
 };

--- a/src/overmap_terrain.cpp
+++ b/src/overmap_terrain.cpp
@@ -10,6 +10,7 @@
 #include "cata_assert.h"
 #include "cata_utility.h"
 #include "catacharset.h"
+#include "catalua_platform_content.h"
 #include "coordinates.h"
 #include "debug.h"
 #include "generic_factory.h"
@@ -86,6 +87,17 @@ generic_factory<oter_type_t> terrain_types( "overmap terrain type" );
 generic_factory<oter_t> terrains( "overmap terrain" );
 
 } // namespace
+
+generic_factory<overmap_land_use_code> &
+cata::lua_platform::detail::overmap_land_use_code_registry()
+{
+    return land_use_codes;
+}
+
+generic_factory<oter_vision> &cata::lua_platform::detail::overmap_vision_registry()
+{
+    return oter_vision_factory;
+}
 
 template<>
 const overmap_land_use_code &overmap_land_use_code_id::obj() const

--- a/src/regional_settings.cpp
+++ b/src/regional_settings.cpp
@@ -10,6 +10,7 @@
 #include <utility>
 #include <variant>
 
+#include "catalua_platform_content.h"
 #include "debug.h"
 #include "flexbuffer_json.h"
 #include "generic_factory.h"
@@ -56,6 +57,12 @@ generic_factory<forest_biome_mapgen> forest_biome_mapgen_factory( "forest_biome_
 generic_factory<map_extra_collection> map_extra_collection_factory( "map_extra_collection" );
 generic_factory<region_settings> region_settings_factory( "region_settings_new" );
 } // namespace
+
+generic_factory<map_extra_collection> &
+cata::lua_platform::detail::map_extra_collection_registry()
+{
+    return map_extra_collection_factory;
+}
 
 /** OBJ */
 template<>

--- a/src/scent_map.cpp
+++ b/src/scent_map.cpp
@@ -5,6 +5,7 @@
 
 #include "calendar.h"
 #include "cata_assert.h"
+#include "catalua_platform_content.h"
 #include "color.h"
 #include "cuboid_rectangle.h"
 #include "cursesdef.h"
@@ -272,6 +273,11 @@ namespace
 {
 generic_factory<scent_type> scent_factory( "scent_type" );
 } // namespace
+
+generic_factory<scent_type> &cata::lua_platform::detail::scent_type_registry()
+{
+    return scent_factory;
+}
 
 template<>
 const scent_type &string_id<scent_type>::obj() const

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -620,18 +620,54 @@ void sfx::load_playlist( const JsonObject &jsobj )
     }
 
     for( JsonObject playlist : jsobj.get_array( "playlists" ) ) {
-        const std::string playlist_id = playlist.get_string( "id" );
-        music_playlist playlist_to_load;
-        playlist_to_load.shuffle = playlist.get_bool( "shuffle", false );
+        playlist_definition definition;
+        definition.id = playlist.get_string( "id" );
+        definition.shuffle = playlist.get_bool( "shuffle", false );
 
         for( JsonObject entry : playlist.get_array( "files" ) ) {
-            const music_playlist::entry e{ entry.get_string( "file" ),  entry.get_int( "volume" ) };
-            playlist_to_load.entries.push_back( e );
+            definition.entries.push_back( playlist_entry_definition{
+                entry.get_string( "file" ), entry.get_int( "volume" )
+            } );
         }
+        playlist_registry_set( definition );
+    }
+}
 
-        playlists[playlist_id] = std::move( playlist_to_load );
+std::optional<sfx::playlist_definition> sfx::playlist_registry_get(
+    const std::string_view id )
+{
+    const auto found = playlists.find( std::string( id ) );
+    if( found == playlists.end() ) {
+        return std::nullopt;
+    }
+    playlist_definition result;
+    result.id = std::string( id );
+    result.shuffle = found->second.shuffle;
+    for( const music_playlist::entry &entry : found->second.entries ) {
+        result.entries.push_back( playlist_entry_definition{ entry.file, entry.volume } );
+    }
+    return result;
+}
 
-        music::update_music_id_is_empty_flag( playlist_id, true );
+void sfx::playlist_registry_set( const playlist_definition &value )
+{
+    music_playlist native;
+    native.shuffle = value.shuffle;
+    for( const playlist_entry_definition &entry : value.entries ) {
+        native.entries.push_back( music_playlist::entry{ entry.file, entry.volume } );
+    }
+    playlists[value.id] = std::move( native );
+    if( value.id == "mp3" || value.id == "instrument" || value.id == "sound" ||
+        value.id == "title" ) {
+        music::update_music_id_is_empty_flag( value.id, true );
+    }
+}
+
+void sfx::playlist_registry_erase( const std::string_view id )
+{
+    playlists.erase( std::string( id ) );
+    if( id == "mp3" || id == "instrument" || id == "sound" || id == "title" ) {
+        music::update_music_id_is_empty_flag( std::string( id ), false );
     }
 }
 

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -2034,6 +2034,29 @@ bool sfx::has_exact_variant_sound( std::string_view id, std::string_view variant
 
 #else // if defined(SDL_SOUND)
 
+namespace
+{
+std::unordered_map<std::string, sfx::playlist_definition> disabled_playlists;
+}
+
+std::optional<sfx::playlist_definition> sfx::playlist_registry_get(
+    const std::string_view id )
+{
+    const auto found = disabled_playlists.find( std::string( id ) );
+    return found == disabled_playlists.end() ? std::nullopt :
+           std::optional<playlist_definition>( found->second );
+}
+
+void sfx::playlist_registry_set( const playlist_definition &value )
+{
+    disabled_playlists[value.id] = value;
+}
+
+void sfx::playlist_registry_erase( const std::string_view id )
+{
+    disabled_playlists.erase( std::string( id ) );
+}
+
 /** Dummy implementations for builds without sound */
 /*@{*/
 void sfx::load_sound_effects( const JsonObject & ) { }

--- a/src/sounds.h
+++ b/src/sounds.h
@@ -99,6 +99,21 @@ struct enum_traits<sounds::sound_t> {
 
 namespace sfx
 {
+
+struct playlist_entry_definition {
+    std::string file;
+    int volume = 100;
+};
+
+struct playlist_definition {
+    std::string id;
+    bool shuffle = false;
+    std::vector<playlist_entry_definition> entries;
+};
+
+std::optional<playlist_definition> playlist_registry_get( std::string_view id );
+void playlist_registry_set( const playlist_definition &value );
+void playlist_registry_erase( std::string_view id );
 //Channel assignments:
 enum class channel : int {
     any = -1,                   //Finds the first available channel

--- a/src/speech.cpp
+++ b/src/speech.cpp
@@ -40,3 +40,21 @@ const SpeechBubble &get_speech( const std::string &label )
 
     return random_entry_ref( speech_type->second );
 }
+
+const std::vector<SpeechBubble> *cata::lua_platform::detail::speech_registry_find(
+    const std::string_view label )
+{
+    const auto found = speech.find( std::string( label ) );
+    return found == speech.end() ? nullptr : &found->second;
+}
+
+void cata::lua_platform::detail::speech_registry_set(
+    const std::string &label, std::vector<SpeechBubble> lines )
+{
+    speech[label] = std::move( lines );
+}
+
+void cata::lua_platform::detail::speech_registry_erase( const std::string_view label )
+{
+    speech.erase( std::string( label ) );
+}

--- a/src/speech.h
+++ b/src/speech.h
@@ -3,6 +3,8 @@
 #define CATA_SRC_SPEECH_H
 
 #include <string>
+#include <string_view>
+#include <vector>
 
 #include "translation.h"
 
@@ -16,5 +18,12 @@ struct SpeechBubble {
 void load_speech( const JsonObject &jo );
 void reset_speech();
 const SpeechBubble &get_speech( const std::string &label );
+
+namespace cata::lua_platform::detail
+{
+const std::vector<SpeechBubble> *speech_registry_find( std::string_view label );
+void speech_registry_set( const std::string &label, std::vector<SpeechBubble> lines );
+void speech_registry_erase( std::string_view label );
+} // namespace cata::lua_platform::detail
 
 #endif // CATA_SRC_SPEECH_H

--- a/src/weather_gen.cpp
+++ b/src/weather_gen.cpp
@@ -11,6 +11,7 @@
 
 #include "avatar.h"
 #include "cata_utility.h"
+#include "catalua_platform_runtime.h"
 #include "dialogue.h"
 #include "flexbuffer_json.h"
 #include "game_constants.h"
@@ -258,7 +259,13 @@ weather_type_id weather_generator::get_weather_conditions( const w_point &w ) co
             }
         }
 
-        if( required_weather && type->condition( d ) ) {
+        if( !required_weather ) {
+            continue;
+        }
+        const std::optional<bool> lua_condition =
+            cata::lua_platform::invoke_weather_type_handler( type.str(), w );
+        const bool condition_matches = lua_condition ? *lua_condition : type->condition( d );
+        if( condition_matches ) {
             current_conditions = type;
             continue;
         }


### PR DESCRIPTION
#### Summary

Infrastructure "Expose native world and presentation catalogs"

#### Responsible human

@LYHGLYTX

#### Purpose of change

Lua-first world content needs native access to construction, fields, emissions, map presentation, weather, speech, sounds, and related catalogs without passing legacy JSON objects.

#### Describe the solution

Expose the world and presentation catalog primitives required by later Platform definitions, with reversible native registry operations. This layer contains 27 focused file-level commits.

#### Describe alternatives you've considered

Publishing JSON loaders or EOC-shaped wrappers would preserve the legacy authoring model. Keeping all 49,000 added lines in one PR would make ownership, dependency, and rollback review impractical.

#### Testing

Not run by explicit user direction. This is a draft, `implemented_unverified` stack layer; compilation, tests, formatters, `git diff --check`, and all validation/check commands remain pending approval.

#### Documentation impact

Introduces or supports native contracts documented by stack layer 14.

#### Related CCB-Docs PR

https://github.com/CrimsonCrossBunker/CCB-Docs/pull/35

#### Affected documentation IDs

architecture.lua-first-platform, architecture.lua-first-roadmap, architecture.lua-first-glossary

#### Generated reference impact

None in this layer; later layers update LuaLS declarations and exact replacement references.

#### Additional context

Stack layer 3/14. Base: `agent/lua-first-stack-02-item-crafting-catalogs` (PR #620). Previous: https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/pull/620. Next: `agent/lua-first-stack-04-creature-content-catalogs`. Do not merge out of order.
