### PR TITLE
Infrastructure: expose native creature and character catalogs

### DIFF
--- a/src/anatomy.cpp
+++ b/src/anatomy.cpp
@@ -35,6 +35,11 @@ generic_factory<anatomy> anatomy_factory( "anatomy" );
 
 } // namespace
 
+generic_factory<anatomy> &cata::lua_platform::detail::anatomy_registry()
+{
+    return anatomy_factory;
+}
+
 template<>
 bool anatomy_id::is_valid() const
 {
@@ -363,3 +368,4 @@ bodypart_id anatomy::select_body_part_projectile_attack( const double range_min,
     // And now, select the right body part
     return graph.select( range_min, range_max, value );
 }
+#include "catalua_platform_content.h"

--- a/src/anatomy.h
+++ b/src/anatomy.h
@@ -13,12 +13,18 @@
 class Creature;
 class JsonObject;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+} // namespace cata::lua_platform
+
 /**
  * A structure that contains body parts.
  * Keeps caches for weighted selections.
  */
 class anatomy
 {
+        friend class cata::lua_platform::content_transaction;
     private:
         std::vector<bodypart_str_id> unloaded_bps;
         std::vector<bodypart_id> cached_bps;

--- a/src/behavior.cpp
+++ b/src/behavior.cpp
@@ -1,15 +1,16 @@
 #include "behavior.h"
 
-#include <list>
 #include <unordered_map>
 #include <utility>
 
 #include "behavior_oracle.h"
 #include "behavior_strategy.h"
 #include "cata_assert.h"
+#include "catalua_platform_content.h"
 #include "debug.h"
 #include "flexbuffer_json.h"
 #include "generic_factory.h"
+#include "monstergenerator.h"
 
 using namespace behavior;
 
@@ -30,6 +31,22 @@ void node_t::set_goal( const std::string &new_goal )
 void node_t::add_child( const node_t *new_child )
 {
     children.push_back( new_child );
+}
+void node_t::add_child_id( const std::string &new_child )
+{
+    authored_children.push_back( new_child );
+}
+const std::vector<std::string> &node_t::child_ids() const
+{
+    return authored_children;
+}
+void node_t::rebuild_children()
+{
+    children.clear();
+    children.reserve( authored_children.size() );
+    for( const std::string &child : authored_children ) {
+        children.push_back( &string_id<node_t>( child ).obj() );
+    }
 }
 void node_t::set_score_function( const score_type &func, const std::string &argument )
 {
@@ -126,15 +143,13 @@ void tree::add( const node_t *new_node )
 
 namespace
 {
-// This struct only exists to hold node data until finalization.
-struct node_data {
-    string_id<node_t> id;
-    std::vector<std::string> children;
-};
-
 generic_factory<behavior::node_t> behavior_factory( "behavior" );
-std::list<node_data> temp_node_data;
 } // namespace
+
+generic_factory<behavior::node_t> &cata::lua_platform::detail::behavior_registry()
+{
+    return behavior_factory;
+}
 
 /** @relates string_id */
 template<>
@@ -156,13 +171,9 @@ void behavior::load_behavior( const JsonObject &jo, const std::string &src )
 
 void node_t::load( const JsonObject &jo, std::string_view )
 {
-    // We don't initialize the node unless it has no children (opportunistic optimization).
-    // Instead we initialize a parallel struct that holds the labels until finalization.
     if( jo.has_array( "children" ) ) {
-        temp_node_data.emplace_back();
-        node_data &new_data = temp_node_data.back();
-        new_data.id = id;
-        optional( jo, was_loaded, "children", new_data.children );
+        authored_children.clear();
+        optional( jo, was_loaded, "children", authored_children );
     }
     if( jo.has_string( "strategy" ) ) {
         std::unordered_map<std::string, const strategy_t *>::iterator new_strategy =
@@ -223,20 +234,16 @@ void node_t::check() const
 
 void behavior::reset()
 {
-    temp_node_data.clear();
     behavior_factory.reset();
 }
 
 void behavior::finalize()
 {
     behavior_factory.finalize();
-    for( const node_data &new_node : temp_node_data ) {
-        for( const std::string &child : new_node.children ) {
-            const_cast<node_t &>( new_node.id.obj() ).
-            add_child( &string_id<node_t>( child ).obj() );
-        }
+    for( const node_t &node : behavior_factory.get_all() ) {
+        const_cast<node_t &>( node ).rebuild_children();
     }
-    temp_node_data.clear();
+    MonsterGenerator::generator().refresh_behavior_goals();
 }
 
 void behavior::check_consistency()

--- a/src/behavior.h
+++ b/src/behavior.h
@@ -77,6 +77,9 @@ class node_t
                             new_predicate, const std::string &argument = "", const bool &invert_result = false );
         void set_goal( const std::string &new_goal );
         void add_child( const node_t *new_child );
+        void add_child_id( const std::string &new_child );
+        const std::vector<std::string> &child_ids() const;
+        void rebuild_children();
         using score_type = std::function<float( const oracle_t *, std::string_view )>;
         void set_score_function( const score_type &func, const std::string &argument = "" );
 
@@ -88,6 +91,7 @@ class node_t
         bool was_loaded = false;
     private:
         std::vector<const node_t *> children;
+        std::vector<std::string> authored_children;
         const strategy_t *strategy = nullptr;
         using predicate_type = std::function<status_t( const oracle_t *, const std::string & )>;
         std::vector<std::tuple<predicate_type, std::string, bool>> conditions;

--- a/src/behavior_oracle.cpp
+++ b/src/behavior_oracle.cpp
@@ -21,19 +21,33 @@ status_t return_running( const oracle_t *, std::string_view )
 static std::function < status_t( const oracle_t *, std::string_view ) >
 make_function( status_t ( character_oracle_t::* fun )( std::string_view ) const )
 {
-    return static_cast<status_t ( oracle_t::* )( std::string_view ) const>( fun );
+    return [fun]( const oracle_t *oracle, const std::string_view argument ) {
+        const character_oracle_t *character =
+            dynamic_cast<const character_oracle_t *>( oracle );
+        return character == nullptr ? status_t::failure :
+               ( character->*fun )( argument );
+    };
 }
 
 static std::function < status_t( const oracle_t *, std::string_view ) >
 make_function( status_t ( monster_oracle_t::* fun )( std::string_view ) const )
 {
-    return static_cast<status_t ( oracle_t::* )( std::string_view ) const>( fun );
+    return [fun]( const oracle_t *oracle, const std::string_view argument ) {
+        const monster_oracle_t *monster =
+            dynamic_cast<const monster_oracle_t *>( oracle );
+        return monster == nullptr ? status_t::failure :
+               ( monster->*fun )( argument );
+    };
 }
 
 static std::function<float( const oracle_t *, std::string_view )>
 make_score_function( float ( character_oracle_t::* fun )( std::string_view ) const )
 {
-    return static_cast<float ( oracle_t::* )( std::string_view ) const>( fun );
+    return [fun]( const oracle_t *oracle, const std::string_view argument ) {
+        const character_oracle_t *character =
+            dynamic_cast<const character_oracle_t *>( oracle );
+        return character == nullptr ? 0.0f : ( character->*fun )( argument );
+    };
 }
 
 std::unordered_map<std::string, std::function<status_t( const oracle_t *, std::string_view ) >>

--- a/src/behavior_oracle.h
+++ b/src/behavior_oracle.h
@@ -7,6 +7,8 @@
 #include <string_view>
 #include <unordered_map>
 
+class Creature;
+
 namespace behavior
 {
 enum class status_t : char;
@@ -20,6 +22,9 @@ enum class status_t : char;
  */
 class oracle_t
 {
+    public:
+        virtual ~oracle_t() = default;
+        virtual const Creature *get_subject() const = 0;
 };
 
 status_t return_running( const oracle_t *, std::string_view );

--- a/src/bodygraph.cpp
+++ b/src/bodygraph.cpp
@@ -46,6 +46,11 @@ generic_factory<bodygraph> bodygraph_factory( "bodygraph" );
 
 } // namespace
 
+generic_factory<bodygraph> &cata::lua_platform::detail::bodygraph_registry()
+{
+    return bodygraph_factory;
+}
+
 /** @relates string_id */
 template<>
 const bodygraph &string_id<bodygraph>::obj() const
@@ -728,3 +733,4 @@ std::vector<std::string> get_bodygraph_lines( const Character &u,
     }
     return ret;
 }
+#include "catalua_platform_content.h"

--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -10,6 +10,7 @@
 
 #include "body_part_set.h"
 #include "calendar.h"
+#include "catalua_platform_content.h"
 #include "creature.h"
 #include "debug.h"
 #include "enum_conversions.h"
@@ -108,6 +109,27 @@ generic_factory<limb_score> limb_score_factory( "limb score" );
 std::unordered_map<bodypart_str_id, std::vector<bodypart_str_id>> combined_similar_bodyparts;
 
 } // namespace
+
+generic_factory<limb_score> &cata::lua_platform::detail::limb_score_registry()
+{
+    return limb_score_factory;
+}
+
+generic_factory<body_part_type> &cata::lua_platform::detail::body_part_registry()
+{
+    return body_part_factory;
+}
+
+void cata::lua_platform::detail::refresh_body_part_similarity_cache()
+{
+    combined_similar_bodyparts.clear();
+    for( const body_part_type &part : body_part_factory.get_all() ) {
+        if( part.similar_bodypart.has_value() ) {
+            combined_similar_bodyparts[*part.similar_bodypart].emplace_back( part.id );
+            combined_similar_bodyparts[part.id].emplace_back( *part.similar_bodypart );
+        }
+    }
+}
 
 static body_part legacy_id_to_enum( const std::string &legacy_id )
 {

--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -34,6 +34,11 @@ struct localized_comparator;
 template <typename E> struct enum_traits;
 template <typename T> class generic_factory;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+} // namespace cata::lua_platform
+
 using bodypart_id = int_id<body_part_type>;
 
 extern const bodypart_str_id body_part_head;
@@ -138,6 +143,7 @@ struct limb_score {
         bool was_loaded = false;
         friend class generic_factory<limb_score>;
         friend struct mod_tracker;
+        friend class cata::lua_platform::content_transaction;
 };
 
 struct bp_limb_score {
@@ -195,6 +201,7 @@ struct bp_qualities_provided {
 };
 
 struct body_part_type {
+        friend class cata::lua_platform::content_transaction;
     public:
         /**
          * the different types of body parts there are.

--- a/src/character_modifier.cpp
+++ b/src/character_modifier.cpp
@@ -4,9 +4,12 @@
 #include <cmath>
 #include <functional>
 #include <limits>
+#include <optional>
 
 #include "bodypart.h"
 #include "character.h"
+#include "catalua_platform_content.h"
+#include "catalua_platform_runtime.h"
 #include "debug.h"
 #include "effect.h"
 #include "enum_conversions.h"
@@ -37,6 +40,11 @@ namespace
 generic_factory<character_modifier> character_modifier_factory( "character modifier" );
 
 } // namespace
+
+generic_factory<character_modifier> &cata::lua_platform::detail::character_modifier_registry()
+{
+    return character_modifier_factory;
+}
 
 /** @relates string_id */
 template<>
@@ -370,6 +378,11 @@ static float call_builtin( const std::string &builtin, const Character &c, const
 // for straight limb_score: nominator == 0, subtractor == 0, max_val == 0, min_val == 0
 float character_modifier::modifier( const Character &c, const skill_id &skill ) const
 {
+    if( const std::optional<double> lua_result =
+            cata::lua_platform::invoke_character_modifier_handler(
+                id.str(), c, skill.str() ) ) {
+        return static_cast<float>( *lua_result );
+    }
     // use builtin to calculate modifier
     if( !builtin.empty() ) {
         return call_builtin( builtin, c, skill );

--- a/src/character_modifier.h
+++ b/src/character_modifier.h
@@ -16,6 +16,11 @@ class Character;
 class JsonObject;
 template <typename T> class generic_factory;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+}
+
 struct character_modifier {
     public:
         enum mod_type {
@@ -73,6 +78,7 @@ struct character_modifier {
         std::string builtin;
         bool was_loaded = false;
         friend class generic_factory<character_modifier>;
+        friend class cata::lua_platform::content_transaction;
         friend struct mod_tracker;
 };
 

--- a/src/character_oracle.cpp
+++ b/src/character_oracle.cpp
@@ -69,6 +69,11 @@ static bool npc_within_camp( const npc &n )
 namespace behavior
 {
 
+const Creature *character_oracle_t::get_subject() const
+{
+    return subject;
+}
+
 // To avoid a local minima when the character has access to warmth in a shelter but gets cold
 // when they go outside, this method needs to only alert when travel time to known shelter
 // approaches time to freeze.

--- a/src/character_oracle.h
+++ b/src/character_oracle.h
@@ -18,6 +18,7 @@ class character_oracle_t : public oracle_t
         explicit character_oracle_t( const Character *subject ) {
             this->subject = subject;
         }
+        const Creature *get_subject() const override;
         /**
          * Predicates used by AI to determine goals.
          */

--- a/src/climbing.cpp
+++ b/src/climbing.cpp
@@ -5,6 +5,7 @@
 #include <utility>
 
 #include "cata_utility.h"
+#include "catalua_platform_content.h"
 #include "character.h"
 #include "creature_tracker.h"
 #include "debug.h"
@@ -23,6 +24,16 @@ namespace
 {
 generic_factory<climbing_aid> climbing_aid_factory( "climbing_aid" );
 } // namespace
+
+generic_factory<climbing_aid> &cata::lua_platform::detail::climbing_aid_registry()
+{
+    return climbing_aid_factory;
+}
+
+void cata::lua_platform::detail::refresh_climbing_aid_registry()
+{
+    climbing_aid::finalize_all();
+}
 
 static climbing_aid::lookup climbing_lookup;
 

--- a/src/damage.cpp
+++ b/src/damage.cpp
@@ -9,6 +9,8 @@
 
 #include "bodypart.h"
 #include "cata_utility.h"
+#include "catalua_platform_content.h"
+#include "catalua_platform_runtime.h"
 #include "creature.h"
 #include "debug.h"
 #include "dialogue.h"
@@ -36,6 +38,16 @@ generic_factory<damage_type> damage_type_factory( "damage type" );
 generic_factory<damage_info_order> damage_info_order_factory( "damage info order" );
 
 } // namespace
+
+generic_factory<damage_type> &cata::lua_platform::detail::damage_type_registry()
+{
+    return damage_type_factory;
+}
+
+generic_factory<damage_info_order> &cata::lua_platform::detail::damage_info_order_registry()
+{
+    return damage_info_order_factory;
+}
 
 /** @relates string_id */
 template<>
@@ -282,6 +294,7 @@ static void prepare_sorted_lists( std::vector<damage_info_order> &list,
 void damage_info_order::finalize_all()
 {
     damage_info_order_factory.finalize();
+    sorted_order_lists.clear();
     sorted_order_lists.emplace( info_type::NONE, damage_info_order_factory.get_all() );
     sorted_order_lists.emplace( info_type::BIO, damage_info_order_factory.get_all() );
     sorted_order_lists.emplace( info_type::PROT, damage_info_order_factory.get_all() );
@@ -294,6 +307,11 @@ void damage_info_order::finalize_all()
     prepare_sorted_lists( sorted_order_lists[info_type::PET], info_type::PET );
     prepare_sorted_lists( sorted_order_lists[info_type::MELEE], info_type::MELEE );
     prepare_sorted_lists( sorted_order_lists[info_type::ABLATE], info_type::ABLATE );
+}
+
+void cata::lua_platform::detail::refresh_damage_info_order_registry()
+{
+    damage_info_order::finalize_all();
 }
 
 void damage_info_order::finalize()
@@ -406,6 +424,7 @@ void damage_type::onhit_effects( Creature *source, Creature *target ) const
         eoc->activate_activation_only( d, "a damage type effect", "damage type effect being activated",
                                        "damage type" );
     }
+    cata::lua_platform::invoke_damage_type_handler( id.str(), "on_hit", source, target );
 }
 
 void damage_instance::ondamage_effects( Creature *source, Creature *target,
@@ -448,6 +467,8 @@ void damage_type::ondamage_effects( Creature *source, Creature *target, bodypart
         eoc->activate_activation_only( d, "a damage type effect", "damage type effect being activated",
                                        "damage type" );
     }
+    cata::lua_platform::invoke_damage_type_handler(
+        id.str(), "on_damage", source, target, bp.str(), total_damage, damage_taken );
 }
 
 //This returns the damage from this damage_instance. The damage done to the target will be reduced by their armor.

--- a/src/disease.cpp
+++ b/src/disease.cpp
@@ -1,5 +1,6 @@
 #include "disease.h"
 
+#include "catalua_platform_content.h"
 #include "debug.h"
 #include "generic_factory.h"
 
@@ -7,6 +8,11 @@ namespace
 {
 generic_factory<disease_type> disease_factory( "disease_type" );
 } // namespace
+
+generic_factory<disease_type> &cata::lua_platform::detail::disease_type_registry()
+{
+    return disease_factory;
+}
 
 template<>
 const disease_type &string_id<disease_type>::obj() const
@@ -65,4 +71,3 @@ void disease_type::check_disease_consistency()
         }
     }
 }
-

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -8,6 +8,7 @@
 
 #include "bodypart.h"
 #include "cata_assert.h"
+#include "catalua_platform_content.h"
 #include "character.h"
 #include "color.h"
 #include "debug.h"
@@ -59,6 +60,23 @@ namespace
 {
 std::map<efftype_id, effect_type> effect_types;
 } // namespace
+
+const effect_type *cata::lua_platform::detail::effect_type_registry_find(
+    const std::string &id )
+{
+    const auto found = effect_types.find( efftype_id( id ) );
+    return found == effect_types.end() ? nullptr : &found->second;
+}
+
+void cata::lua_platform::detail::effect_type_registry_set( const effect_type &value )
+{
+    effect_types[value.id] = value;
+}
+
+void cata::lua_platform::detail::effect_type_registry_erase( const std::string &id )
+{
+    effect_types.erase( efftype_id( id ) );
+}
 
 void vitamin_rate_effect::load( const JsonObject &jo )
 {

--- a/src/effect.h
+++ b/src/effect.h
@@ -28,6 +28,11 @@ class JsonObject;
 class JsonOut;
 class effect_type;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+} // namespace cata::lua_platform
+
 /** Handles the large variety of weed messages. */
 void weed_msg( Character &p );
 
@@ -106,6 +111,7 @@ class effect_type
         friend void load_effect_type( const JsonObject &jo, std::string_view src );
         friend class effect;
         friend struct mod_tracker;
+        friend class cata::lua_platform::content_transaction;
     public:
         enum class memorial_gender : int {
             male,

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -15,6 +15,7 @@
 #include "calendar.h"
 #include "cata_imgui.h"
 #include "catalua_lua_call.h"
+#include "catalua_platform_runtime.h"
 #include "cata_utility.h"
 #include "catacharset.h"
 #include "character.h"
@@ -1314,8 +1315,13 @@ float spell::spell_fail( const Character &guy ) const
                                          static_cast<float>( 45 ) );
         }
     }
-    bool has_type_fail_chance = type->magic_type.has_value() &&
-                                type->magic_type.value()->failure_chance_formula_id.has_value();
+    const std::optional<double> platform_fail_chance = type->magic_type ?
+            cata::lua_platform::invoke_magic_type_number_handler(
+                type->magic_type->str(), "failure_chance", id().str(), &guy ) :
+            std::nullopt;
+    bool has_type_fail_chance = platform_fail_chance.has_value() ||
+                                ( type->magic_type.has_value() &&
+                                  type->magic_type.value()->failure_chance_formula_id.has_value() );
     // add an if statement in here because sufficiently large numbers will definitely overflow because of exponents
     if( !has_type_fail_chance ) {
         if( ( effective_skill > 30.0f && !is_psi ) || ( psi_effective_skill > 40.0f && is_psi ) ) {
@@ -1326,7 +1332,9 @@ float spell::spell_fail( const Character &guy ) const
     }
 
     float fail_chance = 0;
-    if( has_type_fail_chance ) {
+    if( platform_fail_chance ) {
+        fail_chance = static_cast<float>( *platform_fail_chance );
+    } else if( has_type_fail_chance ) {
         const_dialogue d( get_const_talker_for( guy ), nullptr );
         d.set_value( "spell_id", id().str() );
         fail_chance = type->magic_type.value()->failure_chance_formula_id.value()->eval( d );
@@ -1793,6 +1801,11 @@ std::optional<jmath_func_id> spell_type::overall_exp_for_level_formula_id() cons
 double spell::get_failure_cost_percent( Creature &caster ) const
 {
     if( type->magic_type.has_value() ) {
+        if( const std::optional<double> value =
+                cata::lua_platform::invoke_magic_type_number_handler(
+                    type->magic_type->str(), "failure_cost", id().str(), &caster ) ) {
+            return *value;
+        }
         const_dialogue d( get_const_talker_for( caster ), nullptr );
         return type->magic_type.value()->failure_cost_percent.evaluate( d );
     } else {
@@ -1803,6 +1816,11 @@ double spell::get_failure_cost_percent( Creature &caster ) const
 double spell::get_failure_exp_percent( Creature &caster ) const
 {
     if( type->magic_type.has_value() ) {
+        if( const std::optional<double> value =
+                cata::lua_platform::invoke_magic_type_number_handler(
+                    type->magic_type->str(), "failure_experience", id().str(), &caster ) ) {
+            return *value;
+        }
         const_dialogue d( get_const_talker_for( caster ), nullptr );
         return type->magic_type.value()->failure_exp_percent.evaluate( d );
     } else {
@@ -1870,6 +1888,14 @@ std::vector<effect_on_condition_id> spell::get_failure_eoc_ids() const
     }
 }
 
+void spell::invoke_magic_type_failure( Character &caster ) const
+{
+    if( type->magic_type ) {
+        cata::lua_platform::invoke_magic_type_failure_handler(
+            type->magic_type->str(), id().str(), caster );
+    }
+}
+
 int spell::get_level() const
 {
     return type->get_level( experience );
@@ -1877,6 +1903,14 @@ int spell::get_level() const
 
 int spell_type::get_level( int experience ) const
 {
+    if( magic_type ) {
+        if( const std::optional<double> value =
+                cata::lua_platform::invoke_magic_type_number_handler(
+                    magic_type->str(), "level_for_experience", id.str(), nullptr,
+                    static_cast<double>( experience ) ) ) {
+            return std::max( static_cast<int>( std::floor( *value ) ), 0 );
+        }
+    }
     std::optional<jmath_func_id> level_formula = overall_get_level_formula_id();
 
     // you aren't at the next level unless you have the requisite xp, so floor
@@ -1967,6 +2001,14 @@ int spell_type::exp_for_level( int level ) const
     if( level == 0 ) {
         return 0;
     }
+    if( magic_type ) {
+        if( const std::optional<double> value =
+                cata::lua_platform::invoke_magic_type_number_handler(
+                    magic_type->str(), "experience_for_level", id.str(), nullptr,
+                    static_cast<double>( level ) ) ) {
+            return static_cast<int>( std::ceil( *value ) );
+        }
+    }
     std::optional<jmath_func_id> func_id = overall_exp_for_level_formula_id();
     if( func_id.has_value() ) {
         std::vector<double> params = { static_cast<double>( level ) };
@@ -2003,6 +2045,13 @@ float spell::exp_modifier( const Character &guy ) const
 
 int spell::casting_exp( const Character &guy ) const
 {
+    if( type->magic_type ) {
+        if( const std::optional<double> value =
+                cata::lua_platform::invoke_magic_type_number_handler(
+                    type->magic_type->str(), "casting_experience", id().str(), &guy ) ) {
+            return static_cast<int>( std::round( *value ) );
+        }
+    }
     if( type->magic_type.has_value() && type->magic_type.value()->casting_xp_formula_id.has_value() ) {
         const_dialogue d( get_const_talker_for( guy ), nullptr );
         d.set_value( "spell_id", id().str() );

--- a/src/magic.h
+++ b/src/magic.h
@@ -687,6 +687,7 @@ class spell
         double get_failure_exp_percent( Creature &caster ) const;
         void consume_spell_cost( Character &caster, bool cast_success = true ) const;
         std::vector<effect_on_condition_id> get_failure_eoc_ids() const;
+        void invoke_magic_type_failure( Character &caster ) const;
 
         // tries to create a field at the location specified
         void create_field( const tripoint_bub_ms &at, Creature &caster ) const;

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -12,6 +12,7 @@
 
 #include "bodypart.h"
 #include "cata_imgui.h"
+#include "catalua_platform_content.h"
 #include "cata_utility.h"
 #include "character.h"
 #include "character_attire.h"
@@ -74,6 +75,11 @@ generic_factory<ma_buff> ma_buffs( "martial art buff" );
 generic_factory<attack_vector> attack_vector_factory( "attack vector" );
 } // namespace
 
+generic_factory<attack_vector> &cata::lua_platform::detail::attack_vector_registry()
+{
+    return attack_vector_factory;
+}
+
 /** @relates string_id */
 template<>
 const attack_vector &string_id<attack_vector>::obj() const
@@ -110,6 +116,8 @@ void attack_vector::load( const JsonObject &jo, std::string_view )
     optional( jo, was_loaded, "bp_hp_limit", bp_hp_limit, 10 );
     optional( jo, was_loaded, "required_limb_flags", required_limb_flags );
     optional( jo, was_loaded, "forbidden_limb_flags", forbidden_limb_flags );
+    authored_limbs = limbs;
+    authored_contact_area = contact_area;
 }
 
 template<>
@@ -647,6 +655,35 @@ class ma_buff_effect_type : public effect_type
 };
 } // namespace
 
+void cata::lua_platform::detail::refresh_attack_vector_registry()
+{
+    attack_vector_factory.finalize();
+    for( attack_vector &vector : attack_vector_factory.get_all_mod() ) {
+        vector.limbs = vector.authored_limbs;
+        vector.contact_area = vector.authored_contact_area;
+        if( vector.strict_limb_definition ) {
+            continue;
+        }
+        std::vector<bodypart_str_id> similar_bp;
+        for( const bodypart_str_id &bp : vector.authored_limbs ) {
+            for( const bodypart_str_id &similar : bp->get_all_combined_similar_bodyparts() ) {
+                similar_bp.emplace_back( similar );
+            }
+        }
+        vector.limbs.insert( vector.limbs.end(), similar_bp.begin(), similar_bp.end() );
+
+        std::vector<sub_bodypart_str_id> similar_sbp;
+        for( const sub_bodypart_str_id &sbp : vector.authored_contact_area ) {
+            for( const sub_bodypart_str_id &similar :
+                 sbp->get_all_combined_similar_sub_bodyparts() ) {
+                similar_sbp.emplace_back( similar );
+            }
+        }
+        vector.contact_area.insert( vector.contact_area.end(), similar_sbp.begin(),
+                                    similar_sbp.end() );
+    }
+}
+
 void finalize_martial_arts()
 {
     // This adds an effect type for each ma_buff, so we can later refer to it and don't need a
@@ -657,34 +694,8 @@ void finalize_martial_arts()
         // bother us because ma_buff_effect_type does not have any members that can be sliced.
         effect_type::register_ma_buff_effect( new_eff );
     }
-    attack_vector_factory.finalize();
+    cata::lua_platform::detail::refresh_attack_vector_registry();
     ma_buffs.finalize();
-    for( const attack_vector &vector : attack_vector_factory.get_all() ) {
-        // Check if this vector allows substitutions in the first place
-        if( vector.strict_limb_definition ) {
-            continue;
-        }
-        // Add similar parts
-        // The vector needs both a limb and a contact area, so we can substitute safely
-        std::vector<bodypart_str_id> similar_bp;
-        for( const bodypart_str_id &bp : vector.limbs ) {
-            for( const bodypart_str_id &similar : bp->get_all_combined_similar_bodyparts() ) {
-                similar_bp.emplace_back( similar );
-            }
-        }
-        const_cast<attack_vector &>( vector ).limbs.insert( vector.limbs.end(), similar_bp.begin(),
-                similar_bp.end() );
-
-        std::vector<sub_bodypart_str_id> similar_sbp;
-        for( const sub_bodypart_str_id &sbp : vector.contact_area ) {
-            for( const sub_bodypart_str_id &similar : sbp->get_all_combined_similar_sub_bodyparts() ) {
-                similar_sbp.emplace_back( similar );
-            }
-        }
-
-        const_cast<attack_vector &>( vector ).contact_area.insert( vector.contact_area.end(),
-                similar_sbp.begin(), similar_sbp.end() );
-    }
 }
 
 std::string martialart_difficulty( const matype_id &mstyle )

--- a/src/martialarts.h
+++ b/src/martialarts.h
@@ -27,6 +27,11 @@ struct itype;
 template <typename T> class generic_factory;
 enum class bp_type;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+} // namespace cata::lua_platform
+
 const matec_id tec_none( "tec_none" );
 
 class weapon_category
@@ -57,6 +62,7 @@ class weapon_category
     private:
         friend class generic_factory<weapon_category>;
         friend struct mod_tracker;
+        friend class cata::lua_platform::content_transaction;
 
         weapon_category_id id;
         std::vector<std::pair<weapon_category_id, mod_id>> src;
@@ -76,10 +82,13 @@ struct attack_vector {
 
     // Explicit bodypart definitions
     std::vector<bodypart_str_id> limbs;
+    // Authored values used to rebuild substitution expansions idempotently.
+    std::vector<bodypart_str_id> authored_limbs;
     // If true no limb substitution step happens
     bool strict_limb_definition = false;
     // The actual contact area for unarmed damage calcs
     std::vector<sub_bodypart_str_id> contact_area;
+    std::vector<sub_bodypart_str_id> authored_contact_area;
     // If we have any bodypart count restrictions
     std::vector<std::pair<bp_type, int>> limb_req;
     // Do we care about armor damage bonuses

--- a/src/monfaction.cpp
+++ b/src/monfaction.cpp
@@ -7,10 +7,16 @@
 
 #include "debug.h"
 #include "debug_menu.h"
+#include "catalua_platform_content.h"
 #include "generic_factory.h"
 
 // for legacy reasons "monfaction::id" is called "name" in json
 static generic_factory<monfaction> faction_factory( "MONSTER_FACTION", "name" );
+
+generic_factory<monfaction> &cata::lua_platform::detail::monster_faction_registry()
+{
+    return faction_factory;
+}
 
 /** @relates int_id */
 template<>
@@ -149,12 +155,32 @@ void monfaction::populate_attitude_vec() const
 
 void monfaction::finalize()
 {
+    rebuild_attitude_map();
     // `detect_base_faction_cycle` detects a cycle that is formed by valid `base_faction` relations.
     // it will produce a warning if cycle is detected
     if( detect_base_faction_cycle() ) {
         // break the cycle
         base_faction = mfaction_str_id::NULL_ID();
     }
+}
+
+void monfaction::rebuild_attitude_map()
+{
+    attitude_map.clear();
+    for( const mfaction_str_id &mfac : _att_by_mood ) {
+        attitude_map[mfac] = MFA_BY_MOOD;
+    }
+    for( const mfaction_str_id &mfac : _att_neutral ) {
+        attitude_map[mfac] = MFA_NEUTRAL;
+    }
+    for( const mfaction_str_id &mfac : _att_friendly ) {
+        attitude_map[mfac] = MFA_FRIENDLY;
+    }
+    for( const mfaction_str_id &mfac : _att_hate ) {
+        attitude_map[mfac] = MFA_HATE;
+    }
+    attitude_map.emplace( id, MFA_FRIENDLY );
+    attitude_vec.clear();
 }
 
 void monfactions::finalize()
@@ -190,22 +216,7 @@ void monfaction::load( const JsonObject &jo, std::string_view )
     optional( jo, was_loaded, "friendly", _att_friendly, string_id_reader<monfaction>() );
     optional( jo, was_loaded, "hate", _att_hate, string_id_reader<monfaction>() );
 
-    attitude_map.clear();
-    for( const mfaction_str_id &mfac : _att_by_mood ) {
-        attitude_map[mfac] = MFA_BY_MOOD;
-    }
-    for( const mfaction_str_id &mfac : _att_neutral ) {
-        attitude_map[mfac] = MFA_NEUTRAL;
-    }
-    for( const mfaction_str_id &mfac : _att_friendly ) {
-        attitude_map[mfac] = MFA_FRIENDLY;
-    }
-    for( const mfaction_str_id &mfac : _att_hate ) {
-        attitude_map[mfac] = MFA_HATE;
-    }
-
-    // by default faction is friendly to itself (don't overwrite if explicitly specified)
-    attitude_map.emplace( id, MFA_FRIENDLY );
+    rebuild_attitude_map();
 }
 
 const std::vector<monfaction> &monfactions::get_all()

--- a/src/monfaction.h
+++ b/src/monfaction.h
@@ -19,6 +19,11 @@ class monfaction;
 template <typename E> struct enum_traits;
 template <typename T> class generic_factory;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+} // namespace cata::lua_platform
+
 enum mf_attitude {
     MFA_BY_MOOD = 0,    // Hostile if angry
     MFA_NEUTRAL,        // Neutral even when angry
@@ -92,6 +97,9 @@ class monfaction
         // populates attitude_vec using `attitude_rec` function
         void populate_attitude_vec() const;
 
+        /** Rebuild explicit relations before deriving inherited caches. */
+        void rebuild_attitude_map();
+
         /** Load from JSON */
         void load( const JsonObject &jo, std::string_view src );
 
@@ -99,6 +107,7 @@ class monfaction
 
         friend void monfactions::finalize();
         friend class generic_factory<monfaction>;
+        friend class cata::lua_platform::content_transaction;
 };
 
 #endif // CATA_SRC_MONFACTION_H

--- a/src/monster_oracle.cpp
+++ b/src/monster_oracle.cpp
@@ -16,6 +16,11 @@
 namespace behavior
 {
 
+const Creature *monster_oracle_t::get_subject() const
+{
+    return subject;
+}
+
 status_t monster_oracle_t::not_hallucination( std::string_view ) const
 {
     return subject->is_hallucination() ? status_t::failure : status_t::running;

--- a/src/monster_oracle.h
+++ b/src/monster_oracle.h
@@ -18,6 +18,7 @@ class monster_oracle_t : public oracle_t
         explicit monster_oracle_t( const monster *subject ) {
             this->subject = subject;
         }
+        const Creature *get_subject() const override;
         /**
          * Predicates used by AI to determine goals.
          */

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -10,6 +10,7 @@
 
 #include "cached_options.h"
 #include "calendar.h"
+#include "catalua_platform_content.h"
 #include "cata_utility.h"
 #include "color.h"
 #include "condition.h"
@@ -55,6 +56,40 @@ namespace
 {
 generic_factory<mon_flag> mon_flags( "monster flags" );
 } // namespace
+
+generic_factory<mon_flag> &cata::lua_platform::detail::monster_flag_registry()
+{
+    return mon_flags;
+}
+
+generic_factory<species_type> &cata::lua_platform::detail::species_registry()
+{
+    return *MonsterGenerator::generator().mon_species;
+}
+
+generic_factory<mtype> &cata::lua_platform::detail::monster_type_registry()
+{
+    return *MonsterGenerator::generator().mon_templates;
+}
+
+const mtype_special_attack *cata::lua_platform::detail::monster_attack_registry_find(
+    const std::string &id )
+{
+    const auto &attacks = MonsterGenerator::generator().attack_map;
+    const auto found = attacks.find( id );
+    return found == attacks.end() ? nullptr : &found->second;
+}
+
+void cata::lua_platform::detail::monster_attack_registry_set(
+    const mtype_special_attack &value )
+{
+    MonsterGenerator::generator().attack_map[value->id] = value;
+}
+
+void cata::lua_platform::detail::monster_attack_registry_erase( const std::string &id )
+{
+    MonsterGenerator::generator().attack_map.erase( id );
+}
 
 namespace behavior
 {
@@ -348,6 +383,7 @@ static void build_behavior_tree( mtype &type )
             type.add_goal( attack.first );
         } /* TODO: Make this an error once all the special attacks are migrated. */
     }
+    type.rebuild_goals();
 }
 
 void MonsterGenerator::finalize_mtypes()
@@ -477,15 +513,89 @@ void MonsterGenerator::finalize_mtypes()
         }
     }
 
+    refresh_hallucination_monsters();
+
+    // now add the fake monsters to the mon_templates
+    for( mtype &mon : extra_mtypes ) {
+        mon_templates->insert( mon );
+    }
+}
+
+void MonsterGenerator::finalize_lua_first_mtype( mtype &mon )
+{
+    mon.flags.clear();
+    for( const mon_flag_str_id &flag : mon.pre_flags_ ) {
+        mon.flags.emplace( flag );
+    }
+    apply_species_attributes( mon );
+    validate_species_ids( mon );
+    mon.size = volume_to_size( mon.volume );
+
+    mon.speed *= get_option<int>( "MONSTER_SPEED" ) / 100.0;
+    mon.hp *= get_option<int>( "MONSTER_RESILIENCE" ) / 100.0;
+    for( const monster_adjustment &adjustment : adjustments ) {
+        adjustment.apply( mon );
+    }
+
+    if( mon.bash_skill.empty() ) {
+        mon.bash_skill = calc_bash_skill( mon );
+    }
+    finalize_damage_map( mon.armor.resist_vals, true );
+
+    const float melee_damage_total = mon.melee_damage.total_damage();
+    float armor_difficulty = 3.0f;
+    for( const auto &[damage_id, value] : mon.armor.resist_vals ) {
+        if( damage_id->mon_difficulty ) {
+            armor_difficulty += value;
+        }
+    }
+    static const std::unordered_set<std::string> difficulty_exempt_attacks = {
+        "PARROT", "PARROT_AT_DANGER", "GRAZE", "EAT_CROP", "EAT_FOOD", "EAT_CARRION"
+    };
+    int special_attack_difficulty = 0;
+    for( const auto &[id, attack] : mon.special_attacks ) {
+        static_cast<void>( attack );
+        if( difficulty_exempt_attacks.count( id ) == 0 ) {
+            ++special_attack_difficulty;
+        }
+    }
+    mon.difficulty = ( mon.melee_skill + 1 ) * mon.melee_dice *
+                     ( melee_damage_total + mon.melee_sides ) * 0.04 +
+                     ( mon.sk_dodge + 1 ) * armor_difficulty * 0.04 +
+                     ( mon.get_difficulty_adjustment() + special_attack_difficulty +
+                       8 * mon.emit_fields.size() );
+    mon.difficulty *=
+        ( mon.hp + mon.speed - mon.attack_cost + ( mon.morale + mon.agro ) * 0.1 ) * 0.01 +
+        ( mon.vision_day + 2 * mon.vision_night ) * 0.01;
+    mon.difficulty = std::max( 1, mon.difficulty );
+    mon.status_chance_multiplier = std::max( 0.0f, mon.status_chance_multiplier );
+    mon.hp = std::max( mon.hp, 1 );
+
+    build_behavior_tree( mon );
+    finalize_pathfinding_settings( mon );
+    mon.mdeath_effect.has_effect = mon.mdeath_effect.sp.is_valid();
+
+    mon.weakpoints.clear();
+    for( const weakpoints_id &set : mon.weakpoints_deferred ) {
+        mon.weakpoints.add_from_set( set, true );
+    }
+    mon.weakpoints.finalize();
+}
+
+void MonsterGenerator::refresh_hallucination_monsters()
+{
+    hallucination_monsters.clear();
     for( const mtype &mon : mon_templates->get_all() ) {
         if( !mon.has_flag( mon_flag_NOT_HALLUCINATION ) ) {
             hallucination_monsters.push_back( mon.id );
         }
     }
+}
 
-    // now add the fake monsters to the mon_templates
-    for( mtype &mon : extra_mtypes ) {
-        mon_templates->insert( mon );
+void MonsterGenerator::refresh_behavior_goals()
+{
+    for( mtype &mon : mon_templates->get_all_mod() ) {
+        mon.rebuild_goals();
     }
 }
 

--- a/src/monstergenerator.h
+++ b/src/monstergenerator.h
@@ -53,6 +53,15 @@ struct species_type {
     static void finalize_all();
 };
 
+namespace cata::lua_platform::detail
+{
+generic_factory<species_type> &species_registry();
+generic_factory<mtype> &monster_type_registry();
+const mtype_special_attack *monster_attack_registry_find( const std::string &id );
+void monster_attack_registry_set( const mtype_special_attack &value );
+void monster_attack_registry_erase( const std::string &id );
+} // namespace cata::lua_platform::detail
+
 class MonsterGenerator
 {
     public:
@@ -73,6 +82,15 @@ class MonsterGenerator
 
         // combines mtype and species information, sets bitflags
         void finalize_mtypes();
+
+        /** Finalize one freshly constructed Lua-first mtype exactly once. */
+        void finalize_lua_first_mtype( mtype &mon );
+
+        /** Rebuild the derived hallucination candidate list after a transaction. */
+        void refresh_hallucination_monsters();
+
+        /** Re-resolve behavior ids after the behavior factory changes storage. */
+        void refresh_behavior_goals();
 
         mtype generate_fake_pseudo_dormant_monster( const mtype &mon );
 
@@ -110,6 +128,16 @@ class MonsterGenerator
         friend class string_id<mtype>;
         friend class string_id<species_type>;
         friend class string_id<mattack_actor>;
+        friend generic_factory<species_type> &
+        cata::lua_platform::detail::species_registry();
+        friend generic_factory<mtype> &
+        cata::lua_platform::detail::monster_type_registry();
+        friend const mtype_special_attack *
+        cata::lua_platform::detail::monster_attack_registry_find( const std::string &id );
+        friend void cata::lua_platform::detail::monster_attack_registry_set(
+            const mtype_special_attack &value );
+        friend void cata::lua_platform::detail::monster_attack_registry_erase(
+            const std::string &id );
 
         pimpl<generic_factory<mtype>> mon_templates;
         pimpl<generic_factory<species_type>> mon_species;

--- a/src/mtype.cpp
+++ b/src/mtype.cpp
@@ -563,7 +563,12 @@ void mtype::set_strategy()
 
 void mtype::add_goal( const std::string &goal_id )
 {
-    goals.add_child( &string_id<behavior::node_t>( goal_id ).obj() );
+    goals.add_child_id( goal_id );
+}
+
+void mtype::rebuild_goals()
+{
+    goals.rebuild_children();
 }
 
 const behavior::node_t *mtype::get_goals() const

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -41,6 +41,11 @@ using mon_action_defend = void ( * )( monster &, Creature *, dealt_projectile_at
 using bodytype_id = std::string;
 class JsonObject;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+} // namespace cata::lua_platform
+
 // These are triggers which may affect the monster's anger or morale.
 // They are handled in monster::check_triggers(), in monster.cpp
 enum class mon_trigger : int {
@@ -336,6 +341,7 @@ struct revive_type {
 struct mtype {
     private:
         friend class MonsterGenerator;
+        friend class cata::lua_platform::content_transaction;
 
         enum_bitset<mon_trigger> anger;
         enum_bitset<mon_trigger> fear;
@@ -610,6 +616,7 @@ struct mtype {
         std::string get_footsteps() const;
         void set_strategy();
         void add_goal( const std::string &goal_id );
+        void rebuild_goals();
         const behavior::node_t *get_goals() const;
         std::string get_difficulty_description() const;
         std::string get_size_name() const;

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -37,6 +37,11 @@ struct const_dialogue;
 struct dream;
 template <typename E> struct enum_traits;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+} // namespace cata::lua_platform
+
 extern std::vector<dream> dreams;
 extern std::map<mutation_category_id, std::vector<trait_id> > mutations_category;
 
@@ -556,6 +561,8 @@ struct mutation_category_trait {
         static void check_consistency();
 
         static void load( const JsonObject &jsobj );
+
+        friend class cata::lua_platform::content_transaction;
 };
 
 void load_mutation_type( const JsonObject &jsobj );

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "catalua_lua_call.h"
+#include "catalua_platform_content.h"
 #include "color.h"
 #include "condition.h"
 #include "debug.h"
@@ -57,6 +58,24 @@ generic_factory<mutation_branch> trait_factory( "trait" );
 std::vector<dream> dreams;
 std::map<mutation_category_id, std::vector<trait_id> > mutations_category;
 static std::map<mutation_category_id, mutation_category_trait> mutation_category_traits;
+
+const mutation_category_trait *
+cata::lua_platform::detail::mutation_category_registry_find( const std::string &id )
+{
+    const auto found = mutation_category_traits.find( mutation_category_id( id ) );
+    return found == mutation_category_traits.end() ? nullptr : &found->second;
+}
+
+void cata::lua_platform::detail::mutation_category_registry_set(
+    const mutation_category_trait &value )
+{
+    mutation_category_traits[value.id] = value;
+}
+
+void cata::lua_platform::detail::mutation_category_registry_erase( const std::string &id )
+{
+    mutation_category_traits.erase( mutation_category_id( id ) );
+}
 
 template<>
 const mutation_branch &string_id<mutation_branch>::obj() const

--- a/src/mutation_type.cpp
+++ b/src/mutation_type.cpp
@@ -1,5 +1,6 @@
 #include "mutation.h" // IWYU pragma: associated
 
+#include "catalua_platform_content.h"
 #include "flexbuffer_json.h"
 
 namespace
@@ -22,6 +23,21 @@ void load_mutation_type( const JsonObject &jsobj )
 bool mutation_type_exists( const std::string &id )
 {
     return mutation_types.find( id ) != mutation_types.end();
+}
+
+bool cata::lua_platform::detail::mutation_type_registry_contains( const std::string &id )
+{
+    return mutation_type_exists( id );
+}
+
+void cata::lua_platform::detail::mutation_type_registry_set( const std::string &id )
+{
+    mutation_types[id] = mutation_type{ id };
+}
+
+void cata::lua_platform::detail::mutation_type_registry_erase( const std::string &id )
+{
+    mutation_types.erase( id );
 }
 
 std::vector<trait_id> get_mutations_in_type( const std::string &id )

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "ammo_effect.h"
+#include "catalua_platform_runtime.h"
 #include "bodypart.h"
 #include "calendar.h"
 #include "character.h"
@@ -219,10 +220,14 @@ void apply_ammo_effects( Creature *source, const tripoint_bub_ms &p,
                 foamcrete_build( p );
             }
 
+            Creature *const impact_target = get_creature_tracker().creature_at( p );
+            cata::lua_platform::invoke_ammo_effect_handler(
+                ae.id.str(), source, impact_target, p, dealt_damage );
+
             //run EoCs
             for( const effect_on_condition_id &eoc : ae.eoc ) {
-                Creature *critter = get_creature_tracker().creature_at( p );
-                dialogue d( get_talker_for( *source ), critter == nullptr ? nullptr : get_talker_for( critter ) );
+                dialogue d( get_talker_for( *source ), impact_target == nullptr ?
+                            nullptr : get_talker_for( impact_target ) );
                 write_var_value( var_type::context, "proj_damage", &d, dealt_damage );
                 eoc->activate( d );
             }

--- a/src/subbodypart.cpp
+++ b/src/subbodypart.cpp
@@ -18,6 +18,22 @@ std::unordered_map<sub_bodypart_str_id, std::vector<sub_bodypart_str_id>>
 
 } // namespace
 
+generic_factory<sub_body_part_type> &cata::lua_platform::detail::sub_body_part_registry()
+{
+    return sub_body_part_factory;
+}
+
+void cata::lua_platform::detail::refresh_sub_body_part_similarity_cache()
+{
+    combined_similar_sub_bodyparts.clear();
+    for( const sub_body_part_type &part : sub_body_part_factory.get_all() ) {
+        if( part.similar_bodypart.has_value() ) {
+            combined_similar_sub_bodyparts[*part.similar_bodypart].emplace_back( part.id );
+            combined_similar_sub_bodyparts[part.id].emplace_back( *part.similar_bodypart );
+        }
+    }
+}
+
 /**@relates string_id*/
 template<>
 bool string_id<sub_body_part_type>::is_valid() const
@@ -123,3 +139,4 @@ std::vector<sub_bodypart_str_id> sub_body_part_type::get_all_combined_similar_su
 
     return std::vector<sub_bodypart_str_id>();
 }
+#include "catalua_platform_content.h"

--- a/src/text_snippets.cpp
+++ b/src/text_snippets.cpp
@@ -189,6 +189,8 @@ void snippet_library::clear_snippets()
     hash_to_id_migration = std::nullopt;
     snippets_by_category.clear();
     snippets_by_id.clear();
+    name_by_id.clear();
+    EOC_by_id.clear();
     // Needed by world creation etc
     reload_names( PATH_INFO::names() );
 }

--- a/src/text_snippets.h
+++ b/src/text_snippets.h
@@ -18,6 +18,11 @@ class JsonArray;
 class JsonObject;
 class cata_path;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+}
+
 class snippet_library
 {
     public:
@@ -124,6 +129,7 @@ class snippet_library
                 bool add_null_id = false );
 
     private:
+        friend class cata::lua_platform::content_transaction;
         std::unordered_map<snippet_id, translation> snippets_by_id;
         // front facing name
         std::unordered_map<snippet_id, translation> name_by_id;

--- a/src/weakpoint.cpp
+++ b/src/weakpoint.cpp
@@ -50,6 +50,11 @@ generic_factory<weakpoints> weakpoints_factory( "weakpoint sets" );
 
 } // namespace
 
+generic_factory<weakpoints> &cata::lua_platform::detail::weakpoint_set_registry()
+{
+    return weakpoints_factory;
+}
+
 /** @relates string_id */
 template<>
 const weakpoints &string_id<weakpoints>::obj() const
@@ -784,3 +789,4 @@ void weakpoints::del_from_set( const weakpoints &set )
         }
     }
 }
+#include "catalua_platform_content.h"


### PR DESCRIPTION
#### Summary

Infrastructure "Expose native creature and character catalogs"

#### Responsible human

@LYHGLYTX

#### Purpose of change

A complete Lua-native creature graph needs reversible access to effects, weakpoints, body parts, anatomy, behavior, attacks, factions, mutations, and monster factories.

#### Describe the solution

Add the native creature-content foundations and cache refresh hooks needed for safe transaction apply, finalization, replacement, and rollback. This layer contains 38 focused file-level commits.

#### Describe alternatives you've considered

Publishing JSON loaders or EOC-shaped wrappers would preserve the legacy authoring model. Keeping all 49,000 added lines in one PR would make ownership, dependency, and rollback review impractical.

#### Testing

Not run by explicit user direction. This is a draft, `implemented_unverified` stack layer; compilation, tests, formatters, `git diff --check`, and all validation/check commands remain pending approval.

#### Documentation impact

Introduces or supports native contracts documented by stack layer 14.

#### Related CCB-Docs PR

https://github.com/CrimsonCrossBunker/CCB-Docs/pull/35

#### Affected documentation IDs

architecture.lua-first-platform, architecture.lua-first-roadmap, architecture.lua-first-glossary

#### Generated reference impact

None in this layer; later layers update LuaLS declarations and exact replacement references.

#### Additional context

Stack layer 4/14. Base: `agent/lua-first-stack-03-world-content-catalogs` (PR #621). Previous: https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/pull/621. Next: `agent/lua-first-stack-05-platform-runtime`. Do not merge out of order.
