### PR TITLE
Features: add the native Lua-first Platform runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1426,14 +1426,14 @@ src/version.h: version
 src/version.cpp: src/version.h
 
 BUILTIN_MODS_HEADER := $(ODIR)/builtin_mods_generated.h
-BUILTIN_MODINFO := $(shell find data/mods -type f -name modinfo.json)
+BUILTIN_MOD_SOURCES := $(shell find data/mods -type f \( -name modinfo.json -o -name main.lua -o -name mod.lua \))
 
 .PHONY: check-builtin-mod-manifest
 check-builtin-mod-manifest:
 	mkdir -p $(dir $(BUILTIN_MODS_HEADER))
 	python3 tools/generate_builtin_mods.py --source data/mods --output $(BUILTIN_MODS_HEADER)
 
-$(BUILTIN_MODS_HEADER): tools/generate_builtin_mods.py $(BUILTIN_MODINFO) | check-builtin-mod-manifest
+$(BUILTIN_MODS_HEADER): tools/generate_builtin_mods.py $(BUILTIN_MOD_SOURCES) | check-builtin-mod-manifest
 	@:
 
 $(ODIR)/mod_manager.o: $(BUILTIN_MODS_HEADER)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,8 +89,10 @@ list(REMOVE_ITEM CATACLYSM_DDA_SOURCES ${MAIN_CPP} ${MESSAGES_CPP})
 file(GLOB CATACLYSM_DDA_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
 
 find_package(Python3 COMPONENTS Interpreter REQUIRED)
-file(GLOB_RECURSE BUILTIN_MODINFO CONFIGURE_DEPENDS
-    ${CMAKE_SOURCE_DIR}/data/mods/**/modinfo.json)
+file(GLOB_RECURSE BUILTIN_MOD_SOURCES CONFIGURE_DEPENDS
+    ${CMAKE_SOURCE_DIR}/data/mods/**/modinfo.json
+    ${CMAKE_SOURCE_DIR}/data/mods/*/main.lua
+    ${CMAKE_SOURCE_DIR}/data/mods/*/mod.lua)
 set(BUILTIN_MODS_HEADER ${CMAKE_CURRENT_BINARY_DIR}/builtin_mods_generated.h)
 execute_process(
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/generate_builtin_mods.py
@@ -106,7 +108,7 @@ add_custom_command(
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/generate_builtin_mods.py
                 --source ${CMAKE_SOURCE_DIR}/data/mods
                 --output ${BUILTIN_MODS_HEADER}
-        DEPENDS ${CMAKE_SOURCE_DIR}/tools/generate_builtin_mods.py ${BUILTIN_MODINFO}
+        DEPENDS ${CMAKE_SOURCE_DIR}/tools/generate_builtin_mods.py ${BUILTIN_MOD_SOURCES}
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         VERBATIM)
 add_custom_target(builtin_mod_manifest DEPENDS ${BUILTIN_MODS_HEADER})

--- a/src/catalua_platform.cpp
+++ b/src/catalua_platform.cpp
@@ -1,0 +1,720 @@
+#include "catalua_platform.h"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdint>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <set>
+#include <sstream>
+#include <stdexcept>
+#include <string_view>
+#include <system_error>
+#include <utility>
+
+#include "debug.h"
+
+#if defined(CATA_ENABLE_LUA_UI) && CATA_ENABLE_LUA_UI
+
+#include "catalua_platform_runtime.h"
+#include "catalua_sol.h"
+
+namespace cata::lua_platform
+{
+
+namespace
+{
+
+namespace fs = std::filesystem;
+
+struct runtime_state {
+    std::string id;
+    fs::path root;
+    fs::path entry;
+    std::unique_ptr<sol::state> lua;
+    std::shared_ptr<runtime> platform;
+};
+
+std::vector<runtime_state> active_states;
+std::vector<runtime_state> prepared_states;
+bool candidate_is_prepared = false;
+bool candidate_content_is_applied = false;
+bool candidate_content_is_finalized = false;
+std::size_t generation_counter = 0;
+
+bool path_is_within( const fs::path &path, const fs::path &directory )
+{
+    auto path_it = path.begin();
+    auto directory_it = directory.begin();
+    while( directory_it != directory.end() ) {
+        if( path_it == path.end() || *path_it != *directory_it ) {
+            return false;
+        }
+        ++path_it;
+        ++directory_it;
+    }
+    return true;
+}
+
+bool is_safe_module_name( const std::string_view name )
+{
+    if( name.empty() || name.size() > 256 || name.front() == '.' ||
+        name.back() == '.' || name.find( ".." ) != std::string_view::npos ) {
+        return false;
+    }
+    return std::all_of( name.begin(), name.end(), []( const unsigned char value ) {
+        return std::isalnum( value ) != 0 || value == '_' || value == '-' || value == '.';
+    } );
+}
+
+std::optional<fs::path> resolve_local_module( const fs::path &root,
+        const std::string &module_name )
+{
+    if( !is_safe_module_name( module_name ) ) {
+        return std::nullopt;
+    }
+    std::string relative = module_name;
+    std::replace( relative.begin(), relative.end(), '.',
+                  static_cast<char>( fs::path::preferred_separator ) );
+    const std::array<fs::path, 2> candidates = {
+        root / ( relative + ".lua" ),
+        root / relative / "init.lua"
+    };
+    for( const fs::path &candidate : candidates ) {
+        std::error_code filesystem_error;
+        const fs::path canonical_candidate = fs::canonical( candidate, filesystem_error );
+        if( !filesystem_error && path_is_within( canonical_candidate, root ) &&
+            fs::is_regular_file( canonical_candidate, filesystem_error ) && !filesystem_error ) {
+            return canonical_candidate;
+        }
+    }
+    return std::nullopt;
+}
+
+mod_source resolve_source( const mod_source &source )
+{
+    if( source.id.empty() || source.id.size() > 256 ||
+        source.id.find( '#' ) != std::string::npos ||
+        source.id.find( '\0' ) != std::string::npos ) {
+        throw std::runtime_error( "Invalid Lua-first Mod id '" + source.id + "'" );
+    }
+
+    std::error_code filesystem_error;
+    const fs::path root = fs::canonical( source.root, filesystem_error );
+    if( filesystem_error || !fs::is_directory( root, filesystem_error ) || filesystem_error ) {
+        throw std::runtime_error( "Cannot resolve Lua-first Mod root for '" + source.id + "'" );
+    }
+    const fs::path requested_entry = source.entry.is_absolute() ? source.entry :
+                                     root / source.entry;
+    const fs::path entry = fs::canonical( requested_entry, filesystem_error );
+    if( filesystem_error || !path_is_within( entry, root ) ) {
+        throw std::runtime_error( "Lua-first Mod entry for '" + source.id +
+                                  "' escapes its root or cannot be resolved" );
+    }
+    if( !fs::is_regular_file( entry, filesystem_error ) || filesystem_error ) {
+        throw std::runtime_error( "Lua-first Mod entry for '" + source.id +
+                                  "' is not a regular file" );
+    }
+    return { source.id, root, entry };
+}
+
+template<typename T>
+void set_optional_field( const sol::table &values, const char *key, T &field, bool &was_set )
+{
+    const sol::object value = values.raw_get<sol::object>( key );
+    if( !value.valid() || value.get_type() == sol::type::nil ) {
+        return;
+    }
+    field = value.as<T>();
+    was_set = true;
+}
+
+std::vector<std::string> dependency_array( const sol::table &values )
+{
+    constexpr std::size_t maximum_dependencies = 256;
+    const std::size_t count = values.size();
+    if( count > maximum_dependencies ) {
+        throw std::runtime_error( "ModDefinition dependencies exceed 256 entries" );
+    }
+    std::size_t observed = 0;
+    for( const auto &entry : values ) {
+        const sol::object key = entry.first;
+        if( !key.is<lua_Integer>() ) {
+            throw std::runtime_error(
+                "ModDefinition dependencies must be a dense array" );
+        }
+        const lua_Integer index = key.as<lua_Integer>();
+        if( index < 1 || static_cast<std::uint64_t>( index ) > count ) {
+            throw std::runtime_error(
+                "ModDefinition dependencies must be a dense array" );
+        }
+        ++observed;
+    }
+    if( observed != count ) {
+        throw std::runtime_error(
+            "ModDefinition dependencies must be a dense array" );
+    }
+    std::vector<std::string> result;
+    result.reserve( count );
+    for( std::size_t index = 1; index <= count; ++index ) {
+        const sol::object entry = values.raw_get<sol::object>( index );
+        if( entry.get_type() != sol::type::string ) {
+            throw std::runtime_error(
+                "ModDefinition dependencies may only contain strings" );
+        }
+        result.push_back( entry.as<std::string>() );
+    }
+    return result;
+}
+
+mod_definition make_mod_definition( const sol::table &values )
+{
+    mod_definition result;
+    set_optional_field( values, "id", result.id, result.id_set );
+    set_optional_field( values, "name", result.name, result.name_set );
+    set_optional_field( values, "version", result.version, result.version_set );
+    set_optional_field( values, "entry", result.entry, result.entry_set );
+    set_optional_field( values, "core", result.core, result.core_set );
+    const sol::object dependencies = values.raw_get<sol::object>( "dependencies" );
+    if( dependencies.valid() && dependencies.get_type() != sol::type::nil ) {
+        if( dependencies.get_type() != sol::type::table ) {
+            throw std::runtime_error(
+                "ModDefinition dependencies must be a dense array" );
+        }
+        result.dependencies = dependency_array( dependencies.as<sol::table>() );
+        result.dependencies_set = true;
+    }
+    return result;
+}
+
+void install_mod_definition( sol::table &ccb )
+{
+    ccb.new_usertype<mod_definition>(
+        "ModDefinition",
+        sol::factories( []( const sol::table & values ) {
+            return make_mod_definition( values );
+        } ),
+        "id", sol::property(
+    []( const mod_definition & definition ) {
+        return definition.id;
+    },
+    []( mod_definition & definition, std::string value ) {
+        definition.id = std::move( value );
+        definition.id_set = true;
+    } ),
+    "name", sol::property(
+    []( const mod_definition & definition ) {
+        return definition.name;
+    },
+    []( mod_definition & definition, std::string value ) {
+        definition.name = std::move( value );
+        definition.name_set = true;
+    } ),
+    "version", sol::property(
+    []( const mod_definition & definition ) {
+        return definition.version;
+    },
+    []( mod_definition & definition, std::string value ) {
+        definition.version = std::move( value );
+        definition.version_set = true;
+    } ),
+    "entry", sol::property(
+    []( const mod_definition & definition ) {
+        return definition.entry;
+    },
+    []( mod_definition & definition, std::string value ) {
+        definition.entry = std::move( value );
+        definition.entry_set = true;
+    } ),
+    "dependencies", sol::property(
+    []( const mod_definition & definition ) {
+        return definition.dependencies;
+    },
+    []( mod_definition & definition, const sol::table & value ) {
+        definition.dependencies = dependency_array( value );
+        definition.dependencies_set = true;
+    } ),
+    "core", sol::property(
+    []( const mod_definition & definition ) {
+        return definition.core;
+    },
+    []( mod_definition & definition, bool value ) {
+        definition.core = value;
+        definition.core_set = true;
+    } ) );
+}
+
+sol::protected_function_result execute_file( sol::state &lua, const fs::path &path )
+{
+    sol::load_result loaded = lua.load_file( path.string() );
+    if( !loaded.valid() ) {
+        const sol::error error = loaded;
+        throw std::runtime_error( path.string() + ": " + error.what() );
+    }
+    sol::protected_function script = loaded;
+    sol::protected_function_result result = script();
+    if( !result.valid() ) {
+        const sol::error error = result;
+        throw std::runtime_error( path.string() + ": " + error.what() );
+    }
+    return result;
+}
+
+sol::object require_local_module( sol::state &lua, const fs::path &root,
+                                  const std::string &module_name )
+{
+    sol::table package = lua["package"];
+    sol::table loaded_modules = package["loaded"];
+    const sol::object cached = loaded_modules.raw_get<sol::object>( module_name );
+    if( cached.valid() && cached.get_type() != sol::type::nil &&
+        ( !cached.is<bool>() || cached.as<bool>() ) ) {
+        return cached;
+    }
+    if( !is_safe_module_name( module_name ) ) {
+        throw std::runtime_error( "invalid local module name '" + module_name + "'" );
+    }
+    const std::optional<fs::path> path = resolve_local_module( root, module_name );
+    if( !path ) {
+        throw std::runtime_error( "module '" + module_name +
+                                  "' was not found inside the Mod root" );
+    }
+
+    // Match Lua require's recursive-load behavior while keeping resolution
+    // independent from author-mutated package.path/searchers.
+    loaded_modules[module_name] = true;
+    try {
+        sol::protected_function_result execution = execute_file( lua, *path );
+        sol::object exported = loaded_modules.raw_get<sol::object>( module_name );
+        if( execution.return_count() > 0 && execution.get_type() != sol::type::nil ) {
+            exported = execution.get<sol::object>();
+        } else if( !exported.valid() || exported.get_type() == sol::type::nil ) {
+            exported = sol::make_object( lua, true );
+        }
+        loaded_modules[module_name] = exported;
+        return exported;
+    } catch( ... ) {
+        loaded_modules[module_name] = sol::make_object( lua, sol::lua_nil );
+        throw;
+    }
+}
+
+void initialize_state( sol::state &lua, const fs::path &requested_root,
+                       const std::shared_ptr<runtime> &platform = nullptr )
+{
+    // Platform Mods are trusted extensions, not v5 capability-sandboxed scripts.
+    lua.open_libraries();
+
+    std::error_code filesystem_error;
+    const fs::path root = fs::canonical( requested_root, filesystem_error );
+    if( filesystem_error || !fs::is_directory( root, filesystem_error ) || filesystem_error ) {
+        throw std::runtime_error( "Cannot resolve Lua-first Mod root '" +
+                                  requested_root.generic_u8string() + "'" );
+    }
+
+    sol::table ccb = lua.create_table();
+    ccb["platform_version"] = platform_version;
+    install_mod_definition( ccb );
+    if( platform ) {
+        install_runtime_api( platform, lua, ccb );
+    }
+
+    sol::table package = lua["package"];
+    sol::table loaded = package["loaded"];
+    loaded["ccb"] = ccb;
+
+    package["path"] = ( root / "?.lua" ).generic_u8string() + ";" +
+                      ( root / "?" / "init.lua" ).generic_u8string();
+    package["cpath"] = std::string();
+    lua.set_function( "require", [&lua, root]( const std::string &module_name ) {
+        return require_local_module( lua, root, module_name );
+    } );
+}
+
+runtime_state load_source( const mod_source &source )
+{
+    const mod_source resolved = resolve_source( source );
+    DebugLog( D_WARNING, D_MAIN )
+            << "Executing trusted Lua-first Mod entry with full process privileges: "
+            << resolved.entry.generic_u8string();
+    runtime_state result;
+    result.id = resolved.id;
+    result.root = resolved.root;
+    result.entry = resolved.entry;
+    result.lua = std::make_unique<sol::state>();
+    result.platform = make_runtime( resolved.id, generation_counter + 1,
+                                    *result.lua );
+    initialize_state( *result.lua, resolved.root, result.platform );
+    execute_file( *result.lua, resolved.entry );
+    return result;
+}
+
+} // namespace
+
+bool read_mod_definition( const fs::path &root, mod_definition &result, std::string &error )
+{
+    try {
+        std::error_code filesystem_error;
+        const fs::path canonical_root = fs::canonical( root, filesystem_error );
+        if( filesystem_error || !fs::is_directory( canonical_root, filesystem_error ) ||
+            filesystem_error ) {
+            throw std::runtime_error( "Cannot resolve Lua-first Mod root '" +
+                                      root.generic_u8string() + "'" );
+        }
+        const fs::path path = fs::canonical( canonical_root / "mod.lua", filesystem_error );
+        if( filesystem_error || !path_is_within( path, canonical_root ) ||
+            !fs::is_regular_file( path, filesystem_error ) || filesystem_error ) {
+            throw std::runtime_error( "Lua-first mod.lua escapes its Mod root or is not a regular file" );
+        }
+        DebugLog( D_WARNING, D_MAIN )
+                << "Executing trusted Lua-first Mod metadata with full process privileges: "
+                << path.generic_u8string();
+        sol::state lua;
+        initialize_state( lua, canonical_root );
+        sol::protected_function_result execution = execute_file( lua, path );
+        if( execution.return_count() != 1 ) {
+            error = path.generic_u8string() +
+                    ": expected exactly one ccb.ModDefinition return value";
+            return false;
+        }
+        sol::object value = execution.get<sol::object>();
+        if( !value.is<mod_definition>() ) {
+            error = path.generic_u8string() +
+                    ": expected a native ccb.ModDefinition return value";
+            return false;
+        }
+        result = value.as<mod_definition>();
+        error.clear();
+        return true;
+    } catch( const std::exception &exception ) {
+        error = exception.what();
+        return false;
+    }
+}
+
+bool prepare_mods( const std::vector<mod_source> &sources, std::string &error )
+{
+    discard_prepared_mods();
+    std::vector<runtime_state> candidate;
+    candidate.reserve( sources.size() );
+    try {
+        if( generation_counter == std::numeric_limits<std::size_t>::max() ) {
+            throw std::runtime_error( "Lua-first Platform generation space is exhausted" );
+        }
+        std::set<std::string> seen_ids;
+        for( const mod_source &source : sources ) {
+            if( !seen_ids.insert( source.id ).second ) {
+                throw std::runtime_error( "Duplicate Lua-first Mod id '" + source.id + "'" );
+            }
+            candidate.push_back( load_source( source ) );
+            if( !validate_runtime( candidate.back().platform, false, error ) ) {
+                throw std::runtime_error( error );
+            }
+        }
+    } catch( const std::exception &exception ) {
+        error = exception.what();
+        return false;
+    }
+    prepared_states = std::move( candidate );
+    candidate_is_prepared = true;
+    candidate_content_is_applied = false;
+    candidate_content_is_finalized = false;
+    error.clear();
+    return true;
+}
+
+bool apply_prepared_content( std::string &error )
+{
+    if( !candidate_is_prepared ) {
+        error = "No Lua-first Platform candidate is prepared";
+        return false;
+    }
+    if( candidate_content_is_applied ) {
+        error.clear();
+        return true;
+    }
+    std::vector<std::shared_ptr<runtime>> applied;
+    for( runtime_state &state : prepared_states ) {
+        if( !validate_runtime( state.platform, true, error ) ||
+            !apply_runtime_content( state.platform, error ) ) {
+            for( auto it = applied.rbegin(); it != applied.rend(); ++it ) {
+                rollback_runtime_content( *it );
+            }
+            return false;
+        }
+        applied.push_back( state.platform );
+    }
+    candidate_content_is_applied = true;
+    candidate_content_is_finalized = false;
+    error.clear();
+    return true;
+}
+
+bool validate_finalized_prepared_content( std::string &error )
+{
+    if( !candidate_is_prepared || !candidate_content_is_applied ) {
+        error = "No applied Lua-first Platform candidate is prepared";
+        return false;
+    }
+    for( const runtime_state &state : prepared_states ) {
+        if( !validate_finalized_runtime_content( state.platform, error ) ) {
+            return false;
+        }
+    }
+    candidate_content_is_finalized = true;
+    error.clear();
+    return true;
+}
+
+void commit_prepared_mods()
+{
+    if( !candidate_is_prepared ) {
+        return;
+    }
+    if( !candidate_content_is_applied ) {
+        std::string error;
+        if( !apply_prepared_content( error ) ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Cannot commit Lua-first Platform candidate: " << error;
+            discard_prepared_mods();
+            return;
+        }
+    }
+    if( !candidate_content_is_finalized ) {
+        DebugLog( D_ERROR, D_MAIN )
+                << "Cannot commit Lua-first Platform candidate before global finalization validation";
+        discard_prepared_mods();
+        return;
+    }
+    clear_active_runtimes();
+    for( const runtime_state &state : prepared_states ) {
+        commit_runtime( state.platform );
+    }
+    active_states = std::move( prepared_states );
+    std::vector<std::shared_ptr<runtime>> active;
+    active.reserve( active_states.size() );
+    for( const runtime_state &state : active_states ) {
+        active.push_back( state.platform );
+    }
+    set_active_runtimes( active );
+    ++generation_counter;
+    prepared_states.clear();
+    candidate_is_prepared = false;
+    candidate_content_is_applied = false;
+    candidate_content_is_finalized = false;
+}
+
+void discard_prepared_mods()
+{
+    for( auto it = prepared_states.rbegin(); it != prepared_states.rend(); ++it ) {
+        discard_runtime( it->platform );
+    }
+    prepared_states.clear();
+    candidate_is_prepared = false;
+    candidate_content_is_applied = false;
+    candidate_content_is_finalized = false;
+}
+
+bool validate_mods( const std::vector<mod_source> &sources, std::string &error )
+{
+    const bool valid = prepare_mods( sources, error );
+    discard_prepared_mods();
+    return valid;
+}
+
+void shutdown()
+{
+    discard_prepared_mods();
+    clear_active_runtimes();
+    active_states.clear();
+}
+
+std::vector<std::string> loaded_mod_ids()
+{
+    std::vector<std::string> result;
+    result.reserve( active_states.size() );
+    std::transform( active_states.begin(), active_states.end(), std::back_inserter( result ),
+    []( const runtime_state & state ) {
+        return state.id;
+    } );
+    return result;
+}
+
+std::string prepared_content_fingerprint()
+{
+    std::ostringstream joined;
+    for( const runtime_state &state : prepared_states ) {
+        joined << state.id.size() << ':' << state.id << ':'
+               << runtime_fingerprint( state.platform ) << ';';
+    }
+    return joined.str();
+}
+
+bool reload_active_mods( std::string &error )
+{
+    if( active_states.empty() ) {
+        error.clear();
+        return true;
+    }
+
+    std::ostringstream active_fingerprint;
+    std::vector<mod_source> sources;
+    sources.reserve( active_states.size() );
+    for( const runtime_state &state : active_states ) {
+        active_fingerprint << state.id.size() << ':' << state.id << ':'
+                           << runtime_fingerprint( state.platform ) << ';';
+        sources.push_back( { state.id, state.root, state.entry } );
+    }
+
+    if( !prepare_mods( sources, error ) ) {
+        return false;
+    }
+    if( prepared_content_fingerprint() != active_fingerprint.str() ) {
+        discard_prepared_mods();
+        error = "requires_full_data_reload: Lua-first static content changed";
+        return false;
+    }
+
+    std::vector<std::shared_ptr<runtime>> replacement;
+    replacement.reserve( prepared_states.size() );
+    for( const runtime_state &state : prepared_states ) {
+        seal_runtime_content( state.platform );
+        replacement.push_back( state.platform );
+    }
+    hot_swap_active_runtimes( replacement );
+    active_states = std::move( prepared_states );
+    ++generation_counter;
+    prepared_states.clear();
+    candidate_is_prepared = false;
+    candidate_content_is_applied = false;
+    candidate_content_is_finalized = false;
+    error.clear();
+    return true;
+}
+
+void on_world_ready( bool new_game )
+{
+    runtime_world_ready( new_game );
+}
+
+void before_save()
+{
+    runtime_before_save();
+}
+
+bool save_persistent_state( std::string &error )
+{
+    return runtime_save( error );
+}
+
+void after_save( bool success, const std::string &error )
+{
+    runtime_after_save( success, error );
+}
+
+void on_turn()
+{
+    runtime_process_tasks();
+}
+
+} // namespace cata::lua_platform
+
+#else // CATA_ENABLE_LUA_UI
+
+namespace cata::lua_platform
+{
+
+namespace
+{
+
+constexpr const char *disabled_error = "Lua-first Platform is not enabled in this build";
+
+} // namespace
+
+bool read_mod_definition( const std::filesystem::path &, mod_definition &, std::string &error )
+{
+    error = disabled_error;
+    return false;
+}
+
+bool prepare_mods( const std::vector<mod_source> &sources, std::string &error )
+{
+    if( sources.empty() ) {
+        error.clear();
+        return true;
+    }
+    error = disabled_error;
+    return false;
+}
+
+bool apply_prepared_content( std::string &error )
+{
+    error.clear();
+    return true;
+}
+
+bool validate_finalized_prepared_content( std::string &error )
+{
+    error.clear();
+    return true;
+}
+
+void commit_prepared_mods()
+{
+}
+
+void discard_prepared_mods()
+{
+}
+
+bool validate_mods( const std::vector<mod_source> &sources, std::string &error )
+{
+    return prepare_mods( sources, error );
+}
+
+void shutdown()
+{
+}
+
+std::vector<std::string> loaded_mod_ids()
+{
+    return {};
+}
+
+std::string prepared_content_fingerprint()
+{
+    return {};
+}
+
+bool reload_active_mods( std::string &error )
+{
+    error.clear();
+    return true;
+}
+
+void on_world_ready( bool )
+{
+}
+
+void before_save()
+{
+}
+
+bool save_persistent_state( std::string &error )
+{
+    error.clear();
+    return true;
+}
+
+void after_save( bool, const std::string & )
+{
+}
+
+void on_turn()
+{
+}
+
+} // namespace cata::lua_platform
+
+#endif // CATA_ENABLE_LUA_UI

--- a/src/catalua_platform.h
+++ b/src/catalua_platform.h
@@ -1,0 +1,105 @@
+#pragma once
+#ifndef CATA_SRC_CATALUA_PLATFORM_H
+#define CATA_SRC_CATALUA_PLATFORM_H
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace cata::lua_platform
+{
+
+constexpr int platform_version = 1;
+
+constexpr bool is_enabled() noexcept
+{
+#if defined(CATA_ENABLE_LUA_UI) && CATA_ENABLE_LUA_UI
+    return true;
+#else
+    return false;
+#endif
+}
+
+/** Native metadata returned by a Platform Mod's optional mod.lua. */
+struct mod_definition {
+    std::string id;
+    std::string name;
+    std::string version;
+    std::string entry = "main.lua";
+    std::vector<std::string> dependencies;
+    bool core = false;
+
+    bool id_set = false;
+    bool name_set = false;
+    bool version_set = false;
+    bool entry_set = false;
+    bool dependencies_set = false;
+    bool core_set = false;
+};
+
+/** A resolved Platform source.  Paths must already be confined to root. */
+struct mod_source {
+    std::string id;
+    std::filesystem::path root;
+    std::filesystem::path entry;
+};
+
+/** Execute root/mod.lua and require exactly one native ccb.ModDefinition result. */
+bool read_mod_definition( const std::filesystem::path &root, mod_definition &result,
+                          std::string &error );
+
+/**
+ * Execute every entry in fresh per-Mod states.  Successful states remain candidates
+ * until commit_prepared_mods() or discard_prepared_mods() is called.
+ */
+bool prepare_mods( const std::vector<mod_source> &sources, std::string &error );
+
+/** Validate and inject every prepared native definition before global finalization. */
+bool apply_prepared_content( std::string &error );
+
+/** Confirm global finalization retained every prepared native definition. */
+bool validate_finalized_prepared_content( std::string &error );
+
+/** Replace the active Platform states with the last completely prepared candidate. */
+void commit_prepared_mods();
+
+/** Drop the last candidate without changing the active Platform states. */
+void discard_prepared_mods();
+
+/** Execute entries in isolated candidate states and always discard them. */
+bool validate_mods( const std::vector<mod_source> &sources, std::string &error );
+
+/** Destroy active and candidate states. */
+void shutdown();
+
+/** IDs whose entry states are currently active, in dependency/load order. */
+std::vector<std::string> loaded_mod_ids();
+
+/** Deterministic fingerprint of the currently prepared static definitions. */
+std::string prepared_content_fingerprint();
+
+/**
+ * Re-execute active entries and swap runtime registrations only when their
+ * static content fingerprint is unchanged.  A changed fingerprint returns
+ * false with `requires_full_data_reload` in @p error.
+ */
+bool reload_active_mods( std::string &error );
+
+/** Activate world-bound services and load engine-owned Platform sidecars. */
+void on_world_ready( bool new_game );
+
+/** Dispatch the synchronous pre-save lifecycle hook. */
+void before_save();
+
+/** Persist Platform character/world state and named tasks. */
+bool save_persistent_state( std::string &error );
+
+/** Report the final save outcome to lifecycle subscribers. */
+void after_save( bool success, const std::string &error );
+
+/** Run due named persistent tasks at the current game turn. */
+void on_turn();
+
+} // namespace cata::lua_platform
+
+#endif // CATA_SRC_CATALUA_PLATFORM_H

--- a/src/catalua_platform_content.h
+++ b/src/catalua_platform_content.h
@@ -1,0 +1,199 @@
+#pragma once
+#ifndef CATA_SRC_CATALUA_PLATFORM_CONTENT_H
+#define CATA_SRC_CATALUA_PLATFORM_CONTENT_H
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+template<typename T>
+class generic_factory;
+
+class ascii_art;
+struct add_type;
+struct character_modifier;
+struct attack_vector;
+class bash_damage_profile;
+class anatomy;
+struct body_part_type;
+struct bodygraph;
+struct clothing_mod;
+struct damage_type;
+struct damage_info_order;
+struct construction_category;
+struct construction_group;
+struct connect_group;
+struct crafting_category;
+class disease_type;
+class emit;
+class effect_type;
+class fault_group;
+class harvest_drop_type;
+class harvest_list;
+class item_category;
+class json_flag;
+struct map_extra_collection;
+class material_type;
+class mattack_actor;
+class monfaction;
+struct mtype;
+struct mtype_special_attack;
+struct mon_flag;
+struct mutation_category_trait;
+class mood_face;
+class move_mode;
+class overmap_land_use_code;
+struct overmap_location;
+class oter_vision;
+struct limb_score;
+class magic_type;
+class proficiency;
+struct proficiency_category;
+struct profession_group;
+struct quality;
+class scent_type;
+class score;
+class start_location;
+class climbing_aid;
+class speed_description;
+class vitamin;
+class vpart_category;
+class vpart_location;
+class weapon_category;
+class zone_type;
+struct weather_type;
+struct end_screen;
+class morale_type_data;
+class VehicleGroup;
+struct species_type;
+struct sub_body_part_type;
+struct weakpoints;
+
+namespace behavior
+{
+class node_t;
+} // namespace behavior
+
+namespace cata::lua_platform::detail
+{
+
+/** Internal native registries used by the Lua-first content transaction. */
+generic_factory<ascii_art> &ascii_art_registry();
+generic_factory<add_type> &addiction_type_registry();
+generic_factory<character_modifier> &character_modifier_registry();
+generic_factory<start_location> &start_location_registry();
+generic_factory<climbing_aid> &climbing_aid_registry();
+void refresh_climbing_aid_registry();
+generic_factory<weather_type> &weather_type_registry();
+generic_factory<end_screen> &end_screen_registry();
+generic_factory<attack_vector> &attack_vector_registry();
+void refresh_attack_vector_registry();
+generic_factory<magic_type> &magic_type_registry();
+generic_factory<bash_damage_profile> &bash_damage_profile_registry();
+generic_factory<clothing_mod> &clothing_mod_registry();
+void refresh_clothing_mod_registry_cache();
+generic_factory<overmap_land_use_code> &overmap_land_use_code_registry();
+generic_factory<oter_vision> &overmap_vision_registry();
+generic_factory<overmap_location> &overmap_location_registry();
+generic_factory<profession_group> &profession_group_registry();
+generic_factory<map_extra_collection> &map_extra_collection_registry();
+generic_factory<fault_group> &fault_group_registry();
+generic_factory<quality> &tool_quality_registry();
+generic_factory<vitamin> &vitamin_registry();
+generic_factory<material_type> &material_registry();
+generic_factory<damage_type> &damage_type_registry();
+generic_factory<damage_info_order> &damage_info_order_registry();
+void refresh_damage_info_order_registry();
+generic_factory<json_flag> &json_flag_registry();
+generic_factory<item_category> &item_category_registry();
+generic_factory<crafting_category> &crafting_category_registry();
+generic_factory<weapon_category> &weapon_category_registry();
+generic_factory<proficiency_category> &proficiency_category_registry();
+generic_factory<proficiency> &proficiency_registry();
+generic_factory<scent_type> &scent_type_registry();
+generic_factory<score> &score_registry();
+generic_factory<speed_description> &speed_description_registry();
+generic_factory<harvest_drop_type> &harvest_drop_type_registry();
+generic_factory<harvest_list> &harvest_list_registry();
+generic_factory<behavior::node_t> &behavior_registry();
+generic_factory<weakpoints> &weakpoint_set_registry();
+generic_factory<body_part_type> &body_part_registry();
+void refresh_body_part_similarity_cache();
+generic_factory<sub_body_part_type> &sub_body_part_registry();
+void refresh_sub_body_part_similarity_cache();
+generic_factory<anatomy> &anatomy_registry();
+generic_factory<bodygraph> &bodygraph_registry();
+generic_factory<morale_type_data> &morale_type_registry();
+generic_factory<move_mode> &movement_mode_registry();
+void refresh_movement_mode_registry();
+generic_factory<zone_type> &zone_type_registry();
+generic_factory<disease_type> &disease_type_registry();
+generic_factory<mon_flag> &monster_flag_registry();
+generic_factory<species_type> &species_registry();
+generic_factory<mtype> &monster_type_registry();
+const mtype_special_attack *monster_attack_registry_find( const std::string &id );
+void monster_attack_registry_set( const mtype_special_attack &value );
+void monster_attack_registry_erase( const std::string &id );
+generic_factory<monfaction> &monster_faction_registry();
+const emit *emission_registry_find( const std::string &id );
+void emission_registry_set( const emit &value );
+void emission_registry_erase( const std::string &id );
+const effect_type *effect_type_registry_find( const std::string &id );
+void effect_type_registry_set( const effect_type &value );
+void effect_type_registry_erase( const std::string &id );
+generic_factory<mood_face> &mood_face_registry();
+generic_factory<limb_score> &limb_score_registry();
+generic_factory<construction_category> &construction_category_registry();
+generic_factory<construction_group> &construction_group_registry();
+const connect_group *connect_group_registry_find( const std::string &id );
+std::size_t connect_group_registry_size();
+void connect_group_registry_set( const connect_group &value );
+void connect_group_registry_erase( const std::string &id );
+const mutation_category_trait *mutation_category_registry_find( const std::string &id );
+void mutation_category_registry_set( const mutation_category_trait &value );
+void mutation_category_registry_erase( const std::string &id );
+generic_factory<vpart_location> &vehicle_part_location_registry();
+const vpart_category *vehicle_part_category_registry_find( const std::string &id );
+void vehicle_part_category_registry_set( const vpart_category &value );
+void vehicle_part_category_registry_erase( const std::string &id );
+void vehicle_part_category_registry_finalize();
+bool mutation_type_registry_contains( const std::string &id );
+void mutation_type_registry_set( const std::string &id );
+void mutation_type_registry_erase( const std::string &id );
+
+const VehicleGroup *vehicle_group_registry_find( const std::string &id );
+void vehicle_group_registry_set( const std::string &id, const VehicleGroup &value );
+void vehicle_group_registry_erase( const std::string &id );
+
+struct named_color_native_definition {
+    std::string name;
+    std::uint8_t red = 0;
+    std::uint8_t green = 0;
+    std::uint8_t blue = 0;
+    std::uint8_t alpha = 255;
+};
+
+std::vector<named_color_native_definition> named_color_registry_snapshot();
+bool named_color_registry_contains( const std::string &name );
+bool named_color_registry_color_in_use( const named_color_native_definition &value,
+                                        const std::string &except_name );
+void named_color_registry_set( const named_color_native_definition &value );
+void named_color_registry_restore(
+    const std::vector<named_color_native_definition> &snapshot );
+
+struct rotatable_symbol_native_entry {
+    std::uint32_t symbol = 0;
+    std::array<std::uint32_t, 3> rotations = {};
+};
+
+std::vector<rotatable_symbol_native_entry> rotatable_symbol_registry_snapshot();
+std::vector<std::uint32_t> rotatable_symbol_registry_group( std::uint32_t symbol );
+void rotatable_symbol_registry_set( const std::vector<std::uint32_t> &symbols );
+void rotatable_symbol_registry_restore(
+    const std::vector<rotatable_symbol_native_entry> &snapshot );
+
+} // namespace cata::lua_platform::detail
+
+#endif // CATA_SRC_CATALUA_PLATFORM_CONTENT_H

--- a/src/catalua_platform_runtime.cpp
+++ b/src/catalua_platform_runtime.cpp
@@ -1,0 +1,20153 @@
+#include "catalua_platform_runtime.h"
+
+#if defined(CATA_ENABLE_LUA_UI) && CATA_ENABLE_LUA_UI
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+#include <iomanip>
+#include <limits>
+#include <map>
+#include <random>
+#include <set>
+#include <sstream>
+#include <stdexcept>
+#include <system_error>
+#include <tuple>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <variant>
+
+#include "calendar.h"
+#include "addiction.h"
+#include "activity_actor.h"
+#include "activity_handlers.h"
+#include "activity_type.h"
+#include "ammo.h"
+#include "ammo_effect.h"
+#include "anatomy.h"
+#include "ascii_art.h"
+#include "behavior.h"
+#include "behavior_oracle.h"
+#include "behavior_strategy.h"
+#include "bodypart.h"
+#include "bodygraph.h"
+#include "butchery_requirements.h"
+#include "cata_path.h"
+#include "catacharset.h"
+#include "cata_utility.h"
+#include "cata_variant.h"
+#include "catalua_platform_content.h"
+#include "catalua_ui_state.h"
+#include "catalua_bindings_coords.h"
+#include "catalua_bindings_values.h"
+#include "catalua_game_handle.h"
+#include "catalua_ui_achievements.h"
+#include "catalua_ui_addictions.h"
+#include "catalua_ui_bionics.h"
+#include "catalua_ui_camps.h"
+#include "catalua_ui_crafting.h"
+#include "catalua_ui_creatures.h"
+#include "catalua_ui_effects.h"
+#include "catalua_ui_eocs.h"
+#include "catalua_ui_factions.h"
+#include "catalua_ui_game.h"
+#include "catalua_ui_game_info.h"
+#include "catalua_ui_hordes.h"
+#include "catalua_ui_interaction.h"
+#include "catalua_ui_items.h"
+#include "catalua_ui_magic.h"
+#include "catalua_ui_martial_arts.h"
+#include "catalua_ui_missions.h"
+#include "catalua_ui_mutations.h"
+#include "catalua_ui_needs.h"
+#include "catalua_ui_npcs.h"
+#include "catalua_ui_overmap.h"
+#include "catalua_ui_proficiencies.h"
+#include "catalua_ui_skills.h"
+#include "catalua_ui_statistics.h"
+#include "catalua_ui_time.h"
+#include "catalua_ui_vehicles.h"
+#include "catalua_ui_vitamins.h"
+#include "catalua_ui_weather.h"
+#include "catalua_ui_world.h"
+#include "catalua_ui_world_services.h"
+#include "catalua_ui_zones.h"
+#include "character.h"
+#include "character_modifier.h"
+#include "climbing.h"
+#include "clothing_mod.h"
+#include "clzones.h"
+#include "color.h"
+#include "coordinates.h"
+#include "creature.h"
+#include "construction_category.h"
+#include "construction_group.h"
+#include "crafting_gui.h"
+#include "debug.h"
+#include "disease.h"
+#include "emit.h"
+#include "effect.h"
+#include "enum_conversions.h"
+#include "end_screen.h"
+#include "event.h"
+#include "event_bus.h"
+#include "event_statistics.h"
+#include "event_subscriber.h"
+#include "explosion_light.h"
+#include "fault.h"
+#include "field_type.h"
+#include "filesystem.h"
+#include "flag.h"
+#include "flexbuffer_json.h"
+#include "generic_factory.h"
+#include "item.h"
+#include "item_group.h"
+#include "harvest.h"
+#include "help.h"
+#include "hsv_color.h"
+#include "item_category.h"
+#include "item_factory.h"
+#include "item_location.h"
+#include "itype.h"
+#include "iuse.h"
+#include "json.h"
+#include "map.h"
+#include "map_accessories.h"
+#include "mapdata.h"
+#include "map_scale_constants.h"
+#include "magic_type.h"
+#include "mattack_common.h"
+#include "material.h"
+#include "martialarts.h"
+#include "messages.h"
+#include "morale_types.h"
+#include "mood_face.h"
+#include "mod_tracker.h"
+#include "monfaction.h"
+#include "mondefense.h"
+#include "monster.h"
+#include "monstergenerator.h"
+#include "move_mode.h"
+#include "mtype.h"
+#include "mutation.h"
+#include "omdata.h"
+#include "overmap_location.h"
+#include "output.h"
+#include "overlay_ordering.h"
+#include "proficiency.h"
+#include "profession_group.h"
+#include "player_activity.h"
+#include "path_info.h"
+#include "recipe.h"
+#include "recipe_dictionary.h"
+#include "recipe_groups.h"
+#include "regional_settings.h"
+#include "requirements.h"
+#include "rotatable_symbols.h"
+#include "scent_map.h"
+#include "skill.h"
+#include "sounds.h"
+#include "speech.h"
+#include "speed_description.h"
+#include "start_location.h"
+#include "string_input_popup.h"
+#include "string_formatter.h"
+#include "subbodypart.h"
+#include "translation.h"
+#include "talker.h"
+#include "text_snippets.h"
+#include "type_id.h"
+#include "units.h"
+#include "uilist.h"
+#include "vehicle.h"
+#include "vehicle_group.h"
+#include "vehicle_part_location.h"
+#include "veh_type.h"
+#include "vitamin.h"
+#include "weather_gen.h"
+#include "weather_type.h"
+#include "weakpoint.h"
+#include "worldfactory.h"
+
+namespace cata::lua_platform
+{
+
+namespace
+{
+
+using persistent_state = cata::lua_ui::script_persistent_state;
+using persistent_value = cata::lua_ui::script_persistent_value;
+
+enum class definition_operation : int {
+    add,
+    replace,
+    edit
+};
+
+enum class handle_lifecycle : int {
+    building,
+    committed,
+    discarded
+};
+
+std::size_t require_dense_array( const sol::table &values,
+                                 const std::string_view description,
+                                 const std::size_t minimum,
+                                 const std::size_t maximum )
+{
+    const std::size_t count = values.size();
+    if( count < minimum || count > maximum ) {
+        throw std::invalid_argument( std::string( description ) +
+                                     " has an invalid number of entries" );
+    }
+    std::size_t observed = 0;
+    for( const auto &entry : values ) {
+        const sol::object key = entry.first;
+        if( !key.is<lua_Integer>() ) {
+            throw std::invalid_argument( std::string( description ) +
+                                         " must be a dense array" );
+        }
+        const lua_Integer index = key.as<lua_Integer>();
+        if( index < 1 || static_cast<std::uint64_t>( index ) > count ) {
+            throw std::invalid_argument( std::string( description ) +
+                                         " must be a dense array" );
+        }
+        ++observed;
+    }
+    if( observed != count ) {
+        throw std::invalid_argument( std::string( description ) +
+                                     " must be a dense array" );
+    }
+    return count;
+}
+
+struct owner_token {
+    std::string mod_id;
+    std::size_t generation = 0;
+    handle_lifecycle lifecycle = handle_lifecycle::building;
+};
+
+struct material_part {
+    std::string id;
+    std::int64_t portions = 1;
+};
+
+struct quality_level {
+    std::string id;
+    std::int64_t level = 1;
+};
+
+struct item_definition_data {
+    std::string id;
+    std::string name;
+    std::string description;
+    std::string symbol = "?";
+    std::int64_t mass_grams = 0;
+    std::int64_t volume_ml = 0;
+    std::int64_t price_cents = 0;
+    std::vector<material_part> materials;
+    std::vector<quality_level> qualities;
+    std::set<std::string> flags;
+    std::string use_handler;
+    std::string use_label;
+    bool registered = false;
+};
+
+struct component_requirement {
+    std::string id;
+    std::int64_t count = 1;
+};
+
+struct recipe_definition_data {
+    std::string id;
+    bool nested_category = false;
+    std::string result;
+    std::string name;
+    std::string description;
+    std::string category = "CC_MISC";
+    std::string subcategory = "CSC_MISC";
+    double activity_level = NO_EXERCISE;
+    std::set<std::string> nested_recipes;
+    std::string skill;
+    std::int64_t difficulty = 0;
+    std::int64_t time_moves = 100;
+    bool autolearn = true;
+    bool reversible = false;
+    std::vector<std::vector<component_requirement>> components;
+    std::vector<std::vector<component_requirement>> tools;
+    std::map<std::string, std::int64_t> required_skills;
+    std::map<std::string, std::int64_t> external_requirements;
+    bool registered = false;
+};
+
+struct quality_requirement_definition {
+    std::string id;
+    std::int64_t level = 1;
+    std::int64_t count = 1;
+};
+
+struct requirement_definition_data {
+    std::string id;
+    std::string name;
+    std::vector<std::vector<component_requirement>> components;
+    std::vector<std::vector<component_requirement>> tools;
+    std::vector<std::vector<quality_requirement_definition>> qualities;
+    bool registered = false;
+};
+
+struct recipe_group_terrain_data {
+    std::string overmap_terrain;
+    std::string match_type = "TYPE";
+    std::map<std::string, std::set<std::string>> parameters;
+};
+
+struct recipe_group_recipe_data {
+    std::string id;
+    std::string description;
+    std::vector<recipe_group_terrain_data> terrains;
+};
+
+struct recipe_group_definition_data {
+    std::string id;
+    std::string building_type = "NONE";
+    std::vector<recipe_group_recipe_data> recipes;
+    bool registered = false;
+};
+
+struct scent_type_definition_data {
+    std::string id;
+    std::set<std::string> receptive_species;
+    bool registered = false;
+};
+
+struct speed_description_value_data {
+    double threshold = 0.0;
+    std::vector<std::string> descriptions;
+};
+
+struct speed_description_definition_data {
+    std::string id;
+    std::vector<speed_description_value_data> values;
+    bool registered = false;
+};
+
+struct harvest_drop_type_definition_data {
+    std::string id;
+    std::vector<std::string> skills;
+    std::string field_dress_success;
+    std::string field_dress_failure;
+    std::string butcher_success;
+    std::string butcher_failure;
+    std::string dissect_success;
+    std::string dissect_failure;
+    bool item_group = false;
+    bool dissect_only = false;
+    bool registered = false;
+};
+
+struct harvest_entry_definition_data {
+    std::string output;
+    std::string category;
+    double base_minimum = 1.0;
+    double base_maximum = 1.0;
+    double skill_minimum = 0.0;
+    double skill_maximum = 0.0;
+    std::int64_t maximum = 1000;
+    double mass_ratio = 0.0;
+    std::set<std::string> flags;
+    std::set<std::string> faults;
+};
+
+struct harvest_definition_data {
+    std::string id;
+    std::string message;
+    std::string leftovers = "ruined_chunks";
+    std::string butchery_requirements = "default";
+    std::vector<harvest_entry_definition_data> entries;
+    bool registered = false;
+};
+
+struct behavior_condition_definition_data {
+    std::string policy;
+    std::string argument;
+    bool native = false;
+    bool inverted = false;
+};
+
+struct behavior_score_definition_data {
+    std::string policy;
+    std::string argument;
+    bool native = false;
+};
+
+struct behavior_definition_data {
+    std::string id;
+    std::string strategy;
+    std::string goal;
+    std::vector<std::string> children;
+    std::vector<behavior_condition_definition_data> conditions;
+    std::optional<behavior_score_definition_data> score;
+    bool registered = false;
+};
+
+struct effect_type_definition_data {
+    std::string id;
+    std::vector<std::string> names;
+    std::vector<std::string> descriptions;
+    std::vector<std::string> reduced_descriptions;
+    std::string remove_message;
+    std::string apply_memorial_log;
+    std::string remove_memorial_log;
+    std::string blood_analysis_description;
+    std::int64_t maximum_intensity = 1;
+    std::int64_t maximum_duration_turns = 31536000;
+    std::int64_t intensity_duration_turns = 0;
+    std::int64_t duration_add_percent = 100;
+    std::int64_t intensity_add_value = 0;
+    std::int64_t intensity_decay_step = -1;
+    std::int64_t intensity_decay_tick = 0;
+    bool intensity_decay_removes = false;
+    bool main_parts_only = false;
+    bool show_in_info = false;
+    bool show_intensity = true;
+    bool part_descriptions = false;
+    std::set<std::string> flags;
+    std::set<std::string> immune_character_flags;
+    std::set<std::string> immune_bodypart_flags;
+    std::set<std::string> resist_traits;
+    std::set<std::string> resist_effects;
+    std::set<std::string> removes_effects;
+    std::set<std::string> blocks_effects;
+    bool registered = false;
+};
+
+struct monster_attack_definition_data {
+    std::string id;
+    double cooldown = 1.0;
+    std::string handler;
+    bool registered = false;
+};
+
+struct weakpoint_effect_definition_data {
+    std::string effect;
+    double chance = 100.0;
+    bool permanent = false;
+    std::int64_t duration_min_turns = 0;
+    std::int64_t duration_max_turns = 0;
+    std::int64_t intensity_min = 1;
+    std::int64_t intensity_max = 1;
+    double damage_required_min = 0.0;
+    double damage_required_max = 100.0;
+    std::string message;
+};
+
+struct weakpoint_definition_data {
+    std::string id;
+    std::string name;
+    double coverage = 100.0;
+    bool good = true;
+    bool head = false;
+    std::map<std::string, double> armor_multipliers;
+    std::map<std::string, double> armor_penalties;
+    std::map<std::string, double> damage_multipliers;
+    std::map<std::string, double> critical_multipliers;
+    std::vector<weakpoint_effect_definition_data> effects;
+};
+
+struct weakpoint_set_definition_data {
+    std::string id;
+    std::vector<weakpoint_definition_data> weakpoints;
+    bool registered = false;
+};
+
+struct field_effect_definition_data {
+    std::string effect;
+    std::int64_t duration_min_turns = 0;
+    std::int64_t duration_max_turns = 0;
+    std::int64_t intensity = 1;
+    std::string body_part;
+    bool environmental = true;
+    std::string message;
+    std::string npc_message;
+};
+
+struct field_intensity_definition_data {
+    std::string name;
+    std::string symbol = "%";
+    std::string color = "white";
+    bool dangerous = false;
+    bool transparent = true;
+    std::int64_t move_cost = 0;
+    std::int64_t upgrade_chance = 0;
+    std::int64_t upgrade_duration_turns = 0;
+    double light_emitted = 0.0;
+    double local_light_override = -1.0;
+    double translucency = 0.0;
+    std::int64_t concentration = 1;
+    std::int64_t convection_temperature_modifier = 0;
+    std::int64_t scent_neutralization = 0;
+    std::vector<field_effect_definition_data> effects;
+};
+
+struct field_type_definition_data {
+    std::string id;
+    std::vector<field_intensity_definition_data> intensity_levels;
+    std::int64_t underwater_age_speedup_turns = 0;
+    std::int64_t outdoor_age_speedup_turns = 0;
+    std::int64_t decay_amount_factor = 0;
+    std::int64_t percent_spread = 0;
+    std::int64_t gas_absorption_turns = 0;
+    std::int64_t priority = 0;
+    std::int64_t half_life_turns = 0;
+    std::string phase = "null";
+    std::string description_affix = "in";
+    std::string wandering_field;
+    std::string looks_like;
+    bool splattering = false;
+    bool has_fire = false;
+    bool has_acid = false;
+    bool has_electricity = false;
+    bool has_fume = false;
+    bool moppable = false;
+    bool accelerated_decay = false;
+    bool display_items = true;
+    bool display_field = false;
+    bool linear_half_life = false;
+    bool indestructible = false;
+    bool mopsafe = false;
+    bool decrease_intensity_on_contact = false;
+    std::set<std::string> immune_monsters;
+    std::set<std::string> blocked_monsters;
+    bool registered = false;
+};
+
+struct item_group_entry_definition_data {
+    std::string id;
+    bool group = false;
+    std::int64_t probability = 100;
+    std::string variant;
+};
+
+struct item_group_definition_data {
+    std::string id;
+    std::string kind = "distribution";
+    std::int64_t with_ammo = 0;
+    std::int64_t with_magazine = 0;
+    std::vector<item_group_entry_definition_data> entries;
+    bool registered = false;
+};
+
+struct sub_body_part_definition_data {
+    std::string id;
+    std::string name;
+    std::string plural_name;
+    std::string parent;
+    std::string opposite;
+    std::string side = "both";
+    bool secondary = false;
+    std::int64_t maximum_coverage = 100;
+    std::vector<std::string> locations_under;
+    std::string similar_body_part;
+    std::map<std::string, double> unarmed_damage;
+    bool registered = false;
+};
+
+struct body_part_limb_score_definition_data {
+    double score = 0.0;
+    double maximum = 0.0;
+};
+
+struct body_part_quality_definition_data {
+    std::string id;
+    std::int64_t level = 1;
+    double disable_fraction = 0.0;
+};
+
+struct body_part_definition_data {
+    std::string id;
+    std::string name;
+    std::string plural_name;
+    std::string accusative;
+    std::string plural_accusative;
+    std::string heading;
+    std::string plural_heading;
+    std::string encumbrance_text;
+    std::string hp_bar_text;
+    std::string main_part;
+    std::string connected_to;
+    std::string opposite;
+    std::string side = "both";
+    double hit_size = 1.0;
+    double hit_difficulty = 1.0;
+    std::int64_t base_health = 60;
+    std::int64_t drench_capacity = 0;
+    bool limb = true;
+    bool vital = false;
+    std::vector<std::string> sub_parts;
+    std::map<std::string, double> limb_types;
+    std::map<std::string, double> armor;
+    std::map<std::string, double> unarmed_damage;
+    std::set<std::string> flags;
+    std::map<std::string, body_part_limb_score_definition_data> limb_scores;
+    std::vector<body_part_quality_definition_data> qualities;
+    bool registered = false;
+};
+
+struct anatomy_definition_data {
+    std::string id;
+    std::vector<std::string> parts;
+    bool registered = false;
+};
+
+struct body_graph_part_definition_data {
+    std::string symbol;
+    std::vector<std::string> body_parts;
+    std::vector<std::string> sub_body_parts;
+    std::string nested_graph;
+    std::string selected_color = "white";
+    std::string display_symbol;
+};
+
+struct body_graph_definition_data {
+    std::string id;
+    std::string parent_body_part;
+    std::string mirror;
+    std::vector<std::string> rows;
+    std::vector<std::string> fill_rows;
+    std::vector<body_graph_part_definition_data> parts;
+    std::string label_fill;
+    std::string fill_symbol = " ";
+    std::string fill_color = "white";
+    bool registered = false;
+};
+
+struct monster_damage_definition_data {
+    double amount = 0.0;
+    double armor_penetration = 0.0;
+};
+
+struct monster_attack_reference_definition_data {
+    std::string id;
+    std::optional<double> cooldown;
+};
+
+struct monster_definition_data {
+    std::string id;
+    std::string name;
+    std::string plural_name;
+    std::string description;
+    std::string symbol = "?";
+    std::string color = "white";
+    std::string looks_like;
+    std::string body_type;
+    std::string default_faction;
+    std::string harvest = "human";
+    std::string dissect;
+    std::string decay;
+    std::string speed_description = "DEFAULT";
+    std::string death_drops;
+    std::int64_t volume_ml = 62499;
+    std::int64_t weight_grams = 81499;
+    std::string phase = "solid";
+    std::int64_t difficulty_adjustment = 0;
+    std::int64_t hp = 1;
+    std::int64_t speed = 100;
+    std::int64_t aggression = 0;
+    std::int64_t morale = 0;
+    std::int64_t tracking_distance = 8;
+    std::int64_t attack_cost = 100;
+    std::int64_t melee_skill = 0;
+    std::int64_t melee_dice = 0;
+    std::int64_t melee_sides = 0;
+    std::int64_t melee_armor_penetration = 0;
+    std::int64_t dodge = 0;
+    std::int64_t vision_day = 40;
+    std::int64_t vision_night = 1;
+    std::int64_t regenerates = 0;
+    std::int64_t bleed_rate = 100;
+    double status_chance_multiplier = 1.0;
+    double luminance = 0.0;
+    bool regenerates_in_dark = false;
+    bool regenerates_morale = false;
+    bool aggressive_to_characters = true;
+    std::map<std::string, std::int64_t> materials;
+    std::set<std::string> species;
+    std::set<std::string> categories;
+    std::set<std::string> flags;
+    std::map<std::string, double> armor;
+    std::map<std::string, monster_damage_definition_data> melee_damage;
+    std::vector<monster_attack_reference_definition_data> attacks;
+    std::vector<std::string> weakpoint_sets;
+    std::map<std::string, std::int64_t> emissions;
+    std::map<std::string, std::int64_t> starting_ammo;
+    std::set<std::string> tracked_scents;
+    std::set<std::string> ignored_scents;
+    std::map<std::string, std::int64_t> regeneration_modifiers;
+    std::vector<std::string> goals;
+    std::set<std::string> anger_triggers;
+    std::set<std::string> fear_triggers;
+    std::set<std::string> placate_triggers;
+    bool registered = false;
+};
+
+class lua_monster_attack_actor final : public mattack_actor
+{
+    public:
+        lua_monster_attack_actor( std::string id_value, const double cooldown_value,
+                                  std::string owner_value, std::string handler_value ) :
+            mattack_actor( id_value ), owner_( std::move( owner_value ) ),
+            handler_( std::move( handler_value ) ) {
+            cooldown = cooldown_value;
+            was_loaded = true;
+        }
+
+        bool call( monster &attacker ) const override {
+            return invoke_monster_attack_handler(
+                       owner_, id, handler_, attacker ).value_or( false );
+        }
+
+        std::unique_ptr<mattack_actor> clone() const override {
+            return std::make_unique<lua_monster_attack_actor>( *this );
+        }
+
+        void load_internal( const JsonObject &, const std::string & ) override {}
+
+    private:
+        std::string owner_;
+        std::string handler_;
+};
+
+struct morale_type_definition_data {
+    std::string id;
+    std::string text;
+    bool permanent = false;
+    bool registered = false;
+};
+
+struct disease_type_definition_data {
+    std::string id;
+    std::string symptoms;
+    std::int64_t minimum_duration_turns = 1;
+    std::int64_t maximum_duration_turns = 1;
+    std::int64_t minimum_intensity = 1;
+    std::int64_t maximum_intensity = 1;
+    std::optional<std::int64_t> health_threshold;
+    std::set<std::string> affected_body_parts;
+    bool registered = false;
+};
+
+struct monster_flag_definition_data {
+    std::string id;
+    bool registered = false;
+};
+
+struct species_definition_data {
+    std::string id;
+    std::string description;
+    std::string footsteps = "footsteps.";
+    std::string bleeds = "fd_null";
+    std::set<std::string> flags;
+    std::set<std::string> anger;
+    std::set<std::string> fear;
+    std::set<std::string> placate;
+    bool registered = false;
+};
+
+struct emission_definition_data {
+    std::string id;
+    std::string field;
+    std::int64_t intensity = 1;
+    std::int64_t quantity = 1;
+    std::int64_t chance = 100;
+    std::string profile_handler;
+    bool registered = false;
+};
+
+struct monster_faction_definition_data {
+    std::string id;
+    std::string base;
+    std::map<std::string, std::string> attitudes;
+    bool registered = false;
+};
+
+struct mutation_type_definition_data {
+    std::string id;
+    bool registered = false;
+};
+
+struct connect_group_definition_data {
+    std::string id;
+    bool registered = false;
+};
+
+struct mutation_category_definition_data {
+    std::string id;
+    std::string name;
+    std::string threshold_mutation;
+    std::string mutagen_message;
+    std::string memorial_message = "Crossed a threshold";
+    std::string vitamin = "null";
+    std::int64_t threshold_minimum = 2200;
+    std::int64_t base_removal_chance = 100;
+    double base_removal_cost_multiplier = 3.0;
+    bool work_in_progress = false;
+    bool skip_consistency_test = false;
+    bool registered = false;
+};
+
+struct construction_category_definition_data {
+    std::string id;
+    std::string name;
+    bool registered = false;
+};
+
+struct construction_group_definition_data {
+    std::string id;
+    std::string name;
+    bool registered = false;
+};
+
+struct vehicle_part_location_definition_data {
+    std::string id;
+    std::string name;
+    std::string description;
+    std::int64_t z_order = 0;
+    std::int64_t list_order = 5;
+    bool registered = false;
+};
+
+struct mood_face_value_definition_data {
+    std::int64_t score = 0;
+    std::string face;
+};
+
+struct mood_face_definition_data {
+    std::string id;
+    std::vector<mood_face_value_definition_data> values;
+    bool registered = false;
+};
+
+struct damage_info_order_section_definition_data {
+    std::string section;
+    std::int64_t order = -1;
+    bool show_type = true;
+};
+
+struct damage_info_order_definition_data {
+    std::string id;
+    std::string display = "detailed";
+    std::string verb;
+    std::vector<damage_info_order_section_definition_data> sections;
+    bool registered = false;
+};
+
+struct vehicle_part_category_definition_data {
+    std::string id;
+    std::string name;
+    std::string short_name;
+    std::int64_t priority = 0;
+    bool registered = false;
+};
+
+struct named_color_definition_data {
+    std::string id;
+    std::string name;
+    std::int64_t red = 0;
+    std::int64_t green = 0;
+    std::int64_t blue = 0;
+    std::int64_t alpha = 255;
+    bool registered = false;
+};
+
+struct rotatable_symbol_definition_data {
+    std::string id;
+    std::string key;
+    std::vector<std::uint32_t> symbols;
+    bool registered = false;
+};
+
+struct ascii_art_definition_data {
+    std::string id;
+    std::vector<std::string> lines;
+    bool registered = false;
+};
+
+struct limb_score_definition_data {
+    std::string id;
+    std::string name;
+    bool affected_by_wounds = true;
+    bool affected_by_encumbrance = true;
+    bool registered = false;
+};
+
+struct hit_range_definition_data {
+    std::string id = "global";
+    std::vector<std::int64_t> even_good;
+    bool registered = false;
+};
+
+struct bash_damage_profile_definition_data {
+    std::string id;
+    std::map<std::string, double> factors;
+    bool registered = false;
+};
+
+struct clothing_modifier_definition_data {
+    std::string stat;
+    double amount = 0.0;
+    bool round_up = false;
+    bool per_thickness = false;
+    bool per_coverage = false;
+};
+
+struct clothing_mod_definition_data {
+    std::string id;
+    std::string flag;
+    std::string material_item;
+    std::string apply_prompt;
+    std::string remove_prompt;
+    bool restricted = false;
+    std::vector<clothing_modifier_definition_data> modifiers;
+    bool registered = false;
+};
+
+struct overmap_land_use_code_definition_data {
+    std::string id;
+    std::int64_t code = 0;
+    std::string name;
+    std::string description;
+    std::uint32_t symbol = 0;
+    std::string color = "black";
+    bool registered = false;
+};
+
+struct overmap_vision_level_definition_data {
+    std::string name;
+    std::uint32_t symbol = 0;
+    std::string color = "black";
+    std::string looks_like;
+    bool blends_adjacent = false;
+};
+
+struct overmap_vision_definition_data {
+    std::string id;
+    std::vector<overmap_vision_level_definition_data> levels;
+    bool registered = false;
+};
+
+struct overmap_location_definition_data {
+    std::string id;
+    std::vector<std::string> terrains;
+    std::vector<std::string> terrain_flags;
+    bool registered = false;
+};
+
+struct profession_group_definition_data {
+    std::string id;
+    std::vector<std::string> professions;
+    bool registered = false;
+};
+
+struct map_extra_collection_definition_data {
+    std::string id;
+    std::int64_t chance = 0;
+    std::vector<std::pair<std::string, std::int64_t>> entries;
+    bool registered = false;
+};
+
+struct vehicle_group_definition_data {
+    std::string id;
+    std::vector<std::pair<std::string, std::int64_t>> entries;
+    bool registered = false;
+};
+
+struct fault_group_definition_data {
+    std::string id;
+    std::vector<std::pair<std::string, std::int64_t>> entries;
+    bool registered = false;
+};
+
+struct explosion_light_definition_data {
+    std::string id;
+    std::vector<light_stop> stops;
+    std::string easing = "linear";
+    double wave_travel = 0.38;
+    double wave_gap = 0.25;
+    double rise = 0.05;
+    double fade = 0.1;
+    double blend = 0.05;
+    double spread_jitter = 0.07;
+    double color_jitter = 0.05;
+    double flicker = 0.18;
+    double duration_base_ms = 120.0;
+    double duration_per_tile_ms = 45.0;
+    double duration_min_ms = 150.0;
+    double duration_max_ms = 900.0;
+    double screen_shake_magnitude = 0.0;
+    double screen_shake_duration_ms = 0.0;
+    bool shockwave = false;
+    double shockwave_strength = 0.0;
+    double shockwave_speed = 1.0;
+    double shockwave_thickness = 1.5;
+    bool registered = false;
+};
+
+struct ammo_field_definition_data {
+    std::string field;
+    std::int64_t intensity_min = 1;
+    std::int64_t intensity_max = 1;
+    std::int64_t radius = 1;
+    std::int64_t height = 0;
+    std::int64_t chance = 100;
+    std::int64_t footprint = 0;
+    bool passable_only = false;
+};
+
+struct ammo_character_effect_definition_data {
+    std::string effect;
+    std::int64_t duration_turns = 1;
+    std::int64_t intensity_min = 1;
+    std::int64_t intensity_max = 1;
+    std::int64_t chance = 100;
+    std::int64_t radius = 1;
+    std::int64_t hits_min = 1;
+    std::int64_t hits_max = 1;
+    bool touch_skin = false;
+    bool all_body_parts = false;
+};
+
+struct ammo_spell_definition_data {
+    std::string spell;
+    std::int64_t level = 0;
+    bool self = false;
+};
+
+struct ammo_effect_definition_data {
+    std::string id;
+    std::int64_t trigger_chance = 100;
+    std::vector<ammo_field_definition_data> field_bursts;
+    std::vector<ammo_field_definition_data> trails;
+    std::vector<ammo_character_effect_definition_data> on_hit_effects;
+    std::vector<ammo_character_effect_definition_data> area_effects;
+    bool has_explosion = false;
+    double explosion_power = 0.0;
+    double explosion_distance_factor = 0.8;
+    std::int64_t explosion_max_noise = 90000000;
+    bool explosion_fire = false;
+    std::string explosion_light;
+    bool has_shrapnel = false;
+    std::int64_t casing_mass = 0;
+    double fragment_mass = 0.005;
+    std::int64_t fragment_recovery = 0;
+    std::string fragment_drop = "null";
+    bool flashbang = false;
+    bool emp = false;
+    bool foamcrete = false;
+    bool cast_spells_on_miss = false;
+    std::vector<ammo_spell_definition_data> spells;
+    std::string impact_handler;
+    bool registered = false;
+};
+
+struct addiction_type_definition_data {
+    std::string id;
+    std::string name;
+    std::string type_name;
+    std::string description;
+    std::string craving_morale;
+    std::string tick_handler;
+    bool registered = false;
+};
+
+struct character_modifier_definition_data {
+    std::string id;
+    std::string description;
+    std::string operation = "multiply";
+    std::string evaluator_handler;
+    bool registered = false;
+};
+
+struct start_location_target_definition_data {
+    std::string terrain;
+    std::string match = "type";
+    std::unordered_map<std::string, std::string> parameters;
+};
+
+struct start_location_definition_data {
+    std::string id;
+    std::string name;
+    std::vector<start_location_target_definition_data> targets;
+    std::set<std::string> flags;
+    std::int64_t city_size_min = 0;
+    std::int64_t city_size_max = std::numeric_limits<int>::max();
+    std::int64_t city_distance_min = 0;
+    std::int64_t city_distance_max = std::numeric_limits<int>::max();
+    std::int64_t z_min = -OVERMAP_DEPTH;
+    std::int64_t z_max = OVERMAP_HEIGHT;
+    bool registered = false;
+};
+
+struct climbing_aid_definition_data {
+    std::string id;
+    std::int64_t slip_chance_modifier = 0;
+    std::string category;
+    std::string flag;
+    std::int64_t uses = 0;
+    std::int64_t range = 1;
+    std::int64_t max_height = 1;
+    std::int64_t easy_climb_back_up = 0;
+    bool allow_remaining_height = true;
+    std::string menu_text;
+    std::string unavailable_text;
+    std::string hotkey;
+    std::string confirm_text;
+    std::string before_message;
+    std::string after_message;
+    std::int64_t pain = 0;
+    std::int64_t damage = 0;
+    std::int64_t kilocalories = 0;
+    std::int64_t thirst = 0;
+    std::string deploy_furniture;
+    bool registered = false;
+};
+
+struct weather_passive_effect_definition_data {
+    std::string effect;
+    std::int64_t minimum_duration_turns = 1;
+    std::int64_t maximum_duration_turns = 1;
+    std::int64_t intensity = 1;
+    std::string body_part;
+    bool environmental = true;
+    bool immune_in_vehicle = false;
+    bool immune_inside_vehicle = false;
+    bool immune_outside_vehicle = false;
+    std::int64_t chance_in_vehicle = 0;
+    std::int64_t chance_inside_vehicle = 0;
+    std::int64_t chance_outside_vehicle = 0;
+    std::string message;
+    std::string npc_message;
+};
+
+struct weather_type_definition_data {
+    std::string id;
+    std::string name;
+    std::string color = "white";
+    std::string map_color = "white";
+    std::string symbol = "%";
+    std::string sun_symbol = "☼";
+    std::int64_t ranged_penalty = 0;
+    double sight_penalty = 1.0;
+    std::int64_t light_modifier = 0;
+    double temperature_delta_kelvin = 0.0;
+    double light_multiplier = 1.0;
+    double sun_multiplier = 1.0;
+    std::int64_t sound_attenuation = 0;
+    bool dangerous = false;
+    std::string precipitation = "none";
+    bool rains = false;
+    std::string tiles_animation;
+    std::string sound_category = "silent";
+    std::int64_t priority = 0;
+    std::int64_t minimum_duration_turns = 300;
+    std::int64_t maximum_duration_turns = 300;
+    bool has_animation = false;
+    double animation_factor = 0.0;
+    std::string animation_color = "white";
+    std::string animation_symbol;
+    std::vector<std::string> required_weathers;
+    std::vector<weather_passive_effect_definition_data> passive_effects;
+    std::string condition_handler;
+    bool registered = false;
+};
+
+struct score_definition_data {
+    std::string id;
+    std::string statistic;
+    std::string description;
+    bool registered = false;
+};
+
+struct overlay_order_definition_data {
+    std::string id = "global";
+    std::map<std::string, std::int64_t> orders;
+    bool registered = false;
+};
+
+struct zone_type_definition_data {
+    std::string id;
+    std::string name;
+    std::string description;
+    std::string display_field;
+    bool can_be_personal = false;
+    bool hidden = false;
+    bool registered = false;
+};
+
+struct speech_pool_definition_data {
+    std::string id;
+    std::vector<std::pair<std::string, std::int64_t>> lines;
+    bool registered = false;
+};
+
+struct end_screen_definition_data {
+    std::string id;
+    std::string picture;
+    std::int64_t priority = 0;
+    std::vector<std::tuple<std::int64_t, std::int64_t, std::string>> information;
+    std::string last_words_label;
+    std::string condition_handler;
+    bool registered = false;
+};
+
+struct activity_type_definition_data {
+    std::string id;
+    std::string verb;
+    bool rooted = false;
+    bool interruptable = true;
+    bool interruptable_with_keyboard = true;
+    std::string based_on = "speed";
+    bool can_resume = true;
+    bool multi_activity = false;
+    bool fetch_items_to_zone = true;
+    bool refuel_fires = false;
+    bool auto_needs = false;
+    double activity_level = NO_EXERCISE;
+    std::set<std::string> ignored_distractions;
+    std::string do_turn_handler;
+    std::string completion_handler;
+    bool registered = false;
+};
+
+struct help_topic_definition_data {
+    std::string id;
+    std::string title;
+    std::optional<std::int64_t> order;
+    std::vector<std::string> paragraphs;
+    bool registered = false;
+};
+
+struct snippet_entry_definition_data {
+    std::string id;
+    std::string text;
+    std::string name;
+    std::int64_t weight = 1;
+    std::string examine_handler;
+};
+
+struct snippet_category_definition_data {
+    std::string id;
+    std::vector<snippet_entry_definition_data> entries;
+    bool registered = false;
+};
+
+struct playlist_definition_data {
+    std::string id;
+    bool shuffle = false;
+    std::vector<std::pair<std::string, std::int64_t>> tracks;
+    bool registered = false;
+};
+
+struct attack_vector_definition_data {
+    std::string id;
+    bool weapon = false;
+    bool strict_limbs = false;
+    bool armor_bonus = true;
+    std::int64_t encumbrance_limit = 100;
+    std::int64_t health_percent_limit = 10;
+    std::vector<std::string> limbs;
+    std::vector<std::string> contacts;
+    std::vector<std::pair<std::string, std::int64_t>> limb_requirements;
+    std::set<std::string> required_flags;
+    std::set<std::string> forbidden_flags;
+    bool registered = false;
+};
+
+struct tool_quality_definition_data {
+    std::string id;
+    std::string name;
+    std::vector<std::pair<std::int64_t, std::string>> usages;
+    bool registered = false;
+};
+
+struct skill_display_definition_data {
+    std::string id;
+    std::string label;
+    bool registered = false;
+};
+
+struct skill_definition_data {
+    std::string id;
+    std::string name;
+    std::string description;
+    std::string display_category = "none";
+    std::int64_t sort_rank = 1000000;
+    std::set<std::string> tags;
+    std::map<std::string, std::int64_t> companion_practice;
+    std::map<std::int64_t, std::string> theory_descriptions;
+    std::map<std::int64_t, std::string> practice_descriptions;
+    std::set<std::string> requires_all_traits;
+    std::set<std::string> requires_any_traits;
+    std::int64_t attack_min_time = 50;
+    std::int64_t attack_base_time = 220;
+    std::int64_t attack_reduction_per_level = 25;
+    std::int64_t companion_combat_rank_factor = 0;
+    std::int64_t companion_survival_rank_factor = 0;
+    std::int64_t companion_industry_rank_factor = 0;
+    bool teachable = true;
+    bool obsolete = false;
+    bool consumes_focus = true;
+    bool registered = false;
+};
+
+struct vitamin_definition_data {
+    std::string id;
+    std::string name;
+    std::string type = "vitamin";
+    std::string deficiency;
+    std::string excess;
+    std::int64_t minimum = 0;
+    std::int64_t maximum = 0;
+    std::int64_t rate_turns = 1;
+    std::optional<std::int64_t> weight_micrograms;
+    std::vector<std::pair<std::int64_t, std::int64_t>> disease;
+    std::vector<std::pair<std::int64_t, std::int64_t>> disease_excess;
+    std::vector<std::pair<std::string, std::int64_t>> decays_into;
+    std::set<std::string> flags;
+    bool registered = false;
+};
+
+struct json_flag_definition_data {
+    std::string id;
+    std::string info;
+    std::string restriction;
+    std::string name;
+    std::string item_prefix;
+    std::string item_suffix;
+    std::string requires_flag;
+    std::set<std::string> conflicts;
+    std::int64_t taste_modifier = 0;
+    bool inherit = true;
+    bool craft_inherit = false;
+    bool registered = false;
+};
+
+struct material_burn_definition {
+    bool immune = false;
+    std::int64_t volume_ml_per_turn = 0;
+    double fuel = 0.0;
+    double smoke = 0.0;
+    double burn = 0.0;
+};
+
+struct material_definition_data {
+    std::string id;
+    std::string name;
+    std::string salvaged_into;
+    std::string repaired_with;
+    std::string bash_damage_verb = "damages";
+    std::string cut_damage_verb = "damages";
+    std::vector<std::string> damage_adjectives = {
+        "lightly damaged", "damaged", "very damaged", "thoroughly damaged"
+    };
+    std::map<std::string, double> resistances;
+    std::map<std::string, double> vitamins;
+    std::vector<material_burn_definition> burn_data;
+    std::vector<std::pair<std::string, double>> burn_products;
+    std::int64_t chip_resistance = 0;
+    std::int64_t breathability = 0;
+    std::int64_t repair_difficulty = 10;
+    std::optional<std::int64_t> wind_resistance;
+    double density = 1.0;
+    double sheet_thickness = 0.0;
+    double specific_heat_liquid = 4.186;
+    double specific_heat_solid = 2.108;
+    double latent_heat = 334.0;
+    double freezing_point = 0.0;
+    bool rotting = false;
+    bool soft = false;
+    bool uncomfortable = false;
+    bool conductive = false;
+    bool has_fuel = false;
+    std::int64_t fuel_energy_kilojoules = 0;
+    std::string fuel_pump_terrain = "t_null";
+    bool perpetual_fuel = false;
+    std::int64_t explosion_chance_hot = 0;
+    std::int64_t explosion_chance_cold = 0;
+    double explosion_factor = 0.0;
+    bool fiery_explosion = false;
+    double fuel_size_factor = 0.0;
+    bool registered = false;
+};
+
+struct damage_type_definition_data {
+    std::string id;
+    std::string name;
+    std::string skill;
+    std::string magic_color = "black";
+    std::string derived_from;
+    std::string on_hit_handler;
+    std::string on_damage_handler;
+    double derived_factor = 0.0;
+    double bash_conversion_factor = 0.1;
+    std::set<std::string> character_immune_flags;
+    std::set<std::string> monster_immune_flags;
+    bool melee_only = false;
+    bool physical = false;
+    bool monster_difficulty = false;
+    bool no_resist = false;
+    bool edged = false;
+    bool environmental = false;
+    bool material_required = false;
+    bool registered = false;
+};
+
+struct magic_type_definition_data {
+    std::string id;
+    std::string energy_source = "none";
+    std::string vitamin;
+    std::string energy_color = "cyan";
+    std::set<std::string> cannot_cast_flags;
+    std::optional<std::string> cannot_cast_message;
+    std::optional<std::int64_t> max_book_level;
+    double failure_cost_fraction = 0.0;
+    double failure_experience_fraction = 0.2;
+    std::string level_for_experience_handler;
+    std::string experience_for_level_handler;
+    std::string casting_experience_handler;
+    std::string failure_chance_handler;
+    std::string failure_cost_handler;
+    std::string failure_experience_handler;
+    std::string failure_handler;
+    bool registered = false;
+};
+
+struct movement_mode_message_definition_data {
+    std::string steed;
+    std::string prepare;
+    std::string success;
+    std::string failure = "You feel bugs crawl over your skin.";
+};
+
+struct movement_mode_definition_data {
+    std::string id;
+    std::string name;
+    std::string kind = "walking";
+    std::uint32_t character_symbol = 0;
+    std::uint32_t panel_symbol = 0;
+    std::string panel_color = "white";
+    std::string symbol_color = "white";
+    double exertion = 1.0;
+    double riding_exertion = 0.0;
+    double stamina_multiplier = 1.0;
+    double sound_multiplier = 1.0;
+    double speed_multiplier = 1.0;
+    std::int64_t mech_power_kilojoules = 2;
+    std::int64_t swim_speed_modifier = 0;
+    bool stop_hauling = false;
+    std::vector<movement_mode_message_definition_data> messages;
+    bool registered = false;
+};
+
+struct ammunition_type_definition_data {
+    std::string id;
+    std::string name;
+    std::string default_item;
+    bool registered = false;
+};
+
+struct item_category_priority_definition {
+    std::string zone;
+    bool filthy = false;
+    std::set<std::string> flags;
+};
+
+struct item_category_definition_data {
+    std::string id;
+    std::string header;
+    std::string noun;
+    std::int64_t sort_rank = 0;
+    double spawn_rate = 1.0;
+    std::string zone;
+    std::vector<item_category_priority_definition> priority_zones;
+    bool registered = false;
+};
+
+struct crafting_category_definition_data {
+    std::string id;
+    std::vector<std::string> subcategories;
+    bool hidden = false;
+    bool practice = false;
+    bool building = false;
+    bool wildcard = false;
+    bool registered = false;
+};
+
+struct proficiency_category_definition_data {
+    std::string id;
+    std::string name;
+    std::string description;
+    bool registered = false;
+};
+
+struct proficiency_bonus_definition {
+    std::string category;
+    std::string attribute;
+    double value = 0.0;
+};
+
+struct proficiency_definition_data {
+    std::string id;
+    std::string name;
+    std::string description;
+    std::string category;
+    std::int64_t time_to_learn_turns = 35996400;
+    std::set<std::string> required;
+    std::vector<proficiency_bonus_definition> bonuses;
+    double time_multiplier = 2.0;
+    double skill_penalty = 1.0;
+    double weakpoint_bonus = 0.0;
+    double weakpoint_penalty = 0.0;
+    bool can_learn = false;
+    bool ignore_focus = false;
+    bool teachable = true;
+    bool registered = false;
+};
+
+struct weapon_category_definition_data {
+    std::string id;
+    std::string name;
+    std::vector<std::string> proficiencies;
+    bool registered = false;
+};
+
+template<typename Definition>
+void require_building_handle( const std::shared_ptr<owner_token> &token,
+                              const Definition &definition,
+                              const char *kind )
+{
+    if( !token || token->lifecycle != handle_lifecycle::building ) {
+        throw std::runtime_error( std::string( "stale " ) + kind +
+                                  " definition handle" );
+    }
+    if( definition.registered ) {
+        throw std::runtime_error( std::string( kind ) +
+                                  " definition is already registered" );
+    }
+}
+
+template<typename Definition>
+void require_readable_handle( const std::shared_ptr<owner_token> &token,
+                              const Definition &, const char *kind )
+{
+    if( !token || token->lifecycle != handle_lifecycle::building ) {
+        throw std::runtime_error( std::string( "stale " ) + kind +
+                                  " definition handle" );
+    }
+}
+
+struct item_definition_handle {
+    std::shared_ptr<item_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    item_definition_handle &mass( std::int64_t grams ) {
+        require_building_handle( token, *definition, "item" );
+        if( grams < 0 || grams > std::numeric_limits<std::int64_t>::max() / 1000 ) {
+            throw std::runtime_error( "item mass is outside the native range" );
+        }
+        definition->mass_grams = grams;
+        return *this;
+    }
+
+    item_definition_handle &volume( std::int64_t milliliters ) {
+        require_building_handle( token, *definition, "item" );
+        if( milliliters < 0 ||
+            milliliters > std::numeric_limits<units::volume::value_type>::max() ) {
+            throw std::runtime_error( "item volume is outside the native range" );
+        }
+        definition->volume_ml = milliliters;
+        return *this;
+    }
+
+    item_definition_handle &price( std::int64_t cents ) {
+        require_building_handle( token, *definition, "item" );
+        if( cents < 0 || cents > std::numeric_limits<units::money::value_type>::max() ) {
+            throw std::runtime_error( "item price is outside the native range" );
+        }
+        definition->price_cents = cents;
+        return *this;
+    }
+
+    item_definition_handle &material( const std::string &id, std::int64_t portions ) {
+        require_building_handle( token, *definition, "item" );
+        if( id.empty() || portions <= 0 || portions > std::numeric_limits<int>::max() ) {
+            throw std::runtime_error( "item material requires a non-empty id and positive portions" );
+        }
+        definition->materials.push_back( { id, portions } );
+        return *this;
+    }
+
+    item_definition_handle &quality( const std::string &id, std::int64_t level ) {
+        require_building_handle( token, *definition, "item" );
+        if( id.empty() || level <= 0 || level > std::numeric_limits<int>::max() ) {
+            throw std::runtime_error( "item quality requires a non-empty id and positive level" );
+        }
+        definition->qualities.push_back( { id, level } );
+        return *this;
+    }
+
+    item_definition_handle &flag( const std::string &id ) {
+        require_building_handle( token, *definition, "item" );
+        if( id.empty() ) {
+            throw std::runtime_error( "item flag id cannot be empty" );
+        }
+        definition->flags.insert( id );
+        return *this;
+    }
+
+    item_definition_handle &on_use( const std::string &handler,
+                                    const sol::optional<std::string> &label ) {
+        require_building_handle( token, *definition, "item" );
+        if( handler.empty() ) {
+            throw std::runtime_error( "item use handler id cannot be empty" );
+        }
+        definition->use_handler = handler;
+        definition->use_label = label.value_or( handler );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "item" );
+        return definition->id;
+    }
+};
+
+struct recipe_definition_handle {
+    std::shared_ptr<recipe_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    recipe_definition_handle &duration( std::int64_t moves ) {
+        require_building_handle( token, *definition, "recipe" );
+        if( moves <= 0 ) {
+            throw std::runtime_error( "recipe duration must be positive" );
+        }
+        definition->time_moves = moves;
+        return *this;
+    }
+
+    recipe_definition_handle &component( const std::string &id, std::int64_t count ) {
+        require_building_handle( token, *definition, "recipe" );
+        if( id.empty() || count <= 0 || count > std::numeric_limits<int>::max() ) {
+            throw std::runtime_error( "recipe component requires a non-empty id and positive count" );
+        }
+        definition->components.push_back( { { id, count } } );
+        return *this;
+    }
+
+    recipe_definition_handle &component_any( const sol::table &choices ) {
+        require_building_handle( token, *definition, "recipe" );
+        const std::size_t count = require_dense_array(
+                                      choices, "recipe component alternatives", 1, 128 );
+        std::vector<component_requirement> group;
+        group.reserve( count );
+        for( std::size_t index = 1; index <= count; ++index ) {
+            const sol::object value = choices.raw_get<sol::object>( index );
+            if( !value.is<sol::table>() ) {
+                throw std::runtime_error( "recipe component alternatives must be tables" );
+            }
+            const sol::table choice = value.as<sol::table>();
+            const std::string id = choice.get_or( "id", std::string() );
+            const std::int64_t count = choice.get_or<std::int64_t>( "count", 1 );
+            if( id.empty() || count <= 0 || count > std::numeric_limits<int>::max() ) {
+                throw std::runtime_error( "recipe component alternative requires an id and positive count" );
+            }
+            group.push_back( { id, count } );
+        }
+        definition->components.push_back( std::move( group ) );
+        return *this;
+    }
+
+    recipe_definition_handle &tool( const std::string &id, std::int64_t count ) {
+        require_building_handle( token, *definition, "recipe" );
+        if( id.empty() || count <= 0 || count > std::numeric_limits<int>::max() ) {
+            throw std::runtime_error(
+                "recipe tool requires a non-empty id and positive instance count" );
+        }
+        definition->tools.push_back( { { id, -count } } );
+        return *this;
+    }
+
+    recipe_definition_handle &tool_charges( const std::string &id, std::int64_t charges ) {
+        require_building_handle( token, *definition, "recipe" );
+        if( id.empty() || charges <= 0 || charges > std::numeric_limits<int>::max() ) {
+            throw std::runtime_error(
+                "recipe tool charges require a non-empty id and positive charge count" );
+        }
+        definition->tools.push_back( { { id, charges } } );
+        return *this;
+    }
+
+    recipe_definition_handle &tool_any( const sol::table &choices ) {
+        require_building_handle( token, *definition, "recipe" );
+        const std::size_t count = require_dense_array(
+                                      choices, "recipe tool alternatives", 1, 128 );
+        std::vector<component_requirement> group;
+        group.reserve( count );
+        for( std::size_t index = 1; index <= count; ++index ) {
+            const sol::object value = choices.raw_get<sol::object>( index );
+            if( !value.is<sol::table>() ) {
+                throw std::runtime_error( "recipe tool alternatives must be tables" );
+            }
+            const sol::table choice = value.as<sol::table>();
+            const std::string id = choice.get_or( "id", std::string() );
+            const sol::object raw_count = choice.raw_get<sol::object>( "count" );
+            const sol::object raw_charges = choice.raw_get<sol::object>( "charges" );
+            if( raw_count.valid() && raw_count.get_type() != sol::type::nil &&
+                raw_charges.valid() && raw_charges.get_type() != sol::type::nil ) {
+                throw std::runtime_error(
+                    "recipe tool alternative cannot specify both count and charges" );
+            }
+            const bool consumes_charges = raw_charges.valid() &&
+                                          raw_charges.get_type() != sol::type::nil;
+            const std::int64_t amount = consumes_charges ?
+                                        raw_charges.as<std::int64_t>() :
+                                        choice.get_or<std::int64_t>( "count", 1 );
+            if( id.empty() || amount <= 0 || amount > std::numeric_limits<int>::max() ) {
+                throw std::runtime_error(
+                    "recipe tool alternative requires an id and positive amount" );
+            }
+            group.push_back( { id, consumes_charges ? amount : -amount } );
+        }
+        definition->tools.push_back( std::move( group ) );
+        return *this;
+    }
+
+    recipe_definition_handle &requires_skill( const std::string &id, std::int64_t level ) {
+        require_building_handle( token, *definition, "recipe" );
+        if( id.empty() || level < 0 || level > MAX_SKILL ) {
+            throw std::runtime_error( "recipe skill requires a non-empty id and non-negative level" );
+        }
+        definition->required_skills[id] = level;
+        return *this;
+    }
+
+    recipe_definition_handle &requirement( const std::string &id,
+                                           std::int64_t multiplier ) {
+        require_building_handle( token, *definition, "recipe" );
+        if( id.empty() || multiplier <= 0 || multiplier > std::numeric_limits<int>::max() ) {
+            throw std::runtime_error(
+                "recipe external requirement needs a non-empty id and positive multiplier" );
+        }
+        definition->external_requirements[id] = multiplier;
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "recipe" );
+        return definition->id;
+    }
+};
+
+struct nested_recipe_category_definition_handle {
+    std::shared_ptr<recipe_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    nested_recipe_category_definition_handle &recipe( const std::string &id ) {
+        require_building_handle( token, *definition, "nested recipe category" );
+        if( id.empty() || !definition->nested_recipes.insert( id ).second ) {
+            throw std::runtime_error(
+                "nested recipe category requires unique non-empty recipe ids" );
+        }
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "nested recipe category" );
+        return definition->id;
+    }
+};
+
+struct requirement_definition_handle {
+    std::shared_ptr<requirement_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    requirement_definition_handle &component( const std::string &id, std::int64_t count ) {
+        require_building_handle( token, *definition, "requirement" );
+        if( id.empty() || count <= 0 || count > std::numeric_limits<int>::max() ) {
+            throw std::runtime_error( "requirement component needs an id and positive count" );
+        }
+        definition->components.push_back( { { id, count } } );
+        return *this;
+    }
+
+    requirement_definition_handle &component_any( const sol::table &choices ) {
+        require_building_handle( token, *definition, "requirement" );
+        const std::size_t count = require_dense_array(
+                                      choices, "requirement component alternatives", 1, 128 );
+        std::vector<component_requirement> group;
+        group.reserve( count );
+        for( std::size_t index = 1; index <= count; ++index ) {
+            const sol::table choice = choices.raw_get<sol::table>( index );
+            const std::string id = choice.get_or( "id", std::string() );
+            const std::int64_t amount = choice.get_or<std::int64_t>( "count", 1 );
+            if( id.empty() || amount <= 0 || amount > std::numeric_limits<int>::max() ) {
+                throw std::runtime_error(
+                    "requirement component alternative needs an id and positive count" );
+            }
+            group.push_back( { id, amount } );
+        }
+        definition->components.push_back( std::move( group ) );
+        return *this;
+    }
+
+    requirement_definition_handle &tool( const std::string &id, std::int64_t count ) {
+        require_building_handle( token, *definition, "requirement" );
+        if( id.empty() || count <= 0 || count > std::numeric_limits<int>::max() ) {
+            throw std::runtime_error( "requirement tool needs an id and positive count" );
+        }
+        definition->tools.push_back( { { id, -count } } );
+        return *this;
+    }
+
+    requirement_definition_handle &tool_charges( const std::string &id,
+            std::int64_t charges ) {
+        require_building_handle( token, *definition, "requirement" );
+        if( id.empty() || charges <= 0 || charges > std::numeric_limits<int>::max() ) {
+            throw std::runtime_error( "requirement tool charges need an id and positive amount" );
+        }
+        definition->tools.push_back( { { id, charges } } );
+        return *this;
+    }
+
+    requirement_definition_handle &tool_any( const sol::table &choices ) {
+        require_building_handle( token, *definition, "requirement" );
+        const std::size_t count = require_dense_array(
+                                      choices, "requirement tool alternatives", 1, 128 );
+        std::vector<component_requirement> group;
+        group.reserve( count );
+        for( std::size_t index = 1; index <= count; ++index ) {
+            const sol::table choice = choices.raw_get<sol::table>( index );
+            const std::string id = choice.get_or( "id", std::string() );
+            const sol::object raw_count = choice.raw_get<sol::object>( "count" );
+            const sol::object raw_charges = choice.raw_get<sol::object>( "charges" );
+            if( raw_count.valid() && raw_count.get_type() != sol::type::nil &&
+                raw_charges.valid() && raw_charges.get_type() != sol::type::nil ) {
+                throw std::runtime_error(
+                    "requirement tool alternative cannot specify count and charges" );
+            }
+            const bool charges = raw_charges.valid() &&
+                                 raw_charges.get_type() != sol::type::nil;
+            const std::int64_t amount = charges ? raw_charges.as<std::int64_t>() :
+                                        choice.get_or<std::int64_t>( "count", 1 );
+            if( id.empty() || amount <= 0 || amount > std::numeric_limits<int>::max() ) {
+                throw std::runtime_error(
+                    "requirement tool alternative needs an id and positive amount" );
+            }
+            group.push_back( { id, charges ? amount : -amount } );
+        }
+        definition->tools.push_back( std::move( group ) );
+        return *this;
+    }
+
+    requirement_definition_handle &quality( const std::string &id,
+            std::int64_t level, std::int64_t count ) {
+        require_building_handle( token, *definition, "requirement" );
+        if( id.empty() || level <= 0 || count <= 0 ||
+            level > std::numeric_limits<int>::max() ||
+            count > std::numeric_limits<int>::max() ) {
+            throw std::runtime_error(
+                "requirement quality needs an id, positive level, and positive count" );
+        }
+        definition->qualities.push_back( { { id, level, count } } );
+        return *this;
+    }
+
+    requirement_definition_handle &quality_any( const sol::table &choices ) {
+        require_building_handle( token, *definition, "requirement" );
+        const std::size_t count = require_dense_array(
+                                      choices, "requirement quality alternatives", 1, 128 );
+        std::vector<quality_requirement_definition> group;
+        group.reserve( count );
+        for( std::size_t index = 1; index <= count; ++index ) {
+            const sol::table choice = choices.raw_get<sol::table>( index );
+            quality_requirement_definition entry;
+            entry.id = choice.get_or( "id", std::string() );
+            entry.level = choice.get_or<std::int64_t>( "level", 1 );
+            entry.count = choice.get_or<std::int64_t>( "count", 1 );
+            if( entry.id.empty() || entry.level <= 0 || entry.count <= 0 ||
+                entry.level > std::numeric_limits<int>::max() ||
+                entry.count > std::numeric_limits<int>::max() ) {
+                throw std::runtime_error(
+                    "requirement quality alternative has invalid values" );
+            }
+            group.push_back( std::move( entry ) );
+        }
+        definition->qualities.push_back( std::move( group ) );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "requirement" );
+        return definition->id;
+    }
+};
+
+struct tool_quality_definition_handle {
+    std::shared_ptr<tool_quality_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    tool_quality_definition_handle &usage( std::int64_t level, const std::string &text ) {
+        require_building_handle( token, *definition, "tool quality" );
+        if( level < 0 || level > std::numeric_limits<int>::max() || text.empty() ) {
+            throw std::runtime_error(
+                "tool quality usage requires a non-negative native level and text" );
+        }
+        definition->usages.emplace_back( level, text );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "tool quality" );
+        return definition->id;
+    }
+};
+
+struct skill_display_definition_handle {
+    std::shared_ptr<skill_display_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "skill display category" );
+        return definition->id;
+    }
+};
+
+struct skill_definition_handle {
+    std::shared_ptr<skill_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    skill_definition_handle &tag( const std::string &value ) {
+        require_building_handle( token, *definition, "skill" );
+        if( value.empty() ) {
+            throw std::runtime_error( "skill tag cannot be empty" );
+        }
+        definition->tags.insert( value );
+        return *this;
+    }
+
+    skill_definition_handle &companion_practice( const std::string &id,
+            std::int64_t weight ) {
+        require_building_handle( token, *definition, "skill" );
+        if( id.empty() || weight < std::numeric_limits<int>::min() ||
+            weight > std::numeric_limits<int>::max() ) {
+            throw std::runtime_error( "skill companion practice entry is outside the native range" );
+        }
+        definition->companion_practice[id] = weight;
+        return *this;
+    }
+
+    skill_definition_handle &level_description( std::int64_t level,
+            const std::string &theory, const sol::optional<std::string> &practice ) {
+        require_building_handle( token, *definition, "skill" );
+        if( level < 0 || level > MAX_SKILL || theory.empty() ) {
+            throw std::runtime_error( "skill level description is invalid" );
+        }
+        definition->theory_descriptions[level] = theory;
+        definition->practice_descriptions[level] = practice.value_or( theory );
+        return *this;
+    }
+
+    skill_definition_handle &requires_all_trait( const std::string &id ) {
+        require_building_handle( token, *definition, "skill" );
+        if( id.empty() ) {
+            throw std::runtime_error( "skill required trait id cannot be empty" );
+        }
+        definition->requires_all_traits.insert( id );
+        return *this;
+    }
+
+    skill_definition_handle &requires_any_trait( const std::string &id ) {
+        require_building_handle( token, *definition, "skill" );
+        if( id.empty() ) {
+            throw std::runtime_error( "skill required trait id cannot be empty" );
+        }
+        definition->requires_any_traits.insert( id );
+        return *this;
+    }
+
+    skill_definition_handle &attack_time( std::int64_t minimum,
+                                          std::int64_t base,
+                                          std::int64_t reduction_per_level ) {
+        require_building_handle( token, *definition, "skill" );
+        if( minimum < 0 || base < minimum ||
+            base > std::numeric_limits<int>::max() ||
+            reduction_per_level < 0 || reduction_per_level > std::numeric_limits<int>::max() ) {
+            throw std::runtime_error( "skill attack timing is outside the native range" );
+        }
+        definition->attack_min_time = minimum;
+        definition->attack_base_time = base;
+        definition->attack_reduction_per_level = reduction_per_level;
+        return *this;
+    }
+
+    skill_definition_handle &companion_rank_factors( std::int64_t combat,
+            std::int64_t survival, std::int64_t industry ) {
+        require_building_handle( token, *definition, "skill" );
+        const auto in_range = []( const std::int64_t value ) {
+            return value >= std::numeric_limits<int>::min() &&
+                   value <= std::numeric_limits<int>::max();
+        };
+        if( !in_range( combat ) || !in_range( survival ) || !in_range( industry ) ) {
+            throw std::runtime_error( "skill companion rank factor is outside the native range" );
+        }
+        definition->companion_combat_rank_factor = combat;
+        definition->companion_survival_rank_factor = survival;
+        definition->companion_industry_rank_factor = industry;
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "skill" );
+        return definition->id;
+    }
+};
+
+struct vitamin_definition_handle {
+    std::shared_ptr<vitamin_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    vitamin_definition_handle &weight_micrograms( std::int64_t value ) {
+        require_building_handle( token, *definition, "vitamin" );
+        if( value <= 0 || value > std::numeric_limits<int>::max() ) {
+            throw std::runtime_error( "vitamin unit weight is outside the native range" );
+        }
+        definition->weight_micrograms = value;
+        return *this;
+    }
+
+    vitamin_definition_handle &deficiency_range( std::int64_t start,
+            std::int64_t end ) {
+        require_building_handle( token, *definition, "vitamin" );
+        if( start < std::numeric_limits<int>::min() || start > std::numeric_limits<int>::max() ||
+            end < std::numeric_limits<int>::min() || end > std::numeric_limits<int>::max() ) {
+            throw std::runtime_error( "vitamin deficiency range is outside the native range" );
+        }
+        definition->disease.emplace_back( start, end );
+        return *this;
+    }
+
+    vitamin_definition_handle &excess_range( std::int64_t start, std::int64_t end ) {
+        require_building_handle( token, *definition, "vitamin" );
+        if( start < std::numeric_limits<int>::min() || start > std::numeric_limits<int>::max() ||
+            end < std::numeric_limits<int>::min() || end > std::numeric_limits<int>::max() ) {
+            throw std::runtime_error( "vitamin excess range is outside the native range" );
+        }
+        definition->disease_excess.emplace_back( start, end );
+        return *this;
+    }
+
+    vitamin_definition_handle &decays_into( const std::string &id, std::int64_t rate ) {
+        require_building_handle( token, *definition, "vitamin" );
+        if( id.empty() || rate <= 0 || rate > std::numeric_limits<int>::max() ) {
+            throw std::runtime_error( "vitamin decay requires an id and positive native rate" );
+        }
+        definition->decays_into.emplace_back( id, rate );
+        return *this;
+    }
+
+    vitamin_definition_handle &flag( const std::string &id ) {
+        require_building_handle( token, *definition, "vitamin" );
+        if( id.empty() ) {
+            throw std::runtime_error( "vitamin flag cannot be empty" );
+        }
+        definition->flags.insert( id );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "vitamin" );
+        return definition->id;
+    }
+};
+
+struct json_flag_definition_handle {
+    std::shared_ptr<json_flag_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    json_flag_definition_handle &conflicts_with( const std::string &id ) {
+        require_building_handle( token, *definition, "JSON flag" );
+        if( id.empty() ) {
+            throw std::runtime_error( "JSON flag conflict id cannot be empty" );
+        }
+        definition->conflicts.insert( id );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "JSON flag" );
+        return definition->id;
+    }
+};
+
+struct material_definition_handle {
+    std::shared_ptr<material_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    material_definition_handle &resistance( const std::string &damage_id, double value ) {
+        require_building_handle( token, *definition, "material" );
+        if( damage_id.empty() || !std::isfinite( value ) ) {
+            throw std::runtime_error( "material resistance requires a damage id and finite value" );
+        }
+        definition->resistances[damage_id] = value;
+        return *this;
+    }
+
+    material_definition_handle &vitamin( const std::string &vitamin_id, double value ) {
+        require_building_handle( token, *definition, "material" );
+        if( vitamin_id.empty() || !std::isfinite( value ) ) {
+            throw std::runtime_error( "material vitamin requires an id and finite value" );
+        }
+        definition->vitamins[vitamin_id] = value;
+        return *this;
+    }
+
+    material_definition_handle &damage_adjective( const std::int64_t level,
+            const std::string &value ) {
+        require_building_handle( token, *definition, "material" );
+        if( level < 1 || level > 64 || value.empty() ) {
+            throw std::runtime_error( "material damage adjective level is invalid" );
+        }
+        if( definition->damage_adjectives.size() < static_cast<std::size_t>( level ) ) {
+            definition->damage_adjectives.resize( static_cast<std::size_t>( level ) );
+        }
+        definition->damage_adjectives[static_cast<std::size_t>( level - 1 )] = value;
+        return *this;
+    }
+
+    material_definition_handle &burn( const std::int64_t intensity,
+                                      const bool immune,
+                                      const std::int64_t volume_ml_per_turn,
+                                      const double fuel, const double smoke,
+                                      const double burned ) {
+        require_building_handle( token, *definition, "material" );
+        if( intensity < 1 || intensity > 64 || volume_ml_per_turn < 0 ||
+            volume_ml_per_turn > std::numeric_limits<units::volume::value_type>::max() ||
+            !std::isfinite( fuel ) || !std::isfinite( smoke ) || !std::isfinite( burned ) ) {
+            throw std::runtime_error( "material burn data is outside the native range" );
+        }
+        if( definition->burn_data.size() < static_cast<std::size_t>( intensity ) ) {
+            definition->burn_data.resize( static_cast<std::size_t>( intensity ) );
+        }
+        definition->burn_data[static_cast<std::size_t>( intensity - 1 )] = {
+            immune, volume_ml_per_turn, fuel, smoke, burned
+        };
+        return *this;
+    }
+
+    material_definition_handle &burn_product( const std::string &item_id,
+            const double efficiency ) {
+        require_building_handle( token, *definition, "material" );
+        if( item_id.empty() || !std::isfinite( efficiency ) ) {
+            throw std::runtime_error( "material burn product is invalid" );
+        }
+        definition->burn_products.emplace_back( item_id, efficiency );
+        return *this;
+    }
+
+    material_definition_handle &fuel( const std::int64_t energy_kilojoules,
+                                      const sol::optional<std::string> &pump_terrain,
+                                      const sol::optional<bool> &perpetual ) {
+        require_building_handle( token, *definition, "material" );
+        if( energy_kilojoules < 0 ||
+            energy_kilojoules > std::numeric_limits<std::int64_t>::max() / 1000000 ) {
+            throw std::runtime_error( "material fuel energy is outside the native range" );
+        }
+        definition->has_fuel = true;
+        definition->fuel_energy_kilojoules = energy_kilojoules;
+        definition->fuel_pump_terrain = pump_terrain.value_or( "t_null" );
+        definition->perpetual_fuel = perpetual.value_or( false );
+        return *this;
+    }
+
+    material_definition_handle &fuel_explosion( const std::int64_t chance_hot,
+            const std::int64_t chance_cold, const double factor, const bool fiery,
+            const double size_factor ) {
+        require_building_handle( token, *definition, "material" );
+        if( chance_hot < 0 || chance_hot > std::numeric_limits<int>::max() ||
+            chance_cold < 0 || chance_cold > std::numeric_limits<int>::max() ||
+            !std::isfinite( factor ) || !std::isfinite( size_factor ) ) {
+            throw std::runtime_error( "material fuel explosion data is outside the native range" );
+        }
+        definition->explosion_chance_hot = chance_hot;
+        definition->explosion_chance_cold = chance_cold;
+        definition->explosion_factor = factor;
+        definition->fiery_explosion = fiery;
+        definition->fuel_size_factor = size_factor;
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "material" );
+        return definition->id;
+    }
+};
+
+struct damage_type_definition_handle {
+    std::shared_ptr<damage_type_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    damage_type_definition_handle &derived( const std::string &id, const double factor ) {
+        require_building_handle( token, *definition, "damage type" );
+        if( id.empty() || !std::isfinite( factor ) ) {
+            throw std::runtime_error( "derived damage requires an id and finite factor" );
+        }
+        definition->derived_from = id;
+        definition->derived_factor = factor;
+        return *this;
+    }
+
+    damage_type_definition_handle &immune_character_flag( const std::string &id ) {
+        require_building_handle( token, *definition, "damage type" );
+        if( id.empty() ) {
+            throw std::runtime_error( "damage immunity flag cannot be empty" );
+        }
+        definition->character_immune_flags.insert( id );
+        return *this;
+    }
+
+    damage_type_definition_handle &immune_monster_flag( const std::string &id ) {
+        require_building_handle( token, *definition, "damage type" );
+        if( id.empty() ) {
+            throw std::runtime_error( "damage immunity flag cannot be empty" );
+        }
+        definition->monster_immune_flags.insert( id );
+        return *this;
+    }
+
+    damage_type_definition_handle &on_hit( const std::string &handler_id ) {
+        require_building_handle( token, *definition, "damage type" );
+        if( handler_id.empty() ) {
+            throw std::runtime_error( "damage on-hit handler id cannot be empty" );
+        }
+        definition->on_hit_handler = handler_id;
+        return *this;
+    }
+
+    damage_type_definition_handle &on_damage( const std::string &handler_id ) {
+        require_building_handle( token, *definition, "damage type" );
+        if( handler_id.empty() ) {
+            throw std::runtime_error( "damage on-damage handler id cannot be empty" );
+        }
+        definition->on_damage_handler = handler_id;
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "damage type" );
+        return definition->id;
+    }
+};
+
+struct magic_type_definition_handle {
+    std::shared_ptr<magic_type_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    magic_type_definition_handle &cannot_cast_when( const std::string &flag ) {
+        require_building_handle( token, *definition, "magic type" );
+        if( flag.empty() ) {
+            throw std::runtime_error( "magic-type casting flag cannot be empty" );
+        }
+        definition->cannot_cast_flags.insert( flag );
+        return *this;
+    }
+
+    magic_type_definition_handle &progression( const std::string &level_handler,
+            const std::string &experience_handler ) {
+        require_building_handle( token, *definition, "magic type" );
+        if( level_handler.empty() || experience_handler.empty() ) {
+            throw std::runtime_error( "magic-type progression needs two named handlers" );
+        }
+        definition->level_for_experience_handler = level_handler;
+        definition->experience_for_level_handler = experience_handler;
+        return *this;
+    }
+
+    magic_type_definition_handle &casting_experience( const std::string &handler_id ) {
+        require_building_handle( token, *definition, "magic type" );
+        if( handler_id.empty() ) {
+            throw std::runtime_error( "magic-type casting-experience handler cannot be empty" );
+        }
+        definition->casting_experience_handler = handler_id;
+        return *this;
+    }
+
+    magic_type_definition_handle &failure_chance( const std::string &handler_id ) {
+        require_building_handle( token, *definition, "magic type" );
+        if( handler_id.empty() ) {
+            throw std::runtime_error( "magic-type failure-chance handler cannot be empty" );
+        }
+        definition->failure_chance_handler = handler_id;
+        return *this;
+    }
+
+    magic_type_definition_handle &failure_cost( const std::string &handler_id ) {
+        require_building_handle( token, *definition, "magic type" );
+        if( handler_id.empty() ) {
+            throw std::runtime_error( "magic-type failure-cost handler cannot be empty" );
+        }
+        definition->failure_cost_handler = handler_id;
+        return *this;
+    }
+
+    magic_type_definition_handle &failure_experience( const std::string &handler_id ) {
+        require_building_handle( token, *definition, "magic type" );
+        if( handler_id.empty() ) {
+            throw std::runtime_error( "magic-type failure-experience handler cannot be empty" );
+        }
+        definition->failure_experience_handler = handler_id;
+        return *this;
+    }
+
+    magic_type_definition_handle &on_failure( const std::string &handler_id ) {
+        require_building_handle( token, *definition, "magic type" );
+        if( handler_id.empty() ) {
+            throw std::runtime_error( "magic-type failure handler cannot be empty" );
+        }
+        definition->failure_handler = handler_id;
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "magic type" );
+        return definition->id;
+    }
+};
+
+struct movement_mode_definition_handle {
+    std::shared_ptr<movement_mode_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    movement_mode_definition_handle &messages( const std::string &steed,
+            const sol::table &options ) {
+        require_building_handle( token, *definition, "movement mode" );
+        movement_mode_message_definition_data messages;
+        messages.steed = steed;
+        messages.prepare = options.get_or( "prepare", std::string() );
+        messages.success = options.get_or( "success", std::string() );
+        messages.failure = options.get_or(
+                               "failure", std::string( "You feel bugs crawl over your skin." ) );
+        if( messages.prepare.empty() || messages.success.empty() || messages.failure.empty() ) {
+            throw std::runtime_error( "movement-mode messages cannot be empty" );
+        }
+        definition->messages.push_back( std::move( messages ) );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "movement mode" );
+        return definition->id;
+    }
+};
+
+struct recipe_group_definition_handle {
+    std::shared_ptr<recipe_group_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    recipe_group_definition_handle &recipe( const std::string &id,
+                                             const std::string &description ) {
+        require_building_handle( token, *definition, "recipe group" );
+        if( id.empty() || description.empty() ) {
+            throw std::runtime_error( "recipe-group entry needs an id and description" );
+        }
+        definition->recipes.push_back( { id, description, {} } );
+        return *this;
+    }
+
+    recipe_group_definition_handle &terrain( const std::string &recipe_id,
+            const std::string &overmap_terrain, const std::string &match_type ) {
+        require_building_handle( token, *definition, "recipe group" );
+        const auto found = std::find_if(
+                               definition->recipes.rbegin(), definition->recipes.rend(),
+        [&recipe_id]( const recipe_group_recipe_data & entry ) {
+            return entry.id == recipe_id;
+        } );
+        if( found == definition->recipes.rend() || overmap_terrain.empty() ||
+            match_type.empty() ) {
+            throw std::runtime_error(
+                "recipe-group terrain needs an existing recipe, terrain id, and match type" );
+        }
+        found->terrains.push_back( { overmap_terrain, match_type, {} } );
+        return *this;
+    }
+
+    recipe_group_definition_handle &terrain_parameter( const std::string &recipe_id,
+            const std::string &parameter, const sol::table &values ) {
+        require_building_handle( token, *definition, "recipe group" );
+        const auto found = std::find_if(
+                               definition->recipes.rbegin(), definition->recipes.rend(),
+        [&recipe_id]( const recipe_group_recipe_data & entry ) {
+            return entry.id == recipe_id;
+        } );
+        if( found == definition->recipes.rend() || found->terrains.empty() || parameter.empty() ) {
+            throw std::runtime_error(
+                "recipe-group terrain parameter needs an existing terrain and parameter name" );
+        }
+        const std::size_t count = require_dense_array(
+                                      values, "recipe-group terrain parameter values", 1, 128 );
+        std::set<std::string> &target = found->terrains.back().parameters[parameter];
+        for( std::size_t index = 1; index <= count; ++index ) {
+            const std::string value = values.raw_get<std::string>( index );
+            if( value.empty() ) {
+                throw std::runtime_error(
+                    "recipe-group terrain parameter value cannot be empty" );
+            }
+            target.insert( value );
+        }
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "recipe group" );
+        return definition->id;
+    }
+};
+
+struct scent_type_definition_handle {
+    std::shared_ptr<scent_type_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    scent_type_definition_handle &receptive_species( const std::string &id ) {
+        require_building_handle( token, *definition, "scent type" );
+        if( id.empty() ) {
+            throw std::runtime_error( "scent receptive species id cannot be empty" );
+        }
+        definition->receptive_species.insert( id );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "scent type" );
+        return definition->id;
+    }
+};
+
+struct speed_description_definition_handle {
+    std::shared_ptr<speed_description_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    speed_description_definition_handle &value( const double threshold,
+            const sol::table &descriptions ) {
+        require_building_handle( token, *definition, "speed description" );
+        if( !std::isfinite( threshold ) || threshold < 0.0 ) {
+            throw std::runtime_error(
+                "speed-description threshold must be finite and non-negative" );
+        }
+        speed_description_value_data entry;
+        entry.threshold = threshold;
+        const std::size_t count = require_dense_array(
+                                      descriptions, "speed descriptions", 1, 128 );
+        entry.descriptions.reserve( count );
+        for( std::size_t index = 1; index <= count; ++index ) {
+            const std::string description = descriptions.raw_get<std::string>( index );
+            if( description.empty() ) {
+                throw std::runtime_error( "speed description text cannot be empty" );
+            }
+            entry.descriptions.push_back( description );
+        }
+        definition->values.push_back( std::move( entry ) );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "speed description" );
+        return definition->id;
+    }
+};
+
+struct harvest_drop_type_definition_handle {
+    std::shared_ptr<harvest_drop_type_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    harvest_drop_type_definition_handle &skill( const std::string &id ) {
+        require_building_handle( token, *definition, "harvest drop type" );
+        if( id.empty() ) {
+            throw std::runtime_error( "harvest-drop skill id cannot be empty" );
+        }
+        definition->skills.push_back( id );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "harvest drop type" );
+        return definition->id;
+    }
+};
+
+struct harvest_definition_handle {
+    std::shared_ptr<harvest_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    harvest_definition_handle &drop( const sol::table &options ) {
+        require_building_handle( token, *definition, "harvest" );
+        harvest_entry_definition_data entry;
+        entry.output = options.get_or( "output", std::string() );
+        entry.category = options.get_or( "category", std::string() );
+        entry.base_minimum = options.get_or( "base_minimum", 1.0 );
+        entry.base_maximum = options.get_or( "base_maximum", entry.base_minimum );
+        entry.skill_minimum = options.get_or( "skill_minimum", 0.0 );
+        entry.skill_maximum = options.get_or( "skill_maximum", entry.skill_minimum );
+        entry.maximum = options.get_or<std::int64_t>( "maximum", 1000 );
+        entry.mass_ratio = options.get_or( "mass_ratio", 0.0 );
+        if( entry.output.empty() || std::any_of(
+                definition->entries.begin(), definition->entries.end(),
+        [&entry]( const harvest_entry_definition_data & existing ) {
+        return existing.output == entry.output;
+        } ) ) {
+            throw std::runtime_error( "harvest drop needs a unique non-empty output id" );
+        }
+        definition->entries.push_back( std::move( entry ) );
+        return *this;
+    }
+
+    harvest_definition_handle &item_flag( const std::string &output,
+                                           const std::string &flag ) {
+        require_building_handle( token, *definition, "harvest" );
+        harvest_entry_definition_data &entry = require_drop( output );
+        if( flag.empty() ) {
+            throw std::runtime_error( "harvest item flag cannot be empty" );
+        }
+        entry.flags.insert( flag );
+        return *this;
+    }
+
+    harvest_definition_handle &item_fault( const std::string &output,
+                                            const std::string &fault ) {
+        require_building_handle( token, *definition, "harvest" );
+        harvest_entry_definition_data &entry = require_drop( output );
+        if( fault.empty() ) {
+            throw std::runtime_error( "harvest item fault cannot be empty" );
+        }
+        entry.faults.insert( fault );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "harvest" );
+        return definition->id;
+    }
+
+    private:
+        harvest_entry_definition_data &require_drop( const std::string &output ) {
+            const auto found = std::find_if(
+                                   definition->entries.rbegin(), definition->entries.rend(),
+            [&output]( const harvest_entry_definition_data & entry ) {
+                return entry.output == output;
+            } );
+            if( found == definition->entries.rend() ) {
+                throw std::runtime_error(
+                    "harvest item metadata requires an output staged earlier on this definition" );
+            }
+            return *found;
+        }
+};
+
+struct behavior_definition_handle {
+    std::shared_ptr<behavior_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    behavior_definition_handle &child( const std::string &id ) {
+        require_building_handle( token, *definition, "behavior" );
+        if( id.empty() || std::find( definition->children.begin(),
+                                     definition->children.end(), id ) !=
+            definition->children.end() ) {
+            throw std::runtime_error( "behavior child needs a unique non-empty id" );
+        }
+        definition->children.push_back( id );
+        return *this;
+    }
+
+    behavior_definition_handle &when( const std::string &handler,
+                                      const sol::optional<std::string> &argument,
+                                      const sol::optional<bool> &inverted ) {
+        return add_condition( handler, argument.value_or( std::string() ), false,
+                              inverted.value_or( false ) );
+    }
+
+    behavior_definition_handle &when_native(
+        const std::string &predicate, const sol::optional<std::string> &argument,
+        const sol::optional<bool> &inverted ) {
+        return add_condition( predicate, argument.value_or( std::string() ), true,
+                              inverted.value_or( false ) );
+    }
+
+    behavior_definition_handle &score( const std::string &handler,
+                                       const sol::optional<std::string> &argument ) {
+        return set_score( handler, argument.value_or( std::string() ), false );
+    }
+
+    behavior_definition_handle &score_native(
+        const std::string &predicate, const sol::optional<std::string> &argument ) {
+        return set_score( predicate, argument.value_or( std::string() ), true );
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "behavior" );
+        return definition->id;
+    }
+
+    private:
+        behavior_definition_handle &add_condition( const std::string &policy,
+                const std::string &argument, const bool native, const bool inverted ) {
+            require_building_handle( token, *definition, "behavior" );
+            if( policy.empty() ) {
+                throw std::runtime_error( "behavior condition policy cannot be empty" );
+            }
+            definition->conditions.push_back( { policy, argument, native, inverted } );
+            return *this;
+        }
+
+        behavior_definition_handle &set_score( const std::string &policy,
+                                                const std::string &argument,
+                                                const bool native ) {
+            require_building_handle( token, *definition, "behavior" );
+            if( policy.empty() ) {
+                throw std::runtime_error( "behavior score policy cannot be empty" );
+            }
+            definition->score = behavior_score_definition_data{ policy, argument, native };
+            return *this;
+        }
+};
+
+struct effect_type_definition_handle {
+    std::shared_ptr<effect_type_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    effect_type_definition_handle &name( const std::string &text ) {
+        return append_text( definition->names, text, "effect name" );
+    }
+
+    effect_type_definition_handle &description( const std::string &text ) {
+        return append_text( definition->descriptions, text, "effect description" );
+    }
+
+    effect_type_definition_handle &reduced_description( const std::string &text ) {
+        return append_text( definition->reduced_descriptions, text,
+                            "reduced effect description" );
+    }
+
+    effect_type_definition_handle &flag( const std::string &id ) {
+        return insert_id( definition->flags, id, "effect flag" );
+    }
+
+    effect_type_definition_handle &immune_character_flag( const std::string &id ) {
+        return insert_id( definition->immune_character_flags, id,
+                          "effect immunity character flag" );
+    }
+
+    effect_type_definition_handle &immune_bodypart_flag( const std::string &id ) {
+        return insert_id( definition->immune_bodypart_flags, id,
+                          "effect immunity body-part flag" );
+    }
+
+    effect_type_definition_handle &resist_trait( const std::string &id ) {
+        return insert_id( definition->resist_traits, id, "effect resistance trait" );
+    }
+
+    effect_type_definition_handle &resist_effect( const std::string &id ) {
+        return insert_id( definition->resist_effects, id, "resistance effect" );
+    }
+
+    effect_type_definition_handle &removes_effect( const std::string &id ) {
+        return insert_id( definition->removes_effects, id, "removed effect" );
+    }
+
+    effect_type_definition_handle &blocks_effect( const std::string &id ) {
+        return insert_id( definition->blocks_effects, id, "blocked effect" );
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "effect type" );
+        return definition->id;
+    }
+
+    private:
+        effect_type_definition_handle &append_text( std::vector<std::string> &target,
+                const std::string &text, const std::string_view label ) {
+            require_building_handle( token, *definition, "effect type" );
+            if( text.empty() ) {
+                throw std::runtime_error( std::string( label ) + " cannot be empty" );
+            }
+            target.push_back( text );
+            return *this;
+        }
+
+        effect_type_definition_handle &insert_id( std::set<std::string> &target,
+                const std::string &id, const std::string_view label ) {
+            require_building_handle( token, *definition, "effect type" );
+            if( id.empty() ) {
+                throw std::runtime_error( std::string( label ) + " cannot be empty" );
+            }
+            target.insert( id );
+            return *this;
+        }
+};
+
+struct monster_attack_definition_handle {
+    std::shared_ptr<monster_attack_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    monster_attack_definition_handle &policy( const std::string &handler ) {
+        require_building_handle( token, *definition, "monster attack" );
+        if( handler.empty() ) {
+            throw std::runtime_error( "monster attack policy cannot be empty" );
+        }
+        definition->handler = handler;
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "monster attack" );
+        return definition->id;
+    }
+};
+
+struct weakpoint_set_definition_handle {
+    std::shared_ptr<weakpoint_set_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    weakpoint_set_definition_handle &weakpoint( const sol::table &options ) {
+        require_building_handle( token, *definition, "weakpoint set" );
+        weakpoint_definition_data value;
+        value.id = options.get_or( "id", std::string() );
+        value.name = options.get_or( "name", std::string() );
+        value.coverage = options.get_or( "coverage", 100.0 );
+        value.good = options.get_or( "good", true );
+        value.head = options.get_or( "head", false );
+        if( value.id.empty() || std::any_of(
+                definition->weakpoints.begin(), definition->weakpoints.end(),
+        [&value]( const weakpoint_definition_data & existing ) {
+            return existing.id == value.id;
+        } ) ) {
+            throw std::runtime_error( "weakpoint needs a unique non-empty id" );
+        }
+        definition->weakpoints.push_back( std::move( value ) );
+        return *this;
+    }
+
+    weakpoint_set_definition_handle &armor_multiplier(
+        const std::string &weakpoint_id, const std::string &damage_type,
+        const double value ) {
+        return set_damage_value( weakpoint_id, damage_type, value,
+        []( weakpoint_definition_data & point ) -> std::map<std::string, double> & {
+            return point.armor_multipliers;
+        }, "armor multiplier" );
+    }
+
+    weakpoint_set_definition_handle &armor_penalty(
+        const std::string &weakpoint_id, const std::string &damage_type,
+        const double value ) {
+        return set_damage_value( weakpoint_id, damage_type, value,
+        []( weakpoint_definition_data & point ) -> std::map<std::string, double> & {
+            return point.armor_penalties;
+        }, "armor penalty" );
+    }
+
+    weakpoint_set_definition_handle &damage_multiplier(
+        const std::string &weakpoint_id, const std::string &damage_type,
+        const double value ) {
+        return set_damage_value( weakpoint_id, damage_type, value,
+        []( weakpoint_definition_data & point ) -> std::map<std::string, double> & {
+            return point.damage_multipliers;
+        }, "damage multiplier" );
+    }
+
+    weakpoint_set_definition_handle &critical_multiplier(
+        const std::string &weakpoint_id, const std::string &damage_type,
+        const double value ) {
+        return set_damage_value( weakpoint_id, damage_type, value,
+        []( weakpoint_definition_data & point ) -> std::map<std::string, double> & {
+            return point.critical_multipliers;
+        }, "critical multiplier" );
+    }
+
+    weakpoint_set_definition_handle &effect( const std::string &weakpoint_id,
+            const sol::table &options ) {
+        require_building_handle( token, *definition, "weakpoint set" );
+        weakpoint_effect_definition_data value;
+        value.effect = options.get_or( "effect", std::string() );
+        value.chance = options.get_or( "chance", 100.0 );
+        value.permanent = options.get_or( "permanent", false );
+        value.duration_min_turns = options.get_or<std::int64_t>(
+                                       "duration_min_turns", 0 );
+        value.duration_max_turns = options.get_or<std::int64_t>(
+                                       "duration_max_turns", value.duration_min_turns );
+        value.intensity_min = options.get_or<std::int64_t>( "intensity_min", 1 );
+        value.intensity_max = options.get_or<std::int64_t>(
+                                  "intensity_max", value.intensity_min );
+        value.damage_required_min = options.get_or( "damage_required_min", 0.0 );
+        value.damage_required_max = options.get_or(
+                                        "damage_required_max", 100.0 );
+        value.message = options.get_or( "message", std::string() );
+        require_weakpoint( weakpoint_id ).effects.push_back( std::move( value ) );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "weakpoint set" );
+        return definition->id;
+    }
+
+    private:
+        weakpoint_definition_data &require_weakpoint( const std::string &id ) {
+            const auto found = std::find_if(
+                                   definition->weakpoints.begin(), definition->weakpoints.end(),
+            [&id]( const weakpoint_definition_data & point ) {
+                return point.id == id;
+            } );
+            if( found == definition->weakpoints.end() ) {
+                throw std::runtime_error(
+                    "weakpoint metadata requires an id staged earlier on this definition" );
+            }
+            return *found;
+        }
+
+        template<typename Select>
+        weakpoint_set_definition_handle &set_damage_value(
+            const std::string &weakpoint_id, const std::string &damage_type,
+            const double value, Select select, const std::string_view label ) {
+            require_building_handle( token, *definition, "weakpoint set" );
+            if( damage_type.empty() || !std::isfinite( value ) ) {
+                throw std::runtime_error( "weakpoint " + std::string( label ) +
+                                          " needs a damage type and finite value" );
+            }
+            select( require_weakpoint( weakpoint_id ) )[damage_type] = value;
+            return *this;
+        }
+};
+
+struct sub_body_part_definition_handle {
+    std::shared_ptr<sub_body_part_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    sub_body_part_definition_handle &location_under( const std::string &id ) {
+        require_building_handle( token, *definition, "sub body part" );
+        if( id.empty() ) {
+            throw std::runtime_error( "sub-body-part lower location cannot be empty" );
+        }
+        definition->locations_under.push_back( id );
+        return *this;
+    }
+
+    sub_body_part_definition_handle &unarmed_damage( const std::string &damage_type,
+            const double amount ) {
+        require_building_handle( token, *definition, "sub body part" );
+        if( damage_type.empty() || !std::isfinite( amount ) || amount < 0.0 ) {
+            throw std::runtime_error( "sub-body-part unarmed damage is invalid" );
+        }
+        definition->unarmed_damage[damage_type] = amount;
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "sub body part" );
+        return definition->id;
+    }
+};
+
+struct body_part_definition_handle {
+    std::shared_ptr<body_part_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    body_part_definition_handle &sub_part( const std::string &id ) {
+        require_building_handle( token, *definition, "body part" );
+        if( id.empty() ) {
+            throw std::runtime_error( "body-part sub location cannot be empty" );
+        }
+        definition->sub_parts.push_back( id );
+        return *this;
+    }
+
+    body_part_definition_handle &limb_type( const std::string &kind,
+                                            const sol::optional<double> &weight ) {
+        require_building_handle( token, *definition, "body part" );
+        const double value = weight.value_or( 1.0 );
+        if( kind.empty() || !std::isfinite( value ) || value <= 0.0 ) {
+            throw std::runtime_error( "body-part limb type is invalid" );
+        }
+        definition->limb_types[kind] = value;
+        return *this;
+    }
+
+    body_part_definition_handle &armor( const std::string &damage_type,
+                                        const double amount ) {
+        return set_damage( definition->armor, damage_type, amount, "armor" );
+    }
+
+    body_part_definition_handle &unarmed_damage( const std::string &damage_type,
+            const double amount ) {
+        return set_damage( definition->unarmed_damage, damage_type, amount,
+                           "unarmed damage" );
+    }
+
+    body_part_definition_handle &flag( const std::string &id ) {
+        require_building_handle( token, *definition, "body part" );
+        if( id.empty() ) {
+            throw std::runtime_error( "body-part flag cannot be empty" );
+        }
+        definition->flags.insert( id );
+        return *this;
+    }
+
+    body_part_definition_handle &limb_score( const std::string &id,
+            const double score, const sol::optional<double> &maximum ) {
+        require_building_handle( token, *definition, "body part" );
+        const double maximum_value = maximum.value_or( score );
+        if( id.empty() || !std::isfinite( score ) || !std::isfinite( maximum_value ) ||
+            score < 0.0 || maximum_value < score ) {
+            throw std::runtime_error( "body-part limb score is invalid" );
+        }
+        definition->limb_scores[id] = { score, maximum_value };
+        return *this;
+    }
+
+    body_part_definition_handle &quality( const std::string &id,
+                                          const std::int64_t level,
+                                          const sol::optional<double> &disable_fraction ) {
+        require_building_handle( token, *definition, "body part" );
+        definition->qualities.push_back( {
+            id, level, disable_fraction.value_or( 0.0 )
+        } );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "body part" );
+        return definition->id;
+    }
+
+    private:
+        body_part_definition_handle &set_damage( std::map<std::string, double> &target,
+                const std::string &damage_type, const double amount,
+                const std::string_view label ) {
+            require_building_handle( token, *definition, "body part" );
+            if( damage_type.empty() || !std::isfinite( amount ) || amount < 0.0 ) {
+                throw std::runtime_error( "body-part " + std::string( label ) + " is invalid" );
+            }
+            target[damage_type] = amount;
+            return *this;
+        }
+};
+
+struct anatomy_definition_handle {
+    std::shared_ptr<anatomy_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    anatomy_definition_handle &part( const std::string &id ) {
+        require_building_handle( token, *definition, "anatomy" );
+        if( id.empty() || std::find( definition->parts.begin(),
+                                     definition->parts.end(), id ) != definition->parts.end() ) {
+            throw std::runtime_error( "anatomy part needs a unique non-empty id" );
+        }
+        definition->parts.push_back( id );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "anatomy" );
+        return definition->id;
+    }
+};
+
+struct body_graph_definition_handle {
+    std::shared_ptr<body_graph_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    body_graph_definition_handle &row( const std::string &value,
+                                       const sol::optional<std::string> &fill ) {
+        require_building_handle( token, *definition, "body graph" );
+        if( value.empty() ) {
+            throw std::runtime_error( "body-graph row cannot be empty" );
+        }
+        definition->rows.push_back( value );
+        if( fill ) {
+            if( definition->fill_rows.size() + 1 != definition->rows.size() ) {
+                throw std::runtime_error(
+                    "body-graph fill rows must be supplied for every row" );
+            }
+            definition->fill_rows.push_back( *fill );
+        } else if( !definition->fill_rows.empty() ) {
+            throw std::runtime_error(
+                "body-graph fill rows must be supplied for every row" );
+        }
+        return *this;
+    }
+
+    body_graph_definition_handle &part( const std::string &symbol,
+                                        const sol::table &options ) {
+        require_building_handle( token, *definition, "body graph" );
+        body_graph_part_definition_data value;
+        value.symbol = symbol;
+        value.nested_graph = options.get_or( "nested_graph", std::string() );
+        value.selected_color = options.get_or(
+                                   "selected_color", std::string( "white" ) );
+        value.display_symbol = options.get_or( "display_symbol", std::string() );
+        const auto read_ids = []( const sol::optional<sol::table> &source,
+        const std::string_view label ) {
+            std::vector<std::string> ids;
+            if( !source ) {
+                return ids;
+            }
+            const std::size_t count = require_dense_array( *source, label, 0, 256 );
+            ids.reserve( count );
+            for( std::size_t index = 1; index <= count; ++index ) {
+                const sol::object raw = source->raw_get<sol::object>( index );
+                if( raw.get_type() != sol::type::string ) {
+                    throw std::invalid_argument( std::string( label ) +
+                                                 " must contain strings" );
+                }
+                ids.push_back( raw.as<std::string>() );
+            }
+            return ids;
+        };
+        value.body_parts = read_ids(
+                               options.get<sol::optional<sol::table>>( "body_parts" ),
+                               "body graph body parts" );
+        value.sub_body_parts = read_ids(
+                                   options.get<sol::optional<sol::table>>( "sub_body_parts" ),
+                                   "body graph sub body parts" );
+        if( symbol.empty() || std::any_of( definition->parts.begin(),
+                                          definition->parts.end(),
+        [&symbol]( const body_graph_part_definition_data & existing ) {
+            return existing.symbol == symbol;
+        } ) ) {
+            throw std::runtime_error( "body-graph part needs a unique symbol" );
+        }
+        definition->parts.push_back( std::move( value ) );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "body graph" );
+        return definition->id;
+    }
+};
+
+struct monster_definition_handle {
+    std::shared_ptr<monster_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    monster_definition_handle &material( const std::string &id,
+                                         const sol::optional<std::int64_t> &portions ) {
+        require_building_handle( token, *definition, "monster" );
+        const std::int64_t value = portions.value_or( 1 );
+        if( id.empty() || value <= 0 ) {
+            throw std::runtime_error( "monster material needs an id and positive portions" );
+        }
+        definition->materials[id] = value;
+        return *this;
+    }
+
+    monster_definition_handle &species( const std::string &id ) {
+        return insert_id( definition->species, id, "species" );
+    }
+
+    monster_definition_handle &category( const std::string &id ) {
+        return insert_id( definition->categories, id, "category" );
+    }
+
+    monster_definition_handle &flag( const std::string &id ) {
+        return insert_id( definition->flags, id, "flag" );
+    }
+
+    monster_definition_handle &armor( const std::string &damage_type,
+                                      const double amount ) {
+        require_building_handle( token, *definition, "monster" );
+        if( damage_type.empty() || !std::isfinite( amount ) || amount < 0.0 ) {
+            throw std::runtime_error( "monster armor is invalid" );
+        }
+        definition->armor[damage_type] = amount;
+        return *this;
+    }
+
+    monster_definition_handle &melee_damage(
+        const std::string &damage_type, const double amount,
+        const sol::optional<double> &armor_penetration ) {
+        require_building_handle( token, *definition, "monster" );
+        const double penetration = armor_penetration.value_or( 0.0 );
+        if( damage_type.empty() || !std::isfinite( amount ) || amount < 0.0 ||
+            !std::isfinite( penetration ) || penetration < 0.0 ) {
+            throw std::runtime_error( "monster melee damage is invalid" );
+        }
+        definition->melee_damage[damage_type] = { amount, penetration };
+        return *this;
+    }
+
+    monster_definition_handle &attack( const std::string &id,
+                                       const sol::optional<double> &cooldown ) {
+        require_building_handle( token, *definition, "monster" );
+        if( id.empty() || std::any_of( definition->attacks.begin(),
+                                      definition->attacks.end(),
+        [&id]( const monster_attack_reference_definition_data & value ) {
+            return value.id == id;
+        } ) ) {
+            throw std::runtime_error( "monster attack reference needs a unique id" );
+        }
+        definition->attacks.push_back( { id, cooldown } );
+        return *this;
+    }
+
+    monster_definition_handle &weakpoint_set( const std::string &id ) {
+        require_building_handle( token, *definition, "monster" );
+        if( id.empty() || std::find( definition->weakpoint_sets.begin(),
+                                     definition->weakpoint_sets.end(), id ) !=
+            definition->weakpoint_sets.end() ) {
+            throw std::runtime_error( "monster weakpoint set needs a unique id" );
+        }
+        definition->weakpoint_sets.push_back( id );
+        return *this;
+    }
+
+    monster_definition_handle &emission( const std::string &id,
+                                         const std::int64_t interval_turns ) {
+        require_building_handle( token, *definition, "monster" );
+        if( id.empty() || interval_turns <= 0 ) {
+            throw std::runtime_error( "monster emission needs an id and positive interval" );
+        }
+        definition->emissions[id] = interval_turns;
+        return *this;
+    }
+
+    monster_definition_handle &starting_ammo( const std::string &id,
+            const std::int64_t amount ) {
+        require_building_handle( token, *definition, "monster" );
+        if( id.empty() || amount <= 0 ) {
+            throw std::runtime_error( "monster starting ammo needs an id and positive amount" );
+        }
+        definition->starting_ammo[id] = amount;
+        return *this;
+    }
+
+    monster_definition_handle &track_scent( const std::string &id ) {
+        return insert_id( definition->tracked_scents, id, "tracked scent" );
+    }
+
+    monster_definition_handle &ignore_scent( const std::string &id ) {
+        return insert_id( definition->ignored_scents, id, "ignored scent" );
+    }
+
+    monster_definition_handle &regeneration_modifier( const std::string &effect,
+            const std::int64_t amount ) {
+        require_building_handle( token, *definition, "monster" );
+        if( effect.empty() || amount < std::numeric_limits<int>::min() ||
+            amount > std::numeric_limits<int>::max() ) {
+            throw std::runtime_error( "monster regeneration modifier is invalid" );
+        }
+        definition->regeneration_modifiers[effect] = amount;
+        return *this;
+    }
+
+    monster_definition_handle &goal( const std::string &id ) {
+        require_building_handle( token, *definition, "monster" );
+        if( id.empty() || std::find( definition->goals.begin(), definition->goals.end(), id ) !=
+            definition->goals.end() ) {
+            throw std::runtime_error( "monster behavior goal needs a unique id" );
+        }
+        definition->goals.push_back( id );
+        return *this;
+    }
+
+    monster_definition_handle &anger_trigger( const std::string &id ) {
+        return insert_id( definition->anger_triggers, id, "anger trigger" );
+    }
+
+    monster_definition_handle &fear_trigger( const std::string &id ) {
+        return insert_id( definition->fear_triggers, id, "fear trigger" );
+    }
+
+    monster_definition_handle &placate_trigger( const std::string &id ) {
+        return insert_id( definition->placate_triggers, id, "placate trigger" );
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "monster" );
+        return definition->id;
+    }
+
+    private:
+        monster_definition_handle &insert_id( std::set<std::string> &target,
+                const std::string &id, const std::string_view label ) {
+            require_building_handle( token, *definition, "monster" );
+            if( id.empty() ) {
+                throw std::runtime_error( "monster " + std::string( label ) +
+                                          " cannot be empty" );
+            }
+            target.insert( id );
+            return *this;
+        }
+};
+
+struct item_group_definition_handle {
+    std::shared_ptr<item_group_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    item_group_definition_handle &item( const std::string &id,
+                                        const sol::optional<std::int64_t> &probability,
+                                        const sol::optional<std::string> &variant ) {
+        return add_entry( id, false, probability.value_or( 100 ),
+                          variant.value_or( std::string() ) );
+    }
+
+    item_group_definition_handle &group( const std::string &id,
+                                         const sol::optional<std::int64_t> &probability ) {
+        return add_entry( id, true, probability.value_or( 100 ), std::string() );
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "item group" );
+        return definition->id;
+    }
+
+    private:
+        item_group_definition_handle &add_entry( const std::string &id, const bool group,
+                const std::int64_t probability, const std::string &variant ) {
+            require_building_handle( token, *definition, "item group" );
+            if( id.empty() ) {
+                throw std::runtime_error( "item-group entry id cannot be empty" );
+            }
+            definition->entries.push_back( { id, group, probability, variant } );
+            return *this;
+        }
+};
+
+struct field_type_definition_handle {
+    std::shared_ptr<field_type_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    field_type_definition_handle &intensity( const sol::table &options ) {
+        require_building_handle( token, *definition, "field type" );
+        field_intensity_definition_data value;
+        value.name = options.get_or( "name", std::string() );
+        value.symbol = options.get_or( "symbol", std::string( "%" ) );
+        value.color = options.get_or( "color", std::string( "white" ) );
+        value.dangerous = options.get_or( "dangerous", false );
+        value.transparent = options.get_or( "transparent", true );
+        value.move_cost = options.get_or<std::int64_t>( "move_cost", 0 );
+        value.upgrade_chance = options.get_or<std::int64_t>( "upgrade_chance", 0 );
+        value.upgrade_duration_turns = options.get_or<std::int64_t>(
+                                           "upgrade_duration_turns", 0 );
+        value.light_emitted = options.get_or( "light_emitted", 0.0 );
+        value.local_light_override = options.get_or( "local_light_override", -1.0 );
+        value.translucency = options.get_or( "translucency", 0.0 );
+        value.concentration = options.get_or<std::int64_t>( "concentration", 1 );
+        value.convection_temperature_modifier = options.get_or<std::int64_t>(
+                    "convection_temperature_modifier", 0 );
+        value.scent_neutralization = options.get_or<std::int64_t>(
+                                         "scent_neutralization", 0 );
+        definition->intensity_levels.push_back( std::move( value ) );
+        return *this;
+    }
+
+    field_type_definition_handle &effect( const std::int64_t intensity_index,
+                                          const sol::table &options ) {
+        require_building_handle( token, *definition, "field type" );
+        if( intensity_index <= 0 ||
+            static_cast<std::size_t>( intensity_index ) >
+            definition->intensity_levels.size() ) {
+            throw std::runtime_error( "field effect needs an existing one-based intensity" );
+        }
+        field_effect_definition_data value;
+        value.effect = options.get_or( "effect", std::string() );
+        value.duration_min_turns = options.get_or<std::int64_t>(
+                                       "duration_min_turns", 0 );
+        value.duration_max_turns = options.get_or<std::int64_t>(
+                                       "duration_max_turns", value.duration_min_turns );
+        value.intensity = options.get_or<std::int64_t>( "intensity", 1 );
+        value.body_part = options.get_or( "body_part", std::string() );
+        value.environmental = options.get_or( "environmental", true );
+        value.message = options.get_or( "message", std::string() );
+        value.npc_message = options.get_or( "npc_message", std::string() );
+        definition->intensity_levels[static_cast<std::size_t>( intensity_index - 1 )].
+        effects.push_back( std::move( value ) );
+        return *this;
+    }
+
+    field_type_definition_handle &immune_monster( const std::string &id ) {
+        return insert_monster( definition->immune_monsters, id, "immune monster" );
+    }
+
+    field_type_definition_handle &block_monster( const std::string &id ) {
+        return insert_monster( definition->blocked_monsters, id, "blocked monster" );
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "field type" );
+        return definition->id;
+    }
+
+    private:
+        field_type_definition_handle &insert_monster( std::set<std::string> &target,
+                const std::string &id, const std::string_view label ) {
+            require_building_handle( token, *definition, "field type" );
+            if( id.empty() ) {
+                throw std::runtime_error( std::string( label ) + " cannot be empty" );
+            }
+            target.insert( id );
+            return *this;
+        }
+};
+
+struct morale_type_definition_handle {
+    std::shared_ptr<morale_type_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "morale type" );
+        return definition->id;
+    }
+};
+
+struct disease_type_definition_handle {
+    std::shared_ptr<disease_type_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    disease_type_definition_handle &affected_body_part( const std::string &id ) {
+        require_building_handle( token, *definition, "disease type" );
+        if( id.empty() ) {
+            throw std::runtime_error( "disease affected body-part id cannot be empty" );
+        }
+        definition->affected_body_parts.insert( id );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "disease type" );
+        return definition->id;
+    }
+};
+
+struct monster_flag_definition_handle {
+    std::shared_ptr<monster_flag_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "monster flag" );
+        return definition->id;
+    }
+};
+
+struct species_definition_handle {
+    std::shared_ptr<species_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    species_definition_handle &flag( const std::string &id ) {
+        require_building_handle( token, *definition, "species" );
+        if( id.empty() ) {
+            throw std::runtime_error( "species flag id cannot be empty" );
+        }
+        definition->flags.insert( id );
+        return *this;
+    }
+
+    species_definition_handle &anger( const std::string &trigger ) {
+        require_building_handle( token, *definition, "species" );
+        if( trigger.empty() ) {
+            throw std::runtime_error( "species anger trigger cannot be empty" );
+        }
+        definition->anger.insert( trigger );
+        return *this;
+    }
+
+    species_definition_handle &fear( const std::string &trigger ) {
+        require_building_handle( token, *definition, "species" );
+        if( trigger.empty() ) {
+            throw std::runtime_error( "species fear trigger cannot be empty" );
+        }
+        definition->fear.insert( trigger );
+        return *this;
+    }
+
+    species_definition_handle &placate( const std::string &trigger ) {
+        require_building_handle( token, *definition, "species" );
+        if( trigger.empty() ) {
+            throw std::runtime_error( "species placate trigger cannot be empty" );
+        }
+        definition->placate.insert( trigger );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "species" );
+        return definition->id;
+    }
+};
+
+struct emission_definition_handle {
+    std::shared_ptr<emission_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    emission_definition_handle &profile( const std::string &handler_id ) {
+        require_building_handle( token, *definition, "emission" );
+        if( handler_id.empty() ) {
+            throw std::runtime_error( "emission profile handler id cannot be empty" );
+        }
+        definition->profile_handler = handler_id;
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "emission" );
+        return definition->id;
+    }
+};
+
+struct monster_faction_definition_handle {
+    std::shared_ptr<monster_faction_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    monster_faction_definition_handle &attitude( const std::string &kind,
+            const std::string &target ) {
+        require_building_handle( token, *definition, "monster faction" );
+        if( target.empty() ) {
+            throw std::runtime_error( "monster faction attitude target cannot be empty" );
+        }
+        if( kind != "by_mood" && kind != "neutral" &&
+            kind != "friendly" && kind != "hate" ) {
+            throw std::runtime_error( "monster faction attitude must be by_mood, neutral, friendly, or hate" );
+        }
+        definition->attitudes[target] = kind;
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "monster faction" );
+        return definition->id;
+    }
+};
+
+struct mutation_type_definition_handle {
+    std::shared_ptr<mutation_type_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "mutation type" );
+        return definition->id;
+    }
+};
+
+struct connect_group_definition_handle {
+    std::shared_ptr<connect_group_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "connect group" );
+        return definition->id;
+    }
+};
+
+struct mutation_category_definition_handle {
+    std::shared_ptr<mutation_category_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "mutation category" );
+        return definition->id;
+    }
+};
+
+struct construction_category_definition_handle {
+    std::shared_ptr<construction_category_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "construction category" );
+        return definition->id;
+    }
+};
+
+struct construction_group_definition_handle {
+    std::shared_ptr<construction_group_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "construction group" );
+        return definition->id;
+    }
+};
+
+struct vehicle_part_location_definition_handle {
+    std::shared_ptr<vehicle_part_location_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "vehicle part location" );
+        return definition->id;
+    }
+};
+
+struct mood_face_definition_handle {
+    std::shared_ptr<mood_face_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    mood_face_definition_handle &value( const std::int64_t score,
+                                        const std::string &face ) {
+        require_building_handle( token, *definition, "mood face" );
+        if( score < std::numeric_limits<int>::min() ||
+            score > std::numeric_limits<int>::max() || face.empty() ) {
+            throw std::runtime_error( "mood-face value is outside the native range" );
+        }
+        definition->values.push_back( { score, face } );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "mood face" );
+        return definition->id;
+    }
+};
+
+struct damage_info_order_definition_handle {
+    std::shared_ptr<damage_info_order_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    damage_info_order_definition_handle &section( const std::string &section,
+            const std::int64_t order, const bool show_type ) {
+        require_building_handle( token, *definition, "damage info order" );
+        static const std::set<std::string> supported = {
+            "bionic", "protection", "pet_protection", "melee", "ablative"
+        };
+        if( supported.count( section ) == 0 ||
+            order < std::numeric_limits<int>::min() ||
+            order > std::numeric_limits<int>::max() ) {
+            throw std::runtime_error( "damage-info section is unknown or outside the native range" );
+        }
+        const auto duplicate = std::find_if(
+                                   definition->sections.begin(), definition->sections.end(),
+        [&section]( const damage_info_order_section_definition_data & value ) {
+            return value.section == section;
+        } );
+        if( duplicate != definition->sections.end() ) {
+            throw std::runtime_error( "damage-info section is already defined" );
+        }
+        definition->sections.push_back( { section, order, show_type } );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "damage info order" );
+        return definition->id;
+    }
+};
+
+struct vehicle_part_category_definition_handle {
+    std::shared_ptr<vehicle_part_category_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "vehicle part category" );
+        return definition->id;
+    }
+};
+
+struct named_color_definition_handle {
+    std::shared_ptr<named_color_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    std::string name() const {
+        require_readable_handle( token, *definition, "named color" );
+        return definition->name;
+    }
+};
+
+struct rotatable_symbol_definition_handle {
+    std::shared_ptr<rotatable_symbol_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    std::string key() const {
+        require_readable_handle( token, *definition, "rotatable symbol" );
+        return definition->key;
+    }
+};
+
+struct ascii_art_definition_handle {
+    std::shared_ptr<ascii_art_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    ascii_art_definition_handle &line( const std::string &text ) {
+        require_building_handle( token, *definition, "ASCII art" );
+        if( utf8_width( remove_color_tags( text ) ) > 41 ) {
+            throw std::runtime_error( "ASCII-art line exceeds the native display width" );
+        }
+        definition->lines.push_back( text );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "ASCII art" );
+        return definition->id;
+    }
+};
+
+struct limb_score_definition_handle {
+    std::shared_ptr<limb_score_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "limb score" );
+        return definition->id;
+    }
+};
+
+struct hit_range_definition_handle {
+    std::shared_ptr<hit_range_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "hit range" );
+        return definition->id;
+    }
+};
+
+struct bash_damage_profile_definition_handle {
+    std::shared_ptr<bash_damage_profile_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    bash_damage_profile_definition_handle &factor( const std::string &damage_type,
+            const double multiplier ) {
+        require_building_handle( token, *definition, "bash damage profile" );
+        if( damage_type.empty() || !std::isfinite( multiplier ) || multiplier < 0.0 ) {
+            throw std::runtime_error( "bash damage factor requires a damage type and non-negative multiplier" );
+        }
+        definition->factors[damage_type] = multiplier;
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "bash damage profile" );
+        return definition->id;
+    }
+};
+
+struct clothing_mod_definition_handle {
+    std::shared_ptr<clothing_mod_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    clothing_mod_definition_handle &modifier( const sol::table &options ) {
+        require_building_handle( token, *definition, "clothing modification" );
+        clothing_modifier_definition_data value;
+        value.stat = options.get_or( "stat", std::string() );
+        value.amount = options.get_or( "amount", 0.0 );
+        value.round_up = options.get_or( "round_up", false );
+        if( value.stat.empty() || !std::isfinite( value.amount ) ) {
+            throw std::runtime_error( "clothing modifier requires a stat and finite amount" );
+        }
+        const sol::optional<sol::table> scaling =
+            options.get<sol::optional<sol::table>>( "scale" );
+        if( scaling ) {
+            const std::size_t count = require_dense_array(
+                                          *scaling, "clothing modifier scale", 0, 2 );
+            for( std::size_t index = 1; index <= count; ++index ) {
+                const std::string dimension = scaling->raw_get<std::string>( index );
+                if( dimension == "thickness" ) {
+                    value.per_thickness = true;
+                } else if( dimension == "coverage" ) {
+                    value.per_coverage = true;
+                } else {
+                    throw std::runtime_error( "clothing modifier scale must use thickness or coverage" );
+                }
+            }
+        }
+        definition->modifiers.push_back( std::move( value ) );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "clothing modification" );
+        return definition->id;
+    }
+};
+
+struct overmap_land_use_code_definition_handle {
+    std::shared_ptr<overmap_land_use_code_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "overmap land-use code" );
+        return definition->id;
+    }
+};
+
+struct overmap_vision_definition_handle {
+    std::shared_ptr<overmap_vision_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    overmap_vision_definition_handle &appearance( const sol::table &options ) {
+        require_building_handle( token, *definition, "overmap vision" );
+        overmap_vision_level_definition_data level;
+        level.name = options.get_or( "name", std::string() );
+        level.color = options.get_or( "color", std::string( "black" ) );
+        level.looks_like = options.get_or( "looks_like", std::string() );
+        const std::string symbol = options.get_or( "symbol", std::string() );
+        const utf8_wrapper wrapped( symbol );
+        if( level.name.empty() || wrapped.size() != 1 ) {
+            throw std::runtime_error(
+                "overmap-vision appearance needs a name and one Unicode symbol" );
+        }
+        level.symbol = wrapped.at( 0 );
+        definition->levels.push_back( std::move( level ) );
+        return *this;
+    }
+
+    overmap_vision_definition_handle &blend_adjacent() {
+        require_building_handle( token, *definition, "overmap vision" );
+        overmap_vision_level_definition_data level;
+        level.blends_adjacent = true;
+        definition->levels.push_back( std::move( level ) );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "overmap vision" );
+        return definition->id;
+    }
+};
+
+struct overmap_location_definition_handle {
+    std::shared_ptr<overmap_location_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    overmap_location_definition_handle &terrain( const std::string &terrain_id ) {
+        require_building_handle( token, *definition, "overmap location" );
+        if( terrain_id.empty() ) {
+            throw std::runtime_error( "overmap-location terrain id cannot be empty" );
+        }
+        definition->terrains.push_back( terrain_id );
+        return *this;
+    }
+
+    overmap_location_definition_handle &terrain_flag( const std::string &flag ) {
+        require_building_handle( token, *definition, "overmap location" );
+        if( flag.empty() ) {
+            throw std::runtime_error( "overmap-location terrain flag cannot be empty" );
+        }
+        definition->terrain_flags.push_back( flag );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "overmap location" );
+        return definition->id;
+    }
+};
+
+struct profession_group_definition_handle {
+    std::shared_ptr<profession_group_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    profession_group_definition_handle &profession( const std::string &profession_id ) {
+        require_building_handle( token, *definition, "profession group" );
+        if( profession_id.empty() ) {
+            throw std::runtime_error( "profession-group entry id cannot be empty" );
+        }
+        definition->professions.push_back( profession_id );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "profession group" );
+        return definition->id;
+    }
+};
+
+struct map_extra_collection_definition_handle {
+    std::shared_ptr<map_extra_collection_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    map_extra_collection_definition_handle &extra( const std::string &extra_id,
+            const std::int64_t weight ) {
+        require_building_handle( token, *definition, "map-extra collection" );
+        if( extra_id.empty() || weight <= 0 ) {
+            throw std::runtime_error( "map-extra collection entries need an id and positive weight" );
+        }
+        definition->entries.emplace_back( extra_id, weight );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "map-extra collection" );
+        return definition->id;
+    }
+};
+
+struct vehicle_group_definition_handle {
+    std::shared_ptr<vehicle_group_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    vehicle_group_definition_handle &vehicle( const std::string &vehicle_id,
+            const std::int64_t weight ) {
+        require_building_handle( token, *definition, "vehicle group" );
+        if( vehicle_id.empty() || weight <= 0 ) {
+            throw std::runtime_error( "vehicle-group entries need an id and positive weight" );
+        }
+        definition->entries.emplace_back( vehicle_id, weight );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "vehicle group" );
+        return definition->id;
+    }
+};
+
+struct fault_group_definition_handle {
+    std::shared_ptr<fault_group_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    fault_group_definition_handle &fault( const std::string &fault_id,
+                                          const std::int64_t weight ) {
+        require_building_handle( token, *definition, "fault group" );
+        if( fault_id.empty() || weight <= 0 ) {
+            throw std::runtime_error( "fault-group entries need an id and positive weight" );
+        }
+        definition->entries.emplace_back( fault_id, weight );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "fault group" );
+        return definition->id;
+    }
+};
+
+struct explosion_light_definition_handle {
+    std::shared_ptr<explosion_light_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    explosion_light_definition_handle &stop( const std::int64_t red,
+            const std::int64_t green, const std::int64_t blue,
+            const std::int64_t alpha ) {
+        require_building_handle( token, *definition, "explosion light" );
+        const auto component = []( const std::int64_t value, const char *name ) {
+            if( value < 0 || value > 255 ) {
+                throw std::runtime_error( std::string( "explosion-light " ) + name +
+                                          " must be from zero through 255" );
+            }
+            return static_cast<std::uint8_t>( value );
+        };
+        light_stop value;
+        value.color = { {
+                component( red, "red" ), component( green, "green" ),
+                component( blue, "blue" )
+            } };
+        value.alpha = component( alpha, "alpha" );
+        definition->stops.push_back( value );
+        return *this;
+    }
+
+    explosion_light_definition_handle &waves( const sol::table &options ) {
+        require_building_handle( token, *definition, "explosion light" );
+        definition->wave_travel = options.get_or( "travel", definition->wave_travel );
+        definition->wave_gap = options.get_or( "gap", definition->wave_gap );
+        definition->rise = options.get_or( "rise", definition->rise );
+        definition->fade = options.get_or( "fade", definition->fade );
+        definition->blend = options.get_or( "blend", definition->blend );
+        definition->spread_jitter = options.get_or(
+                                         "spread_jitter", definition->spread_jitter );
+        definition->color_jitter = options.get_or(
+                                        "color_jitter", definition->color_jitter );
+        definition->flicker = options.get_or( "flicker", definition->flicker );
+        definition->easing = options.get_or( "easing", definition->easing );
+        return *this;
+    }
+
+    explosion_light_definition_handle &duration( const sol::table &options ) {
+        require_building_handle( token, *definition, "explosion light" );
+        definition->duration_base_ms = options.get_or(
+                                           "base_ms", definition->duration_base_ms );
+        definition->duration_per_tile_ms = options.get_or(
+                                               "per_tile_ms", definition->duration_per_tile_ms );
+        definition->duration_min_ms = options.get_or(
+                                          "minimum_ms", definition->duration_min_ms );
+        definition->duration_max_ms = options.get_or(
+                                          "maximum_ms", definition->duration_max_ms );
+        return *this;
+    }
+
+    explosion_light_definition_handle &screen_shake( const double magnitude,
+            const double duration_ms ) {
+        require_building_handle( token, *definition, "explosion light" );
+        definition->screen_shake_magnitude = magnitude;
+        definition->screen_shake_duration_ms = duration_ms;
+        return *this;
+    }
+
+    explosion_light_definition_handle &shockwave( const sol::table &options ) {
+        require_building_handle( token, *definition, "explosion light" );
+        definition->shockwave = options.get_or( "enabled", true );
+        definition->shockwave_strength = options.get_or(
+                                             "strength", definition->shockwave_strength );
+        definition->shockwave_speed = options.get_or(
+                                          "speed", definition->shockwave_speed );
+        definition->shockwave_thickness = options.get_or(
+                                              "thickness", definition->shockwave_thickness );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "explosion light" );
+        return definition->id;
+    }
+};
+
+struct ammo_effect_definition_handle {
+    std::shared_ptr<ammo_effect_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    ammo_effect_definition_handle &field_burst( const sol::table &options ) {
+        require_building_handle( token, *definition, "ammo effect" );
+        ammo_field_definition_data value;
+        value.field = options.get_or( "field", std::string() );
+        value.intensity_min = options.get_or<std::int64_t>( "intensity_min", 1 );
+        value.intensity_max = options.get_or<std::int64_t>(
+                                  "intensity_max", value.intensity_min );
+        value.radius = options.get_or<std::int64_t>( "radius", 1 );
+        value.height = options.get_or<std::int64_t>( "height", 0 );
+        value.chance = options.get_or<std::int64_t>( "chance", 100 );
+        value.footprint = options.get_or<std::int64_t>( "footprint", 0 );
+        value.passable_only = options.get_or( "passable_only", false );
+        definition->field_bursts.push_back( std::move( value ) );
+        return *this;
+    }
+
+    ammo_effect_definition_handle &trail( const sol::table &options ) {
+        require_building_handle( token, *definition, "ammo effect" );
+        ammo_field_definition_data value;
+        value.field = options.get_or( "field", std::string() );
+        value.intensity_min = options.get_or<std::int64_t>( "intensity_min", 1 );
+        value.intensity_max = options.get_or<std::int64_t>(
+                                  "intensity_max", value.intensity_min );
+        value.chance = options.get_or<std::int64_t>( "chance", 100 );
+        definition->trails.push_back( std::move( value ) );
+        return *this;
+    }
+
+    ammo_effect_definition_handle &on_hit( const sol::table &options ) {
+        require_building_handle( token, *definition, "ammo effect" );
+        ammo_character_effect_definition_data value;
+        value.effect = options.get_or( "effect", std::string() );
+        value.duration_turns = options.get_or<std::int64_t>( "duration_turns", 1 );
+        value.intensity_min = options.get_or<std::int64_t>( "intensity", 1 );
+        value.intensity_max = value.intensity_min;
+        value.touch_skin = options.get_or( "touch_skin", false );
+        definition->on_hit_effects.push_back( std::move( value ) );
+        return *this;
+    }
+
+    ammo_effect_definition_handle &area_effect( const sol::table &options ) {
+        require_building_handle( token, *definition, "ammo effect" );
+        ammo_character_effect_definition_data value;
+        value.effect = options.get_or( "effect", std::string() );
+        value.duration_turns = options.get_or<std::int64_t>( "duration_turns", 1 );
+        value.intensity_min = options.get_or<std::int64_t>( "intensity_min", 1 );
+        value.intensity_max = options.get_or<std::int64_t>(
+                                  "intensity_max", value.intensity_min );
+        value.chance = options.get_or<std::int64_t>( "chance", 100 );
+        value.radius = options.get_or<std::int64_t>( "radius", 1 );
+        value.hits_min = options.get_or<std::int64_t>( "hits_min", 1 );
+        value.hits_max = options.get_or<std::int64_t>( "hits_max", value.hits_min );
+        value.all_body_parts = options.get_or( "all_body_parts", false );
+        definition->area_effects.push_back( std::move( value ) );
+        return *this;
+    }
+
+    ammo_effect_definition_handle &explosion( const sol::table &options ) {
+        require_building_handle( token, *definition, "ammo effect" );
+        definition->has_explosion = true;
+        definition->explosion_power = options.get_or( "power", 0.0 );
+        definition->explosion_distance_factor = options.get_or( "distance_factor", 0.8 );
+        definition->explosion_max_noise = options.get_or<std::int64_t>(
+                                              "max_noise", 90000000 );
+        definition->explosion_fire = options.get_or( "fire", false );
+        definition->explosion_light = options.get_or( "light", std::string() );
+        return *this;
+    }
+
+    ammo_effect_definition_handle &shrapnel( const sol::table &options ) {
+        require_building_handle( token, *definition, "ammo effect" );
+        definition->has_shrapnel = true;
+        definition->casing_mass = options.get_or<std::int64_t>( "casing_mass", 0 );
+        definition->fragment_mass = options.get_or( "fragment_mass", 0.005 );
+        definition->fragment_recovery = options.get_or<std::int64_t>( "recovery", 0 );
+        definition->fragment_drop = options.get_or( "drop", std::string( "null" ) );
+        return *this;
+    }
+
+    ammo_effect_definition_handle &flashbang() {
+        require_building_handle( token, *definition, "ammo effect" );
+        definition->flashbang = true;
+        return *this;
+    }
+
+    ammo_effect_definition_handle &emp() {
+        require_building_handle( token, *definition, "ammo effect" );
+        definition->emp = true;
+        return *this;
+    }
+
+    ammo_effect_definition_handle &foamcrete() {
+        require_building_handle( token, *definition, "ammo effect" );
+        definition->foamcrete = true;
+        return *this;
+    }
+
+    ammo_effect_definition_handle &spell( const std::string &spell_id,
+                                          const sol::optional<sol::table> &options ) {
+        require_building_handle( token, *definition, "ammo effect" );
+        ammo_spell_definition_data value;
+        value.spell = spell_id;
+        if( options ) {
+            value.level = options->get_or<std::int64_t>( "level", 0 );
+            value.self = options->get_or( "self", false );
+        }
+        definition->spells.push_back( std::move( value ) );
+        return *this;
+    }
+
+    ammo_effect_definition_handle &cast_spells_on_miss( const bool enabled = true ) {
+        require_building_handle( token, *definition, "ammo effect" );
+        definition->cast_spells_on_miss = enabled;
+        return *this;
+    }
+
+    ammo_effect_definition_handle &impact_policy( const std::string &handler_id ) {
+        require_building_handle( token, *definition, "ammo effect" );
+        definition->impact_handler = handler_id;
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "ammo effect" );
+        return definition->id;
+    }
+};
+
+struct addiction_type_definition_handle {
+    std::shared_ptr<addiction_type_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    addiction_type_definition_handle &tick_policy( const std::string &handler_id ) {
+        require_building_handle( token, *definition, "addiction type" );
+        definition->tick_handler = handler_id;
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "addiction type" );
+        return definition->id;
+    }
+};
+
+struct character_modifier_definition_handle {
+    std::shared_ptr<character_modifier_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    character_modifier_definition_handle &evaluate_with( const std::string &handler_id ) {
+        require_building_handle( token, *definition, "character modifier" );
+        definition->evaluator_handler = handler_id;
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "character modifier" );
+        return definition->id;
+    }
+};
+
+struct start_location_definition_handle {
+    std::shared_ptr<start_location_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    start_location_definition_handle &terrain( const std::string &terrain_id,
+            const sol::optional<sol::table> &options ) {
+        require_building_handle( token, *definition, "start location" );
+        start_location_target_definition_data value;
+        value.terrain = terrain_id;
+        if( options ) {
+            value.match = options->get_or( "match", std::string( "type" ) );
+            const sol::object raw_parameters = options->raw_get<sol::object>( "parameters" );
+            if( raw_parameters.valid() && raw_parameters.get_type() != sol::type::nil ) {
+                if( raw_parameters.get_type() != sol::type::table ) {
+                    throw std::runtime_error( "start-location parameters must be a string table" );
+                }
+                for( const auto &entry : raw_parameters.as<sol::table>() ) {
+                    if( !entry.first.is<std::string>() || !entry.second.is<std::string>() ) {
+                        throw std::runtime_error(
+                            "start-location parameter keys and values must be strings" );
+                    }
+                    value.parameters.emplace( entry.first.as<std::string>(),
+                                              entry.second.as<std::string>() );
+                }
+            }
+        }
+        definition->targets.push_back( std::move( value ) );
+        return *this;
+    }
+
+    start_location_definition_handle &flag( const std::string &flag_id ) {
+        require_building_handle( token, *definition, "start location" );
+        if( flag_id.empty() || !definition->flags.insert( flag_id ).second ) {
+            throw std::runtime_error( "start-location flags must be non-empty and unique" );
+        }
+        return *this;
+    }
+
+    start_location_definition_handle &city_size( const std::int64_t minimum,
+            const std::int64_t maximum ) {
+        require_building_handle( token, *definition, "start location" );
+        definition->city_size_min = minimum;
+        definition->city_size_max = maximum;
+        return *this;
+    }
+
+    start_location_definition_handle &city_distance( const std::int64_t minimum,
+            const std::int64_t maximum ) {
+        require_building_handle( token, *definition, "start location" );
+        definition->city_distance_min = minimum;
+        definition->city_distance_max = maximum;
+        return *this;
+    }
+
+    start_location_definition_handle &z_levels( const std::int64_t minimum,
+            const std::int64_t maximum ) {
+        require_building_handle( token, *definition, "start location" );
+        definition->z_min = minimum;
+        definition->z_max = maximum;
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "start location" );
+        return definition->id;
+    }
+};
+
+struct climbing_aid_definition_handle {
+    std::shared_ptr<climbing_aid_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    climbing_aid_definition_handle &available_when( const sol::table &options ) {
+        require_building_handle( token, *definition, "climbing aid" );
+        definition->category = options.get_or( "category", std::string() );
+        definition->flag = options.get_or( "flag", std::string() );
+        definition->uses = options.get_or<std::int64_t>( "uses", 0 );
+        definition->range = options.get_or<std::int64_t>( "range", 1 );
+        return *this;
+    }
+
+    climbing_aid_definition_handle &descent( const sol::table &options ) {
+        require_building_handle( token, *definition, "climbing aid" );
+        definition->max_height = options.get_or<std::int64_t>( "max_height", 1 );
+        definition->easy_climb_back_up = options.get_or<std::int64_t>(
+                                               "easy_climb_back_up", 0 );
+        definition->allow_remaining_height = options.get_or(
+                                                 "allow_remaining_height", true );
+        definition->menu_text = options.get_or( "menu_text", std::string() );
+        definition->unavailable_text = options.get_or(
+                                           "unavailable_text", std::string() );
+        definition->hotkey = options.get_or( "hotkey", std::string() );
+        definition->confirm_text = options.get_or( "confirm_text", std::string() );
+        definition->before_message = options.get_or(
+                                         "before_message", std::string() );
+        definition->after_message = options.get_or( "after_message", std::string() );
+        return *this;
+    }
+
+    climbing_aid_definition_handle &cost( const sol::table &options ) {
+        require_building_handle( token, *definition, "climbing aid" );
+        definition->pain = options.get_or<std::int64_t>( "pain", 0 );
+        definition->damage = options.get_or<std::int64_t>( "damage", 0 );
+        definition->kilocalories = options.get_or<std::int64_t>( "kilocalories", 0 );
+        definition->thirst = options.get_or<std::int64_t>( "thirst", 0 );
+        return *this;
+    }
+
+    climbing_aid_definition_handle &deploy( const std::string &furniture_id ) {
+        require_building_handle( token, *definition, "climbing aid" );
+        definition->deploy_furniture = furniture_id;
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "climbing aid" );
+        return definition->id;
+    }
+};
+
+struct weather_type_definition_handle {
+    std::shared_ptr<weather_type_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    weather_type_definition_handle &duration( const std::int64_t minimum_turns,
+            const std::int64_t maximum_turns ) {
+        require_building_handle( token, *definition, "weather type" );
+        definition->minimum_duration_turns = minimum_turns;
+        definition->maximum_duration_turns = maximum_turns;
+        return *this;
+    }
+
+    weather_type_definition_handle &animation( const sol::table &options ) {
+        require_building_handle( token, *definition, "weather type" );
+        definition->has_animation = true;
+        definition->animation_factor = options.get_or( "factor", 0.0 );
+        definition->animation_color = options.get_or( "color", std::string( "white" ) );
+        definition->animation_symbol = options.get_or( "symbol", std::string() );
+        return *this;
+    }
+
+    weather_type_definition_handle &requires( const std::string &weather_id ) {
+        require_building_handle( token, *definition, "weather type" );
+        definition->required_weathers.push_back( weather_id );
+        return *this;
+    }
+
+    weather_type_definition_handle &passive_effect( const sol::table &options ) {
+        require_building_handle( token, *definition, "weather type" );
+        weather_passive_effect_definition_data value;
+        value.effect = options.get_or( "effect", std::string() );
+        value.minimum_duration_turns = options.get_or<std::int64_t>(
+                                           "minimum_duration_turns", 1 );
+        value.maximum_duration_turns = options.get_or<std::int64_t>(
+                                           "maximum_duration_turns", value.minimum_duration_turns );
+        value.intensity = options.get_or<std::int64_t>( "intensity", 1 );
+        value.body_part = options.get_or( "body_part", std::string() );
+        value.environmental = options.get_or( "environmental", true );
+        value.immune_in_vehicle = options.get_or( "immune_in_vehicle", false );
+        value.immune_inside_vehicle = options.get_or( "immune_inside_vehicle", false );
+        value.immune_outside_vehicle = options.get_or( "immune_outside_vehicle", false );
+        value.chance_in_vehicle = options.get_or<std::int64_t>( "chance_in_vehicle", 0 );
+        value.chance_inside_vehicle = options.get_or<std::int64_t>(
+                                          "chance_inside_vehicle", 0 );
+        value.chance_outside_vehicle = options.get_or<std::int64_t>(
+                                           "chance_outside_vehicle", 0 );
+        value.message = options.get_or( "message", std::string() );
+        value.npc_message = options.get_or( "npc_message", std::string() );
+        definition->passive_effects.push_back( std::move( value ) );
+        return *this;
+    }
+
+    weather_type_definition_handle &condition( const std::string &handler_id ) {
+        require_building_handle( token, *definition, "weather type" );
+        definition->condition_handler = handler_id;
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "weather type" );
+        return definition->id;
+    }
+};
+
+struct score_definition_handle {
+    std::shared_ptr<score_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "score" );
+        return definition->id;
+    }
+};
+
+struct overlay_order_definition_handle {
+    std::shared_ptr<overlay_order_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    overlay_order_definition_handle &mutation( const std::string &mutation_id,
+            const std::int64_t order ) {
+        require_building_handle( token, *definition, "overlay order" );
+        if( mutation_id.empty() || !definition->orders.emplace( mutation_id, order ).second ) {
+            throw std::runtime_error( "overlay order requires unique non-empty mutation ids" );
+        }
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "overlay order" );
+        return definition->id;
+    }
+};
+
+struct zone_type_definition_handle {
+    std::shared_ptr<zone_type_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "zone type" );
+        return definition->id;
+    }
+};
+
+struct speech_pool_definition_handle {
+    std::shared_ptr<speech_pool_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    speech_pool_definition_handle &line( const std::string &sound,
+                                         const std::int64_t volume ) {
+        require_building_handle( token, *definition, "speech pool" );
+        if( sound.empty() ) {
+            throw std::runtime_error( "speech-pool line cannot be empty" );
+        }
+        definition->lines.emplace_back( sound, volume );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "speech pool" );
+        return definition->id;
+    }
+};
+
+struct end_screen_definition_handle {
+    std::shared_ptr<end_screen_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    end_screen_definition_handle &info( const std::int64_t column,
+                                        const std::int64_t row,
+                                        const std::string &text ) {
+        require_building_handle( token, *definition, "end screen" );
+        if( text.empty() ) {
+            throw std::runtime_error( "end-screen information text cannot be empty" );
+        }
+        definition->information.emplace_back( column, row, text );
+        return *this;
+    }
+
+    end_screen_definition_handle &condition( const std::string &handler_id ) {
+        require_building_handle( token, *definition, "end screen" );
+        if( handler_id.empty() ) {
+            throw std::runtime_error( "end-screen condition handler cannot be empty" );
+        }
+        definition->condition_handler = handler_id;
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "end screen" );
+        return definition->id;
+    }
+};
+
+struct activity_type_definition_handle {
+    std::shared_ptr<activity_type_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    activity_type_definition_handle &ignore( const std::string &distraction ) {
+        require_building_handle( token, *definition, "activity type" );
+        if( distraction.empty() ||
+            !definition->ignored_distractions.insert( distraction ).second ) {
+            throw std::runtime_error(
+                "activity type requires unique non-empty ignored distractions" );
+        }
+        return *this;
+    }
+
+    activity_type_definition_handle &on_turn( const std::string &handler_id ) {
+        require_building_handle( token, *definition, "activity type" );
+        if( handler_id.empty() ) {
+            throw std::runtime_error( "activity-type turn handler cannot be empty" );
+        }
+        definition->do_turn_handler = handler_id;
+        return *this;
+    }
+
+    activity_type_definition_handle &on_finish( const std::string &handler_id ) {
+        require_building_handle( token, *definition, "activity type" );
+        if( handler_id.empty() ) {
+            throw std::runtime_error( "activity-type completion handler cannot be empty" );
+        }
+        definition->completion_handler = handler_id;
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "activity type" );
+        return definition->id;
+    }
+};
+
+struct help_topic_definition_handle {
+    std::shared_ptr<help_topic_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    help_topic_definition_handle &paragraph( const std::string &text ) {
+        require_building_handle( token, *definition, "help topic" );
+        if( text.empty() ) {
+            throw std::runtime_error( "help-topic paragraph cannot be empty" );
+        }
+        definition->paragraphs.push_back( text );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "help topic" );
+        return definition->id;
+    }
+};
+
+struct snippet_category_definition_handle {
+    std::shared_ptr<snippet_category_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    snippet_category_definition_handle &text( const std::string &value,
+            const sol::optional<std::int64_t> &weight ) {
+        require_building_handle( token, *definition, "snippet category" );
+        if( value.empty() ) {
+            throw std::runtime_error( "snippet text cannot be empty" );
+        }
+        definition->entries.push_back( snippet_entry_definition_data{
+            std::string(), value, std::string(), weight.value_or( 1 ), std::string()
+        } );
+        return *this;
+    }
+
+    snippet_category_definition_handle &entry( const sol::table &options ) {
+        require_building_handle( token, *definition, "snippet category" );
+        snippet_entry_definition_data value;
+        value.id = options.get_or( "id", std::string() );
+        value.text = options.get_or( "text", std::string() );
+        value.name = options.get_or( "name", std::string() );
+        value.weight = options.get_or<std::int64_t>( "weight", 1 );
+        value.examine_handler = options.get_or( "on_examine", std::string() );
+        if( value.id.empty() || value.text.empty() ) {
+            throw std::runtime_error(
+                "named snippet entries require non-empty id and text" );
+        }
+        definition->entries.push_back( std::move( value ) );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "snippet category" );
+        return definition->id;
+    }
+};
+
+struct playlist_definition_handle {
+    std::shared_ptr<playlist_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    playlist_definition_handle &track( const std::string &file,
+                                       const sol::optional<std::int64_t> &volume ) {
+        require_building_handle( token, *definition, "playlist" );
+        if( file.empty() ) {
+            throw std::runtime_error( "playlist track file cannot be empty" );
+        }
+        definition->tracks.emplace_back( file, volume.value_or( 100 ) );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "playlist" );
+        return definition->id;
+    }
+};
+
+struct attack_vector_definition_handle {
+    std::shared_ptr<attack_vector_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    attack_vector_definition_handle &limb( const std::string &body_part ) {
+        require_building_handle( token, *definition, "attack vector" );
+        if( body_part.empty() ) {
+            throw std::runtime_error( "attack-vector limb id cannot be empty" );
+        }
+        definition->limbs.push_back( body_part );
+        return *this;
+    }
+
+    attack_vector_definition_handle &contact( const std::string &sub_body_part ) {
+        require_building_handle( token, *definition, "attack vector" );
+        if( sub_body_part.empty() ) {
+            throw std::runtime_error( "attack-vector contact id cannot be empty" );
+        }
+        definition->contacts.push_back( sub_body_part );
+        return *this;
+    }
+
+    attack_vector_definition_handle &requires_limb( const std::string &kind,
+            const std::int64_t count ) {
+        require_building_handle( token, *definition, "attack vector" );
+        if( kind.empty() || count <= 0 ) {
+            throw std::runtime_error( "attack-vector limb requirement must be positive" );
+        }
+        definition->limb_requirements.emplace_back( kind, count );
+        return *this;
+    }
+
+    attack_vector_definition_handle &requires_flag( const std::string &flag ) {
+        require_building_handle( token, *definition, "attack vector" );
+        if( flag.empty() ) {
+            throw std::runtime_error( "attack-vector required flag cannot be empty" );
+        }
+        definition->required_flags.insert( flag );
+        return *this;
+    }
+
+    attack_vector_definition_handle &forbids_flag( const std::string &flag ) {
+        require_building_handle( token, *definition, "attack vector" );
+        if( flag.empty() ) {
+            throw std::runtime_error( "attack-vector forbidden flag cannot be empty" );
+        }
+        definition->forbidden_flags.insert( flag );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "attack vector" );
+        return definition->id;
+    }
+};
+
+struct ammunition_type_definition_handle {
+    std::shared_ptr<ammunition_type_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "ammunition type" );
+        return definition->id;
+    }
+};
+
+struct item_category_definition_handle {
+    std::shared_ptr<item_category_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    item_category_definition_handle &priority_zone( const std::string &zone,
+            const sol::table &flags, bool filthy ) {
+        require_building_handle( token, *definition, "item category" );
+        if( zone.empty() ) {
+            throw std::runtime_error( "item category priority zone id cannot be empty" );
+        }
+        item_category_priority_definition priority;
+        priority.zone = zone;
+        priority.filthy = filthy;
+        const std::size_t count = require_dense_array(
+                                      flags, "item category priority flags", 0, 128 );
+        for( std::size_t index = 1; index <= count; ++index ) {
+            const std::string flag = flags.raw_get<std::string>( index );
+            if( flag.empty() ) {
+                throw std::runtime_error( "item category priority flag cannot be empty" );
+            }
+            priority.flags.insert( flag );
+        }
+        definition->priority_zones.push_back( std::move( priority ) );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "item category" );
+        return definition->id;
+    }
+};
+
+struct crafting_category_definition_handle {
+    std::shared_ptr<crafting_category_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    crafting_category_definition_handle &subcategory( const std::string &id ) {
+        require_building_handle( token, *definition, "recipe category" );
+        if( id.empty() ) {
+            throw std::runtime_error( "recipe subcategory id cannot be empty" );
+        }
+        definition->subcategories.push_back( id );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "recipe category" );
+        return definition->id;
+    }
+};
+
+struct proficiency_category_definition_handle {
+    std::shared_ptr<proficiency_category_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "proficiency category" );
+        return definition->id;
+    }
+};
+
+struct proficiency_definition_handle {
+    std::shared_ptr<proficiency_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    proficiency_definition_handle &requires( const std::string &id ) {
+        require_building_handle( token, *definition, "proficiency" );
+        if( id.empty() || id == definition->id ) {
+            throw std::runtime_error( "proficiency prerequisite must be another non-empty id" );
+        }
+        definition->required.insert( id );
+        return *this;
+    }
+
+    proficiency_definition_handle &bonus( const std::string &category,
+                                          const std::string &attribute, double value ) {
+        require_building_handle( token, *definition, "proficiency" );
+        if( category.empty() || attribute.empty() || !std::isfinite( value ) ) {
+            throw std::runtime_error( "proficiency bonus requires a category, attribute, and finite value" );
+        }
+        definition->bonuses.push_back( { category, attribute, value } );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "proficiency" );
+        return definition->id;
+    }
+};
+
+struct weapon_category_definition_handle {
+    std::shared_ptr<weapon_category_definition_data> definition;
+    std::shared_ptr<owner_token> token;
+
+    weapon_category_definition_handle &proficiency( const std::string &id ) {
+        require_building_handle( token, *definition, "weapon category" );
+        if( id.empty() ) {
+            throw std::runtime_error( "weapon category proficiency id cannot be empty" );
+        }
+        definition->proficiencies.push_back( id );
+        return *this;
+    }
+
+    std::string id() const {
+        require_readable_handle( token, *definition, "weapon category" );
+        return definition->id;
+    }
+};
+
+struct item_registration {
+    definition_operation operation = definition_operation::add;
+    std::shared_ptr<item_definition_data> definition;
+};
+
+struct recipe_registration {
+    definition_operation operation = definition_operation::add;
+    std::shared_ptr<recipe_definition_data> definition;
+};
+
+template<typename Definition>
+struct catalog_registration {
+    definition_operation operation = definition_operation::add;
+    std::shared_ptr<Definition> definition;
+};
+
+using tool_quality_registration = catalog_registration<tool_quality_definition_data>;
+using skill_display_registration = catalog_registration<skill_display_definition_data>;
+using skill_registration = catalog_registration<skill_definition_data>;
+using vitamin_registration = catalog_registration<vitamin_definition_data>;
+using json_flag_registration = catalog_registration<json_flag_definition_data>;
+using material_registration = catalog_registration<material_definition_data>;
+using damage_type_registration = catalog_registration<damage_type_definition_data>;
+using ammunition_type_registration = catalog_registration<ammunition_type_definition_data>;
+using item_category_registration = catalog_registration<item_category_definition_data>;
+using crafting_category_registration = catalog_registration<crafting_category_definition_data>;
+using proficiency_category_registration = catalog_registration<proficiency_category_definition_data>;
+using proficiency_registration = catalog_registration<proficiency_definition_data>;
+using weapon_category_registration = catalog_registration<weapon_category_definition_data>;
+using requirement_registration = catalog_registration<requirement_definition_data>;
+using recipe_group_registration = catalog_registration<recipe_group_definition_data>;
+using scent_type_registration = catalog_registration<scent_type_definition_data>;
+using speed_description_registration = catalog_registration<speed_description_definition_data>;
+using harvest_drop_type_registration = catalog_registration<harvest_drop_type_definition_data>;
+using harvest_registration = catalog_registration<harvest_definition_data>;
+using behavior_registration = catalog_registration<behavior_definition_data>;
+using effect_type_registration = catalog_registration<effect_type_definition_data>;
+using monster_attack_registration = catalog_registration<monster_attack_definition_data>;
+using weakpoint_set_registration = catalog_registration<weakpoint_set_definition_data>;
+using field_type_registration = catalog_registration<field_type_definition_data>;
+using item_group_registration = catalog_registration<item_group_definition_data>;
+using sub_body_part_registration = catalog_registration<sub_body_part_definition_data>;
+using body_part_registration = catalog_registration<body_part_definition_data>;
+using anatomy_registration = catalog_registration<anatomy_definition_data>;
+using body_graph_registration = catalog_registration<body_graph_definition_data>;
+using monster_registration = catalog_registration<monster_definition_data>;
+using morale_type_registration = catalog_registration<morale_type_definition_data>;
+using disease_type_registration = catalog_registration<disease_type_definition_data>;
+using monster_flag_registration = catalog_registration<monster_flag_definition_data>;
+using species_registration = catalog_registration<species_definition_data>;
+using emission_registration = catalog_registration<emission_definition_data>;
+using monster_faction_registration = catalog_registration<monster_faction_definition_data>;
+using mutation_type_registration = catalog_registration<mutation_type_definition_data>;
+using connect_group_registration = catalog_registration<connect_group_definition_data>;
+using mutation_category_registration = catalog_registration<mutation_category_definition_data>;
+using construction_category_registration =
+    catalog_registration<construction_category_definition_data>;
+using construction_group_registration = catalog_registration<construction_group_definition_data>;
+using vehicle_part_location_registration =
+    catalog_registration<vehicle_part_location_definition_data>;
+using mood_face_registration = catalog_registration<mood_face_definition_data>;
+using damage_info_order_registration = catalog_registration<damage_info_order_definition_data>;
+using vehicle_part_category_registration =
+    catalog_registration<vehicle_part_category_definition_data>;
+using named_color_registration = catalog_registration<named_color_definition_data>;
+using rotatable_symbol_registration = catalog_registration<rotatable_symbol_definition_data>;
+using ascii_art_registration = catalog_registration<ascii_art_definition_data>;
+using limb_score_registration = catalog_registration<limb_score_definition_data>;
+using hit_range_registration = catalog_registration<hit_range_definition_data>;
+using bash_damage_profile_registration =
+    catalog_registration<bash_damage_profile_definition_data>;
+using clothing_mod_registration = catalog_registration<clothing_mod_definition_data>;
+using overmap_land_use_code_registration =
+    catalog_registration<overmap_land_use_code_definition_data>;
+using overmap_vision_registration = catalog_registration<overmap_vision_definition_data>;
+using overmap_location_registration = catalog_registration<overmap_location_definition_data>;
+using profession_group_registration = catalog_registration<profession_group_definition_data>;
+using map_extra_collection_registration =
+    catalog_registration<map_extra_collection_definition_data>;
+using vehicle_group_registration = catalog_registration<vehicle_group_definition_data>;
+using fault_group_registration = catalog_registration<fault_group_definition_data>;
+using explosion_light_registration = catalog_registration<explosion_light_definition_data>;
+using ammo_effect_registration = catalog_registration<ammo_effect_definition_data>;
+using addiction_type_registration = catalog_registration<addiction_type_definition_data>;
+using character_modifier_registration = catalog_registration<character_modifier_definition_data>;
+using start_location_registration = catalog_registration<start_location_definition_data>;
+using climbing_aid_registration = catalog_registration<climbing_aid_definition_data>;
+using weather_type_registration = catalog_registration<weather_type_definition_data>;
+using score_registration = catalog_registration<score_definition_data>;
+using overlay_order_registration = catalog_registration<overlay_order_definition_data>;
+using zone_type_registration = catalog_registration<zone_type_definition_data>;
+using speech_pool_registration = catalog_registration<speech_pool_definition_data>;
+using end_screen_registration = catalog_registration<end_screen_definition_data>;
+using activity_type_registration = catalog_registration<activity_type_definition_data>;
+using help_topic_registration = catalog_registration<help_topic_definition_data>;
+using snippet_category_registration = catalog_registration<snippet_category_definition_data>;
+using playlist_registration = catalog_registration<playlist_definition_data>;
+using attack_vector_registration = catalog_registration<attack_vector_definition_data>;
+using magic_type_registration = catalog_registration<magic_type_definition_data>;
+using movement_mode_registration = catalog_registration<movement_mode_definition_data>;
+
+std::string operation_name( definition_operation operation )
+{
+    switch( operation ) {
+        case definition_operation::add:
+            return "add";
+        case definition_operation::replace:
+            return "replace";
+        case definition_operation::edit:
+            return "edit";
+    }
+    return "unknown";
+}
+
+std::optional<magic_energy_type> platform_magic_energy_type( std::string value )
+{
+    std::transform( value.begin(), value.end(), value.begin(), []( const unsigned char ch ) {
+        return static_cast<char>( std::tolower( ch ) );
+    } );
+    if( value == "hp" ) {
+        return magic_energy_type::hp;
+    }
+    if( value == "mana" ) {
+        return magic_energy_type::mana;
+    }
+    if( value == "stamina" ) {
+        return magic_energy_type::stamina;
+    }
+    if( value == "bionic" ) {
+        return magic_energy_type::bionic;
+    }
+    if( value == "vitamin" ) {
+        return magic_energy_type::vitamin;
+    }
+    if( value == "none" ) {
+        return magic_energy_type::none;
+    }
+    return std::nullopt;
+}
+
+std::optional<move_mode_type> platform_movement_mode_type( std::string value )
+{
+    std::transform( value.begin(), value.end(), value.begin(), []( const unsigned char ch ) {
+        return static_cast<char>( std::tolower( ch ) );
+    } );
+    if( value == "prone" ) {
+        return move_mode_type::PRONE;
+    }
+    if( value == "crouching" ) {
+        return move_mode_type::CROUCHING;
+    }
+    if( value == "walking" ) {
+        return move_mode_type::WALKING;
+    }
+    if( value == "running" ) {
+        return move_mode_type::RUNNING;
+    }
+    return std::nullopt;
+}
+
+std::optional<based_on_type> platform_activity_based_on( std::string value )
+{
+    std::transform( value.begin(), value.end(), value.begin(), []( const unsigned char ch ) {
+        return static_cast<char>( std::tolower( ch ) );
+    } );
+    if( value == "time" ) {
+        return based_on_type::TIME;
+    }
+    if( value == "speed" ) {
+        return based_on_type::SPEED;
+    }
+    if( value == "neither" ) {
+        return based_on_type::NEITHER;
+    }
+    return std::nullopt;
+}
+
+std::optional<steed_type> platform_steed_type( std::string value )
+{
+    std::transform( value.begin(), value.end(), value.begin(), []( const unsigned char ch ) {
+        return static_cast<char>( std::tolower( ch ) );
+    } );
+    if( value == "none" ) {
+        return steed_type::NONE;
+    }
+    if( value == "animal" ) {
+        return steed_type::ANIMAL;
+    }
+    if( value == "mech" ) {
+        return steed_type::MECH;
+    }
+    return std::nullopt;
+}
+
+std::optional<vfx_easing> platform_vfx_easing( std::string value )
+{
+    std::transform( value.begin(), value.end(), value.begin(), []( const unsigned char ch ) {
+        return static_cast<char>( std::tolower( ch ) );
+    } );
+    if( value == "linear" ) {
+        return vfx_easing::linear;
+    }
+    if( value == "ease_in" ) {
+        return vfx_easing::ease_in;
+    }
+    if( value == "ease_out" ) {
+        return vfx_easing::ease_out;
+    }
+    if( value == "smoothstep" ) {
+        return vfx_easing::smoothstep;
+    }
+    return std::nullopt;
+}
+
+std::optional<ot_match_type> platform_ot_match_type( std::string value )
+{
+    std::transform( value.begin(), value.end(), value.begin(), []( const unsigned char ch ) {
+        return static_cast<char>( std::tolower( ch ) );
+    } );
+    if( value == "exact" ) {
+        return ot_match_type::exact;
+    }
+    if( value == "type" ) {
+        return ot_match_type::type;
+    }
+    if( value == "subtype" ) {
+        return ot_match_type::subtype;
+    }
+    if( value == "prefix" ) {
+        return ot_match_type::prefix;
+    }
+    if( value == "contains" ) {
+        return ot_match_type::contains;
+    }
+    return std::nullopt;
+}
+
+std::optional<climbing_aid::category> platform_climbing_category( std::string value )
+{
+    std::transform( value.begin(), value.end(), value.begin(), []( const unsigned char ch ) {
+        return static_cast<char>( std::tolower( ch ) );
+    } );
+    if( value == "special" ) {
+        return climbing_aid::category::special;
+    }
+    if( value == "terrain_or_furniture" ) {
+        return climbing_aid::category::ter_furn;
+    }
+    if( value == "vehicle" ) {
+        return climbing_aid::category::veh;
+    }
+    if( value == "item" ) {
+        return climbing_aid::category::item;
+    }
+    if( value == "character" ) {
+        return climbing_aid::category::character;
+    }
+    if( value == "trait" ) {
+        return climbing_aid::category::trait;
+    }
+    return std::nullopt;
+}
+
+std::optional<precip_class> platform_precipitation( std::string value )
+{
+    std::transform( value.begin(), value.end(), value.begin(), []( const unsigned char ch ) {
+        return static_cast<char>( std::tolower( ch ) );
+    } );
+    if( value == "none" ) {
+        return precip_class::none;
+    }
+    if( value == "very_light" ) {
+        return precip_class::very_light;
+    }
+    if( value == "light" ) {
+        return precip_class::light;
+    }
+    if( value == "heavy" ) {
+        return precip_class::heavy;
+    }
+    return std::nullopt;
+}
+
+std::optional<weather_sound_category> platform_weather_sound_category( std::string value )
+{
+    std::transform( value.begin(), value.end(), value.begin(), []( const unsigned char ch ) {
+        return static_cast<char>( std::tolower( ch ) );
+    } );
+    static const std::map<std::string, weather_sound_category> values = {
+        { "silent", weather_sound_category::silent },
+        { "drizzle", weather_sound_category::drizzle },
+        { "rainy", weather_sound_category::rainy },
+        { "rainstorm", weather_sound_category::rainstorm },
+        { "thunder", weather_sound_category::thunder },
+        { "flurries", weather_sound_category::flurries },
+        { "snowstorm", weather_sound_category::snowstorm },
+        { "snow", weather_sound_category::snow },
+        { "portal_storm", weather_sound_category::portal_storm },
+        { "clear", weather_sound_category::clear },
+        { "sunny", weather_sound_category::sunny },
+        { "cloudy", weather_sound_category::cloudy },
+    };
+    const auto found = values.find( value );
+    return found == values.end() ? std::nullopt : std::optional<weather_sound_category>( found->second );
+}
+
+std::uint64_t fnv1a( std::string_view value, std::uint64_t state = 1469598103934665603ULL )
+{
+    for( const unsigned char byte : value ) {
+        state ^= byte;
+        state *= 1099511628211ULL;
+    }
+    return state;
+}
+
+void hash_part( std::uint64_t &state, std::string_view value )
+{
+    state = fnv1a( std::to_string( value.size() ), state );
+    state = fnv1a( ":", state );
+    state = fnv1a( value, state );
+    state = fnv1a( ";", state );
+}
+
+class lua_platform_iuse_actor : public iuse_actor
+{
+    public:
+        lua_platform_iuse_actor( std::string mod_id, std::string handler_id,
+                                 std::string label ) :
+            iuse_actor( "lua_platform" ), mod_id_( std::move( mod_id ) ),
+            handler_id_( std::move( handler_id ) ), label_( std::move( label ) ) {}
+
+        void load( const JsonObject &, const std::string & ) override {}
+
+        std::optional<int> use( Character *character, item &used_item, map *here,
+                                const tripoint_bub_ms &position ) const override {
+            return invoke_use_handler( mod_id_, handler_id_, character, used_item,
+                                       here, position );
+        }
+
+        std::unique_ptr<iuse_actor> clone() const override {
+            return std::make_unique<lua_platform_iuse_actor>( *this );
+        }
+
+        std::string get_name() const override {
+            return label_;
+        }
+
+    private:
+        std::string mod_id_;
+        std::string handler_id_;
+        std::string label_;
+};
+
+struct handler_definition {
+    int payload_version = 1;
+    sol::protected_function callback;
+};
+
+struct task_payload_migration {
+    int target_version = 1;
+    sol::protected_function callback;
+};
+
+struct persistent_task {
+    std::uint64_t id = 0;
+    std::string handler_id;
+    std::int64_t due_turn = 0;
+    std::string owner = "world";
+    int payload_version = 1;
+    persistent_state payload;
+};
+
+struct persistent_scope_record {
+    persistent_state values;
+    std::vector<persistent_task> tasks;
+};
+
+constexpr std::size_t maximum_tasks_per_mod = 1024;
+constexpr std::uintmax_t maximum_platform_state_file_bytes = 16U * 1024U * 1024U;
+constexpr std::size_t maximum_presentation_text_bytes = 32768;
+constexpr std::size_t maximum_presentation_choices = 128;
+
+void require_presentation_text( const std::string &value,
+                                const std::string_view field,
+                                const std::size_t maximum = maximum_presentation_text_bytes )
+{
+    if( value.empty() || value.size() > maximum ||
+        value.find( '\0' ) != std::string::npos ) {
+        throw std::invalid_argument( "presentation " + std::string( field ) +
+                                     " is empty or exceeds its native limit" );
+    }
+}
+
+struct presentation_choice {
+    std::string id;
+    std::string label;
+    std::string description;
+    bool enabled = true;
+};
+
+std::vector<presentation_choice> presentation_choices_from_lua(
+    const sol::table &entries )
+{
+    const std::size_t count = require_dense_array(
+                                  entries, "presentation choices", 1,
+                                  maximum_presentation_choices );
+
+    std::vector<presentation_choice> result;
+    result.reserve( count );
+    std::set<std::string> ids;
+    for( std::size_t index = 1; index <= count; ++index ) {
+        const sol::object raw = entries.raw_get<sol::object>( index );
+        if( raw.get_type() != sol::type::table ) {
+            throw std::invalid_argument( "presentation choices must be tables" );
+        }
+        const sol::table entry = raw.as<sol::table>();
+        presentation_choice choice;
+        choice.id = entry.get_or( "id", std::string() );
+        choice.label = entry.get_or( "label", std::string() );
+        choice.description = entry.get_or( "description", std::string() );
+        choice.enabled = entry.get_or( "enabled", true );
+        require_presentation_text( choice.id, "choice id", 96 );
+        require_presentation_text( choice.label, "choice label", 512 );
+        if( choice.description.size() > 4096 ||
+            choice.description.find( '\0' ) != std::string::npos ) {
+            throw std::invalid_argument(
+                "presentation choice description exceeds its native limit" );
+        }
+        if( !ids.insert( choice.id ).second ) {
+            throw std::invalid_argument(
+                "presentation choice ids must be unique" );
+        }
+        result.push_back( std::move( choice ) );
+    }
+    return result;
+}
+
+struct use_context_data {
+    Character *character = nullptr;
+    item *used_item = nullptr;
+    tripoint_bub_ms position;
+    std::size_t runtime_generation = 0;
+    std::size_t world_generation = 0;
+    bool active = true;
+
+    void require_active() const {
+        if( !active || character == nullptr || used_item == nullptr ) {
+            throw std::runtime_error( "stale item-use context" );
+        }
+    }
+
+    void message( const std::string &value ) const {
+        require_active();
+        character->add_msg_if_player( value );
+    }
+
+    std::string player_name() const {
+        require_active();
+        return character->get_name();
+    }
+
+    std::string item_id() const {
+        require_active();
+        return used_item->typeId().str();
+    }
+
+    int charges() const {
+        require_active();
+        return used_item->charges;
+    }
+
+    void set_charges( std::int64_t value ) {
+        require_active();
+        if( value < 0 || value > std::numeric_limits<int>::max() ) {
+            throw std::runtime_error( "item charges are outside the native range" );
+        }
+        used_item->charges = static_cast<int>( value );
+    }
+
+    cata::lua_ui::game_handle character_handle() const {
+        require_active();
+        const tripoint_abs_ms absolute = character->pos_abs();
+        return cata::lua_ui::game_handle::from_creature( *character, {
+            "platform_item_use_character", character->getID().get_value(),
+            absolute.x(), absolute.y(), absolute.z(), {}
+        }, runtime_generation, world_generation );
+    }
+
+    cata::lua_ui::game_handle item_handle() const {
+        require_active();
+        return cata::lua_ui::game_handle::from_item( *used_item, {
+            "platform_item_use_item", used_item->uid().get_value(), 0, 0, 0, {}
+        }, runtime_generation, world_generation );
+    }
+
+    cata::lua_ui::script_tripoint_coord use_position() const {
+        require_active();
+        return cata::lua_ui::script_tripoint_coord::from_native(
+                   coords::origin::reality_bubble, coords::scale::map_square,
+                   position.raw() );
+    }
+};
+
+std::int64_t nonnegative_turn_difference( const std::int64_t later,
+        const std::int64_t earlier )
+{
+    if( earlier > later ) {
+        return 0;
+    }
+    if( earlier < 0 && later > std::numeric_limits<std::int64_t>::max() + earlier ) {
+        return std::numeric_limits<std::int64_t>::max();
+    }
+    return later - earlier;
+}
+
+persistent_value persistent_from_lua( const sol::object &value,
+                                      const std::string &api_name )
+{
+    switch( value.get_type() ) {
+        case sol::type::boolean:
+            return value.as<bool>();
+        case sol::type::number:
+            if( value.is<lua_Integer>() ) {
+                return static_cast<std::int64_t>( value.as<lua_Integer>() );
+            }
+            if( const double number = value.as<double>(); std::isfinite( number ) ) {
+                return number;
+            }
+            throw std::runtime_error( api_name + " only accepts finite numbers" );
+        case sol::type::string:
+            return value.as<std::string>();
+        default:
+            throw std::runtime_error( api_name +
+                                      " only accepts boolean, number, or string values" );
+    }
+}
+
+void set_persistent_value( persistent_state &store, const std::string &key,
+                           const sol::object &value, const std::string &api_name )
+{
+    if( value.get_type() == sol::type::nil ) {
+        store.erase( key );
+        return;
+    }
+    cata::lua_ui::assign_persistent_value(
+        store, key, persistent_from_lua( value, api_name ) );
+}
+
+sol::object get_persistent_value( const persistent_state &store,
+                                  sol::this_state lua,
+                                  const std::string &key,
+                                  const sol::optional<sol::object> &fallback )
+{
+    const auto found = store.find( key );
+    if( found == store.end() ) {
+        if( fallback && fallback->get_type() != sol::type::nil ) {
+            static_cast<void>( persistent_from_lua( *fallback, "state.get fallback" ) );
+        }
+        return fallback.value_or( sol::make_object( lua, sol::lua_nil ) );
+    }
+    return std::visit( [lua]( const auto &entry ) {
+        return sol::make_object( lua, entry );
+    }, found->second );
+}
+
+sol::table persistent_table( sol::state &lua, const persistent_state &values )
+{
+    sol::table result = lua.create_table();
+    for( const auto &[key, value] : values ) {
+        std::visit( [&result, &key]( const auto &entry ) {
+            result[key] = entry;
+        }, value );
+    }
+    return result;
+}
+
+persistent_state persistent_table_from_lua( const sol::table &table,
+        const std::string &api_name )
+{
+    persistent_state result;
+    for( const auto &entry : table ) {
+        const sol::object key = entry.first;
+        if( !key.is<std::string>() ) {
+            throw std::runtime_error( api_name + " payload keys must be strings" );
+        }
+        const std::string key_string = key.as<std::string>();
+        cata::lua_ui::assign_persistent_value(
+            result, key_string,
+            persistent_from_lua( entry.second, api_name ) );
+    }
+    return result;
+}
+
+persistent_state persistent_table_from_lua( const sol::optional<sol::table> &table,
+        const std::string &api_name )
+{
+    return table ? persistent_table_from_lua( *table, api_name ) : persistent_state{};
+}
+
+void write_typed_values( JsonOut &json, const persistent_state &values )
+{
+    std::vector<std::string> keys;
+    keys.reserve( values.size() );
+    for( const auto &[key, value] : values ) {
+        static_cast<void>( value );
+        keys.push_back( key );
+    }
+    std::sort( keys.begin(), keys.end() );
+    json.start_object();
+    for( const std::string &key : keys ) {
+        json.member( key );
+        json.start_object();
+        std::visit( [&json]( const auto &value ) {
+            using value_type = std::decay_t<decltype( value )>;
+            if constexpr( std::is_same_v<value_type, bool> ) {
+                json.member( "type", "boolean" );
+            } else if constexpr( std::is_same_v<value_type, std::int64_t> ) {
+                json.member( "type", "integer" );
+            } else if constexpr( std::is_same_v<value_type, double> ) {
+                json.member( "type", "float" );
+            } else {
+                json.member( "type", "string" );
+            }
+            json.member( "value", value );
+        }, values.at( key ) );
+        json.end_object();
+    }
+    json.end_object();
+}
+
+persistent_state read_typed_values( const JsonObject &values )
+{
+    persistent_state result;
+    for( const JsonMember member : values ) {
+        const std::string key = member.name();
+        const JsonObject entry = member.get_object();
+        const std::string type = entry.get_string( "type" );
+        if( type == "boolean" ) {
+            cata::lua_ui::assign_persistent_value( result, key,
+                                                   entry.get_bool( "value" ) );
+        } else if( type == "integer" ) {
+            cata::lua_ui::assign_persistent_value( result, key,
+                                                   entry.get_int64( "value" ) );
+        } else if( type == "float" ) {
+            cata::lua_ui::assign_persistent_value( result, key,
+                                                   entry.get_float( "value" ) );
+        } else if( type == "string" ) {
+            cata::lua_ui::assign_persistent_value( result, key,
+                                                   entry.get_string( "value" ) );
+        } else {
+            throw std::runtime_error( "unknown Platform state value type '" + type + "'" );
+        }
+        entry.allow_omitted_members();
+    }
+    values.allow_omitted_members();
+    return result;
+}
+
+} // namespace
+
+class runtime : public std::enable_shared_from_this<runtime>
+{
+    public:
+        runtime( std::string id, std::size_t candidate_generation,
+                 sol::state &state ) : mod_id( std::move( id ) ),
+            generation( candidate_generation ), lua( &state ),
+            content( mod_id, generation ),
+            random_engine( fnv1a( mod_id ) ^ static_cast<std::uint64_t>( generation ) ) {}
+
+        std::string mod_id;
+        std::size_t generation = 0;
+        sol::state *lua = nullptr;
+        content_transaction content;
+        std::unordered_map<std::string, handler_definition> handlers;
+        std::unordered_map<std::string, std::map<int, task_payload_migration>>
+                task_migrations;
+        std::unordered_map<std::string, std::vector<std::string>> subscriptions;
+        std::unordered_map<std::string, std::vector<std::string>> hooks;
+        persistent_state character_state;
+        persistent_state world_state;
+        std::vector<persistent_task> tasks;
+        std::set<std::uint64_t> reported_task_migration_failures;
+        std::uint64_t next_task_id = 1;
+        std::mt19937_64 random_engine;
+        int callback_depth = 0;
+        bool world_is_ready = false;
+};
+
+struct content_transaction::impl {
+    impl( std::string owner_id, std::size_t owner_generation ) :
+        owner( std::move( owner_id ) ), generation( owner_generation ),
+        token( std::make_shared<owner_token>( owner_token{ owner, generation,
+                handle_lifecycle::building } ) ) {}
+
+    std::string owner;
+    std::size_t generation = 0;
+    std::shared_ptr<owner_token> token;
+    std::vector<tool_quality_registration> tool_qualities;
+    std::vector<skill_display_registration> skill_displays;
+    std::vector<skill_registration> skills;
+    std::vector<vitamin_registration> vitamins;
+    std::vector<json_flag_registration> json_flags;
+    std::vector<damage_type_registration> damage_types;
+    std::vector<material_registration> materials;
+    std::vector<ammunition_type_registration> ammunition_types;
+    std::vector<item_category_registration> item_categories;
+    std::vector<crafting_category_registration> crafting_categories;
+    std::vector<proficiency_category_registration> proficiency_categories;
+    std::vector<proficiency_registration> proficiencies;
+    std::vector<weapon_category_registration> weapon_categories;
+    std::vector<requirement_registration> requirements;
+    std::vector<recipe_group_registration> recipe_groups;
+    std::vector<scent_type_registration> scent_types;
+    std::vector<speed_description_registration> speed_descriptions;
+    std::vector<harvest_drop_type_registration> harvest_drop_types;
+    std::vector<harvest_registration> harvests;
+    std::vector<behavior_registration> behaviors;
+    std::vector<effect_type_registration> effect_types;
+    std::vector<monster_attack_registration> monster_attacks;
+    std::vector<weakpoint_set_registration> weakpoint_sets;
+    std::vector<field_type_registration> field_types;
+    std::vector<item_group_registration> item_groups;
+    std::vector<sub_body_part_registration> sub_body_parts;
+    std::vector<body_part_registration> body_parts;
+    std::vector<anatomy_registration> anatomies;
+    std::vector<body_graph_registration> body_graphs;
+    std::vector<monster_registration> monsters;
+    std::vector<morale_type_registration> morale_types;
+    std::vector<disease_type_registration> disease_types;
+    std::vector<monster_flag_registration> monster_flags;
+    std::vector<species_registration> species;
+    std::vector<emission_registration> emissions;
+    std::vector<monster_faction_registration> monster_factions;
+    std::vector<mutation_type_registration> mutation_types;
+    std::vector<connect_group_registration> connect_groups;
+    std::vector<mutation_category_registration> mutation_categories;
+    std::vector<construction_category_registration> construction_categories;
+    std::vector<construction_group_registration> construction_groups;
+    std::vector<vehicle_part_location_registration> vehicle_part_locations;
+    std::vector<mood_face_registration> mood_faces;
+    std::vector<damage_info_order_registration> damage_info_orders;
+    std::vector<vehicle_part_category_registration> vehicle_part_categories;
+    std::vector<named_color_registration> named_colors;
+    std::vector<rotatable_symbol_registration> rotatable_symbols;
+    std::vector<ascii_art_registration> ascii_arts;
+    std::vector<limb_score_registration> limb_scores;
+    std::vector<hit_range_registration> hit_ranges;
+    std::vector<bash_damage_profile_registration> bash_damage_profiles;
+    std::vector<clothing_mod_registration> clothing_mods;
+    std::vector<overmap_land_use_code_registration> overmap_land_use_codes;
+    std::vector<overmap_vision_registration> overmap_visions;
+    std::vector<overmap_location_registration> overmap_locations;
+    std::vector<profession_group_registration> profession_groups;
+    std::vector<map_extra_collection_registration> map_extra_collections;
+    std::vector<vehicle_group_registration> vehicle_groups;
+    std::vector<fault_group_registration> fault_groups;
+    std::vector<explosion_light_registration> explosion_lights;
+    std::vector<ammo_effect_registration> ammo_effects;
+    std::vector<addiction_type_registration> addiction_types;
+    std::vector<character_modifier_registration> character_modifiers;
+    std::vector<start_location_registration> start_locations;
+    std::vector<climbing_aid_registration> climbing_aids;
+    std::vector<weather_type_registration> weather_types;
+    std::vector<score_registration> scores;
+    std::vector<overlay_order_registration> overlay_orders;
+    std::vector<zone_type_registration> zone_types;
+    std::vector<speech_pool_registration> speech_pools;
+    std::vector<end_screen_registration> end_screens;
+    std::vector<activity_type_registration> activity_types;
+    std::vector<help_topic_registration> help_topics;
+    std::vector<snippet_category_registration> snippet_categories;
+    std::vector<playlist_registration> playlists;
+    std::vector<attack_vector_registration> attack_vectors;
+    std::vector<magic_type_registration> magic_types;
+    std::vector<movement_mode_registration> movement_modes;
+    std::vector<item_registration> items;
+    std::vector<recipe_registration> recipes;
+    std::vector<std::pair<quality_id, std::optional<quality>>> tool_quality_undo;
+    std::vector<std::pair<skill_displayType_id, std::optional<SkillDisplayType>>>
+            skill_display_undo;
+    std::vector<std::pair<skill_id, std::optional<Skill>>> skill_undo;
+    std::vector<std::pair<vitamin_id, std::optional<vitamin>>> vitamin_undo;
+    std::vector<std::pair<flag_id, std::optional<json_flag>>> json_flag_undo;
+    std::vector<std::pair<damage_type_id, std::optional<damage_type>>> damage_type_undo;
+    std::vector<std::pair<material_id, std::optional<material_type>>> material_undo;
+    std::vector<std::pair<ammotype, std::optional<ammunition_type>>> ammunition_type_undo;
+    std::vector<std::tuple<item_category_id, std::optional<item_category>, float>>
+            item_category_undo;
+    std::vector<std::pair<crafting_category_id, std::optional<crafting_category>>>
+            crafting_category_undo;
+    std::vector<std::pair<proficiency_category_id, std::optional<proficiency_category>>>
+            proficiency_category_undo;
+    std::vector<std::pair<proficiency_id, std::optional<proficiency>>> proficiency_undo;
+    std::vector<std::pair<weapon_category_id, std::optional<weapon_category>>>
+            weapon_category_undo;
+    std::vector<std::pair<requirement_id, std::optional<requirement_data>>> requirement_undo;
+    std::vector<std::pair<std::string,
+        std::optional<detail::recipe_group_native_definition>>> recipe_group_undo;
+    std::vector<std::pair<scenttype_id, std::optional<scent_type>>> scent_type_undo;
+    std::vector<std::pair<speed_description_id, std::optional<speed_description>>>
+            speed_description_undo;
+    std::vector<std::pair<harvest_drop_type_id, std::optional<harvest_drop_type>>>
+            harvest_drop_type_undo;
+    std::vector<std::pair<harvest_id, std::optional<harvest_list>>> harvest_undo;
+    std::vector<std::pair<string_id<behavior::node_t>,
+        std::optional<behavior::node_t>>> behavior_undo;
+    std::vector<std::pair<std::string, std::optional<effect_type>>> effect_type_undo;
+    std::vector<std::pair<std::string, std::optional<mtype_special_attack>>>
+            monster_attack_undo;
+    std::vector<std::pair<weakpoints_id, std::optional<weakpoints>>> weakpoint_set_undo;
+    std::vector<std::pair<field_type_str_id, std::optional<field_type>>> field_type_undo;
+    std::vector<std::pair<item_group_id, std::unique_ptr<Item_spawn_data>>> item_group_undo;
+    std::vector<std::pair<sub_bodypart_str_id, std::optional<sub_body_part_type>>>
+            sub_body_part_undo;
+    std::vector<std::pair<bodypart_str_id, std::optional<body_part_type>>> body_part_undo;
+    std::vector<std::pair<anatomy_id, std::optional<anatomy>>> anatomy_undo;
+    std::vector<std::pair<bodygraph_id, std::optional<bodygraph>>> body_graph_undo;
+    std::vector<std::pair<mtype_id, std::optional<mtype>>> monster_undo;
+    std::vector<std::pair<morale_type, std::optional<morale_type_data>>> morale_type_undo;
+    std::vector<std::pair<diseasetype_id, std::optional<disease_type>>> disease_type_undo;
+    std::vector<std::pair<mon_flag_str_id, std::optional<mon_flag>>> monster_flag_undo;
+    std::vector<std::pair<species_id, std::optional<species_type>>> species_undo;
+    std::vector<std::pair<std::string, std::optional<emit>>> emission_undo;
+    std::vector<std::pair<mfaction_str_id, std::optional<monfaction>>>
+            monster_faction_undo;
+    std::vector<std::pair<std::string, bool>> mutation_type_undo;
+    std::vector<std::pair<std::string, std::optional<connect_group>>> connect_group_undo;
+    std::vector<std::pair<std::string, std::optional<mutation_category_trait>>>
+            mutation_category_undo;
+    std::vector<std::pair<construction_category_id,
+        std::optional<construction_category>>> construction_category_undo;
+    std::vector<std::pair<construction_group_str_id,
+        std::optional<construction_group>>> construction_group_undo;
+    std::vector<std::pair<vpart_location_id,
+        std::optional<vpart_location>>> vehicle_part_location_undo;
+    std::vector<std::pair<mood_face_id, std::optional<mood_face>>> mood_face_undo;
+    std::vector<std::pair<damage_info_order_id,
+        std::optional<damage_info_order>>> damage_info_order_undo;
+    std::vector<std::pair<std::string,
+        std::optional<vpart_category>>> vehicle_part_category_undo;
+    std::optional<std::vector<detail::named_color_native_definition>> named_color_undo;
+    std::optional<std::vector<detail::rotatable_symbol_native_entry>> rotatable_symbol_undo;
+    std::vector<std::pair<ascii_art_id, std::optional<ascii_art>>> ascii_art_undo;
+    std::vector<std::pair<limb_score_id, std::optional<limb_score>>> limb_score_undo;
+    std::optional<std::vector<int>> hit_range_undo;
+    std::vector<std::pair<bash_damage_profile_id, std::optional<bash_damage_profile>>>
+    bash_damage_profile_undo;
+    std::vector<std::pair<clothing_mod_id, std::optional<clothing_mod>>> clothing_mod_undo;
+    std::vector<std::pair<overmap_land_use_code_id,
+        std::optional<overmap_land_use_code>>> overmap_land_use_code_undo;
+    std::vector<std::pair<oter_vision_id, std::optional<oter_vision>>> overmap_vision_undo;
+    std::vector<std::pair<overmap_location_id, std::optional<overmap_location>>>
+    overmap_location_undo;
+    std::vector<std::pair<profession_group_id, std::optional<profession_group>>>
+    profession_group_undo;
+    std::vector<std::pair<map_extra_collection_id, std::optional<map_extra_collection>>>
+    map_extra_collection_undo;
+    std::vector<std::pair<std::string, std::optional<VehicleGroup>>> vehicle_group_undo;
+    std::vector<std::pair<fault_group_id, std::optional<fault_group>>> fault_group_undo;
+    std::vector<std::pair<explosion_light_str_id, std::optional<explosion_light>>>
+    explosion_light_undo;
+    std::vector<std::pair<ammo_effect_str_id, std::optional<ammo_effect>>> ammo_effect_undo;
+    std::vector<std::pair<addiction_id, std::optional<add_type>>> addiction_type_undo;
+    std::vector<std::pair<character_modifier_id, std::optional<character_modifier>>>
+    character_modifier_undo;
+    std::vector<std::pair<start_location_id, std::optional<start_location>>>
+    start_location_undo;
+    std::vector<std::pair<climbing_aid_id, std::optional<climbing_aid>>>
+    climbing_aid_undo;
+    std::vector<std::pair<weather_type_id, std::optional<weather_type>>> weather_type_undo;
+    std::vector<std::pair<score_id, std::optional<score>>> score_undo;
+    std::vector<std::pair<std::string, std::optional<int>>> overlay_order_undo;
+    std::vector<std::pair<zone_type_id, std::optional<zone_type>>> zone_type_undo;
+    std::vector<std::pair<std::string, std::optional<std::vector<SpeechBubble>>>>
+            speech_pool_undo;
+    std::vector<std::pair<end_screen_id, std::optional<end_screen>>> end_screen_undo;
+    std::vector<std::pair<activity_id, std::optional<activity_type>>> activity_type_undo;
+    std::optional<help> help_undo;
+    std::optional<snippet_library> snippet_library_undo;
+    std::vector<std::pair<std::string, std::optional<sfx::playlist_definition>>>
+            playlist_undo;
+    std::vector<std::pair<attack_vector_id, std::optional<attack_vector>>>
+    attack_vector_undo;
+    std::vector<std::pair<magic_type_id, std::optional<magic_type>>> magic_type_undo;
+    std::vector<std::pair<move_mode_id, std::optional<move_mode>>> movement_mode_undo;
+    std::vector<std::pair<itype_id, std::optional<itype>>> item_undo;
+    std::vector<std::pair<recipe_id, std::optional<recipe>>> recipe_undo;
+    bool applied = false;
+};
+
+namespace
+{
+
+std::vector<std::shared_ptr<runtime>> active_runtimes;
+std::size_t active_world_generation = 0;
+std::map<std::string, persistent_scope_record> orphan_character_records;
+std::map<std::string, persistent_scope_record> orphan_world_records;
+
+std::map<std::string, persistent_scope_record> &orphan_records( const std::string &scope )
+{
+    return scope == "character" ? orphan_character_records : orphan_world_records;
+}
+
+std::shared_ptr<runtime> find_active_runtime( std::string_view id )
+{
+    const auto found = std::find_if( active_runtimes.begin(), active_runtimes.end(),
+    [id]( const std::shared_ptr<runtime> &value ) {
+        return value && value->mod_id == id;
+    } );
+    return found == active_runtimes.end() ? nullptr : *found;
+}
+
+class callback_scope
+{
+    public:
+        explicit callback_scope( runtime &owner ) : owner_( owner ) {
+            ++owner_.callback_depth;
+        }
+
+        callback_scope( const callback_scope & ) = delete;
+        callback_scope &operator=( const callback_scope & ) = delete;
+
+        ~callback_scope() {
+            --owner_.callback_depth;
+        }
+
+    private:
+        runtime &owner_;
+};
+
+void require_live_runtime( const std::weak_ptr<runtime> &weak,
+                           const std::string_view api_name )
+{
+    const std::shared_ptr<runtime> owner = weak.lock();
+    if( !owner || !owner->world_is_ready ) {
+        throw std::runtime_error( std::string( api_name ) +
+                                  " is only available after world_ready" );
+    }
+}
+
+bool runtime_callback_is_active( const std::weak_ptr<runtime> &weak )
+{
+    const std::shared_ptr<runtime> owner = weak.lock();
+    return owner && owner->world_is_ready && owner->callback_depth > 0;
+}
+
+void report_callback_error( const runtime &owner, std::string_view handler,
+                            const sol::protected_function_result &result )
+{
+    const sol::error error = result;
+    const std::string message = "Lua-first handler '" + owner.mod_id + ":" +
+                                std::string( handler ) + "' failed: " + error.what();
+    DebugLog( D_ERROR, D_MAIN ) << message;
+    ::add_msg( m_bad, message );
+}
+
+sol::table event_to_lua( runtime &owner, const cata::event &event )
+{
+    sol::table result = owner.lua->create_table();
+    sol::table data = owner.lua->create_table();
+    sol::table data_types = owner.lua->create_table();
+    result["type"] = io::enum_to_string( event.type() );
+    result["turn"] = to_turn<std::int64_t>( event.time() );
+    for( const auto &[name, value] : event.data() ) {
+        switch( value.type() ) {
+            case cata_variant_type::bool_:
+                data[name] = value.get<cata_variant_type::bool_>();
+                break;
+            case cata_variant_type::int_:
+                data[name] = value.get<cata_variant_type::int_>();
+                break;
+            case cata_variant_type::character_id:
+                data[name] = value.get<cata_variant_type::character_id>().get_value();
+                break;
+            case cata_variant_type::chrono_seconds:
+                data[name] = value.get<cata_variant_type::chrono_seconds>().count();
+                break;
+            default:
+                data[name] = value.get_string();
+                break;
+        }
+        data_types[name] = io::enum_to_string( value.type() );
+    }
+    result["data"] = std::move( data );
+    result["data_types"] = std::move( data_types );
+    return result;
+}
+
+void dispatch_event( runtime &owner, const std::string &name, sol::object payload )
+{
+    const auto subscription = owner.subscriptions.find( name );
+    if( subscription == owner.subscriptions.end() ) {
+        return;
+    }
+    const std::vector<std::string> handler_ids = subscription->second;
+    for( const std::string &handler_id : handler_ids ) {
+        const auto handler = owner.handlers.find( handler_id );
+        if( handler == owner.handlers.end() ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Lua-first event '" << name
+                                        << "' references missing handler '"
+                                        << owner.mod_id << ":" << handler_id << "'";
+            continue;
+        }
+        sol::protected_function callback = handler->second.callback;
+        callback_scope scope( owner );
+        const sol::protected_function_result result = callback( payload );
+        if( !result.valid() ) {
+            report_callback_error( owner, handler_id, result );
+        }
+    }
+}
+
+void dispatch_lifecycle( runtime &owner, const std::string &name,
+                         const sol::optional<sol::table> &payload = sol::nullopt )
+{
+    sol::object argument = payload ? sol::make_object( *owner.lua, *payload ) :
+                           sol::make_object( *owner.lua, sol::lua_nil );
+    dispatch_event( owner, name, std::move( argument ) );
+}
+
+bool migrate_task_payload( runtime &owner, persistent_task &task, std::string &error )
+{
+    const auto handler = owner.handlers.find( task.handler_id );
+    if( handler == owner.handlers.end() ) {
+        error = "missing handler '" + task.handler_id + "'";
+        return false;
+    }
+    const int target_version = handler->second.payload_version;
+    persistent_task candidate = task;
+    std::set<int> visited;
+    while( candidate.payload_version != target_version ) {
+        if( !visited.insert( candidate.payload_version ).second ) {
+            error = "payload migration cycle at version " +
+                    std::to_string( candidate.payload_version );
+            return false;
+        }
+        const auto by_handler = owner.task_migrations.find( task.handler_id );
+        if( by_handler == owner.task_migrations.end() ) {
+            error = "no payload migration registered from version " +
+                    std::to_string( candidate.payload_version );
+            return false;
+        }
+        const auto transition = by_handler->second.find( candidate.payload_version );
+        if( transition == by_handler->second.end() ) {
+            error = "no payload migration registered from version " +
+                    std::to_string( candidate.payload_version );
+            return false;
+        }
+
+        sol::table metadata = owner.lua->create_table();
+        metadata["task_id"] = static_cast<std::int64_t>( candidate.id );
+        metadata["handler_id"] = candidate.handler_id;
+        metadata["owner"] = candidate.owner;
+        metadata["from_version"] = candidate.payload_version;
+        metadata["to_version"] = transition->second.target_version;
+        sol::protected_function callback = transition->second.callback;
+        const sol::protected_function_result result = callback(
+                    persistent_table( *owner.lua, candidate.payload ), metadata );
+        if( !result.valid() ) {
+            const sol::error callback_error = result;
+            error = callback_error.what();
+            return false;
+        }
+        if( result.return_count() == 0 || result.get_type() != sol::type::table ) {
+            error = "payload migration must return a state table";
+            return false;
+        }
+        try {
+            candidate.payload = persistent_table_from_lua(
+                                    result.get<sol::table>(), "runtime.migrate_task_payload" );
+        } catch( const std::exception &exception ) {
+            error = exception.what();
+            return false;
+        }
+        candidate.payload_version = transition->second.target_version;
+    }
+    task = std::move( candidate );
+    error.clear();
+    return true;
+}
+
+cata::lua_ui::game_handle platform_creature_handle( const runtime &owner,
+        const Creature &creature )
+{
+    Creature &mutable_creature = const_cast<Creature &>( creature );
+    const tripoint_abs_ms position = creature.pos_abs();
+    cata::lua_ui::game_handle_locator locator;
+    locator.scope = creature.as_character() != nullptr ?
+                    "platform_callback_character" : "platform_callback_monster";
+    locator.x = position.x();
+    locator.y = position.y();
+    locator.z = position.z();
+    if( const Character *character = creature.as_character() ) {
+        locator.stable_id = character->getID().get_value();
+    }
+    return cata::lua_ui::game_handle::from_creature(
+               mutable_creature, std::move( locator ), owner.generation,
+               active_world_generation );
+}
+
+sol::object platform_talker_to_lua( runtime &owner, const const_talker &talker )
+{
+    sol::state_view lua( *owner.lua );
+    if( const Creature *creature = talker.get_const_creature() ) {
+        return sol::make_object( lua, platform_creature_handle( owner, *creature ) );
+    }
+    if( const item_location *location = talker.get_const_item() ) {
+        if( const item *value = location->get_item() ) {
+            return sol::make_object( lua, cata::lua_ui::game_handle::from_item(
+                                         const_cast<item &>( *value ), {
+                "platform_callback_talker_item", value->uid().get_value(), 0, 0, 0, {}
+            }, owner.generation, active_world_generation ) );
+        }
+    }
+    if( const vehicle *value = talker.get_const_vehicle() ) {
+        const tripoint_abs_ms position = value->pos_abs();
+        return sol::make_object( lua, cata::lua_ui::game_handle::from_vehicle(
+                                     const_cast<vehicle &>( *value ), {
+                "platform_callback_talker_vehicle", 0,
+                position.x(), position.y(), position.z(), {}
+            }, owner.generation, active_world_generation ) );
+    }
+
+    sol::table snapshot = owner.lua->create_table();
+    std::string kind = "talker";
+    if( talker.get_const_computer() != nullptr ) {
+        kind = "computer";
+    } else if( talker.get_const_zone() != nullptr ) {
+        kind = "zone";
+    } else if( talker.disp_name().empty() ) {
+        kind = "topic";
+    }
+    snapshot["kind"] = std::move( kind );
+    snapshot["name"] = talker.disp_name();
+    const tripoint_abs_ms position = talker.pos_abs();
+    sol::table position_value = owner.lua->create_table();
+    position_value["coordinate_space"] = "abs_ms";
+    position_value["x"] = position.x();
+    position_value["y"] = position.y();
+    position_value["z"] = position.z();
+    snapshot["position"] = std::move( position_value );
+    return sol::make_object( lua, std::move( snapshot ) );
+}
+
+sol::object platform_callback_value_to_lua(
+    runtime &owner, const cata::lua_ui::native_callback_value &value )
+{
+    sol::state_view lua( *owner.lua );
+    return std::visit( [&owner, lua]( const auto &entry ) -> sol::object {
+        using value_type = std::decay_t<decltype( entry )>;
+        if constexpr( std::is_same_v<value_type, const Character *> ||
+                      std::is_same_v<value_type, const Creature *> ) {
+            if( entry == nullptr ) {
+                return sol::make_object( lua, sol::lua_nil );
+            }
+            return sol::make_object( lua, platform_creature_handle( owner, *entry ) );
+        } else if constexpr( std::is_same_v<value_type, const item *> ) {
+            if( entry == nullptr ) {
+                return sol::make_object( lua, sol::lua_nil );
+            }
+            return sol::make_object( lua, cata::lua_ui::game_handle::from_item(
+                                         const_cast<item &>( *entry ), {
+                "platform_callback_item", entry->uid().get_value(), 0, 0, 0, {}
+            }, owner.generation, active_world_generation ) );
+        } else if constexpr( std::is_same_v<value_type,
+                             cata::lua_ui::native_callback_point> ) {
+            sol::table point = owner.lua->create_table();
+            point["coordinate_space"] = entry.coordinate_space;
+            point["x"] = entry.pos.x();
+            point["y"] = entry.pos.y();
+            point["z"] = entry.pos.z();
+            return sol::make_object( lua, std::move( point ) );
+        } else if constexpr( std::is_same_v<value_type,
+                             cata::lua_ui::native_callback_id> ) {
+            return sol::make_object( lua,
+                                     cata::lua_ui::script_game_id( entry.kind, entry.value ) );
+        } else if constexpr( std::is_same_v<value_type, std::vector<std::string>> ) {
+            sol::table strings = owner.lua->create_table();
+            for( std::size_t index = 0; index < entry.size(); ++index ) {
+                strings[index + 1] = entry[index];
+            }
+            return sol::make_object( lua, std::move( strings ) );
+        } else if constexpr( std::is_same_v<value_type, const const_talker *> ) {
+            return entry == nullptr ? sol::make_object( lua, sol::lua_nil ) :
+                   platform_talker_to_lua( owner, *entry );
+        } else if constexpr( std::is_same_v<value_type,
+                             cata::lua_ui::native_callback_mission> ) {
+            return sol::make_object( lua, cata::lua_ui::mission_token(
+                                         entry.uid, owner.generation,
+                                         active_world_generation ) );
+        } else {
+            return sol::make_object( lua, entry );
+        }
+    }, value );
+}
+
+sol::table platform_callback_payload(
+    runtime &owner, const cata::lua_ui::native_callback_arguments &arguments )
+{
+    if( arguments.size() > 64 ) {
+        throw std::invalid_argument( "Platform native hook payload exceeds 64 fields" );
+    }
+    sol::table result = owner.lua->create_table();
+    std::set<std::string> names;
+    for( const cata::lua_ui::native_callback_argument &argument : arguments ) {
+        if( argument.name.empty() || argument.name.size() > 128 ||
+            !names.insert( argument.name ).second ) {
+            throw std::invalid_argument( "Platform native hook payload has an invalid field name" );
+        }
+        result[argument.name] = platform_callback_value_to_lua( owner, argument.value );
+    }
+    return result;
+}
+
+std::optional<bool> platform_hook_bool( const sol::table &table, const char *name )
+{
+    const sol::object value = table.raw_get<sol::object>( name );
+    if( !value.valid() || value.get_type() == sol::type::nil ) {
+        return std::nullopt;
+    }
+    if( value.get_type() != sol::type::boolean ) {
+        throw std::invalid_argument( std::string( "Platform hook result '" ) + name +
+                                     "' must be boolean" );
+    }
+    return value.as<bool>();
+}
+
+std::optional<std::string> platform_hook_string( const sol::table &table,
+        const char *name, const std::size_t maximum )
+{
+    const sol::object value = table.raw_get<sol::object>( name );
+    if( !value.valid() || value.get_type() == sol::type::nil ) {
+        return std::nullopt;
+    }
+    if( value.get_type() != sol::type::string ) {
+        throw std::invalid_argument( std::string( "Platform hook result '" ) + name +
+                                     "' must be a string" );
+    }
+    std::string result = value.as<std::string>();
+    if( result.size() > maximum ) {
+        throw std::invalid_argument( std::string( "Platform hook result '" ) + name +
+                                     "' is too large" );
+    }
+    return result;
+}
+
+void apply_platform_hook_table( const std::string_view name, const sol::table &table,
+                                cata::lua_ui::native_hook_result &aggregate,
+                                bool &stop, const bool shared_results )
+{
+    using cata::lua_ui::native_hook_supports_result_field;
+    if( native_hook_supports_result_field( name, "allow" ) ) {
+        std::optional<bool> allow = platform_hook_bool( table, "allow" );
+        if( !allow ) {
+            allow = platform_hook_bool( table, "allowed" );
+        }
+        if( allow ) {
+            aggregate.allowed = aggregate.allowed && *allow;
+            stop = stop || !*allow;
+        }
+    }
+    if( native_hook_supports_result_field( name, "handled" ) ) {
+        if( const std::optional<bool> handled = platform_hook_bool( table, "handled" ) ) {
+            aggregate.handled = aggregate.handled || *handled;
+        }
+    }
+    if( native_hook_supports_result_field( name, "text" ) ) {
+        if( const std::optional<std::string> text =
+                platform_hook_string( table, "text", 32768 ) ) {
+            if( shared_results ) {
+                aggregate.text = *text;
+            } else if( !text->empty() ) {
+                if( aggregate.text.size() + ( aggregate.text.empty() ? 0 : 1 ) +
+                    text->size() > 32768 ) {
+                    throw std::invalid_argument(
+                        "Platform hook aggregate text exceeds 32768 bytes" );
+                }
+                if( !aggregate.text.empty() ) {
+                    aggregate.text.push_back( '\n' );
+                }
+                aggregate.text += *text;
+            }
+        }
+    }
+    if( native_hook_supports_result_field( name, "result" ) ) {
+        if( std::optional<std::string> result =
+                platform_hook_string( table, "result", 512 ) ) {
+            aggregate.result = std::move( result );
+        }
+    }
+    if( native_hook_supports_result_field( name, "results" ) ) {
+        const sol::object raw = table.raw_get<sol::object>( "results" );
+        if( raw.valid() && raw.get_type() != sol::type::nil ) {
+            if( raw.get_type() != sol::type::table ) {
+                throw std::invalid_argument( "Platform hook result 'results' must be a table" );
+            }
+            const sol::table values = raw.as<sol::table>();
+            const std::size_t value_count = require_dense_array(
+                                                values, "Platform hook result strings", 0,
+                                                shared_results ? 256 : 64 );
+            std::vector<std::string> parsed;
+            parsed.reserve( value_count );
+            for( std::size_t index = 1; index <= value_count; ++index ) {
+                const sol::object entry = values.raw_get<sol::object>( index );
+                if( entry.get_type() != sol::type::string ) {
+                    throw std::invalid_argument(
+                        "Platform hook result string lists may only contain strings" );
+                }
+                const std::string text = entry.as<std::string>();
+                if( text.empty() || text.size() > 512 ) {
+                    throw std::invalid_argument( "Platform hook result string is invalid" );
+                }
+                if( std::find( parsed.begin(), parsed.end(), text ) == parsed.end() ) {
+                    parsed.push_back( text );
+                }
+            }
+            if( shared_results ) {
+                aggregate.results = std::move( parsed );
+            } else {
+                for( std::string &text : parsed ) {
+                    if( std::find( aggregate.results.begin(), aggregate.results.end(), text ) ==
+                        aggregate.results.end() ) {
+                        aggregate.results.push_back( std::move( text ) );
+                    }
+                }
+            }
+            if( aggregate.results.size() > 256 ) {
+                throw std::invalid_argument(
+                    "Platform hook aggregate has too many strings" );
+            }
+        }
+    }
+    if( native_hook_supports_result_field( name, "entries" ) ) {
+        const sol::object raw = table.raw_get<sol::object>( "entries" );
+        if( raw.valid() && raw.get_type() != sol::type::nil ) {
+            if( raw.get_type() != sol::type::table ) {
+                throw std::invalid_argument( "Platform hook result 'entries' must be a table" );
+            }
+            const sol::table entries = raw.as<sol::table>();
+            const std::size_t entry_count = require_dense_array(
+                                                entries, "Platform hook menu entries", 0, 64 );
+            if( aggregate.menu_entries.size() + entry_count > 128 ) {
+                throw std::invalid_argument( "Platform hook result has too many menu entries" );
+            }
+            std::set<std::string> known_ids;
+            for( const cata::lua_ui::native_menu_entry &entry : aggregate.menu_entries ) {
+                known_ids.insert( entry.id );
+            }
+            for( std::size_t index = 1; index <= entry_count; ++index ) {
+                const sol::object raw_entry = entries.raw_get<sol::object>( index );
+                if( raw_entry.get_type() != sol::type::table ) {
+                    throw std::invalid_argument( "Platform hook menu entries must be tables" );
+                }
+                const sol::table entry = raw_entry.as<sol::table>();
+                cata::lua_ui::native_menu_entry native;
+                native.id = entry.get_or( "id", std::string() );
+                native.label = entry.get_or( "label", std::string() );
+                native.enabled = entry.get_or( "enabled", true );
+                if( native.id.empty() || native.label.empty() ||
+                    native.id.size() > 96 || native.label.size() > 512 ) {
+                    throw std::invalid_argument( "Platform hook menu entry is invalid" );
+                }
+                if( known_ids.insert( native.id ).second ) {
+                    aggregate.menu_entries.push_back( std::move( native ) );
+                }
+            }
+        }
+    }
+    stop = stop || platform_hook_bool( table, "stop" ).value_or( false );
+}
+
+class platform_event_bridge : public event_subscriber
+{
+    public:
+        using event_subscriber::notify;
+
+        void notify( const cata::event &event ) override {
+            const std::string event_name = "game:" + io::enum_to_string( event.type() );
+            for( const std::shared_ptr<runtime> &owner : active_runtimes ) {
+                if( owner && owner->world_is_ready ) {
+                    dispatch_event( *owner, event_name,
+                                    sol::make_object( *owner->lua,
+                                            event_to_lua( *owner, event ) ) );
+                }
+            }
+        }
+};
+
+std::unique_ptr<platform_event_bridge> event_bridge;
+
+cata_path character_state_path()
+{
+    return PATH_INFO::player_base_save_path() + ".lua_platform.json";
+}
+
+std::optional<cata_path> world_state_path()
+{
+    if( !world_generator || world_generator->active_world == nullptr ) {
+        return std::nullopt;
+    }
+    return world_generator->active_world->folder_path() / "lua_platform_world.json";
+}
+
+void clear_scope( const std::string &scope )
+{
+    orphan_records( scope ).clear();
+    for( const std::shared_ptr<runtime> &owner : active_runtimes ) {
+        if( !owner ) {
+            continue;
+        }
+        if( scope == "character" ) {
+            owner->character_state.clear();
+        } else {
+            owner->world_state.clear();
+        }
+        owner->tasks.erase( std::remove_if( owner->tasks.begin(), owner->tasks.end(),
+        [&scope]( const persistent_task & task ) {
+            return task.owner == scope;
+        } ), owner->tasks.end() );
+    }
+}
+
+void load_scope( const cata_path &path, const std::string &scope,
+                 std::string &error )
+{
+    clear_scope( scope );
+    if( !file_exist( path ) ) {
+        error.clear();
+        return;
+    }
+    try {
+        std::error_code size_error;
+        const std::uintmax_t file_size = std::filesystem::file_size(
+                                             path.get_unrelative_path(), size_error );
+        if( size_error ) {
+            throw std::runtime_error( "unable to inspect Platform state file: " +
+                                      size_error.message() );
+        }
+        if( file_size > maximum_platform_state_file_bytes ) {
+            throw std::runtime_error( "Platform state file exceeds 16 MiB" );
+        }
+        const JsonObject root = json_loader::from_path( path ).get_object();
+        if( root.get_int( "version" ) != 1 ) {
+            throw std::runtime_error( "unsupported Platform state version" );
+        }
+        if( root.get_string( "scope" ) != scope ) {
+            throw std::runtime_error( "Platform state scope mismatch" );
+        }
+        const JsonObject mods = root.get_object( "mods" );
+        for( const JsonMember member : mods ) {
+            const std::shared_ptr<runtime> owner = find_active_runtime( member.name() );
+            const JsonObject stored = member.get_object();
+            persistent_scope_record record;
+            record.values = read_typed_values( stored.get_object( "values" ) );
+            std::set<std::uint64_t> stored_task_ids;
+            if( stored.has_array( "tasks" ) ) {
+                const JsonArray stored_tasks = stored.get_array( "tasks" );
+                if( stored_tasks.size() > maximum_tasks_per_mod ) {
+                    throw std::runtime_error( "Platform state exceeds 1024 persistent tasks per Mod" );
+                }
+                for( const JsonObject task_json : stored_tasks ) {
+                    persistent_task task;
+                    const std::int64_t stored_id = task_json.get_int64( "id" );
+                    if( stored_id <= 0 ) {
+                        throw std::runtime_error( "Platform task id must be positive" );
+                    }
+                    task.id = static_cast<std::uint64_t>( stored_id );
+                    if( !stored_task_ids.insert( task.id ).second ) {
+                        throw std::runtime_error( "Platform state repeats a persistent task id" );
+                    }
+                    task.handler_id = task_json.get_string( "handler" );
+                    if( task.handler_id.empty() ) {
+                        throw std::runtime_error( "Platform task handler id cannot be empty" );
+                    }
+                    task.due_turn = task_json.get_int64( "due_turn" );
+                    task.owner = scope;
+                    task.payload_version = task_json.get_int( "payload_version" );
+                    if( task.payload_version <= 0 ) {
+                        throw std::runtime_error( "Platform task payload version must be positive" );
+                    }
+                    task.payload = read_typed_values( task_json.get_object( "payload" ) );
+                    record.tasks.push_back( std::move( task ) );
+                    task_json.allow_omitted_members();
+                }
+            }
+            if( owner ) {
+                if( owner->tasks.size() + record.tasks.size() > maximum_tasks_per_mod ) {
+                    throw std::runtime_error( "Platform state exceeds 1024 persistent tasks per Mod" );
+                }
+                std::set<std::uint64_t> task_ids;
+                for( const persistent_task &task : owner->tasks ) {
+                    task_ids.insert( task.id );
+                }
+                for( const persistent_task &task : record.tasks ) {
+                    if( !task_ids.insert( task.id ).second ) {
+                        throw std::runtime_error( "Platform state repeats a persistent task id" );
+                    }
+                }
+                persistent_state &state = scope == "character" ?
+                                          owner->character_state : owner->world_state;
+                state = std::move( record.values );
+                for( persistent_task &task : record.tasks ) {
+                    owner->next_task_id = std::max( owner->next_task_id, task.id + 1 );
+                    owner->tasks.push_back( std::move( task ) );
+                }
+            } else {
+                orphan_records( scope )[member.name()] = std::move( record );
+            }
+            stored.allow_omitted_members();
+        }
+        mods.allow_omitted_members();
+        root.allow_omitted_members();
+        error.clear();
+    } catch( const std::exception &exception ) {
+        clear_scope( scope );
+        error = path.get_unrelative_path().string() + ": " + exception.what();
+    }
+}
+
+void write_scope_record( JsonOut &json, const persistent_state &state,
+                         const std::vector<persistent_task> &tasks,
+                         const std::string &scope )
+{
+    json.start_object();
+    json.member( "values" );
+    write_typed_values( json, state );
+    json.member( "tasks" );
+    json.start_array();
+    for( const persistent_task &task : tasks ) {
+        if( task.owner != scope ) {
+            continue;
+        }
+        json.start_object();
+        json.member( "id", static_cast<std::int64_t>( task.id ) );
+        json.member( "handler", task.handler_id );
+        json.member( "due_turn", task.due_turn );
+        json.member( "payload_version", task.payload_version );
+        json.member( "payload" );
+        write_typed_values( json, task.payload );
+        json.end_object();
+    }
+    json.end_array();
+    json.end_object();
+}
+
+void write_scope( const cata_path &path, const std::string &scope )
+{
+    std::ostringstream buffer;
+    JsonOut json( buffer, true );
+    json.start_object();
+    json.member( "version", 1 );
+    json.member( "scope", scope );
+    json.member( "mods" );
+    json.start_object();
+    std::set<std::string> active_ids;
+    for( const std::shared_ptr<runtime> &owner : active_runtimes ) {
+        if( owner ) {
+            active_ids.insert( owner->mod_id );
+        }
+    }
+    for( const auto &[mod_id, record] : orphan_records( scope ) ) {
+        if( active_ids.count( mod_id ) != 0 ) {
+            continue;
+        }
+        json.member( mod_id );
+        write_scope_record( json, record.values, record.tasks, scope );
+    }
+    for( const std::shared_ptr<runtime> &owner : active_runtimes ) {
+        if( !owner ) {
+            continue;
+        }
+        const persistent_state &state = scope == "character" ?
+                                        owner->character_state : owner->world_state;
+        json.member( owner->mod_id );
+        write_scope_record( json, state, owner->tasks, scope );
+    }
+    json.end_object();
+    json.end_object();
+    const std::string serialized = buffer.str();
+    if( serialized.size() > maximum_platform_state_file_bytes ) {
+        throw std::runtime_error( "Platform state file exceeds 16 MiB" );
+    }
+    write_to_file( path, [&serialized]( std::ostream &output ) {
+        output << serialized;
+    } );
+}
+
+} // namespace
+
+content_transaction::content_transaction( std::string owner, std::size_t generation ) :
+    pimpl_( std::make_unique<impl>( std::move( owner ), generation ) )
+{
+}
+
+content_transaction::~content_transaction() = default;
+
+void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
+        const std::shared_ptr<runtime> &owner_runtime )
+{
+    ccb.new_usertype<tool_quality_definition_handle>(
+        "ToolQualityDefinition", sol::no_constructor,
+        "id", sol::property( &tool_quality_definition_handle::id ),
+        "usage", &tool_quality_definition_handle::usage );
+    ccb.new_usertype<skill_display_definition_handle>(
+        "SkillDisplayDefinition", sol::no_constructor,
+        "id", sol::property( &skill_display_definition_handle::id ) );
+    ccb.new_usertype<skill_definition_handle>(
+        "SkillDefinition", sol::no_constructor,
+        "id", sol::property( &skill_definition_handle::id ),
+        "tag", &skill_definition_handle::tag,
+        "companion_practice", &skill_definition_handle::companion_practice,
+        "level_description", &skill_definition_handle::level_description,
+        "requires_all_trait", &skill_definition_handle::requires_all_trait,
+        "requires_any_trait", &skill_definition_handle::requires_any_trait,
+        "attack_time", &skill_definition_handle::attack_time,
+        "companion_rank_factors", &skill_definition_handle::companion_rank_factors );
+    ccb.new_usertype<vitamin_definition_handle>(
+        "VitaminDefinition", sol::no_constructor,
+        "id", sol::property( &vitamin_definition_handle::id ),
+        "weight_micrograms", &vitamin_definition_handle::weight_micrograms,
+        "deficiency_range", &vitamin_definition_handle::deficiency_range,
+        "excess_range", &vitamin_definition_handle::excess_range,
+        "decays_into", &vitamin_definition_handle::decays_into,
+        "flag", &vitamin_definition_handle::flag );
+    ccb.new_usertype<json_flag_definition_handle>(
+        "JsonFlagDefinition", sol::no_constructor,
+        "id", sol::property( &json_flag_definition_handle::id ),
+        "conflicts_with", &json_flag_definition_handle::conflicts_with );
+    ccb.new_usertype<damage_type_definition_handle>(
+        "DamageTypeDefinition", sol::no_constructor,
+        "id", sol::property( &damage_type_definition_handle::id ),
+        "derived", &damage_type_definition_handle::derived,
+        "immune_character_flag", &damage_type_definition_handle::immune_character_flag,
+        "immune_monster_flag", &damage_type_definition_handle::immune_monster_flag,
+        "on_hit", &damage_type_definition_handle::on_hit,
+        "on_damage", &damage_type_definition_handle::on_damage );
+    ccb.new_usertype<material_definition_handle>(
+        "MaterialDefinition", sol::no_constructor,
+        "id", sol::property( &material_definition_handle::id ),
+        "resistance", &material_definition_handle::resistance,
+        "vitamin", &material_definition_handle::vitamin,
+        "damage_adjective", &material_definition_handle::damage_adjective,
+        "burn", &material_definition_handle::burn,
+        "burn_product", &material_definition_handle::burn_product,
+        "fuel", &material_definition_handle::fuel,
+        "fuel_explosion", &material_definition_handle::fuel_explosion );
+    ccb.new_usertype<ammunition_type_definition_handle>(
+        "AmmunitionTypeDefinition", sol::no_constructor,
+        "id", sol::property( &ammunition_type_definition_handle::id ) );
+    ccb.new_usertype<item_category_definition_handle>(
+        "ItemCategoryDefinition", sol::no_constructor,
+        "id", sol::property( &item_category_definition_handle::id ),
+        "priority_zone", &item_category_definition_handle::priority_zone );
+    ccb.new_usertype<crafting_category_definition_handle>(
+        "RecipeCategoryDefinition", sol::no_constructor,
+        "id", sol::property( &crafting_category_definition_handle::id ),
+        "subcategory", &crafting_category_definition_handle::subcategory );
+    ccb.new_usertype<proficiency_category_definition_handle>(
+        "ProficiencyCategoryDefinition", sol::no_constructor,
+        "id", sol::property( &proficiency_category_definition_handle::id ) );
+    ccb.new_usertype<proficiency_definition_handle>(
+        "ProficiencyDefinition", sol::no_constructor,
+        "id", sol::property( &proficiency_definition_handle::id ),
+        "requires", &proficiency_definition_handle::requires,
+        "bonus", &proficiency_definition_handle::bonus );
+    ccb.new_usertype<weapon_category_definition_handle>(
+        "WeaponCategoryDefinition", sol::no_constructor,
+        "id", sol::property( &weapon_category_definition_handle::id ),
+        "proficiency", &weapon_category_definition_handle::proficiency );
+    ccb.new_usertype<item_definition_handle>(
+        "ItemDefinition", sol::no_constructor,
+        "id", sol::property( &item_definition_handle::id ),
+        "mass_grams", &item_definition_handle::mass,
+        "volume_ml", &item_definition_handle::volume,
+        "price_cents", &item_definition_handle::price,
+        "material", &item_definition_handle::material,
+        "quality", &item_definition_handle::quality,
+        "flag", &item_definition_handle::flag,
+        "on_use", &item_definition_handle::on_use );
+    ccb.new_usertype<recipe_definition_handle>(
+        "RecipeDefinition", sol::no_constructor,
+        "id", sol::property( &recipe_definition_handle::id ),
+        "duration_moves", &recipe_definition_handle::duration,
+        "component", &recipe_definition_handle::component,
+        "component_any", &recipe_definition_handle::component_any,
+        "tool", &recipe_definition_handle::tool,
+        "tool_charges", &recipe_definition_handle::tool_charges,
+        "tool_any", &recipe_definition_handle::tool_any,
+        "requires_skill", &recipe_definition_handle::requires_skill,
+        "requirement", &recipe_definition_handle::requirement );
+    ccb.new_usertype<nested_recipe_category_definition_handle>(
+        "NestedRecipeCategoryDefinition", sol::no_constructor,
+        "id", sol::property( &nested_recipe_category_definition_handle::id ),
+        "recipe", &nested_recipe_category_definition_handle::recipe );
+    ccb.new_usertype<requirement_definition_handle>(
+        "RequirementDefinition", sol::no_constructor,
+        "id", sol::property( &requirement_definition_handle::id ),
+        "component", &requirement_definition_handle::component,
+        "component_any", &requirement_definition_handle::component_any,
+        "tool", &requirement_definition_handle::tool,
+        "tool_charges", &requirement_definition_handle::tool_charges,
+        "tool_any", &requirement_definition_handle::tool_any,
+        "quality", &requirement_definition_handle::quality,
+        "quality_any", &requirement_definition_handle::quality_any );
+    ccb.new_usertype<recipe_group_definition_handle>(
+        "RecipeGroupDefinition", sol::no_constructor,
+        "id", sol::property( &recipe_group_definition_handle::id ),
+        "recipe", &recipe_group_definition_handle::recipe,
+        "terrain", &recipe_group_definition_handle::terrain,
+        "terrain_parameter", &recipe_group_definition_handle::terrain_parameter );
+    ccb.new_usertype<scent_type_definition_handle>(
+        "ScentTypeDefinition", sol::no_constructor,
+        "id", sol::property( &scent_type_definition_handle::id ),
+        "receptive_species", &scent_type_definition_handle::receptive_species );
+    ccb.new_usertype<speed_description_definition_handle>(
+        "SpeedDescriptionDefinition", sol::no_constructor,
+        "id", sol::property( &speed_description_definition_handle::id ),
+        "value", &speed_description_definition_handle::value );
+    ccb.new_usertype<harvest_drop_type_definition_handle>(
+        "HarvestDropTypeDefinition", sol::no_constructor,
+        "id", sol::property( &harvest_drop_type_definition_handle::id ),
+        "skill", &harvest_drop_type_definition_handle::skill );
+    ccb.new_usertype<harvest_definition_handle>(
+        "HarvestDefinition", sol::no_constructor,
+        "id", sol::property( &harvest_definition_handle::id ),
+        "drop", &harvest_definition_handle::drop,
+        "item_flag", &harvest_definition_handle::item_flag,
+        "item_fault", &harvest_definition_handle::item_fault );
+    ccb.new_usertype<behavior_definition_handle>(
+        "BehaviorDefinition", sol::no_constructor,
+        "id", sol::property( &behavior_definition_handle::id ),
+        "child", &behavior_definition_handle::child,
+        "when", &behavior_definition_handle::when,
+        "when_native", &behavior_definition_handle::when_native,
+        "score", &behavior_definition_handle::score,
+        "score_native", &behavior_definition_handle::score_native );
+    ccb.new_usertype<monster_attack_definition_handle>(
+        "MonsterAttackDefinition", sol::no_constructor,
+        "id", sol::property( &monster_attack_definition_handle::id ),
+        "policy", &monster_attack_definition_handle::policy );
+    ccb.new_usertype<effect_type_definition_handle>(
+        "EffectTypeDefinition", sol::no_constructor,
+        "id", sol::property( &effect_type_definition_handle::id ),
+        "name", &effect_type_definition_handle::name,
+        "description", &effect_type_definition_handle::description,
+        "reduced_description", &effect_type_definition_handle::reduced_description,
+        "flag", &effect_type_definition_handle::flag,
+        "immune_character_flag", &effect_type_definition_handle::immune_character_flag,
+        "immune_bodypart_flag", &effect_type_definition_handle::immune_bodypart_flag,
+        "resist_trait", &effect_type_definition_handle::resist_trait,
+        "resist_effect", &effect_type_definition_handle::resist_effect,
+        "removes_effect", &effect_type_definition_handle::removes_effect,
+        "blocks_effect", &effect_type_definition_handle::blocks_effect );
+    ccb.new_usertype<weakpoint_set_definition_handle>(
+        "WeakpointSetDefinition", sol::no_constructor,
+        "id", sol::property( &weakpoint_set_definition_handle::id ),
+        "weakpoint", &weakpoint_set_definition_handle::weakpoint,
+        "armor_multiplier", &weakpoint_set_definition_handle::armor_multiplier,
+        "armor_penalty", &weakpoint_set_definition_handle::armor_penalty,
+        "damage_multiplier", &weakpoint_set_definition_handle::damage_multiplier,
+        "critical_multiplier", &weakpoint_set_definition_handle::critical_multiplier,
+        "effect", &weakpoint_set_definition_handle::effect );
+    ccb.new_usertype<field_type_definition_handle>(
+        "FieldTypeDefinition", sol::no_constructor,
+        "id", sol::property( &field_type_definition_handle::id ),
+        "intensity", &field_type_definition_handle::intensity,
+        "effect", &field_type_definition_handle::effect,
+        "immune_monster", &field_type_definition_handle::immune_monster,
+        "block_monster", &field_type_definition_handle::block_monster );
+    ccb.new_usertype<item_group_definition_handle>(
+        "ItemGroupDefinition", sol::no_constructor,
+        "id", sol::property( &item_group_definition_handle::id ),
+        "item", &item_group_definition_handle::item,
+        "group", &item_group_definition_handle::group );
+    ccb.new_usertype<sub_body_part_definition_handle>(
+        "SubBodyPartDefinition", sol::no_constructor,
+        "id", sol::property( &sub_body_part_definition_handle::id ),
+        "location_under", &sub_body_part_definition_handle::location_under,
+        "unarmed_damage", &sub_body_part_definition_handle::unarmed_damage );
+    ccb.new_usertype<body_part_definition_handle>(
+        "BodyPartDefinition", sol::no_constructor,
+        "id", sol::property( &body_part_definition_handle::id ),
+        "sub_part", &body_part_definition_handle::sub_part,
+        "limb_type", &body_part_definition_handle::limb_type,
+        "armor", &body_part_definition_handle::armor,
+        "unarmed_damage", &body_part_definition_handle::unarmed_damage,
+        "flag", &body_part_definition_handle::flag,
+        "limb_score", &body_part_definition_handle::limb_score,
+        "quality", &body_part_definition_handle::quality );
+    ccb.new_usertype<anatomy_definition_handle>(
+        "AnatomyDefinition", sol::no_constructor,
+        "id", sol::property( &anatomy_definition_handle::id ),
+        "part", &anatomy_definition_handle::part );
+    ccb.new_usertype<body_graph_definition_handle>(
+        "BodyGraphDefinition", sol::no_constructor,
+        "id", sol::property( &body_graph_definition_handle::id ),
+        "row", &body_graph_definition_handle::row,
+        "part", &body_graph_definition_handle::part );
+    ccb.new_usertype<monster_definition_handle>(
+        "MonsterDefinition", sol::no_constructor,
+        "id", sol::property( &monster_definition_handle::id ),
+        "material", &monster_definition_handle::material,
+        "species", &monster_definition_handle::species,
+        "category", &monster_definition_handle::category,
+        "flag", &monster_definition_handle::flag,
+        "armor", &monster_definition_handle::armor,
+        "melee_damage", &monster_definition_handle::melee_damage,
+        "attack", &monster_definition_handle::attack,
+        "weakpoint_set", &monster_definition_handle::weakpoint_set,
+        "emission", &monster_definition_handle::emission,
+        "starting_ammo", &monster_definition_handle::starting_ammo,
+        "track_scent", &monster_definition_handle::track_scent,
+        "ignore_scent", &monster_definition_handle::ignore_scent,
+        "regeneration_modifier", &monster_definition_handle::regeneration_modifier,
+        "goal", &monster_definition_handle::goal,
+        "anger_trigger", &monster_definition_handle::anger_trigger,
+        "fear_trigger", &monster_definition_handle::fear_trigger,
+        "placate_trigger", &monster_definition_handle::placate_trigger );
+    ccb.new_usertype<morale_type_definition_handle>(
+        "MoraleTypeDefinition", sol::no_constructor,
+        "id", sol::property( &morale_type_definition_handle::id ) );
+    ccb.new_usertype<disease_type_definition_handle>(
+        "DiseaseTypeDefinition", sol::no_constructor,
+        "id", sol::property( &disease_type_definition_handle::id ),
+        "affected_body_part", &disease_type_definition_handle::affected_body_part );
+    ccb.new_usertype<monster_flag_definition_handle>(
+        "MonsterFlagDefinition", sol::no_constructor,
+        "id", sol::property( &monster_flag_definition_handle::id ) );
+    ccb.new_usertype<species_definition_handle>(
+        "SpeciesDefinition", sol::no_constructor,
+        "id", sol::property( &species_definition_handle::id ),
+        "flag", &species_definition_handle::flag,
+        "anger", &species_definition_handle::anger,
+        "fear", &species_definition_handle::fear,
+        "placate", &species_definition_handle::placate );
+    ccb.new_usertype<emission_definition_handle>(
+        "EmissionDefinition", sol::no_constructor,
+        "id", sol::property( &emission_definition_handle::id ),
+        "profile", &emission_definition_handle::profile );
+    ccb.new_usertype<monster_faction_definition_handle>(
+        "MonsterFactionDefinition", sol::no_constructor,
+        "id", sol::property( &monster_faction_definition_handle::id ),
+        "attitude", &monster_faction_definition_handle::attitude );
+    ccb.new_usertype<mutation_type_definition_handle>(
+        "MutationTypeDefinition", sol::no_constructor,
+        "id", sol::property( &mutation_type_definition_handle::id ) );
+    ccb.new_usertype<connect_group_definition_handle>(
+        "ConnectGroupDefinition", sol::no_constructor,
+        "id", sol::property( &connect_group_definition_handle::id ) );
+    ccb.new_usertype<mutation_category_definition_handle>(
+        "MutationCategoryDefinition", sol::no_constructor,
+        "id", sol::property( &mutation_category_definition_handle::id ) );
+    ccb.new_usertype<construction_category_definition_handle>(
+        "ConstructionCategoryDefinition", sol::no_constructor,
+        "id", sol::property( &construction_category_definition_handle::id ) );
+    ccb.new_usertype<construction_group_definition_handle>(
+        "ConstructionGroupDefinition", sol::no_constructor,
+        "id", sol::property( &construction_group_definition_handle::id ) );
+    ccb.new_usertype<vehicle_part_location_definition_handle>(
+        "VehiclePartLocationDefinition", sol::no_constructor,
+        "id", sol::property( &vehicle_part_location_definition_handle::id ) );
+    ccb.new_usertype<mood_face_definition_handle>(
+        "MoodFaceDefinition", sol::no_constructor,
+        "id", sol::property( &mood_face_definition_handle::id ),
+        "value", &mood_face_definition_handle::value );
+    ccb.new_usertype<damage_info_order_definition_handle>(
+        "DamageInfoOrderDefinition", sol::no_constructor,
+        "id", sol::property( &damage_info_order_definition_handle::id ),
+        "section", &damage_info_order_definition_handle::section );
+    ccb.new_usertype<vehicle_part_category_definition_handle>(
+        "VehiclePartCategoryDefinition", sol::no_constructor,
+        "id", sol::property( &vehicle_part_category_definition_handle::id ) );
+    ccb.new_usertype<named_color_definition_handle>(
+        "NamedColorDefinition", sol::no_constructor,
+        "name", sol::property( &named_color_definition_handle::name ) );
+    ccb.new_usertype<rotatable_symbol_definition_handle>(
+        "RotatableSymbolDefinition", sol::no_constructor,
+        "key", sol::property( &rotatable_symbol_definition_handle::key ) );
+    ccb.new_usertype<ascii_art_definition_handle>(
+        "AsciiArtDefinition", sol::no_constructor,
+        "id", sol::property( &ascii_art_definition_handle::id ),
+        "line", &ascii_art_definition_handle::line );
+    ccb.new_usertype<limb_score_definition_handle>(
+        "LimbScoreDefinition", sol::no_constructor,
+        "id", sol::property( &limb_score_definition_handle::id ) );
+    ccb.new_usertype<hit_range_definition_handle>(
+        "HitRangeDefinition", sol::no_constructor,
+        "id", sol::property( &hit_range_definition_handle::id ) );
+    ccb.new_usertype<bash_damage_profile_definition_handle>(
+        "BashDamageProfileDefinition", sol::no_constructor,
+        "id", sol::property( &bash_damage_profile_definition_handle::id ),
+        "factor", &bash_damage_profile_definition_handle::factor );
+    ccb.new_usertype<clothing_mod_definition_handle>(
+        "ClothingModDefinition", sol::no_constructor,
+        "id", sol::property( &clothing_mod_definition_handle::id ),
+        "modifier", &clothing_mod_definition_handle::modifier );
+    ccb.new_usertype<overmap_land_use_code_definition_handle>(
+        "OvermapLandUseCodeDefinition", sol::no_constructor,
+        "id", sol::property( &overmap_land_use_code_definition_handle::id ) );
+    ccb.new_usertype<overmap_vision_definition_handle>(
+        "OvermapVisionDefinition", sol::no_constructor,
+        "id", sol::property( &overmap_vision_definition_handle::id ),
+        "appearance", &overmap_vision_definition_handle::appearance,
+        "blend_adjacent", &overmap_vision_definition_handle::blend_adjacent );
+    ccb.new_usertype<overmap_location_definition_handle>(
+        "OvermapLocationDefinition", sol::no_constructor,
+        "id", sol::property( &overmap_location_definition_handle::id ),
+        "terrain", &overmap_location_definition_handle::terrain,
+        "terrain_flag", &overmap_location_definition_handle::terrain_flag );
+    ccb.new_usertype<profession_group_definition_handle>(
+        "ProfessionGroupDefinition", sol::no_constructor,
+        "id", sol::property( &profession_group_definition_handle::id ),
+        "profession", &profession_group_definition_handle::profession );
+    ccb.new_usertype<map_extra_collection_definition_handle>(
+        "MapExtraCollectionDefinition", sol::no_constructor,
+        "id", sol::property( &map_extra_collection_definition_handle::id ),
+        "extra", &map_extra_collection_definition_handle::extra );
+    ccb.new_usertype<vehicle_group_definition_handle>(
+        "VehicleGroupDefinition", sol::no_constructor,
+        "id", sol::property( &vehicle_group_definition_handle::id ),
+        "vehicle", &vehicle_group_definition_handle::vehicle );
+    ccb.new_usertype<fault_group_definition_handle>(
+        "FaultGroupDefinition", sol::no_constructor,
+        "id", sol::property( &fault_group_definition_handle::id ),
+        "fault", &fault_group_definition_handle::fault );
+    ccb.new_usertype<explosion_light_definition_handle>(
+        "ExplosionLightDefinition", sol::no_constructor,
+        "id", sol::property( &explosion_light_definition_handle::id ),
+        "stop", &explosion_light_definition_handle::stop,
+        "waves", &explosion_light_definition_handle::waves,
+        "duration", &explosion_light_definition_handle::duration,
+        "screen_shake", &explosion_light_definition_handle::screen_shake,
+        "shockwave", &explosion_light_definition_handle::shockwave );
+    ccb.new_usertype<ammo_effect_definition_handle>(
+        "AmmoEffectDefinition", sol::no_constructor,
+        "id", sol::property( &ammo_effect_definition_handle::id ),
+        "field_burst", &ammo_effect_definition_handle::field_burst,
+        "trail", &ammo_effect_definition_handle::trail,
+        "on_hit", &ammo_effect_definition_handle::on_hit,
+        "area_effect", &ammo_effect_definition_handle::area_effect,
+        "explosion", &ammo_effect_definition_handle::explosion,
+        "shrapnel", &ammo_effect_definition_handle::shrapnel,
+        "flashbang", &ammo_effect_definition_handle::flashbang,
+        "emp", &ammo_effect_definition_handle::emp,
+        "foamcrete", &ammo_effect_definition_handle::foamcrete,
+        "spell", &ammo_effect_definition_handle::spell,
+        "cast_spells_on_miss", &ammo_effect_definition_handle::cast_spells_on_miss,
+        "impact_policy", &ammo_effect_definition_handle::impact_policy );
+    ccb.new_usertype<addiction_type_definition_handle>(
+        "AddictionTypeDefinition", sol::no_constructor,
+        "id", sol::property( &addiction_type_definition_handle::id ),
+        "tick_policy", &addiction_type_definition_handle::tick_policy );
+    ccb.new_usertype<character_modifier_definition_handle>(
+        "CharacterModifierDefinition", sol::no_constructor,
+        "id", sol::property( &character_modifier_definition_handle::id ),
+        "evaluate_with", &character_modifier_definition_handle::evaluate_with );
+    ccb.new_usertype<start_location_definition_handle>(
+        "StartLocationDefinition", sol::no_constructor,
+        "id", sol::property( &start_location_definition_handle::id ),
+        "terrain", &start_location_definition_handle::terrain,
+        "flag", &start_location_definition_handle::flag,
+        "city_size", &start_location_definition_handle::city_size,
+        "city_distance", &start_location_definition_handle::city_distance,
+        "z_levels", &start_location_definition_handle::z_levels );
+    ccb.new_usertype<climbing_aid_definition_handle>(
+        "ClimbingAidDefinition", sol::no_constructor,
+        "id", sol::property( &climbing_aid_definition_handle::id ),
+        "available_when", &climbing_aid_definition_handle::available_when,
+        "descent", &climbing_aid_definition_handle::descent,
+        "cost", &climbing_aid_definition_handle::cost,
+        "deploy", &climbing_aid_definition_handle::deploy );
+    ccb.new_usertype<weather_type_definition_handle>(
+        "WeatherTypeDefinition", sol::no_constructor,
+        "id", sol::property( &weather_type_definition_handle::id ),
+        "duration", &weather_type_definition_handle::duration,
+        "animation", &weather_type_definition_handle::animation,
+        "requires", &weather_type_definition_handle::requires,
+        "passive_effect", &weather_type_definition_handle::passive_effect,
+        "condition", &weather_type_definition_handle::condition );
+    ccb.new_usertype<score_definition_handle>(
+        "ScoreDefinition", sol::no_constructor,
+        "id", sol::property( &score_definition_handle::id ) );
+    ccb.new_usertype<overlay_order_definition_handle>(
+        "OverlayOrderDefinition", sol::no_constructor,
+        "id", sol::property( &overlay_order_definition_handle::id ),
+        "mutation", &overlay_order_definition_handle::mutation );
+    ccb.new_usertype<zone_type_definition_handle>(
+        "ZoneTypeDefinition", sol::no_constructor,
+        "id", sol::property( &zone_type_definition_handle::id ) );
+    ccb.new_usertype<speech_pool_definition_handle>(
+        "SpeechPoolDefinition", sol::no_constructor,
+        "id", sol::property( &speech_pool_definition_handle::id ),
+        "line", &speech_pool_definition_handle::line );
+    ccb.new_usertype<end_screen_definition_handle>(
+        "EndScreenDefinition", sol::no_constructor,
+        "id", sol::property( &end_screen_definition_handle::id ),
+        "info", &end_screen_definition_handle::info,
+        "condition", &end_screen_definition_handle::condition );
+    ccb.new_usertype<activity_type_definition_handle>(
+        "ActivityTypeDefinition", sol::no_constructor,
+        "id", sol::property( &activity_type_definition_handle::id ),
+        "ignore", &activity_type_definition_handle::ignore,
+        "on_turn", &activity_type_definition_handle::on_turn,
+        "on_finish", &activity_type_definition_handle::on_finish );
+    ccb.new_usertype<help_topic_definition_handle>(
+        "HelpTopicDefinition", sol::no_constructor,
+        "id", sol::property( &help_topic_definition_handle::id ),
+        "paragraph", &help_topic_definition_handle::paragraph );
+    ccb.new_usertype<snippet_category_definition_handle>(
+        "SnippetCategoryDefinition", sol::no_constructor,
+        "id", sol::property( &snippet_category_definition_handle::id ),
+        "text", &snippet_category_definition_handle::text,
+        "entry", &snippet_category_definition_handle::entry );
+    ccb.new_usertype<playlist_definition_handle>(
+        "PlaylistDefinition", sol::no_constructor,
+        "id", sol::property( &playlist_definition_handle::id ),
+        "track", &playlist_definition_handle::track );
+    ccb.new_usertype<attack_vector_definition_handle>(
+        "AttackVectorDefinition", sol::no_constructor,
+        "id", sol::property( &attack_vector_definition_handle::id ),
+        "limb", &attack_vector_definition_handle::limb,
+        "contact", &attack_vector_definition_handle::contact,
+        "requires_limb", &attack_vector_definition_handle::requires_limb,
+        "requires_flag", &attack_vector_definition_handle::requires_flag,
+        "forbids_flag", &attack_vector_definition_handle::forbids_flag );
+    ccb.new_usertype<magic_type_definition_handle>(
+        "MagicTypeDefinition", sol::no_constructor,
+        "id", sol::property( &magic_type_definition_handle::id ),
+        "cannot_cast_when", &magic_type_definition_handle::cannot_cast_when,
+        "progression", &magic_type_definition_handle::progression,
+        "casting_experience", &magic_type_definition_handle::casting_experience,
+        "failure_chance", &magic_type_definition_handle::failure_chance,
+        "failure_cost", &magic_type_definition_handle::failure_cost,
+        "failure_experience", &magic_type_definition_handle::failure_experience,
+        "on_failure", &magic_type_definition_handle::on_failure );
+    ccb.new_usertype<movement_mode_definition_handle>(
+        "MovementModeDefinition", sol::no_constructor,
+        "id", sol::property( &movement_mode_definition_handle::id ),
+        "messages", &movement_mode_definition_handle::messages );
+
+    impl *const transaction = pimpl_.get();
+    sol::table content = lua.create_table();
+    content.set_function( "ToolQuality", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<tool_quality_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->name = options.get_or( "name", definition->id );
+        return tool_quality_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "SkillDisplay", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<skill_display_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->label = options.get_or( "label", definition->id );
+        return skill_display_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "Skill", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<skill_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->name = options.get_or( "name", definition->id );
+        definition->description = options.get_or( "description", std::string() );
+        definition->display_category = options.get_or( "display_category", std::string( "none" ) );
+        definition->sort_rank = options.get_or<std::int64_t>( "sort_rank", 1000000 );
+        definition->teachable = options.get_or( "teachable", true );
+        definition->obsolete = options.get_or( "obsolete", false );
+        definition->consumes_focus = options.get_or( "consumes_focus", true );
+        return skill_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "Vitamin", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<vitamin_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->name = options.get_or( "name", definition->id );
+        definition->type = options.get_or( "kind", std::string( "vitamin" ) );
+        definition->deficiency = options.get_or( "deficiency", std::string() );
+        definition->excess = options.get_or( "excess", std::string() );
+        definition->minimum = options.get_or<std::int64_t>( "minimum", 0 );
+        definition->maximum = options.get_or<std::int64_t>( "maximum", 0 );
+        definition->rate_turns = options.get_or<std::int64_t>( "rate_turns", 1 );
+        return vitamin_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "JsonFlag", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<json_flag_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->info = options.get_or( "info", std::string() );
+        definition->restriction = options.get_or( "restriction", std::string() );
+        definition->name = options.get_or( "name", std::string() );
+        definition->item_prefix = options.get_or( "item_prefix", std::string() );
+        definition->item_suffix = options.get_or( "item_suffix", std::string() );
+        definition->requires_flag = options.get_or( "requires_flag", std::string() );
+        definition->taste_modifier = options.get_or<std::int64_t>( "taste_modifier", 0 );
+        definition->inherit = options.get_or( "inherit", true );
+        definition->craft_inherit = options.get_or( "craft_inherit", false );
+        return json_flag_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "DamageType", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<damage_type_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->name = options.get_or( "name", definition->id );
+        definition->skill = options.get_or( "skill", std::string() );
+        definition->magic_color = options.get_or( "magic_color", std::string( "black" ) );
+        definition->melee_only = options.get_or( "melee_only", false );
+        definition->physical = options.get_or( "physical", false );
+        definition->monster_difficulty = options.get_or( "monster_difficulty", false );
+        definition->no_resist = options.get_or( "no_resist", false );
+        definition->edged = options.get_or( "edged", false );
+        definition->environmental = options.get_or( "environmental", false );
+        definition->material_required = options.get_or( "material_required", false );
+        definition->bash_conversion_factor = options.get_or<double>(
+                    "bash_conversion_factor", definition->physical ? 0.5 : 0.1 );
+        return damage_type_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "Material", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<material_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->name = options.get_or( "name", definition->id );
+        definition->salvaged_into = options.get_or( "salvaged_into", std::string() );
+        definition->repaired_with = options.get_or( "repaired_with", std::string() );
+        definition->bash_damage_verb = options.get_or( "bash_damage_verb", std::string( "damages" ) );
+        definition->cut_damage_verb = options.get_or( "cut_damage_verb", std::string( "damages" ) );
+        definition->chip_resistance = options.get_or<std::int64_t>( "chip_resistance", 0 );
+        definition->breathability = options.get_or<std::int64_t>( "breathability", 0 );
+        definition->repair_difficulty = options.get_or<std::int64_t>( "repair_difficulty", 10 );
+        definition->density = options.get_or<double>( "density", 1.0 );
+        definition->sheet_thickness = options.get_or<double>( "sheet_thickness", 0.0 );
+        definition->specific_heat_liquid = options.get_or<double>( "specific_heat_liquid", 4.186 );
+        definition->specific_heat_solid = options.get_or<double>( "specific_heat_solid", 2.108 );
+        definition->latent_heat = options.get_or<double>( "latent_heat", 334.0 );
+        definition->freezing_point = options.get_or<double>( "freezing_point", 0.0 );
+        definition->rotting = options.get_or( "rotting", false );
+        definition->soft = options.get_or( "soft", false );
+        definition->uncomfortable = options.get_or( "uncomfortable", false );
+        definition->conductive = options.get_or( "conductive", false );
+        if( const sol::optional<std::int64_t> wind =
+                options.get<sol::optional<std::int64_t>>( "wind_resistance" ) ) {
+            definition->wind_resistance = *wind;
+        }
+        return material_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "AmmunitionType", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<ammunition_type_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->name = options.get_or( "name", definition->id );
+        definition->default_item = options.get_or( "default_item", std::string() );
+        return ammunition_type_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "ItemCategory", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<item_category_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->header = options.get_or( "header", definition->id );
+        definition->noun = options.get_or( "noun", definition->header );
+        definition->sort_rank = options.get_or<std::int64_t>( "sort_rank", 0 );
+        definition->spawn_rate = options.get_or<double>( "spawn_rate", 1.0 );
+        definition->zone = options.get_or( "zone", std::string() );
+        return item_category_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "RecipeCategory", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<crafting_category_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->hidden = options.get_or( "hidden", false );
+        definition->practice = options.get_or( "practice", false );
+        definition->building = options.get_or( "building", false );
+        definition->wildcard = options.get_or( "wildcard", false );
+        return crafting_category_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "ProficiencyCategory", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<proficiency_category_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->name = options.get_or( "name", definition->id );
+        definition->description = options.get_or( "description", std::string() );
+        return proficiency_category_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "Proficiency", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<proficiency_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->name = options.get_or( "name", definition->id );
+        definition->description = options.get_or( "description", std::string() );
+        definition->category = options.get_or( "category", std::string() );
+        definition->time_to_learn_turns = options.get_or<std::int64_t>(
+                                                "time_to_learn_turns", 35996400 );
+        definition->time_multiplier = options.get_or<double>( "time_multiplier", 2.0 );
+        definition->skill_penalty = options.get_or<double>( "skill_penalty", 1.0 );
+        definition->weakpoint_bonus = options.get_or<double>( "weakpoint_bonus", 0.0 );
+        definition->weakpoint_penalty = options.get_or<double>( "weakpoint_penalty", 0.0 );
+        definition->can_learn = options.get_or( "can_learn", false );
+        definition->ignore_focus = options.get_or( "ignore_focus", false );
+        definition->teachable = options.get_or( "teachable", true );
+        return proficiency_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "WeaponCategory", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<weapon_category_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->name = options.get_or( "name", definition->id );
+        return weapon_category_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "Item", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<item_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->name = options.get_or( "name", definition->id );
+        definition->description = options.get_or( "description", std::string() );
+        definition->symbol = options.get_or( "symbol", std::string( "?" ) );
+        return item_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "Recipe", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<recipe_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->result = options.get_or( "result", std::string() );
+        definition->category = options.get_or( "category", std::string( "CC_MISC" ) );
+        definition->subcategory = options.get_or( "subcategory", std::string( "CSC_MISC" ) );
+        definition->skill = options.get_or( "skill", std::string() );
+        definition->difficulty = options.get_or<std::int64_t>( "difficulty", 0 );
+        definition->time_moves = options.get_or<std::int64_t>( "duration_moves", 100 );
+        definition->autolearn = options.get_or( "autolearn", true );
+        definition->reversible = options.get_or( "reversible", false );
+        return recipe_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "NestedRecipeCategory", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<recipe_definition_data>();
+        definition->nested_category = true;
+        definition->id = options.get_or( "id", std::string() );
+        definition->name = options.get_or( "name", std::string() );
+        definition->description = options.get_or( "description", std::string() );
+        definition->category = options.get_or( "category", std::string() );
+        definition->subcategory = options.get_or( "subcategory", std::string() );
+        definition->activity_level = options.get_or( "activity_level", 1.0 );
+        return nested_recipe_category_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "Requirement", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<requirement_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->name = options.get_or( "name", std::string() );
+        return requirement_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "RecipeGroup", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<recipe_group_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->building_type = options.get_or( "building_type", std::string( "NONE" ) );
+        return recipe_group_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "ScentType", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<scent_type_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        return scent_type_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "SpeedDescription", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<speed_description_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        return speed_description_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "HarvestDropType", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<harvest_drop_type_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->field_dress_success = options.get_or(
+                                              "field_dress_success", std::string() );
+        definition->field_dress_failure = options.get_or(
+                                              "field_dress_failure", std::string() );
+        definition->butcher_success = options.get_or( "butcher_success", std::string() );
+        definition->butcher_failure = options.get_or( "butcher_failure", std::string() );
+        definition->dissect_success = options.get_or( "dissect_success", std::string() );
+        definition->dissect_failure = options.get_or( "dissect_failure", std::string() );
+        definition->item_group = options.get_or( "item_group", false );
+        definition->dissect_only = options.get_or( "dissect_only", false );
+        return harvest_drop_type_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "Harvest", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<harvest_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->message = options.get_or( "message", std::string() );
+        definition->leftovers = options.get_or(
+                                    "leftovers", std::string( "ruined_chunks" ) );
+        definition->butchery_requirements = options.get_or(
+                                                "butchery_requirements", std::string( "default" ) );
+        return harvest_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "Behavior", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<behavior_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->strategy = options.get_or( "strategy", std::string() );
+        definition->goal = options.get_or( "goal", std::string() );
+        return behavior_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "MonsterAttack", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<monster_attack_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->cooldown = options.get_or( "cooldown", 1.0 );
+        definition->handler = options.get_or( "policy", std::string() );
+        return monster_attack_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "EffectType", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<effect_type_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        if( const std::string name = options.get_or( "name", std::string() );
+            !name.empty() ) {
+            definition->names.push_back( name );
+        }
+        if( const std::string description = options.get_or(
+                    "description", std::string() ); !description.empty() ) {
+            definition->descriptions.push_back( description );
+        }
+        definition->remove_message = options.get_or( "remove_message", std::string() );
+        definition->apply_memorial_log = options.get_or(
+                                             "apply_memorial_log", std::string() );
+        definition->remove_memorial_log = options.get_or(
+                                              "remove_memorial_log", std::string() );
+        definition->blood_analysis_description = options.get_or(
+                    "blood_analysis_description", std::string() );
+        definition->maximum_intensity = options.get_or<std::int64_t>(
+                                            "maximum_intensity", 1 );
+        definition->maximum_duration_turns = options.get_or<std::int64_t>(
+                    "maximum_duration_turns", 31536000 );
+        definition->intensity_duration_turns = options.get_or<std::int64_t>(
+                    "intensity_duration_turns", 0 );
+        definition->duration_add_percent = options.get_or<std::int64_t>(
+                                               "duration_add_percent", 100 );
+        definition->intensity_add_value = options.get_or<std::int64_t>(
+                                              "intensity_add_value", 0 );
+        definition->intensity_decay_step = options.get_or<std::int64_t>(
+                                               "intensity_decay_step", -1 );
+        definition->intensity_decay_tick = options.get_or<std::int64_t>(
+                                               "intensity_decay_tick", 0 );
+        definition->intensity_decay_removes = options.get_or(
+                    "intensity_decay_removes", false );
+        definition->main_parts_only = options.get_or( "main_parts_only", false );
+        definition->show_in_info = options.get_or( "show_in_info", false );
+        definition->show_intensity = options.get_or( "show_intensity", true );
+        definition->part_descriptions = options.get_or( "part_descriptions", false );
+        return effect_type_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "WeakpointSet", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<weakpoint_set_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        return weakpoint_set_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "FieldType", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<field_type_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->underwater_age_speedup_turns = options.get_or<std::int64_t>(
+                    "underwater_age_speedup_turns", 0 );
+        definition->outdoor_age_speedup_turns = options.get_or<std::int64_t>(
+                                                   "outdoor_age_speedup_turns", 0 );
+        definition->decay_amount_factor = options.get_or<std::int64_t>(
+                                              "decay_amount_factor", 0 );
+        definition->percent_spread = options.get_or<std::int64_t>( "percent_spread", 0 );
+        definition->gas_absorption_turns = options.get_or<std::int64_t>(
+                                               "gas_absorption_turns", 0 );
+        definition->priority = options.get_or<std::int64_t>( "priority", 0 );
+        definition->half_life_turns = options.get_or<std::int64_t>( "half_life_turns", 0 );
+        definition->phase = options.get_or( "phase", std::string( "null" ) );
+        definition->description_affix = options.get_or(
+                                            "description_affix", std::string( "in" ) );
+        definition->wandering_field = options.get_or( "wandering_field", std::string() );
+        definition->looks_like = options.get_or( "looks_like", std::string() );
+        definition->splattering = options.get_or( "splattering", false );
+        definition->has_fire = options.get_or( "has_fire", false );
+        definition->has_acid = options.get_or( "has_acid", false );
+        definition->has_electricity = options.get_or( "has_electricity", false );
+        definition->has_fume = options.get_or( "has_fume", false );
+        definition->moppable = options.get_or( "moppable", false );
+        definition->accelerated_decay = options.get_or( "accelerated_decay", false );
+        definition->display_items = options.get_or( "display_items", true );
+        definition->display_field = options.get_or( "display_field", false );
+        definition->linear_half_life = options.get_or( "linear_half_life", false );
+        definition->indestructible = options.get_or( "indestructible", false );
+        definition->mopsafe = options.get_or( "mopsafe", false );
+        definition->decrease_intensity_on_contact = options.get_or(
+                    "decrease_intensity_on_contact", false );
+        return field_type_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "ItemGroup", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<item_group_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->kind = options.get_or( "kind", std::string( "distribution" ) );
+        definition->with_ammo = options.get_or<std::int64_t>( "with_ammo", 0 );
+        definition->with_magazine = options.get_or<std::int64_t>( "with_magazine", 0 );
+        return item_group_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "SubBodyPart", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<sub_body_part_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->name = options.get_or( "name", std::string() );
+        definition->plural_name = options.get_or( "plural_name", definition->name );
+        definition->parent = options.get_or( "parent", std::string() );
+        definition->opposite = options.get_or( "opposite", definition->id );
+        definition->side = options.get_or( "side", std::string( "both" ) );
+        definition->secondary = options.get_or( "secondary", false );
+        definition->maximum_coverage = options.get_or<std::int64_t>(
+                                           "maximum_coverage", 100 );
+        definition->similar_body_part = options.get_or(
+                                            "similar_body_part", std::string() );
+        return sub_body_part_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "BodyPart", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<body_part_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->name = options.get_or( "name", std::string() );
+        definition->plural_name = options.get_or( "plural_name", definition->name );
+        definition->accusative = options.get_or( "accusative", definition->name );
+        definition->plural_accusative = options.get_or(
+                                            "plural_accusative", definition->plural_name );
+        definition->heading = options.get_or( "heading", definition->name );
+        definition->plural_heading = options.get_or(
+                                         "plural_heading", definition->plural_name );
+        definition->encumbrance_text = options.get_or(
+                                           "encumbrance_text", definition->name );
+        definition->hp_bar_text = options.get_or( "hp_bar_text", definition->name );
+        definition->main_part = options.get_or( "main_part", definition->id );
+        definition->connected_to = options.get_or(
+                                       "connected_to", definition->main_part );
+        definition->opposite = options.get_or( "opposite", definition->id );
+        definition->side = options.get_or( "side", std::string( "both" ) );
+        definition->hit_size = options.get_or( "hit_size", 1.0 );
+        definition->hit_difficulty = options.get_or( "hit_difficulty", 1.0 );
+        definition->base_health = options.get_or<std::int64_t>( "base_health", 60 );
+        definition->drench_capacity = options.get_or<std::int64_t>(
+                                          "drench_capacity", 0 );
+        definition->limb = options.get_or( "limb", true );
+        definition->vital = options.get_or( "vital", false );
+        return body_part_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "Anatomy", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<anatomy_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        return anatomy_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "BodyGraph", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<body_graph_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->parent_body_part = options.get_or(
+                                           "parent_body_part", std::string() );
+        definition->mirror = options.get_or( "mirror", std::string() );
+        definition->label_fill = options.get_or( "label_fill", std::string() );
+        definition->fill_symbol = options.get_or( "fill_symbol", std::string( " " ) );
+        definition->fill_color = options.get_or( "fill_color", std::string( "white" ) );
+        return body_graph_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "Monster", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<monster_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->name = options.get_or( "name", std::string() );
+        definition->plural_name = options.get_or(
+                                      "plural_name", definition->name );
+        definition->description = options.get_or( "description", std::string() );
+        definition->symbol = options.get_or( "symbol", std::string( "?" ) );
+        definition->color = options.get_or( "color", std::string( "white" ) );
+        definition->looks_like = options.get_or( "looks_like", std::string() );
+        definition->body_type = options.get_or( "body_type", std::string() );
+        definition->default_faction = options.get_or(
+                                          "default_faction", std::string() );
+        definition->harvest = options.get_or( "harvest", std::string( "human" ) );
+        definition->dissect = options.get_or( "dissect", std::string() );
+        definition->decay = options.get_or( "decay", std::string() );
+        definition->speed_description = options.get_or(
+                                            "speed_description", std::string( "DEFAULT" ) );
+        definition->death_drops = options.get_or( "death_drops", std::string() );
+        definition->volume_ml = options.get_or<std::int64_t>( "volume_ml", 62499 );
+        definition->weight_grams = options.get_or<std::int64_t>(
+                                       "weight_grams", 81499 );
+        definition->phase = options.get_or( "phase", std::string( "solid" ) );
+        definition->difficulty_adjustment = options.get_or<std::int64_t>(
+                                                "difficulty_adjustment", 0 );
+        definition->hp = options.get_or<std::int64_t>( "hp", 1 );
+        definition->speed = options.get_or<std::int64_t>( "speed", 100 );
+        definition->aggression = options.get_or<std::int64_t>( "aggression", 0 );
+        definition->morale = options.get_or<std::int64_t>( "morale", 0 );
+        definition->tracking_distance = options.get_or<std::int64_t>(
+                                            "tracking_distance", 8 );
+        definition->attack_cost = options.get_or<std::int64_t>( "attack_cost", 100 );
+        definition->melee_skill = options.get_or<std::int64_t>( "melee_skill", 0 );
+        definition->melee_dice = options.get_or<std::int64_t>( "melee_dice", 0 );
+        definition->melee_sides = options.get_or<std::int64_t>( "melee_sides", 0 );
+        definition->melee_armor_penetration = options.get_or<std::int64_t>(
+                "melee_armor_penetration", 0 );
+        definition->dodge = options.get_or<std::int64_t>( "dodge", 0 );
+        definition->vision_day = options.get_or<std::int64_t>( "vision_day", 40 );
+        definition->vision_night = options.get_or<std::int64_t>( "vision_night", 1 );
+        definition->regenerates = options.get_or<std::int64_t>( "regenerates", 0 );
+        definition->bleed_rate = options.get_or<std::int64_t>( "bleed_rate", 100 );
+        definition->status_chance_multiplier = options.get_or(
+                    "status_chance_multiplier", 1.0 );
+        definition->luminance = options.get_or( "luminance", 0.0 );
+        definition->regenerates_in_dark = options.get_or(
+                                              "regenerates_in_dark", false );
+        definition->regenerates_morale = options.get_or(
+                                             "regenerates_morale", false );
+        definition->aggressive_to_characters = options.get_or(
+                    "aggressive_to_characters", true );
+        return monster_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "MoraleType", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<morale_type_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->text = options.get_or( "text", std::string() );
+        definition->permanent = options.get_or( "permanent", false );
+        return morale_type_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "DiseaseType", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<disease_type_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->symptoms = options.get_or( "symptoms", std::string() );
+        definition->minimum_duration_turns = options.get_or<std::int64_t>(
+                                                 "minimum_duration_turns", 1 );
+        definition->maximum_duration_turns = options.get_or<std::int64_t>(
+                                                 "maximum_duration_turns", 1 );
+        definition->minimum_intensity = options.get_or<std::int64_t>(
+                                            "minimum_intensity", 1 );
+        definition->maximum_intensity = options.get_or<std::int64_t>(
+                                            "maximum_intensity", 1 );
+        if( const sol::optional<std::int64_t> threshold =
+                options.get<sol::optional<std::int64_t>>( "health_threshold" ) ) {
+            definition->health_threshold = *threshold;
+        }
+        return disease_type_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "MonsterFlag", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<monster_flag_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        return monster_flag_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "Species", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<species_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->description = options.get_or( "description", std::string() );
+        definition->footsteps = options.get_or( "footsteps", std::string( "footsteps." ) );
+        definition->bleeds = options.get_or( "bleeds", std::string( "fd_null" ) );
+        return species_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "Emission", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<emission_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->field = options.get_or( "field", std::string() );
+        definition->intensity = options.get_or<std::int64_t>( "intensity", 1 );
+        definition->quantity = options.get_or<std::int64_t>( "quantity", 1 );
+        definition->chance = options.get_or<std::int64_t>( "chance", 100 );
+        return emission_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "MonsterFaction", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<monster_faction_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->base = options.get_or( "base", std::string() );
+        return monster_faction_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "MutationType", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<mutation_type_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        return mutation_type_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "ConnectGroup", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<connect_group_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        return connect_group_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "MutationCategory", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<mutation_category_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->name = options.get_or( "name", definition->id );
+        definition->threshold_mutation = options.get_or( "threshold_mutation", std::string() );
+        definition->mutagen_message = options.get_or( "mutagen_message", std::string() );
+        definition->memorial_message = options.get_or(
+                                           "memorial_message", std::string( "Crossed a threshold" ) );
+        definition->vitamin = options.get_or( "vitamin", std::string( "null" ) );
+        definition->threshold_minimum = options.get_or<std::int64_t>(
+                                            "threshold_minimum", 2200 );
+        definition->base_removal_chance = options.get_or<std::int64_t>(
+                                              "base_removal_chance", 100 );
+        definition->base_removal_cost_multiplier = options.get_or(
+                    "base_removal_cost_multiplier", 3.0 );
+        definition->work_in_progress = options.get_or( "work_in_progress", false );
+        definition->skip_consistency_test = options.get_or(
+                                                "skip_consistency_test", false );
+        return mutation_category_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "ConstructionCategory", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<construction_category_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->name = options.get_or( "name", definition->id );
+        return construction_category_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "ConstructionGroup", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<construction_group_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->name = options.get_or( "name", definition->id );
+        return construction_group_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "VehiclePartLocation", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<vehicle_part_location_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->name = options.get_or( "name", definition->id );
+        definition->description = options.get_or( "description", std::string() );
+        definition->z_order = options.get_or<std::int64_t>( "z_order", 0 );
+        definition->list_order = options.get_or<std::int64_t>( "list_order", 5 );
+        return vehicle_part_location_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "MoodFace", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<mood_face_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        return mood_face_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "DamageInfoOrder", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<damage_info_order_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->display = options.get_or( "display", std::string( "detailed" ) );
+        definition->verb = options.get_or( "verb", std::string() );
+        return damage_info_order_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "VehiclePartCategory", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<vehicle_part_category_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->name = options.get_or( "name", definition->id );
+        definition->short_name = options.get_or( "short_name", definition->name );
+        definition->priority = options.get_or<std::int64_t>( "priority", 0 );
+        return vehicle_part_category_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "NamedColor", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<named_color_definition_data>();
+        definition->name = options.get_or( "name", std::string() );
+        definition->id = definition->name;
+        definition->red = options.get_or<std::int64_t>( "red", 0 );
+        definition->green = options.get_or<std::int64_t>( "green", 0 );
+        definition->blue = options.get_or<std::int64_t>( "blue", 0 );
+        definition->alpha = options.get_or<std::int64_t>( "alpha", 255 );
+        return named_color_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "RotatableSymbol", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        const sol::optional<sol::table> values =
+            options.get<sol::optional<sol::table>>( "symbols" );
+        if( !values ) {
+            throw std::runtime_error( "rotatable symbol requires a symbols array" );
+        }
+        const std::size_t count = require_dense_array(
+                                      *values, "rotatable symbols", 2, 4 );
+        if( count != 2 && count != 4 ) {
+            throw std::runtime_error( "rotatable symbol requires two or four glyphs" );
+        }
+        auto definition = std::make_shared<rotatable_symbol_definition_data>();
+        definition->symbols.reserve( count );
+        for( std::size_t index = 1; index <= count; ++index ) {
+            const std::string glyph = values->raw_get<std::string>( index );
+            const utf8_wrapper wrapped( glyph );
+            if( wrapped.size() != 1 ) {
+                throw std::runtime_error( "each rotatable symbol must be one Unicode codepoint" );
+            }
+            if( index == 1 ) {
+                definition->key = glyph;
+                definition->id = glyph;
+            }
+            definition->symbols.push_back( wrapped.at( 0 ) );
+        }
+        return rotatable_symbol_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "AsciiArt", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<ascii_art_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        return ascii_art_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "LimbScore", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<limb_score_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->name = options.get_or( "name", definition->id );
+        definition->affected_by_wounds = options.get_or( "affected_by_wounds", true );
+        definition->affected_by_encumbrance = options.get_or(
+                "affected_by_encumbrance", true );
+        return limb_score_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "HitRange", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        const sol::optional<sol::table> values =
+            options.get<sol::optional<sol::table>>( "even_good" );
+        if( !values ) {
+            throw std::runtime_error( "hit range requires an even_good array" );
+        }
+        const std::size_t count = require_dense_array(
+                                      *values, "hit-range dispersion values", 1, 4096 );
+        auto definition = std::make_shared<hit_range_definition_data>();
+        definition->even_good.reserve( count );
+        for( std::size_t index = 1; index <= count; ++index ) {
+            definition->even_good.push_back(
+                values->raw_get<std::int64_t>( index ) );
+        }
+        return hit_range_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "BashDamageProfile", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<bash_damage_profile_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        return bash_damage_profile_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "ClothingMod", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<clothing_mod_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->flag = options.get_or( "flag", std::string() );
+        definition->material_item = options.get_or( "material_item", std::string() );
+        definition->apply_prompt = options.get_or( "apply_prompt", std::string() );
+        definition->remove_prompt = options.get_or( "remove_prompt", std::string() );
+        definition->restricted = options.get_or( "restricted", false );
+        return clothing_mod_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "OvermapLandUseCode", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<overmap_land_use_code_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->code = options.get_or<std::int64_t>( "code", 0 );
+        definition->name = options.get_or( "name", definition->id );
+        definition->description = options.get_or( "description", std::string() );
+        definition->color = options.get_or( "color", std::string( "black" ) );
+        const std::string symbol = options.get_or( "symbol", std::string() );
+        const utf8_wrapper wrapped( symbol );
+        if( wrapped.size() != 1 ) {
+            throw std::runtime_error( "overmap land-use symbol must be one Unicode codepoint" );
+        }
+        definition->symbol = wrapped.at( 0 );
+        return overmap_land_use_code_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "OvermapVision", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<overmap_vision_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        return overmap_vision_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "OvermapLocation", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<overmap_location_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        return overmap_location_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "ProfessionGroup", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<profession_group_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        return profession_group_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "MapExtraCollection", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<map_extra_collection_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->chance = options.get_or<std::int64_t>( "chance", 0 );
+        return map_extra_collection_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "VehicleGroup", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<vehicle_group_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        return vehicle_group_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "FaultGroup", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<fault_group_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        return fault_group_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "ExplosionLight", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<explosion_light_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        return explosion_light_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "AmmoEffect", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<ammo_effect_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->trigger_chance = options.get_or<std::int64_t>( "trigger_chance", 100 );
+        return ammo_effect_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "AddictionType", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<addiction_type_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->name = options.get_or( "name", std::string() );
+        definition->type_name = options.get_or( "type_name", std::string() );
+        definition->description = options.get_or( "description", std::string() );
+        definition->craving_morale = options.get_or( "craving_morale", std::string() );
+        return addiction_type_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "CharacterModifier", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<character_modifier_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->description = options.get_or( "description", std::string() );
+        definition->operation = options.get_or( "operation", std::string( "multiply" ) );
+        return character_modifier_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "StartLocation", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<start_location_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->name = options.get_or( "name", std::string() );
+        return start_location_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "ClimbingAid", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<climbing_aid_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->slip_chance_modifier = options.get_or<std::int64_t>(
+                                               "slip_chance_modifier", 0 );
+        return climbing_aid_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "WeatherType", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<weather_type_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->name = options.get_or( "name", std::string() );
+        definition->color = options.get_or( "color", std::string( "white" ) );
+        definition->map_color = options.get_or( "map_color", std::string( "white" ) );
+        definition->symbol = options.get_or( "symbol", std::string( "%" ) );
+        definition->sun_symbol = options.get_or( "sun_symbol", std::string( "☼" ) );
+        definition->ranged_penalty = options.get_or<std::int64_t>( "ranged_penalty", 0 );
+        definition->sight_penalty = options.get_or( "sight_penalty", 1.0 );
+        definition->light_modifier = options.get_or<std::int64_t>( "light_modifier", 0 );
+        definition->temperature_delta_kelvin = options.get_or( "temperature_delta_kelvin", 0.0 );
+        definition->light_multiplier = options.get_or( "light_multiplier", 1.0 );
+        definition->sun_multiplier = options.get_or( "sun_multiplier", 1.0 );
+        definition->sound_attenuation = options.get_or<std::int64_t>( "sound_attenuation", 0 );
+        definition->dangerous = options.get_or( "dangerous", false );
+        definition->precipitation = options.get_or( "precipitation", std::string( "none" ) );
+        definition->rains = options.get_or( "rains", false );
+        definition->tiles_animation = options.get_or( "tiles_animation", std::string() );
+        definition->sound_category = options.get_or( "sound_category", std::string( "silent" ) );
+        definition->priority = options.get_or<std::int64_t>( "priority", 0 );
+        return weather_type_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "Score", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<score_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->statistic = options.get_or( "statistic", std::string() );
+        definition->description = options.get_or( "description", std::string() );
+        return score_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "OverlayOrder", [transaction]() {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        return overlay_order_definition_handle{
+            std::make_shared<overlay_order_definition_data>(), transaction->token
+        };
+    } );
+    content.set_function( "ZoneType", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<zone_type_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->name = options.get_or( "name", std::string() );
+        definition->description = options.get_or( "description", std::string() );
+        definition->display_field = options.get_or( "display_field", std::string() );
+        definition->can_be_personal = options.get_or( "can_be_personal", false );
+        definition->hidden = options.get_or( "hidden", false );
+        return zone_type_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "SpeechPool", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<speech_pool_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        return speech_pool_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "EndScreen", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<end_screen_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->picture = options.get_or( "picture", std::string() );
+        definition->priority = options.get_or<std::int64_t>( "priority", 0 );
+        definition->last_words_label = options.get_or(
+                                           "last_words_label", std::string() );
+        return end_screen_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "ActivityType", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<activity_type_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->verb = options.get_or( "verb", std::string() );
+        definition->rooted = options.get_or( "rooted", false );
+        definition->interruptable = options.get_or( "interruptable", true );
+        definition->interruptable_with_keyboard = options.get_or(
+                    "interruptable_with_keyboard", true );
+        definition->based_on = options.get_or( "based_on", std::string( "speed" ) );
+        definition->can_resume = options.get_or( "can_resume", true );
+        definition->multi_activity = options.get_or( "multi_activity", false );
+        definition->fetch_items_to_zone = options.get_or( "fetch_items_to_zone", true );
+        definition->refuel_fires = options.get_or( "refuel_fires", false );
+        definition->auto_needs = options.get_or( "auto_needs", false );
+        definition->activity_level = options.get_or( "activity_level", 1.0 );
+        return activity_type_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "HelpTopic", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<help_topic_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->title = options.get_or( "title", std::string() );
+        if( const sol::optional<std::int64_t> order =
+                options.get<sol::optional<std::int64_t>>( "order" ) ) {
+            definition->order = *order;
+        }
+        return help_topic_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "SnippetCategory", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<snippet_category_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        return snippet_category_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "Playlist", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<playlist_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->shuffle = options.get_or( "shuffle", false );
+        return playlist_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "AttackVector", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<attack_vector_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->weapon = options.get_or( "weapon", false );
+        definition->strict_limbs = options.get_or( "strict_limbs", false );
+        definition->armor_bonus = options.get_or( "armor_bonus", true );
+        definition->encumbrance_limit = options.get_or<std::int64_t>(
+                                            "encumbrance_limit", 100 );
+        definition->health_percent_limit = options.get_or<std::int64_t>(
+                                               "health_percent_limit", 10 );
+        return attack_vector_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "MagicType", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<magic_type_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->energy_source = options.get_or( "energy", std::string( "none" ) );
+        definition->vitamin = options.get_or( "vitamin", std::string() );
+        definition->energy_color = options.get_or( "energy_color", std::string( "cyan" ) );
+        if( const sol::optional<std::string> message =
+                options.get<sol::optional<std::string>>( "cannot_cast_message" ) ) {
+            definition->cannot_cast_message = *message;
+        }
+        if( const sol::optional<std::int64_t> maximum =
+                options.get<sol::optional<std::int64_t>>( "max_book_level" ) ) {
+            definition->max_book_level = *maximum;
+        }
+        definition->failure_cost_fraction = options.get_or<double>(
+                    "failure_cost_fraction", 0.0 );
+        definition->failure_experience_fraction = options.get_or<double>(
+                    "failure_experience_fraction", 0.2 );
+        return magic_type_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    content.set_function( "MovementMode", [transaction]( const sol::table &options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<movement_mode_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->name = options.get_or( "name", definition->id );
+        definition->kind = options.get_or( "kind", std::string( "walking" ) );
+        definition->panel_color = options.get_or( "panel_color", std::string( "white" ) );
+        definition->symbol_color = options.get_or( "symbol_color", std::string( "white" ) );
+        definition->exertion = options.get_or<double>( "exertion", 1.0 );
+        definition->riding_exertion = options.get_or<double>( "riding_exertion", 0.0 );
+        definition->stamina_multiplier = options.get_or<double>(
+                    "stamina_multiplier", 1.0 );
+        definition->sound_multiplier = options.get_or<double>(
+                                          "sound_multiplier", 1.0 );
+        definition->speed_multiplier = options.get_or<double>(
+                                          "speed_multiplier", 1.0 );
+        definition->mech_power_kilojoules = options.get_or<std::int64_t>(
+                    "mech_power_kilojoules", 2 );
+        definition->swim_speed_modifier = options.get_or<std::int64_t>(
+                    "swim_speed_modifier", 0 );
+        definition->stop_hauling = options.get_or( "stop_hauling", false );
+        const auto read_symbol = [&options]( const char *name ) {
+            const std::string symbol = options.get_or( name, std::string() );
+            const utf8_wrapper wrapped( symbol );
+            if( wrapped.size() != 1 ) {
+                throw std::runtime_error( std::string( "movement-mode " ) + name +
+                                          " must be one Unicode codepoint" );
+            }
+            return wrapped.at( 0 );
+        };
+        definition->character_symbol = read_symbol( "character_symbol" );
+        definition->panel_symbol = read_symbol( "panel_symbol" );
+        return movement_mode_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+
+    auto register_catalog = [transaction]( auto handle, auto &registrations,
+    const definition_operation operation, const char *kind ) {
+        if( handle.token != transaction->token ) {
+            throw std::runtime_error( std::string( "cannot register a " ) + kind +
+                                      " definition owned by another Mod" );
+        }
+        require_building_handle( handle.token, *handle.definition, kind );
+        handle.definition->registered = true;
+        if( operation == definition_operation::edit ) {
+            const auto target = std::find_if(
+                                    registrations.rbegin(), registrations.rend(),
+            [&handle]( const auto & entry ) {
+                return entry.definition->id == handle.definition->id;
+            } );
+            if( target == registrations.rend() ) {
+                handle.definition->registered = false;
+                throw std::runtime_error( std::string( "edit requires a " ) + kind +
+                                          " staged earlier by this Mod" );
+            }
+            target->definition = handle.definition;
+            return;
+        }
+        registrations.push_back( { operation, handle.definition } );
+    };
+
+    auto register_definition = [transaction, register_catalog]( const sol::object &value,
+    definition_operation operation ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        if( value.is<item_definition_handle>() ) {
+            item_definition_handle handle = value.as<item_definition_handle>();
+            if( handle.token != transaction->token ) {
+                throw std::runtime_error( "cannot register an item definition owned by another Mod" );
+            }
+            require_building_handle( handle.token, *handle.definition, "item" );
+            handle.definition->registered = true;
+            if( operation == definition_operation::edit ) {
+                const auto target = std::find_if(
+                                        transaction->items.rbegin(), transaction->items.rend(),
+                [&handle]( const item_registration & entry ) {
+                    return entry.definition->id == handle.definition->id;
+                } );
+                if( target == transaction->items.rend() ) {
+                    handle.definition->registered = false;
+                    throw std::runtime_error(
+                        "edit requires an item staged earlier by this Mod" );
+                }
+                target->definition = handle.definition;
+                return;
+            }
+            transaction->items.push_back( { operation, handle.definition } );
+            return;
+        }
+        if( value.is<tool_quality_definition_handle>() ) {
+            register_catalog( value.as<tool_quality_definition_handle>(),
+                              transaction->tool_qualities, operation, "tool quality" );
+            return;
+        }
+        if( value.is<skill_display_definition_handle>() ) {
+            register_catalog( value.as<skill_display_definition_handle>(),
+                              transaction->skill_displays, operation,
+                              "skill display category" );
+            return;
+        }
+        if( value.is<skill_definition_handle>() ) {
+            register_catalog( value.as<skill_definition_handle>(),
+                              transaction->skills, operation, "skill" );
+            return;
+        }
+        if( value.is<vitamin_definition_handle>() ) {
+            register_catalog( value.as<vitamin_definition_handle>(),
+                              transaction->vitamins, operation, "vitamin" );
+            return;
+        }
+        if( value.is<json_flag_definition_handle>() ) {
+            register_catalog( value.as<json_flag_definition_handle>(),
+                              transaction->json_flags, operation, "JSON flag" );
+            return;
+        }
+        if( value.is<damage_type_definition_handle>() ) {
+            register_catalog( value.as<damage_type_definition_handle>(),
+                              transaction->damage_types, operation, "damage type" );
+            return;
+        }
+        if( value.is<material_definition_handle>() ) {
+            register_catalog( value.as<material_definition_handle>(),
+                              transaction->materials, operation, "material" );
+            return;
+        }
+        if( value.is<ammunition_type_definition_handle>() ) {
+            register_catalog( value.as<ammunition_type_definition_handle>(),
+                              transaction->ammunition_types, operation, "ammunition type" );
+            return;
+        }
+        if( value.is<item_category_definition_handle>() ) {
+            register_catalog( value.as<item_category_definition_handle>(),
+                              transaction->item_categories, operation, "item category" );
+            return;
+        }
+        if( value.is<crafting_category_definition_handle>() ) {
+            register_catalog( value.as<crafting_category_definition_handle>(),
+                              transaction->crafting_categories, operation, "recipe category" );
+            return;
+        }
+        if( value.is<proficiency_category_definition_handle>() ) {
+            register_catalog( value.as<proficiency_category_definition_handle>(),
+                              transaction->proficiency_categories, operation,
+                              "proficiency category" );
+            return;
+        }
+        if( value.is<proficiency_definition_handle>() ) {
+            register_catalog( value.as<proficiency_definition_handle>(),
+                              transaction->proficiencies, operation, "proficiency" );
+            return;
+        }
+        if( value.is<weapon_category_definition_handle>() ) {
+            register_catalog( value.as<weapon_category_definition_handle>(),
+                              transaction->weapon_categories, operation, "weapon category" );
+            return;
+        }
+        if( value.is<requirement_definition_handle>() ) {
+            register_catalog( value.as<requirement_definition_handle>(),
+                              transaction->requirements, operation, "requirement" );
+            return;
+        }
+        if( value.is<recipe_group_definition_handle>() ) {
+            register_catalog( value.as<recipe_group_definition_handle>(),
+                              transaction->recipe_groups, operation, "recipe group" );
+            return;
+        }
+        if( value.is<scent_type_definition_handle>() ) {
+            register_catalog( value.as<scent_type_definition_handle>(),
+                              transaction->scent_types, operation, "scent type" );
+            return;
+        }
+        if( value.is<speed_description_definition_handle>() ) {
+            register_catalog( value.as<speed_description_definition_handle>(),
+                              transaction->speed_descriptions, operation,
+                              "speed description" );
+            return;
+        }
+        if( value.is<harvest_drop_type_definition_handle>() ) {
+            register_catalog( value.as<harvest_drop_type_definition_handle>(),
+                              transaction->harvest_drop_types, operation,
+                              "harvest drop type" );
+            return;
+        }
+        if( value.is<harvest_definition_handle>() ) {
+            register_catalog( value.as<harvest_definition_handle>(),
+                              transaction->harvests, operation, "harvest" );
+            return;
+        }
+        if( value.is<behavior_definition_handle>() ) {
+            register_catalog( value.as<behavior_definition_handle>(),
+                              transaction->behaviors, operation, "behavior" );
+            return;
+        }
+        if( value.is<monster_attack_definition_handle>() ) {
+            register_catalog( value.as<monster_attack_definition_handle>(),
+                              transaction->monster_attacks, operation, "monster attack" );
+            return;
+        }
+        if( value.is<effect_type_definition_handle>() ) {
+            register_catalog( value.as<effect_type_definition_handle>(),
+                              transaction->effect_types, operation, "effect type" );
+            return;
+        }
+        if( value.is<weakpoint_set_definition_handle>() ) {
+            register_catalog( value.as<weakpoint_set_definition_handle>(),
+                              transaction->weakpoint_sets, operation, "weakpoint set" );
+            return;
+        }
+        if( value.is<field_type_definition_handle>() ) {
+            register_catalog( value.as<field_type_definition_handle>(),
+                              transaction->field_types, operation, "field type" );
+            return;
+        }
+        if( value.is<item_group_definition_handle>() ) {
+            register_catalog( value.as<item_group_definition_handle>(),
+                              transaction->item_groups, operation, "item group" );
+            return;
+        }
+        if( value.is<sub_body_part_definition_handle>() ) {
+            register_catalog( value.as<sub_body_part_definition_handle>(),
+                              transaction->sub_body_parts, operation, "sub body part" );
+            return;
+        }
+        if( value.is<body_part_definition_handle>() ) {
+            register_catalog( value.as<body_part_definition_handle>(),
+                              transaction->body_parts, operation, "body part" );
+            return;
+        }
+        if( value.is<anatomy_definition_handle>() ) {
+            register_catalog( value.as<anatomy_definition_handle>(),
+                              transaction->anatomies, operation, "anatomy" );
+            return;
+        }
+        if( value.is<body_graph_definition_handle>() ) {
+            register_catalog( value.as<body_graph_definition_handle>(),
+                              transaction->body_graphs, operation, "body graph" );
+            return;
+        }
+        if( value.is<monster_definition_handle>() ) {
+            register_catalog( value.as<monster_definition_handle>(),
+                              transaction->monsters, operation, "monster" );
+            return;
+        }
+        if( value.is<morale_type_definition_handle>() ) {
+            register_catalog( value.as<morale_type_definition_handle>(),
+                              transaction->morale_types, operation, "morale type" );
+            return;
+        }
+        if( value.is<disease_type_definition_handle>() ) {
+            register_catalog( value.as<disease_type_definition_handle>(),
+                              transaction->disease_types, operation, "disease type" );
+            return;
+        }
+        if( value.is<monster_flag_definition_handle>() ) {
+            register_catalog( value.as<monster_flag_definition_handle>(),
+                              transaction->monster_flags, operation, "monster flag" );
+            return;
+        }
+        if( value.is<species_definition_handle>() ) {
+            register_catalog( value.as<species_definition_handle>(),
+                              transaction->species, operation, "species" );
+            return;
+        }
+        if( value.is<emission_definition_handle>() ) {
+            register_catalog( value.as<emission_definition_handle>(),
+                              transaction->emissions, operation, "emission" );
+            return;
+        }
+        if( value.is<monster_faction_definition_handle>() ) {
+            register_catalog( value.as<monster_faction_definition_handle>(),
+                              transaction->monster_factions, operation,
+                              "monster faction" );
+            return;
+        }
+        if( value.is<mutation_type_definition_handle>() ) {
+            register_catalog( value.as<mutation_type_definition_handle>(),
+                              transaction->mutation_types, operation, "mutation type" );
+            return;
+        }
+        if( value.is<connect_group_definition_handle>() ) {
+            register_catalog( value.as<connect_group_definition_handle>(),
+                              transaction->connect_groups, operation, "connect group" );
+            return;
+        }
+        if( value.is<mutation_category_definition_handle>() ) {
+            register_catalog( value.as<mutation_category_definition_handle>(),
+                              transaction->mutation_categories, operation,
+                              "mutation category" );
+            return;
+        }
+        if( value.is<construction_category_definition_handle>() ) {
+            register_catalog( value.as<construction_category_definition_handle>(),
+                              transaction->construction_categories, operation,
+                              "construction category" );
+            return;
+        }
+        if( value.is<construction_group_definition_handle>() ) {
+            register_catalog( value.as<construction_group_definition_handle>(),
+                              transaction->construction_groups, operation,
+                              "construction group" );
+            return;
+        }
+        if( value.is<vehicle_part_location_definition_handle>() ) {
+            register_catalog( value.as<vehicle_part_location_definition_handle>(),
+                              transaction->vehicle_part_locations, operation,
+                              "vehicle part location" );
+            return;
+        }
+        if( value.is<mood_face_definition_handle>() ) {
+            register_catalog( value.as<mood_face_definition_handle>(),
+                              transaction->mood_faces, operation, "mood face" );
+            return;
+        }
+        if( value.is<damage_info_order_definition_handle>() ) {
+            register_catalog( value.as<damage_info_order_definition_handle>(),
+                              transaction->damage_info_orders, operation,
+                              "damage info order" );
+            return;
+        }
+        if( value.is<vehicle_part_category_definition_handle>() ) {
+            register_catalog( value.as<vehicle_part_category_definition_handle>(),
+                              transaction->vehicle_part_categories, operation,
+                              "vehicle part category" );
+            return;
+        }
+        if( value.is<named_color_definition_handle>() ) {
+            register_catalog( value.as<named_color_definition_handle>(),
+                              transaction->named_colors, operation, "named color" );
+            return;
+        }
+        if( value.is<rotatable_symbol_definition_handle>() ) {
+            register_catalog( value.as<rotatable_symbol_definition_handle>(),
+                              transaction->rotatable_symbols, operation,
+                              "rotatable symbol" );
+            return;
+        }
+        if( value.is<ascii_art_definition_handle>() ) {
+            register_catalog( value.as<ascii_art_definition_handle>(),
+                              transaction->ascii_arts, operation, "ASCII art" );
+            return;
+        }
+        if( value.is<limb_score_definition_handle>() ) {
+            register_catalog( value.as<limb_score_definition_handle>(),
+                              transaction->limb_scores, operation, "limb score" );
+            return;
+        }
+        if( value.is<hit_range_definition_handle>() ) {
+            register_catalog( value.as<hit_range_definition_handle>(),
+                              transaction->hit_ranges, operation, "hit range" );
+            return;
+        }
+        if( value.is<bash_damage_profile_definition_handle>() ) {
+            register_catalog( value.as<bash_damage_profile_definition_handle>(),
+                              transaction->bash_damage_profiles, operation,
+                              "bash damage profile" );
+            return;
+        }
+        if( value.is<clothing_mod_definition_handle>() ) {
+            register_catalog( value.as<clothing_mod_definition_handle>(),
+                              transaction->clothing_mods, operation,
+                              "clothing modification" );
+            return;
+        }
+        if( value.is<overmap_land_use_code_definition_handle>() ) {
+            register_catalog( value.as<overmap_land_use_code_definition_handle>(),
+                              transaction->overmap_land_use_codes, operation,
+                              "overmap land-use code" );
+            return;
+        }
+        if( value.is<overmap_vision_definition_handle>() ) {
+            register_catalog( value.as<overmap_vision_definition_handle>(),
+                              transaction->overmap_visions, operation,
+                              "overmap vision" );
+            return;
+        }
+        if( value.is<overmap_location_definition_handle>() ) {
+            register_catalog( value.as<overmap_location_definition_handle>(),
+                              transaction->overmap_locations, operation,
+                              "overmap location" );
+            return;
+        }
+        if( value.is<profession_group_definition_handle>() ) {
+            register_catalog( value.as<profession_group_definition_handle>(),
+                              transaction->profession_groups, operation,
+                              "profession group" );
+            return;
+        }
+        if( value.is<map_extra_collection_definition_handle>() ) {
+            register_catalog( value.as<map_extra_collection_definition_handle>(),
+                              transaction->map_extra_collections, operation,
+                              "map-extra collection" );
+            return;
+        }
+        if( value.is<vehicle_group_definition_handle>() ) {
+            register_catalog( value.as<vehicle_group_definition_handle>(),
+                              transaction->vehicle_groups, operation,
+                              "vehicle group" );
+            return;
+        }
+        if( value.is<fault_group_definition_handle>() ) {
+            register_catalog( value.as<fault_group_definition_handle>(),
+                              transaction->fault_groups, operation,
+                              "fault group" );
+            return;
+        }
+        if( value.is<explosion_light_definition_handle>() ) {
+            register_catalog( value.as<explosion_light_definition_handle>(),
+                              transaction->explosion_lights, operation,
+                              "explosion light" );
+            return;
+        }
+        if( value.is<ammo_effect_definition_handle>() ) {
+            register_catalog( value.as<ammo_effect_definition_handle>(),
+                              transaction->ammo_effects, operation,
+                              "ammo effect" );
+            return;
+        }
+        if( value.is<addiction_type_definition_handle>() ) {
+            register_catalog( value.as<addiction_type_definition_handle>(),
+                              transaction->addiction_types, operation,
+                              "addiction type" );
+            return;
+        }
+        if( value.is<character_modifier_definition_handle>() ) {
+            register_catalog( value.as<character_modifier_definition_handle>(),
+                              transaction->character_modifiers, operation,
+                              "character modifier" );
+            return;
+        }
+        if( value.is<start_location_definition_handle>() ) {
+            register_catalog( value.as<start_location_definition_handle>(),
+                              transaction->start_locations, operation,
+                              "start location" );
+            return;
+        }
+        if( value.is<climbing_aid_definition_handle>() ) {
+            register_catalog( value.as<climbing_aid_definition_handle>(),
+                              transaction->climbing_aids, operation,
+                              "climbing aid" );
+            return;
+        }
+        if( value.is<weather_type_definition_handle>() ) {
+            register_catalog( value.as<weather_type_definition_handle>(),
+                              transaction->weather_types, operation,
+                              "weather type" );
+            return;
+        }
+        if( value.is<score_definition_handle>() ) {
+            register_catalog( value.as<score_definition_handle>(),
+                              transaction->scores, operation, "score" );
+            return;
+        }
+        if( value.is<overlay_order_definition_handle>() ) {
+            register_catalog( value.as<overlay_order_definition_handle>(),
+                              transaction->overlay_orders, operation, "overlay order" );
+            return;
+        }
+        if( value.is<zone_type_definition_handle>() ) {
+            register_catalog( value.as<zone_type_definition_handle>(),
+                              transaction->zone_types, operation, "zone type" );
+            return;
+        }
+        if( value.is<speech_pool_definition_handle>() ) {
+            register_catalog( value.as<speech_pool_definition_handle>(),
+                              transaction->speech_pools, operation, "speech pool" );
+            return;
+        }
+        if( value.is<end_screen_definition_handle>() ) {
+            register_catalog( value.as<end_screen_definition_handle>(),
+                              transaction->end_screens, operation, "end screen" );
+            return;
+        }
+        if( value.is<activity_type_definition_handle>() ) {
+            register_catalog( value.as<activity_type_definition_handle>(),
+                              transaction->activity_types, operation, "activity type" );
+            return;
+        }
+        if( value.is<help_topic_definition_handle>() ) {
+            register_catalog( value.as<help_topic_definition_handle>(),
+                              transaction->help_topics, operation, "help topic" );
+            return;
+        }
+        if( value.is<snippet_category_definition_handle>() ) {
+            register_catalog( value.as<snippet_category_definition_handle>(),
+                              transaction->snippet_categories, operation,
+                              "snippet category" );
+            return;
+        }
+        if( value.is<playlist_definition_handle>() ) {
+            register_catalog( value.as<playlist_definition_handle>(),
+                              transaction->playlists, operation, "playlist" );
+            return;
+        }
+        if( value.is<attack_vector_definition_handle>() ) {
+            register_catalog( value.as<attack_vector_definition_handle>(),
+                              transaction->attack_vectors, operation,
+                              "attack vector" );
+            return;
+        }
+        if( value.is<magic_type_definition_handle>() ) {
+            register_catalog( value.as<magic_type_definition_handle>(),
+                              transaction->magic_types, operation, "magic type" );
+            return;
+        }
+        if( value.is<movement_mode_definition_handle>() ) {
+            register_catalog( value.as<movement_mode_definition_handle>(),
+                              transaction->movement_modes, operation,
+                              "movement mode" );
+            return;
+        }
+        if( value.is<nested_recipe_category_definition_handle>() ) {
+            register_catalog( value.as<nested_recipe_category_definition_handle>(),
+                              transaction->recipes, operation, "nested recipe category" );
+            return;
+        }
+        if( value.is<recipe_definition_handle>() ) {
+            recipe_definition_handle handle = value.as<recipe_definition_handle>();
+            if( handle.token != transaction->token ) {
+                throw std::runtime_error( "cannot register a recipe definition owned by another Mod" );
+            }
+            require_building_handle( handle.token, *handle.definition, "recipe" );
+            handle.definition->registered = true;
+            if( operation == definition_operation::edit ) {
+                const auto target = std::find_if(
+                                        transaction->recipes.rbegin(), transaction->recipes.rend(),
+                [&handle]( const recipe_registration & entry ) {
+                    return entry.definition->id == handle.definition->id;
+                } );
+                if( target == transaction->recipes.rend() ) {
+                    handle.definition->registered = false;
+                    throw std::runtime_error(
+                        "edit requires a recipe staged earlier by this Mod" );
+                }
+                target->definition = handle.definition;
+                return;
+            }
+            transaction->recipes.push_back( { operation, handle.definition } );
+            return;
+        }
+        throw std::runtime_error(
+            "content registration requires a native Platform definition" );
+    };
+    content.set_function( "add", [register_definition]( const sol::object &value ) {
+        register_definition( value, definition_operation::add );
+    } );
+    content.set_function( "replace", [register_definition]( const sol::object &value ) {
+        register_definition( value, definition_operation::replace );
+    } );
+    content.set_function( "edit", [register_definition]( const sol::object &value ) {
+        register_definition( value, definition_operation::edit );
+    } );
+    auto edit_catalog = [transaction]( const std::string &id, auto &registrations,
+    const char *kind ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        const auto found = std::find_if(
+                               registrations.rbegin(), registrations.rend(),
+        [&id]( const auto & entry ) {
+            return entry.definition->id == id;
+        } );
+        if( found == registrations.rend() ) {
+            throw std::runtime_error( std::string( "edit_" ) + kind +
+                                      " requires a definition staged earlier by this Mod" );
+        }
+        auto definition = std::make_shared<std::decay_t<decltype( *found->definition )>>(
+                              *found->definition );
+        definition->registered = false;
+        return definition;
+    };
+    content.set_function( "edit_tool_quality", [transaction, edit_catalog]( const std::string &id ) {
+        return tool_quality_definition_handle{
+            edit_catalog( id, transaction->tool_qualities, "tool_quality" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_skill_display", [transaction, edit_catalog]( const std::string &id ) {
+        return skill_display_definition_handle{
+            edit_catalog( id, transaction->skill_displays, "skill_display" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_skill", [transaction, edit_catalog]( const std::string &id ) {
+        return skill_definition_handle{
+            edit_catalog( id, transaction->skills, "skill" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_vitamin", [transaction, edit_catalog]( const std::string &id ) {
+        return vitamin_definition_handle{
+            edit_catalog( id, transaction->vitamins, "vitamin" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_json_flag", [transaction, edit_catalog]( const std::string &id ) {
+        return json_flag_definition_handle{
+            edit_catalog( id, transaction->json_flags, "json_flag" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_damage_type", [transaction, edit_catalog]( const std::string &id ) {
+        return damage_type_definition_handle{
+            edit_catalog( id, transaction->damage_types, "damage_type" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_material", [transaction, edit_catalog]( const std::string &id ) {
+        return material_definition_handle{
+            edit_catalog( id, transaction->materials, "material" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_ammunition_type", [transaction, edit_catalog](
+    const std::string &id ) {
+        return ammunition_type_definition_handle{
+            edit_catalog( id, transaction->ammunition_types, "ammunition_type" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_item_category", [transaction, edit_catalog](
+    const std::string &id ) {
+        return item_category_definition_handle{
+            edit_catalog( id, transaction->item_categories, "item_category" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_recipe_category", [transaction, edit_catalog](
+    const std::string &id ) {
+        return crafting_category_definition_handle{
+            edit_catalog( id, transaction->crafting_categories, "recipe_category" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_proficiency_category", [transaction, edit_catalog](
+    const std::string &id ) {
+        return proficiency_category_definition_handle{
+            edit_catalog( id, transaction->proficiency_categories, "proficiency_category" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_proficiency", [transaction, edit_catalog](
+    const std::string &id ) {
+        return proficiency_definition_handle{
+            edit_catalog( id, transaction->proficiencies, "proficiency" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_weapon_category", [transaction, edit_catalog](
+    const std::string &id ) {
+        return weapon_category_definition_handle{
+            edit_catalog( id, transaction->weapon_categories, "weapon_category" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_requirement", [transaction, edit_catalog](
+    const std::string &id ) {
+        return requirement_definition_handle{
+            edit_catalog( id, transaction->requirements, "requirement" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_recipe_group", [transaction, edit_catalog](
+    const std::string &id ) {
+        return recipe_group_definition_handle{
+            edit_catalog( id, transaction->recipe_groups, "recipe_group" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_scent_type", [transaction, edit_catalog](
+    const std::string &id ) {
+        return scent_type_definition_handle{
+            edit_catalog( id, transaction->scent_types, "scent_type" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_speed_description", [transaction, edit_catalog](
+    const std::string &id ) {
+        return speed_description_definition_handle{
+            edit_catalog( id, transaction->speed_descriptions, "speed_description" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_harvest_drop_type", [transaction, edit_catalog](
+    const std::string &id ) {
+        return harvest_drop_type_definition_handle{
+            edit_catalog( id, transaction->harvest_drop_types, "harvest_drop_type" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_harvest", [transaction, edit_catalog](
+    const std::string &id ) {
+        return harvest_definition_handle{
+            edit_catalog( id, transaction->harvests, "harvest" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_behavior", [transaction, edit_catalog](
+    const std::string &id ) {
+        return behavior_definition_handle{
+            edit_catalog( id, transaction->behaviors, "behavior" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_monster_attack", [transaction, edit_catalog](
+    const std::string &id ) {
+        return monster_attack_definition_handle{
+            edit_catalog( id, transaction->monster_attacks, "monster_attack" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_effect_type", [transaction, edit_catalog](
+    const std::string &id ) {
+        return effect_type_definition_handle{
+            edit_catalog( id, transaction->effect_types, "effect_type" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_weakpoint_set", [transaction, edit_catalog](
+    const std::string &id ) {
+        return weakpoint_set_definition_handle{
+            edit_catalog( id, transaction->weakpoint_sets, "weakpoint_set" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_field_type", [transaction, edit_catalog](
+    const std::string &id ) {
+        return field_type_definition_handle{
+            edit_catalog( id, transaction->field_types, "field_type" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_item_group", [transaction, edit_catalog](
+    const std::string &id ) {
+        return item_group_definition_handle{
+            edit_catalog( id, transaction->item_groups, "item_group" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_sub_body_part", [transaction, edit_catalog](
+    const std::string &id ) {
+        return sub_body_part_definition_handle{
+            edit_catalog( id, transaction->sub_body_parts, "sub_body_part" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_body_part", [transaction, edit_catalog](
+    const std::string &id ) {
+        return body_part_definition_handle{
+            edit_catalog( id, transaction->body_parts, "body_part" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_anatomy", [transaction, edit_catalog](
+    const std::string &id ) {
+        return anatomy_definition_handle{
+            edit_catalog( id, transaction->anatomies, "anatomy" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_body_graph", [transaction, edit_catalog](
+    const std::string &id ) {
+        return body_graph_definition_handle{
+            edit_catalog( id, transaction->body_graphs, "body_graph" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_monster", [transaction, edit_catalog](
+    const std::string &id ) {
+        return monster_definition_handle{
+            edit_catalog( id, transaction->monsters, "monster" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_morale_type", [transaction, edit_catalog](
+    const std::string &id ) {
+        return morale_type_definition_handle{
+            edit_catalog( id, transaction->morale_types, "morale_type" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_disease_type", [transaction, edit_catalog](
+    const std::string &id ) {
+        return disease_type_definition_handle{
+            edit_catalog( id, transaction->disease_types, "disease_type" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_monster_flag", [transaction, edit_catalog](
+    const std::string &id ) {
+        return monster_flag_definition_handle{
+            edit_catalog( id, transaction->monster_flags, "monster_flag" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_species", [transaction, edit_catalog](
+    const std::string &id ) {
+        return species_definition_handle{
+            edit_catalog( id, transaction->species, "species" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_emission", [transaction, edit_catalog](
+    const std::string &id ) {
+        return emission_definition_handle{
+            edit_catalog( id, transaction->emissions, "emission" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_monster_faction", [transaction, edit_catalog](
+    const std::string &id ) {
+        return monster_faction_definition_handle{
+            edit_catalog( id, transaction->monster_factions, "monster_faction" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_mutation_type", [transaction, edit_catalog](
+    const std::string &id ) {
+        return mutation_type_definition_handle{
+            edit_catalog( id, transaction->mutation_types, "mutation_type" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_connect_group", [transaction, edit_catalog](
+    const std::string &id ) {
+        return connect_group_definition_handle{
+            edit_catalog( id, transaction->connect_groups, "connect_group" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_mutation_category", [transaction, edit_catalog](
+    const std::string &id ) {
+        return mutation_category_definition_handle{
+            edit_catalog( id, transaction->mutation_categories, "mutation_category" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_construction_category", [transaction, edit_catalog](
+    const std::string &id ) {
+        return construction_category_definition_handle{
+            edit_catalog( id, transaction->construction_categories, "construction_category" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_construction_group", [transaction, edit_catalog](
+    const std::string &id ) {
+        return construction_group_definition_handle{
+            edit_catalog( id, transaction->construction_groups, "construction_group" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_vehicle_part_location", [transaction, edit_catalog](
+    const std::string &id ) {
+        return vehicle_part_location_definition_handle{
+            edit_catalog( id, transaction->vehicle_part_locations, "vehicle_part_location" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_mood_face", [transaction, edit_catalog](
+    const std::string &id ) {
+        return mood_face_definition_handle{
+            edit_catalog( id, transaction->mood_faces, "mood_face" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_damage_info_order", [transaction, edit_catalog](
+    const std::string &id ) {
+        return damage_info_order_definition_handle{
+            edit_catalog( id, transaction->damage_info_orders, "damage_info_order" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_vehicle_part_category", [transaction, edit_catalog](
+    const std::string &id ) {
+        return vehicle_part_category_definition_handle{
+            edit_catalog( id, transaction->vehicle_part_categories,
+                          "vehicle_part_category" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_named_color", [transaction, edit_catalog](
+    const std::string &name ) {
+        return named_color_definition_handle{
+            edit_catalog( name, transaction->named_colors, "named_color" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_rotatable_symbol", [transaction, edit_catalog](
+    const std::string &key ) {
+        return rotatable_symbol_definition_handle{
+            edit_catalog( key, transaction->rotatable_symbols, "rotatable_symbol" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_ascii_art", [transaction, edit_catalog](
+    const std::string &id ) {
+        return ascii_art_definition_handle{
+            edit_catalog( id, transaction->ascii_arts, "ascii_art" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_limb_score", [transaction, edit_catalog](
+    const std::string &id ) {
+        return limb_score_definition_handle{
+            edit_catalog( id, transaction->limb_scores, "limb_score" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_bash_damage_profile", [transaction, edit_catalog](
+    const std::string &id ) {
+        return bash_damage_profile_definition_handle{
+            edit_catalog( id, transaction->bash_damage_profiles, "bash_damage_profile" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_clothing_mod", [transaction, edit_catalog](
+    const std::string &id ) {
+        return clothing_mod_definition_handle{
+            edit_catalog( id, transaction->clothing_mods, "clothing_mod" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_overmap_land_use_code", [transaction, edit_catalog](
+    const std::string &id ) {
+        return overmap_land_use_code_definition_handle{
+            edit_catalog( id, transaction->overmap_land_use_codes,
+                          "overmap_land_use_code" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_overmap_vision", [transaction, edit_catalog](
+    const std::string &id ) {
+        return overmap_vision_definition_handle{
+            edit_catalog( id, transaction->overmap_visions, "overmap_vision" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_overmap_location", [transaction, edit_catalog](
+    const std::string &id ) {
+        return overmap_location_definition_handle{
+            edit_catalog( id, transaction->overmap_locations, "overmap_location" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_profession_group", [transaction, edit_catalog](
+    const std::string &id ) {
+        return profession_group_definition_handle{
+            edit_catalog( id, transaction->profession_groups, "profession_group" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_map_extra_collection", [transaction, edit_catalog](
+    const std::string &id ) {
+        return map_extra_collection_definition_handle{
+            edit_catalog( id, transaction->map_extra_collections, "map_extra_collection" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_vehicle_group", [transaction, edit_catalog](
+    const std::string &id ) {
+        return vehicle_group_definition_handle{
+            edit_catalog( id, transaction->vehicle_groups, "vehicle_group" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_fault_group", [transaction, edit_catalog](
+    const std::string &id ) {
+        return fault_group_definition_handle{
+            edit_catalog( id, transaction->fault_groups, "fault_group" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_explosion_light", [transaction, edit_catalog](
+    const std::string &id ) {
+        return explosion_light_definition_handle{
+            edit_catalog( id, transaction->explosion_lights, "explosion_light" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_ammo_effect", [transaction, edit_catalog](
+    const std::string &id ) {
+        return ammo_effect_definition_handle{
+            edit_catalog( id, transaction->ammo_effects, "ammo_effect" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_addiction_type", [transaction, edit_catalog](
+    const std::string &id ) {
+        return addiction_type_definition_handle{
+            edit_catalog( id, transaction->addiction_types, "addiction_type" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_character_modifier", [transaction, edit_catalog](
+    const std::string &id ) {
+        return character_modifier_definition_handle{
+            edit_catalog( id, transaction->character_modifiers, "character_modifier" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_start_location", [transaction, edit_catalog](
+    const std::string &id ) {
+        return start_location_definition_handle{
+            edit_catalog( id, transaction->start_locations, "start_location" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_climbing_aid", [transaction, edit_catalog](
+    const std::string &id ) {
+        return climbing_aid_definition_handle{
+            edit_catalog( id, transaction->climbing_aids, "climbing_aid" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_weather_type", [transaction, edit_catalog](
+    const std::string &id ) {
+        return weather_type_definition_handle{
+            edit_catalog( id, transaction->weather_types, "weather_type" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_score", [transaction, edit_catalog](
+    const std::string &id ) {
+        return score_definition_handle{
+            edit_catalog( id, transaction->scores, "score" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_overlay_order", [transaction, edit_catalog]() {
+        return overlay_order_definition_handle{
+            edit_catalog( "global", transaction->overlay_orders, "overlay_order" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_zone_type", [transaction, edit_catalog](
+    const std::string &id ) {
+        return zone_type_definition_handle{
+            edit_catalog( id, transaction->zone_types, "zone_type" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_speech_pool", [transaction, edit_catalog](
+    const std::string &id ) {
+        return speech_pool_definition_handle{
+            edit_catalog( id, transaction->speech_pools, "speech_pool" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_end_screen", [transaction, edit_catalog](
+    const std::string &id ) {
+        return end_screen_definition_handle{
+            edit_catalog( id, transaction->end_screens, "end_screen" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_activity_type", [transaction, edit_catalog](
+    const std::string &id ) {
+        return activity_type_definition_handle{
+            edit_catalog( id, transaction->activity_types, "activity_type" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_help_topic", [transaction, edit_catalog](
+    const std::string &id ) {
+        return help_topic_definition_handle{
+            edit_catalog( id, transaction->help_topics, "help_topic" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_snippet_category", [transaction, edit_catalog](
+    const std::string &id ) {
+        return snippet_category_definition_handle{
+            edit_catalog( id, transaction->snippet_categories, "snippet_category" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_playlist", [transaction, edit_catalog](
+    const std::string &id ) {
+        return playlist_definition_handle{
+            edit_catalog( id, transaction->playlists, "playlist" ), transaction->token
+        };
+    } );
+    content.set_function( "edit_attack_vector", [transaction, edit_catalog](
+    const std::string &id ) {
+        return attack_vector_definition_handle{
+            edit_catalog( id, transaction->attack_vectors, "attack_vector" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_magic_type", [transaction, edit_catalog](
+    const std::string &id ) {
+        return magic_type_definition_handle{
+            edit_catalog( id, transaction->magic_types, "magic_type" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_movement_mode", [transaction, edit_catalog](
+    const std::string &id ) {
+        return movement_mode_definition_handle{
+            edit_catalog( id, transaction->movement_modes, "movement_mode" ),
+            transaction->token
+        };
+    } );
+    content.set_function( "edit_item", [transaction]( const std::string &id ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        const auto found = std::find_if(
+                               transaction->items.rbegin(), transaction->items.rend(),
+        [&id]( const item_registration & entry ) {
+            return entry.definition->id == id;
+        } );
+        if( found == transaction->items.rend() ) {
+            throw std::runtime_error(
+                "edit_item requires an item staged earlier by this Mod" );
+        }
+        auto definition = std::make_shared<item_definition_data>( *found->definition );
+        definition->registered = false;
+        return item_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "edit_recipe", [transaction]( const std::string &id ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        const auto found = std::find_if(
+                               transaction->recipes.rbegin(), transaction->recipes.rend(),
+        [&id]( const recipe_registration & entry ) {
+            return entry.definition->id == id;
+        } );
+        if( found == transaction->recipes.rend() ) {
+            throw std::runtime_error(
+                "edit_recipe requires a recipe staged earlier by this Mod" );
+        }
+        auto definition = std::make_shared<recipe_definition_data>( *found->definition );
+        if( definition->nested_category ) {
+            throw std::runtime_error(
+                "edit_recipe cannot edit a nested category; use edit_nested_recipe_category" );
+        }
+        definition->registered = false;
+        return recipe_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "edit_nested_recipe_category", [transaction](
+    const std::string &id ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        const auto found = std::find_if(
+                               transaction->recipes.rbegin(), transaction->recipes.rend(),
+        [&id]( const recipe_registration & entry ) {
+            return entry.definition->id == id;
+        } );
+        if( found == transaction->recipes.rend() || !found->definition->nested_category ) {
+            throw std::runtime_error(
+                "edit_nested_recipe_category requires a nested category staged earlier by this Mod" );
+        }
+        auto definition = std::make_shared<recipe_definition_data>( *found->definition );
+        definition->registered = false;
+        return nested_recipe_category_definition_handle{
+            std::move( definition ), transaction->token
+        };
+    } );
+    ccb["content"] = std::move( content );
+
+    static_cast<void>( owner_runtime );
+}
+
+bool content_transaction::validate( const runtime &owner_runtime,
+                                    bool check_engine_state,
+                                    std::string &error ) const
+{
+    try {
+        const auto require_valid_id = []( const std::string &id, const char *kind ) {
+            if( id.empty() || id.find( '#' ) != std::string::npos || id.size() > 256 ) {
+                throw std::runtime_error( std::string( "invalid " ) + kind + " id '" + id + "'" );
+            }
+        };
+        const auto validate_operation = [check_engine_state]( const definition_operation operation,
+        const bool exists, const std::string &id, const char *kind ) {
+            if( !check_engine_state ) {
+                return;
+            }
+            if( operation == definition_operation::add && exists ) {
+                throw std::runtime_error( std::string( "add would overwrite existing " ) +
+                                          kind + " '" + id + "'; use replace explicitly" );
+            }
+            if( operation == definition_operation::replace && !exists ) {
+                throw std::runtime_error( std::string( "replace requires existing " ) +
+                                          kind + " '" + id + "'" );
+            }
+        };
+
+        std::set<std::string> tool_quality_ids;
+        for( const tool_quality_registration &entry : pimpl_->tool_qualities ) {
+            const tool_quality_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "tool quality" );
+            if( definition.name.empty() || !tool_quality_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "tool quality '" + definition.id +
+                                          "' requires a name and one registration per transaction" );
+            }
+            validate_operation( entry.operation, quality_id( definition.id ).is_valid(),
+                                definition.id, "tool quality" );
+        }
+
+        std::set<std::string> skill_display_ids;
+        for( const skill_display_registration &entry : pimpl_->skill_displays ) {
+            const skill_display_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "skill display category" );
+            if( definition.label.empty() || !skill_display_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "skill display category '" + definition.id +
+                                          "' requires a label and one registration per transaction" );
+            }
+            validate_operation( entry.operation,
+                                skill_displayType_id( definition.id ).is_valid(),
+                                definition.id, "skill display category" );
+        }
+
+        std::set<std::string> skill_ids;
+        for( const skill_registration &entry : pimpl_->skills ) {
+            const skill_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "skill" );
+            if( definition.name.empty() || definition.description.empty() ||
+                !skill_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "skill '" + definition.id +
+                                          "' requires name, description, and one registration per transaction" );
+            }
+            if( definition.sort_rank < std::numeric_limits<int>::min() ||
+                definition.sort_rank > std::numeric_limits<int>::max() ) {
+                throw std::runtime_error( "skill '" + definition.id +
+                                          "' sort rank is outside the native range" );
+            }
+            if( skill_display_ids.count( definition.display_category ) == 0 &&
+                !skill_displayType_id( definition.display_category ).is_valid() ) {
+                throw std::runtime_error( "skill '" + definition.id +
+                                          "' references unknown display category '" +
+                                          definition.display_category + "'" );
+            }
+            validate_operation( entry.operation, skill_id( definition.id ).is_valid(),
+                                definition.id, "skill" );
+        }
+
+        std::set<std::string> vitamin_ids;
+        for( const vitamin_registration &entry : pimpl_->vitamins ) {
+            const vitamin_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "vitamin" );
+            if( definition.name.empty() || !vitamin_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "vitamin '" + definition.id +
+                                          "' requires a name and one registration per transaction" );
+            }
+            if( definition.type != "vitamin" && definition.type != "toxin" &&
+                definition.type != "drug" && definition.type != "counter" ) {
+                throw std::runtime_error( "vitamin '" + definition.id +
+                                          "' has unknown kind '" + definition.type + "'" );
+            }
+            if( definition.minimum < std::numeric_limits<int>::min() ||
+                definition.minimum > std::numeric_limits<int>::max() ||
+                definition.maximum < std::numeric_limits<int>::min() ||
+                definition.maximum > std::numeric_limits<int>::max() ||
+                definition.rate_turns <= 0 ||
+                definition.rate_turns > std::numeric_limits<int>::max() ) {
+                throw std::runtime_error( "vitamin '" + definition.id +
+                                          "' bounds or rate are outside the native range" );
+            }
+            if( !definition.deficiency.empty() &&
+                !efftype_id( definition.deficiency ).is_valid() ) {
+                throw std::runtime_error( "vitamin '" + definition.id +
+                                          "' references unknown deficiency effect '" +
+                                          definition.deficiency + "'" );
+            }
+            if( !definition.excess.empty() && !efftype_id( definition.excess ).is_valid() ) {
+                throw std::runtime_error( "vitamin '" + definition.id +
+                                          "' references unknown excess effect '" +
+                                          definition.excess + "'" );
+            }
+            for( const auto &[decay_id, rate] : definition.decays_into ) {
+                static_cast<void>( rate );
+                if( vitamin_ids.count( decay_id ) == 0 && !vitamin_id( decay_id ).is_valid() ) {
+                    throw std::runtime_error( "vitamin '" + definition.id +
+                                              "' decays into unknown vitamin '" + decay_id + "'" );
+                }
+            }
+            validate_operation( entry.operation, vitamin_id( definition.id ).is_valid(),
+                                definition.id, "vitamin" );
+        }
+
+        std::set<std::string> json_flag_ids;
+        for( const json_flag_registration &entry : pimpl_->json_flags ) {
+            const json_flag_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "JSON flag" );
+            if( !json_flag_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "JSON flag '" + definition.id +
+                                          "' is registered more than once in one transaction" );
+            }
+            if( definition.taste_modifier < std::numeric_limits<int>::min() ||
+                definition.taste_modifier > std::numeric_limits<int>::max() ) {
+                throw std::runtime_error( "JSON flag '" + definition.id +
+                                          "' taste modifier is outside the native range" );
+            }
+            validate_operation( entry.operation, flag_id( definition.id ).is_valid(),
+                                definition.id, "JSON flag" );
+        }
+        for( const json_flag_registration &entry : pimpl_->json_flags ) {
+            const json_flag_definition_data &definition = *entry.definition;
+            if( !definition.requires_flag.empty() &&
+                json_flag_ids.count( definition.requires_flag ) == 0 &&
+                !flag_id( definition.requires_flag ).is_valid() ) {
+                throw std::runtime_error( "JSON flag '" + definition.id +
+                                          "' requires unknown flag '" +
+                                          definition.requires_flag + "'" );
+            }
+            for( const std::string &conflict : definition.conflicts ) {
+                if( json_flag_ids.count( conflict ) == 0 && !flag_id( conflict ).is_valid() ) {
+                    throw std::runtime_error( "JSON flag '" + definition.id +
+                                              "' conflicts with unknown flag '" + conflict + "'" );
+                }
+            }
+        }
+
+        std::set<std::string> damage_type_ids;
+        for( const damage_type_registration &entry : pimpl_->damage_types ) {
+            const damage_type_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "damage type" );
+            if( definition.name.empty() || !std::isfinite( definition.bash_conversion_factor ) ||
+                definition.bash_conversion_factor < 0.0 ||
+                !damage_type_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "damage type '" + definition.id +
+                                          "' has invalid values or a duplicate registration" );
+            }
+            if( !definition.skill.empty() && skill_ids.count( definition.skill ) == 0 &&
+                !skill_id( definition.skill ).is_valid() ) {
+                throw std::runtime_error( "damage type '" + definition.id +
+                                          "' references unknown skill '" + definition.skill + "'" );
+            }
+            if( !definition.on_hit_handler.empty() &&
+                owner_runtime.handlers.count( definition.on_hit_handler ) == 0 ) {
+                throw std::runtime_error( "damage type '" + definition.id +
+                                          "' references missing on-hit handler '" +
+                                          definition.on_hit_handler + "'" );
+            }
+            if( !definition.on_damage_handler.empty() &&
+                owner_runtime.handlers.count( definition.on_damage_handler ) == 0 ) {
+                throw std::runtime_error( "damage type '" + definition.id +
+                                          "' references missing on-damage handler '" +
+                                          definition.on_damage_handler + "'" );
+            }
+            validate_operation( entry.operation, damage_type_id( definition.id ).is_valid(),
+                                definition.id, "damage type" );
+        }
+        for( const damage_type_registration &entry : pimpl_->damage_types ) {
+            const damage_type_definition_data &definition = *entry.definition;
+            if( !definition.derived_from.empty() &&
+                damage_type_ids.count( definition.derived_from ) == 0 &&
+                !damage_type_id( definition.derived_from ).is_valid() ) {
+                throw std::runtime_error( "damage type '" + definition.id +
+                                          "' derives from unknown damage type '" +
+                                          definition.derived_from + "'" );
+            }
+        }
+
+        std::set<std::string> bash_damage_profile_ids;
+        for( const bash_damage_profile_registration &entry :
+             pimpl_->bash_damage_profiles ) {
+            const bash_damage_profile_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "bash damage profile" );
+            if( !bash_damage_profile_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "bash damage profile '" + definition.id +
+                                          "' is registered more than once per transaction" );
+            }
+            for( const auto &[damage_id, multiplier] : definition.factors ) {
+                if( damage_id.empty() || !std::isfinite( multiplier ) || multiplier < 0.0 ) {
+                    throw std::runtime_error( "bash damage profile '" + definition.id +
+                                              "' has an invalid factor" );
+                }
+                if( check_engine_state && damage_type_ids.count( damage_id ) == 0 &&
+                    !damage_type_id( damage_id ).is_valid() ) {
+                    throw std::runtime_error( "bash damage profile '" + definition.id +
+                                              "' references unknown damage type '" +
+                                              damage_id + "'" );
+                }
+            }
+            validate_operation( entry.operation,
+                                bash_damage_profile_id( definition.id ).is_valid(),
+                                definition.id, "bash damage profile" );
+        }
+
+        std::set<std::string> declared_item_ids;
+        for( const item_registration &entry : pimpl_->items ) {
+            declared_item_ids.insert( entry.definition->id );
+        }
+        std::set<std::string> declared_recipe_ids;
+        for( const recipe_registration &entry : pimpl_->recipes ) {
+            declared_recipe_ids.insert( entry.definition->id );
+        }
+
+        std::set<std::string> clothing_mod_ids;
+        for( const clothing_mod_registration &entry : pimpl_->clothing_mods ) {
+            const clothing_mod_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "clothing modification" );
+            if( definition.flag.empty() || definition.material_item.empty() ||
+                definition.apply_prompt.empty() || definition.remove_prompt.empty() ||
+                definition.modifiers.empty() ||
+                !clothing_mod_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "clothing modification '" + definition.id +
+                                          "' requires flag, material item, prompts, modifiers, and one registration" );
+            }
+            if( check_engine_state && json_flag_ids.count( definition.flag ) == 0 &&
+                !flag_id( definition.flag ).is_valid() ) {
+                throw std::runtime_error( "clothing modification '" + definition.id +
+                                          "' references unknown flag '" + definition.flag + "'" );
+            }
+            if( check_engine_state && declared_item_ids.count( definition.material_item ) == 0 &&
+                !item::type_is_defined( itype_id( definition.material_item ) ) ) {
+                throw std::runtime_error( "clothing modification '" + definition.id +
+                                          "' references unknown material item '" +
+                                          definition.material_item + "'" );
+            }
+            static const std::set<std::string> valid_stats = {
+                "acid", "fire", "bash", "cut", "bullet", "encumbrance", "warmth"
+            };
+            for( const clothing_modifier_definition_data &modifier : definition.modifiers ) {
+                if( valid_stats.count( modifier.stat ) == 0 ||
+                    !std::isfinite( modifier.amount ) ) {
+                    throw std::runtime_error( "clothing modification '" + definition.id +
+                                              "' has an invalid modifier" );
+                }
+            }
+            validate_operation( entry.operation, clothing_mod_id( definition.id ).is_valid(),
+                                definition.id, "clothing modification" );
+        }
+
+        std::set<std::string> land_use_code_ids;
+        for( const overmap_land_use_code_registration &entry :
+             pimpl_->overmap_land_use_codes ) {
+            const overmap_land_use_code_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "overmap land-use code" );
+            if( definition.code < std::numeric_limits<int>::min() ||
+                definition.code > std::numeric_limits<int>::max() ||
+                definition.name.empty() || definition.symbol == 0 ||
+                definition.color.empty() ||
+                color_from_string( definition.color, report_color_error::no ) == c_unset ||
+                !land_use_code_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "overmap land-use code '" + definition.id +
+                                          "' has invalid values or a duplicate registration" );
+            }
+            validate_operation( entry.operation,
+                                overmap_land_use_code_id( definition.id ).is_valid(),
+                                definition.id, "overmap land-use code" );
+        }
+
+        std::set<std::string> overmap_vision_ids;
+        for( const overmap_vision_registration &entry : pimpl_->overmap_visions ) {
+            const overmap_vision_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "overmap vision" );
+            if( definition.id.find( '$' ) != std::string::npos ||
+                !overmap_vision_ids.insert( definition.id ).second ||
+                definition.levels.size() > 3 ) {
+                throw std::runtime_error( "overmap vision '" + definition.id +
+                                          "' has an invalid id, too many levels, or a duplicate registration" );
+            }
+            for( const overmap_vision_level_definition_data &level : definition.levels ) {
+                if( level.blends_adjacent ) {
+                    continue;
+                }
+                if( level.name.empty() || level.symbol == 0 || level.color.empty() ||
+                    color_from_string( level.color,
+                                       report_color_error::no ) == c_unset ) {
+                    throw std::runtime_error( "overmap vision '" + definition.id +
+                                              "' has an invalid appearance level" );
+                }
+            }
+            validate_operation( entry.operation,
+                                oter_vision_id( definition.id ).is_valid(),
+                                definition.id, "overmap vision" );
+        }
+
+        std::set<std::string> overmap_location_ids;
+        for( const overmap_location_registration &entry : pimpl_->overmap_locations ) {
+            const overmap_location_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "overmap location" );
+            if( !overmap_location_ids.insert( definition.id ).second ||
+                ( definition.terrains.empty() && definition.terrain_flags.empty() ) ) {
+                throw std::runtime_error( "overmap location '" + definition.id +
+                                          "' needs a unique id and at least one terrain selector" );
+            }
+            std::set<std::string> selectors;
+            for( const std::string &terrain : definition.terrains ) {
+                if( !selectors.insert( "terrain:" + terrain ).second ||
+                    ( check_engine_state && !oter_type_str_id( terrain ).is_valid() ) ) {
+                    throw std::runtime_error( "overmap location '" + definition.id +
+                                              "' has an unknown or duplicate terrain '" + terrain + "'" );
+                }
+            }
+            const std::unordered_map<std::string, oter_flags> &oter_flags_map =
+                io::get_enum_lookup_map<oter_flags>();
+            for( const std::string &flag : definition.terrain_flags ) {
+                if( !selectors.insert( "flag:" + flag ).second ||
+                    oter_flags_map.count( flag ) == 0 ) {
+                    throw std::runtime_error( "overmap location '" + definition.id +
+                                              "' has an unknown or duplicate terrain flag '" + flag + "'" );
+                }
+            }
+            validate_operation( entry.operation,
+                                overmap_location_id( definition.id ).is_valid(),
+                                definition.id, "overmap location" );
+        }
+
+        std::set<std::string> profession_group_ids;
+        for( const profession_group_registration &entry : pimpl_->profession_groups ) {
+            const profession_group_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "profession group" );
+            if( !profession_group_ids.insert( definition.id ).second ||
+                definition.professions.empty() ) {
+                throw std::runtime_error( "profession group '" + definition.id +
+                                          "' needs a unique id and at least one profession" );
+            }
+            std::set<std::string> professions;
+            for( const std::string &profession : definition.professions ) {
+                if( !professions.insert( profession ).second ||
+                    ( check_engine_state && !profession_id( profession ).is_valid() ) ) {
+                    throw std::runtime_error( "profession group '" + definition.id +
+                                              "' has an unknown or duplicate profession '" +
+                                              profession + "'" );
+                }
+            }
+            validate_operation( entry.operation,
+                                profession_group_id( definition.id ).is_valid(),
+                                definition.id, "profession group" );
+        }
+
+        std::set<std::string> map_extra_collection_ids;
+        for( const map_extra_collection_registration &entry : pimpl_->map_extra_collections ) {
+            const map_extra_collection_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "map-extra collection" );
+            if( !map_extra_collection_ids.insert( definition.id ).second ||
+                definition.chance < 0 ||
+                static_cast<std::uint64_t>( definition.chance ) >
+                std::numeric_limits<unsigned int>::max() || definition.entries.empty() ) {
+                throw std::runtime_error( "map-extra collection '" + definition.id +
+                                          "' has an invalid chance, no entries, or a duplicate id" );
+            }
+            std::set<std::string> extras;
+            for( const auto &[extra, weight] : definition.entries ) {
+                if( !extras.insert( extra ).second || weight <= 0 ||
+                    weight > std::numeric_limits<int>::max() ||
+                    ( check_engine_state && !map_extra_id( extra ).is_valid() ) ) {
+                    throw std::runtime_error( "map-extra collection '" + definition.id +
+                                              "' has an unknown, duplicate, or invalidly weighted entry '" +
+                                              extra + "'" );
+                }
+            }
+            validate_operation( entry.operation,
+                                map_extra_collection_id( definition.id ).is_valid(),
+                                definition.id, "map-extra collection" );
+        }
+
+        std::set<std::string> vehicle_group_ids;
+        for( const vehicle_group_registration &entry : pimpl_->vehicle_groups ) {
+            const vehicle_group_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "vehicle group" );
+            if( !vehicle_group_ids.insert( definition.id ).second || definition.entries.empty() ) {
+                throw std::runtime_error( "vehicle group '" + definition.id +
+                                          "' needs a unique id and at least one vehicle" );
+            }
+            std::set<std::string> vehicles;
+            for( const auto &[vehicle, weight] : definition.entries ) {
+                if( !vehicles.insert( vehicle ).second || weight <= 0 ||
+                    weight > std::numeric_limits<int>::max() ||
+                    ( check_engine_state && !vproto_id( vehicle ).is_valid() ) ) {
+                    throw std::runtime_error( "vehicle group '" + definition.id +
+                                              "' has an unknown, duplicate, or invalidly weighted vehicle '" +
+                                              vehicle + "'" );
+                }
+            }
+            validate_operation( entry.operation,
+                                detail::vehicle_group_registry_find( definition.id ) != nullptr,
+                                definition.id, "vehicle group" );
+        }
+
+        std::set<std::string> fault_group_ids;
+        for( const fault_group_registration &entry : pimpl_->fault_groups ) {
+            const fault_group_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "fault group" );
+            if( !fault_group_ids.insert( definition.id ).second || definition.entries.empty() ) {
+                throw std::runtime_error( "fault group '" + definition.id +
+                                          "' needs a unique id and at least one fault" );
+            }
+            std::set<std::string> faults;
+            for( const auto &[fault, weight] : definition.entries ) {
+                if( !faults.insert( fault ).second || weight <= 0 ||
+                    weight > std::numeric_limits<int>::max() ||
+                    ( check_engine_state && !fault_id( fault ).is_valid() ) ) {
+                    throw std::runtime_error( "fault group '" + definition.id +
+                                              "' has an unknown, duplicate, or invalidly weighted fault '" +
+                                              fault + "'" );
+                }
+            }
+            validate_operation( entry.operation, fault_group_id( definition.id ).is_valid(),
+                                definition.id, "fault group" );
+        }
+
+        std::set<std::string> explosion_light_ids;
+        for( const explosion_light_registration &entry : pimpl_->explosion_lights ) {
+            const explosion_light_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "explosion light" );
+            const auto finite_non_negative = []( const double value ) {
+                return std::isfinite( value ) && value >= 0.0 &&
+                       value <= std::numeric_limits<float>::max();
+            };
+            if( !explosion_light_ids.insert( definition.id ).second ||
+                definition.stops.empty() || !platform_vfx_easing( definition.easing ) ||
+                !finite_non_negative( definition.wave_travel ) ||
+                !finite_non_negative( definition.wave_gap ) ||
+                !finite_non_negative( definition.rise ) ||
+                !finite_non_negative( definition.fade ) ||
+                !finite_non_negative( definition.blend ) ||
+                !finite_non_negative( definition.spread_jitter ) ||
+                !finite_non_negative( definition.color_jitter ) ||
+                !finite_non_negative( definition.flicker ) ||
+                !finite_non_negative( definition.duration_base_ms ) ||
+                !finite_non_negative( definition.duration_per_tile_ms ) ||
+                !finite_non_negative( definition.duration_min_ms ) ||
+                definition.duration_min_ms <= 0.0 ||
+                !finite_non_negative( definition.duration_max_ms ) ||
+                definition.duration_max_ms < definition.duration_min_ms ||
+                !finite_non_negative( definition.screen_shake_magnitude ) ||
+                !finite_non_negative( definition.screen_shake_duration_ms ) ||
+                !finite_non_negative( definition.shockwave_strength ) ||
+                !std::isfinite( definition.shockwave_speed ) ||
+                definition.shockwave_speed <= 0.0 ||
+                definition.shockwave_speed > std::numeric_limits<float>::max() ||
+                !finite_non_negative( definition.shockwave_thickness ) ) {
+                throw std::runtime_error( "explosion light '" + definition.id +
+                                          "' has invalid stops, timing, easing, shake, or shockwave values" );
+            }
+            validate_operation( entry.operation,
+                                explosion_light_str_id( definition.id ).is_valid(),
+                                definition.id, "explosion light" );
+        }
+
+        std::set<std::string> ammo_effect_ids;
+        for( const ammo_effect_registration &entry : pimpl_->ammo_effects ) {
+            const ammo_effect_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "ammo effect" );
+            const auto native_int = []( const std::int64_t value ) {
+                return value >= 0 && value <= std::numeric_limits<int>::max();
+            };
+            const auto percent = []( const std::int64_t value ) {
+                return value >= 0 && value <= 100;
+            };
+            const auto finite_float = []( const double value ) {
+                return std::isfinite( value ) &&
+                       std::abs( value ) <= std::numeric_limits<float>::max();
+            };
+            if( !ammo_effect_ids.insert( definition.id ).second ||
+                !percent( definition.trigger_chance ) ) {
+                throw std::runtime_error( "ammo effect '" + definition.id +
+                                          "' has a duplicate id or invalid trigger chance" );
+            }
+            const auto validate_field = [&]( const ammo_field_definition_data &field,
+            const bool trail ) {
+                if( field.field.empty() || !native_int( field.intensity_min ) ||
+                    field.intensity_max < field.intensity_min ||
+                    !native_int( field.intensity_max ) || !percent( field.chance ) ||
+                    ( !trail && ( !native_int( field.radius ) ||
+                                  !native_int( field.height ) ||
+                                  !native_int( field.footprint ) ) ) ||
+                    ( check_engine_state && !field_type_str_id( field.field ).is_valid() ) ) {
+                    throw std::runtime_error( "ammo effect '" + definition.id +
+                                              "' has an invalid " +
+                                              ( trail ? "trail" : "field burst" ) );
+                }
+            };
+            for( const ammo_field_definition_data &field : definition.field_bursts ) {
+                validate_field( field, false );
+            }
+            for( const ammo_field_definition_data &field : definition.trails ) {
+                validate_field( field, true );
+            }
+            const auto validate_character_effect = [&](
+            const ammo_character_effect_definition_data &effect, const bool area ) {
+                if( effect.effect.empty() || effect.duration_turns <= 0 ||
+                    effect.duration_turns > std::numeric_limits<int>::max() ||
+                    effect.intensity_min <= 0 ||
+                    effect.intensity_max < effect.intensity_min ||
+                    !native_int( effect.intensity_max ) ||
+                    ( area && ( !percent( effect.chance ) ||
+                                !native_int( effect.radius ) || effect.hits_min <= 0 ||
+                                effect.hits_max < effect.hits_min ||
+                                !native_int( effect.hits_max ) ) ) ||
+                    ( check_engine_state && !efftype_id( effect.effect ).is_valid() ) ) {
+                    throw std::runtime_error( "ammo effect '" + definition.id +
+                                              "' has an invalid " +
+                                              ( area ? "area effect" : "on-hit effect" ) );
+                }
+            };
+            for( const ammo_character_effect_definition_data &effect :
+                 definition.on_hit_effects ) {
+                validate_character_effect( effect, false );
+            }
+            for( const ammo_character_effect_definition_data &effect : definition.area_effects ) {
+                validate_character_effect( effect, true );
+            }
+            if( definition.has_explosion &&
+                ( !finite_float( definition.explosion_power ) ||
+                  definition.explosion_power < 0.0 ||
+                  !finite_float( definition.explosion_distance_factor ) ||
+                  definition.explosion_distance_factor < 0.0 ||
+                  definition.explosion_distance_factor > 1.0 ||
+                  !native_int( definition.explosion_max_noise ) ||
+                  !native_int( definition.casing_mass ) ||
+                  !finite_float( definition.fragment_mass ) ||
+                  definition.fragment_mass <= 0.0 ||
+                  !percent( definition.fragment_recovery ) ||
+                  ( check_engine_state && !definition.explosion_light.empty() &&
+                    !explosion_light_str_id( definition.explosion_light ).is_valid() ) ||
+                  ( check_engine_state && definition.fragment_drop != "null" &&
+                    !itype_id( definition.fragment_drop ).is_valid() ) ) ) {
+                throw std::runtime_error( "ammo effect '" + definition.id +
+                                          "' has invalid explosion or shrapnel values" );
+            }
+            if( definition.has_shrapnel && !definition.has_explosion ) {
+                throw std::runtime_error( "ammo effect '" + definition.id +
+                                          "' attaches shrapnel without an explosion" );
+            }
+            for( const ammo_spell_definition_data &spell : definition.spells ) {
+                if( spell.spell.empty() || spell.level < 0 ||
+                    spell.level > std::numeric_limits<int>::max() ||
+                    ( check_engine_state && !spell_id( spell.spell ).is_valid() ) ) {
+                    throw std::runtime_error( "ammo effect '" + definition.id +
+                                              "' has an invalid spell" );
+                }
+            }
+            if( !definition.impact_handler.empty() &&
+                owner_runtime.handlers.count( definition.impact_handler ) == 0 ) {
+                throw std::runtime_error( "ammo effect '" + definition.id +
+                                          "' references missing impact handler '" +
+                                          definition.impact_handler + "'" );
+            }
+            validate_operation( entry.operation,
+                                ammo_effect_str_id( definition.id ).is_valid(),
+                                definition.id, "ammo effect" );
+        }
+
+        std::set<std::string> addiction_type_ids;
+        for( const addiction_type_registration &entry : pimpl_->addiction_types ) {
+            const addiction_type_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "addiction type" );
+            if( !addiction_type_ids.insert( definition.id ).second ||
+                definition.name.empty() || definition.type_name.empty() ||
+                definition.description.empty() || definition.tick_handler.empty() ||
+                ( check_engine_state && !definition.craving_morale.empty() &&
+                  !morale_type( definition.craving_morale ).is_valid() ) ) {
+                throw std::runtime_error( "addiction type '" + definition.id +
+                                          "' needs unique text, an optional valid craving morale, and a tick policy" );
+            }
+            if( owner_runtime.handlers.count( definition.tick_handler ) == 0 ) {
+                throw std::runtime_error( "addiction type '" + definition.id +
+                                          "' references missing tick handler '" +
+                                          definition.tick_handler + "'" );
+            }
+            validate_operation( entry.operation, addiction_id( definition.id ).is_valid(),
+                                definition.id, "addiction type" );
+        }
+
+        std::set<std::string> character_modifier_ids;
+        for( const character_modifier_registration &entry : pimpl_->character_modifiers ) {
+            const character_modifier_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "character modifier" );
+            if( !character_modifier_ids.insert( definition.id ).second ||
+                definition.description.empty() ||
+                ( definition.operation != "add" && definition.operation != "multiply" &&
+                  definition.operation != "none" ) ||
+                definition.evaluator_handler.empty() ) {
+                throw std::runtime_error( "character modifier '" + definition.id +
+                                          "' needs a unique id, description, operation, and evaluator" );
+            }
+            if( owner_runtime.handlers.count( definition.evaluator_handler ) == 0 ) {
+                throw std::runtime_error( "character modifier '" + definition.id +
+                                          "' references missing evaluator '" +
+                                          definition.evaluator_handler + "'" );
+            }
+            validate_operation( entry.operation,
+                                character_modifier_id( definition.id ).is_valid(),
+                                definition.id, "character modifier" );
+        }
+
+        std::set<std::string> start_location_ids;
+        for( const start_location_registration &entry : pimpl_->start_locations ) {
+            const start_location_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "start location" );
+            const auto native_bound = []( const std::int64_t value ) {
+                return value >= std::numeric_limits<int>::min() &&
+                       value <= std::numeric_limits<int>::max();
+            };
+            if( !start_location_ids.insert( definition.id ).second ||
+                definition.name.empty() || definition.targets.empty() ||
+                !native_bound( definition.city_size_min ) ||
+                !native_bound( definition.city_size_max ) ||
+                definition.city_size_min < 0 ||
+                definition.city_size_max < definition.city_size_min ||
+                !native_bound( definition.city_distance_min ) ||
+                !native_bound( definition.city_distance_max ) ||
+                definition.city_distance_min < 0 ||
+                definition.city_distance_max < definition.city_distance_min ||
+                !native_bound( definition.z_min ) || !native_bound( definition.z_max ) ||
+                definition.z_min < -OVERMAP_DEPTH || definition.z_max > OVERMAP_HEIGHT ||
+                definition.z_max < definition.z_min ) {
+                throw std::runtime_error( "start location '" + definition.id +
+                                          "' has invalid text, targets, or placement bounds" );
+            }
+            std::set<std::string> target_keys;
+            for( const start_location_target_definition_data &target : definition.targets ) {
+                const std::optional<ot_match_type> match = platform_ot_match_type( target.match );
+                std::string key = target.terrain + "\x1f" + target.match;
+                for( const auto &[parameter, value] : target.parameters ) {
+                    key += "\x1f" + parameter + "=" + value;
+                    if( parameter.empty() || value.empty() || parameter.size() > 128 ||
+                        value.size() > 512 ) {
+                        throw std::runtime_error( "start location '" + definition.id +
+                                                  "' has an invalid mapgen parameter" );
+                    }
+                }
+                if( target.terrain.empty() || !match || target.parameters.size() > 64 ||
+                    !target_keys.insert( key ).second ||
+                    ( check_engine_state && *match == ot_match_type::exact &&
+                      !oter_str_id( target.terrain ).is_valid() ) ||
+                    ( check_engine_state && *match == ot_match_type::type &&
+                      !oter_type_str_id( target.terrain ).is_valid() ) ) {
+                    throw std::runtime_error( "start location '" + definition.id +
+                                              "' has an invalid or duplicate terrain selector" );
+                }
+            }
+            validate_operation( entry.operation, start_location_id( definition.id ).is_valid(),
+                                definition.id, "start location" );
+        }
+
+        std::set<std::string> climbing_aid_ids;
+        for( const climbing_aid_registration &entry : pimpl_->climbing_aids ) {
+            const climbing_aid_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "climbing aid" );
+            const auto native_non_negative = []( const std::int64_t value ) {
+                return value >= 0 && value <= std::numeric_limits<int>::max();
+            };
+            const bool deploys = !definition.deploy_furniture.empty();
+            const std::optional<climbing_aid::category> category =
+                platform_climbing_category( definition.category );
+            if( !climbing_aid_ids.insert( definition.id ).second || !category ||
+                definition.slip_chance_modifier < std::numeric_limits<int>::min() ||
+                definition.slip_chance_modifier > std::numeric_limits<int>::max() ||
+                ( *category != climbing_aid::category::special && definition.flag.empty() ) ||
+                !native_non_negative( definition.uses ) ||
+                !native_non_negative( definition.range ) ||
+                definition.max_height < -1 ||
+                definition.max_height > std::numeric_limits<int>::max() ||
+                !native_non_negative( definition.easy_climb_back_up ) ||
+                ( definition.max_height >= 0 &&
+                  ( definition.menu_text.empty() || definition.confirm_text.empty() ) ) ||
+                definition.hotkey.size() > 1 ||
+                !native_non_negative( definition.pain ) ||
+                !native_non_negative( definition.damage ) ||
+                !native_non_negative( definition.kilocalories ) ||
+                !native_non_negative( definition.thirst ) ||
+                ( deploys && ( definition.unavailable_text.empty() ||
+                               definition.hotkey.size() != 1 ) ) ||
+                ( check_engine_state && deploys &&
+                  !furn_str_id( definition.deploy_furniture ).is_valid() ) ) {
+                throw std::runtime_error( "climbing aid '" + definition.id +
+                                          "' has invalid availability, descent, cost, or deployment data" );
+            }
+            validate_operation( entry.operation, climbing_aid_id( definition.id ).is_valid(),
+                                definition.id, "climbing aid" );
+        }
+
+        std::set<std::string> weather_type_ids;
+        for( const weather_type_registration &entry : pimpl_->weather_types ) {
+            require_valid_id( entry.definition->id, "weather type" );
+            if( !weather_type_ids.insert( entry.definition->id ).second ) {
+                throw std::runtime_error( "weather type '" + entry.definition->id +
+                                          "' is registered more than once" );
+            }
+        }
+        for( const weather_type_registration &entry : pimpl_->weather_types ) {
+            const weather_type_definition_data &definition = *entry.definition;
+            const auto native_int = []( const std::int64_t value ) {
+                return value >= std::numeric_limits<int>::min() &&
+                       value <= std::numeric_limits<int>::max();
+            };
+            const auto finite_float = []( const double value ) {
+                return std::isfinite( value ) &&
+                       std::abs( value ) <= std::numeric_limits<float>::max();
+            };
+            const auto single_codepoint = []( const std::string &symbol ) {
+                if( symbol.empty() ) {
+                    return false;
+                }
+                const std::uint32_t codepoint = UTF8_getch( symbol );
+                return codepoint != UNKNOWN_UNICODE && utf32_to_utf8( codepoint ) == symbol;
+            };
+            if( definition.name.empty() ||
+                color_from_string( definition.color, report_color_error::no ) == c_unset ||
+                color_from_string( definition.map_color, report_color_error::no ) == c_unset ||
+                !single_codepoint( definition.symbol ) ||
+                !single_codepoint( definition.sun_symbol ) ||
+                !native_int( definition.ranged_penalty ) ||
+                !finite_float( definition.sight_penalty ) || definition.sight_penalty < 0.0 ||
+                !native_int( definition.light_modifier ) ||
+                !finite_float( definition.temperature_delta_kelvin ) ||
+                !finite_float( definition.light_multiplier ) ||
+                definition.light_multiplier < 0.0 ||
+                !finite_float( definition.sun_multiplier ) ||
+                definition.sun_multiplier < 0.0 ||
+                !native_int( definition.sound_attenuation ) ||
+                !platform_precipitation( definition.precipitation ) ||
+                !platform_weather_sound_category( definition.sound_category ) ||
+                !native_int( definition.priority ) ||
+                definition.minimum_duration_turns <= 0 ||
+                definition.minimum_duration_turns > std::numeric_limits<int>::max() ||
+                definition.maximum_duration_turns < definition.minimum_duration_turns ||
+                definition.maximum_duration_turns > std::numeric_limits<int>::max() ||
+                definition.condition_handler.empty() ||
+                ( definition.has_animation &&
+                  ( !finite_float( definition.animation_factor ) ||
+                    definition.animation_factor < 0.0 ||
+                    color_from_string( definition.animation_color,
+                                       report_color_error::no ) == c_unset ||
+                    !single_codepoint( definition.animation_symbol ) ) ) ) {
+                throw std::runtime_error( "weather type '" + definition.id +
+                                          "' has invalid presentation, physics, timing, or condition data" );
+            }
+            if( owner_runtime.handlers.count( definition.condition_handler ) == 0 ) {
+                throw std::runtime_error( "weather type '" + definition.id +
+                                          "' references missing condition handler '" +
+                                          definition.condition_handler + "'" );
+            }
+            std::set<std::string> required;
+            for( const std::string &weather : definition.required_weathers ) {
+                if( weather.empty() || !required.insert( weather ).second ||
+                    ( check_engine_state && weather_type_ids.count( weather ) == 0 &&
+                      !weather_type_id( weather ).is_valid() ) ) {
+                    throw std::runtime_error( "weather type '" + definition.id +
+                                              "' has an unknown or duplicate prerequisite" );
+                }
+            }
+            for( const weather_passive_effect_definition_data &effect : definition.passive_effects ) {
+                const auto chance = []( const std::int64_t value ) {
+                    return value >= 0 && value <= 100;
+                };
+                if( effect.effect.empty() || effect.minimum_duration_turns <= 0 ||
+                    effect.minimum_duration_turns > std::numeric_limits<int>::max() ||
+                    effect.maximum_duration_turns < effect.minimum_duration_turns ||
+                    effect.maximum_duration_turns > std::numeric_limits<int>::max() ||
+                    effect.intensity <= 0 ||
+                    effect.intensity > std::numeric_limits<int>::max() ||
+                    !chance( effect.chance_in_vehicle ) ||
+                    !chance( effect.chance_inside_vehicle ) ||
+                    !chance( effect.chance_outside_vehicle ) ||
+                    ( check_engine_state && !efftype_id( effect.effect ).is_valid() ) ||
+                    ( check_engine_state && !effect.body_part.empty() &&
+                      !bodypart_str_id( effect.body_part ).is_valid() ) ) {
+                    throw std::runtime_error( "weather type '" + definition.id +
+                                              "' has an invalid passive character effect" );
+                }
+            }
+            validate_operation( entry.operation, weather_type_id( definition.id ).is_valid(),
+                                definition.id, "weather type" );
+        }
+
+        std::set<std::string> score_ids;
+        for( const score_registration &entry : pimpl_->scores ) {
+            const score_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "score" );
+            if( !score_ids.insert( definition.id ).second ||
+                definition.statistic.empty() ||
+                ( check_engine_state &&
+                  !event_statistic_id( definition.statistic ).is_valid() ) ) {
+                throw std::runtime_error( "score '" + definition.id +
+                                          "' has an invalid statistic or duplicate registration" );
+            }
+            validate_operation( entry.operation, score_id( definition.id ).is_valid(),
+                                definition.id, "score" );
+        }
+
+        if( pimpl_->overlay_orders.size() > 1 ) {
+            throw std::runtime_error(
+                "overlay order singleton is registered more than once per transaction" );
+        }
+        for( const overlay_order_registration &entry : pimpl_->overlay_orders ) {
+            const overlay_order_definition_data &definition = *entry.definition;
+            if( definition.id != "global" || definition.orders.empty() ) {
+                throw std::runtime_error(
+                    "overlay order requires the global singleton and at least one mutation" );
+            }
+            for( const auto &[mutation_id, order] : definition.orders ) {
+                if( mutation_id.empty() ||
+                    order < std::numeric_limits<int>::min() ||
+                    order > std::numeric_limits<int>::max() ) {
+                    throw std::runtime_error( "overlay order for mutation '" + mutation_id +
+                                              "' is outside the native integer range" );
+                }
+                validate_operation(
+                    entry.operation,
+                    base_mutation_overlay_ordering.count( mutation_id ) != 0,
+                    mutation_id, "mutation overlay order" );
+            }
+        }
+
+        std::set<std::string> zone_type_ids;
+        for( const zone_type_registration &entry : pimpl_->zone_types ) {
+            const zone_type_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "zone type" );
+            if( !zone_type_ids.insert( definition.id ).second ||
+                definition.name.empty() || definition.display_field.empty() ||
+                ( check_engine_state &&
+                  !field_type_str_id( definition.display_field ).is_valid() ) ) {
+                throw std::runtime_error( "zone type '" + definition.id +
+                                          "' has invalid presentation or a duplicate registration" );
+            }
+            validate_operation( entry.operation, zone_type_id( definition.id ).is_valid(),
+                                definition.id, "zone type" );
+        }
+
+        std::set<std::string> speech_pool_ids;
+        for( const speech_pool_registration &entry : pimpl_->speech_pools ) {
+            const speech_pool_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "speech pool" );
+            if( !speech_pool_ids.insert( definition.id ).second || definition.lines.empty() ) {
+                throw std::runtime_error( "speech pool '" + definition.id +
+                                          "' requires lines and one registration per transaction" );
+            }
+            for( const auto &[sound, volume] : definition.lines ) {
+                if( sound.empty() || volume < std::numeric_limits<int>::min() ||
+                    volume > std::numeric_limits<int>::max() ) {
+                    throw std::runtime_error( "speech pool '" + definition.id +
+                                              "' has an invalid line" );
+                }
+            }
+            validate_operation(
+                entry.operation,
+                detail::speech_registry_find( definition.id ) != nullptr,
+                definition.id, "speech pool" );
+        }
+
+        std::set<std::string> end_screen_ids;
+        for( const end_screen_registration &entry : pimpl_->end_screens ) {
+            const end_screen_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "end screen" );
+            const bool staged_picture = std::any_of(
+                                            pimpl_->ascii_arts.begin(), pimpl_->ascii_arts.end(),
+            [&definition]( const ascii_art_registration & art ) {
+                return art.definition->id == definition.picture;
+            } );
+            if( !end_screen_ids.insert( definition.id ).second ||
+                definition.picture.empty() || definition.condition_handler.empty() ||
+                definition.priority < std::numeric_limits<int>::min() ||
+                definition.priority > std::numeric_limits<int>::max() ||
+                ( check_engine_state && !staged_picture &&
+                  !ascii_art_id( definition.picture ).is_valid() ) ) {
+                throw std::runtime_error( "end screen '" + definition.id +
+                                          "' has invalid presentation, policy, or a duplicate registration" );
+            }
+            for( const auto &[column, row, text] : definition.information ) {
+                if( text.empty() || column < std::numeric_limits<int>::min() ||
+                    column > std::numeric_limits<int>::max() ||
+                    row < std::numeric_limits<int>::min() ||
+                    row > std::numeric_limits<int>::max() ) {
+                    throw std::runtime_error( "end screen '" + definition.id +
+                                              "' has invalid positioned information" );
+                }
+            }
+            if( owner_runtime.handlers.count( definition.condition_handler ) == 0 ) {
+                throw std::runtime_error( "end screen '" + definition.id +
+                                          "' references missing condition handler '" +
+                                          definition.condition_handler + "'" );
+            }
+            validate_operation( entry.operation, end_screen_id( definition.id ).is_valid(),
+                                definition.id, "end screen" );
+        }
+
+        std::set<std::string> activity_type_ids;
+        for( const activity_type_registration &entry : pimpl_->activity_types ) {
+            const activity_type_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "activity type" );
+            const std::optional<based_on_type> based_on =
+                platform_activity_based_on( definition.based_on );
+            if( !activity_type_ids.insert( definition.id ).second ||
+                definition.verb.empty() || !based_on ||
+                !std::isfinite( definition.activity_level ) ||
+                definition.activity_level <= 0.0 ||
+                definition.activity_level > std::numeric_limits<float>::max() ) {
+                throw std::runtime_error( "activity type '" + definition.id +
+                                          "' has invalid timing, exertion, presentation, or a duplicate registration" );
+            }
+            for( const std::string &distraction : definition.ignored_distractions ) {
+                if( !io::enum_is_valid<distraction_type>( distraction ) ) {
+                    throw std::runtime_error( "activity type '" + definition.id +
+                                              "' has an invalid ignored distraction '" +
+                                              distraction + "'" );
+                }
+            }
+            if( !definition.do_turn_handler.empty() &&
+                owner_runtime.handlers.count( definition.do_turn_handler ) == 0 ) {
+                throw std::runtime_error( "activity type '" + definition.id +
+                                          "' references missing turn handler '" +
+                                          definition.do_turn_handler + "'" );
+            }
+            if( !definition.completion_handler.empty() &&
+                owner_runtime.handlers.count( definition.completion_handler ) == 0 ) {
+                throw std::runtime_error( "activity type '" + definition.id +
+                                          "' references missing completion handler '" +
+                                          definition.completion_handler + "'" );
+            }
+            const activity_id id( definition.id );
+            const bool has_actor = activity_actors::deserialize_functions.count( id ) != 0;
+            const bool has_native_turn = activity_handlers::do_turn_functions.count( id ) != 0;
+            if( *based_on == based_on_type::NEITHER &&
+                definition.do_turn_handler.empty() && !has_actor && !has_native_turn ) {
+                throw std::runtime_error( "activity type '" + definition.id +
+                                          "' is based on neither time nor speed and requires a Lua turn policy, native actor, or native turn handler" );
+            }
+            validate_operation( entry.operation, id.is_valid(), definition.id,
+                                "activity type" );
+        }
+
+        std::set<std::string> help_topic_ids;
+        std::set<int> help_topic_orders;
+        for( const help_topic_registration &entry : pimpl_->help_topics ) {
+            const help_topic_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "help topic" );
+            if( !help_topic_ids.insert( definition.id ).second ||
+                definition.title.empty() || definition.paragraphs.empty() ||
+                ( definition.order &&
+                  ( *definition.order < std::numeric_limits<int>::min() ||
+                    *definition.order > std::numeric_limits<int>::max() ||
+                    !help_topic_orders.insert(
+                        static_cast<int>( *definition.order ) ).second ) ) ) {
+                throw std::runtime_error( "help topic '" + definition.id +
+                                          "' has invalid presentation, order, or a duplicate registration" );
+            }
+            if( std::any_of( definition.paragraphs.begin(), definition.paragraphs.end(),
+            []( const std::string & paragraph ) {
+                return paragraph.empty();
+            } ) ) {
+                throw std::runtime_error( "help topic '" + definition.id +
+                                          "' has an empty paragraph" );
+            }
+            const auto existing_id = get_help().platform_help_topic_orders.find( definition.id );
+            const bool exists = existing_id != get_help().platform_help_topic_orders.end();
+            if( check_engine_state && definition.order ) {
+                const auto existing_order = get_help().help_texts.find(
+                                                static_cast<int>( *definition.order ) );
+                const bool order_owned_by_self = exists &&
+                                                 existing_id->second == *definition.order;
+                if( existing_order != get_help().help_texts.end() && !order_owned_by_self ) {
+                    throw std::runtime_error( "help topic '" + definition.id +
+                                              "' collides with an existing display order" );
+                }
+            }
+            validate_operation( entry.operation, exists, definition.id, "help topic" );
+        }
+
+        std::set<std::string> snippet_category_ids;
+        std::set<std::string> staged_snippet_ids;
+        for( const snippet_category_registration &entry : pimpl_->snippet_categories ) {
+            const snippet_category_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "snippet category" );
+            if( !snippet_category_ids.insert( definition.id ).second ||
+                definition.entries.empty() ) {
+                throw std::runtime_error( "snippet category '" + definition.id +
+                                          "' requires entries and one registration per transaction" );
+            }
+            std::set<snippet_id> existing_category_ids;
+            const auto existing_category = SNIPPET.snippets_by_category.find( definition.id );
+            if( existing_category != SNIPPET.snippets_by_category.end() ) {
+                for( const snippet_library::weighted_id &value : existing_category->second.ids ) {
+                    existing_category_ids.insert( value.value );
+                }
+            }
+            std::uint64_t category_weight = 0;
+            for( const snippet_entry_definition_data &snippet : definition.entries ) {
+                if( snippet.text.empty() || snippet.weight <= 0 ) {
+                    throw std::runtime_error( "snippet category '" + definition.id +
+                                              "' has an invalid text or weight" );
+                }
+                const std::uint64_t weight = static_cast<std::uint64_t>( snippet.weight );
+                if( category_weight > std::numeric_limits<std::uint64_t>::max() - weight ) {
+                    throw std::runtime_error( "snippet category '" + definition.id +
+                                              "' cumulative weight overflows" );
+                }
+                category_weight += weight;
+                if( snippet.id.empty() ) {
+                    if( !snippet.name.empty() || !snippet.examine_handler.empty() ) {
+                        throw std::runtime_error( "anonymous snippet in category '" +
+                                                  definition.id +
+                                                  "' cannot have a name or examine policy" );
+                    }
+                    continue;
+                }
+                require_valid_id( snippet.id, "snippet" );
+                if( !staged_snippet_ids.insert( snippet.id ).second ) {
+                    throw std::runtime_error( "snippet id '" + snippet.id +
+                                              "' is registered more than once per transaction" );
+                }
+                const snippet_id id( snippet.id );
+                if( check_engine_state && id.is_valid() &&
+                    ( entry.operation == definition_operation::add ||
+                      existing_category_ids.count( id ) == 0 ) ) {
+                    throw std::runtime_error( "snippet id '" + snippet.id +
+                                              "' would duplicate an existing snippet" );
+                }
+                if( !snippet.examine_handler.empty() &&
+                    owner_runtime.handlers.count( snippet.examine_handler ) == 0 ) {
+                    throw std::runtime_error( "snippet '" + snippet.id +
+                                              "' references missing examine handler '" +
+                                              snippet.examine_handler + "'" );
+                }
+            }
+            if( check_engine_state && entry.operation == definition_operation::replace &&
+                existing_category == SNIPPET.snippets_by_category.end() ) {
+                throw std::runtime_error( "replace requires existing snippet category '" +
+                                          definition.id + "'" );
+            }
+        }
+
+        std::set<std::string> playlist_ids;
+        for( const playlist_registration &entry : pimpl_->playlists ) {
+            const playlist_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "playlist" );
+            if( !playlist_ids.insert( definition.id ).second || definition.tracks.empty() ) {
+                throw std::runtime_error( "playlist '" + definition.id +
+                                          "' requires tracks and one registration per transaction" );
+            }
+            for( const auto &[file, volume] : definition.tracks ) {
+                const std::filesystem::path path( file );
+                const bool traverses_parent = std::any_of(
+                                                  path.begin(), path.end(), []( const auto & part ) {
+                    return part == "..";
+                } );
+                if( file.empty() || file.size() > 4096 ||
+                    file.find( '\0' ) != std::string::npos || path.is_absolute() ||
+                    traverses_parent || volume < 0 || volume > 128 ) {
+                    throw std::runtime_error( "playlist '" + definition.id +
+                                              "' has an invalid relative track or volume" );
+                }
+            }
+            validate_operation( entry.operation,
+                                sfx::playlist_registry_get( definition.id ).has_value(),
+                                definition.id, "playlist" );
+        }
+
+        std::set<std::string> attack_vector_ids;
+        for( const attack_vector_registration &entry : pimpl_->attack_vectors ) {
+            const attack_vector_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "attack vector" );
+            if( !attack_vector_ids.insert( definition.id ).second ||
+                definition.encumbrance_limit < 0 ||
+                definition.encumbrance_limit > std::numeric_limits<int>::max() ||
+                definition.health_percent_limit < 0 ||
+                definition.health_percent_limit > 100 ||
+                ( !definition.weapon &&
+                  ( definition.limbs.empty() || definition.contacts.empty() ) ) ) {
+                throw std::runtime_error( "attack vector '" + definition.id +
+                                          "' has invalid limits, anatomy, or a duplicate registration" );
+            }
+            std::set<std::string> limbs;
+            for( const std::string &limb : definition.limbs ) {
+                if( !limbs.insert( limb ).second || !bodypart_str_id( limb ).is_valid() ) {
+                    throw std::runtime_error( "attack vector '" + definition.id +
+                                              "' references an invalid or duplicate limb '" +
+                                              limb + "'" );
+                }
+            }
+            std::set<std::string> contacts;
+            for( const std::string &contact : definition.contacts ) {
+                if( !contacts.insert( contact ).second ||
+                    !sub_bodypart_str_id( contact ).is_valid() ) {
+                    throw std::runtime_error( "attack vector '" + definition.id +
+                                              "' references an invalid or duplicate contact '" +
+                                              contact + "'" );
+                }
+            }
+            for( const auto &[kind, count] : definition.limb_requirements ) {
+                if( !io::enum_is_valid<bp_type>( kind ) || count <= 0 ||
+                    count > std::numeric_limits<int>::max() ) {
+                    throw std::runtime_error( "attack vector '" + definition.id +
+                                              "' has an invalid limb requirement" );
+                }
+            }
+            for( const std::string &flag : definition.required_flags ) {
+                if( definition.forbidden_flags.count( flag ) != 0 ) {
+                    throw std::runtime_error( "attack vector '" + definition.id +
+                                              "' both requires and forbids flag '" + flag + "'" );
+                }
+            }
+            if( check_engine_state ) {
+                const auto validate_flag = [&json_flag_ids, &definition](
+                const std::string & flag ) {
+                    if( json_flag_ids.count( flag ) == 0 && !flag_id( flag ).is_valid() ) {
+                        throw std::runtime_error( "attack vector '" + definition.id +
+                                                  "' references unknown limb flag '" + flag + "'" );
+                    }
+                };
+                for( const std::string &flag : definition.required_flags ) {
+                    validate_flag( flag );
+                }
+                for( const std::string &flag : definition.forbidden_flags ) {
+                    validate_flag( flag );
+                }
+            }
+            validate_operation( entry.operation, attack_vector_id( definition.id ).is_valid(),
+                                definition.id, "attack vector" );
+        }
+
+        std::set<std::string> magic_type_ids;
+        for( const magic_type_registration &entry : pimpl_->magic_types ) {
+            const magic_type_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "magic type" );
+            const std::optional<magic_energy_type> energy =
+                platform_magic_energy_type( definition.energy_source );
+            if( !magic_type_ids.insert( definition.id ).second || !energy ||
+                !std::isfinite( definition.failure_cost_fraction ) ||
+                definition.failure_cost_fraction < 0.0 ||
+                !std::isfinite( definition.failure_experience_fraction ) ||
+                definition.failure_experience_fraction < 0.0 ||
+                color_from_string( definition.energy_color,
+                                   report_color_error::no ) == c_unset ||
+                ( definition.max_book_level &&
+                  ( *definition.max_book_level < 0 ||
+                    *definition.max_book_level > std::numeric_limits<int>::max() ) ) ||
+                definition.level_for_experience_handler.empty() !=
+                definition.experience_for_level_handler.empty() ) {
+                throw std::runtime_error( "magic type '" + definition.id +
+                                          "' has invalid energy, progression, limits, or fractions" );
+            }
+            if( *energy == magic_energy_type::vitamin ) {
+                if( definition.vitamin.empty() ||
+                    ( vitamin_ids.count( definition.vitamin ) == 0 &&
+                      !vitamin_id( definition.vitamin ).is_valid() ) ) {
+                    throw std::runtime_error( "magic type '" + definition.id +
+                                              "' needs a valid vitamin energy source" );
+                }
+            } else if( !definition.vitamin.empty() ) {
+                throw std::runtime_error( "magic type '" + definition.id +
+                                          "' declares a vitamin for non-vitamin energy" );
+            }
+            for( const std::string &flag : definition.cannot_cast_flags ) {
+                if( flag.empty() ) {
+                    throw std::runtime_error( "magic type '" + definition.id +
+                                              "' has an empty casting restriction" );
+                }
+            }
+            const std::array<std::pair<const char *, const std::string *>, 7> handlers = { {
+                    { "level-for-experience", &definition.level_for_experience_handler },
+                    { "experience-for-level", &definition.experience_for_level_handler },
+                    { "casting-experience", &definition.casting_experience_handler },
+                    { "failure-chance", &definition.failure_chance_handler },
+                    { "failure-cost", &definition.failure_cost_handler },
+                    { "failure-experience", &definition.failure_experience_handler },
+                    { "failure", &definition.failure_handler },
+                } };
+            for( const auto &[label, handler_id] : handlers ) {
+                if( !handler_id->empty() && owner_runtime.handlers.count( *handler_id ) == 0 ) {
+                    throw std::runtime_error( "magic type '" + definition.id +
+                                              "' references missing " + label +
+                                              " handler '" + *handler_id + "'" );
+                }
+            }
+            validate_operation( entry.operation, magic_type_id( definition.id ).is_valid(),
+                                definition.id, "magic type" );
+        }
+
+        std::set<std::string> movement_mode_ids;
+        for( const movement_mode_registration &entry : pimpl_->movement_modes ) {
+            const movement_mode_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "movement mode" );
+            if( !movement_mode_ids.insert( definition.id ).second ||
+                definition.name.empty() ||
+                !platform_movement_mode_type( definition.kind ) ||
+                definition.character_symbol == 0 || definition.panel_symbol == 0 ||
+                color_from_string( definition.panel_color,
+                                   report_color_error::no ) == c_unset ||
+                color_from_string( definition.symbol_color,
+                                   report_color_error::no ) == c_unset ||
+                !std::isfinite( definition.exertion ) || definition.exertion < 0.0 ||
+                definition.exertion > std::numeric_limits<float>::max() ||
+                !std::isfinite( definition.riding_exertion ) ||
+                definition.riding_exertion < 0.0 ||
+                definition.riding_exertion > std::numeric_limits<float>::max() ||
+                !std::isfinite( definition.stamina_multiplier ) ||
+                definition.stamina_multiplier < 0.0 ||
+                definition.stamina_multiplier > std::numeric_limits<float>::max() ||
+                !std::isfinite( definition.sound_multiplier ) ||
+                definition.sound_multiplier < 0.0 ||
+                definition.sound_multiplier > std::numeric_limits<float>::max() ||
+                !std::isfinite( definition.speed_multiplier ) ||
+                definition.speed_multiplier <= 0.0 ||
+                definition.speed_multiplier > std::numeric_limits<float>::max() ||
+                definition.mech_power_kilojoules < 0 ||
+                definition.mech_power_kilojoules > std::numeric_limits<int>::max() ||
+                definition.swim_speed_modifier < std::numeric_limits<int>::min() ||
+                definition.swim_speed_modifier > std::numeric_limits<int>::max() ) {
+                throw std::runtime_error( "movement mode '" + definition.id +
+                                          "' has invalid symbols, colors, type, or movement values" );
+            }
+            std::set<steed_type> steed_messages;
+            for( const movement_mode_message_definition_data &messages :
+                 definition.messages ) {
+                const std::optional<steed_type> steed =
+                    platform_steed_type( messages.steed );
+                if( !steed || !steed_messages.insert( *steed ).second ||
+                    messages.prepare.empty() || messages.success.empty() ||
+                    messages.failure.empty() ) {
+                    throw std::runtime_error( "movement mode '" + definition.id +
+                                              "' has invalid or duplicate steed messages" );
+                }
+            }
+            if( steed_messages.size() != 3 ) {
+                throw std::runtime_error( "movement mode '" + definition.id +
+                                          "' needs messages for none, animal, and mech" );
+            }
+            validate_operation( entry.operation, move_mode_id( definition.id ).is_valid(),
+                                definition.id, "movement mode" );
+        }
+
+        std::set<std::string> monster_flag_ids;
+        for( const monster_flag_registration &entry : pimpl_->monster_flags ) {
+            const monster_flag_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "monster flag" );
+            if( !monster_flag_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "monster flag '" + definition.id +
+                                          "' is registered more than once per transaction" );
+            }
+            validate_operation( entry.operation, mon_flag_str_id( definition.id ).is_valid(),
+                                definition.id, "monster flag" );
+        }
+
+        std::set<std::string> species_ids;
+        for( const species_registration &entry : pimpl_->species ) {
+            const species_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "species" );
+            if( !species_ids.insert( definition.id ).second ||
+                definition.footsteps.empty() || definition.bleeds.empty() ) {
+                throw std::runtime_error( "species '" + definition.id +
+                                          "' requires footsteps, a bleed field, and one registration per transaction" );
+            }
+            const auto validate_triggers = [&definition]( const std::set<std::string> &values,
+            const char *kind ) {
+                for( const std::string &trigger : values ) {
+                    if( !io::enum_is_valid<mon_trigger>( trigger ) ) {
+                        throw std::runtime_error( "species '" + definition.id +
+                                                  "' has invalid " + kind + " trigger '" + trigger + "'" );
+                    }
+                }
+            };
+            validate_triggers( definition.anger, "anger" );
+            validate_triggers( definition.fear, "fear" );
+            validate_triggers( definition.placate, "placate" );
+            if( check_engine_state ) {
+                for( const std::string &flag : definition.flags ) {
+                    if( !mon_flag_str_id( flag ).is_valid() && !monster_flag_ids.count( flag ) ) {
+                        throw std::runtime_error( "species '" + definition.id +
+                                                  "' references unknown monster flag '" + flag + "'" );
+                    }
+                }
+                if( !field_type_str_id( definition.bleeds ).is_valid() ) {
+                    throw std::runtime_error( "species '" + definition.id +
+                                              "' references unknown bleed field '" + definition.bleeds + "'" );
+                }
+            }
+            validate_operation( entry.operation, species_id( definition.id ).is_valid(),
+                                definition.id, "species" );
+        }
+
+        std::set<std::string> emission_ids;
+        for( const emission_registration &entry : pimpl_->emissions ) {
+            const emission_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "emission" );
+            const field_type_str_id field( definition.field );
+            if( !emission_ids.insert( definition.id ).second ||
+                definition.field.empty() || definition.field == "fd_null" ||
+                definition.intensity <= 0 ||
+                definition.intensity > std::numeric_limits<int>::max() ||
+                definition.quantity <= 0 ||
+                definition.quantity > std::numeric_limits<int>::max() ||
+                definition.chance <= 0 || definition.chance > 100 ||
+                ( check_engine_state &&
+                  ( !field.is_valid() ||
+                    definition.intensity > field->get_max_intensity() ) ) ) {
+                throw std::runtime_error( "emission '" + definition.id +
+                                          "' has an invalid field profile or duplicate registration" );
+            }
+            if( !definition.profile_handler.empty() &&
+                owner_runtime.handlers.count( definition.profile_handler ) == 0 ) {
+                throw std::runtime_error( "emission '" + definition.id +
+                                          "' references missing profile handler '" +
+                                          definition.profile_handler + "'" );
+            }
+            validate_operation(
+                entry.operation,
+                detail::emission_registry_find( definition.id ) != nullptr,
+                definition.id, "emission" );
+        }
+
+        std::set<std::string> monster_faction_ids;
+        for( const monster_faction_registration &entry : pimpl_->monster_factions ) {
+            require_valid_id( entry.definition->id, "monster faction" );
+            if( !monster_faction_ids.insert( entry.definition->id ).second ) {
+                throw std::runtime_error( "monster faction '" + entry.definition->id +
+                                          "' is registered more than once per transaction" );
+            }
+        }
+        for( const monster_faction_registration &entry : pimpl_->monster_factions ) {
+            const monster_faction_definition_data &definition = *entry.definition;
+            if( check_engine_state ) {
+                const auto known_faction = [&monster_faction_ids]( const std::string &id ) {
+                    return mfaction_str_id( id ).is_valid() || monster_faction_ids.count( id );
+                };
+                if( !known_faction( definition.base ) ) {
+                    throw std::runtime_error( "monster faction '" + definition.id +
+                                              "' references unknown base faction '" + definition.base + "'" );
+                }
+                for( const auto &[target, attitude] : definition.attitudes ) {
+                    if( target.empty() || !known_faction( target ) ||
+                        ( attitude != "by_mood" && attitude != "neutral" &&
+                          attitude != "friendly" && attitude != "hate" ) ) {
+                        throw std::runtime_error( "monster faction '" + definition.id +
+                                                  "' has an invalid attitude relation to '" + target + "'" );
+                    }
+                }
+            }
+            validate_operation( entry.operation,
+                                mfaction_str_id( definition.id ).is_valid(),
+                                definition.id, "monster faction" );
+        }
+
+        std::set<std::string> mutation_type_ids;
+        for( const mutation_type_registration &entry : pimpl_->mutation_types ) {
+            const mutation_type_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "mutation type" );
+            if( !mutation_type_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "mutation type '" + definition.id +
+                                          "' is registered more than once per transaction" );
+            }
+            validate_operation( entry.operation,
+                                detail::mutation_type_registry_contains( definition.id ),
+                                definition.id, "mutation type" );
+        }
+
+        std::set<std::string> connect_group_ids;
+        std::size_t new_connect_groups = 0;
+        for( const connect_group_registration &entry : pimpl_->connect_groups ) {
+            const connect_group_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "connect group" );
+            if( !connect_group_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "connect group '" + definition.id +
+                                          "' is registered more than once per transaction" );
+            }
+            const bool exists = detail::connect_group_registry_find( definition.id ) != nullptr;
+            validate_operation( entry.operation, exists, definition.id, "connect group" );
+            if( !exists ) {
+                ++new_connect_groups;
+            }
+        }
+        if( detail::connect_group_registry_size() + new_connect_groups > NUM_TERCONN ) {
+            throw std::runtime_error( "connect-group transaction exceeds the native connection-group limit" );
+        }
+
+        std::set<std::string> mutation_category_ids;
+        for( const mutation_category_registration &entry : pimpl_->mutation_categories ) {
+            const mutation_category_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "mutation category" );
+            if( !mutation_category_ids.insert( definition.id ).second ||
+                definition.name.empty() || definition.mutagen_message.empty() ||
+                definition.memorial_message.empty() || definition.vitamin.empty() ||
+                definition.threshold_minimum < 0 ||
+                definition.threshold_minimum > std::numeric_limits<int>::max() ||
+                definition.base_removal_chance < 0 ||
+                definition.base_removal_chance > 100 ||
+                !std::isfinite( definition.base_removal_cost_multiplier ) ||
+                definition.base_removal_cost_multiplier < 0.0 ||
+                definition.base_removal_cost_multiplier > std::numeric_limits<float>::max() ) {
+                throw std::runtime_error( "mutation category '" + definition.id +
+                                          "' has invalid presentation, thresholds, or removal policy" );
+            }
+            if( check_engine_state && !definition.threshold_mutation.empty() &&
+                !trait_id( definition.threshold_mutation ).is_valid() ) {
+                throw std::runtime_error( "mutation category '" + definition.id +
+                                          "' references unknown threshold mutation '" +
+                                          definition.threshold_mutation + "'" );
+            }
+            if( check_engine_state && definition.vitamin != "null" &&
+                vitamin_ids.count( definition.vitamin ) == 0 &&
+                !vitamin_id( definition.vitamin ).is_valid() ) {
+                throw std::runtime_error( "mutation category '" + definition.id +
+                                          "' references unknown vitamin '" + definition.vitamin + "'" );
+            }
+            validate_operation(
+                entry.operation,
+                detail::mutation_category_registry_find( definition.id ) != nullptr,
+                definition.id, "mutation category" );
+        }
+
+        std::set<std::string> construction_category_ids;
+        for( const construction_category_registration &entry :
+             pimpl_->construction_categories ) {
+            const construction_category_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "construction category" );
+            if( definition.name.empty() ||
+                !construction_category_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "construction category '" + definition.id +
+                                          "' requires a name and one registration per transaction" );
+            }
+            validate_operation( entry.operation,
+                                construction_category_id( definition.id ).is_valid(),
+                                definition.id, "construction category" );
+        }
+
+        std::set<std::string> construction_group_ids;
+        for( const construction_group_registration &entry : pimpl_->construction_groups ) {
+            const construction_group_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "construction group" );
+            if( definition.name.empty() ||
+                !construction_group_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "construction group '" + definition.id +
+                                          "' requires a name and one registration per transaction" );
+            }
+            validate_operation( entry.operation,
+                                construction_group_str_id( definition.id ).is_valid(),
+                                definition.id, "construction group" );
+        }
+
+        std::set<std::string> vehicle_part_location_ids;
+        for( const vehicle_part_location_registration &entry :
+             pimpl_->vehicle_part_locations ) {
+            const vehicle_part_location_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "vehicle part location" );
+            if( definition.name.empty() ||
+                definition.z_order < std::numeric_limits<int>::min() ||
+                definition.z_order > std::numeric_limits<int>::max() ||
+                definition.list_order < std::numeric_limits<int>::min() ||
+                definition.list_order > std::numeric_limits<int>::max() ||
+                !vehicle_part_location_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "vehicle part location '" + definition.id +
+                                          "' has invalid values or a duplicate registration" );
+            }
+            validate_operation( entry.operation,
+                                vpart_location_id( definition.id ).is_valid(),
+                                definition.id, "vehicle part location" );
+        }
+
+        std::set<std::string> mood_face_ids;
+        for( const mood_face_registration &entry : pimpl_->mood_faces ) {
+            const mood_face_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "mood face" );
+            std::set<std::int64_t> scores;
+            if( definition.values.empty() ||
+                !mood_face_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "mood face '" + definition.id +
+                                          "' requires values and one registration per transaction" );
+            }
+            for( const mood_face_value_definition_data &value : definition.values ) {
+                if( value.face.empty() || !scores.insert( value.score ).second ) {
+                    throw std::runtime_error( "mood face '" + definition.id +
+                                              "' has empty text or a duplicate score" );
+                }
+            }
+            validate_operation( entry.operation, mood_face_id( definition.id ).is_valid(),
+                                definition.id, "mood face" );
+        }
+
+        std::set<std::string> damage_info_order_ids;
+        for( const damage_info_order_registration &entry : pimpl_->damage_info_orders ) {
+            const damage_info_order_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "damage info order" );
+            if( definition.display != "none" && definition.display != "basic" &&
+                definition.display != "detailed" ) {
+                throw std::runtime_error( "damage info order '" + definition.id +
+                                          "' has unknown display mode '" +
+                                          definition.display + "'" );
+            }
+            if( definition.sections.empty() ||
+                !damage_info_order_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "damage info order '" + definition.id +
+                                          "' requires sections and one registration per transaction" );
+            }
+            if( damage_type_ids.count( definition.id ) == 0 &&
+                !damage_type_id( definition.id ).is_valid() ) {
+                throw std::runtime_error( "damage info order '" + definition.id +
+                                          "' has no matching damage type" );
+            }
+            validate_operation( entry.operation,
+                                damage_info_order_id( definition.id ).is_valid(),
+                                definition.id, "damage info order" );
+        }
+
+        std::set<std::string> vehicle_part_category_ids;
+        for( const vehicle_part_category_registration &entry :
+             pimpl_->vehicle_part_categories ) {
+            const vehicle_part_category_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "vehicle part category" );
+            if( definition.name.empty() || definition.short_name.empty() ||
+                definition.priority < std::numeric_limits<int>::min() ||
+                definition.priority > std::numeric_limits<int>::max() ||
+                !vehicle_part_category_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "vehicle part category '" + definition.id +
+                                          "' has invalid values or a duplicate registration" );
+            }
+            validate_operation(
+                entry.operation,
+                detail::vehicle_part_category_registry_find( definition.id ) != nullptr,
+                definition.id, "vehicle part category" );
+        }
+
+        std::set<std::string> named_color_ids;
+        std::set<std::uint32_t> named_color_values;
+        for( const named_color_registration &entry : pimpl_->named_colors ) {
+            const named_color_definition_data &definition = *entry.definition;
+            if( definition.name.empty() || definition.red < 0 || definition.red > 255 ||
+                definition.green < 0 || definition.green > 255 ||
+                definition.blue < 0 || definition.blue > 255 ||
+                definition.alpha < 0 || definition.alpha > 255 ||
+                !named_color_ids.insert( definition.name ).second ) {
+                throw std::runtime_error( "named color '" + definition.name +
+                                          "' has invalid channels or a duplicate registration" );
+            }
+            const std::uint32_t packed =
+                ( static_cast<std::uint32_t>( definition.red ) << 24 ) |
+                ( static_cast<std::uint32_t>( definition.green ) << 16 ) |
+                ( static_cast<std::uint32_t>( definition.blue ) << 8 ) |
+                static_cast<std::uint32_t>( definition.alpha );
+            const detail::named_color_native_definition native{
+                definition.name,
+                static_cast<std::uint8_t>( definition.red ),
+                static_cast<std::uint8_t>( definition.green ),
+                static_cast<std::uint8_t>( definition.blue ),
+                static_cast<std::uint8_t>( definition.alpha )
+            };
+            if( !named_color_values.insert( packed ).second ||
+                ( check_engine_state &&
+                  detail::named_color_registry_color_in_use( native, definition.name ) ) ) {
+                throw std::runtime_error( "named color '" + definition.name +
+                                          "' collides with another color value" );
+            }
+            validate_operation( entry.operation,
+                                detail::named_color_registry_contains( definition.name ),
+                                definition.name, "named color" );
+        }
+
+        std::set<std::uint32_t> staged_rotatable_symbols;
+        for( const rotatable_symbol_registration &entry : pimpl_->rotatable_symbols ) {
+            const rotatable_symbol_definition_data &definition = *entry.definition;
+            std::set<std::uint32_t> candidate( definition.symbols.begin(),
+                                              definition.symbols.end() );
+            if( definition.key.empty() ||
+                ( definition.symbols.size() != 2 && definition.symbols.size() != 4 ) ||
+                candidate.size() != definition.symbols.size() ) {
+                throw std::runtime_error( "rotatable symbol '" + definition.key +
+                                          "' requires two or four distinct glyphs" );
+            }
+            for( const std::uint32_t symbol : candidate ) {
+                if( !staged_rotatable_symbols.insert( symbol ).second ) {
+                    throw std::runtime_error( "rotatable symbol groups overlap in one transaction" );
+                }
+            }
+            std::vector<std::uint32_t> current =
+                detail::rotatable_symbol_registry_group( definition.symbols.front() );
+            validate_operation( entry.operation, !current.empty(), definition.key,
+                                "rotatable symbol" );
+            if( check_engine_state && entry.operation == definition_operation::add ) {
+                for( const std::uint32_t symbol : candidate ) {
+                    if( !detail::rotatable_symbol_registry_group( symbol ).empty() ) {
+                        throw std::runtime_error( "rotatable symbol '" + definition.key +
+                                                  "' overlaps an existing group" );
+                    }
+                }
+            } else if( check_engine_state ) {
+                std::vector<std::uint32_t> expected( candidate.begin(), candidate.end() );
+                if( current != expected ) {
+                    throw std::runtime_error( "rotatable symbol '" + definition.key +
+                                              "' replacement must preserve its glyph set" );
+                }
+            }
+        }
+
+        std::set<std::string> ascii_art_ids;
+        for( const ascii_art_registration &entry : pimpl_->ascii_arts ) {
+            const ascii_art_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "ASCII art" );
+            if( definition.lines.empty() ||
+                !ascii_art_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "ASCII art '" + definition.id +
+                                          "' requires lines and one registration per transaction" );
+            }
+            for( const std::string &line : definition.lines ) {
+                if( utf8_width( remove_color_tags( line ) ) > 41 ) {
+                    throw std::runtime_error( "ASCII art '" + definition.id +
+                                              "' contains a line wider than 41 cells" );
+                }
+            }
+            validate_operation( entry.operation, ascii_art_id( definition.id ).is_valid(),
+                                definition.id, "ASCII art" );
+        }
+
+        std::set<std::string> limb_score_ids;
+        for( const limb_score_registration &entry : pimpl_->limb_scores ) {
+            const limb_score_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "limb score" );
+            if( definition.name.empty() ||
+                !limb_score_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "limb score '" + definition.id +
+                                          "' requires a name and one registration per transaction" );
+            }
+            validate_operation( entry.operation, limb_score_id( definition.id ).is_valid(),
+                                definition.id, "limb score" );
+        }
+
+        if( pimpl_->hit_ranges.size() > 1 ) {
+            throw std::runtime_error( "hit range is a singleton and may be registered once" );
+        }
+        for( const hit_range_registration &entry : pimpl_->hit_ranges ) {
+            const hit_range_definition_data &definition = *entry.definition;
+            if( definition.id != "global" || definition.even_good.empty() ) {
+                throw std::runtime_error( "hit range requires the global singleton and values" );
+            }
+            if( entry.operation != definition_operation::replace ) {
+                throw std::runtime_error( "hit range is a global singleton and must use replace" );
+            }
+            for( const std::int64_t value : definition.even_good ) {
+                if( value < 0 || value > std::numeric_limits<int>::max() ) {
+                    throw std::runtime_error( "hit-range dispersion is outside the native range" );
+                }
+            }
+        }
+
+        std::set<std::string> scent_type_ids;
+        for( const scent_type_registration &entry : pimpl_->scent_types ) {
+            const scent_type_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "scent type" );
+            if( definition.receptive_species.empty() ||
+                !scent_type_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "scent type '" + definition.id +
+                                          "' requires receptive species and one registration per transaction" );
+            }
+            for( const std::string &species : definition.receptive_species ) {
+                if( !species_id( species ).is_valid() ) {
+                    throw std::runtime_error( "scent type '" + definition.id +
+                                              "' references unknown species '" + species + "'" );
+                }
+            }
+            validate_operation( entry.operation, scenttype_id( definition.id ).is_valid(),
+                                definition.id, "scent type" );
+        }
+
+        std::set<std::string> speed_description_ids;
+        for( const speed_description_registration &entry : pimpl_->speed_descriptions ) {
+            const speed_description_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "speed description" );
+            if( definition.values.empty() ||
+                !speed_description_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "speed description '" + definition.id +
+                                          "' requires values and one registration per transaction" );
+            }
+            for( const speed_description_value_data &value : definition.values ) {
+                if( !std::isfinite( value.threshold ) || value.threshold < 0.0 ||
+                    value.descriptions.empty() ) {
+                    throw std::runtime_error( "speed description '" + definition.id +
+                                              "' has an invalid threshold or no text" );
+                }
+                for( const std::string &description : value.descriptions ) {
+                    if( description.empty() ) {
+                        throw std::runtime_error( "speed description '" + definition.id +
+                                                  "' contains empty text" );
+                    }
+                }
+            }
+            validate_operation( entry.operation,
+                                speed_description_id( definition.id ).is_valid(),
+                                definition.id, "speed description" );
+        }
+
+        std::set<std::string> item_group_ids;
+        std::map<std::string, std::vector<std::string>> item_group_children;
+        for( const item_group_registration &entry : pimpl_->item_groups ) {
+            const item_group_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "item group" );
+            if( !item_group_ids.insert( definition.id ).second ||
+                ( definition.kind != "collection" && definition.kind != "distribution" ) ||
+                definition.with_ammo < 0 || definition.with_ammo > 100 ||
+                definition.with_magazine < 0 || definition.with_magazine > 100 ) {
+                throw std::runtime_error( "item group '" + definition.id +
+                                          "' has invalid kind, chances, or duplicate registration" );
+            }
+            item_group_children.emplace( definition.id, std::vector<std::string>() );
+            validate_operation( entry.operation,
+                                item_group::group_is_defined( item_group_id( definition.id ) ),
+                                definition.id, "item group" );
+        }
+        for( const item_group_registration &entry : pimpl_->item_groups ) {
+            const item_group_definition_data &definition = *entry.definition;
+            for( const item_group_entry_definition_data &group_entry : definition.entries ) {
+                const bool probability_valid = definition.kind == "collection" ?
+                                               group_entry.probability > 0 &&
+                                               group_entry.probability <= 100 :
+                                               group_entry.probability > 0 &&
+                                               group_entry.probability <= std::numeric_limits<int>::max();
+                if( group_entry.id.empty() || !probability_valid ||
+                    group_entry.variant.size() > 256 ||
+                    group_entry.variant.find( '\0' ) != std::string::npos ||
+                    ( group_entry.group && !group_entry.variant.empty() ) ) {
+                    throw std::runtime_error( "item group '" + definition.id +
+                                              "' contains an invalid entry" );
+                }
+                if( group_entry.group ) {
+                    if( group_entry.id == definition.id ||
+                        ( item_group_ids.count( group_entry.id ) == 0 && check_engine_state &&
+                          !item_group::group_is_defined( item_group_id( group_entry.id ) ) ) ) {
+                        throw std::runtime_error( "item group '" + definition.id +
+                                                  "' references unknown or recursive group '" +
+                                                  group_entry.id + "'" );
+                    }
+                    if( item_group_ids.count( group_entry.id ) != 0 ) {
+                        item_group_children[definition.id].push_back( group_entry.id );
+                    }
+                } else if( declared_item_ids.count( group_entry.id ) == 0 &&
+                           !item::type_is_defined( itype_id( group_entry.id ) ) ) {
+                    throw std::runtime_error( "item group '" + definition.id +
+                                              "' references unknown item '" +
+                                              group_entry.id + "'" );
+                }
+            }
+        }
+        std::set<std::string> visiting_item_groups;
+        std::set<std::string> visited_item_groups;
+        std::function<void( const std::string & )> visit_item_group;
+        visit_item_group = [&]( const std::string &id ) {
+            if( visited_item_groups.count( id ) != 0 ) {
+                return;
+            }
+            if( !visiting_item_groups.insert( id ).second ) {
+                throw std::runtime_error( "item-group graph contains a cycle at '" + id + "'" );
+            }
+            for( const std::string &child : item_group_children.at( id ) ) {
+                visit_item_group( child );
+            }
+            visiting_item_groups.erase( id );
+            visited_item_groups.insert( id );
+        };
+        for( const auto &[id, children] : item_group_children ) {
+            static_cast<void>( children );
+            visit_item_group( id );
+        }
+
+        std::set<std::string> harvest_drop_type_ids;
+        std::map<std::string, bool> harvest_drop_type_item_groups;
+        for( const harvest_drop_type_registration &entry : pimpl_->harvest_drop_types ) {
+            const harvest_drop_type_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "harvest drop type" );
+            if( !harvest_drop_type_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "harvest drop type '" + definition.id +
+                                          "' is registered more than once per transaction" );
+            }
+            const std::vector<std::string> skills = definition.skills.empty() ?
+                    std::vector<std::string>{ "survival" } : definition.skills;
+            for( const std::string &skill : skills ) {
+                if( skill_ids.count( skill ) == 0 && !skill_id( skill ).is_valid() ) {
+                    throw std::runtime_error( "harvest drop type '" + definition.id +
+                                              "' references unknown skill '" + skill + "'" );
+                }
+            }
+            validate_operation( entry.operation,
+                                harvest_drop_type_id( definition.id ).is_valid(),
+                                definition.id, "harvest drop type" );
+            harvest_drop_type_item_groups[definition.id] = definition.item_group;
+        }
+
+        std::set<std::string> harvest_ids;
+        for( const harvest_registration &entry : pimpl_->harvests ) {
+            const harvest_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "harvest" );
+            if( definition.leftovers.empty() || definition.butchery_requirements.empty() ||
+                !harvest_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "harvest '" + definition.id +
+                                          "' requires leftovers, butchery requirements, and one registration" );
+            }
+            if( declared_item_ids.count( definition.leftovers ) == 0 &&
+                !item::type_is_defined( itype_id( definition.leftovers ) ) ) {
+                throw std::runtime_error( "harvest '" + definition.id +
+                                          "' references unknown leftovers item '" +
+                                          definition.leftovers + "'" );
+            }
+            if( check_engine_state &&
+                !butchery_requirements_id( definition.butchery_requirements ).is_valid() ) {
+                throw std::runtime_error( "harvest '" + definition.id +
+                                          "' references unknown butchery requirements '" +
+                                          definition.butchery_requirements + "'" );
+            }
+            std::set<std::string> outputs;
+            for( const harvest_entry_definition_data &drop : definition.entries ) {
+                const auto finite_native_float = []( const double value ) {
+                    return std::isfinite( value ) &&
+                           std::abs( value ) <= std::numeric_limits<float>::max();
+                };
+                if( drop.output.empty() || !outputs.insert( drop.output ).second ||
+                    !finite_native_float( drop.base_minimum ) ||
+                    !finite_native_float( drop.base_maximum ) ||
+                    drop.base_maximum < drop.base_minimum ||
+                    !finite_native_float( drop.skill_minimum ) ||
+                    !finite_native_float( drop.skill_maximum ) ||
+                    drop.skill_maximum < drop.skill_minimum ||
+                    drop.maximum <= 0 ||
+                    drop.maximum > std::numeric_limits<int>::max() ||
+                    !std::isfinite( drop.mass_ratio ) || drop.mass_ratio < 0.0 ||
+                    drop.mass_ratio > 1.0 ) {
+                    throw std::runtime_error( "harvest '" + definition.id +
+                                              "' has an invalid drop for '" + drop.output + "'" );
+                }
+
+                bool output_is_item_group = false;
+                if( !drop.category.empty() ) {
+                    const auto staged_category =
+                        harvest_drop_type_item_groups.find( drop.category );
+                    if( staged_category != harvest_drop_type_item_groups.end() ) {
+                        output_is_item_group = staged_category->second;
+                    } else {
+                        const harvest_drop_type_id category( drop.category );
+                        if( !category.is_valid() ) {
+                            throw std::runtime_error( "harvest '" + definition.id +
+                                                      "' references unknown drop category '" +
+                                                      drop.category + "'" );
+                        }
+                        output_is_item_group = category->is_item_group();
+                    }
+                }
+                if( output_is_item_group ) {
+                    if( item_group_ids.count( drop.output ) == 0 && check_engine_state &&
+                        !item_group::group_is_defined( item_group_id( drop.output ) ) ) {
+                        throw std::runtime_error( "harvest '" + definition.id +
+                                                  "' references unknown item group '" +
+                                                  drop.output + "'" );
+                    }
+                } else if( declared_item_ids.count( drop.output ) == 0 &&
+                           !item::type_is_defined( itype_id( drop.output ) ) ) {
+                    throw std::runtime_error( "harvest '" + definition.id +
+                                              "' references unknown item '" + drop.output + "'" );
+                }
+                for( const std::string &flag : drop.flags ) {
+                    if( json_flag_ids.count( flag ) == 0 && !flag_id( flag ).is_valid() ) {
+                        throw std::runtime_error( "harvest '" + definition.id +
+                                                  "' references unknown item flag '" + flag + "'" );
+                    }
+                }
+                for( const std::string &fault : drop.faults ) {
+                    if( check_engine_state && !fault_id( fault ).is_valid() ) {
+                        throw std::runtime_error( "harvest '" + definition.id +
+                                                  "' references unknown item fault '" + fault + "'" );
+                    }
+                }
+            }
+            validate_operation( entry.operation, harvest_id( definition.id ).is_valid(),
+                                definition.id, "harvest" );
+        }
+
+        std::set<std::string> behavior_ids;
+        std::map<std::string, std::vector<std::string>> behavior_children;
+        for( const behavior_registration &entry : pimpl_->behaviors ) {
+            const behavior_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "behavior" );
+            if( !behavior_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "behavior '" + definition.id +
+                                          "' is registered more than once per transaction" );
+            }
+            behavior_children.emplace( definition.id, definition.children );
+        }
+        for( const behavior_registration &entry : pimpl_->behaviors ) {
+            const behavior_definition_data &definition = *entry.definition;
+            const bool has_children = !definition.children.empty();
+            const bool has_goal = !definition.goal.empty();
+            if( has_children == has_goal || definition.goal.size() > 256 ||
+                definition.goal.find( '\0' ) != std::string::npos ) {
+                throw std::runtime_error( "behavior '" + definition.id +
+                                          "' requires exactly one of child nodes or a bounded goal" );
+            }
+            if( !definition.strategy.empty() &&
+                behavior::strategy_map.count( definition.strategy ) == 0 ) {
+                throw std::runtime_error( "behavior '" + definition.id +
+                                          "' references unknown strategy '" +
+                                          definition.strategy + "'" );
+            }
+            if( has_children && definition.strategy.empty() ) {
+                throw std::runtime_error( "behavior '" + definition.id +
+                                          "' requires a strategy for its child nodes" );
+            }
+            for( const std::string &child : definition.children ) {
+                if( child == definition.id ||
+                    ( behavior_ids.count( child ) == 0 &&
+                      !string_id<behavior::node_t>( child ).is_valid() ) ) {
+                    throw std::runtime_error( "behavior '" + definition.id +
+                                              "' references unknown or recursive child '" + child + "'" );
+                }
+            }
+            for( const behavior_condition_definition_data &condition :
+                 definition.conditions ) {
+                if( condition.policy.empty() || condition.policy.size() > 256 ||
+                    condition.argument.size() > 1024 ||
+                    condition.argument.find( '\0' ) != std::string::npos ) {
+                    throw std::runtime_error( "behavior '" + definition.id +
+                                              "' has an invalid condition policy or argument" );
+                }
+                if( condition.native ) {
+                    if( behavior::predicate_map.count( condition.policy ) == 0 ) {
+                        throw std::runtime_error( "behavior '" + definition.id +
+                                                  "' references unknown native condition '" +
+                                                  condition.policy + "'" );
+                    }
+                } else if( owner_runtime.handlers.count( condition.policy ) == 0 ) {
+                    throw std::runtime_error( "behavior '" + definition.id +
+                                              "' references missing Lua condition '" +
+                                              condition.policy + "'" );
+                }
+            }
+            if( definition.score ) {
+                const behavior_score_definition_data &score = *definition.score;
+                if( score.policy.empty() || score.policy.size() > 256 ||
+                    score.argument.size() > 1024 ||
+                    score.argument.find( '\0' ) != std::string::npos ) {
+                    throw std::runtime_error( "behavior '" + definition.id +
+                                              "' has an invalid score policy or argument" );
+                }
+                if( score.native ) {
+                    if( behavior::score_predicate_map.count( score.policy ) == 0 ) {
+                        throw std::runtime_error( "behavior '" + definition.id +
+                                                  "' references unknown native score '" +
+                                                  score.policy + "'" );
+                    }
+                } else if( owner_runtime.handlers.count( score.policy ) == 0 ) {
+                    throw std::runtime_error( "behavior '" + definition.id +
+                                              "' references missing Lua score '" + score.policy + "'" );
+                }
+            }
+            validate_operation( entry.operation,
+                                string_id<behavior::node_t>( definition.id ).is_valid(),
+                                definition.id, "behavior" );
+        }
+        std::set<std::string> visiting_behaviors;
+        std::set<std::string> visited_behaviors;
+        std::function<void( const std::string & )> visit_behavior;
+        visit_behavior = [&]( const std::string &id ) {
+            if( visited_behaviors.count( id ) != 0 ) {
+                return;
+            }
+            if( !visiting_behaviors.insert( id ).second ) {
+                throw std::runtime_error( "behavior child graph contains a cycle at '" + id + "'" );
+            }
+            for( const std::string &child : behavior_children.at( id ) ) {
+                if( behavior_children.count( child ) != 0 ) {
+                    visit_behavior( child );
+                }
+            }
+            visiting_behaviors.erase( id );
+            visited_behaviors.insert( id );
+        };
+        for( const auto &[id, children] : behavior_children ) {
+            static_cast<void>( children );
+            visit_behavior( id );
+        }
+
+        std::set<std::string> sub_body_part_ids;
+        std::map<std::string, const sub_body_part_definition_data *> staged_sub_body_parts;
+        for( const sub_body_part_registration &entry : pimpl_->sub_body_parts ) {
+            const sub_body_part_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "sub body part" );
+            if( !sub_body_part_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "sub body part '" + definition.id +
+                                          "' is registered more than once per transaction" );
+            }
+            staged_sub_body_parts.emplace( definition.id, &definition );
+            validate_operation( entry.operation,
+                                sub_bodypart_str_id( definition.id ).is_valid(),
+                                definition.id, "sub body part" );
+        }
+
+        std::set<std::string> body_part_ids;
+        std::map<std::string, const body_part_definition_data *> staged_body_parts;
+        for( const body_part_registration &entry : pimpl_->body_parts ) {
+            const body_part_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "body part" );
+            if( !body_part_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "body part '" + definition.id +
+                                          "' is registered more than once per transaction" );
+            }
+            staged_body_parts.emplace( definition.id, &definition );
+            validate_operation( entry.operation, bodypart_str_id( definition.id ).is_valid(),
+                                definition.id, "body part" );
+        }
+
+        std::set<std::string> anatomy_ids;
+        for( const anatomy_registration &entry : pimpl_->anatomies ) {
+            const anatomy_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "anatomy" );
+            if( !anatomy_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "anatomy '" + definition.id +
+                                          "' is registered more than once per transaction" );
+            }
+            validate_operation( entry.operation, anatomy_id( definition.id ).is_valid(),
+                                definition.id, "anatomy" );
+        }
+
+        std::set<std::string> body_graph_ids;
+        for( const body_graph_registration &entry : pimpl_->body_graphs ) {
+            const body_graph_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "body graph" );
+            if( !body_graph_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "body graph '" + definition.id +
+                                          "' is registered more than once per transaction" );
+            }
+            validate_operation( entry.operation, bodygraph_id( definition.id ).is_valid(),
+                                definition.id, "body graph" );
+        }
+
+        const std::set<std::string> body_sides = { "left", "right", "both" };
+        const auto known_body_part = [&]( const std::string &id ) {
+            return body_part_ids.count( id ) != 0 || !check_engine_state ||
+                   bodypart_str_id( id ).is_valid();
+        };
+        const auto known_sub_body_part = [&]( const std::string &id ) {
+            return sub_body_part_ids.count( id ) != 0 || !check_engine_state ||
+                   sub_bodypart_str_id( id ).is_valid();
+        };
+        const auto finite_native_float = []( const double value ) {
+            return std::isfinite( value ) &&
+                   std::abs( value ) <= std::numeric_limits<float>::max();
+        };
+
+        for( const sub_body_part_registration &entry : pimpl_->sub_body_parts ) {
+            const sub_body_part_definition_data &definition = *entry.definition;
+            if( definition.name.empty() || definition.name.size() > 1024 ||
+                definition.plural_name.empty() || definition.plural_name.size() > 1024 ||
+                definition.parent.empty() || !known_body_part( definition.parent ) ||
+                definition.opposite.empty() || !known_sub_body_part( definition.opposite ) ||
+                body_sides.count( definition.side ) == 0 ||
+                definition.maximum_coverage <= 0 || definition.maximum_coverage > 100 ) {
+                throw std::runtime_error( "sub body part '" + definition.id +
+                                          "' has invalid names, links, side, or coverage" );
+            }
+            std::set<std::string> locations;
+            for( const std::string &location : definition.locations_under ) {
+                if( location.empty() || !locations.insert( location ).second ||
+                    !known_sub_body_part( location ) ) {
+                    throw std::runtime_error( "sub body part '" + definition.id +
+                                              "' has an invalid lower location '" + location + "'" );
+                }
+            }
+            if( !definition.similar_body_part.empty() &&
+                !known_sub_body_part( definition.similar_body_part ) ) {
+                throw std::runtime_error( "sub body part '" + definition.id +
+                                          "' references unknown similar part '" +
+                                          definition.similar_body_part + "'" );
+            }
+            for( const auto &[damage_id, amount] : definition.unarmed_damage ) {
+                if( ( damage_type_ids.count( damage_id ) == 0 &&
+                      !damage_type_id( damage_id ).is_valid() ) ||
+                    !finite_native_float( amount ) || amount < 0.0 ) {
+                    throw std::runtime_error( "sub body part '" + definition.id +
+                                              "' has invalid unarmed damage '" + damage_id + "'" );
+                }
+            }
+        }
+
+        static const std::map<std::string, bp_type> platform_body_part_types = {
+            { "head", bp_type::head }, { "torso", bp_type::torso },
+            { "sensor", bp_type::sensor }, { "mouth", bp_type::mouth },
+            { "arm", bp_type::arm }, { "hand", bp_type::hand },
+            { "leg", bp_type::leg }, { "foot", bp_type::foot },
+            { "wing", bp_type::wing }, { "tail", bp_type::tail },
+            { "other", bp_type::other }
+        };
+        for( const body_part_registration &entry : pimpl_->body_parts ) {
+            const body_part_definition_data &definition = *entry.definition;
+            const std::array<std::string, 9> labels = {
+                definition.name, definition.plural_name, definition.accusative,
+                definition.plural_accusative, definition.heading,
+                definition.plural_heading, definition.encumbrance_text,
+                definition.hp_bar_text, definition.id
+            };
+            if( std::any_of( labels.begin(), labels.end(), []( const std::string &value ) {
+            return value.empty() || value.size() > 1024 ||
+                   value.find( '\0' ) != std::string::npos;
+            } ) || definition.main_part.empty() ||
+                !known_body_part( definition.main_part ) ||
+                definition.connected_to.empty() ||
+                !known_body_part( definition.connected_to ) ||
+                definition.opposite.empty() || !known_body_part( definition.opposite ) ||
+                body_sides.count( definition.side ) == 0 ||
+                !finite_native_float( definition.hit_size ) || definition.hit_size <= 0.0 ||
+                !finite_native_float( definition.hit_difficulty ) ||
+                definition.hit_difficulty < 0.0 || definition.base_health <= 0 ||
+                definition.base_health > std::numeric_limits<int>::max() ||
+                definition.drench_capacity < 0 ||
+                definition.drench_capacity > std::numeric_limits<int>::max() ||
+                definition.limb_types.empty() ) {
+                throw std::runtime_error( "body part '" + definition.id +
+                                          "' has invalid text, links, geometry, or health" );
+            }
+            std::set<std::string> sub_parts;
+            for( const std::string &sub_part : definition.sub_parts ) {
+                if( !sub_parts.insert( sub_part ).second || !known_sub_body_part( sub_part ) ) {
+                    throw std::runtime_error( "body part '" + definition.id +
+                                              "' has an invalid sub part '" + sub_part + "'" );
+                }
+                const auto staged = staged_sub_body_parts.find( sub_part );
+                if( staged != staged_sub_body_parts.end() &&
+                    staged->second->parent != definition.id ) {
+                    throw std::runtime_error( "body part '" + definition.id +
+                                              "' claims sub part '" + sub_part +
+                                              "' whose parent is '" + staged->second->parent + "'" );
+                }
+            }
+            for( const auto &[kind, weight] : definition.limb_types ) {
+                if( platform_body_part_types.count( kind ) == 0 ||
+                    !finite_native_float( weight ) || weight <= 0.0 ) {
+                    throw std::runtime_error( "body part '" + definition.id +
+                                              "' has invalid limb type '" + kind + "'" );
+                }
+            }
+            const auto validate_damage_values = [&]( const std::map<std::string, double> &values,
+            const std::string_view label ) {
+                for( const auto &[damage_id, amount] : values ) {
+                    if( ( damage_type_ids.count( damage_id ) == 0 &&
+                          !damage_type_id( damage_id ).is_valid() ) ||
+                        !finite_native_float( amount ) || amount < 0.0 ) {
+                        throw std::runtime_error( "body part '" + definition.id +
+                                                  "' has invalid " + std::string( label ) +
+                                                  " for '" + damage_id + "'" );
+                    }
+                }
+            };
+            validate_damage_values( definition.armor, "armor" );
+            validate_damage_values( definition.unarmed_damage, "unarmed damage" );
+            for( const std::string &flag : definition.flags ) {
+                if( json_flag_ids.count( flag ) == 0 && !json_character_flag( flag ).is_valid() ) {
+                    throw std::runtime_error( "body part '" + definition.id +
+                                              "' references unknown flag '" + flag + "'" );
+                }
+            }
+            for( const auto &[score_id, score] : definition.limb_scores ) {
+                if( ( limb_score_ids.count( score_id ) == 0 &&
+                      !limb_score_id( score_id ).is_valid() ) ||
+                    !finite_native_float( score.score ) || score.score < 0.0 ||
+                    !finite_native_float( score.maximum ) ||
+                    score.maximum < score.score ) {
+                    throw std::runtime_error( "body part '" + definition.id +
+                                              "' has invalid limb score '" + score_id + "'" );
+                }
+            }
+            std::set<std::string> qualities;
+            for( const body_part_quality_definition_data &quality : definition.qualities ) {
+                if( quality.id.empty() || !qualities.insert( quality.id ).second ||
+                    ( tool_quality_ids.count( quality.id ) == 0 &&
+                      !quality_id( quality.id ).is_valid() ) ||
+                    quality.level < std::numeric_limits<int>::min() ||
+                    quality.level > std::numeric_limits<int>::max() ||
+                    !finite_native_float( quality.disable_fraction ) ||
+                    quality.disable_fraction < 0.0 || quality.disable_fraction > 1.0 ) {
+                    throw std::runtime_error( "body part '" + definition.id +
+                                              "' has invalid quality '" + quality.id + "'" );
+                }
+            }
+        }
+
+        for( const anatomy_registration &entry : pimpl_->anatomies ) {
+            const anatomy_definition_data &definition = *entry.definition;
+            std::set<std::string> parts;
+            if( definition.parts.empty() ) {
+                throw std::runtime_error( "anatomy '" + definition.id +
+                                          "' needs at least one body part" );
+            }
+            for( const std::string &part : definition.parts ) {
+                if( !parts.insert( part ).second || !known_body_part( part ) ) {
+                    throw std::runtime_error( "anatomy '" + definition.id +
+                                              "' has an invalid body part '" + part + "'" );
+                }
+            }
+            for( const std::string &part : definition.parts ) {
+                const auto staged = staged_body_parts.find( part );
+                if( staged != staged_body_parts.end() &&
+                    ( parts.count( staged->second->main_part ) == 0 ||
+                      parts.count( staged->second->connected_to ) == 0 ) ) {
+                    throw std::runtime_error( "anatomy '" + definition.id +
+                                              "' omits a staged main or connected body part for '" +
+                                              part + "'" );
+                }
+            }
+        }
+
+        std::map<std::string, std::vector<std::string>> body_graph_children;
+        for( const body_graph_registration &entry : pimpl_->body_graphs ) {
+            const body_graph_definition_data &definition = *entry.definition;
+            if( !definition.parent_body_part.empty() &&
+                !known_body_part( definition.parent_body_part ) ) {
+                throw std::runtime_error( "body graph '" + definition.id +
+                                          "' references unknown parent body part '" +
+                                          definition.parent_body_part + "'" );
+            }
+            if( definition.rows.size() > 20 ||
+                ( definition.mirror.empty() && definition.rows.empty() ) ||
+                ( !definition.mirror.empty() && !definition.rows.empty() ) ||
+                ( !definition.fill_rows.empty() &&
+                  definition.fill_rows.size() != definition.rows.size() ) ||
+                utf8_width( definition.fill_symbol ) != 1 ||
+                color_from_string( definition.fill_color,
+                                   report_color_error::no ) == c_unset ) {
+                throw std::runtime_error( "body graph '" + definition.id +
+                                          "' has invalid rows, mirror, fill symbol, or fill color" );
+            }
+            std::size_t row_width = 0;
+            for( std::size_t index = 0; index < definition.rows.size(); ++index ) {
+                const std::size_t width = utf8_display_split( definition.rows[index] ).size();
+                if( width == 0 || width > 40 ||
+                    ( index != 0 && width != row_width ) ||
+                    ( !definition.fill_rows.empty() &&
+                      utf8_display_split( definition.fill_rows[index] ).size() != width ) ) {
+                    throw std::runtime_error( "body graph '" + definition.id +
+                                              "' has inconsistent or oversized rows" );
+                }
+                row_width = width;
+            }
+            std::vector<std::string> children;
+            if( !definition.mirror.empty() ) {
+                if( definition.mirror == definition.id ||
+                    ( body_graph_ids.count( definition.mirror ) == 0 && check_engine_state &&
+                      !bodygraph_id( definition.mirror ).is_valid() ) ) {
+                    throw std::runtime_error( "body graph '" + definition.id +
+                                              "' has invalid mirror '" + definition.mirror + "'" );
+                }
+                if( body_graph_ids.count( definition.mirror ) != 0 ) {
+                    children.push_back( definition.mirror );
+                }
+            }
+            std::set<std::string> part_symbols;
+            for( const body_graph_part_definition_data &part : definition.parts ) {
+                if( utf8_width( part.symbol ) != 1 ||
+                    !part_symbols.insert( part.symbol ).second ||
+                    ( !part.display_symbol.empty() && utf8_width( part.display_symbol ) != 1 ) ||
+                    color_from_string( part.selected_color,
+                                       report_color_error::no ) == c_unset ||
+                    ( part.body_parts.empty() && part.sub_body_parts.empty() &&
+                      part.nested_graph.empty() ) ) {
+                    throw std::runtime_error( "body graph '" + definition.id +
+                                              "' has an invalid part symbol '" + part.symbol + "'" );
+                }
+                for( const std::string &body_part : part.body_parts ) {
+                    if( !known_body_part( body_part ) ) {
+                        throw std::runtime_error( "body graph '" + definition.id +
+                                                  "' references unknown body part '" + body_part + "'" );
+                    }
+                }
+                for( const std::string &sub_part : part.sub_body_parts ) {
+                    if( !known_sub_body_part( sub_part ) ) {
+                        throw std::runtime_error( "body graph '" + definition.id +
+                                                  "' references unknown sub body part '" + sub_part + "'" );
+                    }
+                }
+                if( !part.nested_graph.empty() ) {
+                    if( part.nested_graph == definition.id ||
+                        ( body_graph_ids.count( part.nested_graph ) == 0 &&
+                          check_engine_state && !bodygraph_id( part.nested_graph ).is_valid() ) ) {
+                        throw std::runtime_error( "body graph '" + definition.id +
+                                                  "' references invalid nested graph '" +
+                                                  part.nested_graph + "'" );
+                    }
+                    if( body_graph_ids.count( part.nested_graph ) != 0 ) {
+                        children.push_back( part.nested_graph );
+                    }
+                }
+            }
+            body_graph_children.emplace( definition.id, std::move( children ) );
+        }
+        std::set<std::string> visiting_body_graphs;
+        std::set<std::string> visited_body_graphs;
+        std::function<void( const std::string & )> visit_body_graph;
+        visit_body_graph = [&]( const std::string &id ) {
+            if( visited_body_graphs.count( id ) != 0 ) {
+                return;
+            }
+            if( !visiting_body_graphs.insert( id ).second ) {
+                throw std::runtime_error( "body-graph dependency cycle at '" + id + "'" );
+            }
+            for( const std::string &child : body_graph_children.at( id ) ) {
+                visit_body_graph( child );
+            }
+            visiting_body_graphs.erase( id );
+            visited_body_graphs.insert( id );
+        };
+        for( const auto &[id, children] : body_graph_children ) {
+            static_cast<void>( children );
+            visit_body_graph( id );
+        }
+
+        std::set<std::string> monster_ids;
+        for( const monster_registration &entry : pimpl_->monsters ) {
+            const monster_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "monster" );
+            if( !monster_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "monster '" + definition.id +
+                                          "' is registered more than once per transaction" );
+            }
+            validate_operation( entry.operation, mtype_id( definition.id ).is_valid(),
+                                definition.id, "monster" );
+        }
+
+        std::set<std::string> effect_type_ids;
+        for( const effect_type_registration &entry : pimpl_->effect_types ) {
+            const effect_type_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "effect type" );
+            const auto bounded_texts = []( const std::vector<std::string> &values ) {
+                return !values.empty() && std::all_of(
+                           values.begin(), values.end(), []( const std::string & value ) {
+                    return !value.empty() && value.size() <= 4096 &&
+                           value.find( '\0' ) == std::string::npos;
+                } );
+            };
+            if( !effect_type_ids.insert( definition.id ).second ||
+                !bounded_texts( definition.names ) ||
+                !bounded_texts( definition.descriptions ) ||
+                ( !definition.reduced_descriptions.empty() &&
+                  !bounded_texts( definition.reduced_descriptions ) ) ||
+                definition.maximum_intensity <= 0 ||
+                definition.maximum_intensity > std::numeric_limits<int>::max() ||
+                definition.maximum_duration_turns < 0 ||
+                definition.maximum_duration_turns > std::numeric_limits<int>::max() ||
+                definition.intensity_duration_turns < 0 ||
+                definition.intensity_duration_turns > std::numeric_limits<int>::max() ||
+                definition.duration_add_percent < std::numeric_limits<int>::min() ||
+                definition.duration_add_percent > std::numeric_limits<int>::max() ||
+                definition.intensity_add_value < std::numeric_limits<int>::min() ||
+                definition.intensity_add_value > std::numeric_limits<int>::max() ||
+                definition.intensity_decay_step < -1 ||
+                definition.intensity_decay_step > std::numeric_limits<int>::max() ||
+                definition.intensity_decay_tick < 0 ||
+                definition.intensity_decay_tick > std::numeric_limits<int>::max() ) {
+                throw std::runtime_error( "effect type '" + definition.id +
+                                          "' has invalid text or intensity/duration bounds" );
+            }
+            validate_operation(
+                entry.operation,
+                detail::effect_type_registry_find( definition.id ) != nullptr,
+                definition.id, "effect type" );
+        }
+        for( const effect_type_registration &entry : pimpl_->effect_types ) {
+            const effect_type_definition_data &definition = *entry.definition;
+            const auto validate_effect_references = [&]( const std::set<std::string> &values,
+            const std::string_view label ) {
+                for( const std::string &id : values ) {
+                    if( effect_type_ids.count( id ) == 0 && check_engine_state &&
+                        !efftype_id( id ).is_valid() ) {
+                        throw std::runtime_error( "effect type '" + definition.id +
+                                                  "' references unknown " + std::string( label ) +
+                                                  " '" + id + "'" );
+                    }
+                }
+            };
+            validate_effect_references( definition.resist_effects, "resistance effect" );
+            validate_effect_references( definition.removes_effects, "removed effect" );
+            validate_effect_references( definition.blocks_effects, "blocked effect" );
+            for( const std::string &trait : definition.resist_traits ) {
+                if( check_engine_state && !trait_id( trait ).is_valid() ) {
+                    throw std::runtime_error( "effect type '" + definition.id +
+                                              "' references unknown resistance trait '" +
+                                              trait + "'" );
+                }
+            }
+        }
+
+        std::set<std::string> field_type_ids;
+        const std::set<std::string> field_phases = {
+            "null", "solid", "liquid", "gas", "plasma"
+        };
+        const std::set<std::string> field_affixes = {
+            "in", "covered_in", "on", "under", "illuminated_by"
+        };
+        for( const field_type_registration &entry : pimpl_->field_types ) {
+            const field_type_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "field type" );
+            const auto native_int = []( const std::int64_t value ) {
+                return value >= std::numeric_limits<int>::min() &&
+                       value <= std::numeric_limits<int>::max();
+            };
+            if( !field_type_ids.insert( definition.id ).second ||
+                definition.intensity_levels.empty() ||
+                !native_int( definition.underwater_age_speedup_turns ) ||
+                !native_int( definition.outdoor_age_speedup_turns ) ||
+                !native_int( definition.decay_amount_factor ) ||
+                definition.percent_spread < 0 || definition.percent_spread > 100 ||
+                !native_int( definition.gas_absorption_turns ) ||
+                definition.gas_absorption_turns < 0 ||
+                !native_int( definition.priority ) ||
+                !native_int( definition.half_life_turns ) ||
+                definition.half_life_turns < 0 ||
+                field_phases.count( definition.phase ) == 0 ||
+                field_affixes.count( definition.description_affix ) == 0 ) {
+                throw std::runtime_error( "field type '" + definition.id +
+                                          "' has invalid lifecycle or presentation options" );
+            }
+            for( const field_intensity_definition_data &level :
+                 definition.intensity_levels ) {
+                if( level.name.empty() || level.name.size() > 1024 ||
+                    level.symbol.empty() || utf8_width( level.symbol ) != 1 ||
+                    color_from_string( level.color, report_color_error::no ) == c_unset ||
+                    !native_int( level.move_cost ) ||
+                    level.upgrade_chance < 0 || level.upgrade_chance > 100 ||
+                    !native_int( level.upgrade_duration_turns ) ||
+                    level.upgrade_duration_turns < 0 ||
+                    !std::isfinite( level.light_emitted ) || level.light_emitted < 0.0 ||
+                    !std::isfinite( level.local_light_override ) ||
+                    !std::isfinite( level.translucency ) || level.translucency < 0.0 ||
+                    !native_int( level.concentration ) || level.concentration < 0 ||
+                    !native_int( level.convection_temperature_modifier ) ||
+                    !native_int( level.scent_neutralization ) ) {
+                    throw std::runtime_error( "field type '" + definition.id +
+                                              "' contains an invalid intensity" );
+                }
+                for( const field_effect_definition_data &effect : level.effects ) {
+                    if( effect.effect.empty() ||
+                        ( effect_type_ids.count( effect.effect ) == 0 &&
+                          check_engine_state && !efftype_id( effect.effect ).is_valid() ) ||
+                        effect.duration_min_turns < 0 ||
+                        effect.duration_max_turns < effect.duration_min_turns ||
+                        !native_int( effect.duration_max_turns ) ||
+                        effect.intensity <= 0 || !native_int( effect.intensity ) ||
+                        ( !effect.body_part.empty() &&
+                          body_part_ids.count( effect.body_part ) == 0 &&
+                          check_engine_state &&
+                          !bodypart_str_id( effect.body_part ).is_valid() ) ||
+                        effect.message.size() > 1024 || effect.npc_message.size() > 1024 ) {
+                        throw std::runtime_error( "field type '" + definition.id +
+                                                  "' contains an invalid field effect" );
+                    }
+                }
+            }
+            validate_operation( entry.operation,
+                                field_type_str_id( definition.id ).is_valid(),
+                                definition.id, "field type" );
+        }
+        for( const field_type_registration &entry : pimpl_->field_types ) {
+            const field_type_definition_data &definition = *entry.definition;
+            if( !definition.wandering_field.empty() &&
+                field_type_ids.count( definition.wandering_field ) == 0 &&
+                check_engine_state &&
+                !field_type_str_id( definition.wandering_field ).is_valid() ) {
+                throw std::runtime_error( "field type '" + definition.id +
+                                          "' references unknown wandering field '" +
+                                          definition.wandering_field + "'" );
+            }
+            for( const std::string &monster_id : definition.immune_monsters ) {
+                if( monster_ids.count( monster_id ) == 0 && check_engine_state &&
+                    !mtype_id( monster_id ).is_valid() ) {
+                    throw std::runtime_error( "field type '" + definition.id +
+                                              "' references unknown immune monster '" +
+                                              monster_id + "'" );
+                }
+            }
+            for( const std::string &monster_id : definition.blocked_monsters ) {
+                if( monster_ids.count( monster_id ) == 0 && check_engine_state &&
+                    !mtype_id( monster_id ).is_valid() ) {
+                    throw std::runtime_error( "field type '" + definition.id +
+                                              "' references unknown blocking monster '" +
+                                              monster_id + "'" );
+                }
+            }
+        }
+
+        std::set<std::string> monster_attack_ids;
+        for( const monster_attack_registration &entry : pimpl_->monster_attacks ) {
+            const monster_attack_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "monster attack" );
+            if( !monster_attack_ids.insert( definition.id ).second ||
+                !std::isfinite( definition.cooldown ) || definition.cooldown < 0.0 ||
+                definition.cooldown > std::numeric_limits<int>::max() ||
+                definition.handler.empty() || definition.handler.size() > 256 ||
+                owner_runtime.handlers.count( definition.handler ) == 0 ) {
+                throw std::runtime_error( "monster attack '" + definition.id +
+                                          "' needs a unique id, bounded cooldown, and named Lua policy" );
+            }
+            validate_operation(
+                entry.operation,
+                detail::monster_attack_registry_find( definition.id ) != nullptr,
+                definition.id, "monster attack" );
+        }
+
+        std::set<std::string> weakpoint_set_ids;
+        for( const weakpoint_set_registration &entry : pimpl_->weakpoint_sets ) {
+            const weakpoint_set_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "weakpoint set" );
+            if( !weakpoint_set_ids.insert( definition.id ).second ||
+                definition.weakpoints.empty() ) {
+                throw std::runtime_error( "weakpoint set '" + definition.id +
+                                          "' needs one registration and at least one weakpoint" );
+            }
+            std::set<std::string> point_ids;
+            for( const weakpoint_definition_data &point : definition.weakpoints ) {
+                const auto finite_native_float = []( const double value ) {
+                    return std::isfinite( value ) &&
+                           std::abs( value ) <= std::numeric_limits<float>::max();
+                };
+                if( point.id.empty() || point.id.size() > 256 ||
+                    point.id.find( '\0' ) != std::string::npos ||
+                    !point_ids.insert( point.id ).second ||
+                    point.name.size() > 1024 ||
+                    !finite_native_float( point.coverage ) || point.coverage < 0.0 ) {
+                    throw std::runtime_error( "weakpoint set '" + definition.id +
+                                              "' contains an invalid weakpoint" );
+                }
+                const auto validate_damage_map = [&](
+                    const std::map<std::string, double> &values,
+                    const bool non_negative, const std::string_view label ) {
+                    for( const auto &[damage_id, value] : values ) {
+                        if( ( damage_type_ids.count( damage_id ) == 0 &&
+                              !damage_type_id( damage_id ).is_valid() ) ||
+                            !finite_native_float( value ) ||
+                            ( non_negative && value < 0.0 ) ) {
+                            throw std::runtime_error( "weakpoint set '" + definition.id +
+                                                      "' has an invalid " + std::string( label ) +
+                                                      " for damage type '" + damage_id + "'" );
+                        }
+                    }
+                };
+                validate_damage_map( point.armor_multipliers, true, "armor multiplier" );
+                validate_damage_map( point.armor_penalties, false, "armor penalty" );
+                validate_damage_map( point.damage_multipliers, true, "damage multiplier" );
+                validate_damage_map( point.critical_multipliers, true, "critical multiplier" );
+                for( const weakpoint_effect_definition_data &effect : point.effects ) {
+                    if( effect.effect.empty() ||
+                        ( effect_type_ids.count( effect.effect ) == 0 &&
+                          check_engine_state && !efftype_id( effect.effect ).is_valid() ) ||
+                        !finite_native_float( effect.chance ) ||
+                        effect.chance < 0.0 || effect.chance > 100.0 ||
+                        effect.duration_min_turns < 0 ||
+                        effect.duration_max_turns < effect.duration_min_turns ||
+                        effect.duration_max_turns > std::numeric_limits<int>::max() ||
+                        effect.intensity_min <= 0 ||
+                        effect.intensity_max < effect.intensity_min ||
+                        effect.intensity_max > std::numeric_limits<int>::max() ||
+                        !finite_native_float( effect.damage_required_min ) ||
+                        !finite_native_float( effect.damage_required_max ) ||
+                        effect.damage_required_min < 0.0 ||
+                        effect.damage_required_max < effect.damage_required_min ||
+                        effect.damage_required_max > 100.0 ||
+                        effect.message.size() > 1024 ) {
+                        throw std::runtime_error( "weakpoint set '" + definition.id +
+                                                  "' has an invalid effect on '" + point.id + "'" );
+                    }
+                }
+            }
+            validate_operation( entry.operation,
+                                weakpoints_id( definition.id ).is_valid(),
+                                definition.id, "weakpoint set" );
+        }
+
+        std::set<std::string> morale_type_ids;
+        for( const morale_type_registration &entry : pimpl_->morale_types ) {
+            const morale_type_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "morale type" );
+            if( definition.text.empty() || !morale_type_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "morale type '" + definition.id +
+                                          "' requires text and one registration per transaction" );
+            }
+            validate_operation( entry.operation, morale_type( definition.id ).is_valid(),
+                                definition.id, "morale type" );
+        }
+
+        std::set<std::string> disease_type_ids;
+        for( const disease_type_registration &entry : pimpl_->disease_types ) {
+            const disease_type_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "disease type" );
+            if( definition.symptoms.empty() || definition.minimum_duration_turns <= 0 ||
+                definition.maximum_duration_turns < definition.minimum_duration_turns ||
+                definition.maximum_duration_turns > std::numeric_limits<int>::max() ||
+                definition.minimum_intensity <= 0 ||
+                definition.maximum_intensity < definition.minimum_intensity ||
+                definition.maximum_intensity > std::numeric_limits<int>::max() ||
+                !disease_type_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "disease type '" + definition.id +
+                                          "' has invalid bounds or a duplicate registration" );
+            }
+            if( !efftype_id( definition.symptoms ).is_valid() ) {
+                throw std::runtime_error( "disease type '" + definition.id +
+                                          "' references unknown symptom effect '" +
+                                          definition.symptoms + "'" );
+            }
+            if( definition.health_threshold &&
+                ( *definition.health_threshold < std::numeric_limits<int>::min() ||
+                  *definition.health_threshold > std::numeric_limits<int>::max() ) ) {
+                throw std::runtime_error( "disease type '" + definition.id +
+                                          "' health threshold is outside the native range" );
+            }
+            for( const std::string &body_part : definition.affected_body_parts ) {
+                if( !bodypart_str_id( body_part ).is_valid() ) {
+                    throw std::runtime_error( "disease type '" + definition.id +
+                                              "' references unknown body part '" + body_part + "'" );
+                }
+            }
+            validate_operation( entry.operation, diseasetype_id( definition.id ).is_valid(),
+                                definition.id, "disease type" );
+        }
+
+        std::set<std::string> proficiency_category_ids;
+        for( const proficiency_category_registration &entry : pimpl_->proficiency_categories ) {
+            const proficiency_category_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "proficiency category" );
+            if( definition.name.empty() || definition.description.empty() ||
+                !proficiency_category_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "proficiency category '" + definition.id +
+                                          "' requires name, description, and one registration per transaction" );
+            }
+            validate_operation( entry.operation,
+                                proficiency_category_id( definition.id ).is_valid(),
+                                definition.id, "proficiency category" );
+        }
+
+        std::set<std::string> proficiency_ids;
+        const std::set<std::string> proficiency_attributes = {
+            "strength", "dexterity", "intelligence", "perception", "stamina"
+        };
+        for( const proficiency_registration &entry : pimpl_->proficiencies ) {
+            const proficiency_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "proficiency" );
+            if( definition.name.empty() || definition.description.empty() ||
+                definition.category.empty() || definition.time_to_learn_turns <= 0 ||
+                definition.time_to_learn_turns > std::numeric_limits<int>::max() ||
+                !std::isfinite( definition.time_multiplier ) || definition.time_multiplier < 0.0 ||
+                !std::isfinite( definition.skill_penalty ) || definition.skill_penalty < 0.0 ||
+                !std::isfinite( definition.weakpoint_bonus ) ||
+                !std::isfinite( definition.weakpoint_penalty ) ||
+                !proficiency_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "proficiency '" + definition.id +
+                                          "' has invalid values or a duplicate registration" );
+            }
+            if( proficiency_category_ids.count( definition.category ) == 0 &&
+                !proficiency_category_id( definition.category ).is_valid() ) {
+                throw std::runtime_error( "proficiency '" + definition.id +
+                                          "' references unknown category '" +
+                                          definition.category + "'" );
+            }
+            for( const proficiency_bonus_definition &bonus : definition.bonuses ) {
+                if( proficiency_attributes.count( bonus.attribute ) == 0 ) {
+                    throw std::runtime_error( "proficiency '" + definition.id +
+                                              "' has unknown bonus attribute '" +
+                                              bonus.attribute + "'" );
+                }
+            }
+            validate_operation( entry.operation, proficiency_id( definition.id ).is_valid(),
+                                definition.id, "proficiency" );
+        }
+        for( const proficiency_registration &entry : pimpl_->proficiencies ) {
+            for( const std::string &required : entry.definition->required ) {
+                if( proficiency_ids.count( required ) == 0 &&
+                    !proficiency_id( required ).is_valid() ) {
+                    throw std::runtime_error( "proficiency '" + entry.definition->id +
+                                              "' requires unknown proficiency '" + required + "'" );
+                }
+            }
+        }
+
+        std::set<std::string> weapon_category_ids;
+        for( const weapon_category_registration &entry : pimpl_->weapon_categories ) {
+            const weapon_category_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "weapon category" );
+            if( definition.name.empty() || !weapon_category_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "weapon category '" + definition.id +
+                                          "' requires a name and one registration per transaction" );
+            }
+            for( const std::string &proficiency_key : definition.proficiencies ) {
+                if( proficiency_ids.count( proficiency_key ) == 0 &&
+                    !proficiency_id( proficiency_key ).is_valid() ) {
+                    throw std::runtime_error( "weapon category '" + definition.id +
+                                              "' references unknown proficiency '" +
+                                              proficiency_key + "'" );
+                }
+            }
+            validate_operation( entry.operation, weapon_category_id( definition.id ).is_valid(),
+                                definition.id, "weapon category" );
+        }
+
+        std::set<std::string> item_category_ids;
+        for( const item_category_registration &entry : pimpl_->item_categories ) {
+            const item_category_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "item category" );
+            if( definition.header.empty() || definition.noun.empty() ||
+                definition.sort_rank < std::numeric_limits<int>::min() ||
+                definition.sort_rank > std::numeric_limits<int>::max() ||
+                !std::isfinite( definition.spawn_rate ) || definition.spawn_rate < 0.0 ||
+                definition.spawn_rate > std::numeric_limits<float>::max() ||
+                !item_category_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "item category '" + definition.id +
+                                          "' has invalid values or a duplicate registration" );
+            }
+            for( const item_category_priority_definition &priority : definition.priority_zones ) {
+                if( priority.zone.empty() || ( !priority.filthy && priority.flags.empty() ) ) {
+                    throw std::runtime_error( "item category '" + definition.id +
+                                              "' has an unusable priority-zone rule" );
+                }
+                for( const std::string &flag : priority.flags ) {
+                    if( json_flag_ids.count( flag ) == 0 && !flag_id( flag ).is_valid() ) {
+                        throw std::runtime_error( "item category '" + definition.id +
+                                                  "' references unknown flag '" + flag + "'" );
+                    }
+                }
+            }
+            validate_operation( entry.operation, item_category_id( definition.id ).is_valid(),
+                                definition.id, "item category" );
+        }
+
+        std::set<std::string> crafting_category_ids;
+        for( const crafting_category_registration &entry : pimpl_->crafting_categories ) {
+            const crafting_category_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "recipe category" );
+            if( definition.id.rfind( "CC_", 0 ) != 0 || definition.subcategories.empty() ||
+                !crafting_category_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "recipe category '" + definition.id +
+                                          "' requires a CC_ id, subcategories, and one registration per transaction" );
+            }
+            const std::string prefix = "CSC_" + definition.id.substr( 3 ) + "_";
+            std::set<std::string> subcategory_ids;
+            for( const std::string &subcategory : definition.subcategories ) {
+                if( ( subcategory != "CSC_ALL" && subcategory.rfind( prefix, 0 ) != 0 ) ||
+                    !subcategory_ids.insert( subcategory ).second ) {
+                    throw std::runtime_error( "recipe category '" + definition.id +
+                                              "' has an invalid or duplicate subcategory '" +
+                                              subcategory + "'" );
+                }
+            }
+            validate_operation( entry.operation,
+                                crafting_category_id( definition.id ).is_valid(),
+                                definition.id, "recipe category" );
+        }
+
+        std::set<std::string> ammunition_type_ids;
+        for( const ammunition_type_registration &entry : pimpl_->ammunition_types ) {
+            const ammunition_type_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "ammunition type" );
+            if( definition.name.empty() || !ammunition_type_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "ammunition type '" + definition.id +
+                                          "' requires a name and one registration per transaction" );
+            }
+            if( !definition.default_item.empty() && definition.default_item != "components" &&
+                definition.default_item != "thrown" &&
+                declared_item_ids.count( definition.default_item ) == 0 &&
+                !item::type_is_defined( itype_id( definition.default_item ) ) ) {
+                throw std::runtime_error( "ammunition type '" + definition.id +
+                                          "' references unknown default item '" +
+                                          definition.default_item + "'" );
+            }
+            validate_operation( entry.operation, ammotype( definition.id ).is_valid(),
+                                definition.id, "ammunition type" );
+        }
+
+        std::set<std::string> requirement_ids;
+        for( const requirement_registration &entry : pimpl_->requirements ) {
+            const requirement_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "requirement" );
+            if( ( definition.components.empty() && definition.tools.empty() &&
+                  definition.qualities.empty() ) ||
+                !requirement_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "requirement '" + definition.id +
+                                          "' must contain native requirements and be registered once per transaction" );
+            }
+            const auto validate_item_groups = [&declared_item_ids, &definition](
+            const std::vector<std::vector<component_requirement>> &groups, const char *kind ) {
+                for( const std::vector<component_requirement> &group : groups ) {
+                    if( group.empty() ) {
+                        throw std::runtime_error( "requirement '" + definition.id +
+                                                  "' has an empty alternative group" );
+                    }
+                    for( const component_requirement &component : group ) {
+                        if( declared_item_ids.count( component.id ) == 0 &&
+                            !item::type_is_defined( itype_id( component.id ) ) ) {
+                            throw std::runtime_error( "requirement '" + definition.id +
+                                                      "' references unknown " + kind + " '" +
+                                                      component.id + "'" );
+                        }
+                    }
+                }
+            };
+            validate_item_groups( definition.components, "component" );
+            validate_item_groups( definition.tools, "tool" );
+            for( const std::vector<quality_requirement_definition> &group :
+                 definition.qualities ) {
+                if( group.empty() ) {
+                    throw std::runtime_error( "requirement '" + definition.id +
+                                              "' has an empty quality alternative group" );
+                }
+                for( const quality_requirement_definition &quality : group ) {
+                    if( tool_quality_ids.count( quality.id ) == 0 &&
+                        !quality_id( quality.id ).is_valid() ) {
+                        throw std::runtime_error( "requirement '" + definition.id +
+                                                  "' references unknown quality '" +
+                                                  quality.id + "'" );
+                    }
+                }
+            }
+            validate_operation( entry.operation,
+                                requirement_data::registry().count(
+                                    requirement_id( definition.id ) ) != 0,
+                                definition.id, "requirement" );
+        }
+
+        std::set<std::string> recipe_group_ids;
+        const std::set<std::string> recipe_group_match_types = {
+            "EXACT", "TYPE", "SUBTYPE", "PREFIX", "CONTAINS"
+        };
+        for( const recipe_group_registration &entry : pimpl_->recipe_groups ) {
+            const recipe_group_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "recipe group" );
+            if( definition.building_type.empty() || definition.recipes.empty() ||
+                !recipe_group_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "recipe group '" + definition.id +
+                                          "' requires a building type, recipes, and one registration per transaction" );
+            }
+            std::set<std::string> group_recipe_ids;
+            for( const recipe_group_recipe_data &recipe_entry : definition.recipes ) {
+                if( recipe_entry.id.empty() || recipe_entry.description.empty() ||
+                    !group_recipe_ids.insert( recipe_entry.id ).second ) {
+                    throw std::runtime_error( "recipe group '" + definition.id +
+                                              "' has an invalid or duplicate recipe entry" );
+                }
+                if( declared_recipe_ids.count( recipe_entry.id ) == 0 &&
+                    !recipe_id( recipe_entry.id ).is_valid() ) {
+                    throw std::runtime_error( "recipe group '" + definition.id +
+                                              "' references unknown recipe '" +
+                                              recipe_entry.id + "'" );
+                }
+                for( const recipe_group_terrain_data &terrain : recipe_entry.terrains ) {
+                    std::string match_type = terrain.match_type;
+                    std::transform( match_type.begin(), match_type.end(), match_type.begin(),
+                    []( const unsigned char byte ) {
+                        return static_cast<char>( std::toupper( byte ) );
+                    } );
+                    if( terrain.overmap_terrain.empty() ||
+                        recipe_group_match_types.count( match_type ) == 0 ) {
+                        throw std::runtime_error( "recipe group '" + definition.id +
+                                                  "' has an invalid overmap-terrain matcher" );
+                    }
+                    for( const auto &[parameter, values] : terrain.parameters ) {
+                        if( parameter.empty() || values.empty() || values.count( "" ) != 0 ) {
+                            throw std::runtime_error( "recipe group '" + definition.id +
+                                                      "' has an invalid terrain parameter" );
+                        }
+                    }
+                }
+            }
+            validate_operation( entry.operation, detail::recipe_group_exists( definition.id ),
+                                definition.id, "recipe group" );
+        }
+
+        std::set<std::string> material_ids;
+        for( const material_registration &entry : pimpl_->materials ) {
+            const material_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "material" );
+            const auto finite = []( const double value ) {
+                return std::isfinite( value );
+            };
+            if( definition.name.empty() || definition.bash_damage_verb.empty() ||
+                definition.cut_damage_verb.empty() || definition.damage_adjectives.size() < 4 ||
+                definition.chip_resistance < 0 ||
+                definition.chip_resistance > std::numeric_limits<int>::max() ||
+                definition.breathability < 0 ||
+                definition.breathability >= static_cast<std::int64_t>( breathability_rating::last ) ||
+                definition.repair_difficulty < 0 || definition.repair_difficulty > MAX_SKILL ||
+                !finite( definition.density ) || definition.density <= 0.0 ||
+                !finite( definition.sheet_thickness ) || definition.sheet_thickness < 0.0 ||
+                !finite( definition.specific_heat_liquid ) ||
+                !finite( definition.specific_heat_solid ) ||
+                !finite( definition.latent_heat ) || !finite( definition.freezing_point ) ||
+                !material_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "material '" + definition.id +
+                                          "' has invalid values or a duplicate registration" );
+            }
+            if( definition.wind_resistance &&
+                ( *definition.wind_resistance < 0 || *definition.wind_resistance > 100 ) ) {
+                throw std::runtime_error( "material '" + definition.id +
+                                          "' wind resistance must be from zero through 100" );
+            }
+            for( const std::string &adjective : definition.damage_adjectives ) {
+                if( adjective.empty() ) {
+                    throw std::runtime_error( "material '" + definition.id +
+                                              "' has an empty damage adjective" );
+                }
+            }
+            for( const auto &[damage_id, amount] : definition.resistances ) {
+                static_cast<void>( amount );
+                if( damage_type_ids.count( damage_id ) == 0 &&
+                    !damage_type_id( damage_id ).is_valid() ) {
+                    throw std::runtime_error( "material '" + definition.id +
+                                              "' references unknown damage type '" + damage_id + "'" );
+                }
+            }
+            for( const auto &[vitamin_key, amount] : definition.vitamins ) {
+                static_cast<void>( amount );
+                if( vitamin_ids.count( vitamin_key ) == 0 && !vitamin_id( vitamin_key ).is_valid() ) {
+                    throw std::runtime_error( "material '" + definition.id +
+                                              "' references unknown vitamin '" + vitamin_key + "'" );
+                }
+            }
+            const auto item_exists = [&declared_item_ids]( const std::string &id ) {
+                return id.empty() || declared_item_ids.count( id ) != 0 ||
+                       item::type_is_defined( itype_id( id ) );
+            };
+            if( !item_exists( definition.salvaged_into ) ||
+                !item_exists( definition.repaired_with ) ) {
+                throw std::runtime_error( "material '" + definition.id +
+                                          "' references an unknown repair or salvage item" );
+            }
+            for( const auto &[product, efficiency] : definition.burn_products ) {
+                static_cast<void>( efficiency );
+                if( !item_exists( product ) ) {
+                    throw std::runtime_error( "material '" + definition.id +
+                                              "' references unknown burn product '" + product + "'" );
+                }
+            }
+            validate_operation( entry.operation, material_id( definition.id ).is_valid(),
+                                definition.id, "material" );
+        }
+
+        std::set<std::string> item_ids;
+        for( const item_registration &entry : pimpl_->items ) {
+            const item_definition_data &definition = *entry.definition;
+            if( definition.id.empty() || definition.id.find( '#' ) != std::string::npos ) {
+                throw std::runtime_error( "invalid item id '" + definition.id + "'" );
+            }
+            if( definition.name.empty() || definition.symbol.empty() ) {
+                throw std::runtime_error( "item '" + definition.id + "' requires a name and symbol" );
+            }
+            if( !item_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "item '" + definition.id + "' is registered more than once in one transaction" );
+            }
+            std::int64_t material_portions = 0;
+            std::map<std::string, std::int64_t> portions_by_material;
+            for( const material_part &material : definition.materials ) {
+                if( material_ids.count( material.id ) == 0 &&
+                    !material_id( material.id ).is_valid() ) {
+                    throw std::runtime_error( "item '" + definition.id +
+                                              "' references unknown material '" + material.id + "'" );
+                }
+                material_portions += material.portions;
+                portions_by_material[material.id] += material.portions;
+                if( material_portions > std::numeric_limits<int>::max() ||
+                    portions_by_material[material.id] > std::numeric_limits<int>::max() ) {
+                    throw std::runtime_error( "item '" + definition.id +
+                                              "' has too many material portions" );
+                }
+            }
+            for( const quality_level &quality : definition.qualities ) {
+                if( tool_quality_ids.count( quality.id ) == 0 &&
+                    !quality_id( quality.id ).is_valid() ) {
+                    throw std::runtime_error( "item '" + definition.id +
+                                              "' references unknown quality '" + quality.id + "'" );
+                }
+            }
+            for( const std::string &flag : definition.flags ) {
+                if( json_flag_ids.count( flag ) == 0 && !flag_id( flag ).is_valid() ) {
+                    throw std::runtime_error( "item '" + definition.id +
+                                              "' references unknown flag '" + flag + "'" );
+                }
+            }
+            const bool exists = item_controller->has_template( itype_id( definition.id ) );
+            if( check_engine_state && entry.operation == definition_operation::add && exists ) {
+                throw std::runtime_error( "add would overwrite existing item '" + definition.id + "'; use replace explicitly" );
+            }
+            if( check_engine_state && entry.operation == definition_operation::replace && !exists ) {
+                throw std::runtime_error( operation_name( entry.operation ) +
+                                          " requires existing item '" + definition.id + "'" );
+            }
+            if( !definition.use_handler.empty() &&
+                owner_runtime.handlers.count( definition.use_handler ) == 0 ) {
+                throw std::runtime_error( "item '" + definition.id +
+                                          "' references missing handler '" +
+                                          definition.use_handler + "'" );
+            }
+        }
+
+        std::set<std::string> recipe_ids;
+        for( const recipe_registration &entry : pimpl_->recipes ) {
+            const recipe_definition_data &definition = *entry.definition;
+            if( definition.id.empty() || definition.id.find( '#' ) != std::string::npos ) {
+                throw std::runtime_error( "recipe requires a valid non-empty id" );
+            }
+            if( !recipe_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "recipe '" + definition.id +
+                                          "' is registered more than once in one transaction" );
+            }
+            const bool exists = recipe_dict.recipes.count( recipe_id( definition.id ) ) > 0;
+            validate_operation( entry.operation, exists, definition.id,
+                                definition.nested_category ?
+                                "nested recipe category" : "recipe" );
+            if( definition.nested_category ) {
+                if( definition.name.empty() || definition.category.empty() ||
+                    definition.subcategory.empty() || definition.nested_recipes.empty() ||
+                    !std::isfinite( definition.activity_level ) ||
+                    definition.activity_level <= 0.0 ||
+                    definition.activity_level > std::numeric_limits<float>::max() ) {
+                    throw std::runtime_error( "nested recipe category '" + definition.id +
+                                              "' has invalid presentation, activity, or members" );
+                }
+                if( crafting_category_ids.count( definition.category ) == 0 &&
+                    !crafting_category_id( definition.category ).is_valid() ) {
+                    throw std::runtime_error( "nested recipe category '" + definition.id +
+                                              "' references unknown category '" +
+                                              definition.category + "'" );
+                }
+                if( check_engine_state ) {
+                    for( const std::string &member : definition.nested_recipes ) {
+                        if( declared_recipe_ids.count( member ) == 0 &&
+                            recipe_dict.recipes.count( recipe_id( member ) ) == 0 ) {
+                            throw std::runtime_error( "nested recipe category '" +
+                                                      definition.id +
+                                                      "' references unknown recipe '" +
+                                                      member + "'" );
+                        }
+                    }
+                }
+                continue;
+            }
+            if( definition.result.empty() ) {
+                throw std::runtime_error( "recipe '" + definition.id +
+                                          "' requires a non-empty result" );
+            }
+            if( definition.time_moves <= 0 || definition.difficulty < 0 ) {
+                throw std::runtime_error( "recipe '" + definition.id +
+                                          "' has invalid duration or difficulty" );
+            }
+            if( definition.difficulty > MAX_SKILL ) {
+                throw std::runtime_error( "recipe '" + definition.id +
+                                          "' difficulty exceeds the native skill range" );
+            }
+            if( crafting_category_ids.count( definition.category ) == 0 &&
+                !crafting_category_id( definition.category ).is_valid() ) {
+                throw std::runtime_error( "recipe '" + definition.id +
+                                          "' references unknown category '" +
+                                          definition.category + "'" );
+            }
+            if( !definition.skill.empty() && skill_ids.count( definition.skill ) == 0 &&
+                !skill_id( definition.skill ).is_valid() ) {
+                throw std::runtime_error( "recipe '" + definition.id +
+                                          "' references unknown skill '" + definition.skill + "'" );
+            }
+            for( const auto &[skill, level] : definition.required_skills ) {
+                if( ( skill_ids.count( skill ) == 0 && !skill_id( skill ).is_valid() ) ||
+                    level > MAX_SKILL ) {
+                    throw std::runtime_error( "recipe '" + definition.id +
+                                              "' has an invalid required skill '" + skill + "'" );
+                }
+            }
+            for( const auto &[requirement_key, multiplier] :
+                 definition.external_requirements ) {
+                static_cast<void>( multiplier );
+                if( requirement_ids.count( requirement_key ) == 0 &&
+                    requirement_data::registry().count(
+                        requirement_id( requirement_key ) ) == 0 ) {
+                    throw std::runtime_error( "recipe '" + definition.id +
+                                              "' references unknown requirement '" +
+                                              requirement_key + "'" );
+                }
+            }
+        }
+
+        const std::set<std::string> monster_phases = {
+            "null", "solid", "liquid", "gas", "plasma"
+        };
+        const std::set<std::string> monster_triggers = {
+            "STALK", "PLAYER_WEAK", "PLAYER_CLOSE", "HOSTILE_SEEN", "HURT",
+            "FIRE", "FRIEND_DIED", "FRIEND_ATTACKED", "SOUND",
+            "PLAYER_NEAR_BABY", "MATING_SEASON", "BRIGHT_LIGHT"
+        };
+        const auto native_int = []( const std::int64_t value ) {
+            return value >= std::numeric_limits<int>::min() &&
+                   value <= std::numeric_limits<int>::max();
+        };
+        for( const monster_registration &entry : pimpl_->monsters ) {
+            const monster_definition_data &definition = *entry.definition;
+            if( definition.name.empty() || definition.name.size() > 1024 ||
+                definition.plural_name.empty() || definition.plural_name.size() > 1024 ||
+                definition.description.size() > 16384 ||
+                utf8_width( definition.symbol ) != 1 ||
+                color_from_string( definition.color, report_color_error::no ) == c_unset ||
+                definition.default_faction.empty() ||
+                ( monster_faction_ids.count( definition.default_faction ) == 0 &&
+                  check_engine_state &&
+                  !mfaction_str_id( definition.default_faction ).is_valid() ) ||
+                definition.harvest.empty() ||
+                ( harvest_ids.count( definition.harvest ) == 0 && check_engine_state &&
+                  !harvest_id( definition.harvest ).is_valid() ) ||
+                ( !definition.dissect.empty() &&
+                  harvest_ids.count( definition.dissect ) == 0 && check_engine_state &&
+                  !harvest_id( definition.dissect ).is_valid() ) ||
+                ( !definition.decay.empty() &&
+                  harvest_ids.count( definition.decay ) == 0 && check_engine_state &&
+                  !harvest_id( definition.decay ).is_valid() ) ||
+                definition.speed_description.empty() ||
+                ( speed_description_ids.count( definition.speed_description ) == 0 &&
+                  check_engine_state &&
+                  !speed_description_id( definition.speed_description ).is_valid() ) ||
+                ( !definition.death_drops.empty() &&
+                  item_group_ids.count( definition.death_drops ) == 0 &&
+                  check_engine_state &&
+                  !item_group::group_is_defined( item_group_id( definition.death_drops ) ) ) ||
+                definition.volume_ml <= 0 || definition.weight_grams <= 0 ||
+                monster_phases.count( definition.phase ) == 0 ||
+                !native_int( definition.difficulty_adjustment ) || definition.hp <= 0 ||
+                !native_int( definition.hp ) || definition.speed < 0 ||
+                !native_int( definition.speed ) || definition.aggression < -100 ||
+                definition.aggression > 100 || !native_int( definition.morale ) ||
+                definition.tracking_distance < 3 ||
+                !native_int( definition.tracking_distance ) ||
+                definition.attack_cost < 0 || !native_int( definition.attack_cost ) ||
+                definition.melee_skill < 0 || !native_int( definition.melee_skill ) ||
+                definition.melee_dice < 0 || !native_int( definition.melee_dice ) ||
+                definition.melee_sides < 0 || !native_int( definition.melee_sides ) ||
+                !native_int( definition.melee_armor_penetration ) ||
+                definition.dodge < 0 || !native_int( definition.dodge ) ||
+                definition.vision_day < 0 || !native_int( definition.vision_day ) ||
+                definition.vision_night < 0 || !native_int( definition.vision_night ) ||
+                !native_int( definition.regenerates ) || definition.bleed_rate < 0 ||
+                !native_int( definition.bleed_rate ) ||
+                !finite_native_float( definition.status_chance_multiplier ) ||
+                definition.status_chance_multiplier < 0.0 ||
+                definition.status_chance_multiplier > 5.0 ||
+                !finite_native_float( definition.luminance ) || definition.luminance < 0.0 ) {
+                throw std::runtime_error( "monster '" + definition.id +
+                                          "' has invalid presentation, dependency, or stat bounds" );
+            }
+            std::int64_t material_total = 0;
+            if( definition.materials.empty() ) {
+                if( material_ids.count( "flesh" ) == 0 && check_engine_state &&
+                    !material_id( "flesh" ).is_valid() ) {
+                    throw std::runtime_error( "monster '" + definition.id +
+                                              "' needs the default flesh material" );
+                }
+            }
+            for( const auto &[material, portions] : definition.materials ) {
+                if( ( material_ids.count( material ) == 0 && check_engine_state &&
+                      !material_id( material ).is_valid() ) || portions <= 0 ||
+                    portions > std::numeric_limits<int>::max() ||
+                    material_total > std::numeric_limits<int>::max() - portions ) {
+                    throw std::runtime_error( "monster '" + definition.id +
+                                              "' has invalid material '" + material + "'" );
+                }
+                material_total += portions;
+            }
+            for( const std::string &species : definition.species ) {
+                if( species_ids.count( species ) == 0 && check_engine_state &&
+                    !species_id( species ).is_valid() ) {
+                    throw std::runtime_error( "monster '" + definition.id +
+                                              "' references unknown species '" + species + "'" );
+                }
+            }
+            for( const std::string &flag : definition.flags ) {
+                if( flag == "GEN_DORMANT" ||
+                    ( monster_flag_ids.count( flag ) == 0 && check_engine_state &&
+                      !mon_flag_str_id( flag ).is_valid() ) ) {
+                    throw std::runtime_error( "monster '" + definition.id +
+                                              "' has unsupported or unknown flag '" + flag + "'" );
+                }
+            }
+            for( const auto &[damage_id, value] : definition.armor ) {
+                if( ( damage_type_ids.count( damage_id ) == 0 &&
+                      !damage_type_id( damage_id ).is_valid() ) ||
+                    !finite_native_float( value ) || value < 0.0 ) {
+                    throw std::runtime_error( "monster '" + definition.id +
+                                              "' has invalid armor for '" + damage_id + "'" );
+                }
+            }
+            for( const auto &[damage_id, value] : definition.melee_damage ) {
+                if( ( damage_type_ids.count( damage_id ) == 0 &&
+                      !damage_type_id( damage_id ).is_valid() ) ||
+                    !finite_native_float( value.amount ) || value.amount < 0.0 ||
+                    !finite_native_float( value.armor_penetration ) ||
+                    value.armor_penetration < 0.0 ) {
+                    throw std::runtime_error( "monster '" + definition.id +
+                                              "' has invalid melee damage for '" + damage_id + "'" );
+                }
+            }
+            for( const monster_attack_reference_definition_data &attack : definition.attacks ) {
+                if( monster_attack_ids.count( attack.id ) == 0 && check_engine_state &&
+                    detail::monster_attack_registry_find( attack.id ) == nullptr ) {
+                    throw std::runtime_error( "monster '" + definition.id +
+                                              "' references unknown attack '" + attack.id + "'" );
+                }
+                if( attack.cooldown && ( !finite_native_float( *attack.cooldown ) ||
+                                         *attack.cooldown < 0.0 ||
+                                         *attack.cooldown > std::numeric_limits<int>::max() ) ) {
+                    throw std::runtime_error( "monster '" + definition.id +
+                                              "' has invalid attack cooldown for '" +
+                                              attack.id + "'" );
+                }
+            }
+            for( const std::string &set : definition.weakpoint_sets ) {
+                if( weakpoint_set_ids.count( set ) == 0 && check_engine_state &&
+                    !weakpoints_id( set ).is_valid() ) {
+                    throw std::runtime_error( "monster '" + definition.id +
+                                              "' references unknown weakpoint set '" + set + "'" );
+                }
+            }
+            for( const auto &[emission, turns] : definition.emissions ) {
+                if( ( emission_ids.count( emission ) == 0 && check_engine_state &&
+                      detail::emission_registry_find( emission ) == nullptr ) ||
+                    turns <= 0 || !native_int( turns ) ) {
+                    throw std::runtime_error( "monster '" + definition.id +
+                                              "' has invalid emission '" + emission + "'" );
+                }
+            }
+            for( const auto &[item_id, amount] : definition.starting_ammo ) {
+                if( ( declared_item_ids.count( item_id ) == 0 && check_engine_state &&
+                      !item::type_is_defined( itype_id( item_id ) ) ) ||
+                    amount <= 0 || !native_int( amount ) ) {
+                    throw std::runtime_error( "monster '" + definition.id +
+                                              "' has invalid starting ammo '" + item_id + "'" );
+                }
+            }
+            const auto validate_scents = [&]( const std::set<std::string> &scents,
+            const std::string_view label ) {
+                for( const std::string &scent : scents ) {
+                    if( scent_type_ids.count( scent ) == 0 && check_engine_state &&
+                        !scenttype_id( scent ).is_valid() ) {
+                        throw std::runtime_error( "monster '" + definition.id +
+                                                  "' references unknown " + std::string( label ) +
+                                                  " '" + scent + "'" );
+                    }
+                }
+            };
+            validate_scents( definition.tracked_scents, "tracked scent" );
+            validate_scents( definition.ignored_scents, "ignored scent" );
+            for( const auto &[effect, amount] : definition.regeneration_modifiers ) {
+                static_cast<void>( amount );
+                if( effect_type_ids.count( effect ) == 0 && check_engine_state &&
+                    !efftype_id( effect ).is_valid() ) {
+                    throw std::runtime_error( "monster '" + definition.id +
+                                              "' references unknown regeneration effect '" +
+                                              effect + "'" );
+                }
+            }
+            for( const std::string &goal : definition.goals ) {
+                if( behavior_ids.count( goal ) == 0 && check_engine_state &&
+                    !string_id<behavior::node_t>( goal ).is_valid() ) {
+                    throw std::runtime_error( "monster '" + definition.id +
+                                              "' references unknown behavior goal '" + goal + "'" );
+                }
+            }
+            const auto validate_triggers = [&]( const std::set<std::string> &triggers ) {
+                for( const std::string &trigger : triggers ) {
+                    if( monster_triggers.count( trigger ) == 0 ) {
+                        throw std::runtime_error( "monster '" + definition.id +
+                                                  "' references unknown trigger '" + trigger + "'" );
+                    }
+                }
+            };
+            validate_triggers( definition.anger_triggers );
+            validate_triggers( definition.fear_triggers );
+            validate_triggers( definition.placate_triggers );
+        }
+        error.clear();
+        return true;
+    } catch( const std::exception &exception ) {
+        error = "Lua-first Mod '" + pimpl_->owner + "': " + exception.what();
+        return false;
+    }
+}
+
+bool content_transaction::apply( std::string &error )
+{
+    if( pimpl_->applied ) {
+        error = "content transaction for '" + pimpl_->owner + "' was already applied";
+        return false;
+    }
+    try {
+        for( const json_flag_registration &entry : pimpl_->json_flags ) {
+            const flag_id id( entry.definition->id );
+            pimpl_->json_flag_undo.emplace_back(
+                id, id.is_valid() ? std::optional<json_flag>( id.obj() ) : std::nullopt );
+            const json_flag_definition_data &source = *entry.definition;
+            json_flag native;
+            native.id = id;
+            native.was_loaded = true;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.info_ = no_translation( source.info );
+            native.restriction_ = no_translation( source.restriction );
+            native.name_ = no_translation( source.name );
+            native.item_prefix_ = no_translation( source.item_prefix );
+            native.item_suffix_ = no_translation( source.item_suffix );
+            native.conflicts_ = source.conflicts;
+            native.inherit_ = source.inherit;
+            native.craft_inherit_ = source.craft_inherit;
+            native.requires_flag_ = source.requires_flag;
+            native.taste_mod_ = static_cast<int>( source.taste_modifier );
+            detail::json_flag_registry().insert( native );
+        }
+
+        for( const tool_quality_registration &entry : pimpl_->tool_qualities ) {
+            const quality_id id( entry.definition->id );
+            pimpl_->tool_quality_undo.emplace_back(
+                id, id.is_valid() ? std::optional<quality>( id.obj() ) : std::nullopt );
+
+            quality native;
+            native.id = id;
+            native.name = no_translation( entry.definition->name );
+            native.was_loaded = true;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            for( const auto &[level, text] : entry.definition->usages ) {
+                native.usages.emplace_back( static_cast<int>( level ), text );
+            }
+            detail::tool_quality_registry().insert( native );
+        }
+
+        for( const skill_display_registration &entry : pimpl_->skill_displays ) {
+            const skill_displayType_id id( entry.definition->id );
+            pimpl_->skill_display_undo.emplace_back(
+                id, id.is_valid() ? std::optional<SkillDisplayType>( id.obj() ) : std::nullopt );
+            SkillDisplayType::skillTypes.erase(
+                std::remove_if( SkillDisplayType::skillTypes.begin(),
+                                SkillDisplayType::skillTypes.end(),
+            [&id]( const SkillDisplayType & value ) {
+                return value.ident() == id;
+            } ), SkillDisplayType::skillTypes.end() );
+            SkillDisplayType::skillTypes.emplace_back(
+                id, no_translation( entry.definition->label ) );
+        }
+
+        for( const skill_registration &entry : pimpl_->skills ) {
+            const skill_id id( entry.definition->id );
+            pimpl_->skill_undo.emplace_back(
+                id, id.is_valid() ? std::optional<Skill>( id.obj() ) : std::nullopt );
+            Skill::skills.erase( std::remove_if( Skill::skills.begin(), Skill::skills.end(),
+            [&id]( const Skill & value ) {
+                return value.ident() == id;
+            } ), Skill::skills.end() );
+            Skill::contextual_skills.erase( id );
+
+            const skill_definition_data &source = *entry.definition;
+            Skill native( id, no_translation( source.name ),
+                          no_translation( source.description ), source.tags,
+                          skill_displayType_id( source.display_category ) );
+            native._sort_rank = static_cast<int>( source.sort_rank );
+            native.consumes_focus = source.consumes_focus;
+            native._teachable = source.teachable;
+            native._obsolete = source.obsolete;
+            native._time_to_attack = {
+                static_cast<int>( source.attack_min_time ),
+                static_cast<int>( source.attack_base_time ),
+                static_cast<int>( source.attack_reduction_per_level )
+            };
+            native._companion_combat_rank_factor =
+                static_cast<int>( source.companion_combat_rank_factor );
+            native._companion_survival_rank_factor =
+                static_cast<int>( source.companion_survival_rank_factor );
+            native._companion_industry_rank_factor =
+                static_cast<int>( source.companion_industry_rank_factor );
+            for( const auto &[practice_id, weight] : source.companion_practice ) {
+                native._companion_skill_practice[practice_id] = static_cast<int>( weight );
+            }
+            for( const auto &[level, description] : source.theory_descriptions ) {
+                native._level_descriptions_theory[static_cast<int>( level )] =
+                    no_translation( description );
+            }
+            for( const auto &[level, description] : source.practice_descriptions ) {
+                native._level_descriptions_practice[static_cast<int>( level )] =
+                    no_translation( description );
+            }
+            native._requires_all_traits = source.requires_all_traits;
+            native._requires_any_traits = source.requires_any_traits;
+            if( native.is_contextual_skill() ) {
+                Skill::contextual_skills[id] = std::move( native );
+            } else {
+                Skill::skills.push_back( std::move( native ) );
+            }
+        }
+
+        for( const vitamin_registration &entry : pimpl_->vitamins ) {
+            const vitamin_id id( entry.definition->id );
+            pimpl_->vitamin_undo.emplace_back(
+                id, id.is_valid() ? std::optional<vitamin>( id.obj() ) : std::nullopt );
+            const vitamin_definition_data &source = *entry.definition;
+            vitamin native;
+            native.id = id;
+            native.was_loaded = true;
+            native.name_ = no_translation( source.name );
+            if( source.type == "vitamin" ) {
+                native.type_ = vitamin_type::VITAMIN;
+            } else if( source.type == "toxin" ) {
+                native.type_ = vitamin_type::TOXIN;
+            } else if( source.type == "drug" ) {
+                native.type_ = vitamin_type::DRUG;
+            } else {
+                native.type_ = vitamin_type::COUNTER;
+            }
+            native.deficiency_ = source.deficiency.empty() ?
+                                 efftype_id::NULL_ID() : efftype_id( source.deficiency );
+            native.excess_ = source.excess.empty() ?
+                             efftype_id::NULL_ID() : efftype_id( source.excess );
+            native.min_ = static_cast<int>( source.minimum );
+            native.max_ = static_cast<int>( source.maximum );
+            native.rate_ = time_duration::from_turns( source.rate_turns );
+            if( source.weight_micrograms ) {
+                native.weight_per_unit = vitamin_units::mass(
+                                             static_cast<int>( *source.weight_micrograms ), {} );
+            }
+            for( const auto &[start, end] : source.disease ) {
+                native.disease_.emplace_back( static_cast<int>( start ), static_cast<int>( end ) );
+            }
+            for( const auto &[start, end] : source.disease_excess ) {
+                native.disease_excess_.emplace_back( static_cast<int>( start ),
+                                                     static_cast<int>( end ) );
+            }
+            for( const auto &[decay_id, rate] : source.decays_into ) {
+                native.decays_into_.emplace_back( vitamin_id( decay_id ),
+                                                  static_cast<int>( rate ) );
+            }
+            native.flags_ = source.flags;
+            detail::vitamin_registry().insert( native );
+        }
+
+        for( const damage_type_registration &entry : pimpl_->damage_types ) {
+            const damage_type_id id( entry.definition->id );
+            pimpl_->damage_type_undo.emplace_back(
+                id, id.is_valid() ? std::optional<damage_type>( id.obj() ) : std::nullopt );
+            const damage_type_definition_data &source = *entry.definition;
+            damage_type native;
+            native.id = id;
+            native.name = no_translation( source.name );
+            native.skill = source.skill.empty() ? skill_id::NULL_ID() : skill_id( source.skill );
+            native.magic_color = color_from_string( source.magic_color );
+            native.bash_conversion_factor = source.bash_conversion_factor;
+            native.melee_only = source.melee_only;
+            native.physical = source.physical;
+            native.mon_difficulty = source.monster_difficulty;
+            native.no_resist = source.no_resist;
+            native.edged = source.edged;
+            native.env = source.environmental;
+            native.material_required = source.material_required;
+            native.immune_flags = cata::flat_set<std::string>(
+                                      source.character_immune_flags.begin(),
+                                      source.character_immune_flags.end() );
+            native.mon_immune_flags = cata::flat_set<std::string>(
+                                          source.monster_immune_flags.begin(),
+                                          source.monster_immune_flags.end() );
+            if( !source.derived_from.empty() ) {
+                native.derived_from = {
+                    damage_type_id( source.derived_from ),
+                    static_cast<float>( source.derived_factor )
+                };
+            }
+            native.was_loaded = true;
+            detail::damage_type_registry().insert( native );
+        }
+
+        for( const bash_damage_profile_registration &entry :
+             pimpl_->bash_damage_profiles ) {
+            const bash_damage_profile_id id( entry.definition->id );
+            pimpl_->bash_damage_profile_undo.emplace_back(
+                id, id.is_valid() ? std::optional<bash_damage_profile>( id.obj() ) :
+                std::nullopt );
+            bash_damage_profile native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            for( const auto &[damage_id, factor] : entry.definition->factors ) {
+                native.profile[damage_type_id( damage_id )] = factor;
+            }
+            detail::bash_damage_profile_registry().insert( native );
+        }
+
+        for( const damage_info_order_registration &entry : pimpl_->damage_info_orders ) {
+            const damage_info_order_id id( entry.definition->id );
+            pimpl_->damage_info_order_undo.emplace_back(
+                id, id.is_valid() ? std::optional<damage_info_order>( id.obj() ) :
+                std::nullopt );
+            const damage_info_order_definition_data &source = *entry.definition;
+            damage_info_order native;
+            native.id = id;
+            native.dmg_type = damage_type_id( source.id );
+            native.verb = source.verb.empty() ? translation() : no_translation( source.verb );
+            native.info_display = source.display == "none" ?
+                                  damage_info_order::info_disp::NONE :
+                                  source.display == "basic" ?
+                                  damage_info_order::info_disp::BASIC :
+                                  damage_info_order::info_disp::DETAILED;
+            const auto assign_section = []( damage_info_order::damage_info_order_entry & target,
+            const damage_info_order_section_definition_data & value ) {
+                target.order = static_cast<int>( value.order );
+                target.show_type = value.show_type;
+            };
+            for( const damage_info_order_section_definition_data &value : source.sections ) {
+                if( value.section == "bionic" ) {
+                    assign_section( native.bionic_info, value );
+                } else if( value.section == "protection" ) {
+                    assign_section( native.protection_info, value );
+                } else if( value.section == "pet_protection" ) {
+                    assign_section( native.pet_prot_info, value );
+                } else if( value.section == "melee" ) {
+                    assign_section( native.melee_combat_info, value );
+                } else {
+                    assign_section( native.ablative_info, value );
+                }
+            }
+            native.was_loaded = true;
+            detail::damage_info_order_registry().insert( native );
+        }
+        if( !pimpl_->damage_info_orders.empty() ) {
+            detail::refresh_damage_info_order_registry();
+        }
+
+        for( const material_registration &entry : pimpl_->materials ) {
+            const material_id id( entry.definition->id );
+            pimpl_->material_undo.emplace_back(
+                id, id.is_valid() ? std::optional<material_type>( id.obj() ) : std::nullopt );
+            const material_definition_data &source = *entry.definition;
+            material_type native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            native._name = no_translation( source.name );
+            if( !source.salvaged_into.empty() ) {
+                native._salvaged_into = itype_id( source.salvaged_into );
+            }
+            native._repaired_with = source.repaired_with.empty() ?
+                                    itype_id::NULL_ID() : itype_id( source.repaired_with );
+            native._chip_resist = static_cast<int>( source.chip_resistance );
+            native._density = static_cast<float>( source.density );
+            native._breathability = static_cast<breathability_rating>( source.breathability );
+            native._wind_resist = source.wind_resistance ?
+                                  std::optional<int>( static_cast<int>( *source.wind_resistance ) ) :
+                                  std::nullopt;
+            native._specific_heat_liquid = static_cast<float>( source.specific_heat_liquid );
+            native._specific_heat_solid = static_cast<float>( source.specific_heat_solid );
+            native._latent_heat = static_cast<float>( source.latent_heat );
+            native._freeze_point = static_cast<float>( source.freezing_point );
+            native._rotting = source.rotting;
+            native._soft = source.soft;
+            native._uncomfortable = source.uncomfortable;
+            native._conductive = source.conductive;
+            native._sheet_thickness = static_cast<float>( source.sheet_thickness );
+            native._repair_difficulty = static_cast<int>( source.repair_difficulty );
+            native._bash_dmg_verb = no_translation( source.bash_damage_verb );
+            native._cut_dmg_verb = no_translation( source.cut_damage_verb );
+            native._dmg_adj.clear();
+            for( const std::string &adjective : source.damage_adjectives ) {
+                native._dmg_adj.push_back( no_translation( adjective ) );
+            }
+            for( const auto &[damage_id, amount] : source.resistances ) {
+                const damage_type_id damage_key( damage_id );
+                native._resistances.set_resist( damage_key, static_cast<float>( amount ) );
+                native._res_was_loaded.push_back( damage_key );
+            }
+            for( const auto &[vitamin_key, amount] : source.vitamins ) {
+                native._vitamins[vitamin_id( vitamin_key )] = amount;
+            }
+            for( const material_burn_definition &burn : source.burn_data ) {
+                native._burn_data.push_back( {
+                    burn.immune,
+                    units::from_milliliter<std::int64_t>( burn.volume_ml_per_turn ),
+                    static_cast<float>( burn.fuel ),
+                    static_cast<float>( burn.smoke ),
+                    static_cast<float>( burn.burn )
+                } );
+            }
+            if( native._burn_data.empty() ) {
+                mat_burn_data default_burn;
+                default_burn.burn = native._resistances.type_resist(
+                                        damage_type_id( "heat" ) ) <= 0.0F;
+                native._burn_data.push_back( default_burn );
+            }
+            for( const auto &[product, efficiency] : source.burn_products ) {
+                native._burn_products.emplace_back( itype_id( product ),
+                                                     static_cast<float>( efficiency ) );
+            }
+            if( source.has_fuel ) {
+                native.fuel.energy = units::from_kilojoule<std::int64_t>(
+                                         source.fuel_energy_kilojoules );
+                native.fuel.pump_terrain = source.fuel_pump_terrain;
+                native.fuel.is_perpetual_fuel = source.perpetual_fuel;
+                native.fuel.explosion_data.explosion_chance_hot =
+                    static_cast<int>( source.explosion_chance_hot );
+                native.fuel.explosion_data.explosion_chance_cold =
+                    static_cast<int>( source.explosion_chance_cold );
+                native.fuel.explosion_data.explosion_factor =
+                    static_cast<float>( source.explosion_factor );
+                native.fuel.explosion_data.fiery_explosion = source.fiery_explosion;
+                native.fuel.explosion_data.fuel_size_factor =
+                    static_cast<float>( source.fuel_size_factor );
+            }
+            detail::material_registry().insert( native );
+        }
+
+        for( const proficiency_category_registration &entry : pimpl_->proficiency_categories ) {
+            const proficiency_category_id id( entry.definition->id );
+            pimpl_->proficiency_category_undo.emplace_back(
+                id, id.is_valid() ? std::optional<proficiency_category>( id.obj() ) :
+                std::nullopt );
+            proficiency_category native;
+            native.id = id;
+            native._name = no_translation( entry.definition->name );
+            native._description = no_translation( entry.definition->description );
+            native.was_loaded = true;
+            detail::proficiency_category_registry().insert( native );
+        }
+
+        const auto proficiency_attribute = []( const std::string &attribute ) {
+            if( attribute == "strength" ) {
+                return proficiency_bonus_type::strength;
+            }
+            if( attribute == "dexterity" ) {
+                return proficiency_bonus_type::dexterity;
+            }
+            if( attribute == "intelligence" ) {
+                return proficiency_bonus_type::intelligence;
+            }
+            if( attribute == "perception" ) {
+                return proficiency_bonus_type::perception;
+            }
+            return proficiency_bonus_type::stamina;
+        };
+        for( const proficiency_registration &entry : pimpl_->proficiencies ) {
+            const proficiency_id id( entry.definition->id );
+            pimpl_->proficiency_undo.emplace_back(
+                id, id.is_valid() ? std::optional<proficiency>( id.obj() ) : std::nullopt );
+            const proficiency_definition_data &source = *entry.definition;
+            proficiency native;
+            native.id = id;
+            native._category = proficiency_category_id( source.category );
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            native._name = no_translation( source.name );
+            native._description = no_translation( source.description );
+            native._can_learn = source.can_learn;
+            native._ignore_focus = source.ignore_focus;
+            native._teachable = source.teachable;
+            native._default_time_multiplier = static_cast<float>( source.time_multiplier );
+            native._default_skill_penalty = static_cast<float>( source.skill_penalty );
+            native._default_weakpoint_bonus = static_cast<float>( source.weakpoint_bonus );
+            native._default_weakpoint_penalty = static_cast<float>( source.weakpoint_penalty );
+            native._time_to_learn = time_duration::from_turns(
+                                        static_cast<int>( source.time_to_learn_turns ) );
+            for( const std::string &required : source.required ) {
+                native._required.insert( proficiency_id( required ) );
+            }
+            for( const proficiency_bonus_definition &bonus : source.bonuses ) {
+                native._bonuses[bonus.category].push_back( {
+                    proficiency_attribute( bonus.attribute ), static_cast<float>( bonus.value )
+                } );
+            }
+            detail::proficiency_registry().insert( native );
+        }
+
+        for( const weapon_category_registration &entry : pimpl_->weapon_categories ) {
+            const weapon_category_id id( entry.definition->id );
+            pimpl_->weapon_category_undo.emplace_back(
+                id, id.is_valid() ? std::optional<weapon_category>( id.obj() ) : std::nullopt );
+            weapon_category native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            native.name_ = no_translation( entry.definition->name );
+            for( const std::string &proficiency_key : entry.definition->proficiencies ) {
+                native.proficiencies_.emplace_back( proficiency_key );
+            }
+            detail::weapon_category_registry().insert( native );
+        }
+
+        for( const item_category_registration &entry : pimpl_->item_categories ) {
+            const item_category_id id( entry.definition->id );
+            pimpl_->item_category_undo.emplace_back(
+                id, id.is_valid() ? std::optional<item_category>( id.obj() ) : std::nullopt,
+                id.is_valid() ? id.obj().get_spawn_rate() : 1.0F );
+            const item_category_definition_data &source = *entry.definition;
+            item_category native( id, no_translation( source.header ),
+                                  no_translation( source.noun ),
+                                  static_cast<int>( source.sort_rank ) );
+            native.was_loaded = true;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            if( !source.zone.empty() ) {
+                native.zone_ = zone_type_id( source.zone );
+            }
+            for( const item_category_priority_definition &priority : source.priority_zones ) {
+                zone_priority_data rule;
+                rule.was_loaded = true;
+                rule.id = zone_type_id( priority.zone );
+                rule.filthy = priority.filthy;
+                for( const std::string &flag : priority.flags ) {
+                    rule.flags.insert( flag_id( flag ) );
+                }
+                native.zone_priority_.push_back( std::move( rule ) );
+            }
+            detail::item_category_registry().insert( native );
+            id.obj().set_spawn_rate( static_cast<float>( source.spawn_rate ) );
+        }
+
+        for( const crafting_category_registration &entry : pimpl_->crafting_categories ) {
+            const crafting_category_id id( entry.definition->id );
+            pimpl_->crafting_category_undo.emplace_back(
+                id, id.is_valid() ? std::optional<crafting_category>( id.obj() ) : std::nullopt );
+            crafting_category native;
+            native.id = id;
+            native.was_loaded = true;
+            native.is_hidden = entry.definition->hidden;
+            native.is_practice = entry.definition->practice;
+            native.is_building = entry.definition->building;
+            native.is_wildcard = entry.definition->wildcard;
+            native.subcategories = entry.definition->subcategories;
+            detail::crafting_category_registry().insert( native );
+        }
+
+        for( const ammunition_type_registration &entry : pimpl_->ammunition_types ) {
+            const ammotype id( entry.definition->id );
+            const auto previous = ammunition_type::registry().find( id );
+            pimpl_->ammunition_type_undo.emplace_back(
+                id, previous == ammunition_type::registry().end() ?
+                std::optional<ammunition_type>() : std::optional<ammunition_type>( previous->second ) );
+            ammunition_type native;
+            native.name_ = no_translation( entry.definition->name );
+            native.default_ammotype_ = itype_id( entry.definition->default_item );
+            ammunition_type::registry()[id] = std::move( native );
+        }
+
+        for( const monster_flag_registration &entry : pimpl_->monster_flags ) {
+            const mon_flag_str_id id( entry.definition->id );
+            pimpl_->monster_flag_undo.emplace_back(
+                id, id.is_valid() ? std::optional<mon_flag>( id.obj() ) : std::nullopt );
+            mon_flag native;
+            native.id = id;
+            native.was_loaded = true;
+            detail::monster_flag_registry().insert( native );
+        }
+
+        for( const species_registration &entry : pimpl_->species ) {
+            const species_id id( entry.definition->id );
+            pimpl_->species_undo.emplace_back(
+                id, id.is_valid() ? std::optional<species_type>( id.obj() ) : std::nullopt );
+            const species_definition_data &source = *entry.definition;
+            species_type native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            native.description = no_translation( source.description );
+            native.footsteps = no_translation( source.footsteps );
+            native.bleeds = field_type_str_id( source.bleeds );
+            for( const std::string &flag : source.flags ) {
+                native.flags.insert( mon_flag_str_id( flag ) );
+            }
+            for( const std::string &trigger : source.anger ) {
+                native.anger.set( io::string_to_enum<mon_trigger>( trigger ) );
+            }
+            for( const std::string &trigger : source.fear ) {
+                native.fear.set( io::string_to_enum<mon_trigger>( trigger ) );
+            }
+            for( const std::string &trigger : source.placate ) {
+                native.placate.set( io::string_to_enum<mon_trigger>( trigger ) );
+            }
+            detail::species_registry().insert( native );
+        }
+        if( !pimpl_->species.empty() ) {
+            detail::species_registry().finalize();
+        }
+
+        for( const emission_registration &entry : pimpl_->emissions ) {
+            const std::string &id = entry.definition->id;
+            const emit *const previous = detail::emission_registry_find( id );
+            pimpl_->emission_undo.emplace_back(
+                id, previous == nullptr ? std::optional<emit>() :
+                std::optional<emit>( *previous ) );
+            const emission_definition_data &source = *entry.definition;
+            emit native;
+            native.id_ = emit_id( id );
+            native.native_profile_ = emit::native_profile{
+                field_type_str_id( source.field ),
+                static_cast<int>( source.intensity ),
+                static_cast<int>( source.quantity ),
+                static_cast<int>( source.chance )
+            };
+            detail::emission_registry_set( native );
+        }
+
+        for( const monster_faction_registration &entry : pimpl_->monster_factions ) {
+            const mfaction_str_id id( entry.definition->id );
+            pimpl_->monster_faction_undo.emplace_back(
+                id, id.is_valid() ? std::optional<monfaction>( id.obj() ) : std::nullopt );
+            const monster_faction_definition_data &source = *entry.definition;
+            monfaction native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            native.base_faction = mfaction_str_id( source.base );
+            for( const auto &[target, attitude] : source.attitudes ) {
+                const mfaction_str_id target_id( target );
+                if( attitude == "by_mood" ) {
+                    native._att_by_mood.insert( target_id );
+                } else if( attitude == "neutral" ) {
+                    native._att_neutral.insert( target_id );
+                } else if( attitude == "friendly" ) {
+                    native._att_friendly.insert( target_id );
+                } else {
+                    native._att_hate.insert( target_id );
+                }
+            }
+            native.rebuild_attitude_map();
+            detail::monster_faction_registry().insert( native );
+        }
+        if( !pimpl_->monster_factions.empty() ) {
+            monfactions::finalize();
+        }
+
+        for( const mutation_type_registration &entry : pimpl_->mutation_types ) {
+            const std::string &id = entry.definition->id;
+            pimpl_->mutation_type_undo.emplace_back(
+                id, detail::mutation_type_registry_contains( id ) );
+            detail::mutation_type_registry_set( id );
+        }
+
+        for( const connect_group_registration &entry : pimpl_->connect_groups ) {
+            const std::string &id = entry.definition->id;
+            const connect_group *const previous = detail::connect_group_registry_find( id );
+            pimpl_->connect_group_undo.emplace_back(
+                id, previous == nullptr ? std::optional<connect_group>() :
+                std::optional<connect_group>( *previous ) );
+            connect_group native;
+            native.id = connect_group_id( id );
+            native.index = 0;
+            detail::connect_group_registry_set( native );
+        }
+
+        for( const mutation_category_registration &entry : pimpl_->mutation_categories ) {
+            const std::string &id = entry.definition->id;
+            const mutation_category_trait *const previous =
+                detail::mutation_category_registry_find( id );
+            pimpl_->mutation_category_undo.emplace_back(
+                id, previous == nullptr ? std::optional<mutation_category_trait>() :
+                std::optional<mutation_category_trait>( *previous ) );
+            const mutation_category_definition_data &source = *entry.definition;
+            mutation_category_trait native;
+            native.id = mutation_category_id( id );
+            native.raw_name = no_translation( source.name );
+            native.raw_mutagen_message = no_translation( source.mutagen_message );
+            native.raw_memorial_message = source.memorial_message;
+            native.threshold_mut = trait_id( source.threshold_mutation );
+            native.vitamin = vitamin_id( source.vitamin );
+            native.threshold_min = static_cast<int>( source.threshold_minimum );
+            native.base_removal_chance = static_cast<int>( source.base_removal_chance );
+            native.base_removal_cost_mul =
+                static_cast<float>( source.base_removal_cost_multiplier );
+            native.wip = source.work_in_progress;
+            native.skip_test = source.skip_consistency_test;
+            detail::mutation_category_registry_set( native );
+        }
+
+        for( const construction_category_registration &entry :
+             pimpl_->construction_categories ) {
+            const construction_category_id id( entry.definition->id );
+            pimpl_->construction_category_undo.emplace_back(
+                id, id.is_valid() ? std::optional<construction_category>( id.obj() ) :
+                std::nullopt );
+            construction_category native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            native._name = no_translation( entry.definition->name );
+            detail::construction_category_registry().insert( native );
+        }
+
+        for( const construction_group_registration &entry : pimpl_->construction_groups ) {
+            const construction_group_str_id id( entry.definition->id );
+            pimpl_->construction_group_undo.emplace_back(
+                id, id.is_valid() ? std::optional<construction_group>( id.obj() ) : std::nullopt );
+            construction_group native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            native._name = no_translation( entry.definition->name );
+            detail::construction_group_registry().insert( native );
+        }
+
+        for( const vehicle_part_location_registration &entry :
+             pimpl_->vehicle_part_locations ) {
+            const vpart_location_id id( entry.definition->id );
+            pimpl_->vehicle_part_location_undo.emplace_back(
+                id, id.is_valid() ? std::optional<vpart_location>( id.obj() ) : std::nullopt );
+            vpart_location native;
+            native.id = id;
+            native.was_loaded = true;
+            native.name = no_translation( entry.definition->name );
+            native.description = no_translation( entry.definition->description );
+            native.z_order = static_cast<int>( entry.definition->z_order );
+            native.list_order = static_cast<int>( entry.definition->list_order );
+            detail::vehicle_part_location_registry().insert( native );
+        }
+
+        for( const vehicle_part_category_registration &entry :
+             pimpl_->vehicle_part_categories ) {
+            const std::string &id = entry.definition->id;
+            const vpart_category *previous =
+                detail::vehicle_part_category_registry_find( id );
+            pimpl_->vehicle_part_category_undo.emplace_back(
+                id, previous ? std::optional<vpart_category>( *previous ) : std::nullopt );
+            vpart_category native;
+            native.id_ = id;
+            native.name_ = no_translation( entry.definition->name );
+            native.short_name_ = no_translation( entry.definition->short_name );
+            native.priority_ = static_cast<int>( entry.definition->priority );
+            detail::vehicle_part_category_registry_set( native );
+        }
+        if( !pimpl_->vehicle_part_categories.empty() ) {
+            detail::vehicle_part_category_registry_finalize();
+        }
+
+        for( const mood_face_registration &entry : pimpl_->mood_faces ) {
+            const mood_face_id id( entry.definition->id );
+            pimpl_->mood_face_undo.emplace_back(
+                id, id.is_valid() ? std::optional<mood_face>( id.obj() ) : std::nullopt );
+            mood_face native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            for( const mood_face_value_definition_data &source : entry.definition->values ) {
+                mood_face_value value;
+                value.was_loaded = true;
+                value.value_ = static_cast<int>( source.score );
+                value.face_ = source.face;
+                native.values_.push_back( std::move( value ) );
+            }
+            std::sort( native.values_.begin(), native.values_.end(),
+            []( const mood_face_value &left, const mood_face_value &right ) {
+                return left.value() > right.value();
+            } );
+            detail::mood_face_registry().insert( native );
+        }
+
+        if( !pimpl_->named_colors.empty() ) {
+            pimpl_->named_color_undo = detail::named_color_registry_snapshot();
+            for( const named_color_registration &entry : pimpl_->named_colors ) {
+                const named_color_definition_data &source = *entry.definition;
+                detail::named_color_registry_set( {
+                    source.name,
+                    static_cast<std::uint8_t>( source.red ),
+                    static_cast<std::uint8_t>( source.green ),
+                    static_cast<std::uint8_t>( source.blue ),
+                    static_cast<std::uint8_t>( source.alpha )
+                } );
+            }
+        }
+
+        if( !pimpl_->rotatable_symbols.empty() ) {
+            pimpl_->rotatable_symbol_undo = detail::rotatable_symbol_registry_snapshot();
+            for( const rotatable_symbol_registration &entry : pimpl_->rotatable_symbols ) {
+                detail::rotatable_symbol_registry_set( entry.definition->symbols );
+            }
+        }
+
+        for( const ascii_art_registration &entry : pimpl_->ascii_arts ) {
+            const ascii_art_id id( entry.definition->id );
+            pimpl_->ascii_art_undo.emplace_back(
+                id, id.is_valid() ? std::optional<ascii_art>( id.obj() ) : std::nullopt );
+            ascii_art native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            native.picture = entry.definition->lines;
+            detail::ascii_art_registry().insert( native );
+        }
+
+        for( const limb_score_registration &entry : pimpl_->limb_scores ) {
+            const limb_score_id id( entry.definition->id );
+            pimpl_->limb_score_undo.emplace_back(
+                id, id.is_valid() ? std::optional<limb_score>( id.obj() ) : std::nullopt );
+            limb_score native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native._name = no_translation( entry.definition->name );
+            native.wound_affect = entry.definition->affected_by_wounds;
+            native.encumb_affect = entry.definition->affected_by_encumbrance;
+            native.was_loaded = true;
+            detail::limb_score_registry().insert( native );
+        }
+
+        if( !pimpl_->hit_ranges.empty() ) {
+            pimpl_->hit_range_undo = Creature::dispersion_for_even_chance_of_good_hit;
+            Creature::dispersion_for_even_chance_of_good_hit.clear();
+            Creature::dispersion_for_even_chance_of_good_hit.reserve(
+                pimpl_->hit_ranges.front().definition->even_good.size() );
+            for( const std::int64_t value :
+                 pimpl_->hit_ranges.front().definition->even_good ) {
+                Creature::dispersion_for_even_chance_of_good_hit.push_back(
+                    static_cast<int>( value ) );
+            }
+        }
+
+        for( const overmap_land_use_code_registration &entry :
+             pimpl_->overmap_land_use_codes ) {
+            const overmap_land_use_code_id id( entry.definition->id );
+            pimpl_->overmap_land_use_code_undo.emplace_back(
+                id, id.is_valid() ? std::optional<overmap_land_use_code>( id.obj() ) :
+                std::nullopt );
+            const overmap_land_use_code_definition_data &source = *entry.definition;
+            overmap_land_use_code native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            native.land_use_code = static_cast<int>( source.code );
+            native.name = no_translation( source.name );
+            native.detailed_definition = no_translation( source.description );
+            native.symbol = source.symbol;
+            native.color = color_from_string( source.color, report_color_error::no );
+            detail::overmap_land_use_code_registry().insert( native );
+        }
+
+        for( const overmap_vision_registration &entry : pimpl_->overmap_visions ) {
+            const oter_vision_id id( entry.definition->id );
+            pimpl_->overmap_vision_undo.emplace_back(
+                id, id.is_valid() ? std::optional<oter_vision>( id.obj() ) : std::nullopt );
+            oter_vision native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            for( const overmap_vision_level_definition_data &source :
+                 entry.definition->levels ) {
+                oter_vision::level level;
+                level.blends_adjacent = source.blends_adjacent;
+                if( !source.blends_adjacent ) {
+                    level.name = no_translation( source.name );
+                    level.symbol = source.symbol;
+                    level.color = color_from_string(
+                                      source.color, report_color_error::no );
+                    level.looks_like = source.looks_like;
+                }
+                native.levels.push_back( std::move( level ) );
+            }
+            detail::overmap_vision_registry().insert( native );
+        }
+        if( !pimpl_->overmap_visions.empty() ) {
+            detail::overmap_vision_registry().finalize();
+        }
+
+        for( const overmap_location_registration &entry : pimpl_->overmap_locations ) {
+            const overmap_location_id id( entry.definition->id );
+            pimpl_->overmap_location_undo.emplace_back(
+                id, id.is_valid() ? std::optional<overmap_location>( id.obj() ) : std::nullopt );
+            overmap_location native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            for( const std::string &terrain : entry.definition->terrains ) {
+                native.terrains.insert( oter_type_str_id( terrain ) );
+            }
+            native.flags = entry.definition->terrain_flags;
+            detail::overmap_location_registry().insert( native );
+        }
+        if( !pimpl_->overmap_locations.empty() ) {
+            detail::overmap_location_registry().finalize();
+        }
+
+        for( const profession_group_registration &entry : pimpl_->profession_groups ) {
+            const profession_group_id id( entry.definition->id );
+            pimpl_->profession_group_undo.emplace_back(
+                id, id.is_valid() ? std::optional<profession_group>( id.obj() ) : std::nullopt );
+            profession_group native;
+            native.id = id;
+            native.was_loaded = true;
+            for( const std::string &profession : entry.definition->professions ) {
+                native.profession_list.emplace_back( profession );
+            }
+            detail::profession_group_registry().insert( native );
+        }
+        if( !pimpl_->profession_groups.empty() ) {
+            detail::profession_group_registry().finalize();
+        }
+
+        for( const map_extra_collection_registration &entry : pimpl_->map_extra_collections ) {
+            const map_extra_collection_id id( entry.definition->id );
+            pimpl_->map_extra_collection_undo.emplace_back(
+                id, id.is_valid() ? std::optional<map_extra_collection>( id.obj() ) : std::nullopt );
+            map_extra_collection native;
+            native.id = id;
+            native.chance = static_cast<unsigned int>( entry.definition->chance );
+            native.was_loaded = true;
+            for( const auto &[extra, weight] : entry.definition->entries ) {
+                native.values.add( map_extra_id( extra ), static_cast<int>( weight ) );
+            }
+            detail::map_extra_collection_registry().insert( native );
+        }
+        if( !pimpl_->map_extra_collections.empty() ) {
+            detail::map_extra_collection_registry().finalize();
+        }
+
+        for( const vehicle_group_registration &entry : pimpl_->vehicle_groups ) {
+            const VehicleGroup *const previous =
+                detail::vehicle_group_registry_find( entry.definition->id );
+            pimpl_->vehicle_group_undo.emplace_back(
+                entry.definition->id,
+                previous ? std::optional<VehicleGroup>( *previous ) : std::nullopt );
+            VehicleGroup native;
+            for( const auto &[vehicle, weight] : entry.definition->entries ) {
+                native.add_vehicle( vproto_id( vehicle ), static_cast<int>( weight ) );
+            }
+            detail::vehicle_group_registry_set( entry.definition->id, native );
+        }
+
+        for( const fault_group_registration &entry : pimpl_->fault_groups ) {
+            const fault_group_id id( entry.definition->id );
+            pimpl_->fault_group_undo.emplace_back(
+                id, id.is_valid() ? std::optional<fault_group>( id.obj() ) : std::nullopt );
+            fault_group native;
+            native.id = id;
+            native.was_loaded = true;
+            for( const auto &[fault, weight] : entry.definition->entries ) {
+                native.fault_weighted_list.add( fault_id( fault ), static_cast<int>( weight ) );
+            }
+            detail::fault_group_registry().insert( native );
+        }
+        if( !pimpl_->fault_groups.empty() ) {
+            detail::fault_group_registry().finalize();
+        }
+
+        for( const explosion_light_registration &entry : pimpl_->explosion_lights ) {
+            const explosion_light_str_id id( entry.definition->id );
+            pimpl_->explosion_light_undo.emplace_back(
+                id, id.is_valid() ? std::optional<explosion_light>( id.obj() ) : std::nullopt );
+            const explosion_light_definition_data &source = *entry.definition;
+            explosion_light native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            native.stops = source.stops;
+            native.easing = *platform_vfx_easing( source.easing );
+            native.wave_travel = static_cast<float>( source.wave_travel );
+            native.wave_gap = static_cast<float>( source.wave_gap );
+            native.rise = static_cast<float>( source.rise );
+            native.fade = static_cast<float>( source.fade );
+            native.blend = static_cast<float>( source.blend );
+            native.spread_jitter = static_cast<float>( source.spread_jitter );
+            native.color_jitter = static_cast<float>( source.color_jitter );
+            native.flicker = static_cast<float>( source.flicker );
+            native.duration_base_ms = static_cast<float>( source.duration_base_ms );
+            native.duration_per_tile_ms = static_cast<float>( source.duration_per_tile_ms );
+            native.duration_min_ms = static_cast<float>( source.duration_min_ms );
+            native.duration_max_ms = static_cast<float>( source.duration_max_ms );
+            native.screen_shake_magnitude =
+                static_cast<float>( source.screen_shake_magnitude );
+            native.screen_shake_duration_ms =
+                static_cast<float>( source.screen_shake_duration_ms );
+            native.shockwave = source.shockwave;
+            native.shockwave_strength = static_cast<float>( source.shockwave_strength );
+            native.shockwave_speed = static_cast<float>( source.shockwave_speed );
+            native.shockwave_thickness = static_cast<float>( source.shockwave_thickness );
+            get_all_explosion_lights().insert( native );
+        }
+        if( !pimpl_->explosion_lights.empty() ) {
+            get_all_explosion_lights().finalize();
+        }
+
+        for( const ammo_effect_registration &entry : pimpl_->ammo_effects ) {
+            const ammo_effect_str_id id( entry.definition->id );
+            pimpl_->ammo_effect_undo.emplace_back(
+                id, id.is_valid() ? std::optional<ammo_effect>( id.obj() ) : std::nullopt );
+            const ammo_effect_definition_data &source = *entry.definition;
+            ammo_effect native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            native.trigger_chance = static_cast<int>( source.trigger_chance );
+            for( const ammo_field_definition_data &field : source.field_bursts ) {
+                aoe_field_effect value;
+                value.field_type = field_type_str_id( field.field );
+                value.intensity_min = static_cast<int>( field.intensity_min );
+                value.intensity_max = static_cast<int>( field.intensity_max );
+                value.radius = static_cast<int>( field.radius );
+                value.radius_z = static_cast<int>( field.height );
+                value.chance = static_cast<int>( field.chance );
+                value.size = static_cast<int>( field.footprint );
+                value.check_passable = field.passable_only;
+                native.aoe_field_types.push_back( std::move( value ) );
+            }
+            for( const ammo_field_definition_data &field : source.trails ) {
+                trail_field_effect value;
+                value.field_type = field_type_str_id( field.field );
+                value.intensity_min = static_cast<int>( field.intensity_min );
+                value.intensity_max = static_cast<int>( field.intensity_max );
+                value.chance = static_cast<int>( field.chance );
+                native.trail_field_types.push_back( std::move( value ) );
+            }
+            for( const ammo_character_effect_definition_data &effect :
+                 source.on_hit_effects ) {
+                on_hit_effect value;
+                value.effect = efftype_id( effect.effect );
+                value.duration = time_duration::from_turns(
+                                     static_cast<int>( effect.duration_turns ) );
+                value.intensity = static_cast<int>( effect.intensity_min );
+                value.need_touch_skin = effect.touch_skin;
+                native.on_hit_effects.push_back( std::move( value ) );
+            }
+            for( const ammo_character_effect_definition_data &effect : source.area_effects ) {
+                aoe_effect value;
+                value.effect = efftype_id( effect.effect );
+                value.duration = time_duration::from_turns(
+                                     static_cast<int>( effect.duration_turns ) );
+                value.intensity_min = static_cast<int>( effect.intensity_min );
+                value.intensity_max = static_cast<int>( effect.intensity_max );
+                value.chance = static_cast<int>( effect.chance );
+                value.radius = static_cast<int>( effect.radius );
+                value.hits_amount = { static_cast<int>( effect.hits_min ),
+                                      static_cast<int>( effect.hits_max ) };
+                value.all_bp = effect.all_body_parts;
+                native.aoe_effects.push_back( std::move( value ) );
+            }
+            if( source.has_explosion ) {
+                native.aoe_explosion_data.power = static_cast<float>( source.explosion_power );
+                native.aoe_explosion_data.distance_factor =
+                    static_cast<float>( source.explosion_distance_factor );
+                native.aoe_explosion_data.max_noise =
+                    static_cast<int>( source.explosion_max_noise );
+                native.aoe_explosion_data.fire = source.explosion_fire;
+                native.aoe_explosion_data.light_effect =
+                    explosion_light_str_id( source.explosion_light );
+                if( source.has_shrapnel ) {
+                    native.aoe_explosion_data.shrapnel = shrapnel_data(
+                            static_cast<int>( source.casing_mass ),
+                            static_cast<float>( source.fragment_mass ),
+                            static_cast<int>( source.fragment_recovery ),
+                            itype_id( source.fragment_drop ) );
+                }
+            }
+            native.do_flashbang = source.flashbang;
+            native.do_emp_blast = source.emp;
+            native.foamcrete_build = source.foamcrete;
+            native.always_cast_spell = source.cast_spells_on_miss;
+            for( const ammo_spell_definition_data &spell_source : source.spells ) {
+                fake_spell spell( spell_id( spell_source.spell ), spell_source.self );
+                spell.level = static_cast<int>( spell_source.level );
+                native.spell_data.push_back( std::move( spell ) );
+            }
+            get_all_ammo_effects().insert( native );
+        }
+        if( !pimpl_->ammo_effects.empty() ) {
+            get_all_ammo_effects().finalize();
+        }
+
+        for( const addiction_type_registration &entry : pimpl_->addiction_types ) {
+            const addiction_id id( entry.definition->id );
+            pimpl_->addiction_type_undo.emplace_back(
+                id, id.is_valid() ? std::optional<add_type>( id.obj() ) : std::nullopt );
+            const addiction_type_definition_data &source = *entry.definition;
+            add_type native;
+            native.id = id;
+            native.was_loaded = true;
+            native._name = no_translation( source.name );
+            native._type_name = no_translation( source.type_name );
+            native._desc = no_translation( source.description );
+            native._craving_morale = source.craving_morale.empty() ?
+                                     morale_type::NULL_ID() : morale_type( source.craving_morale );
+            native._effect = effect_on_condition_id::NULL_ID();
+            native._builtin.clear();
+            native._lua_policy = true;
+            detail::addiction_type_registry().insert( native );
+        }
+        if( !pimpl_->addiction_types.empty() ) {
+            detail::addiction_type_registry().finalize();
+        }
+
+        for( const character_modifier_registration &entry : pimpl_->character_modifiers ) {
+            const character_modifier_id id( entry.definition->id );
+            pimpl_->character_modifier_undo.emplace_back(
+                id, id.is_valid() ? std::optional<character_modifier>( id.obj() ) : std::nullopt );
+            const character_modifier_definition_data &source = *entry.definition;
+            character_modifier native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            native.desc = no_translation( source.description );
+            native.modtype = source.operation == "add" ? character_modifier::ADD :
+                             source.operation == "multiply" ? character_modifier::MULT :
+                             character_modifier::NONE;
+            native.builtin.clear();
+            native.limbscores.clear();
+            detail::character_modifier_registry().insert( native );
+        }
+        if( !pimpl_->character_modifiers.empty() ) {
+            detail::character_modifier_registry().finalize();
+        }
+
+        for( const start_location_registration &entry : pimpl_->start_locations ) {
+            const start_location_id id( entry.definition->id );
+            pimpl_->start_location_undo.emplace_back(
+                id, id.is_valid() ? std::optional<start_location>( id.obj() ) : std::nullopt );
+            const start_location_definition_data &source = *entry.definition;
+            start_location native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            native._name = no_translation( source.name );
+            native._flags = source.flags;
+            native.constraints_.city_size = {
+                static_cast<int>( source.city_size_min ),
+                static_cast<int>( source.city_size_max )
+            };
+            native.constraints_.city_distance = {
+                static_cast<int>( source.city_distance_min ),
+                static_cast<int>( source.city_distance_max )
+            };
+            native.constraints_.allowed_z_levels = {
+                static_cast<int>( source.z_min ), static_cast<int>( source.z_max )
+            };
+            for( const start_location_target_definition_data &target : source.targets ) {
+                omt_types_parameters value;
+                value.omt = target.terrain;
+                value.omt_type = *platform_ot_match_type( target.match );
+                value.parameters = target.parameters;
+                native._locations.push_back( std::move( value ) );
+            }
+            detail::start_location_registry().insert( native );
+        }
+        if( !pimpl_->start_locations.empty() ) {
+            detail::start_location_registry().finalize();
+        }
+
+        for( const climbing_aid_registration &entry : pimpl_->climbing_aids ) {
+            const climbing_aid_id id( entry.definition->id );
+            pimpl_->climbing_aid_undo.emplace_back(
+                id, id.is_valid() ? std::optional<climbing_aid>( id.obj() ) : std::nullopt );
+            const climbing_aid_definition_data &source = *entry.definition;
+            climbing_aid native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            native.slip_chance_mod = static_cast<int>( source.slip_chance_modifier );
+            native.base_condition.cat = *platform_climbing_category( source.category );
+            native.base_condition.flag = source.flag;
+            native.base_condition.uses_item = static_cast<int>( source.uses );
+            native.base_condition.range = static_cast<int>( source.range );
+            native.down.was_loaded = true;
+            native.down.max_height = static_cast<int>( source.max_height );
+            native.down.easy_climb_back_up = static_cast<int>( source.easy_climb_back_up );
+            native.down.allow_remaining_height = source.allow_remaining_height;
+            native.down.menu_text = no_translation( source.menu_text );
+            native.down.menu_cant = source.unavailable_text.empty() ? translation() :
+                                    no_translation( source.unavailable_text );
+            native.down.menu_hotkey = source.hotkey.empty() ? 0 :
+                                      static_cast<unsigned char>( source.hotkey.front() );
+            native.down.confirm_text = no_translation( source.confirm_text );
+            native.down.msg_before = source.before_message.empty() ? translation() :
+                                     no_translation( source.before_message );
+            native.down.msg_after = source.after_message.empty() ? translation() :
+                                    no_translation( source.after_message );
+            native.down.cost.pain = static_cast<int>( source.pain );
+            native.down.cost.damage = static_cast<int>( source.damage );
+            native.down.cost.kcal = static_cast<int>( source.kilocalories );
+            native.down.cost.thirst = static_cast<int>( source.thirst );
+            native.down.deploy_furn = furn_str_id( source.deploy_furniture );
+            detail::climbing_aid_registry().insert( native );
+        }
+        if( !pimpl_->climbing_aids.empty() ) {
+            detail::refresh_climbing_aid_registry();
+        }
+
+        for( const weather_type_registration &entry : pimpl_->weather_types ) {
+            const weather_type_id id( entry.definition->id );
+            pimpl_->weather_type_undo.emplace_back(
+                id, id.is_valid() ? std::optional<weather_type>( id.obj() ) : std::nullopt );
+            const weather_type_definition_data &source = *entry.definition;
+            weather_type native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            native.name = no_translation( source.name );
+            native.color = color_from_string( source.color, report_color_error::no );
+            native.map_color = color_from_string( source.map_color, report_color_error::no );
+            native.symbol = UTF8_getch( source.symbol );
+            native.sun_symbol = UTF8_getch( source.sun_symbol );
+            native.ranged_penalty = static_cast<int>( source.ranged_penalty );
+            native.sight_penalty = static_cast<float>( source.sight_penalty );
+            native.light_modifier = static_cast<int>( source.light_modifier );
+            native.temperature_modifier = units::from_kelvin_delta(
+                                              source.temperature_delta_kelvin );
+            native.light_multiplier = static_cast<float>( source.light_multiplier );
+            native.sun_multiplier = static_cast<float>( source.sun_multiplier );
+            native.sound_attn = static_cast<int>( source.sound_attenuation );
+            native.dangerous = source.dangerous;
+            native.precip = *platform_precipitation( source.precipitation );
+            native.rains = source.rains;
+            native.tiles_animation = source.tiles_animation;
+            native.sound_category = *platform_weather_sound_category( source.sound_category );
+            native.priority = static_cast<int>( source.priority );
+            native.duration_min = time_duration::from_turns(
+                                      static_cast<int>( source.minimum_duration_turns ) );
+            native.duration_max = time_duration::from_turns(
+                                      static_cast<int>( source.maximum_duration_turns ) );
+            if( source.has_animation ) {
+                native.weather_animation.factor = static_cast<float>( source.animation_factor );
+                native.weather_animation.color = color_from_string(
+                        source.animation_color, report_color_error::no );
+                native.weather_animation.symbol = UTF8_getch( source.animation_symbol );
+            }
+            for( const std::string &weather : source.required_weathers ) {
+                native.required_weathers.emplace_back( weather );
+            }
+            for( const weather_passive_effect_definition_data &effect_source :
+                 source.passive_effects ) {
+                field_effect effect;
+                effect.id = efftype_id( effect_source.effect );
+                effect.min_duration = time_duration::from_turns(
+                                          static_cast<int>( effect_source.minimum_duration_turns ) );
+                effect.max_duration = time_duration::from_turns(
+                                          static_cast<int>( effect_source.maximum_duration_turns ) );
+                effect.intensity = static_cast<int>( effect_source.intensity );
+                effect.bp = effect_source.body_part.empty() ?
+                            bodypart_str_id::NULL_ID() :
+                            bodypart_str_id( effect_source.body_part );
+                effect.is_environmental = effect_source.environmental;
+                effect.immune_in_vehicle = effect_source.immune_in_vehicle;
+                effect.immune_inside_vehicle = effect_source.immune_inside_vehicle;
+                effect.immune_outside_vehicle = effect_source.immune_outside_vehicle;
+                effect.chance_in_vehicle = static_cast<int>( effect_source.chance_in_vehicle );
+                effect.chance_inside_vehicle = static_cast<int>(
+                                                   effect_source.chance_inside_vehicle );
+                effect.chance_outside_vehicle = static_cast<int>(
+                                                    effect_source.chance_outside_vehicle );
+                effect.message = effect_source.message.empty() ? translation() :
+                                 no_translation( effect_source.message );
+                effect.message_npc = effect_source.npc_message.empty() ? translation() :
+                                     no_translation( effect_source.npc_message );
+                native.passive_effect.push_back( std::move( effect ) );
+            }
+            native.condition = []( const const_dialogue & ) {
+                return false;
+            };
+            native.debug_cause_eoc.reset();
+            native.debug_leave_eoc.reset();
+            detail::weather_type_registry().insert( native );
+        }
+        if( !pimpl_->weather_types.empty() ) {
+            detail::weather_type_registry().finalize();
+        }
+
+        for( const score_registration &entry : pimpl_->scores ) {
+            const score_id id( entry.definition->id );
+            pimpl_->score_undo.emplace_back(
+                id, id.is_valid() ? std::optional<score>( id.obj() ) : std::nullopt );
+            const score_definition_data &source = *entry.definition;
+            score native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            native.stat_ = event_statistic_id( source.statistic );
+            native.description_ = source.description.empty() ? translation() :
+                                  no_translation( source.description );
+            detail::score_registry().insert( native );
+        }
+        if( !pimpl_->scores.empty() ) {
+            detail::score_registry().finalize();
+        }
+
+        for( const overlay_order_registration &entry : pimpl_->overlay_orders ) {
+            for( const auto &[mutation_id, order] : entry.definition->orders ) {
+                const auto existing = base_mutation_overlay_ordering.find( mutation_id );
+                pimpl_->overlay_order_undo.emplace_back(
+                    mutation_id,
+                    existing == base_mutation_overlay_ordering.end() ? std::nullopt :
+                    std::optional<int>( existing->second ) );
+                base_mutation_overlay_ordering[mutation_id] = static_cast<int>( order );
+            }
+        }
+
+        for( const zone_type_registration &entry : pimpl_->zone_types ) {
+            const zone_type_id id( entry.definition->id );
+            pimpl_->zone_type_undo.emplace_back(
+                id, id.is_valid() ? std::optional<zone_type>( id.obj() ) : std::nullopt );
+            const zone_type_definition_data &source = *entry.definition;
+            zone_type native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            native.name_ = no_translation( source.name );
+            native.desc_ = source.description.empty() ? translation() :
+                           no_translation( source.description );
+            native.field_ = field_type_str_id( source.display_field );
+            native.can_be_personal = source.can_be_personal;
+            native.hidden = source.hidden;
+            detail::zone_type_registry().insert( native );
+        }
+        if( !pimpl_->zone_types.empty() ) {
+            detail::zone_type_registry().finalize();
+        }
+
+        for( const speech_pool_registration &entry : pimpl_->speech_pools ) {
+            const speech_pool_definition_data &source = *entry.definition;
+            const std::vector<SpeechBubble> *const previous =
+                detail::speech_registry_find( source.id );
+            pimpl_->speech_pool_undo.emplace_back(
+                source.id, previous == nullptr ? std::nullopt :
+                std::optional<std::vector<SpeechBubble>>( *previous ) );
+            std::vector<SpeechBubble> native;
+            native.reserve( source.lines.size() );
+            for( const auto &[sound, volume] : source.lines ) {
+                native.push_back( SpeechBubble{
+                    no_translation( sound ), static_cast<int>( volume )
+                } );
+            }
+            detail::speech_registry_set( source.id, std::move( native ) );
+        }
+
+        for( const end_screen_registration &entry : pimpl_->end_screens ) {
+            const end_screen_id id( entry.definition->id );
+            pimpl_->end_screen_undo.emplace_back(
+                id, id.is_valid() ? std::optional<end_screen>( id.obj() ) : std::nullopt );
+            const end_screen_definition_data &source = *entry.definition;
+            end_screen native;
+            native.id = id;
+            native.picture_id = ascii_art_id( source.picture );
+            native.priority = static_cast<int>( source.priority );
+            native.last_words_label = source.last_words_label;
+            for( const auto &[column, row, text] : source.information ) {
+                native.added_info.push_back( {
+                    { static_cast<int>( column ), static_cast<int>( row ) }, text
+                } );
+            }
+            native.condition = []( const const_dialogue & ) {
+                return false;
+            };
+            native.was_loaded = true;
+            detail::end_screen_registry().insert( native );
+        }
+        if( !pimpl_->end_screens.empty() ) {
+            detail::end_screen_registry().finalize();
+        }
+
+        for( const activity_type_registration &entry : pimpl_->activity_types ) {
+            const activity_id id( entry.definition->id );
+            pimpl_->activity_type_undo.emplace_back(
+                id, detail::activity_type_registry_get( id ) );
+            const activity_type_definition_data &source = *entry.definition;
+            activity_type native;
+            native.id_ = id;
+            native.rooted_ = source.rooted;
+            native.verb_ = no_translation( source.verb );
+            native.interruptable_ = source.interruptable;
+            native.interruptable_with_kb_ = source.interruptable_with_keyboard;
+            native.based_on_ = *platform_activity_based_on( source.based_on );
+            native.can_resume_ = source.can_resume;
+            native.multi_activity_ = source.multi_activity;
+            native.fetch_items_to_zone_ = source.fetch_items_to_zone;
+            native.refuel_fires = source.refuel_fires;
+            native.auto_needs = source.auto_needs;
+            native.activity_level = static_cast<float>( source.activity_level );
+            for( const std::string &distraction : source.ignored_distractions ) {
+                native.default_ignored_distractions_.insert(
+                    io::string_to_enum<distraction_type>( distraction ) );
+            }
+            native.completion_EOC = effect_on_condition_id();
+            native.do_turn_EOC = effect_on_condition_id();
+            native.was_loaded = true;
+            detail::activity_type_registry_set( native );
+        }
+
+        if( !pimpl_->help_topics.empty() ) {
+            pimpl_->help_undo = get_help();
+        }
+        for( const help_topic_registration &entry : pimpl_->help_topics ) {
+            const help_topic_definition_data &source = *entry.definition;
+            help &registry = get_help();
+            const auto previous = registry.platform_help_topic_orders.find( source.id );
+            if( previous != registry.platform_help_topic_orders.end() ) {
+                registry.help_texts.erase( previous->second );
+            }
+            std::vector<translation> paragraphs;
+            paragraphs.reserve( source.paragraphs.size() );
+            for( const std::string &paragraph : source.paragraphs ) {
+                paragraphs.push_back( no_translation( paragraph ) );
+            }
+            int order = 0;
+            if( source.order ) {
+                order = static_cast<int>( *source.order );
+            } else if( previous != registry.platform_help_topic_orders.end() ) {
+                order = previous->second;
+            } else if( !registry.help_texts.empty() ) {
+                if( registry.help_texts.crbegin()->first == std::numeric_limits<int>::max() ) {
+                    throw std::runtime_error(
+                        "automatic help-topic display order is exhausted" );
+                }
+                order = registry.help_texts.crbegin()->first + 1;
+            }
+            registry.help_texts[order] = std::make_pair(
+                                            no_translation( source.title ),
+                                            std::move( paragraphs ) );
+            registry.platform_help_topic_orders[source.id] = order;
+        }
+
+        if( !pimpl_->snippet_categories.empty() ) {
+            pimpl_->snippet_library_undo = SNIPPET;
+            SNIPPET.hash_to_id_migration.reset();
+        }
+        for( const snippet_category_registration &entry : pimpl_->snippet_categories ) {
+            const snippet_category_definition_data &source = *entry.definition;
+            auto previous = SNIPPET.snippets_by_category.find( source.id );
+            if( entry.operation == definition_operation::replace &&
+                previous != SNIPPET.snippets_by_category.end() ) {
+                for( const snippet_library::weighted_id &value : previous->second.ids ) {
+                    SNIPPET.snippets_by_id.erase( value.value );
+                    SNIPPET.name_by_id.erase( value.value );
+                    SNIPPET.EOC_by_id.erase( value.value );
+                }
+            }
+            snippet_library::category_snippets &category =
+                SNIPPET.snippets_by_category[source.id];
+            if( entry.operation == definition_operation::replace ) {
+                category.ids.clear();
+                category.no_id.clear();
+            }
+            for( const snippet_entry_definition_data &snippet : source.entries ) {
+                const std::uint64_t weight = static_cast<std::uint64_t>( snippet.weight );
+                if( snippet.id.empty() ) {
+                    const std::uint64_t accumulated = category.no_id.empty() ? weight :
+                                                      category.no_id.back().weight_acc + weight;
+                    category.no_id.push_back( snippet_library::weighted_translation{
+                        accumulated, no_translation( snippet.text )
+                    } );
+                } else {
+                    const snippet_id id( snippet.id );
+                    const std::uint64_t accumulated = category.ids.empty() ? weight :
+                                                      category.ids.back().weight_acc + weight;
+                    category.ids.push_back( snippet_library::weighted_id{ accumulated, id } );
+                    SNIPPET.snippets_by_id[id] = no_translation( snippet.text );
+                    SNIPPET.name_by_id[id] = snippet.name.empty() ? translation() :
+                                                  no_translation( snippet.name );
+                    // Lua-authored snippets deliberately do not populate EOC_by_id.
+                    SNIPPET.EOC_by_id.erase( id );
+                }
+            }
+        }
+
+        for( const playlist_registration &entry : pimpl_->playlists ) {
+            const playlist_definition_data &source = *entry.definition;
+            pimpl_->playlist_undo.emplace_back(
+                source.id, sfx::playlist_registry_get( source.id ) );
+            sfx::playlist_definition native;
+            native.id = source.id;
+            native.shuffle = source.shuffle;
+            for( const auto &[file, volume] : source.tracks ) {
+                native.entries.push_back( sfx::playlist_entry_definition{
+                    file, static_cast<int>( volume )
+                } );
+            }
+            sfx::playlist_registry_set( native );
+        }
+
+        for( const attack_vector_registration &entry : pimpl_->attack_vectors ) {
+            const attack_vector_id id( entry.definition->id );
+            pimpl_->attack_vector_undo.emplace_back(
+                id, id.is_valid() ? std::optional<attack_vector>( id.obj() ) : std::nullopt );
+            const attack_vector_definition_data &source = *entry.definition;
+            attack_vector native;
+            native.id = id;
+            native.weapon = source.weapon;
+            native.strict_limb_definition = source.strict_limbs;
+            native.armor_bonus = source.armor_bonus;
+            native.encumbrance_limit = static_cast<int>( source.encumbrance_limit );
+            native.bp_hp_limit = static_cast<int>( source.health_percent_limit );
+            for( const std::string &limb : source.limbs ) {
+                native.authored_limbs.emplace_back( limb );
+            }
+            for( const std::string &contact : source.contacts ) {
+                native.authored_contact_area.emplace_back( contact );
+            }
+            native.limbs = native.authored_limbs;
+            native.contact_area = native.authored_contact_area;
+            for( const auto &[kind, count] : source.limb_requirements ) {
+                native.limb_req.emplace_back( io::string_to_enum<bp_type>( kind ),
+                                              static_cast<int>( count ) );
+            }
+            for( const std::string &flag : source.required_flags ) {
+                native.required_limb_flags.insert( flag_id( flag ) );
+            }
+            for( const std::string &flag : source.forbidden_flags ) {
+                native.forbidden_limb_flags.insert( flag_id( flag ) );
+            }
+            native.was_loaded = true;
+            detail::attack_vector_registry().insert( native );
+        }
+        if( !pimpl_->attack_vectors.empty() ) {
+            detail::refresh_attack_vector_registry();
+        }
+
+        for( const magic_type_registration &entry : pimpl_->magic_types ) {
+            const magic_type_id id( entry.definition->id );
+            pimpl_->magic_type_undo.emplace_back(
+                id, id.is_valid() ? std::optional<magic_type>( id.obj() ) : std::nullopt );
+            const magic_type_definition_data &source = *entry.definition;
+            magic_type native;
+            native.id = id;
+            native.src_mod = mod_id( pimpl_->owner );
+            native.was_loaded = true;
+            native.energy_source = *platform_magic_energy_type( source.energy_source );
+            if( !source.vitamin.empty() ) {
+                native.vitamin_energy_source_ = vitamin_id( source.vitamin );
+            }
+            native.energy_color_ = color_from_string(
+                                       source.energy_color, report_color_error::no );
+            native.cannot_cast_flags = source.cannot_cast_flags;
+            native.cannot_cast_message = source.cannot_cast_message;
+            if( source.max_book_level ) {
+                native.max_book_level = static_cast<int>( *source.max_book_level );
+            }
+            native.failure_cost_percent = source.failure_cost_fraction;
+            native.failure_exp_percent = source.failure_experience_fraction;
+            detail::magic_type_registry().insert( native );
+        }
+        if( !pimpl_->magic_types.empty() ) {
+            detail::magic_type_registry().finalize();
+        }
+
+        for( const movement_mode_registration &entry : pimpl_->movement_modes ) {
+            const move_mode_id id( entry.definition->id );
+            pimpl_->movement_mode_undo.emplace_back(
+                id, id.is_valid() ? std::optional<move_mode>( id.obj() ) : std::nullopt );
+            const movement_mode_definition_data &source = *entry.definition;
+            move_mode native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            native._name = no_translation( source.name );
+            native._type = *platform_movement_mode_type( source.kind );
+            native._letter = source.character_symbol;
+            native._panel_letter = source.panel_symbol;
+            native._panel_color = color_from_string(
+                                      source.panel_color, report_color_error::no );
+            native._symbol_color = color_from_string(
+                                       source.symbol_color, report_color_error::no );
+            native._exertion_level = static_cast<float>( source.exertion );
+            native._exertion_level_animal_riding =
+                static_cast<float>( source.riding_exertion );
+            native._stamina_multiplier = static_cast<float>( source.stamina_multiplier );
+            native._sound_multiplier = static_cast<float>( source.sound_multiplier );
+            native._move_speed_mult = static_cast<float>( source.speed_multiplier );
+            native._mech_power_use = static_cast<int>( source.mech_power_kilojoules );
+            native._swim_speed_mod = static_cast<int>( source.swim_speed_modifier );
+            native._stop_hauling = source.stop_hauling;
+            for( const movement_mode_message_definition_data &messages : source.messages ) {
+                const steed_type steed = *platform_steed_type( messages.steed );
+                native.prepare_messages[steed] = no_translation( messages.prepare );
+                native.change_messages_success[steed] = no_translation( messages.success );
+                native.change_messages_fail[steed] = no_translation( messages.failure );
+            }
+            detail::movement_mode_registry().insert( native );
+        }
+        if( !pimpl_->movement_modes.empty() ) {
+            detail::refresh_movement_mode_registry();
+        }
+
+        for( const scent_type_registration &entry : pimpl_->scent_types ) {
+            const scenttype_id id( entry.definition->id );
+            pimpl_->scent_type_undo.emplace_back(
+                id, id.is_valid() ? std::optional<scent_type>( id.obj() ) : std::nullopt );
+            scent_type native;
+            native.id = id;
+            native.was_loaded = true;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            for( const std::string &species : entry.definition->receptive_species ) {
+                native.receptive_species.insert( species_id( species ) );
+            }
+            detail::scent_type_registry().insert( native );
+        }
+
+        for( const speed_description_registration &entry : pimpl_->speed_descriptions ) {
+            const speed_description_id id( entry.definition->id );
+            pimpl_->speed_description_undo.emplace_back(
+                id, id.is_valid() ? std::optional<speed_description>( id.obj() ) : std::nullopt );
+            speed_description native;
+            native.id = id;
+            native.was_loaded = true;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            for( const speed_description_value_data &source_value : entry.definition->values ) {
+                speed_description_value value;
+                value.was_loaded = true;
+                value.value_ = source_value.threshold;
+                for( const std::string &description : source_value.descriptions ) {
+                    value.descriptions_.push_back( no_translation( description ) );
+                }
+                native.values_.push_back( std::move( value ) );
+            }
+            std::sort( native.values_.begin(), native.values_.end(),
+            []( const speed_description_value & lhs, const speed_description_value & rhs ) {
+                return lhs.value() > rhs.value();
+            } );
+            detail::speed_description_registry().insert( native );
+        }
+
+        for( const item_group_registration &entry : pimpl_->item_groups ) {
+            const item_group_id id( entry.definition->id );
+            auto previous = item_controller->m_template_groups.find( id );
+            std::unique_ptr<Item_spawn_data> snapshot;
+            if( previous != item_controller->m_template_groups.end() ) {
+                snapshot = std::move( previous->second );
+            }
+            pimpl_->item_group_undo.emplace_back( id, std::move( snapshot ) );
+            const item_group_definition_data &source = *entry.definition;
+            const Item_group::Type kind = source.kind == "collection" ?
+                                          Item_group::G_COLLECTION :
+                                          Item_group::G_DISTRIBUTION;
+            auto native = std::make_unique<Item_group>(
+                              kind, 100, static_cast<int>( source.with_ammo ),
+                              static_cast<int>( source.with_magazine ),
+                              "Lua-first item group " + source.id );
+            for( const item_group_entry_definition_data &source_entry : source.entries ) {
+                if( source_entry.group ) {
+                    native->add_group_entry( item_group_id( source_entry.id ),
+                                             static_cast<int>( source_entry.probability ) );
+                } else {
+                    native->add_item_entry( itype_id( source_entry.id ),
+                                            static_cast<int>( source_entry.probability ),
+                                            source_entry.variant );
+                }
+            }
+            item_controller->m_template_groups[id] = std::move( native );
+        }
+
+        for( const harvest_drop_type_registration &entry : pimpl_->harvest_drop_types ) {
+            const harvest_drop_type_id id( entry.definition->id );
+            pimpl_->harvest_drop_type_undo.emplace_back(
+                id, id.is_valid() ? std::optional<harvest_drop_type>( id.obj() ) : std::nullopt );
+            const harvest_drop_type_definition_data &source = *entry.definition;
+            harvest_drop_type native;
+            native.id = id;
+            native.was_loaded = true;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.is_group_ = source.item_group;
+            native.dissect_only_ = source.dissect_only;
+            native.msg_fielddress_success = source.field_dress_success;
+            native.msg_fielddress_fail = source.field_dress_failure;
+            native.msg_butcher_success = source.butcher_success;
+            native.msg_butcher_fail = source.butcher_failure;
+            native.msg_dissect_success = source.dissect_success;
+            native.msg_dissect_fail = source.dissect_failure;
+            const std::vector<std::string> skills = source.skills.empty() ?
+                    std::vector<std::string>{ "survival" } : source.skills;
+            for( const std::string &skill : skills ) {
+                native.harvest_skills.emplace_back( skill );
+            }
+            detail::harvest_drop_type_registry().insert( native );
+        }
+
+        for( const harvest_registration &entry : pimpl_->harvests ) {
+            const harvest_id id( entry.definition->id );
+            pimpl_->harvest_undo.emplace_back(
+                id, id.is_valid() ? std::optional<harvest_list>( id.obj() ) : std::nullopt );
+            const harvest_definition_data &source = *entry.definition;
+            harvest_list native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            native.message_ = source.message.empty() ? translation() :
+                              no_translation( source.message );
+            native.leftovers = itype_id( source.leftovers );
+            native.butchery_requirements_ = butchery_requirements_id(
+                                                source.butchery_requirements );
+            for( const harvest_entry_definition_data &source_drop : source.entries ) {
+                harvest_entry drop;
+                drop.drop = source_drop.output;
+                drop.base_num = {
+                    static_cast<float>( source_drop.base_minimum ),
+                    static_cast<float>( source_drop.base_maximum )
+                };
+                drop.scale_num = {
+                    static_cast<float>( source_drop.skill_minimum ),
+                    static_cast<float>( source_drop.skill_maximum )
+                };
+                drop.max = static_cast<int>( source_drop.maximum );
+                drop.type = source_drop.category.empty() ?
+                            harvest_drop_type_id::NULL_ID() :
+                            harvest_drop_type_id( source_drop.category );
+                drop.mass_ratio = static_cast<float>( source_drop.mass_ratio );
+                for( const std::string &flag : source_drop.flags ) {
+                    drop.flags.emplace_back( flag );
+                }
+                for( const std::string &fault : source_drop.faults ) {
+                    drop.faults.emplace_back( fault );
+                }
+                drop.was_loaded = true;
+                native.entries_.push_back( std::move( drop ) );
+            }
+            detail::harvest_list_registry().insert( native );
+        }
+
+        for( const behavior_registration &entry : pimpl_->behaviors ) {
+            const string_id<behavior::node_t> id( entry.definition->id );
+            pimpl_->behavior_undo.emplace_back(
+                id, id.is_valid() ? std::optional<behavior::node_t>( id.obj() ) : std::nullopt );
+            const behavior_definition_data &source = *entry.definition;
+            behavior::node_t native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            if( !source.strategy.empty() ) {
+                native.set_strategy( behavior::strategy_map.at( source.strategy ) );
+            }
+            if( !source.goal.empty() ) {
+                native.set_goal( source.goal );
+            }
+            for( const std::string &child : source.children ) {
+                native.add_child_id( child );
+            }
+            for( const behavior_condition_definition_data &condition : source.conditions ) {
+                if( condition.native ) {
+                    native.add_predicate( behavior::predicate_map.at( condition.policy ),
+                                          condition.argument, condition.inverted );
+                } else {
+                    const std::string owner = pimpl_->owner;
+                    const std::string behavior_id = source.id;
+                    const std::string handler_id = condition.policy;
+                    native.add_predicate(
+                    [owner, behavior_id, handler_id]( const behavior::oracle_t *oracle,
+                            const std::string &argument ) {
+                        const Creature *subject = oracle == nullptr ? nullptr : oracle->get_subject();
+                        const std::optional<bool> result = invoke_behavior_condition_handler(
+                                owner, behavior_id, handler_id, subject, argument );
+                        return result.value_or( false ) ? behavior::status_t::running :
+                               behavior::status_t::failure;
+                    }, condition.argument, condition.inverted );
+                }
+            }
+            if( source.score ) {
+                const behavior_score_definition_data &score = *source.score;
+                if( score.native ) {
+                    native.set_score_function(
+                        behavior::score_predicate_map.at( score.policy ), score.argument );
+                } else {
+                    const std::string owner = pimpl_->owner;
+                    const std::string behavior_id = source.id;
+                    const std::string handler_id = score.policy;
+                    native.set_score_function(
+                    [owner, behavior_id, handler_id]( const behavior::oracle_t *oracle,
+                            const std::string_view argument ) {
+                        const Creature *subject = oracle == nullptr ? nullptr : oracle->get_subject();
+                        return static_cast<float>( invoke_behavior_score_handler(
+                                                       owner, behavior_id, handler_id, subject,
+                                                       argument ).value_or( 0.0 ) );
+                    }, score.argument );
+                }
+            }
+            detail::behavior_registry().insert( native );
+        }
+        if( !pimpl_->behaviors.empty() ) {
+            behavior::finalize();
+        }
+
+        for( const effect_type_registration &entry : pimpl_->effect_types ) {
+            const effect_type_definition_data &source = *entry.definition;
+            const effect_type *previous = detail::effect_type_registry_find( source.id );
+            pimpl_->effect_type_undo.emplace_back(
+                source.id, previous == nullptr ? std::optional<effect_type>() :
+                std::optional<effect_type>( *previous ) );
+            effect_type native;
+            native.id = efftype_id( source.id );
+            native.src.emplace_back( native.id, mod_id( pimpl_->owner ) );
+            for( const std::string &value : source.names ) {
+                native.name.push_back( no_translation( value ) );
+            }
+            for( const std::string &value : source.descriptions ) {
+                native.desc.push_back( no_translation( value ) );
+            }
+            if( source.reduced_descriptions.empty() ) {
+                native.reduced_desc = native.desc;
+            } else {
+                for( const std::string &value : source.reduced_descriptions ) {
+                    native.reduced_desc.push_back( no_translation( value ) );
+                }
+            }
+            native.remove_message = source.remove_message.empty() ? translation() :
+                                    no_translation( source.remove_message );
+            native.apply_memorial_log = source.apply_memorial_log;
+            native.remove_memorial_log = source.remove_memorial_log;
+            native.blood_analysis_description =
+                source.blood_analysis_description.empty() ? translation() :
+                no_translation( source.blood_analysis_description );
+            native.max_intensity = static_cast<int>( source.maximum_intensity );
+            native.max_duration = time_duration::from_turns(
+                                      static_cast<int>( source.maximum_duration_turns ) );
+            native.int_dur_factor = time_duration::from_turns(
+                                        static_cast<int>( source.intensity_duration_turns ) );
+            native.dur_add_perc = static_cast<int>( source.duration_add_percent );
+            native.int_add_val = static_cast<int>( source.intensity_add_value );
+            native.int_decay_step = static_cast<int>( source.intensity_decay_step );
+            native.int_decay_tick = static_cast<int>( source.intensity_decay_tick );
+            native.int_decay_remove = source.intensity_decay_removes;
+            native.main_parts_only = source.main_parts_only;
+            native.show_in_info = source.show_in_info;
+            native.show_intensity = source.show_intensity;
+            native.part_descs = source.part_descriptions;
+            for( const std::string &id : source.flags ) {
+                native.flags.emplace( id );
+            }
+            for( const std::string &id : source.immune_character_flags ) {
+                native.immune_flags.emplace( id );
+            }
+            for( const std::string &id : source.immune_bodypart_flags ) {
+                native.immune_bp_flags.emplace( id );
+            }
+            for( const std::string &id : source.resist_traits ) {
+                native.resist_traits.emplace_back( id );
+            }
+            for( const std::string &id : source.resist_effects ) {
+                native.resist_effects.emplace_back( id );
+            }
+            for( const std::string &id : source.removes_effects ) {
+                native.removes_effects.emplace_back( id );
+            }
+            for( const std::string &id : source.blocks_effects ) {
+                native.blocks_effects.emplace_back( id );
+            }
+            detail::effect_type_registry_set( native );
+        }
+
+        static const std::map<std::string, side> platform_body_sides = {
+            { "left", side::LEFT }, { "right", side::RIGHT }, { "both", side::BOTH }
+        };
+        for( const sub_body_part_registration &entry : pimpl_->sub_body_parts ) {
+            const sub_bodypart_str_id id( entry.definition->id );
+            pimpl_->sub_body_part_undo.emplace_back(
+                id, id.is_valid() ? std::optional<sub_body_part_type>( id.obj() ) :
+                std::nullopt );
+            const sub_body_part_definition_data &source = *entry.definition;
+            sub_body_part_type native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.opposite = sub_bodypart_str_id( source.opposite );
+            native.was_loaded = true;
+            native.name = no_translation( source.name );
+            native.name_multiple = no_translation( source.plural_name );
+            native.part_side = platform_body_sides.at( source.side );
+            native.parent = bodypart_str_id( source.parent );
+            native.secondary = source.secondary;
+            native.max_coverage = static_cast<int>( source.maximum_coverage );
+            if( source.locations_under.empty() ) {
+                native.locations_under.push_back( id );
+            } else {
+                for( const std::string &location : source.locations_under ) {
+                    native.locations_under.emplace_back( location );
+                }
+            }
+            if( !source.similar_body_part.empty() ) {
+                native.similar_bodypart = sub_bodypart_str_id( source.similar_body_part );
+            }
+            for( const auto &[damage_id, amount] : source.unarmed_damage ) {
+                native.unarmed_damage.add_damage(
+                    damage_type_id( damage_id ), static_cast<float>( amount ) );
+            }
+            detail::sub_body_part_registry().insert( native ).finalize();
+        }
+        if( !pimpl_->sub_body_parts.empty() ) {
+            detail::refresh_sub_body_part_similarity_cache();
+        }
+
+        static const std::map<std::string, bp_type> platform_body_part_types = {
+            { "head", bp_type::head }, { "torso", bp_type::torso },
+            { "sensor", bp_type::sensor }, { "mouth", bp_type::mouth },
+            { "arm", bp_type::arm }, { "hand", bp_type::hand },
+            { "leg", bp_type::leg }, { "foot", bp_type::foot },
+            { "wing", bp_type::wing }, { "tail", bp_type::tail },
+            { "other", bp_type::other }
+        };
+        for( const body_part_registration &entry : pimpl_->body_parts ) {
+            const bodypart_str_id id( entry.definition->id );
+            pimpl_->body_part_undo.emplace_back(
+                id, id.is_valid() ? std::optional<body_part_type>( id.obj() ) : std::nullopt );
+            const body_part_definition_data &source = *entry.definition;
+            body_part_type native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            native.legacy_id = "BP_NULL";
+            native.token = num_bp;
+            native.name = no_translation( source.name );
+            native.name_multiple = no_translation( source.plural_name );
+            native.accusative = no_translation( source.accusative );
+            native.accusative_multiple = no_translation( source.plural_accusative );
+            native.name_as_heading = no_translation( source.heading );
+            native.name_as_heading_multiple = no_translation( source.plural_heading );
+            native.encumb_text = no_translation( source.encumbrance_text );
+            native.hp_bar_ui_text = no_translation( source.hp_bar_text );
+            native.main_part = bodypart_str_id( source.main_part );
+            native.connected_to = bodypart_str_id( source.connected_to );
+            native.opposite_part = bodypart_str_id( source.opposite );
+            native.part_side = platform_body_sides.at( source.side );
+            native.hit_size = static_cast<float>( source.hit_size );
+            native.hit_difficulty = static_cast<float>( source.hit_difficulty );
+            native.base_hp = static_cast<int>( source.base_health );
+            native.drench_max = static_cast<int>( source.drench_capacity );
+            native.is_limb = source.limb;
+            native.is_vital = source.vital;
+            for( const std::string &sub_part : source.sub_parts ) {
+                native.sub_parts.emplace_back( sub_part );
+            }
+            double highest_weight = -1.0;
+            for( const auto &[kind, weight] : source.limb_types ) {
+                const bp_type type = platform_body_part_types.at( kind );
+                native.limbtypes[type] = static_cast<float>( weight );
+                if( weight > highest_weight ) {
+                    highest_weight = weight;
+                    native._primary_limb_type = type;
+                }
+            }
+            for( const auto &[damage_id, amount] : source.armor ) {
+                native.armor.set_resist(
+                    damage_type_id( damage_id ), static_cast<float>( amount ) );
+            }
+            for( const auto &[damage_id, amount] : source.unarmed_damage ) {
+                native.damage.add_damage(
+                    damage_type_id( damage_id ), static_cast<float>( amount ) );
+            }
+            for( const std::string &flag : source.flags ) {
+                native.flags.emplace( flag );
+            }
+            for( const auto &[score_id, score] : source.limb_scores ) {
+                native.limb_scores[limb_score_id( score_id )] = {
+                    static_cast<float>( score.score ),
+                    static_cast<float>( score.maximum )
+                };
+            }
+            for( const body_part_quality_definition_data &quality : source.qualities ) {
+                native.qualities.push_back( {
+                    quality_id( quality.id ), static_cast<int>( quality.level ),
+                    static_cast<float>( quality.disable_fraction )
+                } );
+            }
+            detail::body_part_registry().insert( native ).finalize();
+        }
+        if( !pimpl_->body_parts.empty() ) {
+            detail::refresh_body_part_similarity_cache();
+        }
+
+        for( const anatomy_registration &entry : pimpl_->anatomies ) {
+            const anatomy_id id( entry.definition->id );
+            pimpl_->anatomy_undo.emplace_back(
+                id, id.is_valid() ? std::optional<anatomy>( id.obj() ) : std::nullopt );
+            anatomy native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            for( const std::string &part : entry.definition->parts ) {
+                native.unloaded_bps.emplace_back( part );
+            }
+            detail::anatomy_registry().insert( native ).finalize();
+        }
+
+        for( const body_graph_registration &entry : pimpl_->body_graphs ) {
+            const bodygraph_id id( entry.definition->id );
+            pimpl_->body_graph_undo.emplace_back(
+                id, id.is_valid() ? std::optional<bodygraph>( id.obj() ) : std::nullopt );
+            const body_graph_definition_data &source = *entry.definition;
+            bodygraph native;
+            native.id = id;
+            native.was_loaded = true;
+            if( !source.parent_body_part.empty() ) {
+                native.parent_bp = bodypart_str_id( source.parent_body_part ).id();
+            }
+            if( !source.mirror.empty() ) {
+                native.mirror = bodygraph_id( source.mirror );
+            }
+            for( const std::string &row : source.rows ) {
+                native.rows.push_back( utf8_display_split( row ) );
+            }
+            for( const std::string &row : source.fill_rows ) {
+                native.fill_rows.push_back( utf8_display_split( row ) );
+            }
+            native.label_fill = source.label_fill;
+            native.fill_sym = source.fill_symbol;
+            native.fill_color = color_from_string(
+                                    source.fill_color, report_color_error::no );
+            for( const body_graph_part_definition_data &source_part : source.parts ) {
+                bodygraph_part part;
+                for( const std::string &body_part : source_part.body_parts ) {
+                    part.bodyparts.push_back( bodypart_str_id( body_part ).id() );
+                }
+                for( const std::string &sub_part : source_part.sub_body_parts ) {
+                    part.sub_bodyparts.push_back( sub_bodypart_str_id( sub_part ).id() );
+                }
+                part.nested_graph = source_part.nested_graph.empty() ?
+                                    bodygraph_id::NULL_ID() :
+                                    bodygraph_id( source_part.nested_graph );
+                part.sel_color = color_from_string(
+                                     source_part.selected_color, report_color_error::no );
+                part.sym = source_part.display_symbol.empty() ?
+                           native.fill_sym : source_part.display_symbol;
+                native.parts.emplace( source_part.symbol, std::move( part ) );
+            }
+            detail::bodygraph_registry().insert( native ).finalize();
+        }
+
+        for( const field_type_registration &entry : pimpl_->field_types ) {
+            const field_type_str_id id( entry.definition->id );
+            pimpl_->field_type_undo.emplace_back(
+                id, id.is_valid() ? std::optional<field_type>( id.obj() ) : std::nullopt );
+            const field_type_definition_data &source = *entry.definition;
+            field_type native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            for( const field_intensity_definition_data &source_level :
+                 source.intensity_levels ) {
+                field_intensity_level level;
+                level.name = no_translation( source_level.name );
+                level.symbol = UTF8_getch( source_level.symbol );
+                level.color = color_from_string(
+                                  source_level.color, report_color_error::no );
+                level.dangerous = source_level.dangerous;
+                level.transparent = source_level.transparent;
+                level.move_cost = static_cast<int>( source_level.move_cost );
+                level.intensity_upgrade_chance = static_cast<int>(
+                                                     source_level.upgrade_chance );
+                level.intensity_upgrade_duration = time_duration::from_turns(
+                                                       static_cast<int>( source_level.upgrade_duration_turns ) );
+                level.light_emitted = static_cast<float>( source_level.light_emitted );
+                level.local_light_override = static_cast<float>(
+                                                 source_level.local_light_override );
+                level.translucency = static_cast<float>( source_level.translucency );
+                level.concentration = static_cast<int>( source_level.concentration );
+                level.convection_temperature_mod = static_cast<int>(
+                        source_level.convection_temperature_modifier );
+                level.scent_neutralization = static_cast<int>(
+                                                 source_level.scent_neutralization );
+                for( const field_effect_definition_data &source_effect :
+                     source_level.effects ) {
+                    field_effect effect;
+                    effect.id = efftype_id( source_effect.effect );
+                    effect.src.emplace_back( effect.id, mod_id( pimpl_->owner ) );
+                    effect.min_duration = time_duration::from_turns(
+                                              static_cast<int>( source_effect.duration_min_turns ) );
+                    effect.max_duration = time_duration::from_turns(
+                                              static_cast<int>( source_effect.duration_max_turns ) );
+                    effect.intensity = static_cast<int>( source_effect.intensity );
+                    effect.bp = source_effect.body_part.empty() ?
+                                bodypart_str_id::NULL_ID() :
+                                bodypart_str_id( source_effect.body_part );
+                    effect.is_environmental = source_effect.environmental;
+                    effect.message = source_effect.message.empty() ? translation() :
+                                     no_translation( source_effect.message );
+                    effect.message_npc = source_effect.npc_message.empty() ? translation() :
+                                         no_translation( source_effect.npc_message );
+                    level.field_effects.push_back( std::move( effect ) );
+                }
+                native.intensity_levels.push_back( std::move( level ) );
+            }
+            native.underwater_age_speedup = time_duration::from_turns(
+                                                static_cast<int>( source.underwater_age_speedup_turns ) );
+            native.outdoor_age_speedup = time_duration::from_turns(
+                                             static_cast<int>( source.outdoor_age_speedup_turns ) );
+            native.decay_amount_factor = static_cast<int>( source.decay_amount_factor );
+            native.percent_spread = static_cast<int>( source.percent_spread );
+            native.gas_absorption_factor = time_duration::from_turns(
+                                               static_cast<int>( source.gas_absorption_turns ) );
+            native.priority = static_cast<int>( source.priority );
+            native.half_life = time_duration::from_turns(
+                                   static_cast<int>( source.half_life_turns ) );
+            static const std::map<std::string, phase_id> phases = {
+                { "null", phase_id::PNULL }, { "solid", phase_id::SOLID },
+                { "liquid", phase_id::LIQUID }, { "gas", phase_id::GAS },
+                { "plasma", phase_id::PLASMA }
+            };
+            static const std::map<std::string, description_affix> affixes = {
+                { "in", description_affix::DESCRIPTION_AFFIX_IN },
+                { "covered_in", description_affix::DESCRIPTION_AFFIX_COVERED_IN },
+                { "on", description_affix::DESCRIPTION_AFFIX_ON },
+                { "under", description_affix::DESCRIPTION_AFFIX_UNDER },
+                { "illuminated_by", description_affix::DESCRIPTION_AFFIX_ILLUMINATED_BY }
+            };
+            native.phase = phases.at( source.phase );
+            native.desc_affix = affixes.at( source.description_affix );
+            native.wandering_field = source.wandering_field.empty() ?
+                                     field_type_str_id::NULL_ID() :
+                                     field_type_str_id( source.wandering_field );
+            native.looks_like = source.looks_like;
+            native.is_splattering = source.splattering;
+            native.has_fire = source.has_fire;
+            native.has_acid = source.has_acid;
+            native.has_elec = source.has_electricity;
+            native.has_fume = source.has_fume;
+            native.moppable = source.moppable;
+            native.accelerated_decay = source.accelerated_decay;
+            native.display_items = source.display_items;
+            native.display_field = source.display_field;
+            native.linear_half_life = source.linear_half_life;
+            native.indestructible = source.indestructible;
+            native.mopsafe = source.mopsafe;
+            native.decrease_intensity_on_contact = source.decrease_intensity_on_contact;
+            for( const std::string &monster_id : source.immune_monsters ) {
+                native.immune_mtypes.emplace( monster_id );
+            }
+            for( const std::string &monster_id : source.blocked_monsters ) {
+                native.block_mtypes.emplace( monster_id );
+            }
+            get_all_field_types().insert( native ).finalize();
+        }
+
+        for( const monster_attack_registration &entry : pimpl_->monster_attacks ) {
+            const monster_attack_definition_data &source = *entry.definition;
+            const mtype_special_attack *previous =
+                detail::monster_attack_registry_find( source.id );
+            pimpl_->monster_attack_undo.emplace_back(
+                source.id, previous == nullptr ?
+                std::optional<mtype_special_attack>() :
+                std::optional<mtype_special_attack>( *previous ) );
+            auto actor = std::make_unique<lua_monster_attack_actor>(
+                             source.id, source.cooldown, pimpl_->owner, source.handler );
+            detail::monster_attack_registry_set(
+                mtype_special_attack( std::move( actor ) ) );
+        }
+
+        for( const weakpoint_set_registration &entry : pimpl_->weakpoint_sets ) {
+            const weakpoints_id id( entry.definition->id );
+            pimpl_->weakpoint_set_undo.emplace_back(
+                id, id.is_valid() ? std::optional<weakpoints>( id.obj() ) : std::nullopt );
+            weakpoints native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            for( const weakpoint_definition_data &source_point :
+                 entry.definition->weakpoints ) {
+                weakpoint point;
+                point.id = source_point.id;
+                point.name = source_point.name.empty() ? translation() :
+                             no_translation( source_point.name );
+                point.coverage = static_cast<float>( source_point.coverage );
+                point.is_good = source_point.good;
+                point.is_head = source_point.head;
+                const auto copy_damage_map = []( const std::map<std::string, double> &source,
+                std::unordered_map<damage_type_id, float> &target ) {
+                    for( const auto &[damage_id, value] : source ) {
+                        target[damage_type_id( damage_id )] = static_cast<float>( value );
+                    }
+                };
+                copy_damage_map( source_point.armor_multipliers, point.armor_mult );
+                copy_damage_map( source_point.armor_penalties, point.armor_penalty );
+                copy_damage_map( source_point.damage_multipliers, point.damage_mult );
+                copy_damage_map( source_point.critical_multipliers, point.crit_mult );
+                for( const weakpoint_effect_definition_data &source_effect :
+                     source_point.effects ) {
+                    weakpoint_effect effect;
+                    effect.effect = efftype_id( source_effect.effect );
+                    effect.chance = static_cast<float>( source_effect.chance );
+                    effect.permanent = source_effect.permanent;
+                    effect.duration = {
+                        time_duration::from_turns(
+                            static_cast<int>( source_effect.duration_min_turns ) ),
+                        time_duration::from_turns(
+                            static_cast<int>( source_effect.duration_max_turns ) )
+                    };
+                    effect.intensity = {
+                        static_cast<int>( source_effect.intensity_min ),
+                        static_cast<int>( source_effect.intensity_max )
+                    };
+                    effect.damage_required = {
+                        static_cast<float>( source_effect.damage_required_min ),
+                        static_cast<float>( source_effect.damage_required_max )
+                    };
+                    effect.message = source_effect.message.empty() ? translation() :
+                                     no_translation( source_effect.message );
+                    point.effects.push_back( std::move( effect ) );
+                }
+                native.weakpoint_list.push_back( std::move( point ) );
+            }
+            std::sort( native.weakpoint_list.begin(), native.weakpoint_list.end(),
+            []( const weakpoint & lhs, const weakpoint & rhs ) {
+                return lhs.coverage < rhs.coverage;
+            } );
+            detail::weakpoint_set_registry().insert( native ).finalize();
+        }
+
+        for( const morale_type_registration &entry : pimpl_->morale_types ) {
+            const morale_type id( entry.definition->id );
+            pimpl_->morale_type_undo.emplace_back(
+                id, id.is_valid() ? std::optional<morale_type_data>( id.obj() ) : std::nullopt );
+            morale_type_data native;
+            native.id = id;
+            native.was_loaded = true;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.text = no_translation( entry.definition->text );
+            native.permanent = entry.definition->permanent;
+            detail::morale_type_registry().insert( native );
+        }
+
+        for( const disease_type_registration &entry : pimpl_->disease_types ) {
+            const diseasetype_id id( entry.definition->id );
+            pimpl_->disease_type_undo.emplace_back(
+                id, id.is_valid() ? std::optional<disease_type>( id.obj() ) : std::nullopt );
+            const disease_type_definition_data &source = *entry.definition;
+            disease_type native;
+            native.id = id;
+            native.was_loaded = true;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.min_duration = time_duration::from_turns(
+                                      static_cast<int>( source.minimum_duration_turns ) );
+            native.max_duration = time_duration::from_turns(
+                                      static_cast<int>( source.maximum_duration_turns ) );
+            native.min_intensity = static_cast<int>( source.minimum_intensity );
+            native.max_intensity = static_cast<int>( source.maximum_intensity );
+            native.symptoms = efftype_id( source.symptoms );
+            if( source.health_threshold ) {
+                native.health_threshold = static_cast<int>( *source.health_threshold );
+            }
+            for( const std::string &body_part : source.affected_body_parts ) {
+                native.affected_bodyparts.insert( bodypart_str_id( body_part ) );
+            }
+            detail::disease_type_registry().insert( native );
+        }
+
+        for( const requirement_registration &entry : pimpl_->requirements ) {
+            const requirement_id id( entry.definition->id );
+            const auto previous = requirement_data::registry().find( id );
+            pimpl_->requirement_undo.emplace_back(
+                id, previous == requirement_data::registry().end() ?
+                std::optional<requirement_data>() :
+                std::optional<requirement_data>( previous->second ) );
+            const requirement_definition_data &source = *entry.definition;
+            requirement_data::alter_item_comp_vector components;
+            for( const std::vector<component_requirement> &source_group : source.components ) {
+                std::vector<item_comp> group;
+                for( const component_requirement &component : source_group ) {
+                    group.emplace_back( itype_id( component.id ),
+                                        static_cast<int>( component.count ) );
+                }
+                components.push_back( std::move( group ) );
+            }
+            requirement_data::alter_tool_comp_vector tools;
+            for( const std::vector<component_requirement> &source_group : source.tools ) {
+                std::vector<tool_comp> group;
+                for( const component_requirement &tool : source_group ) {
+                    group.emplace_back( itype_id( tool.id ), static_cast<int>( tool.count ) );
+                }
+                tools.push_back( std::move( group ) );
+            }
+            requirement_data::alter_quali_req_vector qualities;
+            for( const std::vector<quality_requirement_definition> &source_group :
+                 source.qualities ) {
+                std::vector<quality_requirement> group;
+                for( const quality_requirement_definition &quality : source_group ) {
+                    group.emplace_back( quality_id( quality.id ),
+                                        static_cast<int>( quality.count ),
+                                        static_cast<int>( quality.level ) );
+                }
+                qualities.push_back( std::move( group ) );
+            }
+            requirement_data native( tools, qualities, components );
+            native.id_ = id;
+            native.name_ = no_translation( source.name );
+            requirement_data::registry()[id] = std::move( native );
+        }
+
+        for( const recipe_group_registration &entry : pimpl_->recipe_groups ) {
+            pimpl_->recipe_group_undo.emplace_back(
+                entry.definition->id, detail::recipe_group_get( entry.definition->id ) );
+            detail::recipe_group_native_definition native;
+            native.id = entry.definition->id;
+            native.building_type = entry.definition->building_type;
+            native.sources.emplace_back( native.id, mod_id( pimpl_->owner ) );
+            for( const recipe_group_recipe_data &recipe_entry : entry.definition->recipes ) {
+                detail::recipe_group_recipe_definition native_recipe;
+                native_recipe.id = recipe_entry.id;
+                native_recipe.description = no_translation( recipe_entry.description );
+                for( const recipe_group_terrain_data &terrain : recipe_entry.terrains ) {
+                    detail::recipe_group_terrain_definition native_terrain;
+                    native_terrain.overmap_terrain = terrain.overmap_terrain;
+                    native_terrain.match_type = terrain.match_type;
+                    native_terrain.parameters = terrain.parameters;
+                    native_recipe.overmap_terrains.push_back( std::move( native_terrain ) );
+                }
+                native.recipes.push_back( std::move( native_recipe ) );
+            }
+            detail::recipe_group_set( native );
+        }
+
+        for( const item_registration &entry : pimpl_->items ) {
+            const itype_id id( entry.definition->id );
+            const auto previous = item_controller->m_runtimes.find( id );
+            pimpl_->item_undo.emplace_back(
+                id, previous == item_controller->m_runtimes.end() ?
+                std::optional<itype>() : std::optional<itype>( *previous->second ) );
+
+            auto native = std::make_unique<itype>();
+            native->id = id;
+            native->name = no_translation( entry.definition->name );
+            native->description = no_translation( entry.definition->description );
+            native->sym = entry.definition->symbol;
+            native->weight = units::from_gram<std::int64_t>( entry.definition->mass_grams );
+            native->volume = units::from_milliliter<std::int64_t>( entry.definition->volume_ml );
+            native->price = units::from_cent<std::int64_t>( entry.definition->price_cents );
+            native->was_loaded = true;
+            native->src.emplace_back( id, mod_id( pimpl_->owner ) );
+            for( const material_part &material : entry.definition->materials ) {
+                const material_id material_key( material.id );
+                native->materials[material_key] += static_cast<int>( material.portions );
+                native->mat_portion_total += static_cast<int>( material.portions );
+                if( native->default_mat.is_null() ) {
+                    native->default_mat = material_key;
+                }
+            }
+            for( const quality_level &quality : entry.definition->qualities ) {
+                native->qualities[quality_id( quality.id )] = {
+                    static_cast<int>( quality.level ), 1.0F
+                };
+            }
+            for( const std::string &flag : entry.definition->flags ) {
+                native->item_tags.insert( flag_id( flag ) );
+            }
+            if( !entry.definition->use_handler.empty() ) {
+                const std::string action_id = "lua_platform:" + pimpl_->owner + ":" +
+                                              entry.definition->use_handler;
+                native->use_methods.emplace(
+                    action_id,
+                    use_function( std::make_unique<lua_platform_iuse_actor>(
+                                      pimpl_->owner, entry.definition->use_handler,
+                                      entry.definition->use_label ) ) );
+            }
+            item_controller->m_runtimes[id] = std::move( native );
+            item_controller->m_runtimes_dirty = true;
+            item_controller->templates_all_cache.clear();
+            item_controller->armor_containers.clear();
+        }
+
+        for( const clothing_mod_registration &entry : pimpl_->clothing_mods ) {
+            const clothing_mod_id id( entry.definition->id );
+            pimpl_->clothing_mod_undo.emplace_back(
+                id, id.is_valid() ? std::optional<clothing_mod>( id.obj() ) : std::nullopt );
+            const clothing_mod_definition_data &source = *entry.definition;
+            clothing_mod native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            native.flag = flag_id( source.flag );
+            native.item_string = itype_id( source.material_item );
+            native.implement_prompt = no_translation( source.apply_prompt );
+            native.destroy_prompt = no_translation( source.remove_prompt );
+            native.restricted = source.restricted;
+            for( const clothing_modifier_definition_data &source_modifier : source.modifiers ) {
+                mod_value modifier;
+                modifier.type = io::string_to_enum<clothing_mod_type>( source_modifier.stat );
+                modifier.value = static_cast<float>( source_modifier.amount );
+                modifier.round_up = source_modifier.round_up;
+                modifier.thickness_proportion = source_modifier.per_thickness;
+                modifier.coverage_proportion = source_modifier.per_coverage;
+                native.mod_values.push_back( modifier );
+            }
+            detail::clothing_mod_registry().insert( native );
+        }
+        if( !pimpl_->clothing_mods.empty() ) {
+            detail::refresh_clothing_mod_registry_cache();
+        }
+
+        for( const recipe_registration &entry : pimpl_->recipes ) {
+            const recipe_id id( entry.definition->id );
+            const auto previous = recipe_dict.recipes.find( id );
+            pimpl_->recipe_undo.emplace_back(
+                id, previous == recipe_dict.recipes.end() ?
+                std::optional<recipe>() : std::optional<recipe>( previous->second ) );
+
+            recipe native;
+            native.id = id;
+            if( entry.definition->nested_category ) {
+                native.name_ = no_translation( entry.definition->name );
+                native.description = entry.definition->description.empty() ? translation() :
+                                     no_translation( entry.definition->description );
+                native.category = crafting_category_id( entry.definition->category );
+                native.subcategory = entry.definition->subcategory;
+                native.exertion = static_cast<float>( entry.definition->activity_level );
+                for( const std::string &member : entry.definition->nested_recipes ) {
+                    native.nested_category_data.emplace( member );
+                }
+                native.was_loaded = true;
+                native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+                recipe_dict.recipes[id] = std::move( native );
+                continue;
+            }
+            native.result_ = itype_id( entry.definition->result );
+            native.time = entry.definition->time_moves;
+            native.category = crafting_category_id( entry.definition->category );
+            native.subcategory = entry.definition->subcategory;
+            native.difficulty = static_cast<int>( entry.definition->difficulty );
+            native.skill_used = entry.definition->skill.empty() ?
+                                skill_id::NULL_ID() : skill_id( entry.definition->skill );
+            native.autolearn = entry.definition->autolearn;
+            native.reversible = entry.definition->reversible;
+            native.was_loaded = true;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            for( const auto &[skill, level] : entry.definition->required_skills ) {
+                native.required_skills[skill_id( skill )] = static_cast<int>( level );
+            }
+            requirement_data::alter_item_comp_vector components;
+            for( const std::vector<component_requirement> &group : entry.definition->components ) {
+                std::vector<item_comp> alternatives;
+                for( const component_requirement &component : group ) {
+                    alternatives.emplace_back( itype_id( component.id ),
+                                               static_cast<int>( component.count ) );
+                }
+                components.push_back( std::move( alternatives ) );
+            }
+            requirement_data::alter_tool_comp_vector tools;
+            for( const std::vector<component_requirement> &group : entry.definition->tools ) {
+                std::vector<tool_comp> alternatives;
+                for( const component_requirement &tool : group ) {
+                    alternatives.emplace_back( itype_id( tool.id ),
+                                               static_cast<int>( tool.count ) );
+                }
+                tools.push_back( std::move( alternatives ) );
+            }
+            native.requirements_ = requirement_data( tools, {}, components );
+            if( !entry.definition->external_requirements.empty() ) {
+                std::map<requirement_id, int> external;
+                for( const auto &[requirement_key, multiplier] :
+                     entry.definition->external_requirements ) {
+                    external[requirement_id( requirement_key )] =
+                        static_cast<int>( multiplier );
+                }
+                native.requirements_ = native.requirements_ + requirement_data( external );
+            }
+            native.root_requirements_ = native.requirements_;
+            recipe_dict.recipes[id] = std::move( native );
+        }
+
+        static const std::map<std::string, phase_id> monster_phases = {
+            { "null", phase_id::PNULL }, { "solid", phase_id::SOLID },
+            { "liquid", phase_id::LIQUID }, { "gas", phase_id::GAS },
+            { "plasma", phase_id::PLASMA }
+        };
+        static const std::map<std::string, mon_trigger> monster_triggers = {
+            { "STALK", mon_trigger::STALK },
+            { "PLAYER_WEAK", mon_trigger::HOSTILE_WEAK },
+            { "PLAYER_CLOSE", mon_trigger::HOSTILE_CLOSE },
+            { "HOSTILE_SEEN", mon_trigger::HOSTILE_SEEN },
+            { "HURT", mon_trigger::HURT }, { "FIRE", mon_trigger::FIRE },
+            { "FRIEND_DIED", mon_trigger::FRIEND_DIED },
+            { "FRIEND_ATTACKED", mon_trigger::FRIEND_ATTACKED },
+            { "SOUND", mon_trigger::SOUND },
+            { "PLAYER_NEAR_BABY", mon_trigger::PLAYER_NEAR_BABY },
+            { "MATING_SEASON", mon_trigger::MATING_SEASON },
+            { "BRIGHT_LIGHT", mon_trigger::BRIGHT_LIGHT }
+        };
+        for( const monster_registration &entry : pimpl_->monsters ) {
+            const mtype_id id( entry.definition->id );
+            pimpl_->monster_undo.emplace_back(
+                id, id.is_valid() ? std::optional<mtype>( id.obj() ) : std::nullopt );
+            const monster_definition_data &source = *entry.definition;
+            mtype native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            native.name = pl_translation( source.name, source.plural_name );
+            native.description = source.description.empty() ? translation() :
+                                 no_translation( source.description );
+            native.sym = source.symbol;
+            native.color = color_from_string( source.color, report_color_error::no );
+            native.looks_like = source.looks_like;
+            native.bodytype = source.body_type;
+            native.default_faction = mfaction_str_id( source.default_faction );
+            native.harvest = harvest_id( source.harvest );
+            native.dissect = source.dissect.empty() ? harvest_id::NULL_ID() :
+                             harvest_id( source.dissect );
+            native.decay = source.decay.empty() ? harvest_id::NULL_ID() :
+                           harvest_id( source.decay );
+            native.speed_desc = speed_description_id( source.speed_description );
+            native.death_drops = source.death_drops.empty() ? item_group_id::NULL_ID() :
+                                 item_group_id( source.death_drops );
+            native.volume = units::from_milliliter<std::int64_t>( source.volume_ml );
+            native.weight = units::from_gram<std::int64_t>( source.weight_grams );
+            native.phase = monster_phases.at( source.phase );
+            native.difficulty_adjustment = static_cast<int>( source.difficulty_adjustment );
+            native.hp = static_cast<int>( source.hp );
+            native.speed = static_cast<int>( source.speed );
+            native.agro = static_cast<int>( source.aggression );
+            native.morale = static_cast<int>( source.morale );
+            native.tracking_distance = static_cast<int>( source.tracking_distance );
+            native.attack_cost = static_cast<int>( source.attack_cost );
+            native.melee_skill = static_cast<int>( source.melee_skill );
+            native.melee_dice = static_cast<int>( source.melee_dice );
+            native.melee_sides = static_cast<int>( source.melee_sides );
+            native.melee_dice_ap = static_cast<int>( source.melee_armor_penetration );
+            native.sk_dodge = static_cast<int>( source.dodge );
+            native.vision_day = static_cast<int>( source.vision_day );
+            native.vision_night = static_cast<int>( source.vision_night );
+            native.regenerates = static_cast<int>( source.regenerates );
+            native.bleed_rate = static_cast<int>( source.bleed_rate );
+            native.status_chance_multiplier = static_cast<float>(
+                                                  source.status_chance_multiplier );
+            native.luminance = static_cast<float>( source.luminance );
+            native.regenerates_in_dark = source.regenerates_in_dark;
+            native.regen_morale = source.regenerates_morale;
+            native.aggro_character = source.aggressive_to_characters;
+            native.sp_defense = &mdefense::none;
+
+            native.mat.clear();
+            native.mat_portion_total = 0;
+            if( source.materials.empty() ) {
+                native.mat.emplace( material_id( "flesh" ), 1 );
+                native.mat_portion_total = 1;
+            } else {
+                for( const auto &[material, portions] : source.materials ) {
+                    native.mat.emplace( material_id( material ), static_cast<int>( portions ) );
+                    native.mat_portion_total += static_cast<int>( portions );
+                }
+            }
+            for( const std::string &species : source.species ) {
+                native.species.emplace( species );
+            }
+            native.categories = source.categories;
+            native.pre_flags_.clear();
+            for( const std::string &flag : source.flags ) {
+                native.pre_flags_.emplace( flag );
+            }
+            for( const auto &[damage_id, value] : source.armor ) {
+                native.armor.set_resist(
+                    damage_type_id( damage_id ), static_cast<float>( value ) );
+            }
+            for( const auto &[damage_id, value] : source.melee_damage ) {
+                native.melee_damage.add_damage(
+                    damage_type_id( damage_id ), static_cast<float>( value.amount ),
+                    static_cast<float>( value.armor_penetration ) );
+            }
+            for( const monster_attack_reference_definition_data &source_attack :
+                 source.attacks ) {
+                const mtype_special_attack *prototype =
+                    detail::monster_attack_registry_find( source_attack.id );
+                std::unique_ptr<mattack_actor> actor = prototype->get()->clone();
+                if( source_attack.cooldown ) {
+                    actor->cooldown = *source_attack.cooldown;
+                }
+                native.special_attacks.emplace(
+                    source_attack.id, mtype_special_attack( std::move( actor ) ) );
+                native.special_attacks_names.push_back( source_attack.id );
+            }
+            for( const std::string &set : source.weakpoint_sets ) {
+                native.weakpoints_deferred.emplace_back( set );
+            }
+            for( const auto &[emission, interval_turns] : source.emissions ) {
+                native.emit_fields.emplace(
+                    emit_id( emission ), time_duration::from_turns(
+                        static_cast<int>( interval_turns ) ) );
+            }
+            for( const auto &[item_id, amount] : source.starting_ammo ) {
+                native.starting_ammo.emplace(
+                    itype_id( item_id ), static_cast<int>( amount ) );
+            }
+            for( const std::string &scent : source.tracked_scents ) {
+                native.scents_tracked.emplace( scent );
+            }
+            for( const std::string &scent : source.ignored_scents ) {
+                native.scents_ignored.emplace( scent );
+            }
+            for( const auto &[effect, amount] : source.regeneration_modifiers ) {
+                native.regeneration_modifiers.emplace(
+                    efftype_id( effect ), static_cast<int>( amount ) );
+            }
+            for( const std::string &goal : source.goals ) {
+                native.add_goal( goal );
+            }
+            for( const std::string &trigger : source.anger_triggers ) {
+                native.anger.set( monster_triggers.at( trigger ) );
+            }
+            for( const std::string &trigger : source.fear_triggers ) {
+                native.fear.set( monster_triggers.at( trigger ) );
+            }
+            for( const std::string &trigger : source.placate_triggers ) {
+                native.placate.set( monster_triggers.at( trigger ) );
+            }
+            mtype &inserted = detail::monster_type_registry().insert( native );
+            MonsterGenerator::generator().finalize_lua_first_mtype( inserted );
+        }
+        if( !pimpl_->monsters.empty() ) {
+            MonsterGenerator::generator().refresh_hallucination_monsters();
+        }
+
+        pimpl_->applied = true;
+        error.clear();
+        return true;
+    } catch( const std::exception &exception ) {
+        rollback();
+        error = "Lua-first Mod '" + pimpl_->owner + "': " + exception.what();
+        return false;
+    }
+}
+
+bool content_transaction::validate_finalized( std::string &error ) const
+{
+    if( !pimpl_->applied ) {
+        error = "content transaction for '" + pimpl_->owner + "' is not applied";
+        return false;
+    }
+    for( const json_flag_registration &entry : pimpl_->json_flags ) {
+        if( !flag_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first JSON flag '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const tool_quality_registration &entry : pimpl_->tool_qualities ) {
+        if( !quality_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first tool quality '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const skill_display_registration &entry : pimpl_->skill_displays ) {
+        if( !skill_displayType_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first skill display category '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const skill_registration &entry : pimpl_->skills ) {
+        if( !skill_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first skill '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const vitamin_registration &entry : pimpl_->vitamins ) {
+        if( !vitamin_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first vitamin '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const damage_type_registration &entry : pimpl_->damage_types ) {
+        if( !damage_type_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first damage type '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const bash_damage_profile_registration &entry :
+         pimpl_->bash_damage_profiles ) {
+        if( !bash_damage_profile_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first bash damage profile '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const material_registration &entry : pimpl_->materials ) {
+        if( !material_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first material '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const proficiency_category_registration &entry : pimpl_->proficiency_categories ) {
+        if( !proficiency_category_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first proficiency category '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const proficiency_registration &entry : pimpl_->proficiencies ) {
+        if( !proficiency_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first proficiency '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const weapon_category_registration &entry : pimpl_->weapon_categories ) {
+        if( !weapon_category_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first weapon category '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const item_category_registration &entry : pimpl_->item_categories ) {
+        if( !item_category_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first item category '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const crafting_category_registration &entry : pimpl_->crafting_categories ) {
+        if( !crafting_category_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first recipe category '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const ammunition_type_registration &entry : pimpl_->ammunition_types ) {
+        if( !ammotype( entry.definition->id ).is_valid() ) {
+            error = "Lua-first ammunition type '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const monster_flag_registration &entry : pimpl_->monster_flags ) {
+        if( !mon_flag_str_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first monster flag '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const species_registration &entry : pimpl_->species ) {
+        if( !species_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first species '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const emission_registration &entry : pimpl_->emissions ) {
+        if( detail::emission_registry_find( entry.definition->id ) == nullptr ) {
+            error = "Lua-first emission '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const monster_faction_registration &entry : pimpl_->monster_factions ) {
+        if( !mfaction_str_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first monster faction '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const mutation_type_registration &entry : pimpl_->mutation_types ) {
+        if( !detail::mutation_type_registry_contains( entry.definition->id ) ) {
+            error = "Lua-first mutation type '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const connect_group_registration &entry : pimpl_->connect_groups ) {
+        if( detail::connect_group_registry_find( entry.definition->id ) == nullptr ) {
+            error = "Lua-first connect group '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const mutation_category_registration &entry : pimpl_->mutation_categories ) {
+        if( detail::mutation_category_registry_find( entry.definition->id ) == nullptr ) {
+            error = "Lua-first mutation category '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const construction_category_registration &entry :
+         pimpl_->construction_categories ) {
+        if( !construction_category_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first construction category '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const construction_group_registration &entry : pimpl_->construction_groups ) {
+        if( !construction_group_str_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first construction group '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const vehicle_part_location_registration &entry :
+         pimpl_->vehicle_part_locations ) {
+        if( !vpart_location_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first vehicle part location '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const mood_face_registration &entry : pimpl_->mood_faces ) {
+        if( !mood_face_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first mood face '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const damage_info_order_registration &entry : pimpl_->damage_info_orders ) {
+        if( !damage_info_order_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first damage info order '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const vehicle_part_category_registration &entry :
+         pimpl_->vehicle_part_categories ) {
+        if( detail::vehicle_part_category_registry_find( entry.definition->id ) == nullptr ) {
+            error = "Lua-first vehicle part category '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const named_color_registration &entry : pimpl_->named_colors ) {
+        if( !detail::named_color_registry_contains( entry.definition->name ) ) {
+            error = "Lua-first named color '" + entry.definition->name +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const rotatable_symbol_registration &entry : pimpl_->rotatable_symbols ) {
+        if( detail::rotatable_symbol_registry_group(
+                entry.definition->symbols.front() ).empty() ) {
+            error = "Lua-first rotatable symbol '" + entry.definition->key +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const ascii_art_registration &entry : pimpl_->ascii_arts ) {
+        if( !ascii_art_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first ASCII art '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const limb_score_registration &entry : pimpl_->limb_scores ) {
+        if( !limb_score_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first limb score '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const hit_range_registration &entry : pimpl_->hit_ranges ) {
+        const std::vector<std::int64_t> actual(
+            Creature::dispersion_for_even_chance_of_good_hit.begin(),
+            Creature::dispersion_for_even_chance_of_good_hit.end() );
+        if( actual != entry.definition->even_good ) {
+            error = "Lua-first hit range did not survive global finalization";
+            return false;
+        }
+    }
+    for( const overmap_land_use_code_registration &entry :
+         pimpl_->overmap_land_use_codes ) {
+        if( !overmap_land_use_code_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first overmap land-use code '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const overmap_vision_registration &entry : pimpl_->overmap_visions ) {
+        if( !oter_vision_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first overmap vision '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const overmap_location_registration &entry : pimpl_->overmap_locations ) {
+        if( !overmap_location_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first overmap location '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const profession_group_registration &entry : pimpl_->profession_groups ) {
+        if( !profession_group_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first profession group '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const map_extra_collection_registration &entry : pimpl_->map_extra_collections ) {
+        if( !map_extra_collection_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first map-extra collection '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const vehicle_group_registration &entry : pimpl_->vehicle_groups ) {
+        if( detail::vehicle_group_registry_find( entry.definition->id ) == nullptr ) {
+            error = "Lua-first vehicle group '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const fault_group_registration &entry : pimpl_->fault_groups ) {
+        if( !fault_group_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first fault group '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const explosion_light_registration &entry : pimpl_->explosion_lights ) {
+        if( !explosion_light_str_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first explosion light '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const ammo_effect_registration &entry : pimpl_->ammo_effects ) {
+        if( !ammo_effect_str_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first ammo effect '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const addiction_type_registration &entry : pimpl_->addiction_types ) {
+        if( !addiction_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first addiction type '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const character_modifier_registration &entry : pimpl_->character_modifiers ) {
+        if( !character_modifier_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first character modifier '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const start_location_registration &entry : pimpl_->start_locations ) {
+        if( !start_location_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first start location '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const climbing_aid_registration &entry : pimpl_->climbing_aids ) {
+        if( !climbing_aid_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first climbing aid '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const weather_type_registration &entry : pimpl_->weather_types ) {
+        if( !weather_type_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first weather type '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const score_registration &entry : pimpl_->scores ) {
+        if( !score_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first score '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const overlay_order_registration &entry : pimpl_->overlay_orders ) {
+        for( const auto &[mutation_id, order] : entry.definition->orders ) {
+            const auto found = base_mutation_overlay_ordering.find( mutation_id );
+            if( found == base_mutation_overlay_ordering.end() ||
+                found->second != static_cast<int>( order ) ) {
+                error = "Lua-first overlay order for mutation '" + mutation_id +
+                        "' did not survive global finalization";
+                return false;
+            }
+        }
+    }
+    for( const zone_type_registration &entry : pimpl_->zone_types ) {
+        if( !zone_type_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first zone type '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const speech_pool_registration &entry : pimpl_->speech_pools ) {
+        const std::vector<SpeechBubble> *const found =
+            detail::speech_registry_find( entry.definition->id );
+        if( found == nullptr || found->size() != entry.definition->lines.size() ) {
+            error = "Lua-first speech pool '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+        for( std::size_t index = 0; index < found->size(); ++index ) {
+            if( ( *found )[index].text.translated() !=
+                entry.definition->lines[index].first ||
+                ( *found )[index].volume != entry.definition->lines[index].second ) {
+                error = "Lua-first speech pool '" + entry.definition->id +
+                        "' changed during global finalization";
+                return false;
+            }
+        }
+    }
+    for( const end_screen_registration &entry : pimpl_->end_screens ) {
+        if( !end_screen_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first end screen '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const activity_type_registration &entry : pimpl_->activity_types ) {
+        if( !activity_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first activity type '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const help_topic_registration &entry : pimpl_->help_topics ) {
+        const auto found = get_help().platform_help_topic_orders.find(
+                               entry.definition->id );
+        if( found == get_help().platform_help_topic_orders.end() ||
+            ( entry.definition->order && found->second != *entry.definition->order ) ||
+            get_help().help_texts.count( found->second ) == 0 ) {
+            error = "Lua-first help topic '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const snippet_category_registration &entry : pimpl_->snippet_categories ) {
+        const auto found = SNIPPET.snippets_by_category.find( entry.definition->id );
+        if( found == SNIPPET.snippets_by_category.end() ) {
+            error = "Lua-first snippet category '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+        for( const snippet_entry_definition_data &snippet : entry.definition->entries ) {
+            if( !snippet.id.empty() && !snippet_id( snippet.id ).is_valid() ) {
+                error = "Lua-first snippet '" + snippet.id +
+                        "' did not survive global finalization";
+                return false;
+            }
+        }
+    }
+    for( const playlist_registration &entry : pimpl_->playlists ) {
+        const std::optional<sfx::playlist_definition> found =
+            sfx::playlist_registry_get( entry.definition->id );
+        if( !found || found->entries.size() != entry.definition->tracks.size() ) {
+            error = "Lua-first playlist '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const attack_vector_registration &entry : pimpl_->attack_vectors ) {
+        if( !attack_vector_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first attack vector '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const magic_type_registration &entry : pimpl_->magic_types ) {
+        if( !magic_type_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first magic type '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const movement_mode_registration &entry : pimpl_->movement_modes ) {
+        if( !move_mode_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first movement mode '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const scent_type_registration &entry : pimpl_->scent_types ) {
+        if( !scenttype_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first scent type '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const speed_description_registration &entry : pimpl_->speed_descriptions ) {
+        if( !speed_description_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first speed description '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const item_group_registration &entry : pimpl_->item_groups ) {
+        if( !item_group::group_is_defined( item_group_id( entry.definition->id ) ) ) {
+            error = "Lua-first item group '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const harvest_drop_type_registration &entry : pimpl_->harvest_drop_types ) {
+        if( !harvest_drop_type_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first harvest drop type '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const harvest_registration &entry : pimpl_->harvests ) {
+        const harvest_id id( entry.definition->id );
+        if( !id.is_valid() || id->entries().size() != entry.definition->entries.size() ) {
+            error = "Lua-first harvest '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const behavior_registration &entry : pimpl_->behaviors ) {
+        const string_id<behavior::node_t> id( entry.definition->id );
+        if( !id.is_valid() ||
+            id->child_ids().size() != entry.definition->children.size() ) {
+            error = "Lua-first behavior '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const effect_type_registration &entry : pimpl_->effect_types ) {
+        if( detail::effect_type_registry_find( entry.definition->id ) == nullptr ) {
+            error = "Lua-first effect type '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const sub_body_part_registration &entry : pimpl_->sub_body_parts ) {
+        if( !sub_bodypart_str_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first sub body part '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const body_part_registration &entry : pimpl_->body_parts ) {
+        if( !bodypart_str_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first body part '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const anatomy_registration &entry : pimpl_->anatomies ) {
+        const anatomy_id id( entry.definition->id );
+        if( !id.is_valid() || id->get_bodyparts().size() != entry.definition->parts.size() ) {
+            error = "Lua-first anatomy '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const body_graph_registration &entry : pimpl_->body_graphs ) {
+        if( !bodygraph_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first body graph '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const field_type_registration &entry : pimpl_->field_types ) {
+        const field_type_str_id id( entry.definition->id );
+        if( !id.is_valid() ||
+            id->intensity_levels.size() != entry.definition->intensity_levels.size() ) {
+            error = "Lua-first field type '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const monster_attack_registration &entry : pimpl_->monster_attacks ) {
+        if( detail::monster_attack_registry_find( entry.definition->id ) == nullptr ) {
+            error = "Lua-first monster attack '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const weakpoint_set_registration &entry : pimpl_->weakpoint_sets ) {
+        const weakpoints_id id( entry.definition->id );
+        if( !id.is_valid() ||
+            id->weakpoint_list.size() != entry.definition->weakpoints.size() ) {
+            error = "Lua-first weakpoint set '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const monster_registration &entry : pimpl_->monsters ) {
+        const mtype_id id( entry.definition->id );
+        if( !id.is_valid() || id->special_attacks.size() != entry.definition->attacks.size() ) {
+            error = "Lua-first monster '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const morale_type_registration &entry : pimpl_->morale_types ) {
+        if( !morale_type( entry.definition->id ).is_valid() ) {
+            error = "Lua-first morale type '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const disease_type_registration &entry : pimpl_->disease_types ) {
+        if( !diseasetype_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first disease type '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const requirement_registration &entry : pimpl_->requirements ) {
+        if( requirement_data::registry().count(
+                requirement_id( entry.definition->id ) ) == 0 ) {
+            error = "Lua-first requirement '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const recipe_group_registration &entry : pimpl_->recipe_groups ) {
+        if( !detail::recipe_group_exists( entry.definition->id ) ) {
+            error = "Lua-first recipe group '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const item_registration &entry : pimpl_->items ) {
+        if( item_controller->m_runtimes.count( itype_id( entry.definition->id ) ) == 0 ) {
+            error = "Lua-first item '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const clothing_mod_registration &entry : pimpl_->clothing_mods ) {
+        if( !clothing_mod_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first clothing modification '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const recipe_registration &entry : pimpl_->recipes ) {
+        if( recipe_dict.recipes.count( recipe_id( entry.definition->id ) ) == 0 ) {
+            error = "Lua-first recipe '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    error.clear();
+    return true;
+}
+
+void content_transaction::rollback()
+{
+    for( auto it = pimpl_->monster_undo.rbegin();
+         it != pimpl_->monster_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::monster_type_registry().restore( *it->second );
+        } else {
+            detail::monster_type_registry().erase( it->first );
+        }
+    }
+    if( !pimpl_->monster_undo.empty() ) {
+        MonsterGenerator::generator().refresh_hallucination_monsters();
+        MonsterGenerator::generator().refresh_behavior_goals();
+    }
+    pimpl_->monster_undo.clear();
+
+    for( auto it = pimpl_->recipe_undo.rbegin(); it != pimpl_->recipe_undo.rend(); ++it ) {
+        if( it->second ) {
+            recipe_dict.recipes[it->first] = *it->second;
+        } else {
+            recipe_dict.recipes.erase( it->first );
+        }
+    }
+    pimpl_->recipe_undo.clear();
+
+    for( auto it = pimpl_->clothing_mod_undo.rbegin();
+         it != pimpl_->clothing_mod_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::clothing_mod_registry().restore( *it->second );
+        } else {
+            detail::clothing_mod_registry().erase( it->first );
+        }
+    }
+    if( !pimpl_->clothing_mod_undo.empty() ) {
+        detail::refresh_clothing_mod_registry_cache();
+    }
+    pimpl_->clothing_mod_undo.clear();
+
+    for( auto it = pimpl_->item_undo.rbegin(); it != pimpl_->item_undo.rend(); ++it ) {
+        if( it->second ) {
+            item_controller->m_runtimes[it->first] =
+                std::make_unique<itype>( *it->second );
+        } else {
+            item_controller->m_runtimes.erase( it->first );
+        }
+    }
+    if( !pimpl_->item_undo.empty() ) {
+        item_controller->m_runtimes_dirty = true;
+        item_controller->templates_all_cache.clear();
+        item_controller->armor_containers.clear();
+    }
+    pimpl_->item_undo.clear();
+
+    for( auto it = pimpl_->recipe_group_undo.rbegin();
+         it != pimpl_->recipe_group_undo.rend(); ++it ) {
+        detail::recipe_group_erase( it->first );
+        if( it->second ) {
+            detail::recipe_group_set( *it->second );
+        }
+    }
+    pimpl_->recipe_group_undo.clear();
+
+    for( auto it = pimpl_->requirement_undo.rbegin();
+         it != pimpl_->requirement_undo.rend(); ++it ) {
+        requirement_data::registry().erase( it->first );
+        if( it->second ) {
+            requirement_data::registry()[it->first] = *it->second;
+        }
+    }
+    pimpl_->requirement_undo.clear();
+
+    for( auto it = pimpl_->disease_type_undo.rbegin();
+         it != pimpl_->disease_type_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::disease_type_registry().restore( *it->second );
+        } else {
+            detail::disease_type_registry().erase( it->first );
+        }
+    }
+    pimpl_->disease_type_undo.clear();
+
+    for( auto it = pimpl_->morale_type_undo.rbegin();
+         it != pimpl_->morale_type_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::morale_type_registry().restore( *it->second );
+        } else {
+            detail::morale_type_registry().erase( it->first );
+        }
+    }
+    pimpl_->morale_type_undo.clear();
+
+    for( auto it = pimpl_->weakpoint_set_undo.rbegin();
+         it != pimpl_->weakpoint_set_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::weakpoint_set_registry().restore( *it->second );
+        } else {
+            detail::weakpoint_set_registry().erase( it->first );
+        }
+    }
+    pimpl_->weakpoint_set_undo.clear();
+
+    for( auto it = pimpl_->monster_attack_undo.rbegin();
+         it != pimpl_->monster_attack_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::monster_attack_registry_set( *it->second );
+        } else {
+            detail::monster_attack_registry_erase( it->first );
+        }
+    }
+    pimpl_->monster_attack_undo.clear();
+
+    for( auto it = pimpl_->field_type_undo.rbegin();
+         it != pimpl_->field_type_undo.rend(); ++it ) {
+        if( it->second ) {
+            get_all_field_types().restore( *it->second );
+        } else {
+            get_all_field_types().erase( it->first );
+        }
+    }
+    pimpl_->field_type_undo.clear();
+
+    for( auto it = pimpl_->body_graph_undo.rbegin();
+         it != pimpl_->body_graph_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::bodygraph_registry().restore( *it->second );
+        } else {
+            detail::bodygraph_registry().erase( it->first );
+        }
+    }
+    pimpl_->body_graph_undo.clear();
+
+    for( auto it = pimpl_->anatomy_undo.rbegin();
+         it != pimpl_->anatomy_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::anatomy_registry().restore( *it->second );
+        } else {
+            detail::anatomy_registry().erase( it->first );
+        }
+    }
+    pimpl_->anatomy_undo.clear();
+
+    for( auto it = pimpl_->body_part_undo.rbegin();
+         it != pimpl_->body_part_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::body_part_registry().restore( *it->second );
+        } else {
+            detail::body_part_registry().erase( it->first );
+        }
+    }
+    if( !pimpl_->body_part_undo.empty() ) {
+        detail::refresh_body_part_similarity_cache();
+    }
+    pimpl_->body_part_undo.clear();
+
+    for( auto it = pimpl_->sub_body_part_undo.rbegin();
+         it != pimpl_->sub_body_part_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::sub_body_part_registry().restore( *it->second );
+        } else {
+            detail::sub_body_part_registry().erase( it->first );
+        }
+    }
+    if( !pimpl_->sub_body_part_undo.empty() ) {
+        detail::refresh_sub_body_part_similarity_cache();
+    }
+    pimpl_->sub_body_part_undo.clear();
+
+    for( auto it = pimpl_->effect_type_undo.rbegin();
+         it != pimpl_->effect_type_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::effect_type_registry_set( *it->second );
+        } else {
+            detail::effect_type_registry_erase( it->first );
+        }
+    }
+    pimpl_->effect_type_undo.clear();
+
+    for( auto it = pimpl_->behavior_undo.rbegin();
+         it != pimpl_->behavior_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::behavior_registry().restore( *it->second );
+        } else {
+            detail::behavior_registry().erase( it->first );
+        }
+    }
+    if( !pimpl_->behavior_undo.empty() ) {
+        behavior::finalize();
+    }
+    pimpl_->behavior_undo.clear();
+
+    for( auto it = pimpl_->harvest_undo.rbegin();
+         it != pimpl_->harvest_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::harvest_list_registry().restore( *it->second );
+        } else {
+            detail::harvest_list_registry().erase( it->first );
+        }
+    }
+    pimpl_->harvest_undo.clear();
+
+    for( auto it = pimpl_->harvest_drop_type_undo.rbegin();
+         it != pimpl_->harvest_drop_type_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::harvest_drop_type_registry().restore( *it->second );
+        } else {
+            detail::harvest_drop_type_registry().erase( it->first );
+        }
+    }
+    pimpl_->harvest_drop_type_undo.clear();
+
+    for( auto it = pimpl_->item_group_undo.rbegin();
+         it != pimpl_->item_group_undo.rend(); ++it ) {
+        if( it->second ) {
+            item_controller->m_template_groups[it->first] = std::move( it->second );
+        } else {
+            item_controller->m_template_groups.erase( it->first );
+        }
+    }
+    pimpl_->item_group_undo.clear();
+
+    for( auto it = pimpl_->speed_description_undo.rbegin();
+         it != pimpl_->speed_description_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::speed_description_registry().restore( *it->second );
+        } else {
+            detail::speed_description_registry().erase( it->first );
+        }
+    }
+    pimpl_->speed_description_undo.clear();
+
+    for( auto it = pimpl_->scent_type_undo.rbegin();
+         it != pimpl_->scent_type_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::scent_type_registry().restore( *it->second );
+        } else {
+            detail::scent_type_registry().erase( it->first );
+        }
+    }
+    pimpl_->scent_type_undo.clear();
+
+    for( auto it = pimpl_->movement_mode_undo.rbegin();
+         it != pimpl_->movement_mode_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::movement_mode_registry().restore( *it->second );
+        } else {
+            detail::movement_mode_registry().erase( it->first );
+        }
+    }
+    if( !pimpl_->movement_mode_undo.empty() ) {
+        detail::refresh_movement_mode_registry();
+    }
+    pimpl_->movement_mode_undo.clear();
+
+    for( auto it = pimpl_->magic_type_undo.rbegin();
+         it != pimpl_->magic_type_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::magic_type_registry().restore( *it->second );
+        } else {
+            detail::magic_type_registry().erase( it->first );
+        }
+    }
+    if( !pimpl_->magic_type_undo.empty() ) {
+        detail::magic_type_registry().finalize();
+    }
+    pimpl_->magic_type_undo.clear();
+
+    for( auto it = pimpl_->attack_vector_undo.rbegin();
+         it != pimpl_->attack_vector_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::attack_vector_registry().restore( *it->second );
+        } else {
+            detail::attack_vector_registry().erase( it->first );
+        }
+    }
+    if( !pimpl_->attack_vector_undo.empty() ) {
+        detail::refresh_attack_vector_registry();
+    }
+    pimpl_->attack_vector_undo.clear();
+
+    for( auto it = pimpl_->playlist_undo.rbegin();
+         it != pimpl_->playlist_undo.rend(); ++it ) {
+        if( it->second ) {
+            sfx::playlist_registry_set( *it->second );
+        } else {
+            sfx::playlist_registry_erase( it->first );
+        }
+    }
+    pimpl_->playlist_undo.clear();
+
+    if( pimpl_->snippet_library_undo ) {
+        SNIPPET = *pimpl_->snippet_library_undo;
+    }
+    pimpl_->snippet_library_undo.reset();
+
+    if( pimpl_->help_undo ) {
+        get_help() = *pimpl_->help_undo;
+    }
+    pimpl_->help_undo.reset();
+
+    for( auto it = pimpl_->activity_type_undo.rbegin();
+         it != pimpl_->activity_type_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::activity_type_registry_set( *it->second );
+        } else {
+            detail::activity_type_registry_erase( it->first );
+        }
+    }
+    pimpl_->activity_type_undo.clear();
+
+    for( auto it = pimpl_->end_screen_undo.rbegin();
+         it != pimpl_->end_screen_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::end_screen_registry().restore( *it->second );
+        } else {
+            detail::end_screen_registry().erase( it->first );
+        }
+    }
+    if( !pimpl_->end_screen_undo.empty() ) {
+        detail::end_screen_registry().finalize();
+    }
+    pimpl_->end_screen_undo.clear();
+
+    for( auto it = pimpl_->speech_pool_undo.rbegin();
+         it != pimpl_->speech_pool_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::speech_registry_set( it->first, *it->second );
+        } else {
+            detail::speech_registry_erase( it->first );
+        }
+    }
+    pimpl_->speech_pool_undo.clear();
+
+    for( auto it = pimpl_->zone_type_undo.rbegin();
+         it != pimpl_->zone_type_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::zone_type_registry().restore( *it->second );
+        } else {
+            detail::zone_type_registry().erase( it->first );
+        }
+    }
+    if( !pimpl_->zone_type_undo.empty() ) {
+        detail::zone_type_registry().finalize();
+    }
+    pimpl_->zone_type_undo.clear();
+
+    for( auto it = pimpl_->overlay_order_undo.rbegin();
+         it != pimpl_->overlay_order_undo.rend(); ++it ) {
+        if( it->second ) {
+            base_mutation_overlay_ordering[it->first] = *it->second;
+        } else {
+            base_mutation_overlay_ordering.erase( it->first );
+        }
+    }
+    pimpl_->overlay_order_undo.clear();
+
+    for( auto it = pimpl_->score_undo.rbegin(); it != pimpl_->score_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::score_registry().restore( *it->second );
+        } else {
+            detail::score_registry().erase( it->first );
+        }
+    }
+    if( !pimpl_->score_undo.empty() ) {
+        detail::score_registry().finalize();
+    }
+    pimpl_->score_undo.clear();
+
+    for( auto it = pimpl_->weather_type_undo.rbegin();
+         it != pimpl_->weather_type_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::weather_type_registry().restore( *it->second );
+        } else {
+            detail::weather_type_registry().erase( it->first );
+        }
+    }
+    if( !pimpl_->weather_type_undo.empty() ) {
+        detail::weather_type_registry().finalize();
+    }
+    pimpl_->weather_type_undo.clear();
+
+    for( auto it = pimpl_->climbing_aid_undo.rbegin();
+         it != pimpl_->climbing_aid_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::climbing_aid_registry().restore( *it->second );
+        } else {
+            detail::climbing_aid_registry().erase( it->first );
+        }
+    }
+    if( !pimpl_->climbing_aid_undo.empty() ) {
+        detail::refresh_climbing_aid_registry();
+    }
+    pimpl_->climbing_aid_undo.clear();
+
+    for( auto it = pimpl_->start_location_undo.rbegin();
+         it != pimpl_->start_location_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::start_location_registry().restore( *it->second );
+        } else {
+            detail::start_location_registry().erase( it->first );
+        }
+    }
+    if( !pimpl_->start_location_undo.empty() ) {
+        detail::start_location_registry().finalize();
+    }
+    pimpl_->start_location_undo.clear();
+
+    for( auto it = pimpl_->character_modifier_undo.rbegin();
+         it != pimpl_->character_modifier_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::character_modifier_registry().restore( *it->second );
+        } else {
+            detail::character_modifier_registry().erase( it->first );
+        }
+    }
+    if( !pimpl_->character_modifier_undo.empty() ) {
+        detail::character_modifier_registry().finalize();
+    }
+    pimpl_->character_modifier_undo.clear();
+
+    for( auto it = pimpl_->addiction_type_undo.rbegin();
+         it != pimpl_->addiction_type_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::addiction_type_registry().restore( *it->second );
+        } else {
+            detail::addiction_type_registry().erase( it->first );
+        }
+    }
+    if( !pimpl_->addiction_type_undo.empty() ) {
+        detail::addiction_type_registry().finalize();
+    }
+    pimpl_->addiction_type_undo.clear();
+
+    for( auto it = pimpl_->ammo_effect_undo.rbegin();
+         it != pimpl_->ammo_effect_undo.rend(); ++it ) {
+        if( it->second ) {
+            get_all_ammo_effects().restore( *it->second );
+        } else {
+            get_all_ammo_effects().erase( it->first );
+        }
+    }
+    if( !pimpl_->ammo_effect_undo.empty() ) {
+        get_all_ammo_effects().finalize();
+    }
+    pimpl_->ammo_effect_undo.clear();
+
+    for( auto it = pimpl_->explosion_light_undo.rbegin();
+         it != pimpl_->explosion_light_undo.rend(); ++it ) {
+        if( it->second ) {
+            get_all_explosion_lights().restore( *it->second );
+        } else {
+            get_all_explosion_lights().erase( it->first );
+        }
+    }
+    if( !pimpl_->explosion_light_undo.empty() ) {
+        get_all_explosion_lights().finalize();
+    }
+    pimpl_->explosion_light_undo.clear();
+
+    for( auto it = pimpl_->fault_group_undo.rbegin();
+         it != pimpl_->fault_group_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::fault_group_registry().restore( *it->second );
+        } else {
+            detail::fault_group_registry().erase( it->first );
+        }
+    }
+    if( !pimpl_->fault_group_undo.empty() ) {
+        detail::fault_group_registry().finalize();
+    }
+    pimpl_->fault_group_undo.clear();
+
+    for( auto it = pimpl_->vehicle_group_undo.rbegin();
+         it != pimpl_->vehicle_group_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::vehicle_group_registry_set( it->first, *it->second );
+        } else {
+            detail::vehicle_group_registry_erase( it->first );
+        }
+    }
+    pimpl_->vehicle_group_undo.clear();
+
+    for( auto it = pimpl_->map_extra_collection_undo.rbegin();
+         it != pimpl_->map_extra_collection_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::map_extra_collection_registry().restore( *it->second );
+        } else {
+            detail::map_extra_collection_registry().erase( it->first );
+        }
+    }
+    if( !pimpl_->map_extra_collection_undo.empty() ) {
+        detail::map_extra_collection_registry().finalize();
+    }
+    pimpl_->map_extra_collection_undo.clear();
+
+    for( auto it = pimpl_->profession_group_undo.rbegin();
+         it != pimpl_->profession_group_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::profession_group_registry().restore( *it->second );
+        } else {
+            detail::profession_group_registry().erase( it->first );
+        }
+    }
+    if( !pimpl_->profession_group_undo.empty() ) {
+        detail::profession_group_registry().finalize();
+    }
+    pimpl_->profession_group_undo.clear();
+
+    for( auto it = pimpl_->overmap_location_undo.rbegin();
+         it != pimpl_->overmap_location_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::overmap_location_registry().restore( *it->second );
+        } else {
+            detail::overmap_location_registry().erase( it->first );
+        }
+    }
+    if( !pimpl_->overmap_location_undo.empty() ) {
+        detail::overmap_location_registry().finalize();
+    }
+    pimpl_->overmap_location_undo.clear();
+
+    for( auto it = pimpl_->overmap_vision_undo.rbegin();
+         it != pimpl_->overmap_vision_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::overmap_vision_registry().restore( *it->second );
+        } else {
+            detail::overmap_vision_registry().erase( it->first );
+        }
+    }
+    if( !pimpl_->overmap_vision_undo.empty() ) {
+        detail::overmap_vision_registry().finalize();
+    }
+    pimpl_->overmap_vision_undo.clear();
+
+    for( auto it = pimpl_->overmap_land_use_code_undo.rbegin();
+         it != pimpl_->overmap_land_use_code_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::overmap_land_use_code_registry().restore( *it->second );
+        } else {
+            detail::overmap_land_use_code_registry().erase( it->first );
+        }
+    }
+    pimpl_->overmap_land_use_code_undo.clear();
+
+    if( pimpl_->hit_range_undo ) {
+        Creature::dispersion_for_even_chance_of_good_hit = *pimpl_->hit_range_undo;
+        pimpl_->hit_range_undo.reset();
+    }
+
+    for( auto it = pimpl_->limb_score_undo.rbegin();
+         it != pimpl_->limb_score_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::limb_score_registry().restore( *it->second );
+        } else {
+            detail::limb_score_registry().erase( it->first );
+        }
+    }
+    pimpl_->limb_score_undo.clear();
+
+    for( auto it = pimpl_->ascii_art_undo.rbegin();
+         it != pimpl_->ascii_art_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::ascii_art_registry().restore( *it->second );
+        } else {
+            detail::ascii_art_registry().erase( it->first );
+        }
+    }
+    pimpl_->ascii_art_undo.clear();
+
+    if( pimpl_->rotatable_symbol_undo ) {
+        detail::rotatable_symbol_registry_restore( *pimpl_->rotatable_symbol_undo );
+        pimpl_->rotatable_symbol_undo.reset();
+    }
+
+    if( pimpl_->named_color_undo ) {
+        detail::named_color_registry_restore( *pimpl_->named_color_undo );
+        pimpl_->named_color_undo.reset();
+    }
+
+    for( auto it = pimpl_->mood_face_undo.rbegin();
+         it != pimpl_->mood_face_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::mood_face_registry().restore( *it->second );
+        } else {
+            detail::mood_face_registry().erase( it->first );
+        }
+    }
+    pimpl_->mood_face_undo.clear();
+
+    for( auto it = pimpl_->vehicle_part_category_undo.rbegin();
+         it != pimpl_->vehicle_part_category_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::vehicle_part_category_registry_set( *it->second );
+        } else {
+            detail::vehicle_part_category_registry_erase( it->first );
+        }
+    }
+    if( !pimpl_->vehicle_part_category_undo.empty() ) {
+        detail::vehicle_part_category_registry_finalize();
+    }
+    pimpl_->vehicle_part_category_undo.clear();
+
+    for( auto it = pimpl_->vehicle_part_location_undo.rbegin();
+         it != pimpl_->vehicle_part_location_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::vehicle_part_location_registry().restore( *it->second );
+        } else {
+            detail::vehicle_part_location_registry().erase( it->first );
+        }
+    }
+    pimpl_->vehicle_part_location_undo.clear();
+
+    for( auto it = pimpl_->construction_group_undo.rbegin();
+         it != pimpl_->construction_group_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::construction_group_registry().restore( *it->second );
+        } else {
+            detail::construction_group_registry().erase( it->first );
+        }
+    }
+    pimpl_->construction_group_undo.clear();
+
+    for( auto it = pimpl_->construction_category_undo.rbegin();
+         it != pimpl_->construction_category_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::construction_category_registry().restore( *it->second );
+        } else {
+            detail::construction_category_registry().erase( it->first );
+        }
+    }
+    pimpl_->construction_category_undo.clear();
+
+    for( auto it = pimpl_->mutation_category_undo.rbegin();
+         it != pimpl_->mutation_category_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::mutation_category_registry_set( *it->second );
+        } else {
+            detail::mutation_category_registry_erase( it->first );
+        }
+    }
+    pimpl_->mutation_category_undo.clear();
+
+    for( auto it = pimpl_->connect_group_undo.rbegin();
+         it != pimpl_->connect_group_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::connect_group_registry_set( *it->second );
+        } else {
+            detail::connect_group_registry_erase( it->first );
+        }
+    }
+    pimpl_->connect_group_undo.clear();
+
+    for( auto it = pimpl_->mutation_type_undo.rbegin();
+         it != pimpl_->mutation_type_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::mutation_type_registry_set( it->first );
+        } else {
+            detail::mutation_type_registry_erase( it->first );
+        }
+    }
+    pimpl_->mutation_type_undo.clear();
+
+    for( auto it = pimpl_->monster_faction_undo.rbegin();
+         it != pimpl_->monster_faction_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::monster_faction_registry().restore( *it->second );
+        } else {
+            detail::monster_faction_registry().erase( it->first );
+        }
+    }
+    if( !pimpl_->monster_faction_undo.empty() ) {
+        monfactions::finalize();
+    }
+    pimpl_->monster_faction_undo.clear();
+
+    for( auto it = pimpl_->emission_undo.rbegin();
+         it != pimpl_->emission_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::emission_registry_set( *it->second );
+        } else {
+            detail::emission_registry_erase( it->first );
+        }
+    }
+    pimpl_->emission_undo.clear();
+
+    for( auto it = pimpl_->species_undo.rbegin();
+         it != pimpl_->species_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::species_registry().restore( *it->second );
+        } else {
+            detail::species_registry().erase( it->first );
+        }
+    }
+    if( !pimpl_->species_undo.empty() ) {
+        detail::species_registry().finalize();
+    }
+    pimpl_->species_undo.clear();
+
+    for( auto it = pimpl_->monster_flag_undo.rbegin();
+         it != pimpl_->monster_flag_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::monster_flag_registry().restore( *it->second );
+        } else {
+            detail::monster_flag_registry().erase( it->first );
+        }
+    }
+    pimpl_->monster_flag_undo.clear();
+
+    for( auto it = pimpl_->ammunition_type_undo.rbegin();
+         it != pimpl_->ammunition_type_undo.rend(); ++it ) {
+        ammunition_type::registry().erase( it->first );
+        if( it->second ) {
+            ammunition_type::registry()[it->first] = *it->second;
+        }
+    }
+    pimpl_->ammunition_type_undo.clear();
+
+    for( auto it = pimpl_->crafting_category_undo.rbegin();
+         it != pimpl_->crafting_category_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::crafting_category_registry().restore( *it->second );
+        } else {
+            detail::crafting_category_registry().erase( it->first );
+        }
+    }
+    pimpl_->crafting_category_undo.clear();
+
+    for( auto it = pimpl_->item_category_undo.rbegin();
+         it != pimpl_->item_category_undo.rend(); ++it ) {
+        const item_category_id &id = std::get<0>( *it );
+        if( std::get<1>( *it ) ) {
+            detail::item_category_registry().restore( *std::get<1>( *it ) );
+        } else {
+            detail::item_category_registry().erase( id );
+        }
+        item_category_spawn_rates::get_item_category_spawn_rates().set_spawn_rate(
+            id, std::get<2>( *it ) );
+    }
+    pimpl_->item_category_undo.clear();
+
+    for( auto it = pimpl_->weapon_category_undo.rbegin();
+         it != pimpl_->weapon_category_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::weapon_category_registry().restore( *it->second );
+        } else {
+            detail::weapon_category_registry().erase( it->first );
+        }
+    }
+    pimpl_->weapon_category_undo.clear();
+
+    for( auto it = pimpl_->proficiency_undo.rbegin();
+         it != pimpl_->proficiency_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::proficiency_registry().restore( *it->second );
+        } else {
+            detail::proficiency_registry().erase( it->first );
+        }
+    }
+    pimpl_->proficiency_undo.clear();
+
+    for( auto it = pimpl_->proficiency_category_undo.rbegin();
+         it != pimpl_->proficiency_category_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::proficiency_category_registry().restore( *it->second );
+        } else {
+            detail::proficiency_category_registry().erase( it->first );
+        }
+    }
+    pimpl_->proficiency_category_undo.clear();
+
+    for( auto it = pimpl_->material_undo.rbegin(); it != pimpl_->material_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::material_registry().restore( *it->second );
+        } else {
+            detail::material_registry().erase( it->first );
+        }
+    }
+    pimpl_->material_undo.clear();
+
+    for( auto it = pimpl_->damage_info_order_undo.rbegin();
+         it != pimpl_->damage_info_order_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::damage_info_order_registry().restore( *it->second );
+        } else {
+            detail::damage_info_order_registry().erase( it->first );
+        }
+    }
+    if( !pimpl_->damage_info_order_undo.empty() ) {
+        detail::refresh_damage_info_order_registry();
+    }
+    pimpl_->damage_info_order_undo.clear();
+
+    for( auto it = pimpl_->bash_damage_profile_undo.rbegin();
+         it != pimpl_->bash_damage_profile_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::bash_damage_profile_registry().restore( *it->second );
+        } else {
+            detail::bash_damage_profile_registry().erase( it->first );
+        }
+    }
+    pimpl_->bash_damage_profile_undo.clear();
+
+    for( auto it = pimpl_->damage_type_undo.rbegin();
+         it != pimpl_->damage_type_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::damage_type_registry().restore( *it->second );
+        } else {
+            detail::damage_type_registry().erase( it->first );
+        }
+    }
+    pimpl_->damage_type_undo.clear();
+
+    for( auto it = pimpl_->vitamin_undo.rbegin(); it != pimpl_->vitamin_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::vitamin_registry().restore( *it->second );
+        } else {
+            detail::vitamin_registry().erase( it->first );
+        }
+    }
+    pimpl_->vitamin_undo.clear();
+
+    for( auto it = pimpl_->skill_undo.rbegin(); it != pimpl_->skill_undo.rend(); ++it ) {
+        Skill::skills.erase( std::remove_if( Skill::skills.begin(), Skill::skills.end(),
+        [&it]( const Skill & value ) {
+            return value.ident() == it->first;
+        } ), Skill::skills.end() );
+        Skill::contextual_skills.erase( it->first );
+        if( it->second ) {
+            if( it->second->is_contextual_skill() ) {
+                Skill::contextual_skills[it->first] = *it->second;
+            } else {
+                Skill::skills.push_back( *it->second );
+            }
+        }
+    }
+    pimpl_->skill_undo.clear();
+
+    for( auto it = pimpl_->skill_display_undo.rbegin();
+         it != pimpl_->skill_display_undo.rend(); ++it ) {
+        SkillDisplayType::skillTypes.erase(
+            std::remove_if( SkillDisplayType::skillTypes.begin(),
+                            SkillDisplayType::skillTypes.end(),
+        [&it]( const SkillDisplayType & value ) {
+            return value.ident() == it->first;
+        } ), SkillDisplayType::skillTypes.end() );
+        if( it->second ) {
+            SkillDisplayType::skillTypes.push_back( *it->second );
+        }
+    }
+    pimpl_->skill_display_undo.clear();
+
+    for( auto it = pimpl_->tool_quality_undo.rbegin();
+         it != pimpl_->tool_quality_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::tool_quality_registry().restore( *it->second );
+        } else {
+            detail::tool_quality_registry().erase( it->first );
+        }
+    }
+    pimpl_->tool_quality_undo.clear();
+
+    for( auto it = pimpl_->json_flag_undo.rbegin();
+         it != pimpl_->json_flag_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::json_flag_registry().restore( *it->second );
+        } else {
+            detail::json_flag_registry().erase( it->first );
+        }
+    }
+    pimpl_->json_flag_undo.clear();
+    pimpl_->applied = false;
+}
+
+void content_transaction::commit()
+{
+    if( !pimpl_->applied ) {
+        return;
+    }
+    pimpl_->item_undo.clear();
+    pimpl_->recipe_undo.clear();
+    pimpl_->tool_quality_undo.clear();
+    pimpl_->skill_display_undo.clear();
+    pimpl_->skill_undo.clear();
+    pimpl_->vitamin_undo.clear();
+    pimpl_->json_flag_undo.clear();
+    pimpl_->damage_type_undo.clear();
+    pimpl_->bash_damage_profile_undo.clear();
+    pimpl_->material_undo.clear();
+    pimpl_->ammunition_type_undo.clear();
+    pimpl_->item_category_undo.clear();
+    pimpl_->crafting_category_undo.clear();
+    pimpl_->proficiency_category_undo.clear();
+    pimpl_->proficiency_undo.clear();
+    pimpl_->weapon_category_undo.clear();
+    pimpl_->requirement_undo.clear();
+    pimpl_->recipe_group_undo.clear();
+    pimpl_->scent_type_undo.clear();
+    pimpl_->speed_description_undo.clear();
+    pimpl_->item_group_undo.clear();
+    pimpl_->harvest_drop_type_undo.clear();
+    pimpl_->harvest_undo.clear();
+    pimpl_->behavior_undo.clear();
+    pimpl_->effect_type_undo.clear();
+    pimpl_->sub_body_part_undo.clear();
+    pimpl_->body_part_undo.clear();
+    pimpl_->anatomy_undo.clear();
+    pimpl_->body_graph_undo.clear();
+    pimpl_->monster_undo.clear();
+    pimpl_->field_type_undo.clear();
+    pimpl_->monster_attack_undo.clear();
+    pimpl_->weakpoint_set_undo.clear();
+    pimpl_->morale_type_undo.clear();
+    pimpl_->disease_type_undo.clear();
+    pimpl_->monster_flag_undo.clear();
+    pimpl_->species_undo.clear();
+    pimpl_->emission_undo.clear();
+    pimpl_->monster_faction_undo.clear();
+    pimpl_->mutation_type_undo.clear();
+    pimpl_->connect_group_undo.clear();
+    pimpl_->mutation_category_undo.clear();
+    pimpl_->construction_category_undo.clear();
+    pimpl_->construction_group_undo.clear();
+    pimpl_->vehicle_part_location_undo.clear();
+    pimpl_->mood_face_undo.clear();
+    pimpl_->damage_info_order_undo.clear();
+    pimpl_->vehicle_part_category_undo.clear();
+    pimpl_->named_color_undo.reset();
+    pimpl_->rotatable_symbol_undo.reset();
+    pimpl_->ascii_art_undo.clear();
+    pimpl_->limb_score_undo.clear();
+    pimpl_->hit_range_undo.reset();
+    pimpl_->clothing_mod_undo.clear();
+    pimpl_->overmap_land_use_code_undo.clear();
+    pimpl_->overmap_vision_undo.clear();
+    pimpl_->overmap_location_undo.clear();
+    pimpl_->profession_group_undo.clear();
+    pimpl_->map_extra_collection_undo.clear();
+    pimpl_->vehicle_group_undo.clear();
+    pimpl_->fault_group_undo.clear();
+    pimpl_->explosion_light_undo.clear();
+    pimpl_->ammo_effect_undo.clear();
+    pimpl_->addiction_type_undo.clear();
+    pimpl_->character_modifier_undo.clear();
+    pimpl_->start_location_undo.clear();
+    pimpl_->climbing_aid_undo.clear();
+    pimpl_->weather_type_undo.clear();
+    pimpl_->score_undo.clear();
+    pimpl_->overlay_order_undo.clear();
+    pimpl_->zone_type_undo.clear();
+    pimpl_->speech_pool_undo.clear();
+    pimpl_->end_screen_undo.clear();
+    pimpl_->activity_type_undo.clear();
+    pimpl_->help_undo.reset();
+    pimpl_->snippet_library_undo.reset();
+    pimpl_->playlist_undo.clear();
+    pimpl_->attack_vector_undo.clear();
+    pimpl_->magic_type_undo.clear();
+    pimpl_->movement_mode_undo.clear();
+    pimpl_->token->lifecycle = handle_lifecycle::committed;
+}
+
+void content_transaction::seal()
+{
+    if( pimpl_->token->lifecycle == handle_lifecycle::building ) {
+        pimpl_->token->lifecycle = handle_lifecycle::committed;
+    }
+}
+
+void content_transaction::discard()
+{
+    rollback();
+    pimpl_->token->lifecycle = handle_lifecycle::discarded;
+}
+
+std::string content_transaction::fingerprint() const
+{
+    std::uint64_t state = 1469598103934665603ULL;
+    hash_part( state, pimpl_->owner );
+    for( const json_flag_registration &entry : pimpl_->json_flags ) {
+        hash_part( state, "json_flag" );
+        hash_part( state, operation_name( entry.operation ) );
+        const json_flag_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.info );
+        hash_part( state, value.restriction );
+        hash_part( state, value.name );
+        hash_part( state, value.item_prefix );
+        hash_part( state, value.item_suffix );
+        hash_part( state, value.requires_flag );
+        hash_part( state, std::to_string( value.taste_modifier ) );
+        hash_part( state, value.inherit ? "inherit" : "local" );
+        hash_part( state, value.craft_inherit ? "craft_inherit" : "no_craft_inherit" );
+        for( const std::string &conflict : value.conflicts ) {
+            hash_part( state, conflict );
+        }
+    }
+    for( const tool_quality_registration &entry : pimpl_->tool_qualities ) {
+        hash_part( state, "tool_quality" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+        hash_part( state, entry.definition->name );
+        for( const auto &[level, text] : entry.definition->usages ) {
+            hash_part( state, std::to_string( level ) );
+            hash_part( state, text );
+        }
+    }
+    for( const skill_display_registration &entry : pimpl_->skill_displays ) {
+        hash_part( state, "skill_display" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+        hash_part( state, entry.definition->label );
+    }
+    for( const skill_registration &entry : pimpl_->skills ) {
+        hash_part( state, "skill" );
+        hash_part( state, operation_name( entry.operation ) );
+        const skill_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.name );
+        hash_part( state, value.description );
+        hash_part( state, value.display_category );
+        hash_part( state, std::to_string( value.sort_rank ) );
+        hash_part( state, value.consumes_focus ? "focus" : "no_focus" );
+        hash_part( state, value.teachable ? "teachable" : "not_teachable" );
+        hash_part( state, value.obsolete ? "obsolete" : "current" );
+        hash_part( state, std::to_string( value.attack_min_time ) );
+        hash_part( state, std::to_string( value.attack_base_time ) );
+        hash_part( state, std::to_string( value.attack_reduction_per_level ) );
+        hash_part( state, std::to_string( value.companion_combat_rank_factor ) );
+        hash_part( state, std::to_string( value.companion_survival_rank_factor ) );
+        hash_part( state, std::to_string( value.companion_industry_rank_factor ) );
+        for( const std::string &tag : value.tags ) {
+            hash_part( state, tag );
+        }
+        for( const auto &[id, weight] : value.companion_practice ) {
+            hash_part( state, id );
+            hash_part( state, std::to_string( weight ) );
+        }
+        for( const auto &[level, description] : value.theory_descriptions ) {
+            hash_part( state, std::to_string( level ) );
+            hash_part( state, description );
+        }
+        for( const auto &[level, description] : value.practice_descriptions ) {
+            hash_part( state, std::to_string( level ) );
+            hash_part( state, description );
+        }
+        for( const std::string &trait : value.requires_all_traits ) {
+            hash_part( state, "all" );
+            hash_part( state, trait );
+        }
+        for( const std::string &trait : value.requires_any_traits ) {
+            hash_part( state, "any" );
+            hash_part( state, trait );
+        }
+    }
+    for( const vitamin_registration &entry : pimpl_->vitamins ) {
+        hash_part( state, "vitamin" );
+        hash_part( state, operation_name( entry.operation ) );
+        const vitamin_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.name );
+        hash_part( state, value.type );
+        hash_part( state, value.deficiency );
+        hash_part( state, value.excess );
+        hash_part( state, std::to_string( value.minimum ) );
+        hash_part( state, std::to_string( value.maximum ) );
+        hash_part( state, std::to_string( value.rate_turns ) );
+        hash_part( state, value.weight_micrograms ?
+                   std::to_string( *value.weight_micrograms ) : "no_weight" );
+        for( const auto &[start, end] : value.disease ) {
+            hash_part( state, std::to_string( start ) );
+            hash_part( state, std::to_string( end ) );
+        }
+        for( const auto &[start, end] : value.disease_excess ) {
+            hash_part( state, std::to_string( start ) );
+            hash_part( state, std::to_string( end ) );
+        }
+        for( const auto &[id, rate] : value.decays_into ) {
+            hash_part( state, id );
+            hash_part( state, std::to_string( rate ) );
+        }
+        for( const std::string &flag : value.flags ) {
+            hash_part( state, flag );
+        }
+    }
+    for( const bash_damage_profile_registration &entry :
+         pimpl_->bash_damage_profiles ) {
+        hash_part( state, "bash_damage_profile" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+        for( const auto &[damage_id, factor] : entry.definition->factors ) {
+            hash_part( state, damage_id );
+            hash_part( state, std::to_string( factor ) );
+        }
+    }
+    for( const damage_type_registration &entry : pimpl_->damage_types ) {
+        hash_part( state, "damage_type" );
+        hash_part( state, operation_name( entry.operation ) );
+        const damage_type_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.name );
+        hash_part( state, value.skill );
+        hash_part( state, value.magic_color );
+        hash_part( state, value.derived_from );
+        hash_part( state, value.on_hit_handler );
+        hash_part( state, value.on_damage_handler );
+        hash_part( state, std::to_string( value.derived_factor ) );
+        hash_part( state, std::to_string( value.bash_conversion_factor ) );
+        hash_part( state, value.melee_only ? "melee" : "ranged" );
+        hash_part( state, value.physical ? "physical" : "nonphysical" );
+        hash_part( state, value.monster_difficulty ? "monster_difficulty" : "ordinary" );
+        hash_part( state, value.no_resist ? "no_resist" : "resisted" );
+        hash_part( state, value.edged ? "edged" : "blunt" );
+        hash_part( state, value.environmental ? "environmental" : "direct" );
+        hash_part( state, value.material_required ? "material_required" : "material_optional" );
+        for( const std::string &flag : value.character_immune_flags ) {
+            hash_part( state, "character" );
+            hash_part( state, flag );
+        }
+        for( const std::string &flag : value.monster_immune_flags ) {
+            hash_part( state, "monster" );
+            hash_part( state, flag );
+        }
+    }
+    for( const damage_info_order_registration &entry : pimpl_->damage_info_orders ) {
+        hash_part( state, "damage_info_order" );
+        hash_part( state, operation_name( entry.operation ) );
+        const damage_info_order_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.display );
+        hash_part( state, value.verb );
+        for( const damage_info_order_section_definition_data &section : value.sections ) {
+            hash_part( state, section.section );
+            hash_part( state, std::to_string( section.order ) );
+            hash_part( state, section.show_type ? "shown" : "hidden" );
+        }
+    }
+    for( const material_registration &entry : pimpl_->materials ) {
+        hash_part( state, "material" );
+        hash_part( state, operation_name( entry.operation ) );
+        const material_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.name );
+        hash_part( state, value.salvaged_into );
+        hash_part( state, value.repaired_with );
+        hash_part( state, value.bash_damage_verb );
+        hash_part( state, value.cut_damage_verb );
+        hash_part( state, std::to_string( value.chip_resistance ) );
+        hash_part( state, std::to_string( value.breathability ) );
+        hash_part( state, std::to_string( value.repair_difficulty ) );
+        hash_part( state, value.wind_resistance ?
+                   std::to_string( *value.wind_resistance ) : "no_wind" );
+        hash_part( state, std::to_string( value.density ) );
+        hash_part( state, std::to_string( value.sheet_thickness ) );
+        hash_part( state, std::to_string( value.specific_heat_liquid ) );
+        hash_part( state, std::to_string( value.specific_heat_solid ) );
+        hash_part( state, std::to_string( value.latent_heat ) );
+        hash_part( state, std::to_string( value.freezing_point ) );
+        hash_part( state, value.rotting ? "rotting" : "stable" );
+        hash_part( state, value.soft ? "soft" : "hard" );
+        hash_part( state, value.uncomfortable ? "uncomfortable" : "comfortable" );
+        hash_part( state, value.conductive ? "conductive" : "insulating" );
+        for( const std::string &adjective : value.damage_adjectives ) {
+            hash_part( state, adjective );
+        }
+        for( const auto &[id, amount] : value.resistances ) {
+            hash_part( state, id );
+            hash_part( state, std::to_string( amount ) );
+        }
+        for( const auto &[id, amount] : value.vitamins ) {
+            hash_part( state, id );
+            hash_part( state, std::to_string( amount ) );
+        }
+        for( const material_burn_definition &burn : value.burn_data ) {
+            hash_part( state, burn.immune ? "immune" : "burnable" );
+            hash_part( state, std::to_string( burn.volume_ml_per_turn ) );
+            hash_part( state, std::to_string( burn.fuel ) );
+            hash_part( state, std::to_string( burn.smoke ) );
+            hash_part( state, std::to_string( burn.burn ) );
+        }
+        for( const auto &[id, efficiency] : value.burn_products ) {
+            hash_part( state, id );
+            hash_part( state, std::to_string( efficiency ) );
+        }
+        hash_part( state, value.has_fuel ? "fuel" : "no_fuel" );
+        hash_part( state, std::to_string( value.fuel_energy_kilojoules ) );
+        hash_part( state, value.fuel_pump_terrain );
+        hash_part( state, value.perpetual_fuel ? "perpetual" : "consumed" );
+        hash_part( state, std::to_string( value.explosion_chance_hot ) );
+        hash_part( state, std::to_string( value.explosion_chance_cold ) );
+        hash_part( state, std::to_string( value.explosion_factor ) );
+        hash_part( state, value.fiery_explosion ? "fiery" : "ordinary" );
+        hash_part( state, std::to_string( value.fuel_size_factor ) );
+    }
+    for( const proficiency_category_registration &entry : pimpl_->proficiency_categories ) {
+        hash_part( state, "proficiency_category" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+        hash_part( state, entry.definition->name );
+        hash_part( state, entry.definition->description );
+    }
+    for( const proficiency_registration &entry : pimpl_->proficiencies ) {
+        hash_part( state, "proficiency" );
+        hash_part( state, operation_name( entry.operation ) );
+        const proficiency_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.name );
+        hash_part( state, value.description );
+        hash_part( state, value.category );
+        hash_part( state, std::to_string( value.time_to_learn_turns ) );
+        hash_part( state, std::to_string( value.time_multiplier ) );
+        hash_part( state, std::to_string( value.skill_penalty ) );
+        hash_part( state, std::to_string( value.weakpoint_bonus ) );
+        hash_part( state, std::to_string( value.weakpoint_penalty ) );
+        hash_part( state, value.can_learn ? "learnable" : "fixed" );
+        hash_part( state, value.ignore_focus ? "ignore_focus" : "use_focus" );
+        hash_part( state, value.teachable ? "teachable" : "not_teachable" );
+        for( const std::string &required : value.required ) {
+            hash_part( state, required );
+        }
+        for( const proficiency_bonus_definition &bonus : value.bonuses ) {
+            hash_part( state, bonus.category );
+            hash_part( state, bonus.attribute );
+            hash_part( state, std::to_string( bonus.value ) );
+        }
+    }
+    for( const weapon_category_registration &entry : pimpl_->weapon_categories ) {
+        hash_part( state, "weapon_category" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+        hash_part( state, entry.definition->name );
+        for( const std::string &proficiency_key : entry.definition->proficiencies ) {
+            hash_part( state, proficiency_key );
+        }
+    }
+    for( const item_category_registration &entry : pimpl_->item_categories ) {
+        hash_part( state, "item_category" );
+        hash_part( state, operation_name( entry.operation ) );
+        const item_category_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.header );
+        hash_part( state, value.noun );
+        hash_part( state, std::to_string( value.sort_rank ) );
+        hash_part( state, std::to_string( value.spawn_rate ) );
+        hash_part( state, value.zone );
+        for( const item_category_priority_definition &priority : value.priority_zones ) {
+            hash_part( state, priority.zone );
+            hash_part( state, priority.filthy ? "filthy" : "flagged" );
+            for( const std::string &flag : priority.flags ) {
+                hash_part( state, flag );
+            }
+        }
+    }
+    for( const crafting_category_registration &entry : pimpl_->crafting_categories ) {
+        hash_part( state, "recipe_category" );
+        hash_part( state, operation_name( entry.operation ) );
+        const crafting_category_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.hidden ? "hidden" : "visible" );
+        hash_part( state, value.practice ? "practice" : "ordinary" );
+        hash_part( state, value.building ? "building" : "not_building" );
+        hash_part( state, value.wildcard ? "wildcard" : "concrete" );
+        for( const std::string &subcategory : value.subcategories ) {
+            hash_part( state, subcategory );
+        }
+    }
+    for( const ammunition_type_registration &entry : pimpl_->ammunition_types ) {
+        hash_part( state, "ammunition_type" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+        hash_part( state, entry.definition->name );
+        hash_part( state, entry.definition->default_item );
+    }
+    for( const monster_flag_registration &entry : pimpl_->monster_flags ) {
+        hash_part( state, "monster_flag" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+    }
+    for( const species_registration &entry : pimpl_->species ) {
+        hash_part( state, "species" );
+        hash_part( state, operation_name( entry.operation ) );
+        const species_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.description );
+        hash_part( state, value.footsteps );
+        hash_part( state, value.bleeds );
+        for( const std::string &flag : value.flags ) {
+            hash_part( state, flag );
+        }
+        for( const std::string &trigger : value.anger ) {
+            hash_part( state, "anger" );
+            hash_part( state, trigger );
+        }
+        for( const std::string &trigger : value.fear ) {
+            hash_part( state, "fear" );
+            hash_part( state, trigger );
+        }
+        for( const std::string &trigger : value.placate ) {
+            hash_part( state, "placate" );
+            hash_part( state, trigger );
+        }
+    }
+    for( const emission_registration &entry : pimpl_->emissions ) {
+        hash_part( state, "emission" );
+        hash_part( state, operation_name( entry.operation ) );
+        const emission_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.field );
+        hash_part( state, std::to_string( value.intensity ) );
+        hash_part( state, std::to_string( value.quantity ) );
+        hash_part( state, std::to_string( value.chance ) );
+        hash_part( state, value.profile_handler );
+    }
+    for( const monster_faction_registration &entry : pimpl_->monster_factions ) {
+        hash_part( state, "monster_faction" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+        hash_part( state, entry.definition->base );
+        for( const auto &[target, attitude] : entry.definition->attitudes ) {
+            hash_part( state, target );
+            hash_part( state, attitude );
+        }
+    }
+    for( const mutation_type_registration &entry : pimpl_->mutation_types ) {
+        hash_part( state, "mutation_type" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+    }
+    for( const connect_group_registration &entry : pimpl_->connect_groups ) {
+        hash_part( state, "connect_group" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+    }
+    for( const mutation_category_registration &entry : pimpl_->mutation_categories ) {
+        hash_part( state, "mutation_category" );
+        hash_part( state, operation_name( entry.operation ) );
+        const mutation_category_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.name );
+        hash_part( state, value.threshold_mutation );
+        hash_part( state, value.mutagen_message );
+        hash_part( state, value.memorial_message );
+        hash_part( state, value.vitamin );
+        hash_part( state, std::to_string( value.threshold_minimum ) );
+        hash_part( state, std::to_string( value.base_removal_chance ) );
+        hash_part( state, std::to_string( value.base_removal_cost_multiplier ) );
+        hash_part( state, value.work_in_progress ? "wip" : "complete" );
+        hash_part( state, value.skip_consistency_test ? "skip_test" : "check" );
+    }
+    for( const construction_category_registration &entry :
+         pimpl_->construction_categories ) {
+        hash_part( state, "construction_category" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+        hash_part( state, entry.definition->name );
+    }
+    for( const construction_group_registration &entry : pimpl_->construction_groups ) {
+        hash_part( state, "construction_group" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+        hash_part( state, entry.definition->name );
+    }
+    for( const vehicle_part_location_registration &entry :
+         pimpl_->vehicle_part_locations ) {
+        hash_part( state, "vehicle_part_location" );
+        hash_part( state, operation_name( entry.operation ) );
+        const vehicle_part_location_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.name );
+        hash_part( state, value.description );
+        hash_part( state, std::to_string( value.z_order ) );
+        hash_part( state, std::to_string( value.list_order ) );
+    }
+    for( const vehicle_part_category_registration &entry :
+         pimpl_->vehicle_part_categories ) {
+        hash_part( state, "vehicle_part_category" );
+        hash_part( state, operation_name( entry.operation ) );
+        const vehicle_part_category_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.name );
+        hash_part( state, value.short_name );
+        hash_part( state, std::to_string( value.priority ) );
+    }
+    for( const mood_face_registration &entry : pimpl_->mood_faces ) {
+        hash_part( state, "mood_face" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+        for( const mood_face_value_definition_data &value : entry.definition->values ) {
+            hash_part( state, std::to_string( value.score ) );
+            hash_part( state, value.face );
+        }
+    }
+    for( const named_color_registration &entry : pimpl_->named_colors ) {
+        hash_part( state, "named_color" );
+        hash_part( state, operation_name( entry.operation ) );
+        const named_color_definition_data &value = *entry.definition;
+        hash_part( state, value.name );
+        hash_part( state, std::to_string( value.red ) );
+        hash_part( state, std::to_string( value.green ) );
+        hash_part( state, std::to_string( value.blue ) );
+        hash_part( state, std::to_string( value.alpha ) );
+    }
+    for( const rotatable_symbol_registration &entry : pimpl_->rotatable_symbols ) {
+        hash_part( state, "rotatable_symbol" );
+        hash_part( state, operation_name( entry.operation ) );
+        for( const std::uint32_t symbol : entry.definition->symbols ) {
+            hash_part( state, std::to_string( symbol ) );
+        }
+    }
+    for( const ascii_art_registration &entry : pimpl_->ascii_arts ) {
+        hash_part( state, "ascii_art" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+        for( const std::string &line : entry.definition->lines ) {
+            hash_part( state, line );
+        }
+    }
+    for( const limb_score_registration &entry : pimpl_->limb_scores ) {
+        hash_part( state, "limb_score" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+        hash_part( state, entry.definition->name );
+        hash_part( state, entry.definition->affected_by_wounds ? "wounds" : "no_wounds" );
+        hash_part( state, entry.definition->affected_by_encumbrance ?
+                   "encumbrance" : "no_encumbrance" );
+    }
+    for( const hit_range_registration &entry : pimpl_->hit_ranges ) {
+        hash_part( state, "hit_range" );
+        hash_part( state, operation_name( entry.operation ) );
+        for( const std::int64_t value : entry.definition->even_good ) {
+            hash_part( state, std::to_string( value ) );
+        }
+    }
+    for( const overmap_land_use_code_registration &entry :
+         pimpl_->overmap_land_use_codes ) {
+        hash_part( state, "overmap_land_use_code" );
+        hash_part( state, operation_name( entry.operation ) );
+        const overmap_land_use_code_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, std::to_string( value.code ) );
+        hash_part( state, value.name );
+        hash_part( state, value.description );
+        hash_part( state, std::to_string( value.symbol ) );
+        hash_part( state, value.color );
+    }
+    for( const overmap_vision_registration &entry : pimpl_->overmap_visions ) {
+        hash_part( state, "overmap_vision" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+        for( const overmap_vision_level_definition_data &level :
+             entry.definition->levels ) {
+            hash_part( state, level.blends_adjacent ? "blend" : "appearance" );
+            hash_part( state, level.name );
+            hash_part( state, std::to_string( level.symbol ) );
+            hash_part( state, level.color );
+            hash_part( state, level.looks_like );
+        }
+    }
+    for( const overmap_location_registration &entry : pimpl_->overmap_locations ) {
+        hash_part( state, "overmap_location" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+        for( const std::string &terrain : entry.definition->terrains ) {
+            hash_part( state, "terrain" );
+            hash_part( state, terrain );
+        }
+        for( const std::string &flag : entry.definition->terrain_flags ) {
+            hash_part( state, "flag" );
+            hash_part( state, flag );
+        }
+    }
+    for( const profession_group_registration &entry : pimpl_->profession_groups ) {
+        hash_part( state, "profession_group" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+        for( const std::string &profession : entry.definition->professions ) {
+            hash_part( state, profession );
+        }
+    }
+    for( const map_extra_collection_registration &entry : pimpl_->map_extra_collections ) {
+        hash_part( state, "map_extra_collection" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+        hash_part( state, std::to_string( entry.definition->chance ) );
+        for( const auto &[extra, weight] : entry.definition->entries ) {
+            hash_part( state, extra );
+            hash_part( state, std::to_string( weight ) );
+        }
+    }
+    for( const vehicle_group_registration &entry : pimpl_->vehicle_groups ) {
+        hash_part( state, "vehicle_group" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+        for( const auto &[vehicle, weight] : entry.definition->entries ) {
+            hash_part( state, vehicle );
+            hash_part( state, std::to_string( weight ) );
+        }
+    }
+    for( const fault_group_registration &entry : pimpl_->fault_groups ) {
+        hash_part( state, "fault_group" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+        for( const auto &[fault, weight] : entry.definition->entries ) {
+            hash_part( state, fault );
+            hash_part( state, std::to_string( weight ) );
+        }
+    }
+    for( const explosion_light_registration &entry : pimpl_->explosion_lights ) {
+        hash_part( state, "explosion_light" );
+        hash_part( state, operation_name( entry.operation ) );
+        const explosion_light_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        for( const light_stop &stop : value.stops ) {
+            hash_part( state, std::to_string( stop.color[0] ) );
+            hash_part( state, std::to_string( stop.color[1] ) );
+            hash_part( state, std::to_string( stop.color[2] ) );
+            hash_part( state, std::to_string( stop.alpha ) );
+        }
+        hash_part( state, value.easing );
+        hash_part( state, std::to_string( value.wave_travel ) );
+        hash_part( state, std::to_string( value.wave_gap ) );
+        hash_part( state, std::to_string( value.rise ) );
+        hash_part( state, std::to_string( value.fade ) );
+        hash_part( state, std::to_string( value.blend ) );
+        hash_part( state, std::to_string( value.spread_jitter ) );
+        hash_part( state, std::to_string( value.color_jitter ) );
+        hash_part( state, std::to_string( value.flicker ) );
+        hash_part( state, std::to_string( value.duration_base_ms ) );
+        hash_part( state, std::to_string( value.duration_per_tile_ms ) );
+        hash_part( state, std::to_string( value.duration_min_ms ) );
+        hash_part( state, std::to_string( value.duration_max_ms ) );
+        hash_part( state, std::to_string( value.screen_shake_magnitude ) );
+        hash_part( state, std::to_string( value.screen_shake_duration_ms ) );
+        hash_part( state, value.shockwave ? "shockwave" : "no_shockwave" );
+        hash_part( state, std::to_string( value.shockwave_strength ) );
+        hash_part( state, std::to_string( value.shockwave_speed ) );
+        hash_part( state, std::to_string( value.shockwave_thickness ) );
+    }
+    for( const ammo_effect_registration &entry : pimpl_->ammo_effects ) {
+        hash_part( state, "ammo_effect" );
+        hash_part( state, operation_name( entry.operation ) );
+        const ammo_effect_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, std::to_string( value.trigger_chance ) );
+        const auto hash_field = [&]( const ammo_field_definition_data & field ) {
+            hash_part( state, field.field );
+            hash_part( state, std::to_string( field.intensity_min ) );
+            hash_part( state, std::to_string( field.intensity_max ) );
+            hash_part( state, std::to_string( field.radius ) );
+            hash_part( state, std::to_string( field.height ) );
+            hash_part( state, std::to_string( field.chance ) );
+            hash_part( state, std::to_string( field.footprint ) );
+            hash_part( state, field.passable_only ? "passable" : "any_tile" );
+        };
+        for( const ammo_field_definition_data &field : value.field_bursts ) {
+            hash_part( state, "field_burst" );
+            hash_field( field );
+        }
+        for( const ammo_field_definition_data &field : value.trails ) {
+            hash_part( state, "trail" );
+            hash_field( field );
+        }
+        const auto hash_character_effect = [&] (
+        const ammo_character_effect_definition_data & effect ) {
+            hash_part( state, effect.effect );
+            hash_part( state, std::to_string( effect.duration_turns ) );
+            hash_part( state, std::to_string( effect.intensity_min ) );
+            hash_part( state, std::to_string( effect.intensity_max ) );
+            hash_part( state, std::to_string( effect.chance ) );
+            hash_part( state, std::to_string( effect.radius ) );
+            hash_part( state, std::to_string( effect.hits_min ) );
+            hash_part( state, std::to_string( effect.hits_max ) );
+            hash_part( state, effect.touch_skin ? "touch_skin" : "through_armor" );
+            hash_part( state, effect.all_body_parts ? "all_body_parts" : "random_parts" );
+        };
+        for( const ammo_character_effect_definition_data &effect : value.on_hit_effects ) {
+            hash_part( state, "on_hit" );
+            hash_character_effect( effect );
+        }
+        for( const ammo_character_effect_definition_data &effect : value.area_effects ) {
+            hash_part( state, "area_effect" );
+            hash_character_effect( effect );
+        }
+        hash_part( state, value.has_explosion ? "explosion" : "no_explosion" );
+        hash_part( state, std::to_string( value.explosion_power ) );
+        hash_part( state, std::to_string( value.explosion_distance_factor ) );
+        hash_part( state, std::to_string( value.explosion_max_noise ) );
+        hash_part( state, value.explosion_fire ? "fire" : "no_fire" );
+        hash_part( state, value.explosion_light );
+        hash_part( state, value.has_shrapnel ? "shrapnel" : "no_shrapnel" );
+        hash_part( state, std::to_string( value.casing_mass ) );
+        hash_part( state, std::to_string( value.fragment_mass ) );
+        hash_part( state, std::to_string( value.fragment_recovery ) );
+        hash_part( state, value.fragment_drop );
+        hash_part( state, value.flashbang ? "flashbang" : "no_flashbang" );
+        hash_part( state, value.emp ? "emp" : "no_emp" );
+        hash_part( state, value.foamcrete ? "foamcrete" : "no_foamcrete" );
+        hash_part( state, value.cast_spells_on_miss ? "spells_always" : "spells_on_damage" );
+        for( const ammo_spell_definition_data &spell : value.spells ) {
+            hash_part( state, spell.spell );
+            hash_part( state, std::to_string( spell.level ) );
+            hash_part( state, spell.self ? "self" : "impact" );
+        }
+        hash_part( state, value.impact_handler );
+    }
+    for( const addiction_type_registration &entry : pimpl_->addiction_types ) {
+        hash_part( state, "addiction_type" );
+        hash_part( state, operation_name( entry.operation ) );
+        const addiction_type_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.name );
+        hash_part( state, value.type_name );
+        hash_part( state, value.description );
+        hash_part( state, value.craving_morale );
+        hash_part( state, value.tick_handler );
+    }
+    for( const character_modifier_registration &entry : pimpl_->character_modifiers ) {
+        hash_part( state, "character_modifier" );
+        hash_part( state, operation_name( entry.operation ) );
+        const character_modifier_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.description );
+        hash_part( state, value.operation );
+        hash_part( state, value.evaluator_handler );
+    }
+    for( const start_location_registration &entry : pimpl_->start_locations ) {
+        hash_part( state, "start_location" );
+        hash_part( state, operation_name( entry.operation ) );
+        const start_location_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.name );
+        for( const start_location_target_definition_data &target : value.targets ) {
+            hash_part( state, target.terrain );
+            hash_part( state, target.match );
+            for( const auto &[parameter, parameter_value] : target.parameters ) {
+                hash_part( state, parameter );
+                hash_part( state, parameter_value );
+            }
+        }
+        for( const std::string &flag : value.flags ) {
+            hash_part( state, flag );
+        }
+        hash_part( state, std::to_string( value.city_size_min ) );
+        hash_part( state, std::to_string( value.city_size_max ) );
+        hash_part( state, std::to_string( value.city_distance_min ) );
+        hash_part( state, std::to_string( value.city_distance_max ) );
+        hash_part( state, std::to_string( value.z_min ) );
+        hash_part( state, std::to_string( value.z_max ) );
+    }
+    for( const climbing_aid_registration &entry : pimpl_->climbing_aids ) {
+        hash_part( state, "climbing_aid" );
+        hash_part( state, operation_name( entry.operation ) );
+        const climbing_aid_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, std::to_string( value.slip_chance_modifier ) );
+        hash_part( state, value.category );
+        hash_part( state, value.flag );
+        hash_part( state, std::to_string( value.uses ) );
+        hash_part( state, std::to_string( value.range ) );
+        hash_part( state, std::to_string( value.max_height ) );
+        hash_part( state, std::to_string( value.easy_climb_back_up ) );
+        hash_part( state, value.allow_remaining_height ? "remaining" : "full_height" );
+        hash_part( state, value.menu_text );
+        hash_part( state, value.unavailable_text );
+        hash_part( state, value.hotkey );
+        hash_part( state, value.confirm_text );
+        hash_part( state, value.before_message );
+        hash_part( state, value.after_message );
+        hash_part( state, std::to_string( value.pain ) );
+        hash_part( state, std::to_string( value.damage ) );
+        hash_part( state, std::to_string( value.kilocalories ) );
+        hash_part( state, std::to_string( value.thirst ) );
+        hash_part( state, value.deploy_furniture );
+    }
+    for( const weather_type_registration &entry : pimpl_->weather_types ) {
+        hash_part( state, "weather_type" );
+        hash_part( state, operation_name( entry.operation ) );
+        const weather_type_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.name );
+        hash_part( state, value.color );
+        hash_part( state, value.map_color );
+        hash_part( state, value.symbol );
+        hash_part( state, value.sun_symbol );
+        hash_part( state, std::to_string( value.ranged_penalty ) );
+        hash_part( state, std::to_string( value.sight_penalty ) );
+        hash_part( state, std::to_string( value.light_modifier ) );
+        hash_part( state, std::to_string( value.temperature_delta_kelvin ) );
+        hash_part( state, std::to_string( value.light_multiplier ) );
+        hash_part( state, std::to_string( value.sun_multiplier ) );
+        hash_part( state, std::to_string( value.sound_attenuation ) );
+        hash_part( state, value.dangerous ? "dangerous" : "safe" );
+        hash_part( state, value.precipitation );
+        hash_part( state, value.rains ? "rain" : "not_rain" );
+        hash_part( state, value.tiles_animation );
+        hash_part( state, value.sound_category );
+        hash_part( state, std::to_string( value.priority ) );
+        hash_part( state, std::to_string( value.minimum_duration_turns ) );
+        hash_part( state, std::to_string( value.maximum_duration_turns ) );
+        hash_part( state, value.has_animation ? "animation" : "no_animation" );
+        hash_part( state, std::to_string( value.animation_factor ) );
+        hash_part( state, value.animation_color );
+        hash_part( state, value.animation_symbol );
+        for( const std::string &weather : value.required_weathers ) {
+            hash_part( state, weather );
+        }
+        for( const weather_passive_effect_definition_data &effect : value.passive_effects ) {
+            hash_part( state, effect.effect );
+            hash_part( state, std::to_string( effect.minimum_duration_turns ) );
+            hash_part( state, std::to_string( effect.maximum_duration_turns ) );
+            hash_part( state, std::to_string( effect.intensity ) );
+            hash_part( state, effect.body_part );
+            hash_part( state, effect.environmental ? "environmental" : "internal" );
+            hash_part( state, effect.immune_in_vehicle ? "immune_vehicle" : "not_immune_vehicle" );
+            hash_part( state, effect.immune_inside_vehicle ? "immune_inside" : "not_immune_inside" );
+            hash_part( state, effect.immune_outside_vehicle ? "immune_outside" : "not_immune_outside" );
+            hash_part( state, std::to_string( effect.chance_in_vehicle ) );
+            hash_part( state, std::to_string( effect.chance_inside_vehicle ) );
+            hash_part( state, std::to_string( effect.chance_outside_vehicle ) );
+            hash_part( state, effect.message );
+            hash_part( state, effect.npc_message );
+        }
+        hash_part( state, value.condition_handler );
+    }
+    for( const score_registration &entry : pimpl_->scores ) {
+        hash_part( state, "score" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+        hash_part( state, entry.definition->statistic );
+        hash_part( state, entry.definition->description );
+    }
+    for( const overlay_order_registration &entry : pimpl_->overlay_orders ) {
+        hash_part( state, "overlay_order" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+        for( const auto &[mutation_id, order] : entry.definition->orders ) {
+            hash_part( state, mutation_id );
+            hash_part( state, std::to_string( order ) );
+        }
+    }
+    for( const zone_type_registration &entry : pimpl_->zone_types ) {
+        hash_part( state, "zone_type" );
+        hash_part( state, operation_name( entry.operation ) );
+        const zone_type_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.name );
+        hash_part( state, value.description );
+        hash_part( state, value.display_field );
+        hash_part( state, value.can_be_personal ? "personal" : "faction_only" );
+        hash_part( state, value.hidden ? "hidden" : "visible" );
+    }
+    for( const speech_pool_registration &entry : pimpl_->speech_pools ) {
+        hash_part( state, "speech_pool" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+        for( const auto &[sound, volume] : entry.definition->lines ) {
+            hash_part( state, sound );
+            hash_part( state, std::to_string( volume ) );
+        }
+    }
+    for( const end_screen_registration &entry : pimpl_->end_screens ) {
+        hash_part( state, "end_screen" );
+        hash_part( state, operation_name( entry.operation ) );
+        const end_screen_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.picture );
+        hash_part( state, std::to_string( value.priority ) );
+        hash_part( state, value.last_words_label );
+        hash_part( state, value.condition_handler );
+        for( const auto &[column, row, text] : value.information ) {
+            hash_part( state, std::to_string( column ) );
+            hash_part( state, std::to_string( row ) );
+            hash_part( state, text );
+        }
+    }
+    for( const activity_type_registration &entry : pimpl_->activity_types ) {
+        hash_part( state, "activity_type" );
+        hash_part( state, operation_name( entry.operation ) );
+        const activity_type_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.verb );
+        hash_part( state, value.rooted ? "rooted" : "mobile" );
+        hash_part( state, value.interruptable ? "interruptable" : "uninterruptable" );
+        hash_part( state, value.interruptable_with_keyboard ?
+                   "keyboard_interruptable" : "keyboard_uninterruptable" );
+        hash_part( state, value.based_on );
+        hash_part( state, value.can_resume ? "resumable" : "not_resumable" );
+        hash_part( state, value.multi_activity ? "multi" : "single" );
+        hash_part( state, value.fetch_items_to_zone ? "fetch" : "no_fetch" );
+        hash_part( state, value.refuel_fires ? "refuel" : "no_refuel" );
+        hash_part( state, value.auto_needs ? "auto_needs" : "manual_needs" );
+        hash_part( state, std::to_string( value.activity_level ) );
+        for( const std::string &distraction : value.ignored_distractions ) {
+            hash_part( state, distraction );
+        }
+        hash_part( state, value.do_turn_handler );
+        hash_part( state, value.completion_handler );
+    }
+    for( const help_topic_registration &entry : pimpl_->help_topics ) {
+        hash_part( state, "help_topic" );
+        hash_part( state, operation_name( entry.operation ) );
+        const help_topic_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.title );
+        hash_part( state, value.order ? std::to_string( *value.order ) : "automatic" );
+        for( const std::string &paragraph : value.paragraphs ) {
+            hash_part( state, paragraph );
+        }
+    }
+    for( const snippet_category_registration &entry : pimpl_->snippet_categories ) {
+        hash_part( state, "snippet_category" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+        for( const snippet_entry_definition_data &snippet : entry.definition->entries ) {
+            hash_part( state, snippet.id );
+            hash_part( state, snippet.text );
+            hash_part( state, snippet.name );
+            hash_part( state, std::to_string( snippet.weight ) );
+            hash_part( state, snippet.examine_handler );
+        }
+    }
+    for( const playlist_registration &entry : pimpl_->playlists ) {
+        hash_part( state, "playlist" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+        hash_part( state, entry.definition->shuffle ? "shuffle" : "ordered" );
+        for( const auto &[file, volume] : entry.definition->tracks ) {
+            hash_part( state, file );
+            hash_part( state, std::to_string( volume ) );
+        }
+    }
+    for( const attack_vector_registration &entry : pimpl_->attack_vectors ) {
+        hash_part( state, "attack_vector" );
+        hash_part( state, operation_name( entry.operation ) );
+        const attack_vector_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.weapon ? "weapon" : "unarmed" );
+        hash_part( state, value.strict_limbs ? "strict" : "substitutions" );
+        hash_part( state, value.armor_bonus ? "armor_bonus" : "natural_only" );
+        hash_part( state, std::to_string( value.encumbrance_limit ) );
+        hash_part( state, std::to_string( value.health_percent_limit ) );
+        for( const std::string &limb : value.limbs ) {
+            hash_part( state, limb );
+        }
+        for( const std::string &contact : value.contacts ) {
+            hash_part( state, contact );
+        }
+        for( const auto &[kind, count] : value.limb_requirements ) {
+            hash_part( state, kind );
+            hash_part( state, std::to_string( count ) );
+        }
+        for( const std::string &flag : value.required_flags ) {
+            hash_part( state, "requires" );
+            hash_part( state, flag );
+        }
+        for( const std::string &flag : value.forbidden_flags ) {
+            hash_part( state, "forbids" );
+            hash_part( state, flag );
+        }
+    }
+    for( const magic_type_registration &entry : pimpl_->magic_types ) {
+        hash_part( state, "magic_type" );
+        hash_part( state, operation_name( entry.operation ) );
+        const magic_type_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.energy_source );
+        hash_part( state, value.vitamin );
+        hash_part( state, value.energy_color );
+        hash_part( state, value.cannot_cast_message.value_or( "no_message" ) );
+        hash_part( state, value.max_book_level ?
+                   std::to_string( *value.max_book_level ) : "no_book_limit" );
+        hash_part( state, std::to_string( value.failure_cost_fraction ) );
+        hash_part( state, std::to_string( value.failure_experience_fraction ) );
+        for( const std::string &flag : value.cannot_cast_flags ) {
+            hash_part( state, flag );
+        }
+        hash_part( state, value.level_for_experience_handler );
+        hash_part( state, value.experience_for_level_handler );
+        hash_part( state, value.casting_experience_handler );
+        hash_part( state, value.failure_chance_handler );
+        hash_part( state, value.failure_cost_handler );
+        hash_part( state, value.failure_experience_handler );
+        hash_part( state, value.failure_handler );
+    }
+    for( const movement_mode_registration &entry : pimpl_->movement_modes ) {
+        hash_part( state, "movement_mode" );
+        hash_part( state, operation_name( entry.operation ) );
+        const movement_mode_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.name );
+        hash_part( state, value.kind );
+        hash_part( state, std::to_string( value.character_symbol ) );
+        hash_part( state, std::to_string( value.panel_symbol ) );
+        hash_part( state, value.panel_color );
+        hash_part( state, value.symbol_color );
+        hash_part( state, std::to_string( value.exertion ) );
+        hash_part( state, std::to_string( value.riding_exertion ) );
+        hash_part( state, std::to_string( value.stamina_multiplier ) );
+        hash_part( state, std::to_string( value.sound_multiplier ) );
+        hash_part( state, std::to_string( value.speed_multiplier ) );
+        hash_part( state, std::to_string( value.mech_power_kilojoules ) );
+        hash_part( state, std::to_string( value.swim_speed_modifier ) );
+        hash_part( state, value.stop_hauling ? "stop_hauling" : "keep_hauling" );
+        for( const movement_mode_message_definition_data &messages : value.messages ) {
+            hash_part( state, messages.steed );
+            hash_part( state, messages.prepare );
+            hash_part( state, messages.success );
+            hash_part( state, messages.failure );
+        }
+    }
+    for( const scent_type_registration &entry : pimpl_->scent_types ) {
+        hash_part( state, "scent_type" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+        for( const std::string &species : entry.definition->receptive_species ) {
+            hash_part( state, species );
+        }
+    }
+    for( const speed_description_registration &entry : pimpl_->speed_descriptions ) {
+        hash_part( state, "speed_description" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+        for( const speed_description_value_data &value : entry.definition->values ) {
+            hash_part( state, std::to_string( value.threshold ) );
+            for( const std::string &description : value.descriptions ) {
+                hash_part( state, description );
+            }
+        }
+    }
+    for( const item_group_registration &entry : pimpl_->item_groups ) {
+        hash_part( state, "item_group" );
+        hash_part( state, operation_name( entry.operation ) );
+        const item_group_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.kind );
+        hash_part( state, std::to_string( value.with_ammo ) );
+        hash_part( state, std::to_string( value.with_magazine ) );
+        for( const item_group_entry_definition_data &group_entry : value.entries ) {
+            hash_part( state, group_entry.group ? "group" : "item" );
+            hash_part( state, group_entry.id );
+            hash_part( state, std::to_string( group_entry.probability ) );
+            hash_part( state, group_entry.variant );
+        }
+    }
+    for( const harvest_drop_type_registration &entry : pimpl_->harvest_drop_types ) {
+        hash_part( state, "harvest_drop_type" );
+        hash_part( state, operation_name( entry.operation ) );
+        const harvest_drop_type_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.item_group ? "item_group" : "item" );
+        hash_part( state, value.dissect_only ? "dissect_only" : "all_butchery" );
+        hash_part( state, value.field_dress_success );
+        hash_part( state, value.field_dress_failure );
+        hash_part( state, value.butcher_success );
+        hash_part( state, value.butcher_failure );
+        hash_part( state, value.dissect_success );
+        hash_part( state, value.dissect_failure );
+        for( const std::string &skill : value.skills ) {
+            hash_part( state, skill );
+        }
+    }
+    for( const harvest_registration &entry : pimpl_->harvests ) {
+        hash_part( state, "harvest" );
+        hash_part( state, operation_name( entry.operation ) );
+        const harvest_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.message );
+        hash_part( state, value.leftovers );
+        hash_part( state, value.butchery_requirements );
+        for( const harvest_entry_definition_data &drop : value.entries ) {
+            hash_part( state, drop.output );
+            hash_part( state, drop.category );
+            hash_part( state, std::to_string( drop.base_minimum ) );
+            hash_part( state, std::to_string( drop.base_maximum ) );
+            hash_part( state, std::to_string( drop.skill_minimum ) );
+            hash_part( state, std::to_string( drop.skill_maximum ) );
+            hash_part( state, std::to_string( drop.maximum ) );
+            hash_part( state, std::to_string( drop.mass_ratio ) );
+            for( const std::string &flag : drop.flags ) {
+                hash_part( state, "flag" );
+                hash_part( state, flag );
+            }
+            for( const std::string &fault : drop.faults ) {
+                hash_part( state, "fault" );
+                hash_part( state, fault );
+            }
+        }
+    }
+    for( const behavior_registration &entry : pimpl_->behaviors ) {
+        hash_part( state, "behavior" );
+        hash_part( state, operation_name( entry.operation ) );
+        const behavior_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.strategy );
+        hash_part( state, value.goal );
+        for( const std::string &child : value.children ) {
+            hash_part( state, "child" );
+            hash_part( state, child );
+        }
+        for( const behavior_condition_definition_data &condition : value.conditions ) {
+            hash_part( state, condition.native ? "native_condition" : "lua_condition" );
+            hash_part( state, condition.policy );
+            hash_part( state, condition.argument );
+            hash_part( state, condition.inverted ? "inverted" : "direct" );
+        }
+        if( value.score ) {
+            hash_part( state, value.score->native ? "native_score" : "lua_score" );
+            hash_part( state, value.score->policy );
+            hash_part( state, value.score->argument );
+        } else {
+            hash_part( state, "no_score" );
+        }
+    }
+    for( const effect_type_registration &entry : pimpl_->effect_types ) {
+        hash_part( state, "effect_type" );
+        hash_part( state, operation_name( entry.operation ) );
+        const effect_type_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        for( const std::string &text : value.names ) {
+            hash_part( state, "name" );
+            hash_part( state, text );
+        }
+        for( const std::string &text : value.descriptions ) {
+            hash_part( state, "description" );
+            hash_part( state, text );
+        }
+        for( const std::string &text : value.reduced_descriptions ) {
+            hash_part( state, "reduced_description" );
+            hash_part( state, text );
+        }
+        hash_part( state, value.remove_message );
+        hash_part( state, value.apply_memorial_log );
+        hash_part( state, value.remove_memorial_log );
+        hash_part( state, value.blood_analysis_description );
+        hash_part( state, std::to_string( value.maximum_intensity ) );
+        hash_part( state, std::to_string( value.maximum_duration_turns ) );
+        hash_part( state, std::to_string( value.intensity_duration_turns ) );
+        hash_part( state, std::to_string( value.duration_add_percent ) );
+        hash_part( state, std::to_string( value.intensity_add_value ) );
+        hash_part( state, std::to_string( value.intensity_decay_step ) );
+        hash_part( state, std::to_string( value.intensity_decay_tick ) );
+        hash_part( state, value.intensity_decay_removes ? "decay_removes" : "decay_keeps" );
+        hash_part( state, value.main_parts_only ? "main_parts" : "all_parts" );
+        hash_part( state, value.show_in_info ? "show_info" : "hide_info" );
+        hash_part( state, value.show_intensity ? "show_intensity" : "hide_intensity" );
+        hash_part( state, value.part_descriptions ? "part_descriptions" : "global_descriptions" );
+        const auto hash_ids = [&]( const std::string_view kind,
+        const std::set<std::string> &ids ) {
+            for( const std::string &id : ids ) {
+                hash_part( state, kind );
+                hash_part( state, id );
+            }
+        };
+        hash_ids( "flag", value.flags );
+        hash_ids( "immune_character_flag", value.immune_character_flags );
+        hash_ids( "immune_bodypart_flag", value.immune_bodypart_flags );
+        hash_ids( "resist_trait", value.resist_traits );
+        hash_ids( "resist_effect", value.resist_effects );
+        hash_ids( "removes_effect", value.removes_effects );
+        hash_ids( "blocks_effect", value.blocks_effects );
+    }
+    for( const sub_body_part_registration &entry : pimpl_->sub_body_parts ) {
+        hash_part( state, "sub_body_part" );
+        hash_part( state, operation_name( entry.operation ) );
+        const sub_body_part_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.name );
+        hash_part( state, value.plural_name );
+        hash_part( state, value.parent );
+        hash_part( state, value.opposite );
+        hash_part( state, value.side );
+        hash_part( state, value.secondary ? "secondary" : "primary" );
+        hash_part( state, std::to_string( value.maximum_coverage ) );
+        hash_part( state, value.similar_body_part );
+        for( const std::string &location : value.locations_under ) {
+            hash_part( state, "under" );
+            hash_part( state, location );
+        }
+        for( const auto &[damage_id, amount] : value.unarmed_damage ) {
+            hash_part( state, damage_id );
+            hash_part( state, std::to_string( amount ) );
+        }
+    }
+    for( const body_part_registration &entry : pimpl_->body_parts ) {
+        hash_part( state, "body_part" );
+        hash_part( state, operation_name( entry.operation ) );
+        const body_part_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.name );
+        hash_part( state, value.plural_name );
+        hash_part( state, value.accusative );
+        hash_part( state, value.plural_accusative );
+        hash_part( state, value.heading );
+        hash_part( state, value.plural_heading );
+        hash_part( state, value.encumbrance_text );
+        hash_part( state, value.hp_bar_text );
+        hash_part( state, value.main_part );
+        hash_part( state, value.connected_to );
+        hash_part( state, value.opposite );
+        hash_part( state, value.side );
+        hash_part( state, std::to_string( value.hit_size ) );
+        hash_part( state, std::to_string( value.hit_difficulty ) );
+        hash_part( state, std::to_string( value.base_health ) );
+        hash_part( state, std::to_string( value.drench_capacity ) );
+        hash_part( state, value.limb ? "limb" : "not_limb" );
+        hash_part( state, value.vital ? "vital" : "not_vital" );
+        for( const std::string &sub_part : value.sub_parts ) {
+            hash_part( state, "sub_part" );
+            hash_part( state, sub_part );
+        }
+        for( const auto &[kind, weight] : value.limb_types ) {
+            hash_part( state, kind );
+            hash_part( state, std::to_string( weight ) );
+        }
+        const auto hash_damage_values = [&]( const std::string_view label,
+        const std::map<std::string, double> &values ) {
+            for( const auto &[damage_id, amount] : values ) {
+                hash_part( state, label );
+                hash_part( state, damage_id );
+                hash_part( state, std::to_string( amount ) );
+            }
+        };
+        hash_damage_values( "armor", value.armor );
+        hash_damage_values( "unarmed", value.unarmed_damage );
+        for( const std::string &flag : value.flags ) {
+            hash_part( state, "flag" );
+            hash_part( state, flag );
+        }
+        for( const auto &[score_id, score] : value.limb_scores ) {
+            hash_part( state, score_id );
+            hash_part( state, std::to_string( score.score ) );
+            hash_part( state, std::to_string( score.maximum ) );
+        }
+        for( const body_part_quality_definition_data &quality : value.qualities ) {
+            hash_part( state, quality.id );
+            hash_part( state, std::to_string( quality.level ) );
+            hash_part( state, std::to_string( quality.disable_fraction ) );
+        }
+    }
+    for( const anatomy_registration &entry : pimpl_->anatomies ) {
+        hash_part( state, "anatomy" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+        for( const std::string &part : entry.definition->parts ) {
+            hash_part( state, part );
+        }
+    }
+    for( const body_graph_registration &entry : pimpl_->body_graphs ) {
+        hash_part( state, "body_graph" );
+        hash_part( state, operation_name( entry.operation ) );
+        const body_graph_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.parent_body_part );
+        hash_part( state, value.mirror );
+        hash_part( state, value.label_fill );
+        hash_part( state, value.fill_symbol );
+        hash_part( state, value.fill_color );
+        for( const std::string &row : value.rows ) {
+            hash_part( state, "row" );
+            hash_part( state, row );
+        }
+        for( const std::string &row : value.fill_rows ) {
+            hash_part( state, "fill_row" );
+            hash_part( state, row );
+        }
+        for( const body_graph_part_definition_data &part : value.parts ) {
+            hash_part( state, part.symbol );
+            hash_part( state, part.nested_graph );
+            hash_part( state, part.selected_color );
+            hash_part( state, part.display_symbol );
+            for( const std::string &id : part.body_parts ) {
+                hash_part( state, "body" );
+                hash_part( state, id );
+            }
+            for( const std::string &id : part.sub_body_parts ) {
+                hash_part( state, "sub_body" );
+                hash_part( state, id );
+            }
+        }
+    }
+    for( const monster_registration &entry : pimpl_->monsters ) {
+        hash_part( state, "monster" );
+        hash_part( state, operation_name( entry.operation ) );
+        const monster_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.name );
+        hash_part( state, value.plural_name );
+        hash_part( state, value.description );
+        hash_part( state, value.symbol );
+        hash_part( state, value.color );
+        hash_part( state, value.looks_like );
+        hash_part( state, value.body_type );
+        hash_part( state, value.default_faction );
+        hash_part( state, value.harvest );
+        hash_part( state, value.dissect );
+        hash_part( state, value.decay );
+        hash_part( state, value.speed_description );
+        hash_part( state, value.death_drops );
+        hash_part( state, std::to_string( value.volume_ml ) );
+        hash_part( state, std::to_string( value.weight_grams ) );
+        hash_part( state, value.phase );
+        hash_part( state, std::to_string( value.difficulty_adjustment ) );
+        hash_part( state, std::to_string( value.hp ) );
+        hash_part( state, std::to_string( value.speed ) );
+        hash_part( state, std::to_string( value.aggression ) );
+        hash_part( state, std::to_string( value.morale ) );
+        hash_part( state, std::to_string( value.tracking_distance ) );
+        hash_part( state, std::to_string( value.attack_cost ) );
+        hash_part( state, std::to_string( value.melee_skill ) );
+        hash_part( state, std::to_string( value.melee_dice ) );
+        hash_part( state, std::to_string( value.melee_sides ) );
+        hash_part( state, std::to_string( value.melee_armor_penetration ) );
+        hash_part( state, std::to_string( value.dodge ) );
+        hash_part( state, std::to_string( value.vision_day ) );
+        hash_part( state, std::to_string( value.vision_night ) );
+        hash_part( state, std::to_string( value.regenerates ) );
+        hash_part( state, std::to_string( value.bleed_rate ) );
+        hash_part( state, std::to_string( value.status_chance_multiplier ) );
+        hash_part( state, std::to_string( value.luminance ) );
+        hash_part( state, value.regenerates_in_dark ? "dark_regen" : "no_dark_regen" );
+        hash_part( state, value.regenerates_morale ? "morale_regen" : "no_morale_regen" );
+        hash_part( state, value.aggressive_to_characters ? "character_aggro" : "selective_aggro" );
+        for( const auto &[id, portions] : value.materials ) {
+            hash_part( state, "material" );
+            hash_part( state, id );
+            hash_part( state, std::to_string( portions ) );
+        }
+        const auto hash_ids = [&]( const std::string_view label,
+        const std::set<std::string> &ids ) {
+            for( const std::string &id : ids ) {
+                hash_part( state, label );
+                hash_part( state, id );
+            }
+        };
+        hash_ids( "species", value.species );
+        hash_ids( "category", value.categories );
+        hash_ids( "flag", value.flags );
+        hash_ids( "track_scent", value.tracked_scents );
+        hash_ids( "ignore_scent", value.ignored_scents );
+        hash_ids( "anger", value.anger_triggers );
+        hash_ids( "fear", value.fear_triggers );
+        hash_ids( "placate", value.placate_triggers );
+        for( const auto &[id, amount] : value.armor ) {
+            hash_part( state, "armor" );
+            hash_part( state, id );
+            hash_part( state, std::to_string( amount ) );
+        }
+        for( const auto &[id, damage] : value.melee_damage ) {
+            hash_part( state, "melee_damage" );
+            hash_part( state, id );
+            hash_part( state, std::to_string( damage.amount ) );
+            hash_part( state, std::to_string( damage.armor_penetration ) );
+        }
+        for( const monster_attack_reference_definition_data &attack : value.attacks ) {
+            hash_part( state, "attack" );
+            hash_part( state, attack.id );
+            hash_part( state, attack.cooldown ? std::to_string( *attack.cooldown ) :
+                       "native_cooldown" );
+        }
+        for( const std::string &set : value.weakpoint_sets ) {
+            hash_part( state, "weakpoint_set" );
+            hash_part( state, set );
+        }
+        const auto hash_int_map = [&]( const std::string_view label,
+        const std::map<std::string, std::int64_t> &values ) {
+            for( const auto &[id, amount] : values ) {
+                hash_part( state, label );
+                hash_part( state, id );
+                hash_part( state, std::to_string( amount ) );
+            }
+        };
+        hash_int_map( "emission", value.emissions );
+        hash_int_map( "starting_ammo", value.starting_ammo );
+        hash_int_map( "regeneration_modifier", value.regeneration_modifiers );
+        for( const std::string &goal : value.goals ) {
+            hash_part( state, "goal" );
+            hash_part( state, goal );
+        }
+    }
+    for( const field_type_registration &entry : pimpl_->field_types ) {
+        hash_part( state, "field_type" );
+        hash_part( state, operation_name( entry.operation ) );
+        const field_type_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, std::to_string( value.underwater_age_speedup_turns ) );
+        hash_part( state, std::to_string( value.outdoor_age_speedup_turns ) );
+        hash_part( state, std::to_string( value.decay_amount_factor ) );
+        hash_part( state, std::to_string( value.percent_spread ) );
+        hash_part( state, std::to_string( value.gas_absorption_turns ) );
+        hash_part( state, std::to_string( value.priority ) );
+        hash_part( state, std::to_string( value.half_life_turns ) );
+        hash_part( state, value.phase );
+        hash_part( state, value.description_affix );
+        hash_part( state, value.wandering_field );
+        hash_part( state, value.looks_like );
+        hash_part( state, value.splattering ? "splattering" : "not_splattering" );
+        hash_part( state, value.has_fire ? "fire" : "not_fire" );
+        hash_part( state, value.has_acid ? "acid" : "not_acid" );
+        hash_part( state, value.has_electricity ? "electricity" : "not_electricity" );
+        hash_part( state, value.has_fume ? "fume" : "not_fume" );
+        hash_part( state, value.moppable ? "moppable" : "not_moppable" );
+        hash_part( state, value.accelerated_decay ? "accelerated" : "normal_decay" );
+        hash_part( state, value.display_items ? "display_items" : "hide_items" );
+        hash_part( state, value.display_field ? "display_field" : "hide_field" );
+        hash_part( state, value.linear_half_life ? "linear" : "nonlinear" );
+        hash_part( state, value.indestructible ? "indestructible" : "destructible" );
+        hash_part( state, value.mopsafe ? "mopsafe" : "not_mopsafe" );
+        hash_part( state, value.decrease_intensity_on_contact ?
+                   "contact_decrease" : "contact_stable" );
+        for( const std::string &id : value.immune_monsters ) {
+            hash_part( state, "immune_monster" );
+            hash_part( state, id );
+        }
+        for( const std::string &id : value.blocked_monsters ) {
+            hash_part( state, "blocked_monster" );
+            hash_part( state, id );
+        }
+        for( const field_intensity_definition_data &level : value.intensity_levels ) {
+            hash_part( state, level.name );
+            hash_part( state, level.symbol );
+            hash_part( state, level.color );
+            hash_part( state, level.dangerous ? "dangerous" : "safe" );
+            hash_part( state, level.transparent ? "transparent" : "opaque" );
+            hash_part( state, std::to_string( level.move_cost ) );
+            hash_part( state, std::to_string( level.upgrade_chance ) );
+            hash_part( state, std::to_string( level.upgrade_duration_turns ) );
+            hash_part( state, std::to_string( level.light_emitted ) );
+            hash_part( state, std::to_string( level.local_light_override ) );
+            hash_part( state, std::to_string( level.translucency ) );
+            hash_part( state, std::to_string( level.concentration ) );
+            hash_part( state, std::to_string( level.convection_temperature_modifier ) );
+            hash_part( state, std::to_string( level.scent_neutralization ) );
+            for( const field_effect_definition_data &effect : level.effects ) {
+                hash_part( state, effect.effect );
+                hash_part( state, std::to_string( effect.duration_min_turns ) );
+                hash_part( state, std::to_string( effect.duration_max_turns ) );
+                hash_part( state, std::to_string( effect.intensity ) );
+                hash_part( state, effect.body_part );
+                hash_part( state, effect.environmental ? "environmental" : "direct" );
+                hash_part( state, effect.message );
+                hash_part( state, effect.npc_message );
+            }
+        }
+    }
+    for( const monster_attack_registration &entry : pimpl_->monster_attacks ) {
+        hash_part( state, "monster_attack" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+        hash_part( state, std::to_string( entry.definition->cooldown ) );
+        hash_part( state, entry.definition->handler );
+    }
+    for( const weakpoint_set_registration &entry : pimpl_->weakpoint_sets ) {
+        hash_part( state, "weakpoint_set" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+        for( const weakpoint_definition_data &point : entry.definition->weakpoints ) {
+            hash_part( state, point.id );
+            hash_part( state, point.name );
+            hash_part( state, std::to_string( point.coverage ) );
+            hash_part( state, point.good ? "good" : "neutral" );
+            hash_part( state, point.head ? "head" : "not_head" );
+            const auto hash_damage_map = [&]( const std::string_view kind,
+            const std::map<std::string, double> &values ) {
+                for( const auto &[damage_id, value] : values ) {
+                    hash_part( state, kind );
+                    hash_part( state, damage_id );
+                    hash_part( state, std::to_string( value ) );
+                }
+            };
+            hash_damage_map( "armor_multiplier", point.armor_multipliers );
+            hash_damage_map( "armor_penalty", point.armor_penalties );
+            hash_damage_map( "damage_multiplier", point.damage_multipliers );
+            hash_damage_map( "critical_multiplier", point.critical_multipliers );
+            for( const weakpoint_effect_definition_data &effect : point.effects ) {
+                hash_part( state, effect.effect );
+                hash_part( state, std::to_string( effect.chance ) );
+                hash_part( state, effect.permanent ? "permanent" : "temporary" );
+                hash_part( state, std::to_string( effect.duration_min_turns ) );
+                hash_part( state, std::to_string( effect.duration_max_turns ) );
+                hash_part( state, std::to_string( effect.intensity_min ) );
+                hash_part( state, std::to_string( effect.intensity_max ) );
+                hash_part( state, std::to_string( effect.damage_required_min ) );
+                hash_part( state, std::to_string( effect.damage_required_max ) );
+                hash_part( state, effect.message );
+            }
+        }
+    }
+    for( const morale_type_registration &entry : pimpl_->morale_types ) {
+        hash_part( state, "morale_type" );
+        hash_part( state, operation_name( entry.operation ) );
+        hash_part( state, entry.definition->id );
+        hash_part( state, entry.definition->text );
+        hash_part( state, entry.definition->permanent ? "permanent" : "temporary" );
+    }
+    for( const disease_type_registration &entry : pimpl_->disease_types ) {
+        hash_part( state, "disease_type" );
+        hash_part( state, operation_name( entry.operation ) );
+        const disease_type_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.symptoms );
+        hash_part( state, std::to_string( value.minimum_duration_turns ) );
+        hash_part( state, std::to_string( value.maximum_duration_turns ) );
+        hash_part( state, std::to_string( value.minimum_intensity ) );
+        hash_part( state, std::to_string( value.maximum_intensity ) );
+        hash_part( state, value.health_threshold ?
+                   std::to_string( *value.health_threshold ) : "no_health_threshold" );
+        for( const std::string &body_part : value.affected_body_parts ) {
+            hash_part( state, body_part );
+        }
+    }
+    for( const requirement_registration &entry : pimpl_->requirements ) {
+        hash_part( state, "requirement" );
+        hash_part( state, operation_name( entry.operation ) );
+        const requirement_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.name );
+        for( const auto &group : value.components ) {
+            hash_part( state, "components" );
+            for( const component_requirement &component : group ) {
+                hash_part( state, component.id );
+                hash_part( state, std::to_string( component.count ) );
+            }
+        }
+        for( const auto &group : value.tools ) {
+            hash_part( state, "tools" );
+            for( const component_requirement &tool : group ) {
+                hash_part( state, tool.id );
+                hash_part( state, std::to_string( tool.count ) );
+            }
+        }
+        for( const auto &group : value.qualities ) {
+            hash_part( state, "qualities" );
+            for( const quality_requirement_definition &quality : group ) {
+                hash_part( state, quality.id );
+                hash_part( state, std::to_string( quality.level ) );
+                hash_part( state, std::to_string( quality.count ) );
+            }
+        }
+    }
+    for( const recipe_group_registration &entry : pimpl_->recipe_groups ) {
+        hash_part( state, "recipe_group" );
+        hash_part( state, operation_name( entry.operation ) );
+        const recipe_group_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.building_type );
+        for( const recipe_group_recipe_data &recipe_entry : value.recipes ) {
+            hash_part( state, recipe_entry.id );
+            hash_part( state, recipe_entry.description );
+            for( const recipe_group_terrain_data &terrain : recipe_entry.terrains ) {
+                hash_part( state, terrain.overmap_terrain );
+                hash_part( state, terrain.match_type );
+                for( const auto &[parameter, values] : terrain.parameters ) {
+                    hash_part( state, parameter );
+                    for( const std::string &parameter_value : values ) {
+                        hash_part( state, parameter_value );
+                    }
+                }
+            }
+        }
+    }
+    for( const item_registration &entry : pimpl_->items ) {
+        hash_part( state, "item" );
+        hash_part( state, operation_name( entry.operation ) );
+        const item_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.name );
+        hash_part( state, value.description );
+        hash_part( state, value.symbol );
+        hash_part( state, std::to_string( value.mass_grams ) );
+        hash_part( state, std::to_string( value.volume_ml ) );
+        hash_part( state, std::to_string( value.price_cents ) );
+        hash_part( state, value.use_handler );
+        hash_part( state, value.use_label );
+        for( const material_part &material : value.materials ) {
+            hash_part( state, material.id );
+            hash_part( state, std::to_string( material.portions ) );
+        }
+        for( const quality_level &quality : value.qualities ) {
+            hash_part( state, quality.id );
+            hash_part( state, std::to_string( quality.level ) );
+        }
+        for( const std::string &flag : value.flags ) {
+            hash_part( state, flag );
+        }
+    }
+    for( const clothing_mod_registration &entry : pimpl_->clothing_mods ) {
+        hash_part( state, "clothing_mod" );
+        hash_part( state, operation_name( entry.operation ) );
+        const clothing_mod_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.flag );
+        hash_part( state, value.material_item );
+        hash_part( state, value.apply_prompt );
+        hash_part( state, value.remove_prompt );
+        hash_part( state, value.restricted ? "restricted" : "unrestricted" );
+        for( const clothing_modifier_definition_data &modifier : value.modifiers ) {
+            hash_part( state, modifier.stat );
+            hash_part( state, std::to_string( modifier.amount ) );
+            hash_part( state, modifier.round_up ? "round_up" : "exact" );
+            hash_part( state, modifier.per_thickness ? "thickness" : "no_thickness" );
+            hash_part( state, modifier.per_coverage ? "coverage" : "no_coverage" );
+        }
+    }
+    for( const recipe_registration &entry : pimpl_->recipes ) {
+        hash_part( state, "recipe" );
+        hash_part( state, operation_name( entry.operation ) );
+        const recipe_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.nested_category ? "nested_category" : "craft_recipe" );
+        hash_part( state, value.result );
+        hash_part( state, value.name );
+        hash_part( state, value.description );
+        hash_part( state, value.category );
+        hash_part( state, value.subcategory );
+        hash_part( state, std::to_string( value.activity_level ) );
+        for( const std::string &member : value.nested_recipes ) {
+            hash_part( state, member );
+        }
+        hash_part( state, value.skill );
+        hash_part( state, std::to_string( value.difficulty ) );
+        hash_part( state, std::to_string( value.time_moves ) );
+        hash_part( state, value.autolearn ? "autolearn" : "manual" );
+        hash_part( state, value.reversible ? "reversible" : "irreversible" );
+        for( const auto &group : value.components ) {
+            hash_part( state, "and" );
+            for( const component_requirement &component : group ) {
+                hash_part( state, component.id );
+                hash_part( state, std::to_string( component.count ) );
+            }
+        }
+        for( const auto &group : value.tools ) {
+            hash_part( state, "tool" );
+            for( const component_requirement &tool : group ) {
+                hash_part( state, tool.id );
+                hash_part( state, std::to_string( tool.count ) );
+            }
+        }
+        for( const auto &[skill, level] : value.required_skills ) {
+            hash_part( state, skill );
+            hash_part( state, std::to_string( level ) );
+        }
+        for( const auto &[requirement_key, multiplier] : value.external_requirements ) {
+            hash_part( state, requirement_key );
+            hash_part( state, std::to_string( multiplier ) );
+        }
+    }
+    std::ostringstream result;
+    result << std::hex << state;
+    return result.str();
+}
+
+bool content_transaction::was_applied() const
+{
+    return pimpl_->applied;
+}
+
+bool content_transaction::find_damage_handler( const std::string_view damage_id,
+        const std::string_view phase, std::string &handler_id ) const
+{
+    const auto found = std::find_if(
+                           pimpl_->damage_types.rbegin(), pimpl_->damage_types.rend(),
+    [damage_id]( const damage_type_registration & entry ) {
+        return entry.definition->id == damage_id;
+    } );
+    if( found == pimpl_->damage_types.rend() ) {
+        return false;
+    }
+    if( phase == "on_hit" ) {
+        handler_id = found->definition->on_hit_handler;
+    } else if( phase == "on_damage" ) {
+        handler_id = found->definition->on_damage_handler;
+    } else {
+        handler_id.clear();
+    }
+    return true;
+}
+
+bool content_transaction::find_ammo_effect_handler(
+    const std::string_view ammo_effect_id, std::string &handler_id ) const
+{
+    const auto found = std::find_if(
+                           pimpl_->ammo_effects.rbegin(), pimpl_->ammo_effects.rend(),
+    [ammo_effect_id]( const ammo_effect_registration & entry ) {
+        return entry.definition->id == ammo_effect_id;
+    } );
+    if( found == pimpl_->ammo_effects.rend() ) {
+        return false;
+    }
+    handler_id = found->definition->impact_handler;
+    return true;
+}
+
+bool content_transaction::find_addiction_type_handler(
+    const std::string_view addiction_type_id, std::string &handler_id ) const
+{
+    const auto found = std::find_if(
+                           pimpl_->addiction_types.rbegin(), pimpl_->addiction_types.rend(),
+    [addiction_type_id]( const addiction_type_registration & entry ) {
+        return entry.definition->id == addiction_type_id;
+    } );
+    if( found == pimpl_->addiction_types.rend() ) {
+        return false;
+    }
+    handler_id = found->definition->tick_handler;
+    return true;
+}
+
+bool content_transaction::find_character_modifier_handler(
+    const std::string_view modifier_id, std::string &handler_id ) const
+{
+    const auto found = std::find_if(
+                           pimpl_->character_modifiers.rbegin(), pimpl_->character_modifiers.rend(),
+    [modifier_id]( const character_modifier_registration & entry ) {
+        return entry.definition->id == modifier_id;
+    } );
+    if( found == pimpl_->character_modifiers.rend() ) {
+        return false;
+    }
+    handler_id = found->definition->evaluator_handler;
+    return true;
+}
+
+bool content_transaction::find_weather_type_handler(
+    const std::string_view weather_type_id_value, std::string &handler_id ) const
+{
+    const auto found = std::find_if(
+                           pimpl_->weather_types.rbegin(), pimpl_->weather_types.rend(),
+    [weather_type_id_value]( const weather_type_registration & entry ) {
+        return entry.definition->id == weather_type_id_value;
+    } );
+    if( found == pimpl_->weather_types.rend() ) {
+        return false;
+    }
+    handler_id = found->definition->condition_handler;
+    return true;
+}
+
+bool content_transaction::find_end_screen_handler(
+    const std::string_view end_screen_id_value, std::string &handler_id ) const
+{
+    const auto found = std::find_if(
+                           pimpl_->end_screens.rbegin(), pimpl_->end_screens.rend(),
+    [end_screen_id_value]( const end_screen_registration & entry ) {
+        return entry.definition->id == end_screen_id_value;
+    } );
+    if( found == pimpl_->end_screens.rend() ) {
+        return false;
+    }
+    handler_id = found->definition->condition_handler;
+    return true;
+}
+
+bool content_transaction::find_activity_type_handler(
+    const std::string_view activity_type_id_value, const std::string_view phase,
+    std::string &handler_id ) const
+{
+    const auto found = std::find_if(
+                           pimpl_->activity_types.rbegin(), pimpl_->activity_types.rend(),
+    [activity_type_id_value]( const activity_type_registration & entry ) {
+        return entry.definition->id == activity_type_id_value;
+    } );
+    if( found == pimpl_->activity_types.rend() ) {
+        return false;
+    }
+    if( phase == "do_turn" ) {
+        handler_id = found->definition->do_turn_handler;
+    } else if( phase == "completion" ) {
+        handler_id = found->definition->completion_handler;
+    } else {
+        handler_id.clear();
+    }
+    return true;
+}
+
+bool content_transaction::find_snippet_handler( const std::string_view snippet_id_value,
+        std::string &category_id, std::string &handler_id ) const
+{
+    for( auto category = pimpl_->snippet_categories.rbegin();
+         category != pimpl_->snippet_categories.rend(); ++category ) {
+        const auto found = std::find_if(
+                               category->definition->entries.begin(),
+                               category->definition->entries.end(),
+        [snippet_id_value]( const snippet_entry_definition_data & entry ) {
+            return entry.id == snippet_id_value;
+        } );
+        if( found != category->definition->entries.end() ) {
+            category_id = category->definition->id;
+            handler_id = found->examine_handler;
+            return true;
+        }
+    }
+    return false;
+}
+
+bool content_transaction::find_magic_type_handler( const std::string_view magic_type_id,
+        const std::string_view phase, std::string &handler_id ) const
+{
+    const auto found = std::find_if(
+                           pimpl_->magic_types.rbegin(), pimpl_->magic_types.rend(),
+    [magic_type_id]( const magic_type_registration & entry ) {
+        return entry.definition->id == magic_type_id;
+    } );
+    if( found == pimpl_->magic_types.rend() ) {
+        return false;
+    }
+    const magic_type_definition_data &definition = *found->definition;
+    if( phase == "level_for_experience" ) {
+        handler_id = definition.level_for_experience_handler;
+    } else if( phase == "experience_for_level" ) {
+        handler_id = definition.experience_for_level_handler;
+    } else if( phase == "casting_experience" ) {
+        handler_id = definition.casting_experience_handler;
+    } else if( phase == "failure_chance" ) {
+        handler_id = definition.failure_chance_handler;
+    } else if( phase == "failure_cost" ) {
+        handler_id = definition.failure_cost_handler;
+    } else if( phase == "failure_experience" ) {
+        handler_id = definition.failure_experience_handler;
+    } else if( phase == "on_failure" ) {
+        handler_id = definition.failure_handler;
+    } else {
+        handler_id.clear();
+    }
+    return true;
+}
+
+bool content_transaction::find_emission_handler(
+    const std::string_view emission_id, std::string &handler_id ) const
+{
+    const auto found = std::find_if(
+                           pimpl_->emissions.rbegin(), pimpl_->emissions.rend(),
+    [emission_id]( const emission_registration & entry ) {
+        return entry.definition->id == emission_id;
+    } );
+    if( found == pimpl_->emissions.rend() ) {
+        return false;
+    }
+    handler_id = found->definition->profile_handler;
+    return true;
+}
+
+std::shared_ptr<runtime> make_runtime( const std::string &mod_id,
+                                      std::size_t generation,
+                                      sol::state &lua )
+{
+    return std::make_shared<runtime>( mod_id, generation, lua );
+}
+
+void install_runtime_api( const std::shared_ptr<runtime> &value,
+                          sol::state &lua, sol::table &ccb )
+{
+    value->content.install_lua_api( lua, ccb, value );
+
+    ccb.new_usertype<use_context_data>(
+        "ItemUseContext", sol::no_constructor,
+        "message", &use_context_data::message,
+        "player_name", sol::property( &use_context_data::player_name ),
+        "item_id", sol::property( &use_context_data::item_id ),
+        "character", sol::property( &use_context_data::character_handle ),
+        "item", sol::property( &use_context_data::item_handle ),
+        "position", sol::property( &use_context_data::use_position ),
+        "charges", sol::property( &use_context_data::charges,
+                                  &use_context_data::set_charges ) );
+
+    const std::weak_ptr<runtime> weak = value;
+    sol::table runtime_api = lua.create_table();
+    runtime_api.set_function( "handler", [weak]( const std::string &id,
+    const sol::object &callback, const sol::optional<std::int64_t> &payload_version ) {
+        const std::shared_ptr<runtime> owner = weak.lock();
+        if( !owner ) {
+            throw std::runtime_error( "stale Platform runtime" );
+        }
+        if( id.empty() || id.find( '#' ) != std::string::npos ) {
+            throw std::runtime_error( "handler id must be non-empty and cannot contain '#'" );
+        }
+        if( callback.get_type() != sol::type::function ) {
+            throw std::runtime_error( "handler callback must be a Lua function" );
+        }
+        const std::int64_t requested_version = payload_version.value_or( 1 );
+        if( requested_version <= 0 || requested_version > std::numeric_limits<int>::max() ) {
+            throw std::runtime_error( "handler payload version is outside the native range" );
+        }
+        const int version = static_cast<int>( requested_version );
+        if( !owner->handlers.emplace( id, handler_definition{
+            version, callback.as<sol::protected_function>()
+        } ).second ) {
+            throw std::runtime_error( "duplicate handler id '" + id + "'" );
+        }
+    } );
+    runtime_api.set_function( "on", [weak]( const std::string &event_name,
+    const std::string &handler_id ) {
+        const std::shared_ptr<runtime> owner = weak.lock();
+        if( !owner ) {
+            throw std::runtime_error( "stale Platform runtime" );
+        }
+        if( event_name.empty() || handler_id.empty() ) {
+            throw std::runtime_error( "event and handler ids cannot be empty" );
+        }
+        const bool lifecycle = event_name == "world_ready" || event_name == "before_save" ||
+                               event_name == "after_save" || event_name == "shutdown";
+        if( !lifecycle && ( event_name.size() <= 5 || event_name.compare( 0, 5, "game:" ) != 0 ) ) {
+            throw std::runtime_error( "event must be a lifecycle name or game:<event>" );
+        }
+        std::vector<std::string> &subscriptions = owner->subscriptions[event_name];
+        if( std::find( subscriptions.begin(), subscriptions.end(), handler_id ) !=
+            subscriptions.end() ) {
+            throw std::runtime_error( "duplicate event subscription '" + event_name +
+                                      "' for handler '" + handler_id + "'" );
+        }
+        subscriptions.push_back( handler_id );
+    } );
+    runtime_api.set_function( "migrate_task_payload", [weak](
+    const std::string &handler_id, const std::int64_t from_version,
+    const std::int64_t to_version, const sol::object &callback ) {
+        const std::shared_ptr<runtime> owner = weak.lock();
+        if( !owner ) {
+            throw std::runtime_error( "stale Platform runtime" );
+        }
+        if( handler_id.empty() || handler_id.find( '#' ) != std::string::npos ) {
+            throw std::runtime_error(
+                "task migration handler id must be non-empty and cannot contain '#'" );
+        }
+        if( from_version <= 0 || to_version <= 0 ||
+            from_version > std::numeric_limits<int>::max() ||
+            to_version > std::numeric_limits<int>::max() ||
+            from_version == to_version ) {
+            throw std::runtime_error( "task migration versions are outside the native range" );
+        }
+        if( callback.get_type() != sol::type::function ) {
+            throw std::runtime_error( "task migration callback must be a Lua function" );
+        }
+        std::map<int, task_payload_migration> &migrations =
+            owner->task_migrations[handler_id];
+        const int source = static_cast<int>( from_version );
+        if( !migrations.emplace( source, task_payload_migration{
+        static_cast<int>( to_version ), callback.as<sol::protected_function>()
+        } ).second ) {
+            throw std::runtime_error(
+                "duplicate task payload migration for handler '" + handler_id +
+                "' from version " + std::to_string( from_version ) );
+        }
+    } );
+    runtime_api.set_function( "hook", [weak]( const std::string &hook_name,
+    const std::string &handler_id ) {
+        const std::shared_ptr<runtime> owner = weak.lock();
+        if( !owner ) {
+            throw std::runtime_error( "stale Platform runtime" );
+        }
+        if( hook_name.empty() || !cata::lua_ui::native_hook_contract_exists( hook_name ) ) {
+            throw std::runtime_error( "unknown native hook '" + hook_name + "'" );
+        }
+        if( handler_id.empty() ) {
+            throw std::runtime_error( "native hook handler id cannot be empty" );
+        }
+        std::vector<std::string> &handlers = owner->hooks[hook_name];
+        if( std::find( handlers.begin(), handlers.end(), handler_id ) != handlers.end() ) {
+            throw std::runtime_error( "duplicate native hook subscription '" + hook_name +
+                                      "' for handler '" + handler_id + "'" );
+        }
+        handlers.push_back( handler_id );
+    } );
+    ccb["runtime"] = std::move( runtime_api );
+
+    auto install_state_scope = [&lua, weak]( persistent_state runtime::*member,
+    const std::string &name ) {
+        sol::table scope = lua.create_table();
+        scope.set_function( "get", [weak, member, name]( sol::this_state state,
+        const std::string &key, const sol::optional<sol::object> &fallback ) {
+            const std::shared_ptr<runtime> owner = weak.lock();
+            if( !owner || !owner->world_is_ready ) {
+                throw std::runtime_error( "state." + name + " is only available after world_ready" );
+            }
+            return get_persistent_value( owner.get()->*member, state, key, fallback );
+        } );
+        scope.set_function( "set", [weak, member, name]( const std::string &key,
+        const sol::object &entry ) {
+            const std::shared_ptr<runtime> owner = weak.lock();
+            if( !owner || !owner->world_is_ready ) {
+                throw std::runtime_error( "state." + name + " is only available after world_ready" );
+            }
+            set_persistent_value( owner.get()->*member, key, entry,
+                                  "state." + name + ".set" );
+        } );
+        return scope;
+    };
+    sol::table state_api = lua.create_table();
+    state_api["character"] = install_state_scope( &runtime::character_state, "character" );
+    state_api["world"] = install_state_scope( &runtime::world_state, "world" );
+    ccb["state"] = std::move( state_api );
+
+    sol::table tasks = lua.create_table();
+    tasks.set_function( "after", [weak]( std::int64_t turns,
+    const std::string &handler_id, const sol::optional<sol::table> &payload,
+    const sol::optional<std::int64_t> &payload_version,
+    const sol::optional<std::string> &scope ) {
+        const std::shared_ptr<runtime> owner = weak.lock();
+        if( !owner || !owner->world_is_ready ) {
+            throw std::runtime_error( "persistent tasks are only available after world_ready" );
+        }
+        if( turns < 0 ) {
+            throw std::runtime_error( "task delay cannot be negative" );
+        }
+        if( owner->tasks.size() >= maximum_tasks_per_mod ) {
+            throw std::runtime_error( "persistent task limit of 1024 per Mod reached" );
+        }
+        const auto handler = owner->handlers.find( handler_id );
+        if( handler == owner->handlers.end() ) {
+            throw std::runtime_error( "task references missing handler '" + handler_id + "'" );
+        }
+        const std::string owner_scope = scope.value_or( "world" );
+        if( owner_scope != "world" && owner_scope != "character" ) {
+            throw std::runtime_error( "task owner must be 'world' or 'character'" );
+        }
+        if( owner->next_task_id > static_cast<std::uint64_t>(
+                std::numeric_limits<std::int64_t>::max() ) ) {
+            throw std::runtime_error( "persistent task id space exhausted" );
+        }
+        const std::int64_t now = to_turn<std::int64_t>( calendar::turn );
+        if( turns > 0 && now > std::numeric_limits<std::int64_t>::max() - turns ) {
+            throw std::runtime_error( "persistent task due turn overflows" );
+        }
+        persistent_task task;
+        task.handler_id = handler_id;
+        task.due_turn = now + turns;
+        task.owner = owner_scope;
+        const std::int64_t requested_version = payload_version.value_or(
+                handler->second.payload_version );
+        if( requested_version <= 0 || requested_version > std::numeric_limits<int>::max() ) {
+            throw std::runtime_error( "task payload version is outside the native range" );
+        }
+        if( requested_version != handler->second.payload_version ) {
+            throw std::runtime_error(
+                "new tasks must use the registered handler payload version" );
+        }
+        task.payload_version = static_cast<int>( requested_version );
+        task.payload = persistent_table_from_lua( payload, "tasks.after" );
+        task.id = owner->next_task_id++;
+        owner->tasks.push_back( task );
+        return static_cast<std::int64_t>( task.id );
+    } );
+    tasks.set_function( "cancel", [weak]( std::int64_t id ) {
+        const std::shared_ptr<runtime> owner = weak.lock();
+        if( !owner || !owner->world_is_ready ) {
+            throw std::runtime_error( "persistent tasks are only available after world_ready" );
+        }
+        if( id <= 0 ) {
+            throw std::runtime_error( "persistent task id must be positive" );
+        }
+        const std::uint64_t task_id = static_cast<std::uint64_t>( id );
+        const std::size_t old_size = owner->tasks.size();
+        owner->tasks.erase( std::remove_if( owner->tasks.begin(), owner->tasks.end(),
+        [task_id]( const persistent_task & task ) {
+            return task.id == task_id;
+        } ), owner->tasks.end() );
+        owner->reported_task_migration_failures.erase( task_id );
+        return owner->tasks.size() != old_size;
+    } );
+    ccb["tasks"] = std::move( tasks );
+
+    const auto require_presentation = [weak]() {
+        require_live_runtime( weak, "Platform presentation" );
+        if( !runtime_callback_is_active( weak ) ) {
+            throw std::runtime_error(
+                "Platform presentation is only available inside a runtime callback" );
+        }
+    };
+    sol::table presentation = lua.create_table();
+    presentation.set_function( "notice", [require_presentation]( const std::string &message ) {
+        require_presentation();
+        require_presentation_text( message, "notice" );
+        ::popup( message );
+    } );
+    presentation.set_function( "confirm", [require_presentation]( const std::string &question ) {
+        require_presentation();
+        require_presentation_text( question, "confirmation question" );
+        return query_yn( question );
+    } );
+    presentation.set_function( "choose", [require_presentation](
+    sol::this_state state, const std::string &prompt, const sol::table &entries ) {
+        require_presentation();
+        require_presentation_text( prompt, "choice prompt" );
+        const std::vector<presentation_choice> choices =
+            presentation_choices_from_lua( entries );
+        uilist menu;
+        menu.text = prompt;
+        menu.desc_enabled = std::any_of( choices.begin(), choices.end(),
+        []( const presentation_choice & choice ) {
+            return !choice.description.empty();
+        } );
+        for( std::size_t index = 0; index < choices.size(); ++index ) {
+            menu.addentry_desc( static_cast<int>( index ), choices[index].enabled,
+                                MENU_AUTOASSIGN, choices[index].label,
+                                choices[index].description );
+        }
+        menu.query();
+        sol::state_view lua_state( state );
+        if( menu.ret < 0 || static_cast<std::size_t>( menu.ret ) >= choices.size() ) {
+            return sol::make_object( lua_state, sol::lua_nil );
+        }
+        return sol::make_object( lua_state, choices[menu.ret].id );
+    } );
+    presentation.set_function( "input_text", [require_presentation](
+    sol::this_state state, const std::string &prompt,
+    const sol::optional<sol::table> &options ) {
+        require_presentation();
+        require_presentation_text( prompt, "input prompt", 4096 );
+        std::string initial;
+        std::string description;
+        std::int64_t width = 0;
+        std::int64_t maximum = 1024;
+        bool only_digits = false;
+        if( options ) {
+            initial = options->get_or( "initial", std::string() );
+            description = options->get_or( "description", std::string() );
+            width = options->get_or<std::int64_t>( "width", 0 );
+            maximum = options->get_or<std::int64_t>( "max_length", 1024 );
+            only_digits = options->get_or( "only_digits", false );
+        }
+        if( initial.size() > 32768 || initial.find( '\0' ) != std::string::npos ||
+            description.size() > 32768 || description.find( '\0' ) != std::string::npos ||
+            width < 0 || width > 240 || maximum <= 0 || maximum > 32768 ) {
+            throw std::invalid_argument( "presentation input options exceed native limits" );
+        }
+        string_input_popup popup;
+        popup.title( prompt ).text( initial ).description( description )
+        .width( static_cast<int>( width ) ).max_length( static_cast<int>( maximum ) )
+        .only_digits( only_digits );
+        popup.query();
+        sol::state_view lua_state( state );
+        if( popup.canceled() ) {
+            return sol::make_object( lua_state, sol::lua_nil );
+        }
+        return sol::make_object( lua_state, popup.text() );
+    } );
+    ccb["presentation"] = std::move( presentation );
+
+    sol::table services = lua.create_table();
+    services.set_function( "message", [weak]( const std::string &message ) {
+        const std::shared_ptr<runtime> owner = weak.lock();
+        if( !owner || !owner->world_is_ready ) {
+            throw std::runtime_error( "game services are only available after world_ready" );
+        }
+        ::add_msg( message );
+    } );
+    services.set_function( "turn", [weak]() {
+        const std::shared_ptr<runtime> owner = weak.lock();
+        if( !owner || !owner->world_is_ready ) {
+            throw std::runtime_error( "game services are only available after world_ready" );
+        }
+        return to_turn<std::int64_t>( calendar::turn );
+    } );
+
+    // Platform and the capability-scoped v5 runtime share these native domain
+    // implementations, but not an authoring contract or Lua state.  Platform
+    // installs only the domain-shaped services: it deliberately omits the
+    // legacy EOC bridge, JSON registry, and v5 capability tables.
+    const auto runtime_generation = [weak]() {
+        const std::shared_ptr<runtime> owner = weak.lock();
+        return owner ? owner->generation : std::numeric_limits<std::size_t>::max();
+    };
+    const auto world_generation = []() {
+        return active_world_generation;
+    };
+    const auto require_read = [weak]() {
+        require_live_runtime( weak, "Platform domain services" );
+    };
+    const auto require_write = [weak]() {
+        require_live_runtime( weak, "Platform domain mutations" );
+        if( !runtime_callback_is_active( weak ) ) {
+            throw std::runtime_error(
+                "Platform domain mutations are only available inside a runtime callback" );
+        }
+    };
+    const auto has_callback = [weak]() {
+        return runtime_callback_is_active( weak );
+    };
+    const auto source_id = [weak]() {
+        const std::shared_ptr<runtime> owner = weak.lock();
+        if( !owner ) {
+            throw std::runtime_error( "stale Platform runtime" );
+        }
+        return owner->mod_id;
+    };
+    const auto random_index = [weak]( const std::size_t count ) {
+        const std::shared_ptr<runtime> owner = weak.lock();
+        if( !owner || !owner->world_is_ready || owner->callback_depth <= 0 ) {
+            throw std::runtime_error(
+                "Platform gameplay randomness is only available inside a runtime callback" );
+        }
+        if( count == 0 ) {
+            throw std::invalid_argument( "Platform random selection requires a non-empty range" );
+        }
+        std::uniform_int_distribution<std::size_t> distribution( 0, count - 1 );
+        return distribution( owner->random_engine );
+    };
+
+    cata::lua_ui::install_value_type_api( lua, services, require_read );
+    cata::lua_ui::install_time_api( services, require_read, require_write );
+    cata::lua_ui::install_game_handle_api( lua, services, runtime_generation,
+                                           world_generation, require_read );
+    cata::lua_ui::install_creature_api( services, runtime_generation, world_generation,
+                                        require_read, require_write );
+    cata::lua_ui::install_effect_api( services, runtime_generation, world_generation,
+                                      require_read, require_write );
+    cata::lua_ui::install_bionic_api( services, runtime_generation, world_generation,
+                                      require_read, require_write );
+    cata::lua_ui::install_mutation_api( services, runtime_generation, world_generation,
+                                        require_read, require_write );
+    cata::lua_ui::install_skill_api( services, runtime_generation, world_generation,
+                                     require_read, require_write );
+    cata::lua_ui::install_proficiency_api( services, runtime_generation, world_generation,
+                                           require_read, require_write );
+    cata::lua_ui::install_vitamin_api( services, runtime_generation, world_generation,
+                                       require_read, require_write );
+    cata::lua_ui::install_addiction_api( services, runtime_generation, world_generation,
+                                         require_read, require_write );
+    cata::lua_ui::install_need_api( services, runtime_generation, world_generation,
+                                    require_read, require_write );
+    cata::lua_ui::install_martial_art_api( services, runtime_generation, world_generation,
+                                           require_read, require_write );
+    cata::lua_ui::install_vehicle_api( services, runtime_generation, world_generation,
+                                       require_read, require_write );
+    cata::lua_ui::install_npc_api( services, runtime_generation, world_generation,
+                                   require_read, require_write );
+    cata::lua_ui::install_magic_api( services, runtime_generation, world_generation,
+                                     require_read, require_write );
+    cata::lua_ui::install_mission_api( services, runtime_generation, world_generation,
+                                       require_read, require_write );
+    cata::lua_ui::install_horde_api( services, runtime_generation, world_generation,
+                                     require_read, require_write );
+    cata::lua_ui::install_world_api( services, runtime_generation, world_generation,
+                                     require_read, require_write );
+    cata::lua_ui::install_item_api( services, runtime_generation, world_generation,
+                                    require_read, require_write );
+    cata::lua_ui::install_zone_api( lua, services, runtime_generation, world_generation,
+                                    require_read, require_write );
+    cata::lua_ui::install_achievement_api( services, require_read, require_write );
+    cata::lua_ui::install_statistics_api( services, require_read );
+    cata::lua_ui::install_faction_api( services, require_read, require_write );
+    cata::lua_ui::install_camp_api( services, require_read, require_write );
+    cata::lua_ui::install_weather_api( services, require_read, require_write );
+    cata::lua_ui::install_crafting_api( services, require_read, require_write,
+                                        has_callback, source_id );
+    cata::lua_ui::install_overmap_api( services, require_read, require_write,
+                                       random_index );
+    cata::lua_ui::install_game_snapshot_api( services, require_read );
+    cata::lua_ui::install_game_info_api( services, require_read, require_write,
+                                         has_callback );
+    cata::lua_ui::install_game_interaction_api( services, require_write, has_callback );
+    cata::lua_ui::install_game_world_service_api(
+        services, runtime_generation, world_generation, require_read, require_write,
+        require_write, has_callback );
+    cata::lua_ui::install_variable_api( services, runtime_generation, world_generation,
+                                        require_read, require_write, has_callback );
+    ccb["services"] = std::move( services );
+}
+
+bool validate_runtime( const std::shared_ptr<runtime> &value,
+                       bool check_engine_state,
+                       std::string &error )
+{
+    if( !value ) {
+        error = "missing Platform runtime";
+        return false;
+    }
+    for( const auto &[event_name, handler_ids] : value->subscriptions ) {
+        for( const std::string &handler_id : handler_ids ) {
+            if( value->handlers.count( handler_id ) == 0 ) {
+                error = "Lua-first Mod '" + value->mod_id + "' event '" + event_name +
+                        "' references missing handler '" + handler_id + "'";
+                return false;
+            }
+        }
+    }
+    for( const auto &[handler_id, migrations] : value->task_migrations ) {
+        const auto handler = value->handlers.find( handler_id );
+        if( handler == value->handlers.end() ) {
+            error = "Lua-first Mod '" + value->mod_id +
+                    "' registers task migrations for missing handler '" + handler_id + "'";
+            return false;
+        }
+        for( const auto &[source_version, migration] : migrations ) {
+            std::set<int> visited;
+            int version = source_version;
+            while( version != handler->second.payload_version ) {
+                if( !visited.insert( version ).second ) {
+                    error = "Lua-first Mod '" + value->mod_id + "' task migration for '" +
+                            handler_id + "' contains a cycle at version " +
+                            std::to_string( version );
+                    return false;
+                }
+                const auto transition = migrations.find( version );
+                if( transition == migrations.end() ) {
+                    error = "Lua-first Mod '" + value->mod_id + "' task migration for '" +
+                            handler_id + "' has no route from version " +
+                            std::to_string( source_version ) + " to handler version " +
+                            std::to_string( handler->second.payload_version );
+                    return false;
+                }
+                version = transition->second.target_version;
+            }
+            static_cast<void>( migration );
+        }
+    }
+    for( const auto &[hook_name, handler_ids] : value->hooks ) {
+        for( const std::string &handler_id : handler_ids ) {
+            if( value->handlers.count( handler_id ) == 0 ) {
+                error = "Lua-first Mod '" + value->mod_id + "' native hook '" +
+                        hook_name + "' references missing handler '" + handler_id + "'";
+                return false;
+            }
+        }
+    }
+    return value->content.validate( *value, check_engine_state, error );
+}
+
+bool apply_runtime_content( const std::shared_ptr<runtime> &value, std::string &error )
+{
+    return value && value->content.apply( error );
+}
+
+bool validate_finalized_runtime_content( const std::shared_ptr<runtime> &value,
+        std::string &error )
+{
+    if( !value ) {
+        error = "missing Platform runtime";
+        return false;
+    }
+    return value->content.validate_finalized( error );
+}
+
+void rollback_runtime_content( const std::shared_ptr<runtime> &value )
+{
+    if( value ) {
+        value->content.rollback();
+    }
+}
+
+void commit_runtime( const std::shared_ptr<runtime> &value )
+{
+    if( value ) {
+        value->content.commit();
+    }
+}
+
+void seal_runtime_content( const std::shared_ptr<runtime> &value )
+{
+    if( value ) {
+        value->content.seal();
+    }
+}
+
+void discard_runtime( const std::shared_ptr<runtime> &value )
+{
+    if( value ) {
+        value->content.discard();
+    }
+}
+
+std::string runtime_fingerprint( const std::shared_ptr<runtime> &value )
+{
+    return value ? value->content.fingerprint() : std::string();
+}
+
+void set_active_runtimes( const std::vector<std::shared_ptr<runtime>> &values )
+{
+    active_runtimes = values;
+}
+
+void hot_swap_active_runtimes(
+    const std::vector<std::shared_ptr<runtime>> &values )
+{
+    std::unordered_map<std::string, std::shared_ptr<runtime>> previous;
+    std::set<std::string> previously_ready;
+    for( const std::shared_ptr<runtime> &owner : active_runtimes ) {
+        if( owner ) {
+            previous.emplace( owner->mod_id, owner );
+            if( owner->world_is_ready ) {
+                previously_ready.insert( owner->mod_id );
+            }
+        }
+    }
+    for( auto owner = active_runtimes.rbegin(); owner != active_runtimes.rend(); ++owner ) {
+        const std::shared_ptr<runtime> &value = *owner;
+        if( value && value->world_is_ready ) {
+            dispatch_lifecycle( *value, "shutdown" );
+            value->world_is_ready = false;
+        }
+    }
+    for( const std::shared_ptr<runtime> &owner : values ) {
+        if( !owner ) {
+            continue;
+        }
+        const auto found = previous.find( owner->mod_id );
+        if( found == previous.end() || !found->second ) {
+            continue;
+        }
+        runtime &old = *found->second;
+        owner->character_state = std::move( old.character_state );
+        owner->world_state = std::move( old.world_state );
+        owner->tasks = std::move( old.tasks );
+        owner->reported_task_migration_failures =
+            std::move( old.reported_task_migration_failures );
+        owner->next_task_id = old.next_task_id;
+        owner->random_engine = std::move( old.random_engine );
+        owner->world_is_ready = previously_ready.count( owner->mod_id ) != 0;
+    }
+    active_runtimes = values;
+    for( const std::shared_ptr<runtime> &owner : active_runtimes ) {
+        if( !owner || !owner->world_is_ready ) {
+            continue;
+        }
+        sol::table payload = owner->lua->create_table();
+        payload["new_game"] = false;
+        payload["reloaded"] = true;
+        dispatch_lifecycle( *owner, "world_ready", payload );
+    }
+    runtime_process_tasks();
+}
+
+void clear_active_runtimes()
+{
+    const bool had_active_world = !active_runtimes.empty();
+    for( auto owner = active_runtimes.rbegin(); owner != active_runtimes.rend(); ++owner ) {
+        const std::shared_ptr<runtime> &value = *owner;
+        if( value && value->world_is_ready ) {
+            dispatch_lifecycle( *value, "shutdown" );
+            value->world_is_ready = false;
+        }
+    }
+    if( event_bridge ) {
+        get_event_bus().unsubscribe( event_bridge.get() );
+        event_bridge.reset();
+    }
+    active_runtimes.clear();
+    orphan_character_records.clear();
+    orphan_world_records.clear();
+    if( had_active_world &&
+        active_world_generation != std::numeric_limits<std::size_t>::max() ) {
+        ++active_world_generation;
+    }
+}
+
+bool has_runtime_hook( const std::string_view name )
+{
+    return std::any_of( active_runtimes.begin(), active_runtimes.end(),
+    [name]( const std::shared_ptr<runtime> &owner ) {
+        if( !owner || !owner->world_is_ready ) {
+            return false;
+        }
+        const auto found = owner->hooks.find( std::string( name ) );
+        return found != owner->hooks.end() && !found->second.empty();
+    } );
+}
+
+cata::lua_ui::native_hook_result dispatch_runtime_hook(
+    const std::string_view name,
+    const cata::lua_ui::native_callback_arguments &arguments,
+    const cata::lua_ui::native_hook_result &initial )
+{
+    cata::lua_ui::native_hook_result aggregate = initial;
+    if( cata::lua_ui::native_hook_supports_result_field( name, "allow" ) &&
+        !aggregate.allowed ) {
+        return aggregate;
+    }
+    for( const std::shared_ptr<runtime> &owner : active_runtimes ) {
+        if( !owner || !owner->world_is_ready ) {
+            continue;
+        }
+        const auto subscription = owner->hooks.find( std::string( name ) );
+        if( subscription == owner->hooks.end() ) {
+            continue;
+        }
+        const std::vector<std::string> handler_ids = subscription->second;
+        sol::object previous = sol::make_object( *owner->lua, sol::lua_nil );
+        for( const std::string &handler_id : handler_ids ) {
+            const auto handler = owner->handlers.find( handler_id );
+            if( handler == owner->handlers.end() ) {
+                continue;
+            }
+            if( owner->callback_depth >= 16 ) {
+                DebugLog( D_ERROR, D_MAIN ) << "Lua-first native hook recursion limit reached for '"
+                                            << owner->mod_id << ':' << name << "'";
+                continue;
+            }
+            sol::table payload = platform_callback_payload( *owner, arguments );
+            payload["hook"] = std::string( name );
+            payload["cancellable"] =
+                cata::lua_ui::native_hook_supports_result_field( name, "allow" );
+            sol::table shared = owner->lua->create_table();
+            shared["allowed"] = aggregate.allowed;
+            shared["handled"] = aggregate.handled;
+            shared["text"] = aggregate.text;
+            if( aggregate.result ) {
+                shared["result"] = *aggregate.result;
+            }
+            sol::table strings = owner->lua->create_table();
+            for( std::size_t index = 0; index < aggregate.results.size(); ++index ) {
+                strings[index + 1] = aggregate.results[index];
+            }
+            shared["results"] = std::move( strings );
+            payload["results"] = shared;
+            payload["prev"] = previous;
+
+            sol::protected_function callback = handler->second.callback;
+            callback_scope scope( *owner );
+            const sol::protected_function_result result = callback( payload );
+            if( !result.valid() ) {
+                report_callback_error( *owner, handler_id, result );
+                continue;
+            }
+
+            bool stop = false;
+            cata::lua_ui::native_hook_result candidate = aggregate;
+            try {
+                apply_platform_hook_table( name, shared, candidate, stop, true );
+            } catch( const std::exception &exception ) {
+                DebugLog( D_ERROR, D_MAIN ) << "Lua-first native hook '" << owner->mod_id
+                                            << ':' << handler_id
+                                            << "' mutated invalid shared results: "
+                                            << exception.what();
+                continue;
+            }
+            sol::object returned = sol::make_object( *owner->lua, sol::lua_nil );
+            bool accept_candidate = true;
+            if( result.return_count() > 0 ) {
+                returned = result.get<sol::object>();
+                if( returned.get_type() == sol::type::boolean ) {
+                    if( !cata::lua_ui::native_hook_supports_result_field( name, "allow" ) ) {
+                        DebugLog( D_ERROR, D_MAIN ) << "Lua-first signal hook '" << name
+                                                    << "' ignored a boolean result from '"
+                                                    << owner->mod_id << ':' << handler_id << "'";
+                    } else {
+                        const bool allowed = returned.as<bool>();
+                        candidate.allowed = candidate.allowed && allowed;
+                        stop = stop || !allowed;
+                    }
+                } else if( returned.get_type() == sol::type::string &&
+                           cata::lua_ui::native_hook_supports_result_field( name, "result" ) ) {
+                    const std::string replacement = returned.as<std::string>();
+                    if( replacement.size() > 512 ) {
+                        DebugLog( D_ERROR, D_MAIN ) << "Lua-first native hook result exceeds 512 bytes";
+                        accept_candidate = false;
+                    } else {
+                        candidate.result = replacement;
+                    }
+                } else if( returned.get_type() == sol::type::table ) {
+                    try {
+                        apply_platform_hook_table( name, returned.as<sol::table>(),
+                                                   candidate, stop, false );
+                    } catch( const std::exception &exception ) {
+                        DebugLog( D_ERROR, D_MAIN ) << "Lua-first native hook '" << owner->mod_id
+                                                    << ':' << handler_id << "' returned invalid data: "
+                                                    << exception.what();
+                        accept_candidate = false;
+                    }
+                } else if( returned.get_type() != sol::type::nil ) {
+                    DebugLog( D_ERROR, D_MAIN ) << "Lua-first native hook '" << owner->mod_id
+                                                << ':' << handler_id
+                                                << "' must return nil, boolean, string, or table";
+                    accept_candidate = false;
+                }
+            }
+            if( !accept_candidate ) {
+                continue;
+            }
+            aggregate = std::move( candidate );
+            previous = std::move( returned );
+            if( stop ) {
+                return aggregate;
+            }
+        }
+    }
+    return aggregate;
+}
+
+std::optional<int> invoke_use_handler( std::string_view mod_id,
+                                       std::string_view handler_id,
+                                       Character *character, item &used_item,
+                                       map *, const tripoint_bub_ms &position )
+{
+    const std::shared_ptr<runtime> owner = find_active_runtime( mod_id );
+    if( character == nullptr ) {
+        DebugLog( D_ERROR, D_MAIN ) << "Lua-first item handler '" << mod_id << ':'
+                                    << handler_id << "' was invoked without a Character";
+        return std::nullopt;
+    }
+    if( !owner || !owner->world_is_ready ) {
+        character->add_msg_if_player( "Lua-first Mod runtime is not ready." );
+        return std::nullopt;
+    }
+    const auto handler = owner->handlers.find( std::string( handler_id ) );
+    if( handler == owner->handlers.end() ) {
+        character->add_msg_if_player( "Lua-first item handler is no longer registered." );
+        return std::nullopt;
+    }
+    auto context = std::make_shared<use_context_data>();
+    context->character = character;
+    context->used_item = &used_item;
+    context->position = position;
+    context->runtime_generation = owner->generation;
+    context->world_generation = active_world_generation;
+    sol::protected_function callback = handler->second.callback;
+    callback_scope scope( *owner );
+    const sol::protected_function_result result = callback( context );
+    context->active = false;
+    if( !result.valid() ) {
+        report_callback_error( *owner, handler_id, result );
+        return std::nullopt;
+    }
+    if( result.return_count() == 0 ) {
+        return 0;
+    }
+    const sol::object returned = result.get<sol::object>();
+    if( returned.get_type() == sol::type::nil ) {
+        return std::nullopt;
+    }
+    if( returned.get_type() != sol::type::number || !returned.is<lua_Integer>() ) {
+        ::add_msg( m_bad, "Lua-first item handler must return an integer or nil." );
+        return std::nullopt;
+    }
+    const lua_Integer native_result = returned.as<lua_Integer>();
+    if( native_result < std::numeric_limits<int>::min() ||
+        native_result > std::numeric_limits<int>::max() ) {
+        ::add_msg( m_bad, "Lua-first item handler result is outside the native range." );
+        return std::nullopt;
+    }
+    return static_cast<int>( native_result );
+}
+
+std::optional<bool> invoke_behavior_condition_handler(
+    const std::string_view mod_id, const std::string_view behavior_id,
+    const std::string_view handler_id, const Creature *subject,
+    const std::string_view argument )
+{
+    const std::shared_ptr<runtime> owner = find_active_runtime( mod_id );
+    if( !owner || !owner->world_is_ready ) {
+        return std::nullopt;
+    }
+    const auto handler = owner->handlers.find( std::string( handler_id ) );
+    if( handler == owner->handlers.end() || owner->callback_depth >= 16 ) {
+        DebugLog( D_ERROR, D_MAIN ) << "Lua-first behavior condition unavailable for '"
+                                    << mod_id << ':' << handler_id << "'";
+        return std::nullopt;
+    }
+
+    sol::table payload = owner->lua->create_table();
+    payload["behavior_id"] = std::string( behavior_id );
+    payload["argument"] = std::string( argument );
+    if( subject == nullptr ) {
+        payload["subject_kind"] = "none";
+        payload["subject"] = sol::lua_nil;
+    } else {
+        payload["subject_kind"] = subject->is_avatar() ? "avatar" :
+                                  subject->is_npc() ? "npc" :
+                                  subject->is_monster() ? "monster" : "creature";
+        payload["subject"] = platform_creature_handle( *owner, *subject );
+    }
+
+    sol::protected_function callback = handler->second.callback;
+    callback_scope scope( *owner );
+    const sol::protected_function_result result = callback( payload );
+    if( !result.valid() ) {
+        report_callback_error( *owner, handler_id, result );
+        return std::nullopt;
+    }
+    if( result.return_count() != 1 || result.get_type() != sol::type::boolean ) {
+        DebugLog( D_ERROR, D_MAIN ) << "Lua-first behavior condition '"
+                                    << mod_id << ':' << handler_id
+                                    << "' must return exactly one boolean";
+        return std::nullopt;
+    }
+    return result.get<bool>();
+}
+
+std::optional<double> invoke_behavior_score_handler(
+    const std::string_view mod_id, const std::string_view behavior_id,
+    const std::string_view handler_id, const Creature *subject,
+    const std::string_view argument )
+{
+    const std::shared_ptr<runtime> owner = find_active_runtime( mod_id );
+    if( !owner || !owner->world_is_ready ) {
+        return std::nullopt;
+    }
+    const auto handler = owner->handlers.find( std::string( handler_id ) );
+    if( handler == owner->handlers.end() || owner->callback_depth >= 16 ) {
+        DebugLog( D_ERROR, D_MAIN ) << "Lua-first behavior score unavailable for '"
+                                    << mod_id << ':' << handler_id << "'";
+        return std::nullopt;
+    }
+
+    sol::table payload = owner->lua->create_table();
+    payload["behavior_id"] = std::string( behavior_id );
+    payload["argument"] = std::string( argument );
+    if( subject == nullptr ) {
+        payload["subject_kind"] = "none";
+        payload["subject"] = sol::lua_nil;
+    } else {
+        payload["subject_kind"] = subject->is_avatar() ? "avatar" :
+                                  subject->is_npc() ? "npc" :
+                                  subject->is_monster() ? "monster" : "creature";
+        payload["subject"] = platform_creature_handle( *owner, *subject );
+    }
+
+    sol::protected_function callback = handler->second.callback;
+    callback_scope scope( *owner );
+    const sol::protected_function_result result = callback( payload );
+    if( !result.valid() ) {
+        report_callback_error( *owner, handler_id, result );
+        return std::nullopt;
+    }
+    if( result.return_count() != 1 || result.get_type() != sol::type::number ) {
+        DebugLog( D_ERROR, D_MAIN ) << "Lua-first behavior score '"
+                                    << mod_id << ':' << handler_id
+                                    << "' must return exactly one finite number";
+        return std::nullopt;
+    }
+    const double value = result.get<double>();
+    if( !std::isfinite( value ) ||
+        std::abs( value ) > std::numeric_limits<float>::max() ) {
+        DebugLog( D_ERROR, D_MAIN ) << "Lua-first behavior score '"
+                                    << mod_id << ':' << handler_id
+                                    << "' returned a value outside the native float range";
+        return std::nullopt;
+    }
+    return value;
+}
+
+std::optional<bool> invoke_monster_attack_handler(
+    const std::string_view mod_id, const std::string_view attack_id,
+    const std::string_view handler_id, Creature &attacker )
+{
+    const std::shared_ptr<runtime> owner = find_active_runtime( mod_id );
+    if( !owner || !owner->world_is_ready ) {
+        return std::nullopt;
+    }
+    const auto handler = owner->handlers.find( std::string( handler_id ) );
+    if( handler == owner->handlers.end() || owner->callback_depth >= 16 ) {
+        DebugLog( D_ERROR, D_MAIN ) << "Lua-first monster attack unavailable for '"
+                                    << mod_id << ':' << handler_id << "'";
+        return std::nullopt;
+    }
+
+    sol::table payload = owner->lua->create_table();
+    payload["attack_id"] = std::string( attack_id );
+    payload["attacker"] = platform_creature_handle( *owner, attacker );
+    Creature *target = nullptr;
+    if( monster *attacking_monster = attacker.as_monster() ) {
+        target = attacking_monster->attack_target();
+    }
+    payload["target"] = target == nullptr ?
+                        sol::make_object( *owner->lua, sol::lua_nil ) :
+                        sol::make_object( *owner->lua,
+                                          platform_creature_handle( *owner, *target ) );
+
+    sol::protected_function callback = handler->second.callback;
+    callback_scope scope( *owner );
+    const sol::protected_function_result result = callback( payload );
+    if( !result.valid() ) {
+        report_callback_error( *owner, handler_id, result );
+        return std::nullopt;
+    }
+    if( result.return_count() != 1 || result.get_type() != sol::type::boolean ) {
+        DebugLog( D_ERROR, D_MAIN ) << "Lua-first monster attack '"
+                                    << mod_id << ':' << handler_id
+                                    << "' must return exactly one boolean";
+        return std::nullopt;
+    }
+    return result.get<bool>();
+}
+
+void invoke_damage_type_handler( const std::string_view damage_id,
+                                 const std::string_view phase,
+                                 Creature *source, Creature *target,
+                                 const std::string_view body_part,
+                                 const double total_damage,
+                                 const double damage_taken )
+{
+    for( auto iterator = active_runtimes.rbegin(); iterator != active_runtimes.rend(); ++iterator ) {
+        const std::shared_ptr<runtime> &owner = *iterator;
+        if( !owner ) {
+            continue;
+        }
+        std::string handler_id;
+        if( !owner->content.find_damage_handler( damage_id, phase, handler_id ) ) {
+            continue;
+        }
+        // A later replacement owns the definition even when it deliberately
+        // omits this callback, so an earlier layer must not leak through.
+        if( handler_id.empty() || !owner->world_is_ready ) {
+            return;
+        }
+        const auto handler = owner->handlers.find( handler_id );
+        if( handler == owner->handlers.end() ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Lua-first damage handler '"
+                                        << owner->mod_id << ':' << handler_id
+                                        << "' is no longer registered";
+            return;
+        }
+        if( owner->callback_depth >= 16 ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Lua-first damage handler recursion limit reached for '"
+                                        << owner->mod_id << ':' << handler_id << "'";
+            return;
+        }
+        sol::table payload = owner->lua->create_table();
+        payload["damage_type_id"] = std::string( damage_id );
+        payload["phase"] = std::string( phase );
+        payload["body_part"] = std::string( body_part );
+        payload["total_damage"] = total_damage;
+        payload["damage_taken"] = damage_taken;
+        payload["source"] = source ?
+                            sol::make_object( *owner->lua,
+                                              platform_creature_handle( *owner, *source ) ) :
+                            sol::make_object( *owner->lua, sol::lua_nil );
+        payload["target"] = target ?
+                            sol::make_object( *owner->lua,
+                                              platform_creature_handle( *owner, *target ) ) :
+                            sol::make_object( *owner->lua, sol::lua_nil );
+        sol::protected_function callback = handler->second.callback;
+        callback_scope scope( *owner );
+        const sol::protected_function_result result = callback( payload );
+        if( !result.valid() ) {
+            report_callback_error( *owner, handler_id, result );
+        }
+        return;
+    }
+}
+
+void invoke_ammo_effect_handler( const std::string_view ammo_effect_id,
+                                 Creature *source, Creature *target,
+                                 const tripoint_bub_ms &position,
+                                 const int dealt_damage )
+{
+    for( auto iterator = active_runtimes.rbegin(); iterator != active_runtimes.rend(); ++iterator ) {
+        const std::shared_ptr<runtime> &owner = *iterator;
+        if( !owner ) {
+            continue;
+        }
+        std::string handler_id;
+        if( !owner->content.find_ammo_effect_handler( ammo_effect_id, handler_id ) ) {
+            continue;
+        }
+        // The most recent replacement owns the effect even if it deliberately
+        // has no Lua impact policy.
+        if( handler_id.empty() || !owner->world_is_ready ) {
+            return;
+        }
+        const auto handler = owner->handlers.find( handler_id );
+        if( handler == owner->handlers.end() ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Lua-first ammo-effect handler '"
+                                        << owner->mod_id << ':' << handler_id
+                                        << "' is no longer registered";
+            return;
+        }
+        if( owner->callback_depth >= 16 ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Lua-first ammo-effect handler recursion limit reached for '"
+                                        << owner->mod_id << ':' << handler_id << "'";
+            return;
+        }
+        sol::table payload = owner->lua->create_table();
+        payload["ammo_effect_id"] = std::string( ammo_effect_id );
+        payload["dealt_damage"] = dealt_damage;
+        payload["source"] = source ?
+                            sol::make_object( *owner->lua,
+                                              platform_creature_handle( *owner, *source ) ) :
+                            sol::make_object( *owner->lua, sol::lua_nil );
+        payload["target"] = target ?
+                            sol::make_object( *owner->lua,
+                                              platform_creature_handle( *owner, *target ) ) :
+                            sol::make_object( *owner->lua, sol::lua_nil );
+        sol::table point = owner->lua->create_table();
+        point["coordinate_space"] = "bub_ms";
+        point["x"] = position.x();
+        point["y"] = position.y();
+        point["z"] = position.z();
+        payload["position"] = std::move( point );
+        sol::protected_function callback = handler->second.callback;
+        callback_scope scope( *owner );
+        const sol::protected_function_result result = callback( payload );
+        if( !result.valid() ) {
+            report_callback_error( *owner, handler_id, result );
+        }
+        return;
+    }
+}
+
+std::optional<bool> invoke_addiction_type_handler(
+    const std::string_view addiction_type_id, Character &character,
+    const int intensity, const std::int64_t sated_turns )
+{
+    for( auto iterator = active_runtimes.rbegin(); iterator != active_runtimes.rend(); ++iterator ) {
+        const std::shared_ptr<runtime> &owner = *iterator;
+        if( !owner ) {
+            continue;
+        }
+        std::string handler_id;
+        if( !owner->content.find_addiction_type_handler( addiction_type_id, handler_id ) ) {
+            continue;
+        }
+        if( handler_id.empty() || !owner->world_is_ready ) {
+            return false;
+        }
+        const auto handler = owner->handlers.find( handler_id );
+        if( handler == owner->handlers.end() || owner->callback_depth >= 16 ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Lua-first addiction policy unavailable for '"
+                                        << owner->mod_id << ':' << handler_id << "'";
+            return false;
+        }
+        sol::table payload = owner->lua->create_table();
+        payload["addiction_type_id"] = std::string( addiction_type_id );
+        payload["intensity"] = intensity;
+        payload["sated_turns"] = sated_turns;
+        payload["character"] = platform_creature_handle( *owner, character );
+        sol::protected_function callback = handler->second.callback;
+        callback_scope scope( *owner );
+        const sol::protected_function_result result = callback( payload );
+        if( !result.valid() ) {
+            report_callback_error( *owner, handler_id, result );
+            return false;
+        }
+        if( result.return_count() != 1 || result.get_type() != sol::type::boolean ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Lua-first addiction policy '"
+                                        << owner->mod_id << ':' << handler_id
+                                        << "' must return one boolean";
+            return false;
+        }
+        return result.get<bool>();
+    }
+    return std::nullopt;
+}
+
+std::optional<double> invoke_character_modifier_handler(
+    const std::string_view modifier_id, const Character &character,
+    const std::string_view skill_id_value )
+{
+    for( auto iterator = active_runtimes.rbegin(); iterator != active_runtimes.rend(); ++iterator ) {
+        const std::shared_ptr<runtime> &owner = *iterator;
+        if( !owner ) {
+            continue;
+        }
+        std::string handler_id;
+        if( !owner->content.find_character_modifier_handler( modifier_id, handler_id ) ) {
+            continue;
+        }
+        if( handler_id.empty() || !owner->world_is_ready ) {
+            return 0.0;
+        }
+        const auto handler = owner->handlers.find( handler_id );
+        if( handler == owner->handlers.end() || owner->callback_depth >= 16 ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Lua-first character-modifier evaluator unavailable for '"
+                                        << owner->mod_id << ':' << handler_id << "'";
+            return 0.0;
+        }
+        sol::table payload = owner->lua->create_table();
+        payload["modifier_id"] = std::string( modifier_id );
+        payload["skill_id"] = std::string( skill_id_value );
+        payload["character"] = platform_creature_handle( *owner, character );
+        sol::protected_function callback = handler->second.callback;
+        callback_scope scope( *owner );
+        const sol::protected_function_result result = callback( payload );
+        if( !result.valid() ) {
+            report_callback_error( *owner, handler_id, result );
+            return 0.0;
+        }
+        if( result.return_count() != 1 || result.get_type() != sol::type::number ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Lua-first character-modifier evaluator '"
+                                        << owner->mod_id << ':' << handler_id
+                                        << "' must return one finite number";
+            return 0.0;
+        }
+        const double value = result.get<double>();
+        if( !std::isfinite( value ) ||
+            std::abs( value ) > std::numeric_limits<float>::max() ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Lua-first character-modifier evaluator '"
+                                        << owner->mod_id << ':' << handler_id
+                                        << "' returned a value outside the native float range";
+            return 0.0;
+        }
+        return value;
+    }
+    return std::nullopt;
+}
+
+std::optional<bool> invoke_weather_type_handler(
+    const std::string_view weather_type_id_value, const w_point &sample )
+{
+    for( auto iterator = active_runtimes.rbegin(); iterator != active_runtimes.rend(); ++iterator ) {
+        const std::shared_ptr<runtime> &owner = *iterator;
+        if( !owner ) {
+            continue;
+        }
+        std::string handler_id;
+        if( !owner->content.find_weather_type_handler(
+                weather_type_id_value, handler_id ) ) {
+            continue;
+        }
+        if( handler_id.empty() || !owner->world_is_ready ) {
+            return false;
+        }
+        const auto handler = owner->handlers.find( handler_id );
+        if( handler == owner->handlers.end() || owner->callback_depth >= 16 ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Lua-first weather condition unavailable for '"
+                                        << owner->mod_id << ':' << handler_id << "'";
+            return false;
+        }
+        sol::table payload = owner->lua->create_table();
+        payload["weather_type_id"] = std::string( weather_type_id_value );
+        payload["temperature_kelvin"] = units::to_kelvin( sample.temperature );
+        payload["humidity"] = sample.humidity;
+        payload["pressure"] = sample.pressure;
+        payload["windpower"] = sample.windpower;
+        payload["wind_description"] = sample.wind_desc;
+        payload["wind_direction"] = sample.winddirection;
+        payload["turn"] = to_turn<std::int64_t>( sample.time.t );
+        sol::table location = owner->lua->create_table();
+        location["coordinate_space"] = "abs_ms";
+        location["x"] = sample.location.x();
+        location["y"] = sample.location.y();
+        location["z"] = sample.location.z();
+        payload["location"] = std::move( location );
+        sol::protected_function callback = handler->second.callback;
+        callback_scope scope( *owner );
+        const sol::protected_function_result result = callback( payload );
+        if( !result.valid() ) {
+            report_callback_error( *owner, handler_id, result );
+            return false;
+        }
+        if( result.return_count() != 1 || result.get_type() != sol::type::boolean ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Lua-first weather condition '"
+                                        << owner->mod_id << ':' << handler_id
+                                        << "' must return one boolean";
+            return false;
+        }
+        return result.get<bool>();
+    }
+    return std::nullopt;
+}
+
+std::optional<bool> invoke_end_screen_handler(
+    const std::string_view end_screen_id_value, const Character &character )
+{
+    for( auto iterator = active_runtimes.rbegin(); iterator != active_runtimes.rend(); ++iterator ) {
+        const std::shared_ptr<runtime> &owner = *iterator;
+        if( !owner ) {
+            continue;
+        }
+        std::string handler_id;
+        if( !owner->content.find_end_screen_handler(
+                end_screen_id_value, handler_id ) ) {
+            continue;
+        }
+        if( handler_id.empty() || !owner->world_is_ready ) {
+            return false;
+        }
+        const auto handler = owner->handlers.find( handler_id );
+        if( handler == owner->handlers.end() || owner->callback_depth >= 16 ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Lua-first end-screen policy unavailable for '"
+                                        << owner->mod_id << ':' << handler_id << "'";
+            return false;
+        }
+        sol::table payload = owner->lua->create_table();
+        payload["end_screen_id"] = std::string( end_screen_id_value );
+        payload["character"] = platform_creature_handle( *owner, character );
+        sol::protected_function callback = handler->second.callback;
+        callback_scope scope( *owner );
+        const sol::protected_function_result result = callback( payload );
+        if( !result.valid() ) {
+            report_callback_error( *owner, handler_id, result );
+            return false;
+        }
+        if( result.return_count() != 1 || result.get_type() != sol::type::boolean ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Lua-first end-screen policy '"
+                                        << owner->mod_id << ':' << handler_id
+                                        << "' must return one boolean";
+            return false;
+        }
+        return result.get<bool>();
+    }
+    return std::nullopt;
+}
+
+bool invoke_activity_type_handler(
+    const std::string_view activity_type_id_value, const std::string_view phase,
+    player_activity &activity, Character &character )
+{
+    for( auto iterator = active_runtimes.rbegin(); iterator != active_runtimes.rend(); ++iterator ) {
+        const std::shared_ptr<runtime> &owner = *iterator;
+        if( !owner ) {
+            continue;
+        }
+        std::string handler_id;
+        if( !owner->content.find_activity_type_handler(
+                activity_type_id_value, phase, handler_id ) ) {
+            continue;
+        }
+        // The newest Lua-first definition owns both policy slots.  An omitted
+        // slot intentionally suppresses the legacy EOC rather than exposing a
+        // callback from an older replacement layer.
+        if( handler_id.empty() || !owner->world_is_ready ) {
+            return true;
+        }
+        const auto handler = owner->handlers.find( handler_id );
+        if( handler == owner->handlers.end() || owner->callback_depth >= 16 ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Lua-first activity policy unavailable for '"
+                                        << owner->mod_id << ':' << handler_id << "'";
+            return true;
+        }
+
+        sol::table payload = owner->lua->create_table();
+        payload["activity_type_id"] = std::string( activity_type_id_value );
+        payload["phase"] = std::string( phase );
+        payload["character"] = platform_creature_handle( *owner, character );
+        payload["moves_total"] = activity.moves_total;
+        payload["moves_left"] = activity.moves_left;
+        payload["index"] = activity.index;
+        payload["position"] = activity.position;
+        payload["name"] = activity.name;
+
+        sol::protected_function callback = handler->second.callback;
+        callback_scope scope( *owner );
+        const sol::protected_function_result result = callback( payload );
+        if( !result.valid() ) {
+            report_callback_error( *owner, handler_id, result );
+            return true;
+        }
+        if( result.return_count() == 0 || result.get_type() == sol::type::nil ) {
+            return true;
+        }
+        if( result.return_count() != 1 || result.get_type() != sol::type::table ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Lua-first activity policy '"
+                                        << owner->mod_id << ':' << handler_id
+                                        << "' must return nil or one result table";
+            return true;
+        }
+
+        try {
+            const sol::table returned = result.get<sol::table>();
+            const auto integer_field = [&returned]( const std::string &field,
+            const int fallback ) {
+                const sol::optional<sol::object> candidate =
+                    returned.get<sol::optional<sol::object>>( field );
+                if( !candidate ) {
+                    return fallback;
+                }
+                if( candidate->get_type() != sol::type::number ||
+                    !candidate->is<lua_Integer>() ) {
+                    throw std::invalid_argument( "activity result field '" + field +
+                                                 "' must be an integer" );
+                }
+                const lua_Integer value = candidate->as<lua_Integer>();
+                if( value < std::numeric_limits<int>::min() ||
+                    value > std::numeric_limits<int>::max() ) {
+                    throw std::invalid_argument( "activity result field '" + field +
+                                                 "' is outside the native integer range" );
+                }
+                return static_cast<int>( value );
+            };
+
+            const int moves_total = integer_field( "moves_total", activity.moves_total );
+            const int moves_left = integer_field( "moves_left", activity.moves_left );
+            const int index = integer_field( "index", activity.index );
+            const int position = integer_field( "position", activity.position );
+            if( moves_total < 0 ) {
+                throw std::invalid_argument(
+                    "activity result field 'moves_total' cannot be negative" );
+            }
+
+            bool cancel = false;
+            if( const sol::optional<sol::object> candidate =
+                    returned.get<sol::optional<sol::object>>( "cancel" ) ) {
+                if( candidate->get_type() != sol::type::boolean ) {
+                    throw std::invalid_argument(
+                        "activity result field 'cancel' must be a boolean" );
+                }
+                cancel = candidate->as<bool>();
+            }
+
+            std::string name = activity.name;
+            if( const sol::optional<sol::object> candidate =
+                    returned.get<sol::optional<sol::object>>( "name" ) ) {
+                if( candidate->get_type() != sol::type::string ) {
+                    throw std::invalid_argument(
+                        "activity result field 'name' must be a string" );
+                }
+                name = candidate->as<std::string>();
+                if( name.size() > 1024 || name.find( '\0' ) != std::string::npos ) {
+                    throw std::invalid_argument(
+                        "activity result field 'name' exceeds its native bound" );
+                }
+            }
+
+            activity.moves_total = moves_total;
+            activity.moves_left = moves_left;
+            activity.index = index;
+            activity.position = position;
+            activity.name = std::move( name );
+            if( cancel ) {
+                activity.set_to_null();
+            }
+        } catch( const std::exception &exception ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Lua-first activity policy '"
+                                        << owner->mod_id << ':' << handler_id
+                                        << "' returned invalid data: " << exception.what();
+        }
+        return true;
+    }
+    return false;
+}
+
+bool invoke_snippet_examine_handler( const std::string_view snippet_id_value,
+                                     const std::string_view item_type_id,
+                                     Character &character )
+{
+    for( auto iterator = active_runtimes.rbegin(); iterator != active_runtimes.rend(); ++iterator ) {
+        const std::shared_ptr<runtime> &owner = *iterator;
+        if( !owner ) {
+            continue;
+        }
+        std::string category_id;
+        std::string handler_id;
+        if( !owner->content.find_snippet_handler(
+                snippet_id_value, category_id, handler_id ) ) {
+            continue;
+        }
+        if( handler_id.empty() || !owner->world_is_ready ) {
+            return true;
+        }
+        const auto handler = owner->handlers.find( handler_id );
+        if( handler == owner->handlers.end() || owner->callback_depth >= 16 ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Lua-first snippet examine policy unavailable for '"
+                                        << owner->mod_id << ':' << handler_id << "'";
+            return true;
+        }
+        sol::table payload = owner->lua->create_table();
+        payload["snippet_id"] = std::string( snippet_id_value );
+        payload["category_id"] = category_id;
+        payload["item_type_id"] = std::string( item_type_id );
+        payload["character"] = platform_creature_handle( *owner, character );
+        sol::protected_function callback = handler->second.callback;
+        callback_scope scope( *owner );
+        const sol::protected_function_result result = callback( payload );
+        if( !result.valid() ) {
+            report_callback_error( *owner, handler_id, result );
+        }
+        return true;
+    }
+    return false;
+}
+
+std::optional<double> invoke_magic_type_number_handler(
+    const std::string_view magic_type_id, const std::string_view phase,
+    const std::string_view spell_id, const Creature *caster, const double input )
+{
+    for( auto iterator = active_runtimes.rbegin(); iterator != active_runtimes.rend(); ++iterator ) {
+        const std::shared_ptr<runtime> &owner = *iterator;
+        if( !owner ) {
+            continue;
+        }
+        std::string handler_id;
+        if( !owner->content.find_magic_type_handler( magic_type_id, phase, handler_id ) ) {
+            continue;
+        }
+        // A later replacement owns the policy even if it intentionally uses
+        // the engine default for this phase.
+        if( handler_id.empty() || !owner->world_is_ready ) {
+            return std::nullopt;
+        }
+        const auto handler = owner->handlers.find( handler_id );
+        if( handler == owner->handlers.end() ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Lua-first magic-type handler '"
+                                        << owner->mod_id << ':' << handler_id
+                                        << "' is no longer registered";
+            return std::nullopt;
+        }
+        if( owner->callback_depth >= 16 ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Lua-first magic-type handler recursion limit reached for '"
+                                        << owner->mod_id << ':' << handler_id << "'";
+            return std::nullopt;
+        }
+        sol::table payload = owner->lua->create_table();
+        payload["magic_type_id"] = std::string( magic_type_id );
+        payload["spell_id"] = std::string( spell_id );
+        payload["phase"] = std::string( phase );
+        payload["input"] = input;
+        if( phase == "level_for_experience" ) {
+            payload["experience"] = input;
+        } else if( phase == "experience_for_level" ) {
+            payload["level"] = input;
+        }
+        payload["caster"] = caster ?
+                            sol::make_object( *owner->lua,
+                                              platform_creature_handle( *owner, *caster ) ) :
+                            sol::make_object( *owner->lua, sol::lua_nil );
+        sol::protected_function callback = handler->second.callback;
+        callback_scope scope( *owner );
+        const sol::protected_function_result result = callback( payload );
+        if( !result.valid() ) {
+            report_callback_error( *owner, handler_id, result );
+            return std::nullopt;
+        }
+        if( result.return_count() != 1 ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Lua-first magic-type handler '"
+                                        << owner->mod_id << ':' << handler_id
+                                        << "' must return one finite number";
+            return std::nullopt;
+        }
+        const sol::object returned = result.get<sol::object>();
+        if( returned.get_type() != sol::type::number ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Lua-first magic-type handler '"
+                                        << owner->mod_id << ':' << handler_id
+                                        << "' must return one finite number";
+            return std::nullopt;
+        }
+        const double value = returned.as<double>();
+        const bool integral_domain = phase == "level_for_experience" ||
+                                     phase == "experience_for_level" ||
+                                     phase == "casting_experience";
+        const bool fraction_domain = phase == "failure_chance";
+        if( !std::isfinite( value ) || value < 0.0 ||
+            ( integral_domain && value > std::numeric_limits<int>::max() ) ||
+            ( fraction_domain && value > 1.0 ) ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Lua-first magic-type handler '"
+                                        << owner->mod_id << ':' << handler_id
+                                        << "' returned a value outside the " << phase << " domain";
+            return std::nullopt;
+        }
+        return value;
+    }
+    return std::nullopt;
+}
+
+void invoke_magic_type_failure_handler( const std::string_view magic_type_id,
+                                        const std::string_view spell_id,
+                                        Character &caster )
+{
+    for( auto iterator = active_runtimes.rbegin(); iterator != active_runtimes.rend(); ++iterator ) {
+        const std::shared_ptr<runtime> &owner = *iterator;
+        if( !owner ) {
+            continue;
+        }
+        std::string handler_id;
+        if( !owner->content.find_magic_type_handler(
+                magic_type_id, "on_failure", handler_id ) ) {
+            continue;
+        }
+        if( handler_id.empty() || !owner->world_is_ready ) {
+            return;
+        }
+        const auto handler = owner->handlers.find( handler_id );
+        if( handler == owner->handlers.end() ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Lua-first magic-type failure handler '"
+                                        << owner->mod_id << ':' << handler_id
+                                        << "' is no longer registered";
+            return;
+        }
+        if( owner->callback_depth >= 16 ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Lua-first magic-type failure handler recursion limit reached for '"
+                                        << owner->mod_id << ':' << handler_id << "'";
+            return;
+        }
+        sol::table payload = owner->lua->create_table();
+        payload["magic_type_id"] = std::string( magic_type_id );
+        payload["spell_id"] = std::string( spell_id );
+        payload["caster"] = platform_creature_handle( *owner, caster );
+        sol::protected_function callback = handler->second.callback;
+        callback_scope scope( *owner );
+        const sol::protected_function_result result = callback( payload );
+        if( !result.valid() ) {
+            report_callback_error( *owner, handler_id, result );
+        }
+        return;
+    }
+}
+
+std::optional<emission_profile> invoke_emission_profile_handler(
+    const std::string_view emission_id, const tripoint_bub_ms &position,
+    const emission_profile &fallback )
+{
+    for( auto iterator = active_runtimes.rbegin(); iterator != active_runtimes.rend(); ++iterator ) {
+        const std::shared_ptr<runtime> &owner = *iterator;
+        if( !owner ) {
+            continue;
+        }
+        std::string handler_id;
+        if( !owner->content.find_emission_handler( emission_id, handler_id ) ) {
+            continue;
+        }
+        // A later static replacement owns the emission even when it omits a
+        // dynamic profile, so an older replacement's callback must not leak.
+        if( handler_id.empty() || !owner->world_is_ready ) {
+            return std::nullopt;
+        }
+        const auto handler = owner->handlers.find( handler_id );
+        if( handler == owner->handlers.end() || owner->callback_depth >= 16 ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Lua-first emission profile unavailable for '"
+                                        << owner->mod_id << ':' << handler_id << "'";
+            return std::nullopt;
+        }
+
+        sol::table payload = owner->lua->create_table();
+        payload["emission_id"] = std::string( emission_id );
+        sol::table point = owner->lua->create_table();
+        point["coordinate_space"] = "bub_ms";
+        point["x"] = position.x();
+        point["y"] = position.y();
+        point["z"] = position.z();
+        payload["position"] = std::move( point );
+        sol::table fallback_value = owner->lua->create_table();
+        fallback_value["field"] = fallback.field;
+        fallback_value["intensity"] = fallback.intensity;
+        fallback_value["quantity"] = fallback.quantity;
+        fallback_value["chance"] = fallback.chance;
+        payload["fallback"] = std::move( fallback_value );
+
+        sol::protected_function callback = handler->second.callback;
+        callback_scope scope( *owner );
+        const sol::protected_function_result result = callback( payload );
+        if( !result.valid() ) {
+            report_callback_error( *owner, handler_id, result );
+            return std::nullopt;
+        }
+        if( result.return_count() == 0 || result.get_type() == sol::type::nil ) {
+            return std::nullopt;
+        }
+        if( result.return_count() != 1 || result.get_type() != sol::type::table ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Lua-first emission profile '"
+                                        << owner->mod_id << ':' << handler_id
+                                        << "' must return nil or one complete profile table";
+            return std::nullopt;
+        }
+
+        try {
+            const sol::table returned = result.get<sol::table>();
+            const sol::object field_value = returned.raw_get<sol::object>( "field" );
+            if( field_value.get_type() != sol::type::string ) {
+                throw std::invalid_argument( "field must be a string" );
+            }
+            emission_profile profile;
+            profile.field = field_value.as<std::string>();
+            const auto integer_field = [&returned]( const char *name ) {
+                const sol::object candidate = returned.raw_get<sol::object>( name );
+                if( candidate.get_type() != sol::type::number ||
+                    !candidate.is<lua_Integer>() ) {
+                    throw std::invalid_argument( std::string( name ) + " must be an integer" );
+                }
+                const lua_Integer value = candidate.as<lua_Integer>();
+                if( value < std::numeric_limits<int>::min() ||
+                    value > std::numeric_limits<int>::max() ) {
+                    throw std::invalid_argument( std::string( name ) +
+                                                 " is outside the native integer range" );
+                }
+                return static_cast<int>( value );
+            };
+            profile.intensity = integer_field( "intensity" );
+            profile.quantity = integer_field( "quantity" );
+            profile.chance = integer_field( "chance" );
+
+            const field_type_str_id field( profile.field );
+            if( profile.field.empty() || profile.field == "fd_null" ||
+                profile.field.find( '\0' ) != std::string::npos || !field.is_valid() ||
+                profile.intensity <= 0 ||
+                profile.intensity > field->get_max_intensity() ||
+                profile.quantity < 0 || profile.chance < 0 || profile.chance > 100 ) {
+                throw std::invalid_argument( "field profile is outside native bounds" );
+            }
+            return profile;
+        } catch( const std::exception &exception ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Lua-first emission profile '"
+                                        << owner->mod_id << ':' << handler_id
+                                        << "' returned invalid data: " << exception.what();
+            return std::nullopt;
+        }
+    }
+    return std::nullopt;
+}
+
+void runtime_world_ready( bool new_game )
+{
+    if( active_runtimes.empty() ) {
+        return;
+    }
+    if( active_world_generation != std::numeric_limits<std::size_t>::max() ) {
+        ++active_world_generation;
+    }
+    std::string character_error;
+    load_scope( character_state_path(), "character", character_error );
+    std::string world_error;
+    if( const std::optional<cata_path> path = world_state_path() ) {
+        load_scope( *path, "world", world_error );
+    }
+    if( !event_bridge ) {
+        event_bridge = std::make_unique<platform_event_bridge>();
+        get_event_bus().subscribe( event_bridge.get() );
+    }
+    for( const std::shared_ptr<runtime> &owner : active_runtimes ) {
+        if( owner ) {
+            owner->world_is_ready = true;
+        }
+    }
+    for( const std::shared_ptr<runtime> &owner : active_runtimes ) {
+        if( !owner ) {
+            continue;
+        }
+        sol::table payload = owner->lua->create_table();
+        payload["new_game"] = new_game;
+        dispatch_lifecycle( *owner, "world_ready", payload );
+    }
+    if( !character_error.empty() ) {
+        ::add_msg( m_warning, "Lua-first character state was not loaded: " + character_error );
+    }
+    if( !world_error.empty() ) {
+        ::add_msg( m_warning, "Lua-first world state was not loaded: " + world_error );
+    }
+    runtime_process_tasks();
+}
+
+void runtime_before_save()
+{
+    for( const std::shared_ptr<runtime> &owner : active_runtimes ) {
+        if( owner && owner->world_is_ready ) {
+            dispatch_lifecycle( *owner, "before_save" );
+        }
+    }
+}
+
+bool runtime_save( std::string &error )
+{
+    if( active_runtimes.empty() ) {
+        error.clear();
+        return true;
+    }
+    try {
+        write_scope( character_state_path(), "character" );
+        if( const std::optional<cata_path> path = world_state_path() ) {
+            write_scope( *path, "world" );
+        }
+        error.clear();
+        return true;
+    } catch( const std::exception &exception ) {
+        error = exception.what();
+        return false;
+    }
+}
+
+void runtime_after_save( bool success, std::string_view error )
+{
+    for( const std::shared_ptr<runtime> &owner : active_runtimes ) {
+        if( !owner || !owner->world_is_ready ) {
+            continue;
+        }
+        sol::table payload = owner->lua->create_table();
+        payload["success"] = success;
+        payload["error"] = std::string( error );
+        dispatch_lifecycle( *owner, "after_save", payload );
+    }
+}
+
+void runtime_process_tasks()
+{
+    const std::int64_t now = to_turn<std::int64_t>( calendar::turn );
+    for( const std::shared_ptr<runtime> &owner : active_runtimes ) {
+        if( !owner || !owner->world_is_ready ) {
+            continue;
+        }
+        for( persistent_task &task : owner->tasks ) {
+            const auto handler = owner->handlers.find( task.handler_id );
+            if( handler == owner->handlers.end() ) {
+                if( owner->reported_task_migration_failures.insert( task.id ).second ) {
+                    DebugLog( D_ERROR, D_MAIN ) << "Keeping Lua-first task " << task.id
+                                                << " for missing handler '" << owner->mod_id
+                                                << ':' << task.handler_id << "'";
+                }
+                continue;
+            }
+            if( handler->second.payload_version == task.payload_version ) {
+                owner->reported_task_migration_failures.erase( task.id );
+                continue;
+            }
+            std::string migration_error;
+            if( !migrate_task_payload( *owner, task, migration_error ) ) {
+                if( owner->reported_task_migration_failures.insert( task.id ).second ) {
+                    DebugLog( D_ERROR, D_MAIN ) << "Keeping Lua-first task " << task.id
+                                                << " with unmigrated payload for '"
+                                                << owner->mod_id << ':' << task.handler_id
+                                                << "': " << migration_error;
+                }
+            } else {
+                owner->reported_task_migration_failures.erase( task.id );
+            }
+        }
+        std::vector<persistent_task> due;
+        owner->tasks.erase( std::remove_if( owner->tasks.begin(), owner->tasks.end(),
+        [&due, &owner, now]( const persistent_task & task ) {
+            const auto handler = owner->handlers.find( task.handler_id );
+            if( task.due_turn <= now && handler != owner->handlers.end() &&
+                handler->second.payload_version == task.payload_version ) {
+                due.push_back( task );
+                return true;
+            }
+            return false;
+        } ), owner->tasks.end() );
+        for( const persistent_task &task : due ) {
+            owner->reported_task_migration_failures.erase( task.id );
+        }
+        std::sort( due.begin(), due.end(), []( const persistent_task &lhs,
+        const persistent_task &rhs ) {
+            return std::tie( lhs.due_turn, lhs.id ) < std::tie( rhs.due_turn, rhs.id );
+        } );
+        for( const persistent_task &task : due ) {
+            const auto handler = owner->handlers.find( task.handler_id );
+            if( handler == owner->handlers.end() ) {
+                DebugLog( D_ERROR, D_MAIN ) << "Discarding Lua-first task " << task.id
+                                            << " for missing handler '" << owner->mod_id
+                                            << ":" << task.handler_id << "'";
+                continue;
+            }
+            if( handler->second.payload_version != task.payload_version ) {
+                // Unmigrated tasks remain in owner->tasks and cannot reach the
+                // due list.  Keep this guard for corrupted in-memory input.
+                DebugLog( D_ERROR, D_MAIN ) << "Keeping Lua-first task " << task.id
+                                            << " because payload version "
+                                            << task.payload_version << " does not match handler version "
+                                            << handler->second.payload_version;
+                continue;
+            }
+            sol::table payload = owner->lua->create_table();
+            payload["id"] = static_cast<std::int64_t>( task.id );
+            payload["due_turn"] = task.due_turn;
+            payload["overdue_turns"] = nonnegative_turn_difference( now, task.due_turn );
+            payload["owner"] = task.owner;
+            payload["payload_version"] = task.payload_version;
+            payload["payload"] = persistent_table( *owner->lua, task.payload );
+            sol::protected_function callback = handler->second.callback;
+            callback_scope scope( *owner );
+            const sol::protected_function_result result = callback( payload );
+            if( !result.valid() ) {
+                report_callback_error( *owner, task.handler_id, result );
+            }
+        }
+    }
+}
+
+} // namespace cata::lua_platform
+
+#else
+
+namespace cata::lua_platform
+{
+
+struct content_transaction::impl {};
+
+content_transaction::content_transaction( std::string, std::size_t ) :
+    pimpl_( std::make_unique<impl>() )
+{
+}
+
+content_transaction::~content_transaction() = default;
+
+bool content_transaction::validate( const runtime &, bool, std::string &error ) const
+{
+    error = "Lua-first Platform is not enabled in this build";
+    return false;
+}
+
+bool content_transaction::apply( std::string &error )
+{
+    error = "Lua-first Platform is not enabled in this build";
+    return false;
+}
+
+bool content_transaction::validate_finalized( std::string &error ) const
+{
+    error = "Lua-first Platform is not enabled in this build";
+    return false;
+}
+
+void content_transaction::rollback() {}
+void content_transaction::commit() {}
+void content_transaction::seal() {}
+void content_transaction::discard() {}
+std::string content_transaction::fingerprint() const { return {}; }
+bool content_transaction::was_applied() const { return false; }
+bool content_transaction::find_damage_handler( std::string_view, std::string_view,
+        std::string &handler_id ) const
+{
+    handler_id.clear();
+    return false;
+}
+bool content_transaction::find_ammo_effect_handler( std::string_view,
+        std::string &handler_id ) const
+{
+    handler_id.clear();
+    return false;
+}
+bool content_transaction::find_addiction_type_handler( std::string_view,
+        std::string &handler_id ) const
+{
+    handler_id.clear();
+    return false;
+}
+bool content_transaction::find_character_modifier_handler( std::string_view,
+        std::string &handler_id ) const
+{
+    handler_id.clear();
+    return false;
+}
+bool content_transaction::find_weather_type_handler( std::string_view,
+        std::string &handler_id ) const
+{
+    handler_id.clear();
+    return false;
+}
+bool content_transaction::find_end_screen_handler( std::string_view,
+        std::string &handler_id ) const
+{
+    handler_id.clear();
+    return false;
+}
+bool content_transaction::find_activity_type_handler( std::string_view,
+        std::string_view, std::string &handler_id ) const
+{
+    handler_id.clear();
+    return false;
+}
+bool content_transaction::find_snippet_handler( std::string_view,
+        std::string &category_id, std::string &handler_id ) const
+{
+    category_id.clear();
+    handler_id.clear();
+    return false;
+}
+bool content_transaction::find_magic_type_handler( std::string_view, std::string_view,
+        std::string &handler_id ) const
+{
+    handler_id.clear();
+    return false;
+}
+bool content_transaction::find_emission_handler( std::string_view,
+        std::string &handler_id ) const
+{
+    handler_id.clear();
+    return false;
+}
+
+void invoke_damage_type_handler( std::string_view, std::string_view,
+                                 Creature *, Creature *, std::string_view,
+                                 double, double )
+{
+}
+
+void invoke_ammo_effect_handler( std::string_view, Creature *, Creature *,
+                                 const tripoint_bub_ms &, int )
+{
+}
+
+std::optional<bool> invoke_addiction_type_handler(
+    std::string_view, Character &, int, std::int64_t )
+{
+    return std::nullopt;
+}
+
+std::optional<double> invoke_character_modifier_handler(
+    std::string_view, const Character &, std::string_view )
+{
+    return std::nullopt;
+}
+
+std::optional<bool> invoke_behavior_condition_handler(
+    std::string_view, std::string_view, std::string_view,
+    const Creature *, std::string_view )
+{
+    return std::nullopt;
+}
+
+std::optional<double> invoke_behavior_score_handler(
+    std::string_view, std::string_view, std::string_view,
+    const Creature *, std::string_view )
+{
+    return std::nullopt;
+}
+
+std::optional<bool> invoke_monster_attack_handler(
+    std::string_view, std::string_view, std::string_view, Creature & )
+{
+    return std::nullopt;
+}
+
+std::optional<bool> invoke_weather_type_handler( std::string_view, const w_point & )
+{
+    return std::nullopt;
+}
+
+std::optional<bool> invoke_end_screen_handler( std::string_view, const Character & )
+{
+    return std::nullopt;
+}
+
+bool invoke_activity_type_handler( std::string_view, std::string_view,
+                                   player_activity &, Character & )
+{
+    return false;
+}
+
+bool invoke_snippet_examine_handler( std::string_view, std::string_view,
+                                     Character & )
+{
+    return false;
+}
+
+std::optional<double> invoke_magic_type_number_handler(
+    std::string_view, std::string_view, std::string_view, const Creature *, double )
+{
+    return std::nullopt;
+}
+
+void invoke_magic_type_failure_handler( std::string_view, std::string_view,
+                                        Character & )
+{
+}
+
+std::optional<emission_profile> invoke_emission_profile_handler(
+    std::string_view, const tripoint_bub_ms &, const emission_profile & )
+{
+    return std::nullopt;
+}
+
+} // namespace cata::lua_platform
+
+#endif

--- a/src/catalua_platform_runtime.h
+++ b/src/catalua_platform_runtime.h
@@ -1,0 +1,258 @@
+#pragma once
+#ifndef CATA_SRC_CATALUA_PLATFORM_RUNTIME_H
+#define CATA_SRC_CATALUA_PLATFORM_RUNTIME_H
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+class Character;
+class Creature;
+class item;
+class map;
+class player_activity;
+class recipe;
+struct itype;
+struct tripoint_bub_ms;
+struct w_point;
+
+#if defined(CATA_ENABLE_LUA_UI) && CATA_ENABLE_LUA_UI
+#include "catalua_sol.h"
+#include "catalua_ui.h"
+#endif
+
+namespace cata::lua_platform
+{
+
+class runtime;
+
+/**
+ * Owns native content definitions created by one candidate Platform Mod.
+ *
+ * The class name is intentionally part of the native friendship boundary: it
+ * may populate Item_factory and recipe_dictionary without exposing either
+ * legacy loader to Lua.  Lua only receives generation-checked definition
+ * handles installed by runtime.
+ */
+class content_transaction
+{
+    public:
+        content_transaction( std::string owner, std::size_t generation );
+        ~content_transaction();
+
+        content_transaction( const content_transaction & ) = delete;
+        content_transaction &operator=( const content_transaction & ) = delete;
+
+        bool validate( const runtime &owner_runtime, bool check_engine_state,
+                       std::string &error ) const;
+        bool apply( std::string &error );
+        bool validate_finalized( std::string &error ) const;
+        void rollback();
+        void commit();
+        /** Retire Lua definition handles without reapplying unchanged content. */
+        void seal();
+        void discard();
+
+        std::string fingerprint() const;
+        bool was_applied() const;
+
+        /** Find the named callback owned by this transaction's damage type. */
+        bool find_damage_handler( std::string_view damage_id,
+                                  std::string_view phase,
+                                  std::string &handler_id ) const;
+
+        /** Find the named Lua impact policy owned by this ammunition effect. */
+        bool find_ammo_effect_handler( std::string_view ammo_effect_id,
+                                       std::string &handler_id ) const;
+
+        /** Find the named Lua tick policy owned by this addiction type. */
+        bool find_addiction_type_handler( std::string_view addiction_type_id,
+                                          std::string &handler_id ) const;
+
+        /** Find the named Lua evaluator owned by this character modifier. */
+        bool find_character_modifier_handler( std::string_view modifier_id,
+                                              std::string &handler_id ) const;
+
+        /** Find the named Lua eligibility policy owned by this weather type. */
+        bool find_weather_type_handler( std::string_view weather_type_id,
+                                        std::string &handler_id ) const;
+
+        /** Find the named Lua selection policy owned by this end screen. */
+        bool find_end_screen_handler( std::string_view end_screen_id,
+                                      std::string &handler_id ) const;
+
+        /** Find a named turn or completion policy owned by an activity type. */
+        bool find_activity_type_handler( std::string_view activity_type_id,
+                                         std::string_view phase,
+                                         std::string &handler_id ) const;
+
+        /** Find the named examine policy owned by a Lua-first snippet. */
+        bool find_snippet_handler( std::string_view snippet_id,
+                                   std::string &category_id,
+                                   std::string &handler_id ) const;
+
+        /** Find a named evaluator or failure callback owned by this magic type. */
+        bool find_magic_type_handler( std::string_view magic_type_id,
+                                      std::string_view phase,
+                                      std::string &handler_id ) const;
+
+        /** Find the named Lua profile policy owned by this emission. */
+        bool find_emission_handler( std::string_view emission_id,
+                                    std::string &handler_id ) const;
+
+#if defined(CATA_ENABLE_LUA_UI) && CATA_ENABLE_LUA_UI
+        void install_lua_api( sol::state &lua, sol::table &ccb,
+                              const std::shared_ptr<runtime> &owner_runtime );
+#endif
+
+    private:
+        struct impl;
+        std::unique_ptr<impl> pimpl_;
+};
+
+#if defined(CATA_ENABLE_LUA_UI) && CATA_ENABLE_LUA_UI
+
+std::shared_ptr<runtime> make_runtime( const std::string &mod_id,
+                                      std::size_t generation,
+                                      sol::state &lua );
+void install_runtime_api( const std::shared_ptr<runtime> &value,
+                          sol::state &lua, sol::table &ccb );
+
+bool validate_runtime( const std::shared_ptr<runtime> &value,
+                       bool check_engine_state,
+                       std::string &error );
+bool apply_runtime_content( const std::shared_ptr<runtime> &value,
+                            std::string &error );
+bool validate_finalized_runtime_content( const std::shared_ptr<runtime> &value,
+        std::string &error );
+void rollback_runtime_content( const std::shared_ptr<runtime> &value );
+void commit_runtime( const std::shared_ptr<runtime> &value );
+void seal_runtime_content( const std::shared_ptr<runtime> &value );
+void discard_runtime( const std::shared_ptr<runtime> &value );
+std::string runtime_fingerprint( const std::shared_ptr<runtime> &value );
+
+void set_active_runtimes( const std::vector<std::shared_ptr<runtime>> &values );
+void hot_swap_active_runtimes(
+    const std::vector<std::shared_ptr<runtime>> &values );
+void clear_active_runtimes();
+
+std::optional<int> invoke_use_handler( std::string_view mod_id,
+                                       std::string_view handler_id,
+                                       Character *character, item &used_item,
+                                       map *here,
+                                       const tripoint_bub_ms &position );
+
+void runtime_world_ready( bool new_game );
+void runtime_before_save();
+bool runtime_save( std::string &error );
+void runtime_after_save( bool success, std::string_view error );
+void runtime_process_tasks();
+
+bool has_runtime_hook( std::string_view name );
+cata::lua_ui::native_hook_result dispatch_runtime_hook(
+    std::string_view name,
+    const cata::lua_ui::native_callback_arguments &arguments = {},
+    const cata::lua_ui::native_hook_result &initial = {} );
+
+#endif
+
+} // namespace cata::lua_platform
+
+namespace cata::lua_platform
+{
+
+/** One complete, bounded field-emission decision. */
+struct emission_profile {
+    std::string field;
+    int intensity = 1;
+    int quantity = 1;
+    int chance = 100;
+};
+
+/** Dispatch a native damage-type callback; a non-Lua build provides a no-op. */
+void invoke_damage_type_handler( std::string_view damage_id,
+                                 std::string_view phase,
+                                 Creature *source, Creature *target,
+                                 std::string_view body_part = {},
+                                 double total_damage = 0.0,
+                                 double damage_taken = 0.0 );
+
+/** Dispatch a native Lua ammunition-impact policy; a non-Lua build is a no-op. */
+void invoke_ammo_effect_handler( std::string_view ammo_effect_id,
+                                 Creature *source, Creature *target,
+                                 const tripoint_bub_ms &position,
+                                 int dealt_damage );
+
+/** Run a Lua addiction tick policy; no Lua-authored definition yields nullopt. */
+std::optional<bool> invoke_addiction_type_handler(
+    std::string_view addiction_type_id, Character &character,
+    int intensity, std::int64_t sated_turns );
+
+/** Evaluate a Lua-authored character modifier; no Lua definition yields nullopt. */
+std::optional<double> invoke_character_modifier_handler(
+    std::string_view modifier_id, const Character &character,
+    std::string_view skill_id );
+
+/** Evaluate a Lua-authored behavior condition for one native AI subject. */
+std::optional<bool> invoke_behavior_condition_handler(
+    std::string_view mod_id, std::string_view behavior_id,
+    std::string_view handler_id, const Creature *subject,
+    std::string_view argument );
+
+/** Evaluate a Lua-authored behavior utility score for one native AI subject. */
+std::optional<double> invoke_behavior_score_handler(
+    std::string_view mod_id, std::string_view behavior_id,
+    std::string_view handler_id, const Creature *subject,
+    std::string_view argument );
+
+/** Run one Lua-authored native monster special attack policy. */
+std::optional<bool> invoke_monster_attack_handler(
+    std::string_view mod_id, std::string_view attack_id,
+    std::string_view handler_id, Creature &attacker );
+
+/** Evaluate a Lua-authored weather condition against one generated sample. */
+std::optional<bool> invoke_weather_type_handler(
+    std::string_view weather_type_id, const w_point &sample );
+
+/** Evaluate a Lua-authored end-screen selection policy. */
+std::optional<bool> invoke_end_screen_handler(
+    std::string_view end_screen_id, const Character &character );
+
+/**
+ * Run one Lua-authored activity policy and apply its bounded result table.
+ * Returns true when a Lua-first definition owns the activity type, including
+ * when that definition deliberately omits the requested policy.
+ */
+bool invoke_activity_type_handler( std::string_view activity_type_id,
+                                   std::string_view phase,
+                                   player_activity &activity,
+                                   Character &character );
+
+/** Dispatch one Lua-authored snippet examine policy; true means Lua owns it. */
+bool invoke_snippet_examine_handler( std::string_view snippet_id,
+                                     std::string_view item_type_id,
+                                     Character &character );
+
+/** Evaluate a native Lua magic-type policy; no handler yields std::nullopt. */
+std::optional<double> invoke_magic_type_number_handler(
+    std::string_view magic_type_id, std::string_view phase,
+    std::string_view spell_id, const Creature *caster = nullptr,
+    double input = 0.0 );
+
+/** Dispatch a native Lua magic-type cast-failure callback. */
+void invoke_magic_type_failure_handler( std::string_view magic_type_id,
+                                        std::string_view spell_id,
+                                        Character &caster );
+
+/** Evaluate one Lua-authored emission profile; no override yields nullopt. */
+std::optional<emission_profile> invoke_emission_profile_handler(
+    std::string_view emission_id, const tripoint_bub_ms &position,
+    const emission_profile &fallback );
+
+} // namespace cata::lua_platform
+
+#endif // CATA_SRC_CATALUA_PLATFORM_RUNTIME_H

--- a/src/catalua_ui.cpp
+++ b/src/catalua_ui.cpp
@@ -35,6 +35,7 @@
 #include "catalua_bindings.h"
 #include "catalua_bindings_values.h"
 #include "catalua_game_handle.h"
+#include "catalua_platform_runtime.h"
 #include "catalua_ui_actions.h"
 #include "catalua_ui_actions_internal.h"
 #include "catalua_ui_addictions.h"
@@ -6724,19 +6725,30 @@ native_hook_result dispatch_native_hook_result(
     const std::string_view name,
     const native_callback_arguments &arguments )
 {
-    if( !active_state || is_pool_worker_thread() ) {
+    if( is_pool_worker_thread() ) {
         return {};
     }
+    native_hook_result aggregate;
+    if( active_state ) {
+        try {
+            aggregate = dispatch_script_hook(
+            *active_state, name, [&]( const std::size_t ) {
+                return native_callback_payload( *active_state, arguments );
+            } );
+        } catch( const std::exception &exception ) {
+            record_runtime_error(
+                "Lua native hook '" + std::string( name ) + "'",
+                exception.what() );
+        }
+    }
     try {
-        return dispatch_script_hook(
-        *active_state, name, [&]( const std::size_t ) {
-            return native_callback_payload( *active_state, arguments );
-        } );
+        return cata::lua_platform::dispatch_runtime_hook(
+                   name, arguments, aggregate );
     } catch( const std::exception &exception ) {
         record_runtime_error(
-            "Lua native hook '" + std::string( name ) + "'",
+            "Lua-first Platform native hook '" + std::string( name ) + "'",
             exception.what() );
-        return {};
+        return aggregate;
     }
 }
 
@@ -6749,9 +6761,22 @@ bool dispatch_native_hook(
 
 bool has_native_hook( const std::string_view name )
 {
-    return active_state && !is_pool_worker_thread() &&
-           active_state->hook_registry.has_matching(
-               "hook:" + std::string( name ) );
+    return !is_pool_worker_thread() &&
+           ( ( active_state && active_state->hook_registry.has_matching(
+                   "hook:" + std::string( name ) ) ) ||
+             cata::lua_platform::has_runtime_hook( name ) );
+}
+
+bool native_hook_supports_result_field( const std::string_view name,
+                                        const std::string_view field )
+{
+    const script_hook_spec *spec = find_script_hook_spec( name );
+    return spec != nullptr && script_hook_supports_result( *spec, field );
+}
+
+bool native_hook_contract_exists( const std::string_view name )
+{
+    return find_script_hook_spec( name ) != nullptr;
 }
 
 std::vector<std::string> collect_native_mapgen_factory_usages(

--- a/src/catalua_ui.h
+++ b/src/catalua_ui.h
@@ -149,6 +149,12 @@ native_hook_result dispatch_native_hook_result(
 bool dispatch_native_hook(
     std::string_view name, const native_callback_arguments &arguments = {} );
 bool has_native_hook( std::string_view name );
+bool native_hook_contract_exists( std::string_view name );
+// Shared hook-contract query used by Lua-first Platform dispatch.  This does
+// not expose a legacy handler: it reports which aggregate result fields the
+// native hook site understands (for example `allow`, `result`, or `entries`).
+bool native_hook_supports_result_field( std::string_view name,
+        std::string_view field );
 std::vector<std::string> collect_native_mapgen_factory_usages(
     const std::vector<std::string> &candidates );
 void dispatch_native_monster_spawn(

--- a/src/catalua_ui_disabled.cpp
+++ b/src/catalua_ui_disabled.cpp
@@ -65,6 +65,16 @@ bool has_native_hook( std::string_view )
     return false;
 }
 
+bool native_hook_supports_result_field( std::string_view, std::string_view )
+{
+    return false;
+}
+
+bool native_hook_contract_exists( std::string_view )
+{
+    return false;
+}
+
 std::vector<std::string> collect_native_mapgen_factory_usages(
     const std::vector<std::string> & )
 {

--- a/src/catalua_ui_eocs.cpp
+++ b/src/catalua_ui_eocs.cpp
@@ -737,6 +737,22 @@ void install_eoc_api(
     } );
     game["eocs"] = std::move( eocs );
 
+    install_variable_api( game, std::move( current_runtime_generation ),
+                          std::move( current_world_generation ),
+                          std::move( require_read ), std::move( require_write ),
+                          std::move( has_active_callback ) );
+}
+
+void install_variable_api(
+    sol::table &game,
+    std::function<std::size_t()> current_runtime_generation,
+    std::function<std::size_t()> current_world_generation,
+    std::function<void()> require_read,
+    std::function<void()> require_write,
+    std::function<bool()> has_active_callback )
+{
+    sol::state_view lua( game.lua_state() );
+
     sol::table variables = lua.create_table();
     variables.set_function(
         "get",

--- a/src/catalua_ui_eocs.h
+++ b/src/catalua_ui_eocs.h
@@ -10,6 +10,17 @@
 namespace cata::lua_ui
 {
 
+// Install generation-safe variables attached to creature and vehicle talkers.
+// This domain service is independent from EOC execution and is shared with
+// the Lua-first Platform.
+void install_variable_api(
+    sol::table &game,
+    std::function<std::size_t()> current_runtime_generation,
+    std::function<std::size_t()> current_world_generation,
+    std::function<void()> require_read,
+    std::function<void()> require_write,
+    std::function<bool()> has_active_callback );
+
 // Install the authored EOC bridge.  EOC definitions remain native-owned;
 // Lua receives detached metadata and invokes them through bounded contexts.
 void install_eoc_api(


### PR DESCRIPTION
#### Summary

Features "Add the native Lua-first Platform runtime"

#### Responsible human

@LYHGLYTX

#### Purpose of change

The project needs an isolated Lua-first runtime with native content transactions, generation-safe handles, named policies, services, state, tasks, rollback, and retention checks.

#### Describe the solution

Add the Platform host and runtime implementation, build integration, native content transaction engine, services, callbacks, persistent state/tasks, and safe failure paths. This layer contains 12 focused file-level commits.

#### Describe alternatives you've considered

Publishing JSON loaders or EOC-shaped wrappers would preserve the legacy authoring model. Keeping all 49,000 added lines in one PR would make ownership, dependency, and rollback review impractical.

#### Testing

Not run by explicit user direction. This is a draft, `implemented_unverified` stack layer; compilation, tests, formatters, `git diff --check`, and all validation/check commands remain pending approval.

#### Documentation impact

Introduces or supports native contracts documented by stack layer 14.

#### Related CCB-Docs PR

https://github.com/CrimsonCrossBunker/CCB-Docs/pull/35

#### Affected documentation IDs

architecture.lua-first-platform, architecture.lua-first-roadmap, architecture.lua-first-glossary

#### Generated reference impact

Changes native registrations and runtime contracts; the next layer provides LuaLS declarations and later layers provide exact ledger artifacts.

#### Additional context

Stack layer 5/14. Base: `agent/lua-first-stack-04-creature-content-catalogs` (PR #622). Previous: https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/pull/622. Next: `agent/lua-first-stack-06-luals-contract`. Do not merge out of order.
