### PR TITLE
Mods: add pure Lua authoring templates and example Mod

### DIFF
--- a/data/lua/templates/complete/README.md
+++ b/data/lua/templates/complete/README.md
@@ -1,0 +1,35 @@
+# Complete Lua-first Platform template
+
+This template is a zero-JSON/EOC vertical slice.  Its root `main.lua` defines
+one native item and recipe, registers a named item-use handler, stores typed
+character/world state, and schedules one serializable named task.  Live
+gameplay code can compose generation-safe native domains under
+`ccb.services`; synchronous decisions use `ccb.runtime.hook`, and durable
+payload changes use explicit `ccb.runtime.migrate_task_payload` chains.
+Callback-driven prompts and menus use `ccb.presentation`; keep stable choice
+ids separate from translated labels, pass choices as a dense one-based array,
+and treat cancellation as `nil`.  Item callbacks receive generation-safe
+`context.character` and `context.item` handles plus a tagged
+`context.position`; keep long-lived data as stable ids or typed state instead
+of trying to serialize those live handles.
+
+Runtime-only developer reload preserves typed state, delayed tasks, task ids,
+and the gameplay random stream only when the static content fingerprint is
+unchanged.  A change to an item or recipe definition deliberately requires a
+full data reload.
+
+The `runtime/` directory is only a suggested organization.  The loader does
+not require it, and the scaffold command never overwrites generated files.
+Likewise, `content/token.lua` is an ordinary root-local module with a
+`register(ccb)` function, not a special loader convention.  Add sibling
+modules, compose them from `main.lua`, or replace this layout entirely; only
+the root entry point is conventional.  During scaffolding, the target
+directory name becomes the zero-configuration Mod id and is inserted as the
+content-id namespace, so independently generated Mods do not share the
+template's example item id.  If final installation fails, a pre-existing empty
+target directory is restored instead of being left removed.
+
+For existing JSON/EOC content, start with
+`python3 tools/migrate_lua_first.py INPUT --output TARGET`.  Its output is a
+reviewable skeleton: every unsupported semantic field remains an explicit
+TODO in `MIGRATION_REPORT.md`, never a hidden legacy runner.

--- a/data/lua/templates/complete/content/token.lua
+++ b/data/lua/templates/complete/content/token.lua
@@ -1,0 +1,33 @@
+local token_content = {}
+local MOD_ID = __CCB_LUA_FIRST_MOD_ID__
+local TOKEN_ID = MOD_ID .. "_cleanwater_token"
+
+function token_content.register(ccb)
+    local token = ccb.content.Item {
+        id = TOKEN_ID,
+        name = "Lua clean-water token",
+        description = "A native item defined entirely by Lua-first Platform code.",
+        symbol = "*",
+    }
+    token:mass_grams(25)
+    token:volume_ml(10)
+    token:price_cents(500)
+    token:material("steel", 1)
+    token:on_use("activate_cleanwater_token", "Activate Lua token")
+    ccb.content.add(token)
+
+    local recipe = ccb.content.Recipe {
+        id = TOKEN_ID,
+        result = TOKEN_ID,
+        category = "CC_MISC",
+        subcategory = "CSC_MISC",
+        skill = "fabrication",
+        difficulty = 1,
+        duration_moves = 500,
+        autolearn = true,
+    }
+    recipe:component("scrap", 1)
+    ccb.content.add(recipe)
+end
+
+return token_content

--- a/data/lua/templates/complete/main.lua
+++ b/data/lua/templates/complete/main.lua
@@ -1,0 +1,10 @@
+local ccb = require("ccb")
+local behaviour = require("runtime.behaviour")
+local token_content = require("content.token")
+
+ccb.runtime.handler("activate_cleanwater_token", behaviour.activate, 1)
+ccb.runtime.handler("world_ready", behaviour.world_ready, 1)
+ccb.runtime.handler("remind", behaviour.remind, 1)
+ccb.runtime.on("world_ready", "world_ready")
+
+token_content.register(ccb)

--- a/data/lua/templates/complete/runtime/behaviour.lua
+++ b/data/lua/templates/complete/runtime/behaviour.lua
@@ -1,0 +1,26 @@
+local ccb = require("ccb")
+
+local behaviour = {}
+
+function behaviour.activate(context)
+    local uses = ccb.state.character.get("token_uses", 0) + 1
+    ccb.state.character.set("token_uses", uses)
+    context:message("The Lua token answers directly from handler #" .. uses .. ".")
+    return 0
+end
+
+function behaviour.world_ready(event)
+    if not ccb.state.world.get("first_load_seen", false) then
+        ccb.state.world.set("first_load_seen", true)
+        ccb.tasks.after(10, "remind", { text = "Named Lua task resumed." }, 1, "world")
+    end
+    if event.new_game then
+        ccb.services.message("Lua-first example initialized a new world.")
+    end
+end
+
+function behaviour.remind(task)
+    ccb.services.message(task.payload.text)
+end
+
+return behaviour

--- a/data/lua/templates/minimal/main.lua
+++ b/data/lua/templates/minimal/main.lua
@@ -1,0 +1,7 @@
+local ccb = require("ccb")
+
+ccb.runtime.handler("welcome", function()
+    ccb.services.message("Lua-first Mod is running.")
+end)
+
+ccb.runtime.on("world_ready", "welcome")

--- a/data/mods/Lua_First_Example/README.md
+++ b/data/mods/Lua_First_Example/README.md
@@ -1,0 +1,13 @@
+# Lua-first bundled example
+
+This optional bundled Mod contains no JSON, EOC, manifest, or required `lua/`
+directory.  The directory name supplies its default Mod id.  `main.lua`
+composes ordinary local modules that create a native item and recipe and bind
+their behaviour to named Lua functions.
+
+The example is intentionally small.  It is an executable migration fixture
+for the implemented Platform slice, not a claim that every legacy static
+content domain has already been replaced.  Its item callback can use the
+generation-safe character/item handles and tagged map position exposed by
+`ItemUseContext`; durable data belongs in `ccb.state` or named task payloads,
+not in live handles.

--- a/data/mods/Lua_First_Example/content/cleanwater_charm.lua
+++ b/data/mods/Lua_First_Example/content/cleanwater_charm.lua
@@ -1,0 +1,38 @@
+local content = {}
+
+function content.register(ccb)
+    local charm = ccb.content.Item {
+        id = "lua_first_cleanwater_charm",
+        name = "clean-water charm",
+        description = "A tiny proof that bundled content can be authored as native Lua.",
+        symbol = "*",
+    }
+    charm:mass_grams(20)
+    charm:volume_ml(10)
+    charm:price_cents(250)
+    charm:material("steel", 1)
+    charm:on_use("use_cleanwater_charm", "Listen to the charm")
+    ccb.content.add(charm)
+
+    local recipe = ccb.content.Recipe {
+        id = "lua_first_cleanwater_charm",
+        result = "lua_first_cleanwater_charm",
+        category = "CC_MISC",
+        subcategory = "CSC_MISC",
+        skill = "fabrication",
+        difficulty = 1,
+        duration_moves = 500,
+        autolearn = true,
+    }
+    recipe:component_any {
+        { id = "scrap", count = 1 },
+        { id = "steel_chunk", count = 1 },
+    }
+    recipe:tool_any {
+        { id = "hammer", count = 1 },
+        { id = "rock", count = 1 },
+    }
+    ccb.content.add(recipe)
+end
+
+return content

--- a/data/mods/Lua_First_Example/main.lua
+++ b/data/mods/Lua_First_Example/main.lua
@@ -1,0 +1,9 @@
+local ccb = require("ccb")
+local content = require("content.cleanwater_charm")
+local behaviour = require("runtime.behaviour")
+
+ccb.runtime.handler("use_cleanwater_charm", behaviour.use_charm, 1)
+ccb.runtime.handler("lua_first_example_ready", behaviour.world_ready, 1)
+ccb.runtime.on("world_ready", "lua_first_example_ready")
+
+content.register(ccb)

--- a/data/mods/Lua_First_Example/runtime/behaviour.lua
+++ b/data/mods/Lua_First_Example/runtime/behaviour.lua
@@ -1,0 +1,18 @@
+local ccb = require("ccb")
+
+local behaviour = {}
+
+function behaviour.use_charm(context)
+    local uses = ccb.state.character.get("cleanwater_charm_uses", 0) + 1
+    ccb.state.character.set("cleanwater_charm_uses", uses)
+    context:message("The charm hums.  Lua use count: " .. uses .. ".")
+    return 0
+end
+
+function behaviour.world_ready(event)
+    if event.new_game then
+        ccb.services.message("Lua-first bundled example is active.")
+    end
+end
+
+return behaviour

--- a/tools/create_lua_mod.py
+++ b/tools/create_lua_mod.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Create an author-owned, zero-JSON Lua-first Platform Mod."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import tempfile
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE_ROOT = REPOSITORY_ROOT / "data" / "lua" / "templates"
+MOD_ID_TOKEN = "__CCB_LUA_FIRST_MOD_ID__"
+
+
+def normalized_mod_id(target: Path) -> str:
+    candidate = target.name
+    if (
+        not candidate
+        or "#" in candidate
+        or any(character.isspace() for character in candidate)
+    ):
+        raise ValueError(
+            "target directory name becomes the Mod id and must be non-empty "
+            "without '#'/whitespace"
+        )
+    return candidate
+
+
+def lua_quote(value: str) -> str:
+    escaped = (
+        value.replace("\\", "\\\\")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+        .replace('"', '\\"')
+    )
+    return f'"{escaped}"'
+
+
+def render_template_file(source: Path, destination: Path, mod_id: str) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if source.suffix in {".lua", ".md"}:
+        contents = source.read_text(encoding="utf-8")
+        destination.write_text(
+            contents.replace(MOD_ID_TOKEN, lua_quote(mod_id)),
+            encoding="utf-8",
+        )
+    else:
+        shutil.copyfile(source, destination)
+
+
+def _install_staged_directory(staging: Path, target: Path) -> None:
+    staging.replace(target)
+
+
+def create_mod(target: Path, template: str) -> None:
+    source = TEMPLATE_ROOT / template
+    if not source.is_dir():
+        raise ValueError(f"unknown Lua-first template: {template}")
+    mod_id = normalized_mod_id(target)
+    if target.is_symlink():
+        raise FileExistsError(f"target must not be a symbolic link: {target}")
+    had_empty_target = target.exists()
+    target_identity: tuple[int, int] | None = None
+    if had_empty_target:
+        if not target.is_dir():
+            raise FileExistsError(f"target is not a directory: {target}")
+        if any(target.iterdir()):
+            raise FileExistsError(f"target directory is not empty: {target}")
+        target_stat = target.stat()
+        target_identity = (target_stat.st_dev, target_stat.st_ino)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(
+        tempfile.mkdtemp(
+            prefix=f".{target.name}.lua-first-", dir=target.parent
+        )
+    )
+    try:
+        for entry in sorted(source.rglob("*")):
+            relative = entry.relative_to(source)
+            destination = staging / relative
+            if entry.is_dir():
+                destination.mkdir(parents=True, exist_ok=True)
+            elif entry.is_file():
+                render_template_file(entry, destination, mod_id)
+            else:
+                raise ValueError(f"unsupported template entry: {entry}")
+        removed_empty_target = False
+        if target.exists() or target.is_symlink():
+            if target.is_symlink() or not had_empty_target:
+                raise FileExistsError(
+                    f"target appeared while the scaffold was being prepared: {target}"
+                )
+            current_stat = target.stat()
+            if (current_stat.st_dev, current_stat.st_ino) != target_identity:
+                raise FileExistsError(
+                    f"target changed while the scaffold was being prepared: {target}"
+                )
+            # The target was proven empty above.  If an author or another
+            # process adds a file meanwhile, rmdir fails and preserves it.
+            target.rmdir()
+            removed_empty_target = True
+        try:
+            _install_staged_directory(staging, target)
+        except Exception:
+            # Preserve the caller's pre-existing empty directory when the
+            # final same-filesystem installation itself fails.  Never replace
+            # a path concurrently recreated by somebody else.
+            if (
+                had_empty_target
+                and removed_empty_target
+                and not target.exists()
+                and not target.is_symlink()
+            ):
+                target.mkdir()
+            raise
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Create a manifest-free Lua-first Platform Mod"
+    )
+    parser.add_argument("target", type=Path)
+    parser.add_argument(
+        "--template", choices=("minimal", "complete"), default="minimal"
+    )
+    args = parser.parse_args()
+    try:
+        create_mod(args.target, args.template)
+    except (FileExistsError, OSError, ValueError) as error:
+        parser.error(str(error))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_create_lua_mod.py
+++ b/tools/test_create_lua_mod.py
@@ -1,0 +1,131 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import create_lua_mod
+from create_lua_mod import create_mod
+
+
+class CreateLuaModTest(unittest.TestCase):
+    def test_minimal_template_has_only_root_lua_entry(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory) / "example"
+            create_mod(target, "minimal")
+            self.assertTrue((target / "main.lua").is_file())
+            self.assertFalse((target / "manifest.json").exists())
+            self.assertFalse((target / "modinfo.json").exists())
+            self.assertFalse((target / "lua").exists())
+
+    def test_complete_template_is_zero_json_and_has_vertical_slice(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory) / "complete"
+            create_mod(target, "complete")
+            files = [path for path in target.rglob("*") if path.is_file()]
+            self.assertTrue((target / "runtime" / "behaviour.lua").is_file())
+            self.assertTrue((target / "content" / "token.lua").is_file())
+            self.assertFalse(any(path.suffix == ".json" for path in files))
+            source = "\n".join(
+                path.read_text(encoding="utf-8")
+                for path in files
+                if path.suffix == ".lua"
+            )
+            self.assertIn("ccb.content.Item", source)
+            self.assertIn("ccb.content.Recipe", source)
+            self.assertNotIn("run_eoc", source)
+            self.assertIn(
+                'local MOD_ID = "complete"',
+                (target / "content" / "token.lua").read_text(encoding="utf-8"),
+            )
+
+    def test_nonempty_target_is_never_overwritten(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory) / "owned"
+            target.mkdir()
+            sentinel = target / "main.lua"
+            sentinel.write_text("author owned\n", encoding="utf-8")
+            with self.assertRaises(FileExistsError):
+                create_mod(target, "complete")
+            self.assertEqual(sentinel.read_text(encoding="utf-8"), "author owned\n")
+
+    def test_file_target_is_never_replaced(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory) / "owned"
+            target.write_text("author owned\n", encoding="utf-8")
+            with self.assertRaises(FileExistsError):
+                create_mod(target, "minimal")
+            self.assertEqual(target.read_text(encoding="utf-8"), "author owned\n")
+
+    def test_symlink_target_is_never_replaced(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            owned = root / "owned"
+            owned.mkdir()
+            target = root / "linked_mod"
+            target.symlink_to(owned, target_is_directory=True)
+            with self.assertRaises(FileExistsError):
+                create_mod(target, "minimal")
+            self.assertTrue(target.is_symlink())
+            self.assertEqual(list(owned.iterdir()), [])
+
+    def test_invalid_directory_id_is_rejected_before_creating_target(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory) / "invalid mod"
+            with self.assertRaisesRegex(ValueError, "Mod id"):
+                create_mod(target, "minimal")
+            self.assertFalse(target.exists())
+
+    def test_copy_failure_leaves_an_existing_empty_target_untouched(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory) / "atomic_mod"
+            target.mkdir()
+            with patch(
+                "create_lua_mod.render_template_file",
+                side_effect=OSError("copy failed"),
+            ):
+                with self.assertRaisesRegex(OSError, "copy failed"):
+                    create_mod(target, "complete")
+            self.assertTrue(target.is_dir())
+            self.assertEqual(list(target.iterdir()), [])
+
+    def test_install_failure_restores_an_existing_empty_target(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory) / "atomic_mod"
+            target.mkdir()
+            with patch(
+                "create_lua_mod._install_staged_directory",
+                side_effect=OSError("install failed"),
+            ):
+                with self.assertRaisesRegex(OSError, "install failed"):
+                    create_mod(target, "complete")
+            self.assertTrue(target.is_dir())
+            self.assertFalse(target.is_symlink())
+            self.assertEqual(list(target.iterdir()), [])
+
+    def test_target_created_during_staging_is_preserved(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory) / "raced_mod"
+            real_render = create_lua_mod.render_template_file
+            created = False
+
+            def create_concurrent_target(
+                source: Path, destination: Path, mod_id: str
+            ) -> None:
+                nonlocal created
+                if not created:
+                    target.mkdir()
+                    created = True
+                real_render(source, destination, mod_id)
+
+            with patch(
+                "create_lua_mod.render_template_file",
+                side_effect=create_concurrent_target,
+            ):
+                with self.assertRaisesRegex(FileExistsError, "appeared"):
+                    create_mod(target, "minimal")
+            self.assertTrue(target.is_dir())
+            self.assertEqual(list(target.iterdir()), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#### Summary

Mods "Add pure Lua authoring templates and example Mod"

#### Responsible human

@LYHGLYTX

#### Purpose of change

Developers need copyable, zero-JSON/EOC templates and a complete example that demonstrate idiomatic native Lua composition.

#### Describe the solution

Add minimal and complete author templates, a full bundled example Mod, an atomic scaffolding tool, and focused scaffolding tests. This layer contains 11 focused file-level commits.

#### Describe alternatives you've considered

Publishing JSON loaders or EOC-shaped wrappers would preserve the legacy authoring model. Keeping all 49,000 added lines in one PR would make ownership, dependency, and rollback review impractical.

#### Testing

Not run by explicit user direction. This is a draft, `implemented_unverified` stack layer; compilation, tests, formatters, `git diff --check`, and all validation/check commands remain pending approval.

#### Documentation impact

Introduces or supports native contracts documented by stack layer 14.

#### Related CCB-Docs PR

https://github.com/CrimsonCrossBunker/CCB-Docs/pull/35

#### Affected documentation IDs

architecture.lua-first-platform, architecture.lua-first-roadmap, architecture.lua-first-glossary

#### Generated reference impact

Adds author-owned template and example files; no generated reference is changed here.

#### Additional context

Stack layer 9/14. Base: `agent/lua-first-stack-08-zero-config-discovery` (PR #626). Previous: https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/pull/626. Next: `agent/lua-first-stack-10-migration-extractor`. Do not merge out of order.
