### PR TITLE
Infrastructure: add exact replacement-ledger tooling

### DIFF
--- a/ai/generated-files.yml
+++ b/ai/generated-files.yml
@@ -80,6 +80,11 @@ entries:
     tracked: true
     generated_by: python3 tools/json_api/generate_contracts.py
     validation_id: json-eoc-contract
+  - id: lua-first-replacement-ledger
+    paths: [ai/lua-first-replacement-ledger.yml]
+    tracked: true
+    generated_by: python3 tools/agent/generate_lua_first_replacement_ledger.py
+    validation_id: agent-context
   - id: shader-artifacts
     paths: [data/shaders/*.spv, data/shaders/*.dxil, data/shaders/*.msl, data/shaders/build-*.stamp]
     tracked: false

--- a/ai/lua-first-replacement-ledger.schema.json
+++ b/ai/lua-first-replacement-ledger.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://crimsoncrossbunker.github.io/schemas/lua-first-replacement-ledger-v1.json",
+  "title": "CCB Lua-first replacement ledger",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["$schema", "schema_version", "kind", "contract", "sources", "summary", "entries"],
+  "properties": {
+    "$schema": { "const": "lua-first-replacement-ledger.schema.json" },
+    "schema_version": { "const": 1 },
+    "kind": { "const": "lua_first_replacement_ledger" },
+    "contract": { "type": "string", "minLength": 1 },
+    "sources": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "path", "selector", "source_fingerprint", "entry_count"],
+        "properties": {
+          "id": { "enum": ["json-object-types", "eoc-conditions", "eoc-effects"] },
+          "path": { "type": "string", "minLength": 1 },
+          "selector": { "enum": ["type", "key"] },
+          "source_fingerprint": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+          "entry_count": { "type": "integer", "minimum": 1 }
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["total", "implemented_unverified", "primitive_available_unverified", "planned", "private_adapter", "reviewed_not_applicable"],
+      "properties": {
+        "total": { "type": "integer", "minimum": 1 },
+        "implemented_unverified": { "type": "integer", "minimum": 0 },
+        "primitive_available_unverified": { "type": "integer", "minimum": 0 },
+        "planned": { "type": "integer", "minimum": 0 },
+        "private_adapter": { "type": "integer", "minimum": 0 },
+        "reviewed_not_applicable": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "entries": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["inventory", "selector", "target_kind", "target", "status", "legacy_dependency", "evidence"],
+        "properties": {
+          "inventory": { "enum": ["json-object-types", "eoc-conditions", "eoc-effects"] },
+          "selector": { "type": "string", "minLength": 1 },
+          "target_kind": { "enum": ["platform_domain", "shared_service", "migration", "not_applicable"] },
+          "target": { "type": "string", "minLength": 1 },
+          "status": { "enum": ["implemented_unverified", "primitive_available_unverified", "planned", "private_adapter", "reviewed_not_applicable"] },
+          "legacy_dependency": { "enum": ["none", "private_adapter", "public_legacy"] },
+          "evidence": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    }
+  }
+}

--- a/tools/agent/check_lua_first_replacement_ledger.py
+++ b/tools/agent/check_lua_first_replacement_ledger.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Validate exact, unique replacement-ledger coverage."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+
+import jsonschema
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+LEDGER = ROOT / "ai/lua-first-replacement-ledger.yml"
+SCHEMA = ROOT / "ai/lua-first-replacement-ledger.schema.json"
+
+
+def check() -> dict[str, int]:
+    ledger = yaml.safe_load(LEDGER.read_text(encoding="utf-8"))
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    jsonschema.Draft202012Validator(schema).validate(ledger)
+    entries = ledger["entries"]
+    identities = [(entry["inventory"], entry["selector"]) for entry in entries]
+    duplicates = sorted(key for key, count in Counter(identities).items() if count != 1)
+    if duplicates:
+        raise RuntimeError(f"replacement ledger has duplicate selectors: {duplicates[:20]}")
+
+    source_ids = [source["id"] for source in ledger["sources"]]
+    if len(source_ids) != len(set(source_ids)):
+        raise RuntimeError("replacement ledger repeats an inventory source")
+
+    expected: set[tuple[str, str]] = set()
+    for source in ledger["sources"]:
+        document = json.loads((ROOT / source["path"]).read_text(encoding="utf-8"))
+        if source["source_fingerprint"] != document["source"]["source_fingerprint"]:
+            raise RuntimeError(f"inventory fingerprint changed for {source['id']}")
+        values = {entry[source["selector"]] for entry in document["entries"]}
+        if len(values) != source["entry_count"]:
+            raise RuntimeError(f"inventory count changed for {source['id']}")
+        expected.update((source["id"], value) for value in values)
+    actual = set(identities)
+    missing = sorted(expected - actual)
+    extra = sorted(actual - expected)
+    if missing or extra:
+        raise RuntimeError(
+            f"replacement ledger coverage differs: missing={missing[:20]}, extra={extra[:20]}"
+        )
+    expected_summary = {"total": len(entries)}
+    for status in (
+        "implemented_unverified",
+        "primitive_available_unverified",
+        "planned",
+        "private_adapter",
+        "reviewed_not_applicable",
+    ):
+        expected_summary[status] = sum(entry["status"] == status for entry in entries)
+    if ledger["summary"] != expected_summary:
+        raise RuntimeError("replacement ledger status summary is stale")
+
+    for entry in entries:
+        if entry["status"] in {
+            "implemented_unverified",
+            "primitive_available_unverified",
+        }:
+            evidence = entry["evidence"]
+            required_kinds = (
+                "src/",
+                "data/lua/types/",
+                "tests/",
+                "data/lua/LUA_FIRST_PLATFORM.md",
+            )
+            if any(not any(value.startswith(kind) for value in evidence)
+                   for kind in required_kinds):
+                raise RuntimeError(
+                    "implemented selector or primitive lacks source, declaration, test, or "
+                    f"documentation evidence: {entry['inventory']}:{entry['selector']}"
+                )
+            if entry["legacy_dependency"] != "none":
+                raise RuntimeError(
+                    "implemented selector has an unresolved public legacy dependency: "
+                    f"{entry['inventory']}:{entry['selector']}"
+                )
+        for evidence in entry["evidence"]:
+            if evidence.startswith(("src/", "data/", "tests/", "tools/", "ai/")) and not (
+                ROOT / evidence
+            ).exists():
+                raise RuntimeError(f"replacement evidence path does not exist: {evidence}")
+    return {
+        "total": len(entries),
+        "implemented_unverified": sum(
+            entry["status"] == "implemented_unverified" for entry in entries
+        ),
+    }
+
+
+def main() -> int:
+    result = check()
+    print(
+        f"Lua-first replacement ledger covers {result['total']} selectors; "
+        f"{result['implemented_unverified']} are implemented but not yet verified."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/agent/generate_lua_first_replacement_ledger.py
+++ b/tools/agent/generate_lua_first_replacement_ledger.py
@@ -1,0 +1,1155 @@
+#!/usr/bin/env python3
+"""Generate the exact Lua-first disposition ledger from checked inventories."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+OUTPUT = ROOT / "ai" / "lua-first-replacement-ledger.yml"
+INVENTORIES = {
+    "json-object-types": (
+        ROOT / "data/reference/json/ccb_json_object_types.json",
+        "type",
+    ),
+    "eoc-conditions": (
+        ROOT / "data/reference/json/ccb_eoc_conditions.json",
+        "key",
+    ),
+    "eoc-effects": (
+        ROOT / "data/reference/json/ccb_eoc_effects.json",
+        "key",
+    ),
+}
+
+CONTROL_FLOW = {
+    "and",
+    "or",
+    "not",
+    "if",
+    "foreach",
+    "switch",
+    "weighted_list_eocs",
+}
+
+IMPLEMENTED_JSON = {
+    "MOD_INFO": {
+        "target": "platform.mod-metadata",
+        "evidence": [
+            "src/catalua_platform.cpp",
+            "src/mod_manager.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "ITEM": {
+        "target": "content.items",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "recipe": {
+        "target": "content.recipes",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "tool_quality": {
+        "target": "content.tool-qualities",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/requirements.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "skill_display_type": {
+        "target": "content.skill-display-categories",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/skill.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "skill": {
+        "target": "content.skills",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/skill.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "vitamin": {
+        "target": "content.vitamins",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/vitamin.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "json_flag": {
+        "target": "content.flags",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/flag.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "damage_type": {
+        "target": "content.damage-types",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/damage.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "material": {
+        "target": "content.materials",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/material.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "ammunition_type": {
+        "target": "content.ammunition-types",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/ammo.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "ITEM_CATEGORY": {
+        "target": "content.item-categories",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/item_category.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "recipe_category": {
+        "target": "content.recipe-categories",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/crafting_gui.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "proficiency_category": {
+        "target": "content.proficiency-categories",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/proficiency.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "proficiency": {
+        "target": "content.proficiencies",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/proficiency.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "weapon_category": {
+        "target": "content.weapon-categories",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/martialarts.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "requirement": {
+        "target": "content.requirements",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/requirements.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "recipe_group": {
+        "target": "content.recipe-groups",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/recipe_groups.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "scent_type": {
+        "target": "content.scent-types",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/scent_map.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "speed_description": {
+        "target": "content.speed-descriptions",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/speed_description.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "harvest_drop_type": {
+        "target": "content.harvest-drop-types",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/harvest.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "harvest": {
+        "target": "content.harvest-lists",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/harvest.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "behavior": {
+        "target": "content.behavior-trees",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/behavior.cpp",
+            "src/behavior_oracle.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "monster_attack": {
+        "target": "content.monster-attacks",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/monstergenerator.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "effect_type": {
+        "target": "content.effect-types",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/effect.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "weakpoint_set": {
+        "target": "content.weakpoint-sets",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/weakpoint.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "field_type": {
+        "target": "content.field-types",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/field_type.cpp",
+            "src/map_field.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "item_group": {
+        "target": "content.item-groups",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/item_factory.cpp",
+            "src/item_group.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "sub_body_part": {
+        "target": "content.sub-body-parts",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/subbodypart.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "body_part": {
+        "target": "content.body-parts",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/bodypart.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "anatomy": {
+        "target": "content.anatomies",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/anatomy.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "body_graph": {
+        "target": "content.body-graphs",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/bodygraph.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "MONSTER": {
+        "target": "content.monsters",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/monstergenerator.cpp",
+            "src/mtype.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "morale_type": {
+        "target": "content.morale-types",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/morale_types.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "disease_type": {
+        "target": "content.disease-types",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/disease.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "monster_flag": {
+        "target": "content.monster-flags",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/monstergenerator.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "SPECIES": {
+        "target": "content.species",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/monstergenerator.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "emit": {
+        "target": "content.emissions",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/emit.cpp",
+            "src/map_field.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "MONSTER_FACTION": {
+        "target": "content.monster-factions",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/monfaction.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "mutation_type": {
+        "target": "content.mutation-types",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/mutation_type.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "connect_group": {
+        "target": "content.connect-groups",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/mapdata.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "mutation_category": {
+        "target": "content.mutation-categories",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/mutation_data.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "construction_category": {
+        "target": "content.construction-categories",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/construction_category.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "construction_group": {
+        "target": "content.construction-groups",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/construction_group.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "vehicle_part_location": {
+        "target": "content.vehicle-part-locations",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/vehicle_part_location.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "mood_face": {
+        "target": "content.mood-faces",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/mood_face.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "damage_info_order": {
+        "target": "content.damage-info-presentation",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/damage.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "vehicle_part_category": {
+        "target": "content.vehicle-part-categories",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/veh_type.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "named_color": {
+        "target": "content.named-colors",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/hsv_color.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "rotatable_symbol": {
+        "target": "content.rotatable-symbols",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/rotatable_symbols.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "ascii_art": {
+        "target": "content.ascii-art",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/ascii_art.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "limb_score": {
+        "target": "content.limb-scores",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/bodypart.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "hit_range": {
+        "target": "content.hit-range",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/creature.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "bash_damage_profile": {
+        "target": "content.bash-damage-profiles",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/map_accessories.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "clothing_mod": {
+        "target": "content.clothing-modifications",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/clothing_mod.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "overmap_land_use_code": {
+        "target": "content.overmap-land-use-codes",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/overmap_terrain.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "oter_vision": {
+        "target": "content.overmap-vision",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/overmap_terrain.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "overmap_location": {
+        "target": "content.overmap-locations",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/overmap_location.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "profession_group": {
+        "target": "content.profession-groups",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/profession_group.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "map_extra_collection": {
+        "target": "content.map-extra-collections",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/regional_settings.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "vehicle_group": {
+        "target": "content.vehicle-groups",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/vehicle_group.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "fault_group": {
+        "target": "content.fault-groups",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/fault.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "explosion_light": {
+        "target": "content.explosion-lights",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/explosion_light.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "ammo_effect": {
+        "target": "content.ammunition-effects",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/ammo_effect.cpp",
+            "src/projectile.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "addiction_type": {
+        "target": "content.addiction-types",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/addiction.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "character_mod": {
+        "target": "content.character-modifiers",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/character_modifier.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "start_location": {
+        "target": "content.start-locations",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/start_location.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "climbing_aid": {
+        "target": "content.climbing-aids",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/climbing.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "weather_type": {
+        "target": "content.weather-types",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/weather_type.cpp",
+            "src/weather_gen.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "score": {
+        "target": "content.scores",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/event_statistics.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "overlay_order": {
+        "target": "content.overlay-order",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/overlay_ordering.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "LOOT_ZONE": {
+        "target": "content.zone-types",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/clzones.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "speech": {
+        "target": "content.speech-pools",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/speech.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "end_screen": {
+        "target": "content.end-screens",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/end_screen.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "activity_type": {
+        "target": "content.activity-types",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/activity_type.cpp",
+            "src/player_activity.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "help": {
+        "target": "content.help-topics",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/help.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "snippet": {
+        "target": "content.snippet-categories",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/text_snippets.cpp",
+            "src/item_info.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "playlist": {
+        "target": "content.playlists",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/sdlsound.cpp",
+            "src/sounds.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "nested_category": {
+        "target": "content.nested-recipe-categories",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/recipe.cpp",
+            "src/recipe_dictionary.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "attack_vector": {
+        "target": "content.attack-vectors",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/martialarts.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "magic_type": {
+        "target": "content.magic-types",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/magic_type.cpp",
+            "src/magic.cpp",
+            "src/activity_actor.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "movement_mode": {
+        "target": "content.movement-modes",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/move_mode.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+}
+
+NATIVE_PRIMITIVE_DOMAINS = {
+    "items",
+    "crafting",
+    "map",
+    "vehicles",
+    "missions",
+    "characters",
+    "creatures",
+    "camps",
+    "time-weather",
+    "magic",
+    "bionics",
+    "mutations",
+    "skills",
+    "audio",
+    "factions",
+    "state-and-values",
+    "presentation",
+}
+
+NATIVE_PRIMITIVE_EVIDENCE = [
+    "src/catalua_platform_runtime.cpp",
+    "src/catalua_game_handle.cpp",
+    "data/lua/types/ccb_platform_v1.d.lua",
+    "tests/catalua_ui_test.cpp",
+    "data/lua/LUA_FIRST_PLATFORM.md",
+]
+
+
+def service_for(selector: str) -> str:
+    value = selector.lower()
+    groups = (
+        (("item", "inventory", "wield", "weapon", "armor", "ammo"), "items"),
+        (("recipe", "craft", "disassembly"), "crafting"),
+        (("map", "terrain", "furniture", "field", "location"), "map"),
+        (("vehicle", "veh_"), "vehicles"),
+        (("mission",), "missions"),
+        (("npc", "u_", "character", "talker"), "characters"),
+        (("monster", "mon_", "mtype"), "creatures"),
+        (("camp", "companion"), "camps"),
+        (("weather", "season", "day", "time", "lightning"), "time-weather"),
+        (("spell", "magic"), "magic"),
+        (("bionic", "cbm"), "bionics"),
+        (("mutation", "trait"), "mutations"),
+        (("skill", "proficiency", "martial"), "skills"),
+        (("sound", "music"), "audio"),
+        (("faction",), "factions"),
+        (("var", "state", "math", "debt"), "state-and-values"),
+        (("message", "popup", "query", "menu"), "presentation"),
+    )
+    for needles, domain in groups:
+        if any(needle in value for needle in needles):
+            return domain
+    return "gameplay"
+
+
+def legacy_evidence(entry: dict) -> list[str]:
+    evidence: list[str] = []
+    for registration in entry.get("registrations", []):
+        source = registration.get("source", {})
+        if source.get("path"):
+            evidence.append(source["path"])
+    for symbol in entry.get("handlers", []):
+        if symbol:
+            evidence.append(str(symbol))
+    return sorted(set(evidence))[:8]
+
+
+def disposition(inventory: str, selector: str, entry: dict) -> dict:
+    if inventory == "json-object-types":
+        if selector in IMPLEMENTED_JSON:
+            implemented = IMPLEMENTED_JSON[selector]
+            return {
+                "inventory": inventory,
+                "selector": selector,
+                "target_kind": "platform_domain",
+                "target": implemented["target"],
+                "status": "implemented_unverified",
+                "legacy_dependency": "none",
+                "evidence": implemented["evidence"],
+            }
+        if selector in {"EXTERNAL_OPTION", "WORLD_OPTION", "colordef", "test_data"}:
+            return {
+                "inventory": inventory,
+                "selector": selector,
+                "target_kind": "not_applicable",
+                "target": "engine-owned-configuration",
+                "status": "reviewed_not_applicable",
+                "legacy_dependency": "none",
+                "evidence": legacy_evidence(entry),
+            }
+        return {
+            "inventory": inventory,
+            "selector": selector,
+            "target_kind": "platform_domain",
+            "target": f"content.{service_for(selector)}",
+            "status": "planned",
+            "legacy_dependency": "public_legacy",
+            "evidence": legacy_evidence(entry),
+        }
+
+    if selector in CONTROL_FLOW:
+        return {
+            "inventory": inventory,
+            "selector": selector,
+            "target_kind": "not_applicable",
+            "target": "native-lua-control-flow",
+            "status": "reviewed_not_applicable",
+            "legacy_dependency": "none",
+            "evidence": legacy_evidence(entry),
+        }
+    domain = service_for(selector)
+    if domain in NATIVE_PRIMITIVE_DOMAINS:
+        return {
+            "inventory": inventory,
+            "selector": selector,
+            "target_kind": "shared_service",
+            "target": f"services.{domain}",
+            "status": "primitive_available_unverified",
+            "legacy_dependency": "none",
+            "evidence": NATIVE_PRIMITIVE_EVIDENCE,
+        }
+    return {
+        "inventory": inventory,
+        "selector": selector,
+        "target_kind": "shared_service",
+        "target": f"services.{domain}",
+        "status": "planned",
+        "legacy_dependency": "public_legacy",
+        "evidence": legacy_evidence(entry),
+    }
+
+
+def build_ledger() -> dict:
+    entries: list[dict] = []
+    sources: list[dict] = []
+    for inventory, (path, selector_field) in INVENTORIES.items():
+        document = json.loads(path.read_text(encoding="utf-8"))
+        source_entries = document["entries"]
+        sources.append(
+            {
+                "id": inventory,
+                "path": str(path.relative_to(ROOT)),
+                "selector": selector_field,
+                "source_fingerprint": document["source"]["source_fingerprint"],
+                "entry_count": len(source_entries),
+            }
+        )
+        for entry in source_entries:
+            selector = entry[selector_field]
+            entries.append(disposition(inventory, selector, entry))
+    entries.sort(key=lambda value: (value["inventory"], value["selector"]))
+    return {
+        "$schema": "lua-first-replacement-ledger.schema.json",
+        "schema_version": 1,
+        "kind": "lua_first_replacement_ledger",
+        "contract": (
+            "Every checked legacy selector appears exactly once. Planned entries are "
+            "migration work, not shipped Platform APIs. Primitive-available entries "
+            "have native composition building blocks but are not claims of selector-level parity."
+        ),
+        "sources": sources,
+        "summary": {
+            "total": len(entries),
+            "implemented_unverified": sum(
+                entry["status"] == "implemented_unverified" for entry in entries
+            ),
+            "primitive_available_unverified": sum(
+                entry["status"] == "primitive_available_unverified"
+                for entry in entries
+            ),
+            "planned": sum(entry["status"] == "planned" for entry in entries),
+            "private_adapter": sum(
+                entry["status"] == "private_adapter" for entry in entries
+            ),
+            "reviewed_not_applicable": sum(
+                entry["status"] == "reviewed_not_applicable" for entry in entries
+            ),
+        },
+        "entries": entries,
+    }
+
+
+def render(ledger: dict) -> str:
+    return yaml.safe_dump(ledger, sort_keys=False, allow_unicode=True, width=100)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    expected = render(build_ledger())
+    if args.check:
+        if not OUTPUT.exists() or OUTPUT.read_text(encoding="utf-8") != expected:
+            print(f"stale generated ledger: {OUTPUT.relative_to(ROOT)}")
+            return 1
+        return 0
+    OUTPUT.write_text(expected, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/agent/test_lua_first_replacement_ledger.py
+++ b/tools/agent/test_lua_first_replacement_ledger.py
@@ -1,0 +1,51 @@
+import unittest
+
+from check_lua_first_replacement_ledger import check
+from generate_lua_first_replacement_ledger import OUTPUT, build_ledger, render
+
+
+class LuaFirstReplacementLedgerTest(unittest.TestCase):
+    def test_committed_ledger_covers_every_selector_once(self):
+        result = check()
+        self.assertEqual(result["total"], 775)
+        self.assertEqual(result["implemented_unverified"], 82)
+        self.assertGreater(
+            build_ledger()["summary"]["primitive_available_unverified"], 0
+        )
+
+    def test_generator_preserves_the_three_inventory_denominators(self):
+        generated = build_ledger()
+        counts = {source["id"]: source["entry_count"] for source in generated["sources"]}
+        self.assertEqual(
+            counts,
+            {
+                "json-object-types": 190,
+                "eoc-conditions": 275,
+                "eoc-effects": 310,
+            },
+        )
+
+    def test_creature_content_selectors_have_native_unverified_evidence(self):
+        generated = build_ledger()
+        entries = {
+            entry["selector"]: entry
+            for entry in generated["entries"]
+            if entry["inventory"] == "json-object-types"
+        }
+        for selector in {
+            "monster_attack", "effect_type", "weakpoint_set", "field_type",
+            "item_group", "sub_body_part", "body_part", "anatomy",
+            "body_graph", "MONSTER",
+        }:
+            self.assertEqual(entries[selector]["status"], "implemented_unverified")
+            self.assertIn("tools/migrate_lua_first.py", entries[selector]["evidence"])
+
+    def test_committed_ledger_matches_the_generator(self):
+        self.assertEqual(
+            OUTPUT.read_text(encoding="utf-8"),
+            render(build_ledger()),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#### Summary

Infrastructure "Add exact replacement-ledger tooling"

#### Responsible human

@LYHGLYTX

#### Purpose of change

Replacement claims need a schema-checked generator and exact-set checker covering every inventoried JSON type and EOC selector.

#### Describe the solution

Add the ledger schema, generator, exact coverage checker, generated-file registration, and unit tests. This layer contains 5 focused file-level commits.

#### Describe alternatives you've considered

Publishing JSON loaders or EOC-shaped wrappers would preserve the legacy authoring model. Keeping all 49,000 added lines in one PR would make ownership, dependency, and rollback review impractical.

#### Testing

Not run by explicit user direction. This is a draft, `implemented_unverified` stack layer; compilation, tests, formatters, `git diff --check`, and all validation/check commands remain pending approval.

#### Documentation impact

Introduces or supports native contracts documented by stack layer 14.

#### Related CCB-Docs PR

https://github.com/CrimsonCrossBunker/CCB-Docs/pull/35

#### Affected documentation IDs

architecture.lua-first-platform, architecture.lua-first-roadmap, architecture.lua-first-glossary

#### Generated reference impact

Adds a schema, generator, checker, and generated-file registration for the exact replacement ledger.

#### Additional context

Stack layer 12/14. Base: `agent/lua-first-stack-11-migration-tests` (PR #629). Previous: https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/pull/629. Next: `agent/lua-first-stack-13-replacement-ledger`. Do not merge out of order.
