### PR TITLE
Feature: expand and validate the Lua-first Platform

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -39,3 +39,7 @@ per-file-ignores =
     tools/agent/test_import_legacy_audits.py:E501
     tools/agent/test_project_metadata.py:E501
     tools/agent/test_repository_governance.py:E501
+    # Lua-first extractor: exact emitted Lua/diagnostic strings and matching
+    # fixture assertions are intentionally readable as single source lines.
+    tools/migrate_lua_first.py:E501
+    tools/test_migrate_lua_first.py:E501

--- a/ai/agent-benchmark-baseline.json
+++ b/ai/agent-benchmark-baseline.json
@@ -3,7 +3,7 @@
   "cases": [
     {
       "errors": [],
-      "estimated_tokens": 2008,
+      "estimated_tokens": 2144,
       "id": "repository-navigation",
       "passed": true,
       "selected_routes": [
@@ -12,7 +12,7 @@
     },
     {
       "errors": [],
-      "estimated_tokens": 1869,
+      "estimated_tokens": 1949,
       "id": "cpp-bug",
       "passed": true,
       "selected_routes": [
@@ -21,7 +21,7 @@
     },
     {
       "errors": [],
-      "estimated_tokens": 1552,
+      "estimated_tokens": 1632,
       "id": "json-content",
       "passed": true,
       "selected_routes": [
@@ -30,7 +30,7 @@
     },
     {
       "errors": [],
-      "estimated_tokens": 1961,
+      "estimated_tokens": 2042,
       "id": "eoc",
       "passed": true,
       "selected_routes": [
@@ -39,7 +39,7 @@
     },
     {
       "errors": [],
-      "estimated_tokens": 2477,
+      "estimated_tokens": 3100,
       "id": "lua-api",
       "passed": true,
       "selected_routes": [
@@ -48,7 +48,7 @@
     },
     {
       "errors": [],
-      "estimated_tokens": 2654,
+      "estimated_tokens": 2734,
       "id": "upstream-port",
       "passed": true,
       "selected_routes": [
@@ -57,7 +57,7 @@
     },
     {
       "errors": [],
-      "estimated_tokens": 1889,
+      "estimated_tokens": 1969,
       "id": "save-compatibility",
       "passed": true,
       "selected_routes": [
@@ -66,7 +66,7 @@
     },
     {
       "errors": [],
-      "estimated_tokens": 1660,
+      "estimated_tokens": 1741,
       "id": "generated-file-detection",
       "passed": true,
       "selected_routes": [
@@ -75,7 +75,7 @@
     },
     {
       "errors": [],
-      "estimated_tokens": 2333,
+      "estimated_tokens": 2413,
       "id": "documentation-impact",
       "passed": true,
       "selected_routes": [

--- a/ai/docs-impact.yml
+++ b/ai/docs-impact.yml
@@ -97,6 +97,21 @@ entries:
       - data/lua/LUA_FIRST_PLATFORM.md
       - ai/lua-first-roadmap.yml
       - ai/lua-first-roadmap.schema.json
+      - ai/lua-first-replacement-ledger.yml
+      - ai/lua-first-replacement-ledger.schema.json
+      - data/lua/types/ccb_platform_v1.d.lua
+      - data/lua/templates/**
+      - data/mods/Lua_First_Example/**
+      - tools/create_lua_mod.py
+      - tools/migrate_lua_first.py
+      - src/catalua_platform*.cpp
+      - src/catalua_platform*.h
+      - src/mod_manager.cpp
+      - src/mod_manager.h
+      - src/mod_manager_ui.cpp
+      - src/game_io.cpp
+      - src/game.cpp
+      - src/do_turn.cpp
     documentation_ids:
       - architecture.lua-first-platform
       - architecture.lua-first-roadmap

--- a/ai/documentation-registry.yml
+++ b/ai/documentation-registry.yml
@@ -1,9 +1,9 @@
 schema_version: 1
 kind: documentation_registry
-source_commit: aae884c958bc3ac2c23bbf840b22deadade4a2ec
+source_commit: b2bbec1a2f4f8e41a2fece924c7c43b426ff2dc6
 scope: Tracked documentation and machine contracts from the Git index; untracked build caches are never
   traversed.
-entry_count: 236
+entry_count: 241
 entries:
 - id: repo.deepcode-plans-sim-render-decoupling-plan-md
   path: .deepcode/plans/sim-render-decoupling-plan.md
@@ -313,6 +313,28 @@ entries:
   generated: false
   generated_by: null
   include_in_ai_index: true
+- id: repo.ai-lua-first-replacement-ledger-schema-json
+  path: ai/lua-first-replacement-ledger.schema.json
+  category: authoritative_document
+  status: active
+  authority: governance_contract
+  source_of_truth: true
+  stable_document_id: null
+  ccb_docs_ids: []
+  generated: false
+  generated_by: null
+  include_in_ai_index: true
+- id: repo.ai-lua-first-replacement-ledger-yml
+  path: ai/lua-first-replacement-ledger.yml
+  category: authoritative_document
+  status: active
+  authority: governance_contract
+  source_of_truth: true
+  stable_document_id: null
+  ccb_docs_ids: []
+  generated: true
+  generated_by: python3 tools/agent/generate_lua_first_replacement_ledger.py
+  include_in_ai_index: true
 - id: repo.ai-lua-first-roadmap-schema-json
   path: ai/lua-first-roadmap.schema.json
   category: authoritative_document
@@ -606,8 +628,30 @@ entries:
   generated: false
   generated_by: null
   include_in_ai_index: true
+- id: repo.data-lua-templates-complete-readme-md
+  path: data/lua/templates/complete/README.md
+  category: maintained_document
+  status: active
+  authority: explanatory
+  source_of_truth: false
+  stable_document_id: null
+  ccb_docs_ids: []
+  generated: false
+  generated_by: null
+  include_in_ai_index: true
 - id: repo.data-lua-types-ccb-api-v5-d-lua
   path: data/lua/types/ccb_api_v5.d.lua
+  category: api_contract
+  status: active
+  authority: api_contract
+  source_of_truth: true
+  stable_document_id: null
+  ccb_docs_ids: []
+  generated: false
+  generated_by: null
+  include_in_ai_index: true
+- id: repo.data-lua-types-ccb-platform-v1-d-lua
+  path: data/lua/types/ccb_platform_v1.d.lua
   category: api_contract
   status: active
   authority: api_contract
@@ -679,6 +723,17 @@ entries:
   authority: explanatory
   source_of_truth: false
   stable_document_id: mods.dinomod.overview
+  ccb_docs_ids: []
+  generated: false
+  generated_by: null
+  include_in_ai_index: false
+- id: repo.data-mods-lua-first-example-readme-md
+  path: data/mods/Lua_First_Example/README.md
+  category: historical_document
+  status: historical
+  authority: historical
+  source_of_truth: false
+  stable_document_id: null
   ccb_docs_ids: []
   generated: false
   generated_by: null

--- a/ai/lua-first-replacement-ledger.schema.json
+++ b/ai/lua-first-replacement-ledger.schema.json
@@ -30,10 +30,11 @@
     "summary": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["total", "implemented_unverified", "primitive_available_unverified", "planned", "private_adapter", "reviewed_not_applicable"],
+      "required": ["total", "implemented_unverified", "bounded_implemented_unverified", "primitive_available_unverified", "planned", "private_adapter", "reviewed_not_applicable"],
       "properties": {
         "total": { "type": "integer", "minimum": 1 },
         "implemented_unverified": { "type": "integer", "minimum": 0 },
+        "bounded_implemented_unverified": { "type": "integer", "minimum": 0 },
         "primitive_available_unverified": { "type": "integer", "minimum": 0 },
         "planned": { "type": "integer", "minimum": 0 },
         "private_adapter": { "type": "integer", "minimum": 0 },
@@ -52,7 +53,7 @@
           "selector": { "type": "string", "minLength": 1 },
           "target_kind": { "enum": ["platform_domain", "shared_service", "migration", "not_applicable"] },
           "target": { "type": "string", "minLength": 1 },
-          "status": { "enum": ["implemented_unverified", "primitive_available_unverified", "planned", "private_adapter", "reviewed_not_applicable"] },
+          "status": { "enum": ["implemented_unverified", "bounded_implemented_unverified", "primitive_available_unverified", "planned", "private_adapter", "reviewed_not_applicable"] },
           "legacy_dependency": { "enum": ["none", "private_adapter", "public_legacy"] },
           "evidence": { "type": "array", "items": { "type": "string" } }
         }

--- a/ai/lua-first-replacement-ledger.yml
+++ b/ai/lua-first-replacement-ledger.yml
@@ -2,31 +2,33 @@ $schema: lua-first-replacement-ledger.schema.json
 schema_version: 1
 kind: lua_first_replacement_ledger
 contract: Every checked legacy selector appears exactly once. Planned entries are migration work, not
-  shipped Platform APIs. Primitive-available entries have native composition building blocks but are not
-  claims of selector-level parity.
+  shipped Platform APIs. Bounded entries cover named real shapes without claiming full selector parity.
+  Primitive-available entries have native composition building blocks but are not claims of selector-level
+  parity.
 sources:
 - id: json-object-types
   path: data/reference/json/ccb_json_object_types.json
   selector: type
-  source_fingerprint: sha256:3a9fb8e631868a91950ce2c4646bf101b85eb33458cfb5c71f03c58cb0d0bee4
+  source_fingerprint: sha256:939c256fc667b769da6fa02c29b914a8c6ad0a087944c0923552625adaff7e48
   entry_count: 190
 - id: eoc-conditions
   path: data/reference/json/ccb_eoc_conditions.json
   selector: key
-  source_fingerprint: sha256:3a9fb8e631868a91950ce2c4646bf101b85eb33458cfb5c71f03c58cb0d0bee4
+  source_fingerprint: sha256:939c256fc667b769da6fa02c29b914a8c6ad0a087944c0923552625adaff7e48
   entry_count: 275
 - id: eoc-effects
   path: data/reference/json/ccb_eoc_effects.json
   selector: key
-  source_fingerprint: sha256:3a9fb8e631868a91950ce2c4646bf101b85eb33458cfb5c71f03c58cb0d0bee4
+  source_fingerprint: sha256:939c256fc667b769da6fa02c29b914a8c6ad0a087944c0923552625adaff7e48
   entry_count: 310
 summary:
   total: 775
-  implemented_unverified: 82
-  primitive_available_unverified: 479
-  planned: 203
+  implemented_unverified: 0
+  bounded_implemented_unverified: 119
+  primitive_available_unverified: 440
+  planned: 198
   private_adapter: 0
-  reviewed_not_applicable: 11
+  reviewed_not_applicable: 18
 entries:
 - inventory: eoc-conditions
   selector: and
@@ -47,27 +49,42 @@ entries:
 - inventory: eoc-conditions
   selector: compare_string
   target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target: services.gameplay.strings
+  status: bounded_implemented_unverified
+  legacy_dependency: none
   evidence:
-  - conditional_fun::f_compare_string
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
 - inventory: eoc-conditions
   selector: compare_string_match_all
   target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target: services.gameplay.strings
+  status: bounded_implemented_unverified
+  legacy_dependency: none
   evidence:
-  - conditional_fun::f_compare_string_match_all
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
 - inventory: eoc-conditions
   selector: current_dimension
   target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target: services.gameplay.environment
+  status: bounded_implemented_unverified
+  legacy_dependency: none
   evidence:
-  - conditional_fun::current_dimension
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
 - inventory: eoc-conditions
   selector: expects_vars
   target_kind: shared_service
@@ -83,17 +100,23 @@ entries:
 - inventory: eoc-conditions
   selector: follower_present
   target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target: services.followers
+  status: primitive_available_unverified
+  legacy_dependency: none
   evidence:
-  - conditional_fun::f_follower_present
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/catalua_ui_game_info.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-conditions
   selector: get_condition
-  target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target_kind: not_applicable
+  target: native-lua-control-flow
+  status: reviewed_not_applicable
+  legacy_dependency: none
   evidence:
   - conditional_fun::f_get_condition
 - inventory: eoc-conditions
@@ -195,11 +218,15 @@ entries:
 - inventory: eoc-conditions
   selector: is_outside
   target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target: services.gameplay.environment
+  status: primitive_available_unverified
+  legacy_dependency: none
   evidence:
-  - conditional_fun::f_tile_is_outside
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
 - inventory: eoc-conditions
   selector: is_rotten
   target_kind: shared_service
@@ -225,11 +252,15 @@ entries:
 - inventory: eoc-conditions
   selector: line_of_sight
   target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target: services.gameplay.environment
+  status: primitive_available_unverified
+  legacy_dependency: none
   evidence:
-  - conditional_fun::f_line_of_sight
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
 - inventory: eoc-conditions
   selector: map_field_id
   target_kind: shared_service
@@ -324,11 +355,16 @@ entries:
 - inventory: eoc-conditions
   selector: mod_is_loaded
   target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target: services.gameplay.mods
+  status: bounded_implemented_unverified
+  legacy_dependency: none
   evidence:
-  - conditional_fun::f_mod_is_loaded
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
 - inventory: eoc-conditions
   selector: not
   target_kind: not_applicable
@@ -389,10 +425,19 @@ entries:
 - inventory: eoc-conditions
   selector: npc_can_drop_weapon
   target_kind: shared_service
-  target: services.items
+  target: services.inventory-and-martial-arts
   status: primitive_available_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/melee.cpp
+  - src/catalua_ui_items.cpp
+  - src/catalua_ui_martial_arts.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-conditions
   selector: npc_can_float
   target_kind: shared_service
@@ -494,10 +539,17 @@ entries:
 - inventory: eoc-conditions
   selector: npc_has_activity
   target_kind: shared_service
-  target: services.characters
+  target: services.activities
   status: primitive_available_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/condition.cpp
+  - src/player_activity.cpp
 - inventory: eoc-conditions
   selector: npc_has_any_effect
   target_kind: shared_service
@@ -571,10 +623,18 @@ entries:
 - inventory: eoc-conditions
   selector: npc_has_item
   target_kind: shared_service
-  target: services.items
+  target: services.inventory
   status: primitive_available_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/condition.cpp
+  - src/catalua_ui_items.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-conditions
   selector: npc_has_item_category
   target_kind: shared_service
@@ -620,10 +680,18 @@ entries:
 - inventory: eoc-conditions
   selector: npc_has_move_mode
   target_kind: shared_service
-  target: services.characters
+  target: services.characters.movement
   status: primitive_available_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/condition.cpp
+  - src/catalua_ui_creatures.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-conditions
   selector: npc_has_no_available_mission
   target_kind: shared_service
@@ -718,10 +786,19 @@ entries:
 - inventory: eoc-conditions
   selector: npc_has_weapon
   target_kind: shared_service
-  target: services.items
+  target: services.inventory-and-martial-arts
   status: primitive_available_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/melee.cpp
+  - src/catalua_ui_items.cpp
+  - src/catalua_ui_martial_arts.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-conditions
   selector: npc_has_wielded_with_ammotype
   target_kind: shared_service
@@ -732,10 +809,18 @@ entries:
 - inventory: eoc-conditions
   selector: npc_has_wielded_with_flag
   target_kind: shared_service
-  target: services.items
+  target: services.inventory-and-items
   status: primitive_available_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/talker_character.cpp
+  - src/catalua_ui_items.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-conditions
   selector: npc_has_wielded_with_skill
   target_kind: shared_service
@@ -949,10 +1034,13 @@ entries:
 - inventory: eoc-conditions
   selector: npc_is_travelling
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
-  legacy_dependency: none
-  evidence: *id001
+  target: services.character-navigation
+  status: planned
+  legacy_dependency: public_legacy
+  evidence:
+  - conditional_fun::f_npc_is_travelling
+  - src/condition.cpp
+  - src/character.h
 - inventory: eoc-conditions
   selector: npc_is_underwater
   target_kind: shared_service
@@ -1117,11 +1205,16 @@ entries:
 - inventory: eoc-conditions
   selector: one_in_chance
   target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target: services.random
+  status: bounded_implemented_unverified
+  legacy_dependency: none
   evidence:
-  - conditional_fun::f_one_in_chance
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
 - inventory: eoc-conditions
   selector: or
   target_kind: not_applicable
@@ -1155,17 +1248,22 @@ entries:
 - inventory: eoc-conditions
   selector: roll_contested
   target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target: services.random
+  status: bounded_implemented_unverified
+  legacy_dependency: none
   evidence:
-  - conditional_fun::f_roll_contested
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
 - inventory: eoc-conditions
   selector: test_eoc
-  target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target_kind: not_applicable
+  target: native-lua-control-flow
+  status: reviewed_not_applicable
+  legacy_dependency: none
   evidence:
   - conditional_fun::f_test_eoc
 - inventory: eoc-conditions
@@ -1213,10 +1311,21 @@ entries:
 - inventory: eoc-conditions
   selector: u_can_drop_weapon
   target_kind: shared_service
-  target: services.items
-  status: primitive_available_unverified
+  target: services.inventory-and-martial-arts
+  status: bounded_implemented_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/condition.cpp
+  - src/melee.cpp
+  - src/catalua_ui_items.cpp
+  - src/catalua_ui_martial_arts.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-conditions
   selector: u_can_float
   target_kind: shared_service
@@ -1318,10 +1427,18 @@ entries:
 - inventory: eoc-conditions
   selector: u_has_activity
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
+  target: services.activities
+  status: bounded_implemented_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/condition.cpp
+  - src/player_activity.cpp
 - inventory: eoc-conditions
   selector: u_has_any_effect
   target_kind: shared_service
@@ -1332,10 +1449,19 @@ entries:
 - inventory: eoc-conditions
   selector: u_has_any_trait
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
+  target: services.mutations
+  status: bounded_implemented_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/condition.cpp
+  - src/catalua_ui_mutations.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-conditions
   selector: u_has_available_mission
   target_kind: shared_service
@@ -1346,10 +1472,19 @@ entries:
 - inventory: eoc-conditions
   selector: u_has_bionics
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
+  target: services.bionics
+  status: bounded_implemented_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/condition.cpp
+  - src/catalua_ui_bionics.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-conditions
   selector: u_has_camp
   target_kind: shared_service
@@ -1409,10 +1544,19 @@ entries:
 - inventory: eoc-conditions
   selector: u_has_item
   target_kind: shared_service
-  target: services.items
-  status: primitive_available_unverified
+  target: services.inventory
+  status: bounded_implemented_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/condition.cpp
+  - src/catalua_ui_items.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-conditions
   selector: u_has_item_category
   target_kind: shared_service
@@ -1451,10 +1595,19 @@ entries:
 - inventory: eoc-conditions
   selector: u_has_martial_art
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
+  target: services.martial_arts
+  status: bounded_implemented_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/condition.cpp
+  - src/catalua_ui_martial_arts.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-conditions
   selector: u_has_mission
   target_kind: shared_service
@@ -1465,10 +1618,19 @@ entries:
 - inventory: eoc-conditions
   selector: u_has_move_mode
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
+  target: services.characters.movement
+  status: bounded_implemented_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/condition.cpp
+  - src/catalua_ui_creatures.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-conditions
   selector: u_has_no_available_mission
   target_kind: shared_service
@@ -1514,10 +1676,19 @@ entries:
 - inventory: eoc-conditions
   selector: u_has_proficiency
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
+  target: services.proficiencies
+  status: bounded_implemented_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/condition.cpp
+  - src/catalua_ui_proficiencies.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-conditions
   selector: u_has_software
   target_kind: shared_service
@@ -1549,10 +1720,19 @@ entries:
 - inventory: eoc-conditions
   selector: u_has_trait
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
+  target: services.mutations
+  status: bounded_implemented_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/condition.cpp
+  - src/catalua_ui_mutations.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-conditions
   selector: u_has_visible_trait
   target_kind: shared_service
@@ -1563,10 +1743,21 @@ entries:
 - inventory: eoc-conditions
   selector: u_has_weapon
   target_kind: shared_service
-  target: services.items
-  status: primitive_available_unverified
+  target: services.inventory-and-martial-arts
+  status: bounded_implemented_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/condition.cpp
+  - src/melee.cpp
+  - src/catalua_ui_items.cpp
+  - src/catalua_ui_martial_arts.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-conditions
   selector: u_has_wielded_with_ammotype
   target_kind: shared_service
@@ -1577,10 +1768,20 @@ entries:
 - inventory: eoc-conditions
   selector: u_has_wielded_with_flag
   target_kind: shared_service
-  target: services.items
-  status: primitive_available_unverified
+  target: services.inventory-and-items
+  status: bounded_implemented_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/condition.cpp
+  - src/talker_character.cpp
+  - src/catalua_ui_items.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-conditions
   selector: u_has_wielded_with_skill
   target_kind: shared_service
@@ -1794,10 +1995,13 @@ entries:
 - inventory: eoc-conditions
   selector: u_is_travelling
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
-  legacy_dependency: none
-  evidence: *id001
+  target: services.character-navigation
+  status: planned
+  legacy_dependency: public_legacy
+  evidence:
+  - conditional_fun::f_npc_is_travelling
+  - src/condition.cpp
+  - src/character.h
 - inventory: eoc-conditions
   selector: u_is_underwater
   target_kind: shared_service
@@ -1829,10 +2033,20 @@ entries:
 - inventory: eoc-conditions
   selector: u_know_recipe
   target_kind: shared_service
-  target: services.crafting
-  status: primitive_available_unverified
+  target: services.recipes
+  status: bounded_implemented_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/condition.cpp
+  - src/character_crafting.cpp
+  - src/catalua_ui_crafting.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-conditions
   selector: u_male
   target_kind: shared_service
@@ -1962,10 +2176,19 @@ entries:
 - inventory: eoc-conditions
   selector: u_using_martial_art
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
+  target: services.martial_arts
+  status: bounded_implemented_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/condition.cpp
+  - src/catalua_ui_martial_arts.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-conditions
   selector: u_vehicle_owned_by_avatar
   target_kind: shared_service
@@ -1976,11 +2199,16 @@ entries:
 - inventory: eoc-conditions
   selector: x_in_y_chance
   target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target: services.random
+  status: bounded_implemented_unverified
+  legacy_dependency: none
   evidence:
-  - conditional_fun::f_x_in_y_chance
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
 - inventory: eoc-effects
   selector: abandon_camp
   target_kind: shared_service
@@ -2027,10 +2255,18 @@ entries:
 - inventory: eoc-effects
   selector: assign_mission
   target_kind: shared_service
-  target: services.missions
+  target: services.missions-and-dialogue
   status: primitive_available_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/npctalk.cpp
+  - src/catalua_ui_missions.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-effects
   selector: barber_beard
   target_kind: shared_service
@@ -2155,11 +2391,17 @@ entries:
 - inventory: eoc-effects
   selector: closest_city
   target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target: services.overmap
+  status: primitive_available_unverified
+  legacy_dependency: none
   evidence:
-  - talk_effect_fun::f_closest_city
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/catalua_ui_overmap.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-effects
   selector: companion_mission
   target_kind: shared_service
@@ -2239,11 +2481,15 @@ entries:
 - inventory: eoc-effects
   selector: dimension_name
   target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target: services.gameplay.environment
+  status: primitive_available_unverified
+  legacy_dependency: none
   evidence:
-  - talk_effect_fun::f_dimension_name
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
 - inventory: eoc-effects
   selector: dismount
   target_kind: shared_service
@@ -2439,11 +2685,18 @@ entries:
 - inventory: eoc-effects
   selector: follow
   target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target: services.followers-and-npcs
+  status: primitive_available_unverified
+  legacy_dependency: none
   evidence:
-  - talk_function::follow
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/catalua_ui_game_info.cpp
+  - src/catalua_ui_npcs.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-effects
   selector: follow_only
   target_kind: shared_service
@@ -2463,19 +2716,31 @@ entries:
 - inventory: eoc-effects
   selector: give_achievement
   target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target: services.achievements
+  status: bounded_implemented_unverified
+  legacy_dependency: none
   evidence:
-  - talk_effect_fun::f_give_achievment
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
 - inventory: eoc-effects
   selector: give_aid
   target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target: services.characters-and-effects
+  status: primitive_available_unverified
+  legacy_dependency: none
   evidence:
-  - talk_function::give_aid
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/catalua_ui_creatures.cpp
+  - src/catalua_ui_effects.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-effects
   selector: give_all_aid
   target_kind: shared_service
@@ -2487,27 +2752,41 @@ entries:
 - inventory: eoc-effects
   selector: give_equipment
   target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target: services.inventory-and-presentation
+  status: primitive_available_unverified
+  legacy_dependency: none
   evidence:
-  - talk_effect_fun::f_give_equipment
-  - talk_function::give_equipment
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/catalua_ui_items.cpp
+  - src/catalua_ui_interaction.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-effects
   selector: goto_location
   target_kind: shared_service
-  target: services.map
-  status: primitive_available_unverified
-  legacy_dependency: none
-  evidence: *id001
-- inventory: eoc-effects
-  selector: hostile
-  target_kind: shared_service
-  target: services.gameplay
+  target: workflows.npc-navigation
   status: planned
   legacy_dependency: public_legacy
   evidence:
-  - talk_function::hostile
+  - talk_function::goto_location
+  - src/npctalk_funcs.cpp
+- inventory: eoc-effects
+  selector: hostile
+  target_kind: shared_service
+  target: services.npcs
+  status: primitive_available_unverified
+  legacy_dependency: none
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/catalua_ui_npcs.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-effects
   selector: if
   target_kind: not_applicable
@@ -2573,10 +2852,18 @@ entries:
 - inventory: eoc-effects
   selector: map_spawn_item
   target_kind: shared_service
-  target: services.items
+  target: services.world
   status: primitive_available_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/npctalk.cpp
+  - src/catalua_ui_world.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-effects
   selector: mapgen_update
   target_kind: shared_service
@@ -2594,18 +2881,28 @@ entries:
 - inventory: eoc-effects
   selector: message
   target_kind: shared_service
-  target: services.presentation
-  status: primitive_available_unverified
+  target: services.message
+  status: bounded_implemented_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
 - inventory: eoc-effects
   selector: mirror_coordinates
   target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target: services.coords
+  status: primitive_available_unverified
+  legacy_dependency: none
   evidence:
-  - talk_effect_fun::f_mirror_coordinates
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
 - inventory: eoc-effects
   selector: mission_failure
   target_kind: shared_service
@@ -2630,11 +2927,12 @@ entries:
 - inventory: eoc-effects
   selector: morale_chat_activity
   target_kind: shared_service
-  target: services.gameplay
+  target: workflows.socialize
   status: planned
   legacy_dependency: public_legacy
   evidence:
   - talk_function::morale_chat_activity
+  - src/npctalk_funcs.cpp
 - inventory: eoc-effects
   selector: next_weather
   target_kind: shared_service
@@ -2644,19 +2942,22 @@ entries:
   evidence: *id001
 - inventory: eoc-effects
   selector: nothing
-  target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target_kind: not_applicable
+  target: native-lua-control-flow
+  status: reviewed_not_applicable
+  legacy_dependency: none
   evidence:
   - talk_function::nothing
 - inventory: eoc-effects
   selector: npc_activate
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
-  legacy_dependency: none
-  evidence: *id001
+  target: services.items-and-characters
+  status: planned
+  legacy_dependency: public_legacy
+  evidence:
+  - talk_effect_fun::f_activate
+  - src/npctalk.cpp
+  - src/catalua_ui_items.cpp
 - inventory: eoc-effects
   selector: npc_activate_trait
   target_kind: shared_service
@@ -2702,24 +3003,37 @@ entries:
 - inventory: eoc-effects
   selector: npc_add_wet
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
-  legacy_dependency: none
-  evidence: *id001
+  target: services.wetness
+  status: planned
+  legacy_dependency: public_legacy
+  evidence:
+  - talk_effect_fun::f_add_wet
+  - src/weather.cpp
+  - src/suffer.cpp
 - inventory: eoc-effects
   selector: npc_add_wound
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
-  legacy_dependency: none
-  evidence: *id001
+  target: services.wounds
+  status: planned
+  legacy_dependency: public_legacy
+  evidence:
+  - talk_effect_fun::f_add_wound
+  - src/npctalk.cpp
+  - src/bodypart.cpp
+  - src/wound.cpp
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - data/lua/LUA_FIRST_PLATFORM.md
 - inventory: eoc-effects
   selector: npc_assign_activity
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
-  legacy_dependency: none
-  evidence: *id001
+  target: services.activities
+  status: planned
+  legacy_dependency: public_legacy
+  evidence:
+  - talk_effect_fun::f_assign_activity
+  - src/npctalk.cpp
+  - src/character.cpp
 - inventory: eoc-effects
   selector: npc_attack
   target_kind: shared_service
@@ -2744,10 +3058,18 @@ entries:
 - inventory: eoc-effects
   selector: npc_cancel_activity
   target_kind: shared_service
-  target: services.characters
+  target: services.activities
   status: primitive_available_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/npctalk.cpp
+  - src/character.cpp
+  - src/player_activity.cpp
 - inventory: eoc-effects
   selector: npc_cast_spell
   target_kind: shared_service
@@ -2800,10 +3122,13 @@ entries:
 - inventory: eoc-effects
   selector: npc_deal_damage
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
-  legacy_dependency: none
-  evidence: *id001
+  target: services.combat
+  status: planned
+  legacy_dependency: public_legacy
+  evidence:
+  - talk_effect_fun::f_deal_damage
+  - src/creature.cpp
+  - src/character_health.cpp
 - inventory: eoc-effects
   selector: npc_die
   target_kind: shared_service
@@ -2996,10 +3321,13 @@ entries:
 - inventory: eoc-effects
   selector: npc_pick_bodypart
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
-  legacy_dependency: none
-  evidence: *id001
+  target: services.body-parts-and-wounds
+  status: planned
+  legacy_dependency: public_legacy
+  evidence:
+  - talk_effect_fun::f_pick_bodypart
+  - src/bodypart.cpp
+  - src/npctalk.cpp
 - inventory: eoc-effects
   selector: npc_pickup_items
   target_kind: shared_service
@@ -3052,10 +3380,17 @@ entries:
 - inventory: eoc-effects
   selector: npc_remove_wound
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
-  legacy_dependency: none
-  evidence: *id001
+  target: services.wounds
+  status: planned
+  legacy_dependency: public_legacy
+  evidence:
+  - talk_effect_fun::f_remove_wound
+  - src/npctalk.cpp
+  - src/bodypart.cpp
+  - src/wound.cpp
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - data/lua/LUA_FIRST_PLATFORM.md
 - inventory: eoc-effects
   selector: npc_roll_remainder
   target_kind: shared_service
@@ -3108,17 +3443,29 @@ entries:
 - inventory: eoc-effects
   selector: npc_set_fac_relation
   target_kind: shared_service
-  target: services.characters
+  target: services.factions
   status: primitive_available_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/npctalk.cpp
+  - src/talker_character.cpp
+  - src/catalua_ui_factions.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-effects
   selector: npc_set_fault
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
-  legacy_dependency: none
-  evidence: *id001
+  target: services.items
+  status: planned
+  legacy_dependency: public_legacy
+  evidence:
+  - talk_effect_fun::f_set_fault
+  - src/npctalk.cpp
+  - src/catalua_ui_items.cpp
 - inventory: eoc-effects
   selector: npc_set_field
   target_kind: shared_service
@@ -3129,31 +3476,49 @@ entries:
 - inventory: eoc-effects
   selector: npc_set_flag
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
+  target: services.items
+  status: bounded_implemented_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/effect_on_condition.cpp
+  - src/event_bus.cpp
+  - src/npctalk.cpp
+  - src/catalua_ui_items.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-effects
   selector: npc_set_goal
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
-  legacy_dependency: none
-  evidence: *id001
+  target: services.npc-navigation
+  status: planned
+  legacy_dependency: public_legacy
+  evidence:
+  - talk_effect_fun::f_npc_goal
+  - src/npctalk.cpp
 - inventory: eoc-effects
   selector: npc_set_guard_pos
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
-  legacy_dependency: none
-  evidence: *id001
+  target: services.npc-navigation
+  status: planned
+  legacy_dependency: public_legacy
+  evidence:
+  - talk_effect_fun::f_guard_pos
+  - src/npctalk.cpp
 - inventory: eoc-effects
   selector: npc_set_random_fault_of_type
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
-  legacy_dependency: none
-  evidence: *id001
+  target: services.items
+  status: planned
+  legacy_dependency: public_legacy
+  evidence:
+  - talk_effect_fun::f_set_random_fault_of_type
+  - src/npctalk.cpp
+  - src/catalua_ui_items.cpp
 - inventory: eoc-effects
   selector: npc_set_talker
   target_kind: shared_service
@@ -3185,10 +3550,13 @@ entries:
 - inventory: eoc-effects
   selector: npc_teleport
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
-  legacy_dependency: none
-  evidence: *id001
+  target: services.relocation
+  status: planned
+  legacy_dependency: public_legacy
+  evidence:
+  - talk_effect_fun::f_teleport
+  - src/npctalk.cpp
+  - src/catalua_ui_world_services.cpp
 - inventory: eoc-effects
   selector: npc_thankful
   target_kind: shared_service
@@ -3206,10 +3574,21 @@ entries:
 - inventory: eoc-effects
   selector: npc_unset_flag
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
+  target: services.items
+  status: bounded_implemented_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/effect_on_condition.cpp
+  - src/event_bus.cpp
+  - src/npctalk.cpp
+  - src/catalua_ui_items.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-effects
   selector: npc_wants_to_talk
   target_kind: shared_service
@@ -3323,11 +3702,17 @@ entries:
 - inventory: eoc-effects
   selector: reveal_route
   target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target: services.overmap
+  status: primitive_available_unverified
+  legacy_dependency: none
   evidence:
-  - talk_effect_fun::f_reveal_route
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/catalua_ui_overmap.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-effects
   selector: reveal_stats
   target_kind: shared_service
@@ -3339,11 +3724,12 @@ entries:
 - inventory: eoc-effects
   selector: revert_activity
   target_kind: shared_service
-  target: services.gameplay
+  target: services.npc-work
   status: planned
   legacy_dependency: public_legacy
   evidence:
   - talk_function::revert_activity
+  - src/npc.cpp
 - inventory: eoc-effects
   selector: revert_location
   target_kind: shared_service
@@ -3353,36 +3739,40 @@ entries:
   evidence: *id001
 - inventory: eoc-effects
   selector: run_eoc_selector
-  target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target_kind: not_applicable
+  target: native-lua-control-flow
+  status: reviewed_not_applicable
+  legacy_dependency: none
   evidence:
   - talk_effect_fun::f_run_eoc_selector
 - inventory: eoc-effects
   selector: run_eocs
-  target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target_kind: not_applicable
+  target: native-lua-control-flow
+  status: reviewed_not_applicable
+  legacy_dependency: none
   evidence:
   - talk_effect_fun::f_run_eocs
 - inventory: eoc-effects
   selector: run_lua
-  target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target_kind: not_applicable
+  target: native-lua-control-flow
+  status: reviewed_not_applicable
+  legacy_dependency: none
   evidence:
   - talk_effect_fun::f_run_lua
 - inventory: eoc-effects
   selector: sample_range
   target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target: services.random
+  status: primitive_available_unverified
+  legacy_dependency: none
   evidence:
-  - talk_effect_fun::f_sample_range
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
 - inventory: eoc-effects
   selector: select_vehicle_part_service
   target_kind: shared_service
@@ -3393,17 +3783,19 @@ entries:
 - inventory: eoc-effects
   selector: set_browsed
   target_kind: shared_service
-  target: services.gameplay
+  target: services.items
   status: planned
   legacy_dependency: public_legacy
   evidence:
   - talk_effect_fun::f_set_browsed
+  - src/npctalk.cpp
+  - src/catalua_ui_items.cpp
 - inventory: eoc-effects
   selector: set_condition
-  target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target_kind: not_applicable
+  target: native-lua-control-flow
+  status: reviewed_not_applicable
+  legacy_dependency: none
   evidence:
   - talk_effect_fun::f_set_condition
 - inventory: eoc-effects
@@ -3479,19 +3871,32 @@ entries:
 - inventory: eoc-effects
   selector: set_trap
   target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target: services.world-and-coords
+  status: primitive_available_unverified
+  legacy_dependency: none
   evidence:
-  - talk_effect_fun::f_set_trap
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/catalua_ui_world.cpp
+  - src/catalua_bindings_coords.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-effects
   selector: signal_hordes
   target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target: services.hordes
+  status: primitive_available_unverified
+  legacy_dependency: none
   evidence:
-  - talk_effect_fun::f_signal_hordes
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/catalua_ui_hordes.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-effects
   selector: sort_loot
   target_kind: shared_service
@@ -3563,11 +3968,18 @@ entries:
 - inventory: eoc-effects
   selector: stop_following
   target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target: services.followers-and-npcs
+  status: primitive_available_unverified
+  legacy_dependency: none
   evidence:
-  - talk_function::stop_following
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/catalua_ui_game_info.cpp
+  - src/catalua_ui_npcs.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-effects
   selector: stop_guard
   target_kind: shared_service
@@ -3579,11 +3991,17 @@ entries:
 - inventory: eoc-effects
   selector: stranger_neutral
   target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target: services.npcs
+  status: primitive_available_unverified
+  legacy_dependency: none
   evidence:
-  - talk_function::stranger_neutral
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/catalua_ui_npcs.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-effects
   selector: switch
   target_kind: not_applicable
@@ -3618,9 +4036,12 @@ entries:
   selector: transform_item
   target_kind: shared_service
   target: services.items
-  status: primitive_available_unverified
-  legacy_dependency: none
-  evidence: *id001
+  status: planned
+  legacy_dependency: public_legacy
+  evidence:
+  - talk_effect_fun::f_transform_item
+  - src/npctalk.cpp
+  - src/catalua_ui_items.cpp
 - inventory: eoc-effects
   selector: transform_line
   target_kind: shared_service
@@ -3640,18 +4061,28 @@ entries:
 - inventory: eoc-effects
   selector: turn_cost
   target_kind: shared_service
-  target: services.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target: services.characters-and-time
+  status: primitive_available_unverified
+  legacy_dependency: none
   evidence:
-  - talk_effect_fun::f_turn_cost
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/catalua_ui_creatures.cpp
+  - src/catalua_ui_time.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-effects
   selector: u_activate
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
-  legacy_dependency: none
-  evidence: *id001
+  target: services.items-and-characters
+  status: planned
+  legacy_dependency: public_legacy
+  evidence:
+  - talk_effect_fun::f_activate
+  - src/npctalk.cpp
+  - src/catalua_ui_items.cpp
 - inventory: eoc-effects
   selector: u_activate_trait
   target_kind: shared_service
@@ -3662,31 +4093,70 @@ entries:
 - inventory: eoc-effects
   selector: u_add_bionic
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
+  target: services.bionics
+  status: bounded_implemented_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/bionics.cpp
+  - src/catalua_ui_bionics.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-effects
   selector: u_add_effect
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
+  target: services.effects
+  status: bounded_implemented_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/npctalk.cpp
+  - src/creature.cpp
+  - src/catalua_ui_effects.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-effects
   selector: u_add_faction_trust
   target_kind: shared_service
-  target: services.characters
+  target: services.factions
   status: primitive_available_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/npctalk.cpp
+  - src/talker_character.cpp
+  - src/catalua_ui_factions.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-effects
   selector: u_add_morale
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
+  target: services.morale
+  status: bounded_implemented_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/npctalk.cpp
+  - src/talker_character.cpp
+  - src/character_morale.cpp
+  - src/morale.cpp
+  - src/morale_types.cpp
 - inventory: eoc-effects
   selector: u_add_trait
   target_kind: shared_service
@@ -3704,24 +4174,37 @@ entries:
 - inventory: eoc-effects
   selector: u_add_wet
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
-  legacy_dependency: none
-  evidence: *id001
+  target: services.wetness
+  status: planned
+  legacy_dependency: public_legacy
+  evidence:
+  - talk_effect_fun::f_add_wet
+  - src/weather.cpp
+  - src/suffer.cpp
 - inventory: eoc-effects
   selector: u_add_wound
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
-  legacy_dependency: none
-  evidence: *id001
+  target: services.wounds
+  status: planned
+  legacy_dependency: public_legacy
+  evidence:
+  - talk_effect_fun::f_add_wound
+  - src/npctalk.cpp
+  - src/bodypart.cpp
+  - src/wound.cpp
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - data/lua/LUA_FIRST_PLATFORM.md
 - inventory: eoc-effects
   selector: u_assign_activity
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
-  legacy_dependency: none
-  evidence: *id001
+  target: services.activities
+  status: planned
+  legacy_dependency: public_legacy
+  evidence:
+  - talk_effect_fun::f_assign_activity
+  - src/npctalk.cpp
+  - src/character.cpp
 - inventory: eoc-effects
   selector: u_attack
   target_kind: shared_service
@@ -3760,10 +4243,19 @@ entries:
 - inventory: eoc-effects
   selector: u_cancel_activity
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
+  target: services.activities
+  status: bounded_implemented_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/npctalk.cpp
+  - src/character.cpp
+  - src/player_activity.cpp
 - inventory: eoc-effects
   selector: u_cast_spell
   target_kind: shared_service
@@ -3802,10 +4294,13 @@ entries:
 - inventory: eoc-effects
   selector: u_deal_damage
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
-  legacy_dependency: none
-  evidence: *id001
+  target: services.combat
+  status: planned
+  legacy_dependency: public_legacy
+  evidence:
+  - talk_effect_fun::f_deal_damage
+  - src/creature.cpp
+  - src/character_health.cpp
 - inventory: eoc-effects
   selector: u_die
   target_kind: shared_service
@@ -3837,17 +4332,35 @@ entries:
 - inventory: eoc-effects
   selector: u_forget_martial_art
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
+  target: services.martial_arts
+  status: bounded_implemented_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/character_martial_arts.cpp
+  - src/catalua_ui_martial_arts.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-effects
   selector: u_forget_recipe
   target_kind: shared_service
-  target: services.crafting
-  status: primitive_available_unverified
+  target: services.recipes
+  status: bounded_implemented_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/character_crafting.cpp
+  - src/catalua_ui_crafting.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-effects
   selector: u_knockback
   target_kind: shared_service
@@ -3858,17 +4371,35 @@ entries:
 - inventory: eoc-effects
   selector: u_learn_martial_art
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
+  target: services.martial_arts
+  status: bounded_implemented_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/character_martial_arts.cpp
+  - src/catalua_ui_martial_arts.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-effects
   selector: u_learn_recipe
   target_kind: shared_service
-  target: services.crafting
-  status: primitive_available_unverified
+  target: services.recipes
+  status: bounded_implemented_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/character_crafting.cpp
+  - src/catalua_ui_crafting.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-effects
   selector: u_level_spell_class
   target_kind: shared_service
@@ -3886,10 +4417,19 @@ entries:
 - inventory: eoc-effects
   selector: u_lose_bionic
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
+  target: services.bionics
+  status: bounded_implemented_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/bionics.cpp
+  - src/catalua_ui_bionics.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-effects
   selector: u_lose_category
   target_kind: shared_service
@@ -3900,17 +4440,38 @@ entries:
 - inventory: eoc-effects
   selector: u_lose_effect
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
+  target: services.effects
+  status: bounded_implemented_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/npctalk.cpp
+  - src/creature.cpp
+  - src/catalua_ui_effects.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-effects
   selector: u_lose_morale
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
+  target: services.morale
+  status: bounded_implemented_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/npctalk.cpp
+  - src/talker_character.cpp
+  - src/character_morale.cpp
+  - src/morale.cpp
+  - src/morale_types.cpp
 - inventory: eoc-effects
   selector: u_lose_trait
   target_kind: shared_service
@@ -3984,10 +4545,13 @@ entries:
 - inventory: eoc-effects
   selector: u_pick_bodypart
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
-  legacy_dependency: none
-  evidence: *id001
+  target: services.body-parts-and-wounds
+  status: planned
+  legacy_dependency: public_legacy
+  evidence:
+  - talk_effect_fun::f_pick_bodypart
+  - src/bodypart.cpp
+  - src/npctalk.cpp
 - inventory: eoc-effects
   selector: u_pickup_items
   target_kind: shared_service
@@ -4040,10 +4604,17 @@ entries:
 - inventory: eoc-effects
   selector: u_remove_wound
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
-  legacy_dependency: none
-  evidence: *id001
+  target: services.wounds
+  status: planned
+  legacy_dependency: public_legacy
+  evidence:
+  - talk_effect_fun::f_remove_wound
+  - src/npctalk.cpp
+  - src/bodypart.cpp
+  - src/wound.cpp
+  - src/catalua_platform_runtime.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - data/lua/LUA_FIRST_PLATFORM.md
 - inventory: eoc-effects
   selector: u_roll_remainder
   target_kind: shared_service
@@ -4096,17 +4667,29 @@ entries:
 - inventory: eoc-effects
   selector: u_set_fac_relation
   target_kind: shared_service
-  target: services.characters
+  target: services.factions
   status: primitive_available_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/npctalk.cpp
+  - src/talker_character.cpp
+  - src/catalua_ui_factions.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-effects
   selector: u_set_fault
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
-  legacy_dependency: none
-  evidence: *id001
+  target: services.items
+  status: planned
+  legacy_dependency: public_legacy
+  evidence:
+  - talk_effect_fun::f_set_fault
+  - src/npctalk.cpp
+  - src/catalua_ui_items.cpp
 - inventory: eoc-effects
   selector: u_set_field
   target_kind: shared_service
@@ -4117,31 +4700,46 @@ entries:
 - inventory: eoc-effects
   selector: u_set_flag
   target_kind: shared_service
-  target: services.characters
+  target: services.items
   status: primitive_available_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/npctalk.cpp
+  - src/catalua_ui_items.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-effects
   selector: u_set_goal
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
-  legacy_dependency: none
-  evidence: *id001
+  target: services.npc-navigation
+  status: planned
+  legacy_dependency: public_legacy
+  evidence:
+  - talk_effect_fun::f_npc_goal
+  - src/npctalk.cpp
 - inventory: eoc-effects
   selector: u_set_guard_pos
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
-  legacy_dependency: none
-  evidence: *id001
+  target: services.npc-navigation
+  status: planned
+  legacy_dependency: public_legacy
+  evidence:
+  - talk_effect_fun::f_guard_pos
+  - src/npctalk.cpp
 - inventory: eoc-effects
   selector: u_set_random_fault_of_type
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
-  legacy_dependency: none
-  evidence: *id001
+  target: services.items
+  status: planned
+  legacy_dependency: public_legacy
+  evidence:
+  - talk_effect_fun::f_set_random_fault_of_type
+  - src/npctalk.cpp
+  - src/catalua_ui_items.cpp
 - inventory: eoc-effects
   selector: u_set_talker
   target_kind: shared_service
@@ -4159,10 +4757,18 @@ entries:
 - inventory: eoc-effects
   selector: u_spawn_item
   target_kind: shared_service
-  target: services.items
+  target: services.inventory
   status: primitive_available_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/npctalk.cpp
+  - src/catalua_ui_items.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-effects
   selector: u_spawn_monster
   target_kind: shared_service
@@ -4187,10 +4793,13 @@ entries:
 - inventory: eoc-effects
   selector: u_teleport
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
-  legacy_dependency: none
-  evidence: *id001
+  target: services.relocation
+  status: planned
+  legacy_dependency: public_legacy
+  evidence:
+  - talk_effect_fun::f_teleport
+  - src/npctalk.cpp
+  - src/catalua_ui_world_services.cpp
 - inventory: eoc-effects
   selector: u_transform_radius
   target_kind: shared_service
@@ -4201,17 +4810,27 @@ entries:
 - inventory: eoc-effects
   selector: u_travel_to_dimension
   target_kind: shared_service
-  target: services.characters
-  status: primitive_available_unverified
-  legacy_dependency: none
-  evidence: *id001
+  target: workflows.dimension-travel
+  status: planned
+  legacy_dependency: public_legacy
+  evidence:
+  - talk_effect_fun::f_travel_to_dimension
+  - src/npctalk.cpp
 - inventory: eoc-effects
   selector: u_unset_flag
   target_kind: shared_service
-  target: services.characters
+  target: services.items
   status: primitive_available_unverified
   legacy_dependency: none
-  evidence: *id001
+  evidence:
+  - src/catalua_platform_runtime.cpp
+  - src/catalua_game_handle.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - data/lua/LUA_FIRST_PLATFORM.md
+  - src/npctalk.cpp
+  - src/catalua_ui_items.cpp
+  - data/lua/types/ccb_api_v5.d.lua
 - inventory: eoc-effects
   selector: u_wants_to_talk
   target_kind: shared_service
@@ -4247,12 +4866,13 @@ entries:
   selector: ITEM
   target_kind: platform_domain
   target: content.items
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
   - data/lua/types/ccb_platform_v1.d.lua
   - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
   - data/lua/LUA_FIRST_PLATFORM.md
 - inventory: json-object-types
   selector: ITEM_BLACKLIST
@@ -4266,7 +4886,7 @@ entries:
   selector: ITEM_CATEGORY
   target_kind: platform_domain
   target: content.item-categories
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4279,7 +4899,7 @@ entries:
   selector: LOOT_ZONE
   target_kind: platform_domain
   target: content.zone-types
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4300,19 +4920,20 @@ entries:
   selector: MOD_INFO
   target_kind: platform_domain
   target: platform.mod-metadata
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform.cpp
   - src/mod_manager.cpp
   - data/lua/types/ccb_platform_v1.d.lua
   - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
   - data/lua/LUA_FIRST_PLATFORM.md
 - inventory: json-object-types
   selector: MONSTER
   target_kind: platform_domain
   target: content.monsters
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4334,7 +4955,7 @@ entries:
   selector: MONSTER_FACTION
   target_kind: platform_domain
   target: content.monster-factions
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4363,7 +4984,7 @@ entries:
   selector: SPECIES
   target_kind: platform_domain
   target: content.species
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4416,7 +5037,7 @@ entries:
   selector: activity_type
   target_kind: platform_domain
   target: content.activity-types
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4430,7 +5051,7 @@ entries:
   selector: addiction_type
   target_kind: platform_domain
   target: content.addiction-types
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4443,7 +5064,7 @@ entries:
   selector: ammo_effect
   target_kind: platform_domain
   target: content.ammunition-effects
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4457,7 +5078,7 @@ entries:
   selector: ammunition_type
   target_kind: platform_domain
   target: content.ammunition-types
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4470,7 +5091,7 @@ entries:
   selector: anatomy
   target_kind: platform_domain
   target: content.anatomies
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4483,7 +5104,7 @@ entries:
   selector: ascii_art
   target_kind: platform_domain
   target: content.ascii-art
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4496,7 +5117,7 @@ entries:
   selector: attack_vector
   target_kind: platform_domain
   target: content.attack-vectors
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4509,7 +5130,7 @@ entries:
   selector: bash_damage_profile
   target_kind: platform_domain
   target: content.bash-damage-profiles
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4522,7 +5143,7 @@ entries:
   selector: behavior
   target_kind: platform_domain
   target: content.behavior-trees
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4552,7 +5173,7 @@ entries:
   selector: body_graph
   target_kind: platform_domain
   target: content.body-graphs
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4565,7 +5186,7 @@ entries:
   selector: body_part
   target_kind: platform_domain
   target: content.body-parts
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4594,7 +5215,7 @@ entries:
   selector: character_mod
   target_kind: platform_domain
   target: content.character-modifiers
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4631,7 +5252,7 @@ entries:
   selector: climbing_aid
   target_kind: platform_domain
   target: content.climbing-aids
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4644,7 +5265,7 @@ entries:
   selector: clothing_mod
   target_kind: platform_domain
   target: content.clothing-modifications
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4673,7 +5294,7 @@ entries:
   selector: connect_group
   target_kind: platform_domain
   target: content.connect-groups
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4694,7 +5315,7 @@ entries:
   selector: construction_category
   target_kind: platform_domain
   target: content.construction-categories
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4707,7 +5328,7 @@ entries:
   selector: construction_group
   target_kind: platform_domain
   target: content.construction-groups
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4720,7 +5341,7 @@ entries:
   selector: damage_info_order
   target_kind: platform_domain
   target: content.damage-info-presentation
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4733,7 +5354,7 @@ entries:
   selector: damage_type
   target_kind: platform_domain
   target: content.damage-types
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4762,7 +5383,7 @@ entries:
   selector: disease_type
   target_kind: platform_domain
   target: content.disease-types
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4799,7 +5420,7 @@ entries:
   selector: effect_type
   target_kind: platform_domain
   target: content.effect-types
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4812,7 +5433,7 @@ entries:
   selector: emit
   target_kind: platform_domain
   target: content.emissions
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4834,7 +5455,7 @@ entries:
   selector: end_screen
   target_kind: platform_domain
   target: content.end-screens
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4863,7 +5484,7 @@ entries:
   selector: explosion_light
   target_kind: platform_domain
   target: content.explosion-lights
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4908,7 +5529,7 @@ entries:
   selector: fault_group
   target_kind: platform_domain
   target: content.fault-groups
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4921,7 +5542,7 @@ entries:
   selector: field_type
   target_kind: platform_domain
   target: content.field-types
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4975,7 +5596,7 @@ entries:
   selector: harvest
   target_kind: platform_domain
   target: content.harvest-lists
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -4988,7 +5609,7 @@ entries:
   selector: harvest_drop_type
   target_kind: platform_domain
   target: content.harvest-drop-types
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5001,7 +5622,7 @@ entries:
   selector: help
   target_kind: platform_domain
   target: content.help-topics
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5014,7 +5635,7 @@ entries:
   selector: hit_range
   target_kind: platform_domain
   target: content.hit-range
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5035,7 +5656,7 @@ entries:
   selector: item_group
   target_kind: platform_domain
   target: content.item-groups
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5057,7 +5678,7 @@ entries:
   selector: json_flag
   target_kind: platform_domain
   target: content.flags
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5070,7 +5691,7 @@ entries:
   selector: limb_score
   target_kind: platform_domain
   target: content.limb-scores
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5083,7 +5704,7 @@ entries:
   selector: magic_type
   target_kind: platform_domain
   target: content.magic-types
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5106,7 +5727,7 @@ entries:
   selector: map_extra_collection
   target_kind: platform_domain
   target: content.map-extra-collections
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5135,7 +5756,7 @@ entries:
   selector: material
   target_kind: platform_domain
   target: content.materials
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5180,7 +5801,7 @@ entries:
   selector: monster_attack
   target_kind: platform_domain
   target: content.monster-attacks
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5193,7 +5814,7 @@ entries:
   selector: monster_flag
   target_kind: platform_domain
   target: content.monster-flags
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5214,7 +5835,7 @@ entries:
   selector: mood_face
   target_kind: platform_domain
   target: content.mood-faces
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5227,7 +5848,7 @@ entries:
   selector: morale_type
   target_kind: platform_domain
   target: content.morale-types
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5240,7 +5861,7 @@ entries:
   selector: movement_mode
   target_kind: platform_domain
   target: content.movement-modes
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5261,7 +5882,7 @@ entries:
   selector: mutation_category
   target_kind: platform_domain
   target: content.mutation-categories
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5274,7 +5895,7 @@ entries:
   selector: mutation_type
   target_kind: platform_domain
   target: content.mutation-types
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5287,7 +5908,7 @@ entries:
   selector: named_color
   target_kind: platform_domain
   target: content.named-colors
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5300,7 +5921,7 @@ entries:
   selector: nested_category
   target_kind: platform_domain
   target: content.nested-recipe-categories
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5354,7 +5975,7 @@ entries:
   selector: oter_vision
   target_kind: platform_domain
   target: content.overmap-vision
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5367,7 +5988,7 @@ entries:
   selector: overlay_order
   target_kind: platform_domain
   target: content.overlay-order
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5388,7 +6009,7 @@ entries:
   selector: overmap_land_use_code
   target_kind: platform_domain
   target: content.overmap-land-use-codes
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5401,7 +6022,7 @@ entries:
   selector: overmap_location
   target_kind: platform_domain
   target: content.overmap-locations
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5446,7 +6067,7 @@ entries:
   selector: playlist
   target_kind: platform_domain
   target: content.playlists
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5492,7 +6113,7 @@ entries:
   selector: profession_group
   target_kind: platform_domain
   target: content.profession-groups
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5513,7 +6134,7 @@ entries:
   selector: proficiency
   target_kind: platform_domain
   target: content.proficiencies
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5526,7 +6147,7 @@ entries:
   selector: proficiency_category
   target_kind: platform_domain
   target: content.proficiency-categories
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5547,18 +6168,19 @@ entries:
   selector: recipe
   target_kind: platform_domain
   target: content.recipes
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
   - data/lua/types/ccb_platform_v1.d.lua
   - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
   - data/lua/LUA_FIRST_PLATFORM.md
 - inventory: json-object-types
   selector: recipe_category
   target_kind: platform_domain
   target: content.recipe-categories
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5571,7 +6193,7 @@ entries:
   selector: recipe_group
   target_kind: platform_domain
   target: content.recipe-groups
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5696,7 +6318,7 @@ entries:
   selector: requirement
   target_kind: platform_domain
   target: content.requirements
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5709,7 +6331,7 @@ entries:
   selector: rotatable_symbol
   target_kind: platform_domain
   target: content.rotatable-symbols
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5730,7 +6352,7 @@ entries:
   selector: scent_type
   target_kind: platform_domain
   target: content.scent-types
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5743,7 +6365,7 @@ entries:
   selector: score
   target_kind: platform_domain
   target: content.scores
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5780,7 +6402,7 @@ entries:
   selector: skill
   target_kind: platform_domain
   target: content.skills
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5793,7 +6415,7 @@ entries:
   selector: skill_display_type
   target_kind: platform_domain
   target: content.skill-display-categories
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5806,7 +6428,7 @@ entries:
   selector: snippet
   target_kind: platform_domain
   target: content.snippet-categories
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5836,7 +6458,7 @@ entries:
   selector: speech
   target_kind: platform_domain
   target: content.speech-pools
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5849,7 +6471,7 @@ entries:
   selector: speed_description
   target_kind: platform_domain
   target: content.speed-descriptions
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5870,7 +6492,7 @@ entries:
   selector: start_location
   target_kind: platform_domain
   target: content.start-locations
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5883,7 +6505,7 @@ entries:
   selector: sub_body_part
   target_kind: platform_domain
   target: content.sub-body-parts
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -5952,7 +6574,7 @@ entries:
   selector: tool_quality
   target_kind: platform_domain
   target: content.tool-qualities
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -6021,7 +6643,7 @@ entries:
   selector: vehicle_group
   target_kind: platform_domain
   target: content.vehicle-groups
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -6042,7 +6664,7 @@ entries:
   selector: vehicle_part_category
   target_kind: platform_domain
   target: content.vehicle-part-categories
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -6055,7 +6677,7 @@ entries:
   selector: vehicle_part_location
   target_kind: platform_domain
   target: content.vehicle-part-locations
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -6092,7 +6714,7 @@ entries:
   selector: vitamin
   target_kind: platform_domain
   target: content.vitamins
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -6105,7 +6727,7 @@ entries:
   selector: weakpoint_set
   target_kind: platform_domain
   target: content.weakpoint-sets
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -6118,7 +6740,7 @@ entries:
   selector: weapon_category
   target_kind: platform_domain
   target: content.weapon-categories
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -6139,7 +6761,7 @@ entries:
   selector: weather_type
   target_kind: platform_domain
   target: content.weather-types
-  status: implemented_unverified
+  status: bounded_implemented_unverified
   legacy_dependency: none
   evidence:
   - src/catalua_platform_runtime.cpp
@@ -6160,16 +6782,28 @@ entries:
 - inventory: json-object-types
   selector: wound
   target_kind: platform_domain
-  target: content.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target: content.wounds
+  status: bounded_implemented_unverified
+  legacy_dependency: none
   evidence:
-  - src/init.cpp
+  - src/catalua_platform_runtime.cpp
+  - src/wound.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md
 - inventory: json-object-types
   selector: wound_fix
   target_kind: platform_domain
-  target: content.gameplay
-  status: planned
-  legacy_dependency: public_legacy
+  target: content.wound-fixes
+  status: bounded_implemented_unverified
+  legacy_dependency: none
   evidence:
-  - src/init.cpp
+  - src/catalua_platform_runtime.cpp
+  - src/wound.cpp
+  - data/lua/types/ccb_platform_v1.d.lua
+  - tests/catalua_ui_test.cpp
+  - tools/migrate_lua_first.py
+  - tools/test_migrate_lua_first.py
+  - data/lua/LUA_FIRST_PLATFORM.md

--- a/ai/lua-first-roadmap.yml
+++ b/ai/lua-first-roadmap.yml
@@ -58,6 +58,8 @@ milestones:
       - Exported native references reject stale owners and generations.
       - Private legacy adapters are inventoried and not publicly callable.
     evidence:
+      - src/catalua_game_handle.h
+      - src/catalua_game_handle.cpp
       - src/catalua_platform_runtime.h
       - src/catalua_platform_runtime.cpp
       - src/game_io.cpp
@@ -139,8 +141,8 @@ capabilities:
       - src/mod_manager.h
       - tests/catalua_ui_test.cpp
     next_actions:
-      - Run the written discovery, metadata, path-confinement, and hybrid tests.
-      - Verify rejected pure-Platform entries stay visible and unavailable while rejected optional hybrid entries retain legacy availability, including builds without Lua support.
+      - The 2026-08-11 Lua-enabled local C++ Platform suite passed the written discovery, metadata, path-confinement, hybrid, and rejected-entry coverage; keep these as regression gates.
+      - Complete the still-open no-Lua build variant and desktop/Android Mod-selector interaction checks without weakening visibility of rejected pure-Platform entries or legacy availability of rejected optional hybrid entries.
   - id: trusted-standard-library
     phase: bootstrap
     status: partial
@@ -152,13 +154,13 @@ capabilities:
       - tests/catalua_ui_test.cpp
       - src/lua/lua.h
     next_actions:
-      - Run the written full-library, per-Mod isolation, and candidate rollback tests.
-      - Verify first-enable confirmation covers direct Platform selections and newly pulled Platform dependencies on desktop and Android UIs.
+      - The 2026-08-11 local C++ Platform suite passed the full-library, per-Mod isolation, and candidate rollback coverage; keep these as regression gates.
+      - Complete the still-open desktop and Android first-enable interaction checks for direct Platform selections and newly pulled Platform dependencies.
   - id: static-native-content
     phase: content
     status: partial
     legacy_dependency: none
-    target_surface: ccb.content with transactional foundational, proficiency, category, ammunition, scent, speed-description, harvest-drop, harvest-list, behavior-tree, monster-attack, effect-type, weakpoint-set, field-type, item-group, sub-body-part, body-part, anatomy, body-graph, monster, morale, disease, monster-flag, species, emission, monster-faction, mutation-type, mutation-category, connect-group, construction, vehicle, mood-face, damage-info presentation, named-color, rotatable-symbol, ASCII-art, limb-score, global hit-range, bash-damage, clothing-modification, overmap-land-use, overmap-vision, overmap-location, profession-group, map-extra-collection, vehicle-group, fault-group, explosion-light, ammunition-effect, addiction-type, character-modifier, start-location, climbing-aid, weather-type, score, global mutation-overlay order, zone-type, speech-pool, end-screen, activity-type, help-topic, snippet-category, playlist, nested-recipe-category, attack-vector, magic-type, movement-mode, item, and recipe definitions
+    target_surface: ccb.content with transactional foundational, proficiency, category, ammunition, scent, speed-description, harvest-drop, harvest-list, behavior-tree, monster-attack, effect-type, weakpoint-set, field-type, item-group, sub-body-part, body-part, wound, wound-fix, anatomy, body-graph, monster, morale, disease, monster-flag, species, emission, monster-faction, mutation-type, mutation-category, connect-group, construction, vehicle, mood-face, damage-info presentation, named-color, rotatable-symbol, ASCII-art, limb-score, global hit-range, bash-damage, clothing-modification, overmap-land-use, overmap-vision, overmap-location, profession-group, map-extra-collection, vehicle-group, fault-group, explosion-light, ammunition-effect, addiction-type, character-modifier, start-location, climbing-aid, weather-type, score, global mutation-overlay order, zone-type, speech-pool, end-screen, activity-type, help-topic, snippet-category, playlist, nested-recipe-category, attack-vector, magic-type, movement-mode, item, and recipe definitions
     evidence:
       - src/catalua_platform.cpp
       - src/catalua_platform_runtime.cpp
@@ -170,6 +172,7 @@ capabilities:
       - src/field_type.cpp
       - src/weakpoint.cpp
       - src/bodypart.cpp
+      - src/wound.cpp
       - src/subbodypart.cpp
       - src/anatomy.cpp
       - src/bodygraph.cpp
@@ -179,18 +182,20 @@ capabilities:
       - data/lua/types/ccb_platform_v1.d.lua
       - tests/catalua_ui_test.cpp
     next_actions:
-      - Run the written native transaction, rollback, stale-handle, finalization, creature-catalog, and monster-attack policy tests.
-      - Keep the creature registrars implemented_unverified until the validation gate proves native retention, inverse rollback, and generation-safe callback behavior.
-      - Continue typed registrars beyond the implemented domains without exposing JSON-loader or EOC-runner compatibility surfaces.
+      - The 2026-08-11 local C++ Platform suite passed the written native transaction, rollback, stale-handle, finalization, creature-catalog, and monster-attack policy coverage; focused Wound/WoundFix coverage passed 5 cases and 321 assertions.
+      - The 2026-08-11 unified `[lua]` run passed 190 matching test cases and 2706 assertions, including pre-finalize Monster scaling and adjustment ownership plus idempotent body-part and sub-body-part similarity caches; keep these as regression gates.
+      - Retain bounded dispositions for the documented creature slice; the local gate is evidence for that slice, while field-by-field expansion remains required before full JSON object-type parity.
+      - The bounded concrete `wound` and `wound_fix` extractor now has source-backed conversion tests and emits native builders for finite ranges, typed links, body-part filters, treatment skills/proficiencies, wound sets, and referenced requirements; keep inheritance, implicit indefinite healing, rich translation metadata, and inline requirements partial.
+      - Continue field-complete typed registrar and extractor coverage without exposing JSON-loader or EOC-runner compatibility surfaces.
   - id: native-object-surface
     phase: bindings
     status: partial
     legacy_dependency: none
     target_surface: All bindable public members of explicitly exported native types
-    evidence: [src/catalua_bindings_values.cpp, data/lua/types/ccb_api_v5.d.lua]
+    evidence: [src/catalua_bindings_values.cpp, src/catalua_game_handle.h, src/catalua_game_handle.cpp, tests/catalua_ui_test.cpp, data/lua/types/ccb_api_v5.d.lua]
     next_actions:
       - Add an export-root inventory and report every unbindable public member.
-      - Add owner and generation checks to borrowed native references.
+      - GameHandle plus MissionToken, HordeEntityToken, LegacyHordeToken, and ZoneToken now reject foreign or expired runtime owners in addition to stale runtime/world generations; token equality retains stable weak owner identity after shutdown, and the inactive state remains distinct from every numeric generation. Extend the same explicit-owner model to remaining borrowed native references.
   - id: runtime-events-hooks-callbacks
     phase: runtime
     status: partial
@@ -198,9 +203,8 @@ capabilities:
     target_surface: Typed events, synchronous hooks, and definition callbacks
     evidence: [src/catalua_platform_runtime.cpp, src/catalua_ui.cpp, data/lua/types/ccb_platform_v1.d.lua, data/lua/reference/ccb_public_api_v5.json]
     next_actions:
-      - Verify Platform lifecycle, native game-event, ItemUseContext handles/position, and missing-handler behaviour.
-      - Verify synchronous decision aggregation, typed handles, recursion bounds, and v5 composition.
-      - Verify runtime-only hot reload preserves state, tasks, task ids, and the gameplay random stream and rejects static fingerprint changes.
+      - The 2026-08-11 local C++ Platform suite passed lifecycle, audited semantic event actors and item allowlist, ItemUseContext, missing-handler, decision aggregation, typed-handle, recursion, v5-composition, and runtime-only hot-reload coverage; keep these as regression gates.
+      - Extend semantic actor-kind coverage beyond the audited events and exercise the runtime through the still-open installed-Mod discovery, load, save, reload, and gameplay end-to-end gate.
   - id: presentation-primitives
     phase: runtime
     status: partial
@@ -208,7 +212,8 @@ capabilities:
     target_surface: Callback-only native notice, confirmation, stable-id choice, and text input primitives
     evidence: [src/catalua_platform_runtime.cpp, data/lua/types/ccb_platform_v1.d.lua, tests/catalua_ui_test.cpp, data/lua/LUA_FIRST_PLATFORM.md]
     next_actions:
-      - Run the written non-interactive boundary tests and interactive desktop/Android presentation tests.
+      - The non-interactive callback boundary coverage passed in the 2026-08-11 local C++ Platform suite; keep it as a regression gate.
+      - Complete the still-open interactive desktop and Android presentation checks.
       - Add richer composable forms only as domain objects, not popup- or EOC-key-shaped wrappers.
   - id: persistent-tasks-and-state
     phase: runtime
@@ -217,17 +222,24 @@ capabilities:
     target_surface: Named tasks and serializable character/world state
     evidence: [src/catalua_platform_runtime.cpp, src/catalua_ui_state.cpp, src/do_turn.cpp, src/game_io.cpp, data/lua/templates/complete/runtime/behaviour.lua]
     next_actions:
-      - Run save/load, overdue, missing-handler, payload-version, orphan-preservation, size-limit, and corruption tests.
-      - Verify explicit payload migration chains preserve tasks on missing, cyclic, failing, or invalid transitions.
+      - The 2026-08-11 local C++ Platform suite passed save/load, overdue, missing-handler, payload-version and migration-chain, orphan-preservation, size-limit, and corruption coverage; keep these as regression gates.
+      - Exercise task and typed-state survival through the still-open installed-Mod discovery, load, save, reload, and gameplay end-to-end gate.
   - id: shared-domain-services
     phase: runtime
     status: partial
     legacy_dependency: none
     target_surface: Game-domain services shared by Platform and legacy adapters
-    evidence: [src/catalua_platform_runtime.cpp, src/catalua_game_handle.cpp, src/catalua_ui_creatures.cpp, src/catalua_ui_items.cpp, src/catalua_ui_world.cpp, src/catalua_ui_vehicles.cpp, src/catalua_ui_missions.cpp, src/catalua_ui_magic.cpp, ai/lua-first-replacement-ledger.yml]
+    evidence: [src/catalua_platform_runtime.cpp, src/catalua_game_handle.cpp, src/catalua_ui_creatures.cpp, src/catalua_ui_items.cpp, src/catalua_ui_world.cpp, src/catalua_ui_vehicles.cpp, src/catalua_ui_missions.cpp, src/catalua_ui_magic.cpp, data/lua/types/ccb_platform_v1.d.lua, tests/catalua_ui_test.cpp, data/lua/LUA_FIRST_PLATFORM.md, ai/lua-first-replacement-ledger.yml]
     next_actions:
-      - Review the 479 primitive-available selectors against exact native semantics.
-      - Implement missing gameplay and richer presentation primitives before promoting selector-level parity.
+      - Review the remaining primitive-available selectors against exact native semantics.
+      - Extend the first exact predicate/effect slice beyond string comparison, isolated probability, contested rolls, active-Mod visibility, dimensions, typed map-environment queries, typed avatar single/any-mutation, martial-art, proficiency, specific/any-bionic, learned-recipe, literal item-presence, and literal movement-mode state, achievement awards, avatar bionic installation/removal, literal one-recipe and category/subcategory recipe changes, presentation-independent martial-art learning/forgetting, bounded literal morale changes, and bounded literal creature-effect changes.
+      - The 2026-08-11 local C++ Platform suite passed the documented semantic-event-actor, per-handler payload-isolation, global-recursion, and Platform-only dialogue-projection slices; expand actor-kind proof beyond audited events before converting other actor-dependent `u_*` or `npc_*` shapes, without publishing EOC alpha/beta aliases.
+      - The local C++ coverage passed the written Character activity snapshot, plain time-based assignment, side-effect-free no-op cancellation, duration boundary, native-actor/handler, EOC-policy, multi-activity, automatic-needs, and non-time rejection policies; selector promotion still requires exact migrator-shape evidence.
+      - Extend the locally verified native-order exact-part wound service only through explicit Lua-native policies; keep the four legacy wound selectors planned because their next-best and limit semantics differ.
+      - Add specialized activity-actor construction, wetness, combat-damage, NPC-navigation, and typed relocation services before promoting their audited selectors.
+      - The local C++ coverage passed the documented singular wielded-item query, force-unarmed composition, semantic item-event routing, and instance-owned flag-change reporting slices; promote only actor and event shapes whose legacy talker kinds are proven.
+      - The 2026-08-11 local C++ Platform suite passed the typed bionic summary, capacity-without-instance, learned-recipe query, one-recipe mutation, and category/subcategory forgetting slice; keep dynamic ids and unproven actor shapes partial.
+      - Implement missing environment, dialogue, specialized activity, and richer presentation primitives before promoting selector-level parity.
   - id: developer-templates
     phase: tooling
     status: partial
@@ -235,8 +247,8 @@ capabilities:
     target_surface: Minimal and complete templates plus create_lua_mod.py
     evidence: [tools/create_lua_mod.py, tools/test_create_lua_mod.py, data/lua/templates/minimal/main.lua, data/lua/templates/complete/main.lua, data/mods/Lua_First_Example/main.lua]
     next_actions:
-      - Run scaffold atomic-install, empty-target restoration, concurrent-target preservation, non-overwrite, symlink refusal, Mod-id namespace, and zero-JSON tests.
-      - Run the bundled installed-Mod smoke fixture through discovery, save/load, and gameplay.
+      - The 2026-08-11 local creator/migrator unit-test run passed all 55 cases (46 extractor plus 9 creator), including scaffold atomic-install, empty-target restoration, concurrent-target preservation, non-overwrite, symlink refusal, Mod-id namespace, zero-JSON coverage, and bounded Wound/WoundFix extraction; keep these as regression gates.
+      - Complete the still-open bundled installed-Mod smoke fixture through discovery, load, save, reload, and gameplay.
   - id: migration-extractor
     phase: migration
     status: partial
@@ -247,9 +259,14 @@ capabilities:
       - tools/test_migrate_lua_first.py
       - data/lua/LUA_FIRST_PLATFORM.md
     next_actions:
-      - Run JSONC parser, native-range partial-classification, transactional force rollback, no-overwrite, freshness-check, and no-legacy-output tests.
-      - Run the creature-catalog fixture for monster attacks, effects, weakpoints, fields, item groups, anatomy, body graphs, and monsters.
+      - The 2026-08-11 local creator/migrator unit-test run passed all 55 cases (46 extractor plus 9 creator), including JSONC parsing, native-range partial classification, transactional force rollback, no-overwrite, freshness, no-legacy-output coverage, and bounded Wound/WoundFix extraction; keep these as regression gates.
+      - The local creature-catalog migration fixture passed for monster attacks, effects, weakpoints, fields, item groups, anatomy, body graphs, and monsters; retain bounded classifications until field-by-field parity is proven.
+      - The bounded concrete Wound/WoundFix migration fixtures convert native-builder fields and keep inheritance, implicit indefinite healing, translation metadata, and inline Requirement objects as explicit TODOs without a legacy loader; Platform UTF-8 byte-limit violations, contradictory body-part flags, and proficiency multipliers that become non-positive as native floats now fail closed as explicit TODOs or rejected definitions.
+      - Extend bounded predicate/effect conversion beyond literal string, probability, contested-roll, Mod-visibility, typed avatar mutation/martial-art/proficiency/specific-or-any-bionic/learned-recipe/literal-item-presence/literal-movement-mode state, native Boolean-composition, achievement-award, avatar-bionic add/remove, one-recipe and category/subcategory recipe changes, martial-art learn/forget, exact default-timing morale add/remove, and literal bounded-duration effect add/remove shapes.
+      - 'Local migration coverage confirms that even literal/proven-Character `u_add_wound`, `npc_add_wound`, `u_remove_wound`, and `npc_remove_wound` shapes emit TODOs; keep them planned because legacy handlers may select a next-best body part and legacy add bypasses the per-part limit, while the Lua-native service is exact-part and limit-aware, and do not add a compatibility entry point.'
+      - Keep dynamic bionic/recipe ids, dynamic recipe subcategories, NPC targets, and unproven actor contexts partial until their value and actor semantics have typed source-backed conversion evidence.
       - Add typed conversions only after each target native registrar exists.
+      - The local migration coverage confirms that the private game_start avatar binding is gated by the checked canonical sender set rather than only the event name; retain that gate while extending actor proof to other contexts.
   - id: replacement-audit
     phase: migration
     status: partial
@@ -262,5 +279,6 @@ capabilities:
       - ai/lua-first-replacement-ledger.yml
       - tools/agent/check_lua_first_replacement_ledger.py
     next_actions:
-      - Run schema, generator freshness, uniqueness, and exact-denominator checks.
+      - The 2026-08-11 local schema, generator-freshness, uniqueness, and exact-denominator checks passed for all 775 dispositions; keep these as regression gates.
+      - Keep full, bounded, primitive-only, planned, private-adapter, and not-applicable counts distinct; a bounded shape never establishes whole-selector parity.
       - Review primitive-available selectors for semantic parity and all remaining planned entries domain by domain using the generated ledger summary.

--- a/ai/lua-first-roadmap.yml
+++ b/ai/lua-first-roadmap.yml
@@ -37,58 +37,88 @@ milestones:
       - data/lua/AGENTS.md
   - id: zero-config-discovery
     title: Root main.lua discovery and optional native mod.lua metadata
-    status: planned
+    status: in_progress
     depends_on: [documentation-foundation]
     exit_criteria:
       - A directory containing only main.lua is discoverable as a Mod.
       - No lua subdirectory, manifest.json, or modinfo.json is required.
       - Optional mod.lua resolves dependencies before content loading.
-    evidence: []
+    evidence:
+      - src/catalua_platform.h
+      - src/catalua_platform.cpp
+      - src/mod_manager.cpp
+      - tests/catalua_ui_test.cpp
+      - data/lua/types/ccb_platform_v1.d.lua
   - id: native-content-transaction
     title: Pre-finalize native content objects and transactional commit
-    status: planned
+    status: in_progress
     depends_on: [zero-config-discovery]
     exit_criteria:
       - Platform content runs before global data finalization.
       - Exported native references reject stale owners and generations.
       - Private legacy adapters are inventoried and not publicly callable.
-    evidence: []
+    evidence:
+      - src/catalua_platform_runtime.h
+      - src/catalua_platform_runtime.cpp
+      - src/game_io.cpp
+      - tests/catalua_ui_test.cpp
+      - data/lua/types/ccb_platform_v1.d.lua
   - id: item-recipe-use-slice
     title: Zero-JSON/EOC item, recipe, and Lua use behaviour
-    status: planned
+    status: in_progress
     depends_on: [native-content-transaction]
     exit_criteria:
       - The example Mod loads with no JSON or EOC files.
       - The item and recipe preserve stable ids through save/load.
       - A named Lua handler produces an observable in-game result.
-    evidence: []
+    evidence:
+      - src/catalua_platform_runtime.cpp
+      - data/lua/templates/complete/main.lua
+      - data/lua/templates/complete/runtime/behaviour.lua
+      - tools/create_lua_mod.py
+      - tests/catalua_ui_test.cpp
   - id: behaviour-services
     title: Events, hooks, callbacks, persistent tasks, state, and shared domain services
-    status: planned
+    status: in_progress
     depends_on: [item-recipe-use-slice]
     exit_criteria:
       - EOC handler logic is mapped to shared services rather than key-shaped bindings.
       - Named tasks resume from serializable data after save/load.
       - Workflows can be authored as Lua libraries over the primitive APIs.
-    evidence: []
+    evidence:
+      - src/catalua_platform_runtime.cpp
+      - src/do_turn.cpp
+      - src/game.cpp
+      - src/game_io.cpp
+      - data/lua/types/ccb_platform_v1.d.lua
+      - tests/catalua_ui_test.cpp
   - id: static-domain-coverage
     title: Complete author-facing static content coverage
-    status: planned
+    status: in_progress
     depends_on: [behaviour-services]
     exit_criteria:
       - Every checked JSON/EOC entry has a reviewed replacement disposition.
       - Every supported domain has native registration, tests, declarations, and documentation.
       - No available Platform capability publicly requires a legacy parser.
-    evidence: []
+    evidence:
+      - ai/lua-first-replacement-ledger.yml
+      - ai/lua-first-replacement-ledger.schema.json
+      - tools/agent/generate_lua_first_replacement_ledger.py
+      - tools/agent/check_lua_first_replacement_ledger.py
+      - tools/agent/test_lua_first_replacement_ledger.py
   - id: core-and-bundled-migration
     title: Migrate core and bundled content and freeze covered legacy authoring
-    status: planned
+    status: in_progress
     depends_on: [static-domain-coverage]
     exit_criteria:
       - Targeted core and bundled content is Lua-authored with stable ids.
       - Migration tools emit native-object Lua skeletons and explicit TODOs.
       - New JSON/EOC features are frozen only in domains with complete replacements.
-    evidence: []
+    evidence:
+      - tools/migrate_lua_first.py
+      - tools/test_migrate_lua_first.py
+      - data/mods/Lua_First_Example/main.lua
+      - data/mods/Lua_First_Example/README.md
   - id: legacy-removal-window
     title: Complete deprecation window and allow legacy author-interface removal
     status: planned
@@ -101,31 +131,57 @@ milestones:
 capabilities:
   - id: mod-discovery
     phase: discovery
-    status: absent
-    legacy_dependency: public_legacy
+    status: partial
+    legacy_dependency: none
     target_surface: Root main.lua with optional native mod.lua metadata
-    evidence: [src/mod_manager.cpp]
+    evidence:
+      - src/mod_manager.cpp
+      - src/mod_manager.h
+      - tests/catalua_ui_test.cpp
     next_actions:
-      - Add Platform discovery beside legacy modinfo.json scanning.
-      - Define deterministic defaults and hybrid metadata conflict errors.
+      - Run the written discovery, metadata, path-confinement, and hybrid tests.
+      - Verify rejected pure-Platform entries stay visible and unavailable while rejected optional hybrid entries retain legacy availability, including builds without Lua support.
   - id: trusted-standard-library
     phase: bootstrap
-    status: legacy_only
+    status: partial
     legacy_dependency: none
     target_surface: Complete Lua 5.4 standard libraries and native package loading
-    evidence: [src/catalua_ui.cpp, src/lua/lua.h]
+    evidence:
+      - src/catalua_platform.cpp
+      - src/mod_manager_ui.cpp
+      - tests/catalua_ui_test.cpp
+      - src/lua/lua.h
     next_actions:
-      - Introduce a separately versioned Platform state without v5 capability filtering.
-      - Add user-visible trust warnings for installed and enabled Platform Mods.
+      - Run the written full-library, per-Mod isolation, and candidate rollback tests.
+      - Verify first-enable confirmation covers direct Platform selections and newly pulled Platform dependencies on desktop and Android UIs.
   - id: static-native-content
     phase: content
-    status: absent
-    legacy_dependency: public_legacy
-    target_surface: ccb.content with exported native definition objects
-    evidence: [src/init.cpp, src/game_io.cpp]
+    status: partial
+    legacy_dependency: none
+    target_surface: ccb.content with transactional foundational, proficiency, category, ammunition, scent, speed-description, harvest-drop, harvest-list, behavior-tree, monster-attack, effect-type, weakpoint-set, field-type, item-group, sub-body-part, body-part, anatomy, body-graph, monster, morale, disease, monster-flag, species, emission, monster-faction, mutation-type, mutation-category, connect-group, construction, vehicle, mood-face, damage-info presentation, named-color, rotatable-symbol, ASCII-art, limb-score, global hit-range, bash-damage, clothing-modification, overmap-land-use, overmap-vision, overmap-location, profession-group, map-extra-collection, vehicle-group, fault-group, explosion-light, ammunition-effect, addiction-type, character-modifier, start-location, climbing-aid, weather-type, score, global mutation-overlay order, zone-type, speech-pool, end-screen, activity-type, help-topic, snippet-category, playlist, nested-recipe-category, attack-vector, magic-type, movement-mode, item, and recipe definitions
+    evidence:
+      - src/catalua_platform.cpp
+      - src/catalua_platform_runtime.cpp
+      - src/harvest.cpp
+      - src/behavior.cpp
+      - src/behavior_oracle.cpp
+      - src/emit.cpp
+      - src/effect.cpp
+      - src/field_type.cpp
+      - src/weakpoint.cpp
+      - src/bodypart.cpp
+      - src/subbodypart.cpp
+      - src/anatomy.cpp
+      - src/bodygraph.cpp
+      - src/monstergenerator.cpp
+      - src/map_field.cpp
+      - src/game_io.cpp
+      - data/lua/types/ccb_platform_v1.d.lua
+      - tests/catalua_ui_test.cpp
     next_actions:
-      - Add a pre-finalize Platform execution phase and staging registry.
-      - Define add, replace, edit, commit, and static fingerprint semantics.
+      - Run the written native transaction, rollback, stale-handle, finalization, creature-catalog, and monster-attack policy tests.
+      - Keep the creature registrars implemented_unverified until the validation gate proves native retention, inverse rollback, and generation-safe callback behavior.
+      - Continue typed registrars beyond the implemented domains without exposing JSON-loader or EOC-runner compatibility surfaces.
   - id: native-object-surface
     phase: bindings
     status: partial
@@ -140,46 +196,71 @@ capabilities:
     status: partial
     legacy_dependency: none
     target_surface: Typed events, synchronous hooks, and definition callbacks
-    evidence: [src/catalua_ui.cpp, data/lua/reference/ccb_public_api_v5.json]
+    evidence: [src/catalua_platform_runtime.cpp, src/catalua_ui.cpp, data/lua/types/ccb_platform_v1.d.lua, data/lua/reference/ccb_public_api_v5.json]
     next_actions:
-      - Define Platform-native callback arguments instead of snapshots and talker aliases.
-      - Preserve stable handler ids across runtime reloads.
+      - Verify Platform lifecycle, native game-event, ItemUseContext handles/position, and missing-handler behaviour.
+      - Verify synchronous decision aggregation, typed handles, recursion bounds, and v5 composition.
+      - Verify runtime-only hot reload preserves state, tasks, task ids, and the gameplay random stream and rejects static fingerprint changes.
+  - id: presentation-primitives
+    phase: runtime
+    status: partial
+    legacy_dependency: none
+    target_surface: Callback-only native notice, confirmation, stable-id choice, and text input primitives
+    evidence: [src/catalua_platform_runtime.cpp, data/lua/types/ccb_platform_v1.d.lua, tests/catalua_ui_test.cpp, data/lua/LUA_FIRST_PLATFORM.md]
+    next_actions:
+      - Run the written non-interactive boundary tests and interactive desktop/Android presentation tests.
+      - Add richer composable forms only as domain objects, not popup- or EOC-key-shaped wrappers.
   - id: persistent-tasks-and-state
     phase: runtime
     status: partial
     legacy_dependency: none
     target_surface: Named tasks and serializable character/world state
-    evidence: [src/catalua_ui.cpp, src/catalua_ui_state.cpp]
+    evidence: [src/catalua_platform_runtime.cpp, src/catalua_ui_state.cpp, src/do_turn.cpp, src/game_io.cpp, data/lua/templates/complete/runtime/behaviour.lua]
     next_actions:
-      - Persist mod id, handler id, due time, owner, payload, and payload version.
-      - Specify missing-handler, overdue-task, and migration outcomes.
+      - Run save/load, overdue, missing-handler, payload-version, orphan-preservation, size-limit, and corruption tests.
+      - Verify explicit payload migration chains preserve tasks on missing, cyclic, failing, or invalid transitions.
   - id: shared-domain-services
     phase: runtime
-    status: absent
-    legacy_dependency: public_legacy
+    status: partial
+    legacy_dependency: none
     target_surface: Game-domain services shared by Platform and legacy adapters
-    evidence: [src/condition.cpp, src/npctalk.cpp, src/effect_on_condition.cpp]
+    evidence: [src/catalua_platform_runtime.cpp, src/catalua_game_handle.cpp, src/catalua_ui_creatures.cpp, src/catalua_ui_items.cpp, src/catalua_ui_world.cpp, src/catalua_ui_vehicles.cpp, src/catalua_ui_missions.cpp, src/catalua_ui_magic.cpp, ai/lua-first-replacement-ledger.yml]
     next_actions:
-      - Classify existing handlers by underlying query or mutation service.
-      - Extract the item, recipe, morale, mission, character, and map vertical slice first.
+      - Review the 479 primitive-available selectors against exact native semantics.
+      - Implement missing gameplay and richer presentation primitives before promoting selector-level parity.
   - id: developer-templates
     phase: tooling
-    status: absent
+    status: partial
     legacy_dependency: none
     target_surface: Minimal and complete templates plus create_lua_mod.py
-    evidence: [tools/lua_api/README.md]
+    evidence: [tools/create_lua_mod.py, tools/test_create_lua_mod.py, data/lua/templates/minimal/main.lua, data/lua/templates/complete/main.lua, data/mods/Lua_First_Example/main.lua]
     next_actions:
-      - Ship executable templates with the item-recipe-use vertical slice.
-      - Generate no JSON and never overwrite an existing non-empty target.
+      - Run scaffold atomic-install, empty-target restoration, concurrent-target preservation, non-overwrite, symlink refusal, Mod-id namespace, and zero-JSON tests.
+      - Run the bundled installed-Mod smoke fixture through discovery, save/load, and gameplay.
+  - id: migration-extractor
+    phase: migration
+    status: partial
+    legacy_dependency: none
+    target_surface: Deterministic legacy content extraction into native Lua skeletons and TODO reports
+    evidence:
+      - tools/migrate_lua_first.py
+      - tools/test_migrate_lua_first.py
+      - data/lua/LUA_FIRST_PLATFORM.md
+    next_actions:
+      - Run JSONC parser, native-range partial-classification, transactional force rollback, no-overwrite, freshness-check, and no-legacy-output tests.
+      - Run the creature-catalog fixture for monster attacks, effects, weakpoints, fields, item groups, anatomy, body graphs, and monsters.
+      - Add typed conversions only after each target native registrar exists.
   - id: replacement-audit
     phase: migration
-    status: absent
-    legacy_dependency: private_adapter
+    status: partial
+    legacy_dependency: none
     target_surface: Exact JSON/EOC-to-domain replacement ledger
     evidence:
       - data/reference/json/ccb_json_object_types.json
       - data/reference/json/ccb_eoc_conditions.json
       - data/reference/json/ccb_eoc_effects.json
+      - ai/lua-first-replacement-ledger.yml
+      - tools/agent/check_lua_first_replacement_ledger.py
     next_actions:
-      - Create a checked selector ledger covering every inventory entry exactly once.
-      - Record target domain, shared service, status, and source-backed evidence.
+      - Run schema, generator freshness, uniqueness, and exact-denominator checks.
+      - Review primitive-available selectors for semantic parity and all remaining planned entries domain by domain using the generated ledger summary.

--- a/ai/lua-first-roadmap.yml
+++ b/ai/lua-first-roadmap.yml
@@ -37,7 +37,7 @@ milestones:
       - data/lua/AGENTS.md
   - id: zero-config-discovery
     title: Root main.lua discovery and optional native mod.lua metadata
-    status: in_progress
+    status: complete
     depends_on: [documentation-foundation]
     exit_criteria:
       - A directory containing only main.lua is discoverable as a Mod.
@@ -67,7 +67,7 @@ milestones:
       - data/lua/types/ccb_platform_v1.d.lua
   - id: item-recipe-use-slice
     title: Zero-JSON/EOC item, recipe, and Lua use behaviour
-    status: in_progress
+    status: complete
     depends_on: [native-content-transaction]
     exit_criteria:
       - The example Mod loads with no JSON or EOC files.
@@ -94,6 +94,23 @@ milestones:
       - src/game_io.cpp
       - data/lua/types/ccb_platform_v1.d.lua
       - tests/catalua_ui_test.cpp
+  - id: playable-mvp-v0-1
+    title: Playable and mergeable pure-Lua vertical slice v0.1
+    status: complete
+    depends_on: [behaviour-services]
+    exit_criteria:
+      - A bundled Mod with native mod.lua metadata and no JSON, EOC, manifest, or required lua subdirectory is discovered and selected with its dependency.
+      - Its native item, recipe, and named Lua use handler work before a real game save.
+      - Character state, world state, and a named delayed task survive runtime shutdown plus full data reload; gameplay continues and the overdue task runs exactly once.
+      - Lua-enabled and Lua-disabled test builds preserve an actionable Mod-manager result, and the dedicated merge gate is recorded in ai/test-matrix.yml.
+    evidence:
+      - data/mods/Lua_First_Example/mod.lua
+      - data/mods/Lua_First_Example/main.lua
+      - data/mods/Lua_First_Example/content/cleanwater_charm.lua
+      - data/mods/Lua_First_Example/runtime/behaviour.lua
+      - tests/catalua_ui_test.cpp
+      - tests/mod_manager_test.cpp
+      - ai/test-matrix.yml
   - id: static-domain-coverage
     title: Complete author-facing static content coverage
     status: in_progress
@@ -141,8 +158,9 @@ capabilities:
       - src/mod_manager.h
       - tests/catalua_ui_test.cpp
     next_actions:
-      - The 2026-08-11 Lua-enabled local C++ Platform suite passed the written discovery, metadata, path-confinement, hybrid, and rejected-entry coverage; keep these as regression gates.
-      - Complete the still-open no-Lua build variant and desktop/Android Mod-selector interaction checks without weakening visibility of rejected pure-Platform entries or legacy availability of rejected optional hybrid entries.
+      - The 2026-08-12 playable-MVP gate passed installed bundled-Mod discovery, dependency-aware selection, real data loading, game save, runtime shutdown, full data reload, and continued gameplay; keep it as a regression gate.
+      - The 2026-08-12 no-Lua build gate keeps the pure-Platform example visible with an actionable disabled diagnostic; keep it as a regression gate.
+      - Complete the still-open manual desktop/Android Mod-selector interaction checks without weakening visibility of rejected pure-Platform entries or legacy availability of rejected optional hybrid entries.
   - id: trusted-standard-library
     phase: bootstrap
     status: partial
@@ -204,7 +222,8 @@ capabilities:
     evidence: [src/catalua_platform_runtime.cpp, src/catalua_ui.cpp, data/lua/types/ccb_platform_v1.d.lua, data/lua/reference/ccb_public_api_v5.json]
     next_actions:
       - The 2026-08-11 local C++ Platform suite passed lifecycle, audited semantic event actors and item allowlist, ItemUseContext, missing-handler, decision aggregation, typed-handle, recursion, v5-composition, and runtime-only hot-reload coverage; keep these as regression gates.
-      - Extend semantic actor-kind coverage beyond the audited events and exercise the runtime through the still-open installed-Mod discovery, load, save, reload, and gameplay end-to-end gate.
+      - The 2026-08-12 bundled-Mod playable gate passed discovery, load, real game save, runtime shutdown, full data reload, and continued item-handler gameplay.
+      - Extend semantic actor-kind coverage beyond the audited events.
   - id: presentation-primitives
     phase: runtime
     status: partial
@@ -223,7 +242,8 @@ capabilities:
     evidence: [src/catalua_platform_runtime.cpp, src/catalua_ui_state.cpp, src/do_turn.cpp, src/game_io.cpp, data/lua/templates/complete/runtime/behaviour.lua]
     next_actions:
       - The 2026-08-11 local C++ Platform suite passed save/load, overdue, missing-handler, payload-version and migration-chain, orphan-preservation, size-limit, and corruption coverage; keep these as regression gates.
-      - Exercise task and typed-state survival through the still-open installed-Mod discovery, load, save, reload, and gameplay end-to-end gate.
+      - The 2026-08-12 bundled-Mod playable gate passed typed character/world-state and named-task survival through real game saves, runtime shutdown, full data reload, continued gameplay, and one-time overdue execution.
+      - Extend copied-world and stable-id compatibility coverage beyond the bundled example.
   - id: shared-domain-services
     phase: runtime
     status: partial
@@ -248,7 +268,8 @@ capabilities:
     evidence: [tools/create_lua_mod.py, tools/test_create_lua_mod.py, data/lua/templates/minimal/main.lua, data/lua/templates/complete/main.lua, data/mods/Lua_First_Example/main.lua]
     next_actions:
       - The 2026-08-11 local creator/migrator unit-test run passed all 55 cases (46 extractor plus 9 creator), including scaffold atomic-install, empty-target restoration, concurrent-target preservation, non-overwrite, symlink refusal, Mod-id namespace, zero-JSON coverage, and bounded Wound/WoundFix extraction; keep these as regression gates.
-      - Complete the still-open bundled installed-Mod smoke fixture through discovery, load, save, reload, and gameplay.
+      - The 2026-08-12 bundled installed-Mod fixture passed discovery, dependency-aware selection, load, save, runtime shutdown, full data reload, and continued gameplay.
+      - Add more small end-to-end examples only when they prove a new native domain rather than duplicating this fixture.
   - id: migration-extractor
     phase: migration
     status: partial

--- a/ai/project-map.yml
+++ b/ai/project-map.yml
@@ -26,7 +26,7 @@ entries:
       - Schema, LuaLS declarations, native registrations, generated inventories, and runtime validation tests are authoritative.
       - Lua API v5 describes shipped behaviour and is separate from the planned Lua-first Platform v1.
   - id: lua-first-platform
-    paths: [data/lua/LUA_FIRST_PLATFORM.md, ai/lua-first-roadmap.yml, ai/lua-first-roadmap.schema.json]
+    paths: [data/lua/LUA_FIRST_PLATFORM.md, data/lua/templates/, data/lua/types/ccb_platform_v1.d.lua, data/mods/Lua_First_Example/, ai/lua-first-roadmap.yml, ai/lua-first-roadmap.schema.json, ai/lua-first-replacement-ledger.yml, ai/lua-first-replacement-ledger.schema.json, tools/agent/generate_lua_first_replacement_ledger.py, tools/agent/check_lua_first_replacement_ledger.py, tools/create_lua_mod.py, tools/migrate_lua_first.py, src/catalua_platform.cpp, src/catalua_platform.h, src/catalua_platform_runtime.cpp, src/catalua_platform_runtime.h, src/mod_manager.cpp, src/mod_manager.h, src/mod_manager_ui.cpp, src/game_io.cpp, src/game.cpp, src/do_turn.cpp]
     purpose: Accepted pure-Lua authoring architecture, replacement boundary, and checked implementation roadmap.
     instructions: data/lua/AGENTS.md
     validation_ids: [agent-context]
@@ -34,6 +34,8 @@ entries:
       - The architecture contract defines target design; source and tests alone prove a capability is available.
       - Public Platform APIs use native domain objects and services rather than exposing JSON loaders or EOC-key-shaped wrappers.
       - Core serialization such as saves, settings, caches, and generated inventories may remain JSON internally.
+      - The exact replacement ledger distinguishes implemented, primitive-available, planned, private-adapter, and reviewed-not-applicable selectors.
+      - Migration output is a reviewable Lua skeleton plus explicit TODO report, never a hidden JSON/EOC compatibility call.
   - id: bundled-mods
     paths: [data/mods/]
     purpose: Mods shipped and validated with CCB.

--- a/ai/project-map.yml
+++ b/ai/project-map.yml
@@ -34,7 +34,7 @@ entries:
       - The architecture contract defines target design; source and tests alone prove a capability is available.
       - Public Platform APIs use native domain objects and services rather than exposing JSON loaders or EOC-key-shaped wrappers.
       - Core serialization such as saves, settings, caches, and generated inventories may remain JSON internally.
-      - The exact replacement ledger distinguishes implemented, primitive-available, planned, private-adapter, and reviewed-not-applicable selectors.
+      - The exact replacement ledger distinguishes implemented, bounded-implemented, primitive-available, planned, private-adapter, and reviewed-not-applicable selectors.
       - Migration output is a reviewable Lua skeleton plus explicit TODO report, never a hidden JSON/EOC compatibility call.
   - id: bundled-mods
     paths: [data/mods/]

--- a/ai/task-router.yml
+++ b/ai/task-router.yml
@@ -59,7 +59,7 @@ entries:
       - CCB Lua v5 is a CCB contract and is not inferred from CBN or CDDA APIs.
   - id: lua-first-platform
     keywords: [Lua-first, Platform v1, pure Lua, main.lua, mod.lua, zero-config, JSON replacement, EOC replacement, 纯 Lua, 零配置, 替代 JSON, 替代 EOC]
-    paths: [data/lua/LUA_FIRST_PLATFORM.md, ai/lua-first-roadmap.yml, ai/lua-first-roadmap.schema.json, data/lua/, tools/lua_api/, src/]
+    paths: [data/lua/LUA_FIRST_PLATFORM.md, ai/lua-first-roadmap.yml, ai/lua-first-roadmap.schema.json, ai/lua-first-replacement-ledger.yml, ai/lua-first-replacement-ledger.schema.json, data/lua/, data/mods/Lua_First_Example/, tools/lua_api/, tools/agent/*lua_first*, tools/create_lua_mod.py, tools/migrate_lua_first.py, src/]
     project_ids: [lua-first-platform, lua-api, engine, developer-tools]
     documentation_ids: [architecture.lua-first-platform, architecture.lua-first-roadmap, architecture.lua-first-glossary]
     source_symbols: []

--- a/ai/test-matrix.yml
+++ b/ai/test-matrix.yml
@@ -66,6 +66,28 @@ entries:
     command: python3 tools/lua_api/check_luals_declarations.py && python3 tools/lua_api/check_ccb_inventory.py && python3 tools/lua_api/generate_public_contract.py --check && python3 tools/lua_api/check_public_contract.py && python3 tools/lua_api/check_examples.py && python3 tools/lua_api/check_cmake_contract.py && python3 -m unittest discover -s tools/lua_api -p 'test_*.py'
     workdir: .
     cost: fast
+  - id: lua-playable-mvp
+    paths:
+      - src/catalua_platform.cpp
+      - src/catalua_platform_runtime.cpp
+      - src/game_io.cpp
+      - src/mod_manager.cpp
+      - src/mod_manager_ui.cpp
+      - data/mods/Lua_First_Example/
+      - tests/catalua_ui_test.cpp
+      - tests/mod_manager_test.cpp
+    command: make -j2 BUILD_PREFIX=lua-mvp- ODIR=lua-mvp-obj CATA_ENABLE_LUA_UI=1 ASTYLE=0 LINTJSON=0 LOCALIZE=0 DEBUGSYMS= tests && ./tests/lua-mvp-cata_test '[playable_mvp]' --rng-seed 20260812
+    workdir: .
+    cost: expensive
+  - id: lua-disabled-build
+    paths:
+      - src/catalua_platform.cpp
+      - src/mod_manager.cpp
+      - data/mods/Lua_First_Example/
+      - tests/mod_manager_test.cpp
+    command: make -j2 BUILD_PREFIX=lua-disabled- ODIR=lua-disabled-obj CATA_ENABLE_LUA_UI=0 ASTYLE=0 LINTJSON=0 LOCALIZE=0 DEBUGSYMS= tests && ./tests/lua-disabled-cata_test 'lua_first_platform_disabled_build_rejects_runtime_sources' --rng-seed 20260812
+    workdir: .
+    cost: expensive
   - id: cmake-configure
     paths: [CMakeLists.txt, CMakeModules/, CMakePresets.json]
     command: cmake --preset linux-x64

--- a/data/lua/AGENTS.md
+++ b/data/lua/AGENTS.md
@@ -10,6 +10,9 @@ This subtree contains two distinct contracts:
 
 - `manifest.schema.json`, `types/ccb_api_v5.d.lua`, native registrations, and
   generated inventories are authoritative for the currently shipped v5 API.
+- `types/ccb_platform_v1.d.lua` declares only the separately versioned
+  Platform surface with matching native source.  Implemented-but-unverified
+  entries stay distinct from available v5 APIs; do not merge its types into v5.
 - `LUA_FIRST_PLATFORM.md` is authoritative for Platform v1 design decisions;
   do not present a roadmap item as implemented without matching source and
   tests.
@@ -18,6 +21,19 @@ This subtree contains two distinct contracts:
   uses.  New Platform code follows the separately versioned Platform contract
   and does not expose JSON loaders or EOC-key-shaped APIs.
 - Keep examples runnable and synchronized with declarations.
+- `templates/minimal/` and `templates/complete/` contain no JSON/EOC and are
+  copied by `tools/create_lua_mod.py`; never make their suggested directories
+  loader requirements.  The complete template's Mod-id token is replaced only
+  in the scaffold staging directory before atomic installation.
+- `ai/lua-first-replacement-ledger.yml` is generated.  Change its generator,
+  never the ledger by hand, and do not promote a planned selector without
+  source, declaration, test, and documentation evidence.
+- `primitive_available_unverified` means only that composable native domain
+  building blocks exist; it is not selector-level parity and must not be
+  described as a completed migration.
+- `tools/migrate_lua_first.py` may emit native Lua skeletons and explicit TODO
+  reports.  It must never generate a JSON loader, EOC runner, or raw legacy
+  object as a hidden compatibility path.
 - Platform Mods must not require a `lua/` subdirectory or author-maintained
   JSON manifest.  Templates may recommend structure but may not require it.
 

--- a/data/lua/AGENTS.md
+++ b/data/lua/AGENTS.md
@@ -31,6 +31,9 @@ This subtree contains two distinct contracts:
 - `primitive_available_unverified` means only that composable native domain
   building blocks exist; it is not selector-level parity and must not be
   described as a completed migration.
+- `bounded_implemented_unverified` means one or more explicitly named legacy
+  shapes have source, declarations, tests, migration output, and documentation;
+  it never claims that every legal shape of that selector has parity.
 - `tools/migrate_lua_first.py` may emit native Lua skeletons and explicit TODO
   reports.  It must never generate a JSON loader, EOC runner, or raw legacy
   object as a hidden compatibility path.

--- a/data/lua/LUA_FIRST_PLATFORM.md
+++ b/data/lua/LUA_FIRST_PLATFORM.md
@@ -54,7 +54,8 @@ my_mod/
 
 Defaults are derived without configuration:
 
-- the directory name is the Mod id and display name;
+- the directory name is the Mod id and display name (a hybrid root inherits
+  its sole stable legacy id when no Platform id is supplied);
 - dependencies are empty;
 - the platform version is 1;
 - `main.lua` is the content and runtime registration entry point.
@@ -62,12 +63,18 @@ Defaults are derived without configuration:
 Subdirectories such as `content/`, `runtime/`, `lib/`, and `tests/` are author
 choices.  Templates may recommend them, but the loader must not require them.
 Local `require` searches the Mod root for `?.lua` and `?/init.lua`; trusted
-scripts may further change `package.path`.
+scripts cannot redirect this helper through `package.path`, and module names
+containing traversal or path separators are rejected.  Full-library scripts
+can still perform explicit filesystem or native loading, which remains inside
+the trusted-code boundary rather than the portable module contract.
 
 最小 Platform v1 Mod 只约定根目录存在 `main.lua`。不强制 `lua/` 目录，也不需要
 `manifest.json` 或 `modinfo.json`。目录名默认同时作为 Mod ID 与显示名，依赖默认为
 空，Platform 版本默认为 1。`content/`、`runtime/`、`lib/`、`tests/` 等目录只属于
 作者的组织选择，模板可以推荐，引擎不能强制。
+本地 `require` 只解析 Mod 根目录内的 `?.lua` 与 `?/init.lua`，不接受路径穿越，且不被
+脚本修改后的 `package.path` 重定向。可信脚本仍可显式使用文件和原生加载能力，但这不
+属于可移植模块契约。
 
 ### Optional `mod.lua` / 可选高级元数据
 
@@ -86,6 +93,57 @@ screens and documentation must state this prominently.
 因此 Platform v1 是可信的进程内扩展系统：把 Mod 放进扫描目录本身就可能执行代码，
 不必等到玩家启用。Mod UI 与文档必须醒目说明这一点。
 
+The implemented bootstrap constructor is imported with `require("ccb")`:
+
+```lua
+local ccb = require("ccb")
+
+return ccb.ModDefinition {
+    id = "my_mod",
+    name = "My Mod",
+    version = "1.0.0",
+    dependencies = { "dda" },
+    entry = "main.lua",
+}
+```
+
+`ModDefinition` is native userdata, not a metadata-shaped Lua table.  Its
+current LuaLS contract is `data/lua/types/ccb_platform_v1.d.lua`.  Returning a
+plain table, an empty or `#`-containing id, a self dependency, a duplicate id,
+duplicate or non-dense dependency entries, over-limit metadata, or an entry
+outside the Mod root rejects the Platform candidate.  A hybrid
+root may attach Platform code to exactly one legacy `MOD_INFO`.  An omitted
+Platform id inherits that stable legacy id; an explicit Platform id must agree
+with it.
+
+Rejected pure-Platform candidates remain visible in the installed-Mod catalog
+under their directory id with a bounded diagnostic and cannot be enabled.  A
+hybrid Mod with malformed optional Platform metadata keeps its legacy content
+available while showing the rejected-entry reason; discovery failures are not
+left only in the debug log.  If that directory id is already occupied, the
+catalog assigns the rejected diagnostic entry a deterministic
+`_lua_platform_rejected_N` suffix so neither candidate is hidden.
+
+A build compiled without Lua support applies the same rule without executing
+`mod.lua`: pure Platform roots remain visible and unavailable, while a hybrid
+root keeps its legacy content and records that its optional Platform entry is
+disabled.  This prevents a world from accepting a Mod that can only fail later
+during data loading.
+
+未启用 Lua 的构建不会执行 `mod.lua`，但采用相同规则：纯 Platform 根目录仍显示为
+不可用；混合根目录保留旧内容，只记录可选 Platform 入口被禁用，避免直到世界数据
+加载时才失败。
+
+已实现的引导构造器通过 `require("ccb")` 导入。`ModDefinition` 是原生 userdata，
+不是模仿 JSON 的 Lua table；当前 LuaLS 契约位于
+`data/lua/types/ccb_platform_v1.d.lua`。普通 table、空 ID、含 `#` 的 ID、自依赖、
+重复 ID、逃逸 Mod 根目录的入口都会被拒绝。混合 Mod 根目录只能包含一个旧
+`MOD_INFO`；省略 Platform ID 时继承该稳定旧 ID，显式填写时则必须与旧 ID 一致。
+被拒绝的纯 Platform 候选仍会以目录 ID 出现在已安装 Mod 列表中，显示有界错误且不可
+启用；混合 Mod 的可选 Platform 元数据无效时，旧内容仍可使用并显示拒绝原因，不会只
+把失败藏在调试日志里。如果目录 ID 已被占用，诊断项会使用确定性的
+`_lua_platform_rejected_N` 后缀，避免任一候选被静默隐藏。
+
 ## Trust model / 信任模型
 
 Platform v1 opens the complete bundled Lua 5.4 standard libraries, including
@@ -99,10 +157,20 @@ boundary.  The official API still defines portable behaviour; host-specific
 I/O, processes, native modules, and side effects cannot be rolled back and may
 not work on every platform.
 
+Interactive Mod selection asks for explicit confirmation before adding any
+new Platform Mod, including trusted Platform dependencies pulled in by a
+non-Lua selection.  Rebuilding an already selected Mod order does not prompt.
+This consent protects entry execution; it cannot undo the documented fact that
+`mod.lua` may already execute during discovery.
+
 Platform v1 开放捆绑 Lua 5.4 的完整标准库，包括 `io`、`os`、`debug`、协程、动态
 加载和普通 package 支持，不沿用 v5 capability 沙箱。脚本与游戏进程权限相同；这种
 选择换取最大扩展能力，但不再提供“不可信 Mod”安全边界。文件、进程和原生模块副作用
 无法事务回滚，也不保证跨平台可用。
+
+在 Mod 选择界面首次加入任何 Platform Mod 时会明确确认，包括由普通 Mod 间接拉入的
+Platform 依赖；仅重建已经选择的顺序不会重复询问。这个确认保护入口加载，但不能撤销
+前述 `mod.lua` 可能已在发现阶段执行的事实。
 
 ## Loading lifecycle / 加载生命周期
 
@@ -113,8 +181,19 @@ The target lifecycle is:
 3. Begin one data-load transaction.
 4. Load legacy JSON for a hybrid Mod, when present.
 5. Execute the Platform entry and stage native content definitions.
-6. Commit staged definitions and run normal global finalization.
-7. Make registered runtime handlers active after `world_ready`.
+6. Run normal global finalization over legacy and staged native definitions.
+7. Commit the prepared Platform states only after finalization succeeds.
+8. Make registered runtime handlers active after `world_ready`.
+
+A full world replacement dispatches `shutdown` and retires the previous
+Platform states before the engine unloads their finalized native registries.
+An in-place save reload that deliberately keeps the same data registries may
+reuse the active states and dispatch `world_ready` again.
+
+All active runtimes become readable before dependency-ordered `world_ready`
+callbacks begin, so an early dependency can synchronously publish to later
+Mods without observing a false not-ready state.  `shutdown` runs in reverse
+dependency order, allowing dependents to retire before the services they use.
 
 Top-level code may create content and register handlers.  Access to live map,
 character, or world state is invalid until the world is ready.  A failed data
@@ -126,10 +205,416 @@ content fingerprint is unchanged, runtime registrations can be swapped.  If
 content changed, the reload reports `requires_full_data_reload` rather than
 mutating finalized registries in place.
 
+The runtime-only swap preserves typed character/world state, named tasks, and
+task ids, as well as the per-Mod gameplay random stream.  It dispatches
+`shutdown` to retiring states, retires their handles, then dispatches
+`world_ready` with `reloaded = true` to replacements.  It does not reload
+sidecars or advance the world generation.  Entry failure or a changed
+fingerprint leaves the active states untouched.
+
 目标生命周期依次为：发现入口、解析依赖、开始数据事务、按需加载旧 JSON、执行 Lua
-并暂存原生定义、提交并统一 finalize、最后在 `world_ready` 后激活运行时 handler。
+并暂存原生定义、统一 finalize、成功后提交 Platform state，最后在 `world_ready` 后
+激活运行时 handler。
+完整切换世界时，会在引擎卸载旧原生注册表之前先派发 `shutdown` 并销毁旧 Platform
+state；明确复用同一批数据注册表的存档内快速重载则可以保留 state，并再次派发
+`world_ready`。
+所有 runtime 会先统一进入可读状态，再按依赖顺序执行 `world_ready`，因此前置依赖同步
+发布事件时不会把后续 Mod 误判成未就绪；`shutdown` 则按逆依赖顺序执行，让依赖方先于
+它所使用的服务退出。
 顶层代码可以创建内容和注册回调，但世界就绪前不能访问实时地图或角色。静态内容指纹
 改变时拒绝局部热重载，并要求完整数据重载。
+运行时热替换还会保留每个 Mod 的玩法随机流，避免仅修改 handler 代码就意外重置
+随机序列。
+
+### Current implementation boundary / 当前实现边界
+
+The current implementation branch now has code for discovery, dependency
+metadata, one full-library state per Mod, root-local `require`, candidate
+prepare/apply/commit/discard, native foundational catalogs plus item and recipe
+staging, named item-use
+handlers, lifecycle and native game events, typed character/world state,
+serializable named tasks and payload migrations, synchronous native hooks,
+generation-safe shared domain services, Lua-aware Mod copying, and zero-JSON
+templates.  It also includes visible rejected-metadata diagnostics,
+fingerprint-gated runtime-only hot reload, and callback-only native
+presentation primitives.
+Native item/recipe injection has an undo log; candidate failure restores those
+registries in reverse Mod/load order as well as preserving the previous active
+Lua states.  This also permits a later dependency-ordered Mod to use explicit
+`replace` against content added earlier in the same candidate.  Commit is
+also gated on a post-finalize retention check, so a recipe removed by global
+consistency finalization cannot silently leave a partially active Platform
+candidate.  Trusted filesystem, process, and native-module side effects remain
+outside that transaction.
+
+This code is deliberately still marked **implemented but unverified**.  No
+compile, test, formatter, declaration check, or ledger check has run since the
+owner requested implementation through phase 5 before validation.  The exact
+replacement ledger contains 775 dispositions; its generated summary is the
+authoritative count.  The implemented-but-unverified static slice now covers
+Mod metadata, tool qualities, skill display categories, skills, vitamins,
+JSON flags, damage types, materials, proficiency categories, proficiencies,
+weapon categories, item categories, recipe categories, ammunition types,
+reusable requirements, recipe groups, scent types, speed descriptions,
+harvest-drop types, harvest lists, behavior trees, monster attacks, effect
+types, weakpoint sets, field types, item groups, sub-body parts, body parts,
+anatomies, body graphs, monsters, morale types, disease types, monster flags,
+mutation types, monster species, field emissions, monster factions, construction categories,
+mutation categories, terrain/furniture connection groups, construction groups,
+vehicle-part locations,
+vehicle-part categories, mood-face tables, damage-info presentation orders,
+named colors, rotatable-symbol groups, ASCII-art definitions, limb-score
+definitions, the global hit-range configuration, bash-damage profiles,
+clothing modifications, overmap land-use codes, overmap-vision profiles,
+overmap-location predicates, profession groups, weighted map-extra
+collections, vehicle groups, fault groups, explosion-light recipes, ammunition-effect recipes,
+addiction types, character modifiers, start locations, climbing aids,
+weather types, scores, the global mutation-overlay order, zone types, speech pools, end screens, nested recipe categories, attack vectors, magic types,
+movement modes, items, and
+recipes.  The hit range is deliberately a replace-only singleton because it
+configures one engine-wide table rather than an id-addressed catalog.  Clothing
+modifiers use composable scaling dimensions rather than exposing the legacy
+object shape.  Attack vectors rebuild anatomical substitutions from authored
+limbs and contact surfaces, making repeated finalization idempotent.  This
+remains far short of complete static-domain coverage.
+
+Overmap-vision profiles use an ordered Lua sequence of `appearance` and
+`blend_adjacent` operations.  The sequence directly expresses vague,
+outline, and detail views without exporting the legacy `levels` object shape;
+native validation caps it at the engine's three partial-vision stages.
+
+Magic types are intentionally not a field-for-field export of legacy
+`magic_type`.  Resource choice, casting restrictions, book limits, and default
+failure fractions are native definition data.  Progression, casting
+experience, failure chance, dynamic failure fractions, and failed-cast effects
+are named Lua policies.  Numeric policies receive bounded payloads and must
+return values in their native domains; failed-cast policies receive a
+generation-checked caster handle.  Missing handlers, callback errors, stale
+worlds, and recursion beyond the common Platform limit are isolated.  A later
+replacement owns the entire policy slot, so an earlier callback cannot leak
+through.  Lua-authored magic types create neither jmath formula references nor
+failure EOCs.
+
+Movement modes are native definitions with numeric exertion and multiplier
+values plus one composable message bundle for each steed context (`none`,
+`animal`, and `mech`).  The Platform surface does not expose the legacy
+field-name matrix.  Registry refresh clears and rebuilds speed ordering and
+cycle links, so repeated global finalization and transaction rollback are
+idempotent.
+
+Selection groups use small semantic builders instead of exposing legacy list
+shapes.  Overmap locations compose terrain ids and terrain flags; profession
+groups add professions; map-extra, vehicle, and fault groups add one stable id
+with a positive weight at a time.  Duplicate members are rejected, references
+are checked against native registries, and replacement owns the whole group so
+old members cannot leak through a later layer.
+
+Explosion lights are composed as an ordered color/alpha ramp plus wave,
+duration, screen-shake, and optional shockwave components.  Lua authors do not
+manage the legacy two-color compatibility fields; the native recipe receives
+the completed ramp and renderer-independent numeric parameters directly.
+
+Ammunition effects compose field bursts, trails, direct and area character
+effects, blasts, shrapnel, engine primitives, spells, and an optional named
+Lua impact policy.  The policy receives generation-checked source/target
+handles, impact coordinates, and dealt damage.  Lua-authored effects never
+store or invoke EOCs; the extractor turns a legacy `eoc` member into an
+explicit rewrite TODO instead of preserving the old dispatcher.
+
+Addiction types keep their display text and optional craving-morale reference
+as native definition data.  Every Lua-authored type supplies one named
+`tick_policy`; the callback receives a generation-checked character handle,
+intensity, and remaining sated turns and returns whether it produced an
+observable effect.  The native definition contains neither a builtin selector
+nor an EOC id.
+
+Character modifiers keep only their stable id, description, and combination
+operation as native definition data.  Their value comes from one named Lua
+evaluator receiving a generation-checked character handle and optional skill
+id.  This replaces both the legacy builtin switch and the fixed limb-score
+formula shape, allowing ordinary Lua modules to share richer calculations.
+
+Start locations compose overmap-terrain selectors, mapgen parameters, flags,
+and city/z placement intervals one operation at a time.  Climbing aids compose
+an availability predicate, descent presentation, physical cost, and optional
+deployed furniture.  Neither surface exposes inheritance or legacy nested
+object shapes; reusable Lua constructors provide author-side templates.
+
+Weather types keep presentation, physical modifiers, duration, prerequisites,
+animation, and passive character effects as native definition data.  Their
+eligibility is one named Lua condition receiving a bounded weather sample with
+temperature, humidity, pressure, wind, time, and absolute location.  The
+weather selector calls that policy directly and consults the old condition
+tree only for non-Platform definitions.  Lua-authored weather stores no
+condition tree, jmath reference, or EOC id; the extractor preserves static
+data and emits explicit rewrites for all legacy behaviour.
+
+Scores are native id-to-event-statistic definitions with an optional display
+format.  Lua authors reference the statistic by stable id and do not construct
+or pass a legacy score object.
+
+Mutation-overlay ordering is a native engine-wide singleton composed with
+`OverlayOrder:mutation(id, order)`.  Authors work with one stable mutation id
+at a time instead of the legacy `overlay_ordering` array shape.  `add` requires
+every key to be new, `replace` requires every key to exist, and transactional
+rollback restores or erases each key in reverse order.
+
+Zone types are native id-addressed definitions containing their display field,
+presentation text, visibility, and personal-ownership policy.  Lua authors use
+`content.ZoneType` directly; the historical `LOOT_ZONE` selector name and JSON
+loader are not part of the Platform surface.
+
+Speech is authored as one `SpeechPool` per stable speaker label, with ordered
+`line(text, volume)` composition.  This keeps random selection in the native
+consumer while replacing the legacy repetition of multi-speaker JSON objects;
+the extractor groups all source lines by speaker before emitting Lua.
+
+End screens keep picture, priority, positioned text, and final-input label as
+native data.  Selection is a named Lua condition receiving a generation-safe
+character handle; Lua-authored screens store no legacy condition tree, and
+the UI falls back to that tree only for non-Platform definitions.
+
+Activity types keep native scheduling, interruption, resumption, exertion,
+distraction, fetching, fire-refuelling, and auto-needs policy as static data.
+Turn and completion behaviour are named Lua policies receiving a
+generation-checked character handle plus a bounded activity snapshot.  A
+policy may cancel the activity or update only its native move budget and small
+legacy state fields; restoring positive moves during completion extends the
+activity.  Lua-authored activity types store neither `do_turn_eoc` nor
+`completion_eoc`, and the player-activity dispatcher invokes those old EOCs
+only for non-Platform definitions.  Existing native actors and C++ handlers
+remain composable implementation primitives rather than public legacy APIs.
+
+Help topics use stable Lua-first ids, player-facing titles, and composable
+paragraphs.  Authors may choose an explicit global display order or omit it to
+append deterministically in Mod load order.  The public surface does not
+expose the loader's source-offset bookkeeping or a JSON message array.
+
+Snippet categories are weighted native text pools.  `content.add` contributes
+new entries to an existing category while `content.replace` deliberately owns
+the whole pool, so multiple Mods can extend common vocabulary without copying
+it.  Named entries may declare one named Lua `on_examine` policy receiving the
+snippet/category/item ids and a generation-checked character handle.
+Lua-authored snippets never populate the legacy EOC table, and item
+description discovery falls back to the old examine EOC only for non-Platform
+snippets.
+
+Playlists are native ordered track collections with an optional shuffle
+policy.  Every track uses a soundpack-relative, traversal-safe path and a
+bounded native volume.  The registry remains transactional even in builds
+without SDL sound, while playback naturally remains a platform capability.
+
+Monster species are native inheritance bundles for monster flags, anger/fear/
+placate triggers, footsteps, descriptive text, and bleed fields.  Lua authors
+compose each relation with `flag`, `anger`, `fear`, and `placate`; they do not
+construct the legacy trigger arrays.  Monster factions use one direct
+`attitude(kind, target)` operation per relation plus an optional base faction.
+Finalization clears and rebuilds explicit, inherited, and compact attitude
+caches, so candidate replacement and rollback cannot retain relations from a
+discarded layer.
+
+Field emissions use a native static fallback plus an optional named Lua
+`profile` policy.  The policy runs once per emission decision and returns the
+complete field, intensity, quantity, and chance tuple; it receives the stable
+emission id, bubble-map position, and immutable fallback profile.  Returning
+nil, a callback failure, or an unavailable runtime keeps the native fallback.
+Lua-authored emissions store fixed native values rather than creating
+`str_or_var`, jmath, a condition tree, or an EOC.  A later static replacement
+owns the callback slot and cannot expose an older layer's policy.
+
+```lua
+local emission = ccb.content.Emission {
+    id = "emit_custom_smoke",
+    field = "fd_smoke",
+    intensity = 2,
+    quantity = 10,
+    chance = 50,
+}
+emission:profile("dynamic_smoke_profile") -- optional
+ccb.content.add(emission)
+```
+
+字段排放由一份原生静态 fallback 和可选的命名 Lua `profile` 策略组成。每次排放只进入
+Lua 一次，策略一次性返回 field、强度、数量和概率，并收到稳定排放 ID、现实气泡地图格
+位置及只读 fallback。返回 nil、回调失败或 runtime 尚未就绪时继续使用 fallback。
+Lua 定义的排放只保存固定原生数值，不创建 `str_or_var`、jmath、condition tree 或 EOC；
+后加载的静态 replacement 也会完整接管策略槽，旧层回调不会穿透。
+
+Harvest lists are native `harvest_list` and `harvest_entry` objects composed
+with `Harvest:drop`, `item_flag`, and `item_fault`.  Each drop names an item or,
+when its harvest-drop category is declared as a group, an existing native item
+group.  Base and skill-scaled intervals, maximum quantity, mass share,
+leftovers, and butchery requirements are validated before apply.  Empty lists
+remain valid for native sentinels such as `null` and `exempt`.  Candidate items,
+flags, and harvest-drop types may be referenced in the same transaction; item
+groups, faults, and butchery requirements remain checked native dependencies.
+The registrar writes the native factory directly and participates in retention,
+fingerprinting, and inverse rollback without constructing a JSON object.
+
+```lua
+local harvest = ccb.content.Harvest {
+    id = "custom_harvest",
+    message = "You recover useful material.",
+    leftovers = "ruined_chunks",
+    butchery_requirements = "default",
+}
+harvest:drop {
+    output = "meat",
+    category = "flesh",
+    base_minimum = 1,
+    base_maximum = 4,
+    skill_maximum = 0.5,
+    maximum = 20,
+    mass_ratio = 0.25,
+}
+harvest:item_flag("meat", "FILTHY")
+ccb.content.add(harvest)
+```
+
+采收表直接由原生 `harvest_list` 与 `harvest_entry` 组成，通过 `Harvest:drop`、
+`item_flag` 和 `item_fault` 逐项组合。普通条目引用物品；当采收掉落分类声明为 group 时，
+条目引用已有的原生 item group。基础/技能缩放区间、最大数量、尸体质量比例、残留物和
+屠宰需求都会在 apply 前校验；`null`、`exempt` 这类原生哨兵仍可使用空采收表。同一事务
+声明的物品、flag 与采收掉落分类可以直接引用，item group、fault 和屠宰需求则保持为
+受检的原生依赖。注册器直接写原生目录并进入保留检查、指纹和逆序回滚，不构造 JSON 对象。
+
+Behavior trees are native `behavior::node_t` graphs.  Lua composes stable child
+ids and native traversal strategies, while named Lua policies can decide a
+condition or utility score at tick time.  A policy receives the behavior id,
+an authored argument, the subject kind, and a generation-safe subject handle;
+it returns one boolean or finite number.  Missing handlers, a runtime that is
+not world-ready, callback errors, and recursion-limit failures safely become a
+false condition or zero score.  Native predicates remain available through
+explicit `when_native` and `score_native` composition for migration, but no
+JSON loader, condition tree, jmath expression, or EOC runner is retained.
+
+```lua
+local forage = ccb.content.Behavior {
+    id = "custom_forage_goal",
+    goal = "forage",
+}
+forage:when("can_forage_now", "nearby", false)
+forage:score("forage_utility", "food")
+ccb.content.add(forage)
+
+local root = ccb.content.Behavior {
+    id = "custom_ai_root",
+    strategy = "utility",
+}
+root:child("custom_forage_goal")
+ccb.content.add(root)
+```
+
+行为树直接构造成原生 `behavior::node_t` 图。Lua 使用稳定子节点 ID 与原生遍历策略组合
+结构，并可在每次 tick 时用命名 Lua policy 决定条件或 utility 分数。policy 收到行为 ID、
+作者参数、主体类型和代际安全主体句柄，分别返回一个布尔值或有限数值；handler 缺失、
+runtime 尚未 world-ready、回调报错或递归超限时安全退化为 false/0。迁移核心行为时仍可通过
+显式 `when_native`、`score_native` 组合已有 C++ 谓词，但不会保留 JSON loader、condition
+tree、jmath 或 EOC runner。
+
+Connection groups are stable native ids allocated before terrain and furniture
+definitions consume their compact bit positions.  The transaction preserves a
+replaced group's position and rolls back newly appended ids in reverse order.
+Mutation categories keep threshold, vitamin, player-facing, and starting-trait
+removal policy as native data; Lua authors work with semantic names such as
+`threshold_minimum` and `base_removal_cost_multiplier` rather than abbreviated
+loader keys.
+
+Nested recipe categories are native recipe entries composed from stable recipe
+ids with `NestedRecipeCategory:recipe(id)`.  Name, description, crafting
+category, subcategory, and numeric activity level remain native data; Lua does
+not construct the legacy `nested_category_data` list shape.
+
+当前实现分支已经写入发现、依赖元数据、每 Mod 独立完整标准库 state、根目录本地
+`require`、候选 prepare/apply/commit/discard、原生基础目录及物品/配方事务、命名物品行为、
+生命周期与原生游戏事件、角色/世界状态、可序列化命名任务、Lua Mod 复制和零 JSON
+模板；同时加入了任务 payload 迁移、同步原生 Hook 与代次安全的共享领域 service。
+原生物品/配方注入有逆向恢复日志，候选失败时不仅保留旧 Lua state，也恢复本次
+注入的定义；跨 Mod 叠加严格按加载顺序应用、按逆序回滚，因此后加载 Mod 可以显式
+`replace` 同一候选中先加载的定义。commit 还必须通过 finalize 后的保留检查，避免被全局一致性检查剔除的
+配方造成部分候选悄悄生效。文件、进程和原生模块的外部副作用仍无法回滚。
+
+这些代码目前仍统一标为**已实现但未验证**：按负责人要求，阶段 5 收口前没有运行
+编译、测试、格式、声明或账本检查。775 项的分类数字以生成账本 summary 为准，不在本文
+手工复制。当前静态切片包括 Mod 元数据、工具质量、技能显示分类、技能、维生素、JSON
+flag、伤害类型、材质、熟练度分类、熟练度、武器分类、物品分类、配方分类、弹药
+类型、可复用制作需求、配方组、气味类型、速度描述、采收掉落类型、采收表、行为树、
+怪物攻击、效果类型、弱点集、场类型、物品组、子身体部位、身体部位、解剖、身体图、
+怪物、士气类型、疾病类型、怪物 flag、怪物物种、怪物阵营、突变类型、突变分类、
+地形/家具连接组、建造分类、建造组、载具部件位置、
+物品与配方；它仍远未
+达到静态内容全面覆盖。当前切片还包括载具部件分类、心情表情表、伤害信息显示顺序、
+命名颜色、可旋转符号组、ASCII 图、肢体评分和全局命中距离配置。命中距离配置刻意只
+允许显式 `replace`：它是一张引擎全局表，不是假装拥有普通对象 ID 的目录。当前切片还
+包括 bash 伤害配置、服装改造和大地图土地用途；服装数值使用可组合的厚度/覆盖率缩放
+维度，而不是公开旧 JSON 对象形状。大地图视野配置使用有序的 `appearance` 与
+`blend_adjacent` 组合序列，直接表示模糊、轮廓和细节三个阶段，不公开旧 `levels` 对象
+形状。攻击向量也已纳入原生构造器；相似肢体和接触面每次
+都从作者输入重建，因此重复 finalize 不会不断追加派生项。魔法类型也已纳入：能量来源、
+施法限制、书本等级和默认失败比例是原生定义；等级/经验互算、施法经验、失败率、动态失败
+比例与失败副作用则是命名 Lua 策略。数值策略只接收有界 payload 并必须返回对应原生值域，
+失败副作用接收代次安全的施法者 handle；缺失 handler、回调错误、过期世界和递归上限都被
+隔离。后加载 replacement 独占策略槽，旧层回调不会穿透。Lua 定义不会创建 jmath 公式引用，
+也不会生成 failure EOC。移动模式使用原生数值强度/倍率，并为 `none`、`animal`、`mech`
+三个坐骑上下文分别组合一组消息，不公开旧式字段名矩阵。目录刷新会先清空再重建速度排序
+和循环链接，因此重复全局 finalize 与事务回滚保持幂等。
+大地图位置使用地形 id 与地形 flag 逐项组合；职业组逐项加入职业；地图额外内容、载具和
+故障组逐项加入“稳定 id + 正权重”。这些 API 不公开旧数组形状，拒绝重复成员，按原生目录
+检查引用，并让后加载 replacement 完整拥有组内容，旧层成员不会穿透。
+爆炸光效则由有序颜色/透明度关键帧，以及波形、持续时间、屏幕震动和可选冲击波组件
+构成；Lua 作者不需要感知旧式双颜色兼容字段，原生光效直接接收完整色带与数值参数。
+弹药效果使用字段爆发、轨迹、直接/范围角色效果、爆炸、破片、引擎原语、法术和可选的
+命名 Lua 命中策略进行组合。策略接收代次安全的来源/目标 handle、命中坐标和实际伤害；
+Lua 定义不会保存或调用 EOC，迁移器遇到旧 `eoc` 时只生成明确的 Lua 重写 TODO。
+成瘾类型保留原生显示文本和可选 craving morale 引用，每个 Lua 定义必须提供一个命名
+`tick_policy`。回调接收代次安全的角色 handle、强度和剩余满足回合，并返回本次 tick
+是否产生可见效果；原生定义中既没有 builtin 选择器，也没有 EOC id。
+角色修正器只把稳定 id、说明和组合操作保留为原生定义数据，数值由一个命名 Lua evaluator
+计算；payload 包含代次安全的角色 handle 和可选技能 id。这同时取代旧 builtin 分派和固定
+肢体评分公式形状，让普通 Lua 模块能够共享更丰富的计算逻辑。
+起始位置逐项组合大地图地形选择器、mapgen 参数、flag 与城市/z 轴放置区间；攀爬辅助则
+组合可用条件、下降交互、身体成本及可选部署家具。两者都不公开继承或旧嵌套对象形状，
+作者侧模板由普通 Lua 构造函数复用。
+天气类型把显示、物理修正、持续时间、前置天气、动画和角色被动效果作为原生定义数据；
+是否满足天气条件则由一个命名 Lua policy 判断。payload 只含有界的温度、湿度、气压、
+风、时间和绝对位置快照。天气选择器直接调用该 policy，只有非 Platform 天气才会回退
+旧 condition tree。Lua 天气不保存 condition tree、jmath 引用或 EOC id；迁移器只搬运
+可确定的静态数据，并对旧行为生成明确的 Lua 重写 TODO。
+分数定义则直接把稳定 score id 关联到原生 event-statistic id，并可提供显示格式；Lua
+作者不创建或传递旧 score 对象。
+突变覆盖显示顺序使用一个原生全局 singleton，并通过
+`OverlayOrder:mutation(id, order)` 逐项组合。作者不接触旧 `overlay_ordering` 数组形状；
+`add` 要求每个 key 尚不存在，`replace` 要求每个 key 已存在，事务回滚按逆序逐项恢复
+或删除。
+区域类型是原生按 id 寻址的定义，直接包含显示 field、说明文字、可见性和个人所有权
+策略。Lua 作者使用 `content.ZoneType`；旧 `LOOT_ZONE` selector 名称和 JSON loader 都不
+属于 Platform API。
+语音按稳定 speaker label 定义为 `SpeechPool`，再用有序的 `line(text, volume)` 逐条组合。
+原生消费端仍负责随机选择，但 Lua 不再重复旧式多 speaker JSON 对象；迁移器会先按
+speaker 汇总所有来源行，再生成 Lua。
+结束画面把图片、优先级、定位文字和最终输入标签保留为原生数据；选择逻辑是接收代次安全
+角色 handle 的命名 Lua condition。Lua 画面不保存旧 condition tree，UI 也只为非
+Platform 定义回退旧树。
+活动类型把原生计时、打断、恢复、活动强度、干扰忽略、取物、添柴与自动需求策略保留为
+静态数据；每回合和完成行为则使用命名 Lua policy。回调收到代次安全的角色 handle 和有界
+活动快照，只能取消活动或更新原生 moves 预算及少量旧活动状态字段；完成回调把
+`moves_left` 恢复为正数即可延长活动。Lua 定义既不保存 `do_turn_eoc`，也不保存
+`completion_eoc`，player-activity 分派器只为非 Platform 定义调用旧 EOC。已有原生 actor
+和 C++ handler 仍可作为可组合实现原语，但不是公开的旧接口。
+帮助主题使用稳定 Lua-first id、显示标题和逐段组合的正文。作者可以显式指定全局显示顺序，
+也可以省略顺序，让主题按 Mod 加载顺序确定性追加；公开 API 不暴露旧 loader 的来源偏移
+记账，也不要求构造 JSON messages 数组。
+Snippet 分类是带权重的原生文本池。`content.add` 向已有分类贡献新条目，
+`content.replace` 才明确接管整个池，因此多个 Mod 无需复制公共词库即可扩展它。命名条目
+可以绑定一个命名 Lua `on_examine` policy，payload 包含 snippet、分类、物品类型 id 和代次
+安全角色 handle。Lua snippet 永远不写入旧 EOC 表；物品描述发现也只为非 Platform
+snippet 回退旧 examine EOC。
+播放列表是带可选 shuffle 策略的原生有序音轨集合；每条音轨只能使用相对当前音效包、禁止
+目录穿越的路径和有界原生音量。即使构建未启用 SDL sound，定义注册与事务仍然存在，实际
+播放则自然取决于平台能力。
+嵌套配方分类仍是原生 recipe 条目，但通过 `NestedRecipeCategory:recipe(id)` 逐项组合稳定
+配方 id。名称、说明、制作分类、子分类和数值活动强度保留为原生数据，Lua 不构造旧
+`nested_category_data` 列表形状。
 
 ## Native object model / 原生对象模型
 
@@ -155,6 +640,129 @@ protected 仍遵守 C++ 规则。原生引用带 owner/代次检查，owner 消�
 提交或 runtime 替换后访问会抛 Lua 错误。静态定义使用真实的原生 staging 对象，
 通过显式 `add`、`replace`、事务性 `edit` 提交；普通 Lua 组合取代 JSON `copy-from`。
 
+### Implemented native vertical slice / 已编码的原生纵向切片
+
+The phase-2/3 code exposes constructors on the Mod-local `ccb.content` table.
+They return native userdata, not tables accepted by a generic loader.  `add`
+rejects an existing id, `replace` requires one, and `edit_item`/`edit_recipe`
+clone a definition staged earlier by the same Mod in the current candidate.
+Registering the clone with `ccb.content.edit` replaces that earlier staged
+value while preserving its original add-or-replace intent.  This makes edits
+ordinary Lua module composition and gives cold load, full reload, and
+fingerprint-gated hot reload the same semantics.
+Cross-Mod layers are validated and applied in dependency order, and the whole
+candidate rolls back in reverse order.  Recipe component and tool alternative
+groups are bounded dense one-based arrays, so holes or metadata keys cannot be
+silently interpreted as native requirements.
+
+The same transaction owns the foundational registries required by upper
+content layers: `ToolQuality`, `SkillDisplay`, `Skill`, `Vitamin`, `JsonFlag`,
+`DamageType`, `Material`, `ProficiencyCategory`, `Proficiency`,
+`WeaponCategory`, `ItemCategory`, `RecipeCategory`, `AmmunitionType`,
+`ScentType`, `SpeedDescription`, `HarvestDropType`, `Harvest`, `Behavior`,
+`MonsterAttack`, `EffectType`, `WeakpointSet`, `FieldType`, `ItemGroup`,
+`SubBodyPart`, `BodyPart`, `Anatomy`, `BodyGraph`, `Monster`, `MoraleType`,
+`DiseaseType`, `MonsterFlag`, `MutationType`, `Species`, `Emission`, `MonsterFaction`,
+`ConnectGroup`, `MutationCategory`, `ConstructionCategory`, `ConstructionGroup`, `VehiclePartLocation`,
+`VehiclePartCategory`, `MoodFace`,
+`DamageInfoOrder`, `NamedColor`, `RotatableSymbol`, `OvermapLocation`,
+`ProfessionGroup`, `MapExtraCollection`, `VehicleGroup`, `FaultGroup`,
+`ExplosionLight`, `AmmoEffect`, `AddictionType`, `CharacterModifier`,
+`StartLocation`, `ClimbingAid`, `WeatherType`, and `Score`.
+The transaction also owns reusable `Requirement` graphs and lets recipes
+compose them by id and multiplier without reparsing legacy data.  Native
+`RecipeGroup` definitions organize those recipes for camp/building workflows.
+They are applied before items and recipes, so an
+item may reference a quality, flag, or material authored earlier in the same
+candidate, and a material may reference candidate damage types and vitamins.
+Every registrar participates in explicit add/replace/edit semantics,
+post-finalize retention checks, the static hot-reload fingerprint, and reverse
+rollback.  The native transaction uses concrete-id factory erase and snapshot
+restore operations; it never calls a JSON loader.
+
+Damage-type behaviour uses `DamageTypeDefinition:on_hit` and `on_damage` with
+named Platform handlers instead of `onhit_eocs` or `ondamage_eocs`.  Payloads
+contain generation-safe source/target handles, the stable damage id, body-part
+id, and pre/post-mitigation amounts.  A later replacement owns the callback
+slot even when it deliberately leaves it empty, preventing an earlier Mod's
+handler from leaking through.
+
+```lua
+local ccb = require("ccb")
+
+ccb.runtime.handler("activate", function(context)
+    local uses = ccb.state.character.get("uses", 0) + 1
+    ccb.state.character.set("uses", uses)
+    context:message("Lua activation #" .. uses)
+    return 0
+end, 1)
+
+local item = ccb.content.Item {
+    id = "example_token",
+    name = "example token",
+    description = "A native Lua-defined item.",
+    symbol = "*",
+}
+item:mass_grams(25)
+item:volume_ml(10)
+item:material("steel", 1)
+item:on_use("activate", "Activate token")
+ccb.content.add(item)
+
+local recipe = ccb.content.Recipe {
+    id = "example_token",
+    result = "example_token",
+    duration_moves = 500,
+}
+recipe:component("scrap", 1)
+recipe:tool_any {
+    { id = "hammer", count = 1 },
+    { id = "rock", count = 1 },
+}
+ccb.content.add(recipe)
+```
+
+An item-use handler receives a native `ItemUseContext`.  Its `character` and
+`item` properties are generation-checked `GameHandle` values, and `position`
+is an immutable `TripointCoord` tagged as reality-bubble map-square (`bub` /
+`ms`).  The context itself expires as soon as the callback returns; copied
+handles remain usable only while their runtime generation, world generation,
+and native object are all still valid.  `player_name`, `item_id`, `charges`,
+and `message` are convenience members, not substitutes for the typed handles.
+
+物品 handler 收到原生 `ItemUseContext`。其中 `character` 与 `item` 是带运行时/世界
+代次检查的 `GameHandle`，`position` 是标记为现实气泡地图格（`bub` / `ms`）的不可变
+`TripointCoord`。回调返回后 context 本身立即失效；复制出的 handle 也只有在运行时
+代次、世界代次与原生对象都仍有效时才能继续使用。
+
+The full declarations are in `data/lua/types/ccb_platform_v1.d.lua`.  The
+complete executable template is under `data/lua/templates/complete/`, and
+`python3 tools/create_lua_mod.py TARGET --template complete` copies it only
+into an absent or empty target.  Generated files are author-owned and never
+updated in place.
+
+阶段 2/3 代码在每个 Mod 自己的 `ccb.content` 上提供构造器，返回的是原生 userdata，
+不是交给通用 loader 的 table。`add` 禁止隐式覆盖，`replace` 要求目标已存在；
+`edit_item`/`edit_recipe` 克隆本 Mod 在当前候选事务中更早暂存的定义，修改后再显式交给
+`ccb.content.edit`，并保留原来的 add/replace 意图。因此 Lua 模块组合在冷启动、完整
+重载和受指纹保护的热重载中使用同一套语义。完整声明、纯 Lua 样板和不覆盖作者文件的
+脚手架路径如上。配方的组件/工具备选组也必须是有界、从 1 开始且无空洞的数组，不能把
+额外元数据键静默当成原生需求。
+
+同一事务还直接管理上层内容依赖的基础目录：工具质量、技能显示分类、技能、维生素、
+JSON flag、伤害类型、材质、熟练度分类、熟练度、武器分类、物品分类、配方分类和
+弹药类型、气味类型、速度描述、采收掉落类型、采收表、行为树、怪物攻击、效果类型、
+弱点集、场类型、物品组、子身体部位、身体部位、解剖、身体图、怪物、士气类型、
+疾病类型、怪物 flag、怪物物种、字段排放、怪物阵营、突变类型、突变分类、地形/家具连接组、
+建造分类、建造组、载具部件位置、载具部件分类、心情表情表、伤害信息显示顺序、
+命名颜色、可旋转符号组，以及可由配方按 id 和倍数组合的
+`Requirement` 需求图，以及供营地/建筑流程
+组织配方的 `RecipeGroup`。它们先于物品/配方
+应用，因此同一候选中声明的质量、flag、
+材质、伤害类型与维生素可被后续对象引用；所有目录都进入 add/replace/edit、finalize 后
+保留检查、热重载指纹和逆序回滚。伤害类型的命中/受伤行为绑定命名 Lua handler，不暴露
+`onhit_eocs`、`ondamage_eocs` 或 EOC runner。
+
 ## Behaviour instead of EOC / 用 Lua 行为取代 EOC
 
 Platform v1 uses a small set of orthogonal primitives:
@@ -178,6 +786,271 @@ event、同步 Hook、命名 handler、命名持久任务、可序列化角色/�
 编写的 workflow/state-machine 库。EOC handler 应追踪到背后的通用游戏操作，抽成旧
 EOC 适配层与 Lua binding 共用的 C++ service，而不是逐键复制 Lua API。
 
+The implemented Platform state now installs the shared native domains under
+`ccb.services`: immutable ids/units/coordinates/time, generation-checked
+handles, characters, creatures, effects, bionics, mutations, skills,
+proficiencies, vitamins, addictions, needs, martial arts, items, inventory,
+vehicles, NPCs, factions, camps, zones, spells, missions, recipes, crafting,
+map/world/overmap/hordes, weather, statistics, variables, sound, targeting,
+spawning, followers, and relocation.  These are shared C++ implementations,
+not calls into a v5 Lua state.  Platform deliberately does not install the v5
+EOC table, authored JSON registry, or capability surface.  Reads require
+`world_ready`; mutations additionally require an active Platform callback.
+
+当前 Platform state 已在 `ccb.services` 下安装上述原生领域服务。它们共享的是 C++
+实现，不会调用另一个 v5 Lua state；Platform 明确不安装 v5 的 EOC table、作者 JSON
+registry 或 capability 表。读取要求世界已就绪，修改还要求当前处于 Platform 回调。
+
+`ccb.runtime.hook(native_name, handler_id)` attaches a named handler to the
+checked synchronous native-hook catalog.  Callback payload creatures, items,
+vehicles, missions, and talkers cross the boundary only as generation-bound
+handles or detached values.  Boolean vetoes and structured `allow`, `handled`,
+`text`, `result`, `results`, and `entries` fields are accepted only when that
+native hook declares the corresponding result contract.  Platform handlers
+compose in Mod dependency order with the existing native dispatcher.  String
+result lists and menu-entry lists are bounded dense one-based arrays; invalid
+shared mutation or returned data discards only that handler's candidate result
+and preserves the aggregate produced by earlier handlers.
+
+`ccb.runtime.hook` 将命名 handler 接到受检的同步 Hook 目录；payload 中的活对象只以
+代次绑定 handle 或快照跨界。只有 Hook 契约声明过的否决、文本、替换值或菜单结果才会
+生效，Platform handler 按 Mod 依赖顺序与原生 dispatcher 合成。字符串结果与菜单项必须
+是有界、从 1 开始且无空洞的数组；无效的共享修改或返回值只丢弃当前 handler 的候选
+结果，不会抹掉此前 handler 的聚合结果。
+
+Player-facing interaction is a separate top-level domain rather than an EOC
+effect spelling.  Inside an active callback, `ccb.presentation.notice`,
+`confirm`, `choose`, and `input_text` provide bounded native dialogs.  Choice
+ids are stable values independent from labels, cancellation returns `nil`, and
+input sizes, duplicate ids, and non-dense choice arrays are rejected before UI
+opens.  A choice list must use consecutive integer keys starting at one; extra
+string keys or holes are an error rather than silently ignored content.  Mods
+compose these primitives with ordinary Lua functions, coroutines, handlers,
+and state machines.
+
+面向玩家的交互使用独立的 `ccb.presentation` 领域，而不是照抄 EOC effect 键。活动
+回调内可调用 `notice`、`confirm`、`choose` 与 `input_text`；选项的稳定 ID 与显示文本
+分离，取消返回 nil，打开界面前会检查数量、大小、重复 ID，以及列表是否为从 1 开始
+且没有空洞的连续整数数组；额外字符串键也会被拒绝。复杂流程由普通 Lua 函数、协程、
+handler 和状态机组合。
+
+### Creature content as a native graph / 原生怪物内容图
+
+Creature content is a graph of native definitions, not a JSON-shaped table
+passed through a compatibility loader.  Lua constructs each native staging
+object directly and composes it with ordinary functions and modules.  No part
+of this path calls a JSON loader or EOC runner.
+
+怪物内容是一张原生定义图，不是交给兼容 loader 的 JSON 形状 table。Lua 直接构造每个
+原生暂存对象，再用普通函数与模块组合；这条路径的任何部分都不会调用 JSON loader 或
+EOC runner。
+
+The important dependency edges are:
+
+- `EffectType` feeds `WeakpointSet`, `FieldType`, and Monster regeneration
+  modifiers;
+- `SubBodyPart` and `BodyPart` feed `Anatomy`, `BodyGraph`, and body-targeted
+  field effects;
+- `ItemGroup`, `Behavior`, `MonsterAttack`, and `WeakpointSet` feed `Monster`.
+
+关键依赖关系是：`EffectType` 供弱点、场效果与怪物再生修正引用；`SubBodyPart` 和
+`BodyPart` 供解剖、身体图与按身体部位施加的场效果引用；`ItemGroup`、`Behavior`、
+`MonsterAttack` 与 `WeakpointSet` 最终组成 `Monster`。
+
+Cross-references inside one candidate transaction are validated together, then
+applied in native dependency order rather than source-file order.  If any
+apply, finalization, or post-finalize retention check fails, every applied
+candidate definition is rolled back in reverse order and the previous runtime
+remains active.  Replacement and rollback also rebuild Behavior goal pointers,
+body-part similarity/finalization caches, and the Monster hallucination cache,
+so those derived views cannot retain candidate pointers.
+
+同一候选事务里的交叉引用会先统一验证，再按原生依赖顺序而不是源码顺序应用。如果任一
+apply、finalize 或 finalize 后保留检查失败，所有已应用的候选定义都会逆序回滚，旧
+runtime 继续保持活动。替换与回滚还会重建 Behavior goal 指针、身体部位相似/终结缓存
+和怪物幻觉候选缓存，避免派生视图残留候选指针。
+
+`MonsterAttack` stores a named Lua policy, never a closure or EOC reference in
+the native definition.  Its payload contains a generation-safe attacker handle
+and either a generation-safe target handle or `nil` when no target exists.  A
+missing handler, a runtime that is not ready, a Lua error, recursion-limit
+failure, or a non-boolean return value safely resolves to `false`.  The
+`GEN_DORMANT` Monster flag is currently rejected because it creates a derived
+pseudo-monster for which the transaction does not yet have a safe rollback
+model.
+
+`MonsterAttack` 在原生定义中只保存命名 Lua policy，不保存闭包或 EOC 引用。payload
+携带有代次检查的攻击者 handle；没有目标时 `target` 为 `nil`，否则也是有代次检查的
+handle。handler 缺失、runtime 未就绪、Lua 报错、递归超限或返回值不是 boolean 时，
+攻击会安全退化为 `false`。当前明确拒绝怪物 flag `GEN_DORMANT`，因为它会创建派生伪
+怪物，而事务还没有能安全回滚该派生对象的模型。
+
+The following complete composition uses only native Platform builders.  It
+also demonstrates a same-transaction cycle: the field declares immunity for
+the Monster that is staged later, while the Monster refers back to definitions
+staged throughout the candidate.
+
+下面的完整组合只使用原生 Platform builder。它也展示同事务交叉引用：场类型先声明对
+稍后暂存的怪物免疫，而怪物再引用候选中此前暂存的各类定义。
+
+```lua
+local ccb = require("ccb")
+
+local effect = ccb.content.EffectType {
+    id = "lua_creature_effect",
+    name = "Lua creature effect",
+    description = "Applied by native Lua creature content.",
+    maximum_intensity = 2,
+}
+effect:reduced_description("A reduced Lua creature effect.")
+ccb.content.add(effect)
+
+local weakpoints = ccb.content.WeakpointSet {
+    id = "lua_creature_weakpoints",
+}
+weakpoints:weakpoint {
+    id = "core",
+    name = "core",
+    coverage = 100,
+    good = true,
+}
+weakpoints:armor_multiplier("core", "bash", 0.5)
+weakpoints:damage_multiplier("core", "bash", 1.5)
+weakpoints:effect("core", {
+    effect = "lua_creature_effect",
+    chance = 25,
+    duration_min_turns = 1,
+    duration_max_turns = 3,
+})
+ccb.content.add(weakpoints)
+
+local drops = ccb.content.ItemGroup {
+    id = "lua_creature_drops",
+    kind = "distribution",
+}
+drops:item("rock", 100)
+ccb.content.add(drops)
+
+local surface = ccb.content.SubBodyPart {
+    id = "lua_creature_core_surface",
+    name = "core surface",
+    parent = "lua_creature_core",
+}
+surface:location_under("lua_creature_core_surface")
+surface:unarmed_damage("bash", 1)
+
+local body = ccb.content.BodyPart {
+    id = "lua_creature_core",
+    name = "core",
+    main_part = "lua_creature_core",
+    connected_to = "lua_creature_core",
+    hit_size = 1,
+    hit_difficulty = 1,
+    base_health = 20,
+}
+body:sub_part("lua_creature_core_surface")
+body:limb_type("torso")
+body:armor("bash", 1)
+body:unarmed_damage("bash", 2)
+ccb.content.add(surface)
+ccb.content.add(body)
+
+local anatomy = ccb.content.Anatomy {
+    id = "lua_creature_anatomy",
+}
+anatomy:part("lua_creature_core")
+ccb.content.add(anatomy)
+
+local graph = ccb.content.BodyGraph {
+    id = "lua_creature_graph",
+    parent_body_part = "lua_creature_core",
+}
+graph:row("C")
+graph:part("C", {
+    body_parts = { "lua_creature_core" },
+    sub_body_parts = { "lua_creature_core_surface" },
+    selected_color = "light_red",
+    display_symbol = "C",
+})
+ccb.content.add(graph)
+
+local field = ccb.content.FieldType {
+    id = "fd_lua_creature",
+    phase = "gas",
+}
+field:intensity {
+    name = "Lua creature mist",
+    symbol = "%",
+    color = "light_blue",
+}
+field:effect(1, {
+    effect = "lua_creature_effect",
+    duration_min_turns = 1,
+    duration_max_turns = 2,
+    body_part = "lua_creature_core",
+})
+field:immune_monster("mon_lua_creature")
+ccb.content.add(field)
+
+ccb.runtime.handler("lua_creature_attack", function(payload)
+    if not payload.attacker:is_valid() then
+        return false
+    end
+    if payload.target ~= nil and not payload.target:is_valid() then
+        return false
+    end
+    return payload.attack_id == "lua_creature_attack"
+end, 1)
+
+local attack = ccb.content.MonsterAttack {
+    id = "lua_creature_attack",
+    cooldown = 5,
+}
+attack:policy("lua_creature_attack")
+ccb.content.add(attack)
+
+local behavior = ccb.content.Behavior {
+    id = "lua_creature_goal",
+    goal = "attack",
+}
+ccb.content.add(behavior)
+
+local monster = ccb.content.Monster {
+    id = "mon_lua_creature",
+    name = "native Lua creature",
+    plural_name = "native Lua creatures",
+    description = "A Monster assembled without JSON or EOC.",
+    symbol = "C",
+    color = "light_blue",
+    default_faction = "zombie",
+    harvest = "human",
+    speed_description = "DEFAULT",
+    death_drops = "lua_creature_drops",
+    hp = 20,
+    speed = 80,
+    melee_skill = 2,
+}
+monster:material("flesh", 1)
+monster:species("ZOMBIE")
+monster:armor("bash", 2)
+monster:melee_damage("bash", 3, 1)
+monster:attack("lua_creature_attack", 7)
+monster:weakpoint_set("lua_creature_weakpoints")
+monster:regeneration_modifier("lua_creature_effect", -1)
+monster:goal("lua_creature_goal")
+monster:anger_trigger("HURT")
+ccb.content.add(monster)
+```
+
+This creature graph is currently `implemented_unverified`: native code,
+LuaLS declarations, rollback/retention paths, migration extraction, and tests
+exist, but the requested validation gate has not run.  It must not yet be
+described as verified or production-complete.
+
+这张怪物内容图当前状态是 `implemented_unverified`：原生代码、LuaLS 声明、回滚/保留
+路径、迁移提取器与测试已经存在，但按约定尚未运行验证门，因此不能称为已验证或生产级
+完成。
+
 ## Persistent execution / 持久执行
 
 Closures, coroutine stacks, userdata, and native references are not serialized.
@@ -195,6 +1068,53 @@ coroutines remain useful but do not survive save/load.
 闭包、协程调用栈、userdata 和原生引用不序列化。持久任务只保存稳定的 Mod ID、
 handler ID、到期时间、owner 与 payload；重载后在新 Mod state 中重新绑定函数。
 
+### Implemented runtime primitives / 已编码的运行时原语
+
+Platform code registers a function once under a stable id with
+`ccb.runtime.handler(id, function, payload_version)`.  `ccb.runtime.on` then
+maps lifecycle names (`world_ready`, `before_save`, `after_save`, `shutdown`)
+or a typed native event name (`game:<event>`) to that handler.  A Mod may bind
+multiple named handlers to the same event; registration order is preserved and
+registering the same event/handler pair twice is an error.  Item use actors
+and persistent tasks resolve the same registry; neither stores a Lua closure
+in game data or a save.
+
+`ccb.state.character` and `ccb.state.world` store only boolean, integer,
+finite-number, string, or nil values.  The engine writes internal sidecars;
+Mod authors neither create nor parse their JSON representation.  A task made
+with `ccb.tasks.after` stores its numeric id, handler id, absolute due turn,
+character/world owner, payload version, and a flat typed payload.  Missing
+handlers are preserved with a bounded diagnostic instead of losing durable
+data.  A version mismatch follows the explicit chain registered with
+`ccb.runtime.migrate_task_payload(handler, from, to, function)`; a missing,
+cyclic, failing, or invalid migration also preserves the task for a later Mod
+fix.  A multi-step chain migrates a copy and replaces the durable task only
+after every step succeeds, so a late failure cannot persist a half-migrated
+payload.  New tasks must use the handler's current payload version.
+Overdue tasks run once at the first turn boundary after loading.  A handler may
+schedule a new task to express recurrence in ordinary Lua.
+
+Platform 代码用 `ccb.runtime.handler(id, function, payload_version)` 把函数注册到稳定
+名字，再由 `ccb.runtime.on` 绑定生命周期或 `game:<event>` 原生事件。物品行为与持久
+任务都按名字重新解析，不把闭包写入定义或存档。角色/世界状态只接受布尔、整数、有限
+浮点、字符串和 nil；引擎自行写内部 sidecar，Mod 作者不接触其 JSON 表示。命名任务
+保存 ID、handler、绝对到期回合、owner、payload version 与扁平类型化 payload；缺失
+handler 会记录有界诊断并保留任务。版本不一致时只执行显式注册的
+`migrate_task_payload` 迁移链；缺失、循环、失败或返回非法数据时同样保留，等待 Mod
+修复。多段迁移只操作副本，全部步骤成功后才替换持久任务，因此后段失败不会留下半迁移
+payload。新任务必须使用 handler 当前版本，到期任务在加载后的首个回合边界执行一次。
+同一个事件可以按注册顺序绑定多个命名 handler，但同一事件与 handler 组合不能重复。
+
+Sidecar records belonging to a currently disabled or missing Mod are retained
+unchanged in the typed engine representation when other active Platform Mods
+save.  Re-enabling the Mod restores its record instead of treating another
+Mod's save as permission to delete it.  Malformed records still reject that
+scope as a bounded unit and fall back to empty active state with a diagnostic.
+
+暂时禁用或缺失 Mod 的 sidecar 记录会以引擎内部类型化表示保留；其他 Platform Mod
+保存时不会把它顺带删除。重新启用后会恢复原记录。格式损坏时仍以整个 scope 为有界
+失败单元，清空活动状态并给出诊断。
+
 ## Internal reuse and replacement boundary / 内部复用与替换边界
 
 An early domain may privately adapt staged native definitions to the existing
@@ -210,6 +1130,35 @@ those formats does not increase Lua authoring power and is not a Platform goal.
 早期领域可以在内部把暂存定义适配到现有 loader/finalize 管线，但这只是私有实现捷径，
 必须在路线图记录并逐域替换。长期目标覆盖作者面对的核心与 Mod 内容；存档、设置、翻译
 缓存和生成清单等引擎内部序列化不在替换目标内。
+
+## Exact replacement ledger / 精确替代账本
+
+`ai/lua-first-replacement-ledger.yml` is generated from the three checked
+inventories and contains exactly one disposition for every JSON type, EOC
+condition key, and EOC effect key.  Its statuses have strict meanings:
+
+- `implemented_unverified`: matching Platform code and declaration exist, but
+  the requested validation gate has not run;
+- `primitive_available_unverified`: one or more native domain primitives exist
+  without a public legacy dependency, but selector-level semantic parity has
+  not been demonstrated and migration remains open;
+- `planned`: a target domain/service is named, but no replacement is claimed;
+- `private_adapter`: implementation currently depends on a non-public legacy
+  adapter that must be removed;
+- `reviewed_not_applicable`: normal Lua control flow or engine-owned
+  configuration replaces no author-facing API.
+
+The generator, schema, and exact-set checker live under `tools/agent/`.  A
+selector changes status only with source, declaration, test, and documentation
+evidence.  Grouping a selector under a service is architecture classification,
+not proof that the service exists.
+
+`ai/lua-first-replacement-ledger.yml` 由三份受检清单生成，每个 JSON type、EOC
+condition key 和 effect key 恰好出现一次。`implemented_unverified` 表示已有代码但尚未
+通过本次验证门；`primitive_available_unverified` 表示已有不依赖旧公共接口的原生积木，
+但还没有逐 selector 证明等价；`planned` 只表示已确定目标而没有声称替代完成，`private_adapter` 表示
+仍有不公开的旧实现依赖，`reviewed_not_applicable` 表示 Lua 控制流或引擎配置本来就不该
+产生作者 API。把一项归入某个 service 只是架构分类，不能当作 service 已存在的证据。
 
 ## Migration and removal gates / 迁移与移除门槛
 
@@ -233,6 +1182,45 @@ documentation are usable.  Removal requires all of the following:
 捆绑内容迁移、存档兼容、迁移工具、端到端纯 Lua Mod，以及至少两个稳定版且十二个月
 的弃用窗口。
 
+`tools/migrate_lua_first.py INPUT... --output TARGET` is the implemented
+extractor.  It deterministically translates the currently native item/recipe
+slice, foundational catalogs (including scent, speed-description,
+harvest-drop, harvest-list, behavior-tree, monster-attack, effect-type,
+weakpoint-set, field-type, item-group, sub-body-part, body-part, anatomy,
+body-graph, monster, morale, disease, monster-flag, mutation-type, mutation-category,
+connect-group, construction, species, emissions, monster-faction, and vehicle-part-location definitions, vehicle-part categories, mood faces,
+damage-info presentation, named colors, rotatable symbols, ASCII art, limb
+scores, the global hit-range configuration, bash-damage profiles, clothing
+modifications, overmap land-use codes, overmap-vision profiles,
+overmap locations, profession groups, map-extra collections, vehicle groups,
+fault groups, explosion-light recipes, ammunition effects, addiction types, character modifiers, start locations, climbing aids, weather types, scores, the global mutation-overlay order, zone types, speech pools, end screens, nested recipe categories, attack vectors, magic types, and movement modes), and simple
+event/message behaviour, emits normal Lua composition, and
+writes `MIGRATION_REPORT.md` with a source location for every unresolved
+field.  It accepts the comments and trailing commas used by game data;
+unsupported inheritance, anonymous definitions, disassembly recipes, mixed
+effects, lossy field shapes, malformed numeric shapes, and values outside the
+native integer or skill ranges remain partial with explicit TODOs.  `--check`
+compares an existing extraction without writing.  Normal writes stage output
+before installation, and `--force` restores every previous generated file if
+installation fails midway.  The tool never emits a JSON loader, EOC runner, or
+raw legacy object.  Its report is an input to review, not proof of gameplay
+equivalence.
+
+`tools/migrate_lua_first.py` 是当前迁移提取器：能确定性转出已具备原生构造器的基础目录、
+气味、速度描述、采收掉落类型、采收表、行为树、怪物攻击、效果类型、弱点集、场类型、
+物品组、子身体部位、身体部位、解剖、身体图、怪物、士气、疾病、怪物 flag、怪物物种、
+字段排放、怪物阵营、突变类型、突变分类、地形/家具连接组、建造分类、建造组、载具
+部件位置、载具部件分类、心情表情、伤害信息显示顺序、命名颜色、可旋转符号、物品、
+ASCII 图、肢体评分、全局命中距离配置、bash 伤害配置、服装改造、大地图土地用途、
+大地图视野配置、大地图位置、职业组、地图额外内容集合、载具组、故障组、爆炸光效、弹药效果、成瘾类型、角色修正器、起始位置、攀爬辅助、天气类型、分数、全局突变覆盖显示顺序、区域类型、语音池、结束画面、嵌套配方分类、攻击向量、
+魔法类型、移动模式、配方与简单事件/消息行为，其余字段全部以
+带来源位置的 TODO 写入报告；`--check` 只比较
+现有输出。它支持游戏数据使用的注释与尾逗号；继承、匿名定义、拆解配方、混合 effect
+以及有损字段形状、畸形数字和超出原生整数/技能范围的值都会保持 partial 并写明 TODO。
+普通写入先暂存再安装，`--force` 中途失败时会恢复全部旧生成文件。工具绝不会生成 JSON
+loader、EOC runner 或原始旧对象，报告也
+不等于玩法等价证明。
+
 ## First vertical slice and templates / 首个纵向样板与模板
 
 The first executable slice is one zero-JSON/EOC Mod that defines an item, its
@@ -240,15 +1228,30 @@ recipe, and a Lua use behaviour.  It must exercise discovery, native content,
 cross-id references, a named handler, persistent state, save/load, and an
 observable in-game result.
 
-Developer tooling will provide `minimal` and `complete` templates plus a
+Besides the scaffold template, `data/mods/Lua_First_Example/` is a packaged
+zero-JSON/EOC Mod root discovered from `main.lua`.  It is a bundled executable
+fixture for the implemented item/recipe/handler slice; it is not evidence for
+the remaining static domains.
+
+Developer tooling provides `minimal` and `complete` templates plus a
 scaffolding command.  Generated Mods contain no JSON and no required `lua/`
 directory.  The complete template may recommend `content/`, `runtime/`, and
 `tests/`, but generated files become author-owned and are never overwritten by
-template updates.
+template updates.  Scaffolding is staged before installation, refuses files,
+symlinks, or non-empty targets, and derives the zero-configuration Mod id from
+the target directory name.  The complete template uses that id as its example
+content namespace instead of giving every generated Mod the same item id.  A
+failed final installation restores a pre-existing empty target, and a target
+created or changed concurrently is preserved rather than replaced.
 
 首个可执行样板固定为“物品 + 配方 + Lua 使用行为”的零 JSON/EOC Mod。开发工具将
 提供 minimal、complete 模板和脚手架命令；生成结果不包含 JSON，也不强制 `lua/`
 目录。模板只推荐组织方式，生成后文件完全归作者所有，工具不得覆盖其修改。
+脚手架完成暂存后才安装，拒绝文件、符号链接和非空目标；最终安装失败时会恢复调用者原有
+的空目录。目标目录名就是零配置 Mod ID，
+complete 模板会用它命名空间化样例内容 ID，避免多个开发者样板互相冲突。
+仓库还包含 `data/mods/Lua_First_Example/`，作为由根 `main.lua` 发现的内置纯 Lua
+执行样板；它只证明当前纵向切片，不代表其余静态领域已完成。
 
 ## Maintenance rule / 维护规则
 

--- a/data/lua/LUA_FIRST_PLATFORM.md
+++ b/data/lua/LUA_FIRST_PLATFORM.md
@@ -185,6 +185,13 @@ The target lifecycle is:
 7. Commit the prepared Platform states only after finalization succeeds.
 8. Make registered runtime handlers active after `world_ready`.
 
+During initial loading, staged Monster definitions remain unfinalized until
+the global pass in step 6, so world scaling and Monster adjustment are applied
+exactly once.  Local Monster finalization is reserved for test or hot
+environments where the dynamic data is already finalized.  Body-part and
+sub-body-part similarity caches are rebuilt after global finalization, making
+repeated finalization idempotent instead of appending duplicate relationships.
+
 A full world replacement dispatches `shutdown` and retires the previous
 Platform states before the engine unloads their finalized native registries.
 An in-place save reload that deliberately keeps the same data registries may
@@ -215,6 +222,10 @@ fingerprint leaves the active states untouched.
 目标生命周期依次为：发现入口、解析依赖、开始数据事务、按需加载旧 JSON、执行 Lua
 并暂存原生定义、统一 finalize、成功后提交 Platform state，最后在 `world_ready` 后
 激活运行时 handler。
+初始加载时，暂存的 Monster 定义会一直保留未 finalize 状态，直到统一 finalize 阶段，
+因此世界缩放和 Monster adjustment 只会由全局流程应用一次。只有动态数据已经
+finalized 的测试或热环境才会执行局部 Monster finalize；body part 和 sub-body part 的
+相似关系缓存则会在全局 finalize 后重建，使重复 finalize 保持幂等而不会追加重复关系。
 完整切换世界时，会在引擎卸载旧原生注册表之前先派发 `shutdown` 并销毁旧 Platform
 state；明确复用同一批数据注册表的存档内快速重载则可以保留 state，并再次派发
 `world_ready`。
@@ -247,11 +258,19 @@ consistency finalization cannot silently leave a partially active Platform
 candidate.  Trusted filesystem, process, and native-module side effects remain
 outside that transaction.
 
-This code is deliberately still marked **implemented but unverified**.  No
-compile, test, formatter, declaration check, or ledger check has run since the
-owner requested implementation through phase 5 before validation.  The exact
+Validation has now started, but it does not make the whole Platform complete.
+On 2026-08-11 the Linux Lua-enabled C++ test program compiled and linked, the
+focused Wound/WoundFix and wound-service gates passed, and the complete
+`[lua][platform]` suite passed 45 test cases with 934 assertions after adding
+the bionic-summary and learned-recipe workflow.  The broader `[lua]` filter
+then passed 190 matching test cases with 2706 assertions, including the
+owner-identity, pre-finalize Monster, and body-cache regression coverage.  LuaLS,
+public-contract, coverage, Agent-metadata, and replacement-ledger checks also
+passed.  Interactive desktop/Android presentation checks and field-by-field
+parity for the remaining domains are still open, so only explicitly named
+validated slices may be treated as having crossed their local gate.  The exact
 replacement ledger contains 775 dispositions; its generated summary is the
-authoritative count.  The implemented-but-unverified static slice now covers
+authoritative count.  The remaining implemented-but-unverified static slice covers
 Mod metadata, tool qualities, skill display categories, skills, vitamins,
 JSON flags, damage types, materials, proficiency categories, proficiencies,
 weapon categories, item categories, recipe categories, ammunition types,
@@ -534,9 +553,15 @@ not construct the legacy `nested_category_data` list shape.
 `replace` 同一候选中先加载的定义。commit 还必须通过 finalize 后的保留检查，避免被全局一致性检查剔除的
 配方造成部分候选悄悄生效。文件、进程和原生模块的外部副作用仍无法回滚。
 
-这些代码目前仍统一标为**已实现但未验证**：按负责人要求，阶段 5 收口前没有运行
-编译、测试、格式、声明或账本检查。775 项的分类数字以生成账本 summary 为准，不在本文
-手工复制。当前静态切片包括 Mod 元数据、工具质量、技能显示分类、技能、维生素、JSON
+验证已经开始，但这不表示整个平台已经完成。2026-08-11 的 Linux 本地验证成功编译并链接
+Lua-enabled C++ 测试程序，Wound/WoundFix 与伤口 service 的聚焦门禁全部通过；加入
+仿生摘要与已学配方工作流后，完整 `[lua][platform]` 套件以 45 个用例、934 个断言通过；
+随后更广的 `[lua]` 过滤集也以 190 个匹配用例、2706 个断言通过，其中包含 owner identity、
+Monster pre-finalize 与身体缓存回归覆盖。LuaLS、公开契约、覆盖率、Agent
+元数据与替换账本检查同样通过。桌面/Android 交互式 presentation 与其余领域逐字段等价性
+仍未完成，因此只有本文明确点名的已验证切片可以视为通过本地门禁。775 项的分类数字以
+生成账本 summary 为准，不在本文手工复制。其余已实现但未验证的静态切片包括 Mod 元数据、
+工具质量、技能显示分类、技能、维生素、JSON
 flag、伤害类型、材质、熟练度分类、熟练度、武器分类、物品分类、配方分类、弹药
 类型、可复用制作需求、配方组、气味类型、速度描述、采收掉落类型、采收表、行为树、
 怪物攻击、效果类型、弱点集、场类型、物品组、子身体部位、身体部位、解剖、身体图、
@@ -623,11 +648,20 @@ operator.  Private and protected members retain normal C++ access rules.
 Exported types are explicit; JSON loaders, EOC parsers, and other legacy
 infrastructure are not export roots.
 
-Native references carry an owner and generation check.  Access after object
-destruction, world replacement, content commit, or runtime replacement raises
-a Lua error instead of dereferencing a stale pointer.  Native modules loaded
-by a trusted Mod can bypass this boundary and are outside the compatibility
-guarantee.
+Native references carry an owner identity and generation check.  Every
+Platform Mod runtime receives a distinct opaque owner, including runtimes
+created in the same reload generation.  Handles and live-object tokens retain
+that owner weakly and must match the exact current owner before native
+resolution.  Token equality compares the complete owner-plus-generation
+identity without keeping the owner alive, so copied tokens remain equal after
+shutdown while tokens from different same-generation runtimes never compare
+equal.  Inactive state is explicit rather than encoded as a reserved
+generation number, so every `size_t` generation value, including its maximum,
+remains unambiguous.  Access after object destruction, world replacement,
+content commit, runtime replacement, or crossing into another Mod runtime
+raises a Lua error instead of dereferencing a stale pointer.  Native modules
+loaded by a trusted Mod can bypass this boundary and are outside the
+compatibility guarantee.
 
 Static definitions are real native staging objects.  The target content API
 provides explicit `add`, `replace`, and transactional `edit` operations.
@@ -636,9 +670,15 @@ Lua functions, loops, modules, constructors, and cloning replace JSON
 `copy-from` and inheritance syntax.
 
 Platform 导出的 C++ 类型公开全部可绑定的 public 字段、方法与运算符；private 和
-protected 仍遵守 C++ 规则。原生引用带 owner/代次检查，owner 消失、世界切换、内容
-提交或 runtime 替换后访问会抛 Lua 错误。静态定义使用真实的原生 staging 对象，
-通过显式 `add`、`replace`、事务性 `edit` 提交；普通 Lua 组合取代 JSON `copy-from`。
+protected 仍遵守 C++ 规则。每个 Mod runtime 都有独立且不向 Lua 暴露的 owner 身份，
+即使它们处于同一重载代次也不能交换 handle 或原生活对象 token；二者都只弱引用 owner，
+并在解析前同时核对精确 owner、runtime 代次与世界代次。token 相等比较使用完整的
+owner 控制块身份与代次，但不会延长 owner 生命周期，所以同源副本在 runtime 关闭后仍
+稳定相等，而不同的同代 runtime token 永不相等。失效状态不再占用某个代次数值，因此
+包括 `size_t` 最大值在内的全部代次都不会与哨兵碰撞。owner 消失、跨 Mod runtime、
+世界切换、内容提交或 runtime 替换后访问会抛 Lua 错误。静态定义使用真实的原生
+staging 对象，通过显式 `add`、`replace`、事务性 `edit` 提交；普通 Lua 组合取代 JSON
+`copy-from`。
 
 ### Implemented native vertical slice / 已编码的原生纵向切片
 
@@ -661,7 +701,7 @@ content layers: `ToolQuality`, `SkillDisplay`, `Skill`, `Vitamin`, `JsonFlag`,
 `WeaponCategory`, `ItemCategory`, `RecipeCategory`, `AmmunitionType`,
 `ScentType`, `SpeedDescription`, `HarvestDropType`, `Harvest`, `Behavior`,
 `MonsterAttack`, `EffectType`, `WeakpointSet`, `FieldType`, `ItemGroup`,
-`SubBodyPart`, `BodyPart`, `Anatomy`, `BodyGraph`, `Monster`, `MoraleType`,
+`SubBodyPart`, `BodyPart`, `Wound`, `WoundFix`, `Anatomy`, `BodyGraph`, `Monster`, `MoraleType`,
 `DiseaseType`, `MonsterFlag`, `MutationType`, `Species`, `Emission`, `MonsterFaction`,
 `ConnectGroup`, `MutationCategory`, `ConstructionCategory`, `ConstructionGroup`, `VehiclePartLocation`,
 `VehiclePartCategory`, `MoodFace`,
@@ -679,6 +719,34 @@ Every registrar participates in explicit add/replace/edit semantics,
 post-finalize retention checks, the static hot-reload fingerprint, and reverse
 rollback.  The native transaction uses concrete-id factory erase and snapshot
 restore operations; it never calls a JSON loader.
+
+`Wound` and `WoundFix` are native staging definitions, not JSON-shaped tables
+passed to a compatibility loader.  A wound constructor owns `id`, native
+player-visible `name`/`plural_name`/`description` text, pain and healing-turn
+ranges, damage range, selection `weight`, per-part limit, and optional
+required/forbidden body-part flags.  Its `damage_type`, `limb_score`, `progression`,
+`require_body_part_type`, and `forbid_body_part_type` methods build typed,
+deduplicated links.  Damage ranges, selection weight, and the body-part
+flag/type constraints govern natural damage-selection candidates; they do not
+restrict an explicit direct add through the wound service.  A wound fix owns
+`id`, native player-visible name, description and success-message text,
+duration in turns, and health delta; `skill`, `proficiency`,
+`removes`, `adds`, and `requires` compose its native treatment graph.
+These player-visible fields currently use `no_translation`; structured
+localization data and author-facing localization constructors are not yet
+implemented.
+Proficiency time multipliers must remain positive when represented by the
+native float type.  A requirement multiplier is accepted only when every
+referenced component and tool count remains within the signed native integer
+range after multiplication and when mergeable alternative groups still fit
+that range after native consolidation; quality requirements are linked without
+scaling.  Negative tool counts follow the native post-multiplication `-1`
+clamp.
+References within the same candidate are finalized together.  `add` requires a new id,
+`replace` requires an existing id, and `edit_wound`/`edit_wound_fix` clone an
+earlier same-Mod candidate for transactional `edit`.  Validation failure or a
+later candidate failure restores registries, wound-to-fix links, body-part
+caches, and derived requirements without a JSON loader or EOC callback.
 
 Damage-type behaviour uses `DamageTypeDefinition:on_hit` and `on_damage` with
 named Platform handlers instead of `onhit_eocs` or `ondamage_eocs`.  Payloads
@@ -723,17 +791,22 @@ ccb.content.add(recipe)
 ```
 
 An item-use handler receives a native `ItemUseContext`.  Its `character` and
-`item` properties are generation-checked `GameHandle` values, and `position`
+`item` properties are runtime-owner- and generation-checked `GameHandle`
+values, and `position`
 is an immutable `TripointCoord` tagged as reality-bubble map-square (`bub` /
-`ms`).  The context itself expires as soon as the callback returns; copied
-handles remain usable only while their runtime generation, world generation,
-and native object are all still valid.  `player_name`, `item_id`, `charges`,
-and `message` are convenience members, not substitutes for the typed handles.
+`ms`).  A native RAII callback lease clears both borrowed pointers and expires
+the context on every exit path, including callback errors and C++ unwinding;
+copied handles remain usable only while their exact runtime owner, runtime
+generation, world generation, and native object are all still valid.
+`player_name`, `item_id`, `charges`, and `message` are convenience members, not
+substitutes for the typed handles.
 
-物品 handler 收到原生 `ItemUseContext`。其中 `character` 与 `item` 是带运行时/世界
-代次检查的 `GameHandle`，`position` 是标记为现实气泡地图格（`bub` / `ms`）的不可变
-`TripointCoord`。回调返回后 context 本身立即失效；复制出的 handle 也只有在运行时
-代次、世界代次与原生对象都仍有效时才能继续使用。
+物品 handler 收到原生 `ItemUseContext`。其中 `character` 与 `item` 是带精确 runtime
+owner、运行时代次与世界代次检查的 `GameHandle`，`position` 是标记为现实气泡地图格
+（`bub` / `ms`）的不可变 `TripointCoord`。回调返回后 context 本身立即失效；复制出的
+handle 也只有在原 owner、运行时代次、世界代次与原生对象都仍有效时才能继续使用。原生
+RAII 回调租约会在正常返回、Lua 报错与 C++ 栈展开的所有路径上清空借用指针并使 context
+失效。
 
 The full declarations are in `data/lua/types/ccb_platform_v1.d.lua`.  The
 complete executable template is under `data/lua/templates/complete/`, and
@@ -753,7 +826,7 @@ updated in place.
 JSON flag、伤害类型、材质、熟练度分类、熟练度、武器分类、物品分类、配方分类和
 弹药类型、气味类型、速度描述、采收掉落类型、采收表、行为树、怪物攻击、效果类型、
 弱点集、场类型、物品组、子身体部位、身体部位、解剖、身体图、怪物、士气类型、
-疾病类型、怪物 flag、怪物物种、字段排放、怪物阵营、突变类型、突变分类、地形/家具连接组、
+伤口、伤口修复、疾病类型、怪物 flag、怪物物种、字段排放、怪物阵营、突变类型、突变分类、地形/家具连接组、
 建造分类、建造组、载具部件位置、载具部件分类、心情表情表、伤害信息显示顺序、
 命名颜色、可旋转符号组，以及可由配方按 id 和倍数组合的
 `Requirement` 需求图，以及供营地/建筑流程
@@ -762,6 +835,24 @@ JSON flag、伤害类型、材质、熟练度分类、熟练度、武器分类�
 材质、伤害类型与维生素可被后续对象引用；所有目录都进入 add/replace/edit、finalize 后
 保留检查、热重载指纹和逆序回滚。伤害类型的命中/受伤行为绑定命名 Lua handler，不暴露
 `onhit_eocs`、`ondamage_eocs` 或 EOC runner。
+
+`Wound` 与 `WoundFix` 也是原生暂存定义，不是送进兼容 loader 的 JSON 形状 table。
+伤口构造器直接拥有 `id`、原生玩家可见的单复数名称和描述文本、疼痛/愈合回合范围、伤害范围、
+抽取权重、每身体部位上限，以及可选的身体部位必需/禁止 flag；`damage_type`、
+`limb_score`、`progression`、`require_body_part_type` 与
+`forbid_body_part_type` 负责建立类型化且去重的关系。伤害范围、抽取权重与身体部位
+flag/type 约束用于自然伤害流程的候选筛选，不限制通过伤口 service 显式指定部位的直接
+添加。伤口修复直接拥有原生玩家可见的名称、描述、成功文本、耗时回合和生命值变化，
+并用 `skill`、`proficiency`、`removes`、`adds`、
+`requires` 组合原生治疗图。这些玩家可见字段目前通过 `no_translation` 构造；结构化
+本地化数据与面向作者的本地化构造器尚未实现。熟练度耗时倍数转换成原生 `float` 后仍须
+为正；需求倍数只在
+所引用的每个组件和工具数量相乘后仍落在原生有符号整数区间，并且可合并备选组经原生
+consolidate 后仍不越界时才会被接受；负工具数量在安全乘法后按原生规则夹到 `-1`，质量
+需求不随该倍数缩放。同一候选中的引用一起 finalize；`add` 只新增、`replace` 只
+替换已存在 id，`edit_wound`/`edit_wound_fix` 克隆本 Mod 更早暂存的候选后再事务性
+`edit`。任一校验或后续候选失败都会恢复目录、伤口到修复的链接、身体部位缓存与派生需求，
+全程不调用 JSON loader 或 EOC callback。
 
 ## Behaviour instead of EOC / 用 Lua 行为取代 EOC
 
@@ -801,6 +892,31 @@ EOC table, authored JSON registry, or capability surface.  Reads require
 实现，不会调用另一个 v5 Lua state；Platform 明确不安装 v5 的 EOC table、作者 JSON
 registry 或 capability 表。读取要求世界已就绪，修改还要求当前处于 Platform 回调。
 
+Coordinates embedded in definition-policy and event callback payloads are
+detached plain Lua tables, not borrowed native coordinate objects and not
+`TripointCoord` userdata.  Their mandatory `coordinate_space` tag makes the
+native frame explicit: `bub_ms` means reality-bubble map squares, while
+`abs_ms` means absolute map squares.  Authors must branch or convert at an
+explicit service boundary instead of treating the two spaces as interchangeable.
+
+定义策略与事件回调 payload 中携带的坐标是脱离原生对象的普通 Lua table，不是借用的
+原生坐标对象，也不冒充 `TripointCoord` userdata。必需的 `coordinate_space` 标签明确区分
+原生坐标系：`bub_ms` 表示现实气泡地图格，`abs_ms` 表示绝对地图格；两者不能隐式混用，
+需要由作者在明确的 service 边界判断或转换。
+
+`ZoneToken` also carries an unexposed runtime-owner context and native lifetime
+identity in addition to its readable snapshot.  A token cannot cross into a
+different Mod runtime even when both runtimes use the same numeric generation.
+Deleting a zone and creating a field-for-field identical replacement does not
+revive the old token; only a fresh token from the replacement can resolve it.
+The identity anchor follows ordinary native copies and moves, so container
+reallocation alone does not invalidate a live zone.
+
+`ZoneToken` 除可读快照外还携带不向 Lua 暴露的 runtime owner 上下文与原生生命周期
+身份；即使数值代次相同，token 也不能跨到另一个 Mod runtime。删除区域后，即使逐字段
+创建完全相同的新区域，旧 token 也不会复活；只有新区域返回的新 token 才能解析它。
+身份锚点会跟随原生对象的正常复制与移动，因此仅容器扩容不会误使仍存活的区域失效。
+
 `ccb.runtime.hook(native_name, handler_id)` attaches a named handler to the
 checked synchronous native-hook catalog.  Callback payload creatures, items,
 vehicles, missions, and talkers cross the boundary only as generation-bound
@@ -812,11 +928,28 @@ result lists and menu-entry lists are bounded dense one-based arrays; invalid
 shared mutation or returned data discards only that handler's candidate result
 and preserves the aggregate produced by earlier handlers.
 
+Dialogue hooks use Platform-native semantic fields rather than EOC positional
+talkers.  `on_dialogue_start` receives `avatar`, `interlocutor`, and
+`initial_topic`; `on_dialogue_option` receives `avatar`, `interlocutor`,
+`current_topic`, and `selected_topic`; `on_dialogue_end` receives `avatar`,
+`interlocutor`, and `last_topic`.  Platform never publishes `alpha`/`beta`
+aliases.  The existing Lua API v5 dispatcher keeps its own compatibility
+payload unchanged and runs before Platform, so its candidate result is visible
+through `payload.results` without becoming Platform's authoring vocabulary.
+
 `ccb.runtime.hook` 将命名 handler 接到受检的同步 Hook 目录；payload 中的活对象只以
 代次绑定 handle 或快照跨界。只有 Hook 契约声明过的否决、文本、替换值或菜单结果才会
 生效，Platform handler 按 Mod 依赖顺序与原生 dispatcher 合成。字符串结果与菜单项必须
 是有界、从 1 开始且无空洞的数组；无效的共享修改或返回值只丢弃当前 handler 的候选
 结果，不会抹掉此前 handler 的聚合结果。
+
+对话 Hook 使用 Platform 自己的语义字段，不沿用 EOC 的位置式 talker：
+`on_dialogue_start` 得到 `avatar`、`interlocutor`、`initial_topic`；
+`on_dialogue_option` 得到 `avatar`、`interlocutor`、`current_topic`、`selected_topic`；
+`on_dialogue_end` 得到 `avatar`、`interlocutor`、`last_topic`。Platform 不发布
+`alpha`/`beta` 别名。现有 Lua API v5 dispatcher 为兼容仍保留自己的旧 payload，并先于
+Platform 运行；它产生的候选结果只通过 `payload.results` 进入 Platform，不会成为新的
+作者词汇。
 
 Player-facing interaction is a separate top-level domain rather than an EOC
 effect spelling.  Inside an active callback, `ccb.presentation.notice`,
@@ -1042,14 +1175,15 @@ monster:anger_trigger("HURT")
 ccb.content.add(monster)
 ```
 
-This creature graph is currently `implemented_unverified`: native code,
+This creature graph remains `bounded_implemented_unverified`: native code,
 LuaLS declarations, rollback/retention paths, migration extraction, and tests
-exist, but the requested validation gate has not run.  It must not yet be
-described as verified or production-complete.
+exist, and its written local C++ gate passed on 2026-08-11.  That local result
+validates only the documented bounded slice; it is not production-complete or
+full field-level JSON parity.
 
-这张怪物内容图当前状态是 `implemented_unverified`：原生代码、LuaLS 声明、回滚/保留
-路径、迁移提取器与测试已经存在，但按约定尚未运行验证门，因此不能称为已验证或生产级
-完成。
+这张怪物内容图当前状态是 `bounded_implemented_unverified`：原生代码、LuaLS 声明、回滚/保留
+路径、迁移提取器与测试已经存在，且其书面本地 C++ 门禁已于 2026-08-11 通过。该结果只验证
+本文明确描述的有界切片，不能称为生产级完成，也不能声称已覆盖对应 JSON 类型的全部字段。
 
 ## Persistent execution / 持久执行
 
@@ -1079,6 +1213,24 @@ registering the same event/handler pair twice is an error.  Item use actors
 and persistent tasks resolve the same registry; neither stores a Lua closure
 in game data or a save.
 
+Every `game:<event>` payload contains the native event type, turn, typed data,
+and data-type names.  Its `actors` table maps semantic native `character_id`
+field names such as `character`, `attacker`, `killer`, or `victim` to live,
+generation-checked Character handles.  The bridge neither guesses one primary
+actor nor falls back to the avatar, and it never publishes EOC alpha/beta
+aliases.  `character_wields_item`, `character_wears_item`,
+`character_takeoff_item`, and `character_armor_destroyed` additionally expose
+`actors.item` only when the native producer actually supplied its
+`item_location` talker.  A plain `event_bus.send`, another event with an item in
+the same positional slot, or a missing item talker never falls back to a guessed
+wielded item.  Events whose native schema names no supported live entity simply
+have an empty `actors` table; future vehicle or other entity references must use
+equally semantic native fields instead of positional talker compatibility.
+All subscribed Mod/handler payloads are built before the first callback and
+each handler receives its own table graph, so mutation or failure cannot
+contaminate the next handler.  Per-Mod callback depth remains isolated while a
+global event-bridge depth cap bounds the native stack across all Mods.
+
 `ccb.state.character` and `ccb.state.world` store only boolean, integer,
 finite-number, string, or nil values.  The engine writes internal sidecars;
 Mod authors neither create nor parse their JSON representation.  A task made
@@ -1104,6 +1256,19 @@ handler 会记录有界诊断并保留任务。版本不一致时只执行显式
 修复。多段迁移只操作副本，全部步骤成功后才替换持久任务，因此后段失败不会留下半迁移
 payload。新任务必须使用 handler 当前版本，到期任务在加载后的首个回合边界执行一次。
 同一个事件可以按注册顺序绑定多个命名 handler，但同一事件与 handler 组合不能重复。
+每个 `game:<event>` payload 都包含原生事件类型、回合、类型化 data 与 data type 名称。
+其中 `actors` 表会把 `character`、`attacker`、`killer`、`victim` 等具有语义的原生
+`character_id` 字段名映射成带 generation 检查的 Character handle。桥接层不会猜测
+“主角色”，不会回退到 avatar，也绝不发布 EOC 的 alpha/beta 别名。
+`character_wields_item`、`character_wears_item`、`character_takeoff_item` 与
+`character_armor_destroyed` 只有在原生发送方确实附带对应 `item_location` talker 时才会
+额外提供 `actors.item`。普通 `event_bus.send`、其他事件碰巧把物品放在同一位置，或缺少
+物品 talker 时，都不会回退去猜当前持握物。原生 schema 没有命名受支持活对象的事件只
+得到空 `actors` 表；未来的载具或其他实体引用也必须使用同样有语义的原生字段，而不是
+位置式 talker 兼容。
+所有订阅 Mod/handler 的 payload 都会在第一个回调执行前完成构造，而且每个 handler
+得到独立表图，因此修改或异常不会污染后续 handler。每 Mod 的 callback depth 仍相互
+隔离，同时由事件桥全局 depth 上限约束跨 Mod 的原生调用栈。
 
 Sidecar records belonging to a currently disabled or missing Mod are retained
 unchanged in the typed engine representation when other active Platform Mods
@@ -1114,6 +1279,341 @@ scope as a bounded unit and fall back to empty active state with a diagnostic.
 暂时禁用或缺失 Mod 的 sidecar 记录会以引擎内部类型化表示保留；其他 Platform Mod
 保存时不会把它顺带删除。重新启用后会恢复原记录。格式损坏时仍以整个 scope 为有界
 失败单元，清空活动状态并给出诊断。
+
+Platform gameplay randomness is isolated per Mod in `ccb.services.random`.
+`int`, `chance`, `one_in`, `probability`, `sample_integers`, and `contested`
+all consume that stream only inside a runtime callback.  A runtime-only hot
+reload moves the engine state into the replacement runtime, so reloading code
+does not silently restart a Mod's random sequence.  `sample_integers` returns
+a dense Lua array instead of writing legacy variables.  String predicates are
+ordinary composition through `ccb.services.gameplay.strings.any_equal` and
+`all_equal`; active Mod visibility is queried through
+`ccb.services.gameplay.mods.is_loaded`.  These primitives replace behaviour,
+not old EOC-shaped keys.  The current dimension is exposed as the stable id
+returned by `ccb.services.gameplay.environment.dimension()` and compared with
+ordinary Lua operators.  `environment.is_outside` and `line_of_sight` consume
+typed absolute map-square coordinates, so callers can compose them with
+creature handles and coordinate utilities without recreating EOC variables.
+Native gameplay awards use `ccb.services.achievements.complete(GameId)`; it
+completes any tracked pending achievement and reports whether state changed,
+instead of exposing an EOC activation entry point.
+Avatar and NPC gameplay changes use
+`ccb.services.bionics.grant(GameHandle, GameId)` and `remove_type`; these
+Platform operations call native character rules directly and are not capped
+by the v5 inspection-list limit or forced through UID enumeration.  The
+Platform-only `summary(GameHandle)` query returns installed count, current and
+maximum typed energy, and the independent capacity fact, so Lua can express
+"any installed bionic or power capacity" without an EOC-shaped predicate.
+Recipe knowledge uses `ccb.services.recipes.knows(GameHandle, GameId)`,
+`learn`, and `forget`.  They operate on learned knowledge rather than temporary
+book or helper availability; `learn` preserves the native `never_learn`
+policy.  `forget_category(GameHandle, GameId, subcategory?)` is a separate
+typed batch operation.  It applies the native category/subcategory selection
+rules, returns before/after counts, and does not disguise a category as a
+recipe id.
+Martial-art knowledge uses `ccb.services.martial_arts.learn(GameHandle, GameId)`
+and `forget`.  Platform learning intentionally changes the native style
+collection without displaying UI text, so Mods can compose presentation
+separately; both methods report whether known state changed.
+Physical weapon state uses the Platform-only
+`ccb.services.inventory.wielded(GameHandle)` singular query.  It returns a live
+item handle or nil in constant work and deliberately does not bake in legacy
+weapon-predicate names.  A selected martial art may set
+`martial_arts.current(character).force_unarmed` while an item remains physically
+wielded, so Lua composes those facts explicitly.  `services.items.has_flag`
+reads the item's effective flags, including type inheritance, while
+`services.items.set_flag(item, flag, enabled)` changes only the instance-owned
+flag set.  Its `value.changed` compares `own_before` with `own_after`; therefore
+an inherited effective flag may remain true before and after a real instance
+change, or remain true while an idempotent unset correctly reports false.
+
+```lua
+local wielded = service_value(services.inventory.wielded(character))
+local style = service_value(services.martial_arts.current(character))
+local physically_armed = wielded ~= nil
+local attacks_unarmed = not physically_armed or style.force_unarmed
+local can_release = physically_armed and not service_value(
+    services.items.has_flag(wielded, services.types.id("json_flag", "NO_UNWIELD")))
+```
+
+Typed morale instances use
+`ccb.services.morale.add(GameHandle, GameId, bonus, max_bonus, options)` and
+`remove`.  `add` delegates to native morale stacking and accepts optional typed
+`duration`, `decay_start`, and `capped` values; `remove` clears every
+item-specific instance of the requested morale type, matching the native
+character operation.  Both methods return the matching net bonus before and
+after the mutation.  This is a Lua domain service rather than an EOC-shaped
+wrapper: callers supply an explicit Character handle and compose timing or
+presentation in Lua.
+Current activity state uses `ccb.services.activities.snapshot(GameHandle)`.
+The returned value is a detached snapshot with a typed activity id, native
+move budget, interruption/resumption flags, and bounded progress; it works for
+avatar and NPC Character handles without exposing a borrowed `player_activity`.
+`assign_timed` converts a positive typed `TimeDuration` to a checked native
+move budget and delegates to `Character::assign_activity`, preserving native
+resume, backlog, and NPC bookkeeping.  It accepts only plain time-based
+activities.  Specialized native actors or handlers, EOC policies,
+multi-activity workflows, automatic-needs activities, and speed/neither move
+budgets are rejected; they need explicit Lua-native domain constructors rather
+than empty target/value arrays or a hidden return to EOC.  `cancel` delegates
+to `Character::cancel_activity` only when an activity is active, preserving
+actor cleanup, resumable-backlog handling, hauling cleanup, events, and
+activity sound shutdown without mutating backlog on a no-op.  All three
+operations return the standard structured service result.
+Wound state uses `ccb.services.wounds.snapshot(character, body_part)` with a
+typed `GameId<body_part>`.  It returns a detached array in native per-part
+order; every entry contains a typed wound id, base/current pain, typed healing
+time and progress, and healing fraction.  The body part must exist exactly in
+the Character's current anatomy; the service never chooses a nearest or
+fallback part.  After the Platform exact-part and per-part-limit policies
+admit the operation, `add(character, body_part, wound)` delegates to
+`Character::apply_wound`, preserving native add-or-worsen rules and immediate
+perceived-pain derived-state synchronization.  `remove` removes every instance
+of that wound type from that exact part and performs the same synchronization
+after a change.  Explicit direct add intentionally bypasses the Wound's natural
+damage-selection body-part eligibility: the caller's exact part is
+authoritative.  The Platform service enforces the Wound's per-part limit, so
+an add at the limit is a successful no-op with `changed = false`.  Writes are callback-only; snapshot remains a
+world-ready read.  Successful mutations return `changed` plus complete
+`before`/`after` snapshots, and removing an absent type reports
+`changed = false`.  Wrong GameId kinds or unknown ids raise `invalid_argument`
+before mutation; stale/destroyed handles, non-Character targets, and missing
+parts return the standard structured service errors.  This
+API models the wound domain and never exposes `u_add_wound`, alpha/beta, an
+EOC runner, or a JSON object channel.
+The 2026-08-11 local gate proves these service semantics directly.  Its
+deterministic callback adds wounds A(4 pain), B(7), then A(4), observes native
+snapshot order A/B/A, and observes pain, perceived pain, and Character morale
+move through 4, 11, 15, 7, and 0 as add/remove operations run.  It also proves
+that snapshot remains an available empty read outside a callback while direct
+`add` and `remove` both fail with the callback-only diagnostic.  The focused
+service tag and the complete Platform suite both passed after compiling the
+native implementation and its test.
+This Lua-native policy is intentionally not a drop-in execution backend for
+the legacy wound selectors.  Legacy `f_add_wound` and `f_remove_wound` resolve
+the requested body part through `Creature::get_part(bodypart_id)`, whose
+default filter may choose `next_best`; the Platform service requires the exact
+current-anatomy part.  The legacy add path also calls add-or-worsen without the
+per-part-limit check that the Platform service enforces.  Therefore
+`u_add_wound`, `npc_add_wound`, `u_remove_wound`, and `npc_remove_wound` all
+remain planned migration work, even for literal ids and a proven Character
+actor.  The extractor emits a TODO instead of silently changing gameplay.
+Authors rewriting one of these selectors must choose the new exact-part and
+limit-aware policy explicitly; Platform will not add a legacy-shaped
+compatibility switch or entry point.
+Creature effects reuse the typed `ccb.services.effects` domain.  The bounded
+migration slice accepts a literal effect id with either a positive literal
+duration of at most 365 days or `PERMANENT`, and accepts single literal removal
+without a body-part selector.  It deliberately leaves dynamic ids and
+durations, ranges, intensity/force/body-part extensions, arrays, `RANDOM`, and
+`ALL` as partial work; those shapes require explicit value, actor, and anatomy
+semantics rather than a legacy-key wrapper.  The legacy single variable-object
+remove shape also remains partial because the old implementation silently
+performs no removal.
+Legacy `u_*` names identify the EOC alpha talker, not the avatar type.  The
+extractor therefore binds a private local actor to the avatar only for the
+bounded `game_start` event shape, where that identity is proven.  The extractor
+checks the reviewed canonical native sender set and fails closed if it changes;
+the event name alone is never treated as sufficient proof.  The separately
+audited `character_wields_item`, `character_wears_item`,
+`character_takeoff_item`, and `character_armor_destroyed` slice binds the
+legacy `u` Character to `context.actors.character`.  In those same four events
+only, literal legacy `npc_set_flag`/`npc_unset_flag` effects may target
+`context.actors.item`; generated Lua guards nil because a plain native send has
+no item talker.  This does not generalize `npc` into an item or Character in any
+other context, and `u_set_flag` remains partial because `u` is the Character
+talker there.  Other event and dialogue shapes remain partial until the
+extractor maps their semantic Platform actor fields and proves each kind;
+silently replacing an unproven actor with `services.characters.avatar()` would
+change gameplay.  Dialogue hooks now expose `avatar`/`interlocutor`, but that
+does not by itself prove which legacy talker a selector uses.  This
+migration-only decision never adds alpha/beta to Platform.
+Domain audits intentionally override name-based ledger guesses.  Native
+Wound/WoundFix staging and the exact-body-part wound service passed their local
+compiled validation gates: the content tag passed 5 cases and 321 assertions,
+including add/replace/edit, rollback, requirement finalization, reverse-link
+refresh, body-part cache refresh, and stale handles; the service evidence is
+described above.  The static extractor now converts bounded concrete `wound`
+and `wound_fix` definitions into those native builders, including finite
+pain/healing/damage ranges, typed links, body-part filters, skills,
+proficiencies, removed/added wounds, and referenced requirements.  Inheritance,
+implicit indefinite healing, rich translation metadata, and inline requirement
+objects remain explicit TODOs rather than hidden legacy loading.  The two JSON
+selectors are therefore `bounded_implemented_unverified`.
+The local creator/migrator run now passes 55 cases (46 extractor plus 9
+scaffolder).  Wound/WoundFix extraction fails closed at Platform UTF-8 byte
+limits: overlong ids or text and contradictory body-part flags become explicit
+TODOs or rejected definitions, and proficiency multipliers are rejected when
+their native `float` conversion is no longer positive.
+
+This does not change the four legacy `u_*`/`npc_*` wound mutation selectors:
+they remain planned because their next-best body-part resolution and add-limit
+behaviour do not match the deliberately strict, limit-aware service.  Service
+availability and static-definition extraction are not effect-selector parity
+and do not authorize automatic conversion.
+Rain wetness, direct damage, specialized activity-actor construction,
+navigation, and general teleportation remain planned native domains because
+current Character/item primitives do not carry their complete side effects.
+Character activity snapshot, plain time-based
+assignment, and cancellation are implemented, and their written local C++
+policy coverage passed; legacy selector promotion still requires exact shape
+conversion.  In the proven `game_start` actor shape, a
+literal `u_has_item` now composes `inventory.resources` through a local Lua
+helper and preserves the native charges-or-amount test, while a literal
+`u_has_move_mode` compares the typed Character snapshot.  The bounded proven
+Character slice converts string `u_has_weapon`/`u_can_drop_weapon` and a literal
+`u_has_wielded_with_flag`: generated helpers compose the singular physical
+wielded handle, `force_unarmed`, effective item flags, and `NO_UNWIELD` exactly
+instead of publishing EOC-shaped APIs.  The four-event item-talker slice also
+converts bounded literal `npc_set_flag`/`npc_unset_flag` behind the semantic
+item guard.  Those five selectors are therefore
+`bounded_implemented_unverified`, not full parity; NPC weapon predicates,
+`u_set_flag`/`u_unset_flag`, dynamic flags, other actor sources, mission
+reservation, and bounded move cost remain primitive-only or planned.  The
+ledger target describes domain ownership; it is never evidence that an
+unlisted selector shape is interchangeable.
+Typed character predicates reuse the same result-bearing services: single or
+any-of mutation presence through `mutations.has`, martial-art knowledge through
+`martial_arts.get`, selected-style state through the same snapshot, proficiency
+knowledge through `proficiencies.get`, a specific installed bionic through
+`bionics.has`, installed-count/capacity facts through `bionics.summary`, and
+learned recipe knowledge through `recipes.knows`.
+They remain normal Lua expressions; the migration output uses one local helper
+to propagate a `CcbResult` error before reading its value.
+
+Platform 的玩法随机流按 Mod 隔离在 `ccb.services.random` 中；`int`、`chance`、
+`one_in`、`probability`、`sample_integers` 和 `contested` 只允许在运行时回调中消耗
+该随机流。仅重载运行时代码时会把随机引擎状态移动到新 runtime，不会偷偷重启随机
+序列。整数采样直接返回稠密 Lua 数组，不再写旧变量。字符串集合判断使用
+`ccb.services.gameplay.strings.any_equal/all_equal` 普通组合，Mod 可见性使用
+`ccb.services.gameplay.mods.is_loaded`；这些是适合 Lua 的行为原语，不是旧 EOC key 的
+同名包装。当前维度由 `ccb.services.gameplay.environment.dimension()` 返回稳定 ID，
+直接使用普通 Lua 运算符比较。`environment.is_outside` 与 `line_of_sight` 接受类型化
+绝对地图格坐标，因此事件、任务和物品行为可以把生物 handle 与坐标工具直接组合，
+无需重建 EOC 变量模型。
+玩法成就使用 `ccb.services.achievements.complete(GameId)` 授予；它完成任意当前受跟踪且
+pending 的成就并报告状态是否变化，不公开 EOC 激活入口。
+玩家与 NPC 的玩法变更使用 `ccb.services.bionics.grant(GameHandle, GameId)` 和
+`remove_type`；这些 Platform 操作直接调用角色原生规则，不受 v5 检查清单数量上限约束，
+也不强制作者先枚举 UID。Platform 专属的 `summary(GameHandle)` 会同时返回安装数量、当前与
+最大类型化能量以及独立的容量事实，使 Lua 能表达“存在任一仿生装置或电力容量”，而无需
+增加 EOC 形状谓词。
+角色配方知识使用 `ccb.services.recipes.knows(GameHandle, GameId)`、`learn` 与 `forget`；
+它们只处理已学知识，不把书本或助手临时提供的配方算进去，`learn` 保留原生
+`never_learn` 策略。`forget_category(GameHandle, GameId, subcategory?)` 是单独的类型化
+批量操作：它遵循原生分类/子分类选择规则并返回变更前后数量，不会把分类伪装成配方 ID。
+武术流派知识使用 `ccb.services.martial_arts.learn(GameHandle, GameId)` 与 `forget`。
+Platform 学习只改变原生流派集合，不自行显示 UI 文本，使 Mod 可以独立组合呈现；两者都会
+报告已知状态是否发生变化。
+物理持握状态通过 Platform 专属的
+`ccb.services.inventory.wielded(GameHandle)` 单项查询读取；它以常量规模返回活物品 handle
+或 nil，不把旧武器谓词名称固化进新 API。选中的武术流派可能令
+`martial_arts.current(character).force_unarmed` 为真，但物品仍然在物理上被持握，因此 Lua
+应显式组合这两个事实。`services.items.has_flag` 读取包含类型继承在内的有效 flag；
+`services.items.set_flag(item, flag, enabled)` 只改变实例自有 flag 集合，其
+`value.changed` 比较 `own_before` 与 `own_after`。所以继承 flag 的有效状态可以在一次真实
+实例变更前后都保持 true；幂等 unset 也会正确报告 false。
+类型化士气实例使用
+`ccb.services.morale.add(GameHandle, GameId, bonus, max_bonus, options)` 与
+`remove`。`add` 直接复用原生士气叠加规则，并可接收类型化的 `duration`、
+`decay_start` 与 `capped` 选项；`remove` 按原生角色操作移除该士气类型的全部
+物品特定实例。两者都返回变更前后的匹配净加成。这是面向 Lua 组合的领域 service，
+不是 EOC 字段形状包装：调用者必须显式提供 Character handle，计时与呈现也由 Lua
+自行组合。
+当前 activity 状态使用 `ccb.services.activities.snapshot(GameHandle)` 读取。返回值是脱离
+原生对象的有界快照，包含类型化 activity ID、原生 moves 预算、打断/恢复标志与进度；
+avatar 和 NPC 的 Character handle 都可使用，不会把借用的 `player_activity` 暴露给 Lua。
+`assign_timed` 把正数类型化 `TimeDuration` 转换为经过边界检查的原生 moves，并直接调用
+`Character::assign_activity`，从而保留恢复、backlog 和 NPC 记账。它只接受普通的 time-based
+activity；专用原生 actor/handler、EOC policy、multi-activity、自动需求 activity，以及
+speed/neither moves 预算都会被拒绝。这些形状需要显式 Lua-native 领域构造器，不能用空的
+targets/values 强行构造，也不能暗中重新进入 EOC。`cancel` 只在确有当前 activity 时调用
+`Character::cancel_activity`，因此既保留 actor 清理、可恢复 backlog、搬运清理、事件与活动
+音效收尾，也不会让无操作取消悄悄改写 backlog。三个操作都返回统一的结构化 service result。
+伤口状态使用
+`ccb.services.wounds.snapshot(character, body_part)` 和类型化的
+`GameId<body_part>` 读取。返回值按该身体部位的原生顺序给出脱离原生对象的数组，每项包含
+类型化伤口 id、基础/当前疼痛、类型化愈合总时长/已进度与愈合比例。身体部位必须精确存在
+于该 Character 当前解剖，service 不会选择 next-best 或其他回退部位。
+通过 Platform 的精确部位与每部位上限策略后，`add(character, body_part, wound)` 会调用
+`Character::apply_wound`，保留原生 add-or-worsen 规则并立即同步 Character 的
+`perceived_pain` 派生状态；`remove` 则删除该精确部位上指定类型的全部实例，并在发生变化后
+执行同样的同步。显式 direct add 有意绕过 Wound 在自然伤害候选选择中的身体部位
+eligibility，调用者指定的精确部位具有最终决定权。Platform service 会执行 Wound 的每部位
+上限策略，达到上限后的 add 是
+成功的无操作并返回 `changed = false`。写操作只允许在 Platform runtime callback 内进行；snapshot
+仍是 world-ready 只读查询。成功变更返回 `changed` 和完整的 `before`/`after` 快照；移除
+不存在的类型时 `changed = false`。错误 GameId kind 或未知 id 会在变更前抛出
+`invalid_argument`；过期/已销毁 handle、非 Character 目标与不存在的身体部位则返回统一的
+结构化 service 错误。这个 API 建模的是伤口
+领域，不公开 `u_add_wound`、alpha/beta、EOC runner 或 JSON 对象通道。
+2026-08-11 的本地门禁直接证明了这些 service 语义。确定性 callback 依次添加伤口
+A（疼痛 4）、B（疼痛 7）、A（疼痛 4），快照保持原生 A/B/A 顺序；随后 add/remove
+过程中 pain、perceived pain 与 Character morale 依次同步为 4、11、15、7、0。门禁还证明
+callback 外仍可读取空 snapshot，而直接 `add` 与 `remove` 都会以 callback-only 诊断拒绝。
+聚焦 service 标签与完整 Platform 套件都在原生实现和测试重新编译后通过。
+这套 Lua-native 策略有意不作为旧伤口 selector 的直接执行后端。旧
+`f_add_wound`/`f_remove_wound` 通过默认可采用 `next_best` 的
+`Creature::get_part(bodypart_id)` 解析身体部位，而 Platform service 只接受当前解剖中精确
+存在的部位；旧 add 路径也直接调用 add-or-worsen，不执行 Platform service 所强制的每部位
+上限检查。因此即使 id 都是字面量且 Character actor 已证明，`u_add_wound`、
+`npc_add_wound`、`u_remove_wound` 与 `npc_remove_wound` 仍是 planned 迁移工作。迁移器会
+生成 TODO，不会静默改变玩法。作者重写时必须显式选择新的“精确部位、上限生效”策略；
+Platform 不会增加旧字段形状的兼容开关或入口。
+生物效果复用类型化的 `ccb.services.effects` 领域。当前有界迁移只接受字面量效果 ID，
+其 duration 必须是正整数且不超过 365 天，或为 `PERMANENT`；移除只接受不带身体部位
+选择器的单个字面量 ID。动态 ID/时长、随机范围、intensity/force/身体部位扩展、数组、
+`RANDOM` 与 `ALL` 都继续保持 partial，因为这些形状需要显式建模取值、角色和解剖语义，
+不能伪装成旧 key 包装。旧版单个变量对象 remove 实际会静默不做任何移除，因此也不会被
+迁移器擅自“修好”。
+旧 `u_*` 名称表示 EOC 的 alpha talker，并不等于 avatar 类型。迁移器只在有界的
+`game_start` 事件形状中把私有局部 actor 绑定为 avatar，因为该身份在这里已经证明；迁移器
+还会检查经过审查的原生规范 sender 集合，一旦集合变化就安全降级，绝不会只凭事件名证明。
+另一个单独审计过的切片只覆盖 `character_wields_item`、`character_wears_item`、
+`character_takeoff_item` 与 `character_armor_destroyed`：其中旧 `u` Character 绑定为
+`context.actors.character`；也只有在这四类事件中，字面量旧
+`npc_set_flag`/`npc_unset_flag` 才能以 `context.actors.item` 为目标。普通原生 send 没有
+物品 talker，所以生成代码必须先检查 nil。该规则不会把其他上下文的 `npc` 泛化成物品或
+Character；这里的 `u_set_flag` 也继续保持 partial，因为 `u` 是 Character talker。
+其他事件和对话形状会保持 partial，直到迁移器把对应的 Platform 语义 actor 字段映射清楚，
+并证明每个 handle 的类型；擅自把未证明的角色替换成 `services.characters.avatar()` 会改变
+玩法。对话 Hook 已提供 `avatar`/`interlocutor`，但这本身并不能证明某个旧 selector 使用
+哪一个 talker。这个仅属于迁移器的决定绝不会给 Platform 添加 alpha/beta。
+领域语义审计会有意覆盖按名称猜测的账本结果。原生 `Wound`/`WoundFix` 暂存与精确身体
+部位伤口 service 已通过本地编译验证门禁：内容标签的 5 个用例、321 个断言覆盖
+add/replace/edit、回滚、requirement finalize、反向链接刷新、身体部位缓存刷新与过期 handle；
+service 证据见上文。静态提取器现在可把有界、具体的 `wound` 与 `wound_fix` JSON 定义转换为
+原生 builder，包括有限疼痛/愈合/伤害区间、类型化链接、身体部位过滤、技能、熟练度、移除/
+新增伤口及外部 Requirement 引用；继承、隐式无限愈合、复杂翻译元数据和内联 requirement
+对象仍会生成明确 TODO，不会暗中调用旧 loader。因此这两个 JSON selector 已是
+`bounded_implemented_unverified`。
+本地 creator/migrator 现已通过 55 个用例（提取器 46 个、脚手架 9 个）。Wound/WoundFix
+提取会按 Platform 的 UTF-8 字节上限安全失败：超长 id/文本及互相冲突的身体部位 flag 会
+生成明确 TODO 或拒绝该定义，熟练度倍率转成原生 `float` 后不再为正时也会被拒绝。
+
+四个旧 `u_*`/`npc_*` 伤口变更 selector 仍保持 planned，因为它们的 next-best 身体部位解析
+和 add 上限行为与这套有意采用严格部位、上限生效的 service 不一致。具备领域 service 或
+静态定义提取器不等于 effect selector 等价，也不能据此自动转换。淋雨湿润、直接伤害、专用 activity actor 构造、
+导航和通用传送仍是 planned 原生领域，因为当前
+Character/物品原语没有保留它们的完整副作用。Character activity 快照、普通 time-based
+分配与取消已经实现，其书面本地 C++ 策略覆盖也已通过；旧 selector 仍需完成精确形状转换后
+才能晋级。在已证明为
+`game_start` actor 的形状中，
+字面量 `u_has_item` 现在会通过局部 Lua helper 组合 `inventory.resources` 并保留原生的
+“charges 或 amount”判断；字面量 `u_has_move_mode` 则比较类型化 Character snapshot。
+已证明为 Character 的有界切片会转换字符串 `u_has_weapon`/`u_can_drop_weapon` 与字面量
+`u_has_wielded_with_flag`；生成 helper 会精确组合单项物理持握 handle、`force_unarmed`、
+有效物品 flag 和 `NO_UNWIELD`，不会公开 EOC 形状 API。四事件物品 talker 切片也会在
+语义物品 nil guard 后转换字面量 `npc_set_flag`/`npc_unset_flag`。因此这五个 selector 是
+`bounded_implemented_unverified`，绝不表示完整 parity；NPC 武器谓词、
+`u_set_flag`/`u_unset_flag`、动态 flag、其他角色来源、任务预留与有界 moves 扣减仍保持
+primitive-only 或 planned。账本 target 只描述领域归属，不能证明未列出的 selector 形状
+已经可互换。
+类型化角色谓词复用同一批带结果的 service：`mutations.has` 查询单个或任一突变，
+`martial_arts.get` 查询武术知识和当前选中状态，`proficiencies.get` 查询熟练度知识，
+`bionics.has` 查询指定已安装仿生装置，`bionics.summary` 查询安装数量与容量事实，
+`recipes.knows` 查询已学配方知识。它们仍是普通 Lua
+表达式；迁移输出只用一个局部 helper 在读取值前传播 `CcbResult` 错误。
 
 ## Internal reuse and replacement boundary / 内部复用与替换边界
 
@@ -1137,8 +1637,13 @@ those formats does not increase Lua authoring power and is not a Platform goal.
 inventories and contains exactly one disposition for every JSON type, EOC
 condition key, and EOC effect key.  Its statuses have strict meanings:
 
-- `implemented_unverified`: matching Platform code and declaration exist, but
-  the requested validation gate has not run;
+- `implemented_unverified`: full selector-level replacement is represented by
+  matching Platform code, declaration, tests, migration, and documentation,
+  but the requested validation gate has not run;
+- `bounded_implemented_unverified`: at least one explicitly bounded, real
+  legacy shape has matching Platform code, declaration, tests, migration, and
+  documentation, but other legal values, actors, options, or shapes keep the
+  selector below full parity;
 - `primitive_available_unverified`: one or more native domain primitives exist
   without a public legacy dependency, but selector-level semantic parity has
   not been demonstrated and migration remains open;
@@ -1151,14 +1656,37 @@ condition key, and EOC effect key.  Its statuses have strict meanings:
 The generator, schema, and exact-set checker live under `tools/agent/`.  A
 selector changes status only with source, declaration, test, and documentation
 evidence.  Grouping a selector under a service is architecture classification,
-not proof that the service exists.
+not proof that the service exists.  A bounded migratable shape may reach only
+`bounded_implemented_unverified`; it never promotes its whole selector to
+`implemented_unverified` while dynamic, actor, option, or alternate-shape
+semantics remain.
+
+The audit also records composable-but-inexact starting points instead of
+leaving them as unspecified plans: follower presence, following transitions,
+NPC hostility/neutrality, nearest-city and route reveal operations, aid,
+equipment selection, turn cost, trap placement, and horde signalling already
+have native follower, NPC, overmap, character, effect, inventory,
+presentation, time, world, coordinate, or horde primitives.  Their legacy
+selectors remain unconverted until target selection, variable semantics,
+side effects, and result behaviour are proven end to end.
 
 `ai/lua-first-replacement-ledger.yml` 由三份受检清单生成，每个 JSON type、EOC
-condition key 和 effect key 恰好出现一次。`implemented_unverified` 表示已有代码但尚未
-通过本次验证门；`primitive_available_unverified` 表示已有不依赖旧公共接口的原生积木，
+condition key 和 effect key 恰好出现一次。`implemented_unverified` 表示整个 selector
+已由源码、声明、测试、迁移与文档表示，但尚未通过本次验证门；
+`bounded_implemented_unverified` 表示至少一个明确限定的真实旧形状已经具备源码、声明、
+测试、迁移输出与文档，但 selector 的其他合法动态值、角色、选项或形状仍未等价；
+`primitive_available_unverified` 表示已有不依赖旧公共接口的原生积木，
 但还没有逐 selector 证明等价；`planned` 只表示已确定目标而没有声称替代完成，`private_adapter` 表示
 仍有不公开的旧实现依赖，`reviewed_not_applicable` 表示 Lua 控制流或引擎配置本来就不该
 产生作者 API。把一项归入某个 service 只是架构分类，不能当作 service 已存在的证据。
+只完成有界可迁移形状最多晋级为 `bounded_implemented_unverified`，绝不会让整个 selector
+成为 `implemented_unverified`；仍缺动态值、角色、选项或其他合法形状时必须保留该边界。
+
+审计也会把“已有组合积木但还不等价”的入口从笼统计划中拆出来：随从存在与跟随状态、
+NPC 敌对/中立、最近城市与路线揭示、治疗援助、装备选择、回合消耗、陷阱放置和尸群信号
+已经有 follower、NPC、overmap、character、effect、inventory、presentation、time、
+world、coordinate 或 horde 原语；在目标选择、变量语义、副作用与返回行为完成端到端证明
+之前，它们仍不会被标成已完成迁移。
 
 ## Migration and removal gates / 迁移与移除门槛
 
@@ -1194,12 +1722,58 @@ scores, the global hit-range configuration, bash-damage profiles, clothing
 modifications, overmap land-use codes, overmap-vision profiles,
 overmap locations, profession groups, map-extra collections, vehicle groups,
 fault groups, explosion-light recipes, ammunition effects, addiction types, character modifiers, start locations, climbing aids, weather types, scores, the global mutation-overlay order, zone types, speech pools, end screens, nested recipe categories, attack vectors, magic types, and movement modes), and simple
-event/message behaviour, emits normal Lua composition, and
+event/message behaviour.  Bounded literal `compare_string`,
+`compare_string_match_all`, `one_in_chance`, `x_in_y_chance`,
+`roll_contested`, `mod_is_loaded`, and `current_dimension` conditions become ordinary Lua
+predicates over Platform services.  Random conditions convert only finite
+literal values inside the native service ranges: dynamic denominators,
+non-positive or out-of-range `x/y`, and non-positive, dynamic, or oversized
+die sizes remain explicit TODOs.  Literal avatar `u_has_trait`,
+literal-array `u_has_any_trait`,
+`u_has_martial_art`, `u_using_martial_art`, `u_has_proficiency`, and specific-id
+`u_has_bionics` conditions reuse typed mutation, martial-art, proficiency, and
+bionic queries.  In the proven `game_start` avatar slice, literal
+`u_has_bionics: "ANY"` composes `bionics.summary`, and literal
+`u_know_recipe` composes `recipes.knows`; dynamic values and unproven actor
+contexts remain explicit TODOs.  The proven `game_start` and four item-event Character slices
+also convert string `u_has_weapon`/`u_can_drop_weapon` and literal
+`u_has_wielded_with_flag`; literal `npc_set_flag`/`npc_unset_flag` convert only
+for those item events and retain the optional semantic item guard.  `and`,
+`or`, and `not` become native Lua
+control flow.  Literal values, typed native-event data values, and character-state
+values are emitted as normal Lua expressions instead of legacy variable
+objects.  Literal `message` effects call the Platform message service;
+`give_achievement` effects become typed achievement-service calls; literal
+avatar `u_add_bionic` and `u_lose_bionic` effects become typed bionic-service
+calls; literal one-recipe `u_learn_recipe` and `u_forget_recipe` effects become
+typed recipe-service calls.  Literal category and subcategory
+`u_forget_recipe` shapes become `recipes.forget_category`; dynamic identifiers,
+dynamic subcategories, NPC targets, and unproven actor contexts stay partial.
+Literal avatar `u_learn_martial_art` and
+`u_forget_martial_art` effects become presentation-independent typed
+martial-art service calls.  The exact three-field literal avatar
+`u_add_morale` shape and the one-field literal avatar `u_lose_morale` shape
+become typed morale-service calls; dynamic values and timing extensions remain
+partial until their actor and value semantics are represented explicitly.
+Bounded literal avatar `u_add_effect` and `u_lose_effect` shapes become typed
+effect-service calls; effect options, dynamic values, body-part selectors, and
+batch removal remain partial.
+All legacy `u_add_wound`, `npc_add_wound`, `u_remove_wound`, and
+`npc_remove_wound` shapes remain explicit TODOs.  This includes literal ids,
+non-empty literal removal arrays, and proven Character actors: the old path
+may select a next-best body part and its add bypasses the per-part limit, while
+the Lua-native wound service is exact-part and limit-aware.  Emitting service
+calls would therefore be a behavioural rewrite rather than extraction.
+The extractor emits normal Lua composition and
 writes `MIGRATION_REPORT.md` with a source location for every unresolved
 field.  It accepts the comments and trailing commas used by game data;
 unsupported inheritance, anonymous definitions, disassembly recipes, mixed
 effects, lossy field shapes, malformed numeric shapes, and values outside the
-native integer or skill ranges remain partial with explicit TODOs.  `--check`
+native integer or skill ranges remain partial with explicit TODOs.  A legacy
+`MOD_INFO` is fully classified only for the bounded `id`, plain `name`, string
+`version`, unique `dependencies`, and Boolean `core` shape; every additional
+metadata field remains an explicit TODO rather than being silently discarded.
+`--check`
 compares an existing extraction without writing.  Normal writes stage output
 before installation, and `--force` restores every previous generated file if
 installation fails midway.  The tool never emits a JSON loader, EOC runner, or
@@ -1213,10 +1787,40 @@ equivalence.
 部件位置、载具部件分类、心情表情、伤害信息显示顺序、命名颜色、可旋转符号、物品、
 ASCII 图、肢体评分、全局命中距离配置、bash 伤害配置、服装改造、大地图土地用途、
 大地图视野配置、大地图位置、职业组、地图额外内容集合、载具组、故障组、爆炸光效、弹药效果、成瘾类型、角色修正器、起始位置、攀爬辅助、天气类型、分数、全局突变覆盖显示顺序、区域类型、语音池、结束画面、嵌套配方分类、攻击向量、
-魔法类型、移动模式、配方与简单事件/消息行为，其余字段全部以
+魔法类型、移动模式、配方与简单事件/消息行为。受限的字面量
+`compare_string`、`compare_string_match_all`、`one_in_chance`、
+`x_in_y_chance`、`roll_contested`、`mod_is_loaded` 和 `current_dimension` 条件会转成 Platform service
+上的普通 Lua 谓词；随机条件只转换处于原生 service 范围内的有限字面量，动态分母、非正或
+越界的 `x/y`，以及非正、动态或过大的 die size 都会保留显式 TODO。字面量玩家
+`u_has_trait`、字面量数组 `u_has_any_trait`、`u_has_martial_art`、
+`u_using_martial_art`、`u_has_proficiency` 与指定 ID 的 `u_has_bionics` 会复用类型化
+突变、武术、熟练度和仿生装置查询。在已证明的 `game_start` avatar 切片中，字面量
+`u_has_bionics: "ANY"` 会组合 `bionics.summary`，字面量 `u_know_recipe` 会组合
+`recipes.knows`；动态值和未证明的 actor 上下文仍生成明确 TODO。已证明的
+`game_start` 与四类物品事件 Character 切片还会转换字符串
+`u_has_weapon`/`u_can_drop_weapon` 和字面量 `u_has_wielded_with_flag`；字面量
+`npc_set_flag`/`npc_unset_flag` 只在这四类物品事件中转换，并保留可选语义物品 guard。
+`and/or/not` 会转成 Lua 自身控制流。字面量、类型化原生事件 data 值
+和角色 state 值会直接生成普通 Lua 表达式，而不是旧变量对象；字面量 `message` effect
+会调用 Platform 消息 service，`give_achievement` effect 会生成类型化成就 service 调用，字面量玩家
+`u_add_bionic` 与 `u_lose_bionic` effect 会生成类型化仿生装置 service 调用，字面量
+`u_learn_recipe` 与单配方 `u_forget_recipe` effect 会生成类型化配方 service 调用；字面量
+分类和子分类 `u_forget_recipe` 会生成 `recipes.forget_category`，动态 ID、动态子分类、
+NPC 目标与未证明 actor 上下文仍保持 partial；字面量玩家 `u_learn_martial_art` 与
+`u_forget_martial_art` 会生成不绑定呈现的类型化武术 service 调用；仅含三个必需字段的
+字面量玩家 `u_add_morale` 与单字段字面量玩家 `u_lose_morale` 会生成类型化士气 service
+调用，动态值和扩展计时形状在角色与取值语义被显式建模前仍保持 partial；有界的字面量
+玩家 `u_add_effect` 与 `u_lose_effect` 会生成类型化效果 service 调用，效果选项、动态值、
+身体部位选择器与批量移除仍保持 partial。所有旧 `u_add_wound`、`npc_add_wound`、
+`u_remove_wound` 与 `npc_remove_wound` 形状都会生成显式 TODO；即使 id 是字面量、remove
+数组非空且 Character actor 已证明也不会自动转换，因为旧路径可能选择 next-best 身体部位，
+且旧 add 绕过每部位上限，而 Lua-native 伤口 service 要求精确部位并执行上限。生成 service
+调用会成为行为重写而不是提取；其余字段全部以
 带来源位置的 TODO 写入报告；`--check` 只比较
 现有输出。它支持游戏数据使用的注释与尾逗号；继承、匿名定义、拆解配方、混合 effect
 以及有损字段形状、畸形数字和超出原生整数/技能范围的值都会保持 partial 并写明 TODO。
+旧 `MOD_INFO` 只有 `id`、普通 `name`、字符串 `version`、唯一 `dependencies` 与布尔
+`core` 的有界形状才能完整归类；任何额外元数据字段都会保留显式 TODO，不会被静默丢弃。
 普通写入先暂存再安装，`--force` 中途失败时会恢复全部旧生成文件。工具绝不会生成 JSON
 loader、EOC runner 或原始旧对象，报告也
 不等于玩法等价证明。

--- a/data/lua/LUA_FIRST_PLATFORM.md
+++ b/data/lua/LUA_FIRST_PLATFORM.md
@@ -258,6 +258,41 @@ consistency finalization cannot silently leave a partially active Platform
 candidate.  Trusted filesystem, process, and native-module side effects remain
 outside that transaction.
 
+### Playable MVP v0.1 merge gate / 可玩 MVP v0.1 合并门槛
+
+Playable MVP v0.1 is a deliberately narrow vertical slice, not a declaration
+that Platform v1 replaces every JSON type or EOC selector.  It is mergeable
+when one bundled zero-JSON/EOC Mod proves all of the following in the real
+engine paths:
+
+1. root `mod.lua`/`main.lua` discovery and dependency-aware Mod selection;
+2. native item and recipe loading plus an observable named Lua use handler;
+3. `game::save()` persistence for typed character state, typed world state,
+   and a named delayed task;
+4. runtime shutdown followed by full core/Mod data reload, continued item
+   gameplay, restored state, and exactly-once execution of the overdue task;
+5. an actionable catalog entry in a build compiled without Lua, instead of a
+   Mod that appears selectable and fails only while loading a world.
+
+The bundled `data/mods/Lua_First_Example` and the
+`[playable_mvp]` integration test are the executable acceptance fixture.  The
+dedicated test-matrix entries keep both Lua-enabled and Lua-disabled builds as
+merge gates.  Manual desktop/Android selector and interactive presentation
+checks remain separate platform follow-up work; they do not expand this MVP
+into full static-domain or EOC parity.
+
+可玩 MVP v0.1 是刻意收窄的纵向切片，并不表示 Platform v1 已经替代所有 JSON 类型或
+EOC selector。它的合并门槛是：一个内置、零 JSON/EOC 的 Mod 必须通过真实引擎路径完成
+根目录元数据与入口发现、依赖选择、原生物品/配方加载、命名 Lua 使用行为、
+`game::save()`、角色/世界状态与延迟任务持久化；销毁 runtime 并完整重载核心和 Mod 数据
+以后，物品行为和状态必须继续生效，逾期任务只能执行一次。未编译 Lua 的版本也必须在
+Mod 列表中给出明确的不可用诊断，不能让玩家直到加载世界时才失败。
+
+`data/mods/Lua_First_Example` 与 `[playable_mvp]` 集成测试是这套验收标准的可执行样例，
+`ai/test-matrix.yml` 分别记录 Lua-enabled 与 Lua-disabled 门禁。桌面/Android 的人工选择器
+和交互式 presentation 验证仍是独立后续工作，不能据此把 MVP 扩大解释成完整静态领域或
+EOC 等价。
+
 Validation has now started, but it does not make the whole Platform complete.
 On 2026-08-11 the Linux Lua-enabled C++ test program compiled and linked, the
 focused Wound/WoundFix and wound-service gates passed, and the complete
@@ -266,7 +301,16 @@ the bionic-summary and learned-recipe workflow.  The broader `[lua]` filter
 then passed 190 matching test cases with 2706 assertions, including the
 owner-identity, pre-finalize Monster, and body-cache regression coverage.  LuaLS,
 public-contract, coverage, Agent-metadata, and replacement-ledger checks also
-passed.  Interactive desktop/Android presentation checks and field-by-field
+passed.  On 2026-08-12 the new bundled-Mod playable fixture passed 32
+assertions through discovery, dependency-aware selection, native item/recipe
+use, three real game saves, runtime shutdown, full data reload, restored typed
+state, and one-time overdue task execution.  After its test-fixture cleanup was
+made position-safe, the broader `[lua]` gate passed 191 cases and 2738
+assertions.  A fresh build compiled without Lua also linked successfully, and
+its focused Mod-manager fallback passed 13 assertions.  An Android arm64-v8a
+Stable Release with Lua enabled also compiled, linked, and packaged
+successfully; its unsigned APK contained `lib/arm64-v8a/libmain.so`.
+Interactive desktop/Android Mod-selector and presentation checks and field-by-field
 parity for the remaining domains are still open, so only explicitly named
 validated slices may be treated as having crossed their local gate.  The exact
 replacement ledger contains 775 dispositions; its generated summary is the
@@ -558,7 +602,13 @@ Lua-enabled C++ 测试程序，Wound/WoundFix 与伤口 service 的聚焦门禁�
 仿生摘要与已学配方工作流后，完整 `[lua][platform]` 套件以 45 个用例、934 个断言通过；
 随后更广的 `[lua]` 过滤集也以 190 个匹配用例、2706 个断言通过，其中包含 owner identity、
 Monster pre-finalize 与身体缓存回归覆盖。LuaLS、公开契约、覆盖率、Agent
-元数据与替换账本检查同样通过。桌面/Android 交互式 presentation 与其余领域逐字段等价性
+元数据与替换账本检查同样通过。2026-08-12 新增的内置 Mod 可玩闭环以 32 个断言通过，
+真实覆盖发现、依赖选择、原生物品/配方使用、三次 `game::save()`、runtime 销毁、完整数据
+重载、类型化状态恢复与逾期任务单次执行；修正测试夹具的安全角色位置后，更广的 `[lua]`
+门禁以 191 个用例、2738 个断言通过。全新无 Lua 构建也成功链接，其 Mod 管理器降级测试以
+13 个断言通过。启用 Lua 的 Android arm64-v8a Stable Release 也已成功编译、链接并打包；
+生成的未签名 APK 包含 `lib/arm64-v8a/libmain.so`。桌面/Android Mod 选择器与交互式
+presentation 人工验证，以及其余领域逐字段等价性
 仍未完成，因此只有本文明确点名的已验证切片可以视为通过本地门禁。775 项的分类数字以
 生成账本 summary 为准，不在本文手工复制。其余已实现但未验证的静态切片包括 Mod 元数据、
 工具质量、技能显示分类、技能、维生素、JSON

--- a/data/lua/reference/ccb_native_inventory.json
+++ b/data/lua/reference/ccb_native_inventory.json
@@ -1,10 +1,11 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "source": {
     "project": "Cataclysm-Cleanwater-Bomb",
     "id_registry": "src/catalua_bindings_values.cpp",
     "json_registry": "src/init.cpp",
-    "event_registry": "src/event.h"
+    "event_registry": "src/event.h",
+    "export_registry": "src/catalua*.cpp"
   },
   "id_kinds": [
     { "kind": "achievement", "native_type": "achievement" },
@@ -487,5 +488,17357 @@
     { "id": "weather", "requirement": "Inspect forecasts and control weather overrides." },
     { "id": "world", "requirement": "Query and mutate the active map and world services." },
     { "id": "zones", "requirement": "Inspect and mutate loot and personal zones." }
+  ],
+  "export_surfaces": [
+    {
+      "id": "api_v5",
+      "api_version": 5,
+      "declarations": "data/lua/types/ccb_api_v5.d.lua",
+      "entrypoint": "api_v5.initialize_state",
+      "roots": [
+        "GameEnum",
+        "GameHandle",
+        "GameId",
+        "HordeEntityToken",
+        "LegacyHordeToken",
+        "MissionToken",
+        "PointCoord",
+        "ScriptDialogueContext",
+        "ScriptMapgenContext",
+        "ScriptUiContext",
+        "ScriptUiEnvironment",
+        "TimeDuration",
+        "TimePoint",
+        "TripointCoord",
+        "UnitValue",
+        "ZoneToken"
+      ]
+    },
+    {
+      "id": "platform_v1",
+      "api_version": 1,
+      "declarations": "data/lua/types/ccb_platform_v1.d.lua",
+      "entrypoint": "platform_v1.initialize_state",
+      "roots": [
+        "ActivityTypeDefinition",
+        "AddictionTypeDefinition",
+        "AmmoEffectDefinition",
+        "AmmunitionTypeDefinition",
+        "AnatomyDefinition",
+        "AsciiArtDefinition",
+        "AttackVectorDefinition",
+        "BashDamageProfileDefinition",
+        "BehaviorDefinition",
+        "BodyGraphDefinition",
+        "BodyPartDefinition",
+        "CharacterModifierDefinition",
+        "ClimbingAidDefinition",
+        "ClothingModDefinition",
+        "ConnectGroupDefinition",
+        "ConstructionCategoryDefinition",
+        "ConstructionGroupDefinition",
+        "DamageInfoOrderDefinition",
+        "DamageTypeDefinition",
+        "DiseaseTypeDefinition",
+        "EffectTypeDefinition",
+        "EmissionDefinition",
+        "EndScreenDefinition",
+        "ExplosionLightDefinition",
+        "FaultGroupDefinition",
+        "FieldTypeDefinition",
+        "GameEnum",
+        "GameHandle",
+        "GameId",
+        "HarvestDefinition",
+        "HarvestDropTypeDefinition",
+        "HelpTopicDefinition",
+        "HitRangeDefinition",
+        "HordeEntityToken",
+        "ItemCategoryDefinition",
+        "ItemDefinition",
+        "ItemGroupDefinition",
+        "ItemUseContext",
+        "JsonFlagDefinition",
+        "LegacyHordeToken",
+        "LimbScoreDefinition",
+        "MagicTypeDefinition",
+        "MapExtraCollectionDefinition",
+        "MaterialDefinition",
+        "MissionToken",
+        "ModDefinition",
+        "MonsterAttackDefinition",
+        "MonsterDefinition",
+        "MonsterFactionDefinition",
+        "MonsterFlagDefinition",
+        "MoodFaceDefinition",
+        "MoraleTypeDefinition",
+        "MovementModeDefinition",
+        "MutationCategoryDefinition",
+        "MutationTypeDefinition",
+        "NamedColorDefinition",
+        "NestedRecipeCategoryDefinition",
+        "OverlayOrderDefinition",
+        "OvermapLandUseCodeDefinition",
+        "OvermapLocationDefinition",
+        "OvermapVisionDefinition",
+        "PlaylistDefinition",
+        "PointCoord",
+        "ProfessionGroupDefinition",
+        "ProficiencyCategoryDefinition",
+        "ProficiencyDefinition",
+        "RecipeCategoryDefinition",
+        "RecipeDefinition",
+        "RecipeGroupDefinition",
+        "RequirementDefinition",
+        "RotatableSymbolDefinition",
+        "ScentTypeDefinition",
+        "ScoreDefinition",
+        "SkillDefinition",
+        "SkillDisplayDefinition",
+        "SnippetCategoryDefinition",
+        "SpeciesDefinition",
+        "SpeechPoolDefinition",
+        "SpeedDescriptionDefinition",
+        "StartLocationDefinition",
+        "SubBodyPartDefinition",
+        "TimeDuration",
+        "TimePoint",
+        "ToolQualityDefinition",
+        "TripointCoord",
+        "UnitValue",
+        "VehicleGroupDefinition",
+        "VehiclePartCategoryDefinition",
+        "VehiclePartLocationDefinition",
+        "VitaminDefinition",
+        "WeakpointSetDefinition",
+        "WeaponCategoryDefinition",
+        "WeatherTypeDefinition",
+        "WoundDefinition",
+        "WoundFixDefinition",
+        "ZoneToken",
+        "ZoneTypeDefinition"
+      ]
+    }
+  ],
+  "export_installation_graph": {
+    "installers": [
+      {
+        "id": "api_v5.initialize_state",
+        "function": "initialize_state",
+        "namespace": "global",
+        "source": {
+          "path": "src/catalua_ui.cpp",
+          "line": 3694
+        },
+        "direct_roots": [
+          "ScriptDialogueContext",
+          "ScriptMapgenContext",
+          "ScriptUiContext",
+          "ScriptUiEnvironment"
+        ]
+      },
+      {
+        "id": "platform_v1.initialize_state",
+        "function": "initialize_state",
+        "namespace": "ccb",
+        "source": {
+          "path": "src/catalua_platform.cpp",
+          "line": 320
+        },
+        "direct_roots": []
+      },
+      {
+        "id": "platform_v1.install_mod_definition",
+        "function": "install_mod_definition",
+        "namespace": "ccb",
+        "source": {
+          "path": "src/catalua_platform.cpp",
+          "line": 196
+        },
+        "direct_roots": [
+          "ModDefinition"
+        ]
+      },
+      {
+        "id": "platform_v1.install_runtime_api",
+        "function": "install_runtime_api",
+        "namespace": "ccb",
+        "source": {
+          "path": "src/catalua_platform_runtime.cpp",
+          "line": 19431
+        },
+        "direct_roots": [
+          "ItemUseContext"
+        ]
+      },
+      {
+        "id": "platform_v1.content_transaction.install_lua_api",
+        "function": "content_transaction::install_lua_api",
+        "namespace": "ccb",
+        "source": {
+          "path": "src/catalua_platform_runtime.cpp",
+          "line": 6734
+        },
+        "direct_roots": [
+          "ActivityTypeDefinition",
+          "AddictionTypeDefinition",
+          "AmmoEffectDefinition",
+          "AmmunitionTypeDefinition",
+          "AnatomyDefinition",
+          "AsciiArtDefinition",
+          "AttackVectorDefinition",
+          "BashDamageProfileDefinition",
+          "BehaviorDefinition",
+          "BodyGraphDefinition",
+          "BodyPartDefinition",
+          "CharacterModifierDefinition",
+          "ClimbingAidDefinition",
+          "ClothingModDefinition",
+          "ConnectGroupDefinition",
+          "ConstructionCategoryDefinition",
+          "ConstructionGroupDefinition",
+          "DamageInfoOrderDefinition",
+          "DamageTypeDefinition",
+          "DiseaseTypeDefinition",
+          "EffectTypeDefinition",
+          "EmissionDefinition",
+          "EndScreenDefinition",
+          "ExplosionLightDefinition",
+          "FaultGroupDefinition",
+          "FieldTypeDefinition",
+          "HarvestDefinition",
+          "HarvestDropTypeDefinition",
+          "HelpTopicDefinition",
+          "HitRangeDefinition",
+          "ItemCategoryDefinition",
+          "ItemDefinition",
+          "ItemGroupDefinition",
+          "JsonFlagDefinition",
+          "LimbScoreDefinition",
+          "MagicTypeDefinition",
+          "MapExtraCollectionDefinition",
+          "MaterialDefinition",
+          "MonsterAttackDefinition",
+          "MonsterDefinition",
+          "MonsterFactionDefinition",
+          "MonsterFlagDefinition",
+          "MoodFaceDefinition",
+          "MoraleTypeDefinition",
+          "MovementModeDefinition",
+          "MutationCategoryDefinition",
+          "MutationTypeDefinition",
+          "NamedColorDefinition",
+          "NestedRecipeCategoryDefinition",
+          "OverlayOrderDefinition",
+          "OvermapLandUseCodeDefinition",
+          "OvermapLocationDefinition",
+          "OvermapVisionDefinition",
+          "PlaylistDefinition",
+          "ProfessionGroupDefinition",
+          "ProficiencyCategoryDefinition",
+          "ProficiencyDefinition",
+          "RecipeCategoryDefinition",
+          "RecipeDefinition",
+          "RecipeGroupDefinition",
+          "RequirementDefinition",
+          "RotatableSymbolDefinition",
+          "ScentTypeDefinition",
+          "ScoreDefinition",
+          "SkillDefinition",
+          "SkillDisplayDefinition",
+          "SnippetCategoryDefinition",
+          "SpeciesDefinition",
+          "SpeechPoolDefinition",
+          "SpeedDescriptionDefinition",
+          "StartLocationDefinition",
+          "SubBodyPartDefinition",
+          "ToolQualityDefinition",
+          "VehicleGroupDefinition",
+          "VehiclePartCategoryDefinition",
+          "VehiclePartLocationDefinition",
+          "VitaminDefinition",
+          "WeakpointSetDefinition",
+          "WeaponCategoryDefinition",
+          "WeatherTypeDefinition",
+          "WoundDefinition",
+          "WoundFixDefinition",
+          "ZoneTypeDefinition"
+        ]
+      },
+      {
+        "id": "shared.install_value_type_api",
+        "function": "install_value_type_api",
+        "namespace": "global",
+        "source": {
+          "path": "src/catalua_bindings_values.cpp",
+          "line": 1051
+        },
+        "direct_roots": [
+          "GameId",
+          "TimeDuration",
+          "TimePoint",
+          "UnitValue"
+        ]
+      },
+      {
+        "id": "shared.install_enum_value_api",
+        "function": "install_enum_value_api",
+        "namespace": "global",
+        "source": {
+          "path": "src/catalua_bindings_enums.cpp",
+          "line": 516
+        },
+        "direct_roots": [
+          "GameEnum"
+        ]
+      },
+      {
+        "id": "shared.install_coordinate_value_api",
+        "function": "install_coordinate_value_api",
+        "namespace": "global",
+        "source": {
+          "path": "src/catalua_bindings_coords.cpp",
+          "line": 944
+        },
+        "direct_roots": [
+          "PointCoord",
+          "TripointCoord"
+        ]
+      },
+      {
+        "id": "shared.install_game_handle_api",
+        "function": "install_game_handle_api",
+        "namespace": "global",
+        "source": {
+          "path": "src/catalua_game_handle.cpp",
+          "line": 315
+        },
+        "direct_roots": [
+          "GameHandle"
+        ]
+      },
+      {
+        "id": "shared.install_mission_api",
+        "function": "install_mission_api",
+        "namespace": "global",
+        "source": {
+          "path": "src/catalua_ui_missions.cpp",
+          "line": 1223
+        },
+        "direct_roots": [
+          "MissionToken"
+        ]
+      },
+      {
+        "id": "shared.install_horde_api",
+        "function": "install_horde_api",
+        "namespace": "global",
+        "source": {
+          "path": "src/catalua_ui_hordes.cpp",
+          "line": 2122
+        },
+        "direct_roots": [
+          "HordeEntityToken",
+          "LegacyHordeToken"
+        ]
+      },
+      {
+        "id": "shared.install_zone_api",
+        "function": "install_zone_api",
+        "namespace": "global",
+        "source": {
+          "path": "src/catalua_ui_zones.cpp",
+          "line": 1460
+        },
+        "direct_roots": [
+          "ZoneToken"
+        ]
+      }
+    ],
+    "edges": [
+      {
+        "caller": "api_v5.initialize_state",
+        "callee": "shared.install_value_type_api",
+        "source": {
+          "path": "src/catalua_ui.cpp",
+          "line": 4154
+        },
+        "surfaces": [
+          "api_v5"
+        ]
+      },
+      {
+        "caller": "api_v5.initialize_state",
+        "callee": "shared.install_game_handle_api",
+        "source": {
+          "path": "src/catalua_ui.cpp",
+          "line": 4266
+        },
+        "surfaces": [
+          "api_v5"
+        ]
+      },
+      {
+        "caller": "api_v5.initialize_state",
+        "callee": "shared.install_zone_api",
+        "source": {
+          "path": "src/catalua_ui.cpp",
+          "line": 4507
+        },
+        "surfaces": [
+          "api_v5"
+        ]
+      },
+      {
+        "caller": "api_v5.initialize_state",
+        "callee": "shared.install_mission_api",
+        "source": {
+          "path": "src/catalua_ui.cpp",
+          "line": 4535
+        },
+        "surfaces": [
+          "api_v5"
+        ]
+      },
+      {
+        "caller": "api_v5.initialize_state",
+        "callee": "shared.install_horde_api",
+        "source": {
+          "path": "src/catalua_ui.cpp",
+          "line": 4592
+        },
+        "surfaces": [
+          "api_v5"
+        ]
+      },
+      {
+        "caller": "platform_v1.initialize_state",
+        "callee": "platform_v1.install_mod_definition",
+        "source": {
+          "path": "src/catalua_platform.cpp",
+          "line": 335
+        },
+        "surfaces": [
+          "platform_v1"
+        ]
+      },
+      {
+        "caller": "platform_v1.initialize_state",
+        "callee": "platform_v1.install_runtime_api",
+        "source": {
+          "path": "src/catalua_platform.cpp",
+          "line": 337
+        },
+        "surfaces": [
+          "platform_v1"
+        ]
+      },
+      {
+        "caller": "platform_v1.install_runtime_api",
+        "callee": "platform_v1.content_transaction.install_lua_api",
+        "source": {
+          "path": "src/catalua_platform_runtime.cpp",
+          "line": 19434
+        },
+        "surfaces": [
+          "platform_v1"
+        ]
+      },
+      {
+        "caller": "platform_v1.install_runtime_api",
+        "callee": "shared.install_value_type_api",
+        "source": {
+          "path": "src/catalua_platform_runtime.cpp",
+          "line": 19784
+        },
+        "surfaces": [
+          "platform_v1"
+        ]
+      },
+      {
+        "caller": "platform_v1.install_runtime_api",
+        "callee": "shared.install_game_handle_api",
+        "source": {
+          "path": "src/catalua_platform_runtime.cpp",
+          "line": 19786
+        },
+        "surfaces": [
+          "platform_v1"
+        ]
+      },
+      {
+        "caller": "platform_v1.install_runtime_api",
+        "callee": "shared.install_mission_api",
+        "source": {
+          "path": "src/catalua_platform_runtime.cpp",
+          "line": 20414
+        },
+        "surfaces": [
+          "platform_v1"
+        ]
+      },
+      {
+        "caller": "platform_v1.install_runtime_api",
+        "callee": "shared.install_horde_api",
+        "source": {
+          "path": "src/catalua_platform_runtime.cpp",
+          "line": 20416
+        },
+        "surfaces": [
+          "platform_v1"
+        ]
+      },
+      {
+        "caller": "platform_v1.install_runtime_api",
+        "callee": "shared.install_zone_api",
+        "source": {
+          "path": "src/catalua_platform_runtime.cpp",
+          "line": 20458
+        },
+        "surfaces": [
+          "platform_v1"
+        ]
+      },
+      {
+        "caller": "shared.install_value_type_api",
+        "callee": "shared.install_enum_value_api",
+        "source": {
+          "path": "src/catalua_bindings_values.cpp",
+          "line": 1247
+        },
+        "surfaces": [
+          "api_v5",
+          "platform_v1"
+        ]
+      },
+      {
+        "caller": "shared.install_value_type_api",
+        "callee": "shared.install_coordinate_value_api",
+        "source": {
+          "path": "src/catalua_bindings_values.cpp",
+          "line": 1248
+        },
+        "surfaces": [
+          "api_v5",
+          "platform_v1"
+        ]
+      }
+    ]
+  },
+  "export_roots": [
+    {
+      "id": "ActivityTypeDefinition",
+      "cpp_type": "activity_type_definition_handle",
+      "lua_name": "ActivityTypeDefinition",
+      "registration_name": "ActivityTypeDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7152,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ActivityTypeDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7154
+              }
+            ]
+          },
+          {
+            "id": "ignore",
+            "cpp_members": [
+              "ignore"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ActivityTypeDefinition.ignore"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7155
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4605
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4606
+              }
+            ]
+          },
+          {
+            "id": "on_finish",
+            "cpp_members": [
+              "on_finish"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ActivityTypeDefinition.on_finish"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7157
+              }
+            ]
+          },
+          {
+            "id": "on_turn",
+            "cpp_members": [
+              "on_turn"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ActivityTypeDefinition.on_turn"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7156
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "AddictionTypeDefinition",
+      "cpp_type": "addiction_type_definition_handle",
+      "lua_name": "AddictionTypeDefinition",
+      "registration_name": "AddictionTypeDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7102,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "AddictionTypeDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7104
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4300
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4301
+              }
+            ]
+          },
+          {
+            "id": "tick_policy",
+            "cpp_members": [
+              "tick_policy"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "AddictionTypeDefinition.tick_policy"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7105
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "AmmoEffectDefinition",
+      "cpp_type": "ammo_effect_definition_handle",
+      "lua_name": "AmmoEffectDefinition",
+      "registration_name": "AmmoEffectDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7087,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "area_effect",
+            "cpp_members": [
+              "area_effect"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "AmmoEffectDefinition.area_effect"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7093
+              }
+            ]
+          },
+          {
+            "id": "cast_spells_on_miss",
+            "cpp_members": [
+              "cast_spells_on_miss"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "AmmoEffectDefinition.cast_spells_on_miss"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7100
+              }
+            ]
+          },
+          {
+            "id": "emp",
+            "cpp_members": [
+              "emp"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "AmmoEffectDefinition.emp"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7097
+              }
+            ]
+          },
+          {
+            "id": "explosion",
+            "cpp_members": [
+              "explosion"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "AmmoEffectDefinition.explosion"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7094
+              }
+            ]
+          },
+          {
+            "id": "field_burst",
+            "cpp_members": [
+              "field_burst"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "AmmoEffectDefinition.field_burst"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7090
+              }
+            ]
+          },
+          {
+            "id": "flashbang",
+            "cpp_members": [
+              "flashbang"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "AmmoEffectDefinition.flashbang"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7096
+              }
+            ]
+          },
+          {
+            "id": "foamcrete",
+            "cpp_members": [
+              "foamcrete"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "AmmoEffectDefinition.foamcrete"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7098
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "AmmoEffectDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7089
+              }
+            ]
+          },
+          {
+            "id": "impact_policy",
+            "cpp_members": [
+              "impact_policy"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "AmmoEffectDefinition.impact_policy"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7101
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4168
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4169
+              }
+            ]
+          },
+          {
+            "id": "on_hit",
+            "cpp_members": [
+              "on_hit"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "AmmoEffectDefinition.on_hit"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7092
+              }
+            ]
+          },
+          {
+            "id": "shrapnel",
+            "cpp_members": [
+              "shrapnel"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "AmmoEffectDefinition.shrapnel"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7095
+              }
+            ]
+          },
+          {
+            "id": "spell",
+            "cpp_members": [
+              "spell"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "AmmoEffectDefinition.spell"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7099
+              }
+            ]
+          },
+          {
+            "id": "trail",
+            "cpp_members": [
+              "trail"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "AmmoEffectDefinition.trail"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7091
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "AmmunitionTypeDefinition",
+      "cpp_type": "ammunition_type_definition_handle",
+      "lua_name": "AmmunitionTypeDefinition",
+      "registration_name": "AmmunitionTypeDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6784,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "AmmunitionTypeDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6786
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4776
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4777
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "AnatomyDefinition",
+      "cpp_type": "anatomy_definition_handle",
+      "lua_name": "AnatomyDefinition",
+      "registration_name": "AnatomyDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6943,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "AnatomyDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6945
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3202
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3203
+              }
+            ]
+          },
+          {
+            "id": "part",
+            "cpp_members": [
+              "part"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "AnatomyDefinition.part"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6946
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "AsciiArtDefinition",
+      "cpp_type": "ascii_art_definition_handle",
+      "lua_name": "AsciiArtDefinition",
+      "registration_name": "AsciiArtDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7032,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "AsciiArtDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7034
+              }
+            ]
+          },
+          {
+            "id": "line",
+            "cpp_members": [
+              "line"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "AsciiArtDefinition.line"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7035
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3837
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3838
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "AttackVectorDefinition",
+      "cpp_type": "attack_vector_definition_handle",
+      "lua_name": "AttackVectorDefinition",
+      "registration_name": "AttackVectorDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7171,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "contact",
+            "cpp_members": [
+              "contact"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "AttackVectorDefinition.contact"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7175
+              }
+            ]
+          },
+          {
+            "id": "forbids_flag",
+            "cpp_members": [
+              "forbids_flag"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "AttackVectorDefinition.forbids_flag"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7178
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "AttackVectorDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7173
+              }
+            ]
+          },
+          {
+            "id": "limb",
+            "cpp_members": [
+              "limb"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "AttackVectorDefinition.limb"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7174
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4720
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4721
+              }
+            ]
+          },
+          {
+            "id": "requires_flag",
+            "cpp_members": [
+              "requires_flag"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "AttackVectorDefinition.requires_flag"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7177
+              }
+            ]
+          },
+          {
+            "id": "requires_limb",
+            "cpp_members": [
+              "requires_limb"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "AttackVectorDefinition.requires_limb"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7176
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "BashDamageProfileDefinition",
+      "cpp_type": "bash_damage_profile_definition_handle",
+      "lua_name": "BashDamageProfileDefinition",
+      "registration_name": "BashDamageProfileDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7042,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "factor",
+            "cpp_members": [
+              "factor"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "BashDamageProfileDefinition.factor"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7045
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "BashDamageProfileDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7044
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3876
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3877
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "BehaviorDefinition",
+      "cpp_type": "behavior_definition_handle",
+      "lua_name": "BehaviorDefinition",
+      "registration_name": "BehaviorDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6866,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "child",
+            "cpp_members": [
+              "child"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "BehaviorDefinition.child"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6869
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "BehaviorDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6868
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2629
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2630
+              }
+            ]
+          },
+          {
+            "id": "score",
+            "cpp_members": [
+              "score"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "BehaviorDefinition.score"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6872
+              }
+            ]
+          },
+          {
+            "id": "score_native",
+            "cpp_members": [
+              "score_native"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "BehaviorDefinition.score_native"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6873
+              }
+            ]
+          },
+          {
+            "id": "when",
+            "cpp_members": [
+              "when"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "BehaviorDefinition.when"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6870
+              }
+            ]
+          },
+          {
+            "id": "when_native",
+            "cpp_members": [
+              "when_native"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "BehaviorDefinition.when_native"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6871
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "BodyGraphDefinition",
+      "cpp_type": "body_graph_definition_handle",
+      "lua_name": "BodyGraphDefinition",
+      "registration_name": "BodyGraphDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6947,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "BodyGraphDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6949
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3222
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3223
+              }
+            ]
+          },
+          {
+            "id": "part",
+            "cpp_members": [
+              "part"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "BodyGraphDefinition.part"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6951
+              }
+            ]
+          },
+          {
+            "id": "row",
+            "cpp_members": [
+              "row"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "BodyGraphDefinition.row"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6950
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "BodyPartDefinition",
+      "cpp_type": "body_part_definition_handle",
+      "lua_name": "BodyPartDefinition",
+      "registration_name": "BodyPartDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6925,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "armor",
+            "cpp_members": [
+              "armor"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "BodyPartDefinition.armor"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6930
+              }
+            ]
+          },
+          {
+            "id": "flag",
+            "cpp_members": [
+              "flag"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "BodyPartDefinition.flag"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6932
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "BodyPartDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6927
+              }
+            ]
+          },
+          {
+            "id": "limb_score",
+            "cpp_members": [
+              "limb_score"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "BodyPartDefinition.limb_score"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6933
+              }
+            ]
+          },
+          {
+            "id": "limb_type",
+            "cpp_members": [
+              "limb_type"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "BodyPartDefinition.limb_type"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6929
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2934
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2935
+              }
+            ]
+          },
+          {
+            "id": "quality",
+            "cpp_members": [
+              "quality"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "BodyPartDefinition.quality"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6934
+              }
+            ]
+          },
+          {
+            "id": "sub_part",
+            "cpp_members": [
+              "sub_part"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "BodyPartDefinition.sub_part"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6928
+              }
+            ]
+          },
+          {
+            "id": "unarmed_damage",
+            "cpp_members": [
+              "unarmed_damage"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "BodyPartDefinition.unarmed_damage"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6931
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "CharacterModifierDefinition",
+      "cpp_type": "character_modifier_definition_handle",
+      "lua_name": "CharacterModifierDefinition",
+      "registration_name": "CharacterModifierDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7106,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "evaluate_with",
+            "cpp_members": [
+              "evaluate_with"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "CharacterModifierDefinition.evaluate_with"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7109
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "CharacterModifierDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7108
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4316
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4317
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "ClimbingAidDefinition",
+      "cpp_type": "climbing_aid_definition_handle",
+      "lua_name": "ClimbingAidDefinition",
+      "registration_name": "ClimbingAidDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7118,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "available_when",
+            "cpp_members": [
+              "available_when"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ClimbingAidDefinition.available_when"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7121
+              }
+            ]
+          },
+          {
+            "id": "cost",
+            "cpp_members": [
+              "cost"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ClimbingAidDefinition.cost"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7123
+              }
+            ]
+          },
+          {
+            "id": "deploy",
+            "cpp_members": [
+              "deploy"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ClimbingAidDefinition.deploy"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7124
+              }
+            ]
+          },
+          {
+            "id": "descent",
+            "cpp_members": [
+              "descent"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ClimbingAidDefinition.descent"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7122
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ClimbingAidDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7120
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4400
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4401
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "ClothingModDefinition",
+      "cpp_type": "clothing_mod_definition_handle",
+      "lua_name": "ClothingModDefinition",
+      "registration_name": "ClothingModDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7046,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ClothingModDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7048
+              }
+            ]
+          },
+          {
+            "id": "modifier",
+            "cpp_members": [
+              "modifier"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ClothingModDefinition.modifier"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7049
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3896
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3897
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "ConnectGroupDefinition",
+      "cpp_type": "connect_group_definition_handle",
+      "lua_name": "ConnectGroupDefinition",
+      "registration_name": "ConnectGroupDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7000,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ConnectGroupDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7002
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3703
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3704
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "ConstructionCategoryDefinition",
+      "cpp_type": "construction_category_definition_handle",
+      "lua_name": "ConstructionCategoryDefinition",
+      "registration_name": "ConstructionCategoryDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7006,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ConstructionCategoryDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7008
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3723
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3724
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "ConstructionGroupDefinition",
+      "cpp_type": "construction_group_definition_handle",
+      "lua_name": "ConstructionGroupDefinition",
+      "registration_name": "ConstructionGroupDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7009,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ConstructionGroupDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7011
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3733
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3734
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "DamageInfoOrderDefinition",
+      "cpp_type": "damage_info_order_definition_handle",
+      "lua_name": "DamageInfoOrderDefinition",
+      "registration_name": "DamageInfoOrderDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7019,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "DamageInfoOrderDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7021
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3774
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3775
+              }
+            ]
+          },
+          {
+            "id": "section",
+            "cpp_members": [
+              "section"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "DamageInfoOrderDefinition.section"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7022
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "DamageTypeDefinition",
+      "cpp_type": "damage_type_definition_handle",
+      "lua_name": "DamageTypeDefinition",
+      "registration_name": "DamageTypeDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6766,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "derived",
+            "cpp_members": [
+              "derived"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "DamageTypeDefinition.derived"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6769
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "DamageTypeDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6768
+              }
+            ]
+          },
+          {
+            "id": "immune_character_flag",
+            "cpp_members": [
+              "immune_character_flag"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "DamageTypeDefinition.immune_character_flag"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6770
+              }
+            ]
+          },
+          {
+            "id": "immune_monster_flag",
+            "cpp_members": [
+              "immune_monster_flag"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "DamageTypeDefinition.immune_monster_flag"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6771
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2270
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2271
+              }
+            ]
+          },
+          {
+            "id": "on_damage",
+            "cpp_members": [
+              "on_damage"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "DamageTypeDefinition.on_damage"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6773
+              }
+            ]
+          },
+          {
+            "id": "on_hit",
+            "cpp_members": [
+              "on_hit"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "DamageTypeDefinition.on_hit"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6772
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "DiseaseTypeDefinition",
+      "cpp_type": "disease_type_definition_handle",
+      "lua_name": "DiseaseTypeDefinition",
+      "registration_name": "DiseaseTypeDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6975,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "affected_body_part",
+            "cpp_members": [
+              "affected_body_part"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "DiseaseTypeDefinition.affected_body_part"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6978
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "DiseaseTypeDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6977
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3575
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3576
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "EffectTypeDefinition",
+      "cpp_type": "effect_type_definition_handle",
+      "lua_name": "EffectTypeDefinition",
+      "registration_name": "EffectTypeDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6878,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "blocks_effect",
+            "cpp_members": [
+              "blocks_effect"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "EffectTypeDefinition.blocks_effect"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6890
+              }
+            ]
+          },
+          {
+            "id": "description",
+            "cpp_members": [
+              "description"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "EffectTypeDefinition.description"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6882
+              }
+            ]
+          },
+          {
+            "id": "flag",
+            "cpp_members": [
+              "flag"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "EffectTypeDefinition.flag"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6884
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "EffectTypeDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6880
+              }
+            ]
+          },
+          {
+            "id": "immune_bodypart_flag",
+            "cpp_members": [
+              "immune_bodypart_flag"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "EffectTypeDefinition.immune_bodypart_flag"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6886
+              }
+            ]
+          },
+          {
+            "id": "immune_character_flag",
+            "cpp_members": [
+              "immune_character_flag"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "EffectTypeDefinition.immune_character_flag"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6885
+              }
+            ]
+          },
+          {
+            "id": "name",
+            "cpp_members": [
+              "name"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "EffectTypeDefinition.name"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6881
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2696
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2697
+              }
+            ]
+          },
+          {
+            "id": "reduced_description",
+            "cpp_members": [
+              "reduced_description"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "EffectTypeDefinition.reduced_description"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6883
+              }
+            ]
+          },
+          {
+            "id": "removes_effect",
+            "cpp_members": [
+              "removes_effect"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "EffectTypeDefinition.removes_effect"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6889
+              }
+            ]
+          },
+          {
+            "id": "resist_effect",
+            "cpp_members": [
+              "resist_effect"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "EffectTypeDefinition.resist_effect"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6888
+              }
+            ]
+          },
+          {
+            "id": "resist_trait",
+            "cpp_members": [
+              "resist_trait"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "EffectTypeDefinition.resist_trait"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6887
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "EmissionDefinition",
+      "cpp_type": "emission_definition_handle",
+      "lua_name": "EmissionDefinition",
+      "registration_name": "EmissionDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6989,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "EmissionDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6991
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3650
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3651
+              }
+            ]
+          },
+          {
+            "id": "profile",
+            "cpp_members": [
+              "profile"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "EmissionDefinition.profile"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6992
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "EndScreenDefinition",
+      "cpp_type": "end_screen_definition_handle",
+      "lua_name": "EndScreenDefinition",
+      "registration_name": "EndScreenDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7147,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "condition",
+            "cpp_members": [
+              "condition"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "EndScreenDefinition.condition"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7151
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "EndScreenDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7149
+              }
+            ]
+          },
+          {
+            "id": "info",
+            "cpp_members": [
+              "info"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "EndScreenDefinition.info"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7150
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4575
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4576
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "ExplosionLightDefinition",
+      "cpp_type": "explosion_light_definition_handle",
+      "lua_name": "ExplosionLightDefinition",
+      "registration_name": "ExplosionLightDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7079,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "duration",
+            "cpp_members": [
+              "duration"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ExplosionLightDefinition.duration"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7084
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ExplosionLightDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7081
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4087
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4088
+              }
+            ]
+          },
+          {
+            "id": "screen_shake",
+            "cpp_members": [
+              "screen_shake"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ExplosionLightDefinition.screen_shake"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7085
+              }
+            ]
+          },
+          {
+            "id": "shockwave",
+            "cpp_members": [
+              "shockwave"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ExplosionLightDefinition.shockwave"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7086
+              }
+            ]
+          },
+          {
+            "id": "stop",
+            "cpp_members": [
+              "stop"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ExplosionLightDefinition.stop"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7082
+              }
+            ]
+          },
+          {
+            "id": "waves",
+            "cpp_members": [
+              "waves"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ExplosionLightDefinition.waves"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7083
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "FaultGroupDefinition",
+      "cpp_type": "fault_group_definition_handle",
+      "lua_name": "FaultGroupDefinition",
+      "registration_name": "FaultGroupDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7075,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "fault",
+            "cpp_members": [
+              "fault"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "FaultGroupDefinition.fault"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7078
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "FaultGroupDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7077
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4067
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4068
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "FieldTypeDefinition",
+      "cpp_type": "field_type_definition_handle",
+      "lua_name": "FieldTypeDefinition",
+      "registration_name": "FieldTypeDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6900,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "block_monster",
+            "cpp_members": [
+              "block_monster"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "FieldTypeDefinition.block_monster"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6906
+              }
+            ]
+          },
+          {
+            "id": "effect",
+            "cpp_members": [
+              "effect"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "FieldTypeDefinition.effect"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6904
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "FieldTypeDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6902
+              }
+            ]
+          },
+          {
+            "id": "immune_monster",
+            "cpp_members": [
+              "immune_monster"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "FieldTypeDefinition.immune_monster"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6905
+              }
+            ]
+          },
+          {
+            "id": "intensity",
+            "cpp_members": [
+              "intensity"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "FieldTypeDefinition.intensity"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6903
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3488
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3489
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "GameEnum",
+      "cpp_type": "script_enum_value",
+      "lua_name": "GameEnum",
+      "registration_name": "GameEnum",
+      "registration": {
+        "path": "src/catalua_bindings_enums.cpp",
+        "line": 519,
+        "installer": "shared.install_enum_value_api",
+        "namespace": "global"
+      },
+      "surfaces": [
+        "api_v5",
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "api_v5",
+          "namespace": "global",
+          "installer_chain": [
+            "api_v5.initialize_state",
+            "shared.install_value_type_api",
+            "shared.install_enum_value_api"
+          ]
+        },
+        {
+          "surface": "platform_v1",
+          "namespace": "global",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "shared.install_value_type_api",
+            "shared.install_enum_value_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "lua-owned-value",
+        "guards": []
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "__eq",
+            "cpp_members": [],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "GameEnum.__eq"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_enums.cpp",
+                "line": 525
+              }
+            ]
+          },
+          {
+            "id": "__tostring",
+            "cpp_members": [
+              "to_string"
+            ],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "GameEnum.__tostring"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_enums.cpp",
+                "line": 524
+              }
+            ]
+          },
+          {
+            "id": "kind",
+            "cpp_members": [
+              "kind"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "GameEnum.kind"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_enums.cpp",
+                "line": 521
+              }
+            ]
+          },
+          {
+            "id": "name",
+            "cpp_members": [
+              "name"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "GameEnum.name"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_enums.cpp",
+                "line": 522
+              }
+            ]
+          },
+          {
+            "id": "ordinal",
+            "cpp_members": [
+              "ordinal"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "GameEnum.ordinal"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_enums.cpp",
+                "line": 523
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "GameHandle",
+      "cpp_type": "game_handle",
+      "lua_name": "GameHandle",
+      "registration_name": "GameHandle",
+      "registration": {
+        "path": "src/catalua_game_handle.cpp",
+        "line": 321,
+        "installer": "shared.install_game_handle_api",
+        "namespace": "global"
+      },
+      "surfaces": [
+        "api_v5",
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "api_v5",
+          "namespace": "global",
+          "installer_chain": [
+            "api_v5.initialize_state",
+            "shared.install_game_handle_api"
+          ]
+        },
+        {
+          "surface": "platform_v1",
+          "namespace": "global",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "shared.install_game_handle_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "generation-checked-safe-reference",
+        "guards": [
+          "safe-reference",
+          "runtime-owner-identity",
+          "runtime-generation",
+          "world-generation",
+          "active-runtime-match"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "is_valid",
+            "cpp_members": [
+              "validation_error"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "GameHandle.is_valid"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_game_handle.cpp",
+                "line": 327
+              }
+            ]
+          },
+          {
+            "id": "kind",
+            "cpp_members": [
+              "kind_name"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "GameHandle.kind"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_game_handle.cpp",
+                "line": 323
+              }
+            ]
+          },
+          {
+            "id": "locator",
+            "cpp_members": [
+              "locator"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "GameHandle.locator"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_game_handle.cpp",
+                "line": 324
+              }
+            ]
+          },
+          {
+            "id": "native.resolve_creature",
+            "cpp_members": [
+              "resolve_creature"
+            ],
+            "cpp_kind": "method",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-pointer-escape",
+            "reason": "The native resolver returns a raw engine pointer; Lua must use audited handle-backed services instead.",
+            "evidence": [
+              {
+                "path": "src/catalua_game_handle.h",
+                "line": 122
+              }
+            ]
+          },
+          {
+            "id": "native.resolve_item",
+            "cpp_members": [
+              "resolve_item"
+            ],
+            "cpp_kind": "method",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-pointer-escape",
+            "reason": "The native resolver returns a raw engine pointer; Lua must use audited handle-backed services instead.",
+            "evidence": [
+              {
+                "path": "src/catalua_game_handle.h",
+                "line": 125
+              }
+            ]
+          },
+          {
+            "id": "native.resolve_vehicle",
+            "cpp_members": [
+              "resolve_vehicle"
+            ],
+            "cpp_kind": "method",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-pointer-escape",
+            "reason": "The native resolver returns a raw engine pointer; Lua must use audited handle-backed services instead.",
+            "evidence": [
+              {
+                "path": "src/catalua_game_handle.h",
+                "line": 128
+              }
+            ]
+          },
+          {
+            "id": "native.runtime_generation",
+            "cpp_members": [
+              "runtime_generation"
+            ],
+            "cpp_kind": "method",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "lifetime-generation-internal",
+            "reason": "Generation counters are internal lifetime guards and cannot be authored or inspected by Lua.",
+            "evidence": [
+              {
+                "path": "src/catalua_game_handle.h",
+                "line": 119
+              }
+            ]
+          },
+          {
+            "id": "native.runtime_owner",
+            "cpp_members": [
+              "runtime_owner_"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The weak runtime-owner identity is an internal stale-handle guard and cannot be observed or replaced by Lua.",
+            "evidence": [
+              {
+                "path": "src/catalua_game_handle.h",
+                "line": 138
+              }
+            ]
+          },
+          {
+            "id": "native.validation_error",
+            "cpp_members": [
+              "validation_error"
+            ],
+            "cpp_kind": "method",
+            "lua_access": [
+              "GameHandle.is_valid",
+              "GameHandle.status"
+            ],
+            "disposition": "adapted",
+            "reason_code": "result-envelope-adapter",
+            "reason": "Validation is exposed as a boolean and a detached result envelope instead of a native optional error object.",
+            "evidence": [
+              {
+                "path": "src/catalua_game_handle.h",
+                "line": 131
+              }
+            ]
+          },
+          {
+            "id": "native.world_generation",
+            "cpp_members": [
+              "world_generation"
+            ],
+            "cpp_kind": "method",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "lifetime-generation-internal",
+            "reason": "Generation counters are internal lifetime guards and cannot be authored or inspected by Lua.",
+            "evidence": [
+              {
+                "path": "src/catalua_game_handle.h",
+                "line": 120
+              }
+            ]
+          },
+          {
+            "id": "status",
+            "cpp_members": [
+              "validation_error"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "GameHandle.status"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_game_handle.cpp",
+                "line": 332
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "GameId",
+      "cpp_type": "script_game_id",
+      "lua_name": "GameId",
+      "registration_name": "GameId",
+      "registration": {
+        "path": "src/catalua_bindings_values.cpp",
+        "line": 1054,
+        "installer": "shared.install_value_type_api",
+        "namespace": "global"
+      },
+      "surfaces": [
+        "api_v5",
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "api_v5",
+          "namespace": "global",
+          "installer_chain": [
+            "api_v5.initialize_state",
+            "shared.install_value_type_api"
+          ]
+        },
+        {
+          "surface": "platform_v1",
+          "namespace": "global",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "shared.install_value_type_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "lua-owned-value",
+        "guards": []
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "__eq",
+            "cpp_members": [],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "GameId.__eq"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1061
+              }
+            ]
+          },
+          {
+            "id": "__tostring",
+            "cpp_members": [
+              "to_string"
+            ],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "GameId.__tostring"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1060
+              }
+            ]
+          },
+          {
+            "id": "is_null",
+            "cpp_members": [
+              "is_null"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "GameId.is_null"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1058
+              }
+            ]
+          },
+          {
+            "id": "is_valid",
+            "cpp_members": [
+              "is_valid"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "GameId.is_valid"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1059
+              }
+            ]
+          },
+          {
+            "id": "kind",
+            "cpp_members": [
+              "kind"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "GameId.kind"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1056
+              }
+            ]
+          },
+          {
+            "id": "value",
+            "cpp_members": [
+              "value"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "GameId.value"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1057
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "HarvestDefinition",
+      "cpp_type": "harvest_definition_handle",
+      "lua_name": "HarvestDefinition",
+      "registration_name": "HarvestDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6860,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "drop",
+            "cpp_members": [
+              "drop"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "HarvestDefinition.drop"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6863
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "HarvestDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6862
+              }
+            ]
+          },
+          {
+            "id": "item_fault",
+            "cpp_members": [
+              "item_fault"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "HarvestDefinition.item_fault"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6865
+              }
+            ]
+          },
+          {
+            "id": "item_flag",
+            "cpp_members": [
+              "item_flag"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "HarvestDefinition.item_flag"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6864
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2561
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2562
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "HarvestDropTypeDefinition",
+      "cpp_type": "harvest_drop_type_definition_handle",
+      "lua_name": "HarvestDropTypeDefinition",
+      "registration_name": "HarvestDropTypeDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6856,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "HarvestDropTypeDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6858
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2542
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2543
+              }
+            ]
+          },
+          {
+            "id": "skill",
+            "cpp_members": [
+              "skill"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "HarvestDropTypeDefinition.skill"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6859
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "HelpTopicDefinition",
+      "cpp_type": "help_topic_definition_handle",
+      "lua_name": "HelpTopicDefinition",
+      "registration_name": "HelpTopicDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7158,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "HelpTopicDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7160
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4643
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4644
+              }
+            ]
+          },
+          {
+            "id": "paragraph",
+            "cpp_members": [
+              "paragraph"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "HelpTopicDefinition.paragraph"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7161
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "HitRangeDefinition",
+      "cpp_type": "hit_range_definition_handle",
+      "lua_name": "HitRangeDefinition",
+      "registration_name": "HitRangeDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7039,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "HitRangeDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7041
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3866
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3867
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "HordeEntityToken",
+      "cpp_type": "horde_entity_token",
+      "lua_name": "HordeEntityToken",
+      "registration_name": "HordeEntityToken",
+      "registration": {
+        "path": "src/catalua_ui_hordes.cpp",
+        "line": 2130,
+        "installer": "shared.install_horde_api",
+        "namespace": "global"
+      },
+      "surfaces": [
+        "api_v5",
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "api_v5",
+          "namespace": "global",
+          "installer_chain": [
+            "api_v5.initialize_state",
+            "shared.install_horde_api"
+          ]
+        },
+        {
+          "surface": "platform_v1",
+          "namespace": "global",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "shared.install_horde_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "runtime-owner-and-identity-checked-token",
+        "guards": [
+          "runtime-owner-identity",
+          "runtime-generation",
+          "world-generation",
+          "active-runtime-match",
+          "native-entity-identity"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "__eq",
+            "cpp_members": [],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "HordeEntityToken.__eq"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_hordes.cpp",
+                "line": 2159
+              }
+            ]
+          },
+          {
+            "id": "__tostring",
+            "cpp_members": [
+              "to_string"
+            ],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "HordeEntityToken.__tostring"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_hordes.cpp",
+                "line": 2157
+              }
+            ]
+          },
+          {
+            "id": "is_valid",
+            "cpp_members": [],
+            "cpp_kind": "member",
+            "lua_access": [
+              "HordeEntityToken.is_valid"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_hordes.cpp",
+                "line": 2144
+              }
+            ]
+          },
+          {
+            "id": "monster",
+            "cpp_members": [
+              "monster"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "HordeEntityToken.monster"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_hordes.cpp",
+                "line": 2135
+              }
+            ]
+          },
+          {
+            "id": "native.belongs_to",
+            "cpp_members": [
+              "belongs_to"
+            ],
+            "cpp_kind": "method",
+            "lua_access": [
+              "HordeEntityToken.is_valid"
+            ],
+            "disposition": "adapted",
+            "reason_code": "runtime-identity-adapter",
+            "reason": "Lua receives a validity predicate that combines runtime owner identity with the token's other native guards.",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_hordes.cpp",
+                "line": 145
+              }
+            ]
+          },
+          {
+            "id": "native.runtime_context",
+            "cpp_members": [
+              "runtime_"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The complete runtime owner and generation context is an internal stale-token guard.",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_hordes.cpp",
+                "line": 163
+              }
+            ]
+          },
+          {
+            "id": "position",
+            "cpp_members": [
+              "position"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "HordeEntityToken.position"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_hordes.cpp",
+                "line": 2132
+              }
+            ]
+          },
+          {
+            "id": "runtime_generation",
+            "cpp_members": [
+              "runtime_generation"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "HordeEntityToken.runtime_generation"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_hordes.cpp",
+                "line": 2138
+              }
+            ]
+          },
+          {
+            "id": "world_generation",
+            "cpp_members": [
+              "world_generation"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "HordeEntityToken.world_generation"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_hordes.cpp",
+                "line": 2141
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "ItemCategoryDefinition",
+      "cpp_type": "item_category_definition_handle",
+      "lua_name": "ItemCategoryDefinition",
+      "registration_name": "ItemCategoryDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6787,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ItemCategoryDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6789
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4786
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4787
+              }
+            ]
+          },
+          {
+            "id": "priority_zone",
+            "cpp_members": [
+              "priority_zone"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ItemCategoryDefinition.priority_zone"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6790
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "ItemDefinition",
+      "cpp_type": "item_definition_handle",
+      "lua_name": "ItemDefinition",
+      "registration_name": "ItemDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6807,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "flag",
+            "cpp_members": [
+              "flag"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ItemDefinition.flag"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6815
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ItemDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6809
+              }
+            ]
+          },
+          {
+            "id": "mass_grams",
+            "cpp_members": [
+              "mass"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ItemDefinition.mass_grams"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6810
+              }
+            ]
+          },
+          {
+            "id": "material",
+            "cpp_members": [
+              "material"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ItemDefinition.material"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6813
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 1624
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 1625
+              }
+            ]
+          },
+          {
+            "id": "on_use",
+            "cpp_members": [
+              "on_use"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ItemDefinition.on_use"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6816
+              }
+            ]
+          },
+          {
+            "id": "price_cents",
+            "cpp_members": [
+              "price"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ItemDefinition.price_cents"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6812
+              }
+            ]
+          },
+          {
+            "id": "quality",
+            "cpp_members": [
+              "quality"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ItemDefinition.quality"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6814
+              }
+            ]
+          },
+          {
+            "id": "volume_ml",
+            "cpp_members": [
+              "volume"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ItemDefinition.volume_ml"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6811
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "ItemGroupDefinition",
+      "cpp_type": "item_group_definition_handle",
+      "lua_name": "ItemGroupDefinition",
+      "registration_name": "ItemGroupDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6907,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "group",
+            "cpp_members": [
+              "group"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ItemGroupDefinition.group"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6911
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ItemGroupDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6909
+              }
+            ]
+          },
+          {
+            "id": "item",
+            "cpp_members": [
+              "item"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ItemGroupDefinition.item"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6910
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3455
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3456
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "ItemUseContext",
+      "cpp_type": "use_context_data",
+      "lua_name": "ItemUseContext",
+      "registration_name": "ItemUseContext",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 19436,
+        "installer": "platform_v1.install_runtime_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "callback-borrowed",
+        "guards": [
+          "scope-lease",
+          "active-flag",
+          "noncopyable-nonmovable",
+          "runtime-owner-identity",
+          "runtime-generation",
+          "world-generation"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "character",
+            "cpp_members": [
+              "character_handle"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ItemUseContext.character"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 19441
+              }
+            ]
+          },
+          {
+            "id": "charges",
+            "cpp_members": [
+              "charges",
+              "set_charges"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ItemUseContext.charges"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 19444
+              }
+            ]
+          },
+          {
+            "id": "item",
+            "cpp_members": [
+              "item_handle"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ItemUseContext.item"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 19442
+              }
+            ]
+          },
+          {
+            "id": "item_id",
+            "cpp_members": [
+              "item_id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ItemUseContext.item_id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 19440
+              }
+            ]
+          },
+          {
+            "id": "message",
+            "cpp_members": [
+              "message"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ItemUseContext.message"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 19438
+              }
+            ]
+          },
+          {
+            "id": "native.active",
+            "cpp_members": [
+              "active"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "callback-lifetime-internal",
+            "reason": "Callback lifetime guards are enforced internally.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 5347
+              }
+            ]
+          },
+          {
+            "id": "native.character",
+            "cpp_members": [
+              "character"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-pointer-escape",
+            "reason": "Raw callback pointers cannot escape into Lua.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 5350
+              }
+            ]
+          },
+          {
+            "id": "native.copy_assignment",
+            "cpp_members": [
+              "operator=(const&)"
+            ],
+            "cpp_kind": "operator",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "callback-lifetime-internal",
+            "reason": "Callback userdata is pinned to one native scope lease and cannot be copied or moved.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 5338
+              }
+            ]
+          },
+          {
+            "id": "native.copy_constructor",
+            "cpp_members": [
+              "use_context_data(const&)"
+            ],
+            "cpp_kind": "constructor",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "callback-lifetime-internal",
+            "reason": "Callback userdata is pinned to one native scope lease and cannot be copied or moved.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 5337
+              }
+            ]
+          },
+          {
+            "id": "native.handle_runtime",
+            "cpp_members": [
+              "handle_runtime"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "callback-lifetime-internal",
+            "reason": "Callback lifetime guards are enforced internally.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 5345
+              }
+            ]
+          },
+          {
+            "id": "native.move_assignment",
+            "cpp_members": [
+              "operator=(&&)"
+            ],
+            "cpp_kind": "operator",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "callback-lifetime-internal",
+            "reason": "Callback userdata is pinned to one native scope lease and cannot be copied or moved.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 5340
+              }
+            ]
+          },
+          {
+            "id": "native.move_constructor",
+            "cpp_members": [
+              "use_context_data(&&)"
+            ],
+            "cpp_kind": "constructor",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "callback-lifetime-internal",
+            "reason": "Callback userdata is pinned to one native scope lease and cannot be copied or moved.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 5339
+              }
+            ]
+          },
+          {
+            "id": "native.require_active",
+            "cpp_members": [
+              "require_active"
+            ],
+            "cpp_kind": "method",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "callback-lifetime-internal",
+            "reason": "Callback lifetime guards are enforced internally.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 5349
+              }
+            ]
+          },
+          {
+            "id": "native.used_item",
+            "cpp_members": [
+              "used_item"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-pointer-escape",
+            "reason": "Raw callback pointers cannot escape into Lua.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 5350
+              }
+            ]
+          },
+          {
+            "id": "native.world_generation",
+            "cpp_members": [
+              "world_generation"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "callback-lifetime-internal",
+            "reason": "Callback lifetime guards are enforced internally.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 5346
+              }
+            ]
+          },
+          {
+            "id": "player_name",
+            "cpp_members": [
+              "player_name"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ItemUseContext.player_name"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 19439
+              }
+            ]
+          },
+          {
+            "id": "position",
+            "cpp_members": [
+              "use_position"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ItemUseContext.position"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 19443
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "JsonFlagDefinition",
+      "cpp_type": "json_flag_definition_handle",
+      "lua_name": "JsonFlagDefinition",
+      "registration_name": "JsonFlagDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6762,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "conflicts_with",
+            "cpp_members": [
+              "conflicts_with"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "JsonFlagDefinition.conflicts_with"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6765
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "JsonFlagDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6764
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2148
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2149
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "LegacyHordeToken",
+      "cpp_type": "legacy_horde_token",
+      "lua_name": "LegacyHordeToken",
+      "registration_name": "LegacyHordeToken",
+      "registration": {
+        "path": "src/catalua_ui_hordes.cpp",
+        "line": 2164,
+        "installer": "shared.install_horde_api",
+        "namespace": "global"
+      },
+      "surfaces": [
+        "api_v5",
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "api_v5",
+          "namespace": "global",
+          "installer_chain": [
+            "api_v5.initialize_state",
+            "shared.install_horde_api"
+          ]
+        },
+        {
+          "surface": "platform_v1",
+          "namespace": "global",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "shared.install_horde_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "runtime-owner-and-identity-checked-token",
+        "guards": [
+          "runtime-owner-identity",
+          "runtime-generation",
+          "world-generation",
+          "active-runtime-match",
+          "native-entity-identity"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "__eq",
+            "cpp_members": [],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "LegacyHordeToken.__eq"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_hordes.cpp",
+                "line": 2193
+              }
+            ]
+          },
+          {
+            "id": "__tostring",
+            "cpp_members": [
+              "to_string"
+            ],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "LegacyHordeToken.__tostring"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_hordes.cpp",
+                "line": 2191
+              }
+            ]
+          },
+          {
+            "id": "group",
+            "cpp_members": [
+              "group"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "LegacyHordeToken.group"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_hordes.cpp",
+                "line": 2169
+              }
+            ]
+          },
+          {
+            "id": "is_valid",
+            "cpp_members": [],
+            "cpp_kind": "member",
+            "lua_access": [
+              "LegacyHordeToken.is_valid"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_hordes.cpp",
+                "line": 2178
+              }
+            ]
+          },
+          {
+            "id": "native.belongs_to",
+            "cpp_members": [
+              "belongs_to"
+            ],
+            "cpp_kind": "method",
+            "lua_access": [
+              "LegacyHordeToken.is_valid"
+            ],
+            "disposition": "adapted",
+            "reason_code": "runtime-identity-adapter",
+            "reason": "Lua receives a validity predicate that combines runtime owner identity with the token's other native guards.",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_hordes.cpp",
+                "line": 220
+              }
+            ]
+          },
+          {
+            "id": "native.runtime_context",
+            "cpp_members": [
+              "runtime_"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The complete runtime owner and generation context is an internal stale-token guard.",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_hordes.cpp",
+                "line": 238
+              }
+            ]
+          },
+          {
+            "id": "position",
+            "cpp_members": [
+              "position"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "LegacyHordeToken.position"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_hordes.cpp",
+                "line": 2166
+              }
+            ]
+          },
+          {
+            "id": "runtime_generation",
+            "cpp_members": [
+              "runtime_generation"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "LegacyHordeToken.runtime_generation"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_hordes.cpp",
+                "line": 2172
+              }
+            ]
+          },
+          {
+            "id": "world_generation",
+            "cpp_members": [
+              "world_generation"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "LegacyHordeToken.world_generation"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_hordes.cpp",
+                "line": 2175
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "LimbScoreDefinition",
+      "cpp_type": "limb_score_definition_handle",
+      "lua_name": "LimbScoreDefinition",
+      "registration_name": "LimbScoreDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7036,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "LimbScoreDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7038
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3856
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3857
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "MagicTypeDefinition",
+      "cpp_type": "magic_type_definition_handle",
+      "lua_name": "MagicTypeDefinition",
+      "registration_name": "MagicTypeDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7179,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "cannot_cast_when",
+            "cpp_members": [
+              "cannot_cast_when"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MagicTypeDefinition.cannot_cast_when"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7182
+              }
+            ]
+          },
+          {
+            "id": "casting_experience",
+            "cpp_members": [
+              "casting_experience"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MagicTypeDefinition.casting_experience"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7184
+              }
+            ]
+          },
+          {
+            "id": "failure_chance",
+            "cpp_members": [
+              "failure_chance"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MagicTypeDefinition.failure_chance"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7185
+              }
+            ]
+          },
+          {
+            "id": "failure_cost",
+            "cpp_members": [
+              "failure_cost"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MagicTypeDefinition.failure_cost"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7186
+              }
+            ]
+          },
+          {
+            "id": "failure_experience",
+            "cpp_members": [
+              "failure_experience"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MagicTypeDefinition.failure_experience"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7187
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "MagicTypeDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7181
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2326
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2327
+              }
+            ]
+          },
+          {
+            "id": "on_failure",
+            "cpp_members": [
+              "on_failure"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MagicTypeDefinition.on_failure"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7188
+              }
+            ]
+          },
+          {
+            "id": "progression",
+            "cpp_members": [
+              "progression"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MagicTypeDefinition.progression"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7183
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "MapExtraCollectionDefinition",
+      "cpp_type": "map_extra_collection_definition_handle",
+      "lua_name": "MapExtraCollectionDefinition",
+      "registration_name": "MapExtraCollectionDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7067,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "extra",
+            "cpp_members": [
+              "extra"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MapExtraCollectionDefinition.extra"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7070
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "MapExtraCollectionDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7069
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4027
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4028
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "MaterialDefinition",
+      "cpp_type": "material_definition_handle",
+      "lua_name": "MaterialDefinition",
+      "registration_name": "MaterialDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6774,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "burn",
+            "cpp_members": [
+              "burn"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MaterialDefinition.burn"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6780
+              }
+            ]
+          },
+          {
+            "id": "burn_product",
+            "cpp_members": [
+              "burn_product"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MaterialDefinition.burn_product"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6781
+              }
+            ]
+          },
+          {
+            "id": "damage_adjective",
+            "cpp_members": [
+              "damage_adjective"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MaterialDefinition.damage_adjective"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6779
+              }
+            ]
+          },
+          {
+            "id": "fuel",
+            "cpp_members": [
+              "fuel"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MaterialDefinition.fuel"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6782
+              }
+            ]
+          },
+          {
+            "id": "fuel_explosion",
+            "cpp_members": [
+              "fuel_explosion"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MaterialDefinition.fuel_explosion"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6783
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "MaterialDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6776
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2167
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2168
+              }
+            ]
+          },
+          {
+            "id": "resistance",
+            "cpp_members": [
+              "resistance"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MaterialDefinition.resistance"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6777
+              }
+            ]
+          },
+          {
+            "id": "vitamin",
+            "cpp_members": [
+              "vitamin"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MaterialDefinition.vitamin"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6778
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "MissionToken",
+      "cpp_type": "mission_token",
+      "lua_name": "MissionToken",
+      "registration_name": "MissionToken",
+      "registration": {
+        "path": "src/catalua_ui_missions.cpp",
+        "line": 1231,
+        "installer": "shared.install_mission_api",
+        "namespace": "global"
+      },
+      "surfaces": [
+        "api_v5",
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "api_v5",
+          "namespace": "global",
+          "installer_chain": [
+            "api_v5.initialize_state",
+            "shared.install_mission_api"
+          ]
+        },
+        {
+          "surface": "platform_v1",
+          "namespace": "global",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "shared.install_mission_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "runtime-owner-and-generation-checked-token",
+        "guards": [
+          "runtime-owner-identity",
+          "runtime-generation",
+          "world-generation",
+          "active-runtime-match",
+          "native-token-resolution"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "__eq",
+            "cpp_members": [],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "MissionToken.__eq"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_missions.cpp",
+                "line": 1250
+              }
+            ]
+          },
+          {
+            "id": "__tostring",
+            "cpp_members": [
+              "to_string"
+            ],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "MissionToken.__tostring"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_missions.cpp",
+                "line": 1248
+              }
+            ]
+          },
+          {
+            "id": "is_valid",
+            "cpp_members": [],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MissionToken.is_valid"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_missions.cpp",
+                "line": 1240
+              }
+            ]
+          },
+          {
+            "id": "native.belongs_to",
+            "cpp_members": [
+              "belongs_to"
+            ],
+            "cpp_kind": "method",
+            "lua_access": [
+              "MissionToken.is_valid"
+            ],
+            "disposition": "adapted",
+            "reason_code": "runtime-identity-adapter",
+            "reason": "Lua receives a validity predicate that combines runtime owner identity with the token's other native guards.",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_missions.h",
+                "line": 25
+              }
+            ]
+          },
+          {
+            "id": "native.runtime_context",
+            "cpp_members": [
+              "runtime_"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The complete runtime owner and generation context is an internal stale-token guard.",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_missions.h",
+                "line": 38
+              }
+            ]
+          },
+          {
+            "id": "runtime_generation",
+            "cpp_members": [
+              "runtime_generation"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "MissionToken.runtime_generation"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_missions.cpp",
+                "line": 1234
+              }
+            ]
+          },
+          {
+            "id": "uid",
+            "cpp_members": [
+              "uid"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "MissionToken.uid"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_missions.cpp",
+                "line": 1233
+              }
+            ]
+          },
+          {
+            "id": "world_generation",
+            "cpp_members": [
+              "world_generation"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "MissionToken.world_generation"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_missions.cpp",
+                "line": 1237
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "ModDefinition",
+      "cpp_type": "mod_definition",
+      "lua_name": "ModDefinition",
+      "registration_name": "_ModDefinitionNative",
+      "registration": {
+        "path": "src/catalua_platform.cpp",
+        "line": 198,
+        "installer": "platform_v1.install_mod_definition",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_mod_definition"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "lua-owned-value",
+        "guards": []
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "core",
+            "cpp_members": [],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ModDefinition.core"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform.cpp",
+                "line": 240
+              }
+            ]
+          },
+          {
+            "id": "dependencies",
+            "cpp_members": [],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ModDefinition.dependencies"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform.cpp",
+                "line": 232
+              }
+            ]
+          },
+          {
+            "id": "entry",
+            "cpp_members": [],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ModDefinition.entry"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform.cpp",
+                "line": 224
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ModDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform.cpp",
+                "line": 200
+              }
+            ]
+          },
+          {
+            "id": "name",
+            "cpp_members": [],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ModDefinition.name"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform.cpp",
+                "line": 208
+              }
+            ]
+          },
+          {
+            "id": "native.core_set",
+            "cpp_members": [
+              "core_set"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "parser-presence-state",
+            "reason": "Field-presence tracking belongs to native metadata validation and is not Mod-authored state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform.h",
+                "line": 37
+              }
+            ]
+          },
+          {
+            "id": "native.dependencies_set",
+            "cpp_members": [
+              "dependencies_set"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "parser-presence-state",
+            "reason": "Field-presence tracking belongs to native metadata validation and is not Mod-authored state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform.h",
+                "line": 36
+              }
+            ]
+          },
+          {
+            "id": "native.entry_set",
+            "cpp_members": [
+              "entry_set"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "parser-presence-state",
+            "reason": "Field-presence tracking belongs to native metadata validation and is not Mod-authored state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform.h",
+                "line": 35
+              }
+            ]
+          },
+          {
+            "id": "native.id_set",
+            "cpp_members": [
+              "id_set"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "parser-presence-state",
+            "reason": "Field-presence tracking belongs to native metadata validation and is not Mod-authored state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform.h",
+                "line": 32
+              }
+            ]
+          },
+          {
+            "id": "native.name_set",
+            "cpp_members": [
+              "name_set"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "parser-presence-state",
+            "reason": "Field-presence tracking belongs to native metadata validation and is not Mod-authored state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform.h",
+                "line": 33
+              }
+            ]
+          },
+          {
+            "id": "native.version_set",
+            "cpp_members": [
+              "version_set"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "parser-presence-state",
+            "reason": "Field-presence tracking belongs to native metadata validation and is not Mod-authored state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform.h",
+                "line": 34
+              }
+            ]
+          },
+          {
+            "id": "version",
+            "cpp_members": [],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ModDefinition.version"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform.cpp",
+                "line": 216
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "MonsterAttackDefinition",
+      "cpp_type": "monster_attack_definition_handle",
+      "lua_name": "MonsterAttackDefinition",
+      "registration_name": "MonsterAttackDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6874,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "MonsterAttackDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6876
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2770
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2771
+              }
+            ]
+          },
+          {
+            "id": "policy",
+            "cpp_members": [
+              "policy"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MonsterAttackDefinition.policy"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6877
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "MonsterDefinition",
+      "cpp_type": "monster_definition_handle",
+      "lua_name": "MonsterDefinition",
+      "registration_name": "MonsterDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6952,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "anger_trigger",
+            "cpp_members": [
+              "anger_trigger"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MonsterDefinition.anger_trigger"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6969
+              }
+            ]
+          },
+          {
+            "id": "armor",
+            "cpp_members": [
+              "armor"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MonsterDefinition.armor"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6959
+              }
+            ]
+          },
+          {
+            "id": "attack",
+            "cpp_members": [
+              "attack"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MonsterDefinition.attack"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6961
+              }
+            ]
+          },
+          {
+            "id": "category",
+            "cpp_members": [
+              "category"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MonsterDefinition.category"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6957
+              }
+            ]
+          },
+          {
+            "id": "emission",
+            "cpp_members": [
+              "emission"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MonsterDefinition.emission"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6963
+              }
+            ]
+          },
+          {
+            "id": "fear_trigger",
+            "cpp_members": [
+              "fear_trigger"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MonsterDefinition.fear_trigger"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6970
+              }
+            ]
+          },
+          {
+            "id": "flag",
+            "cpp_members": [
+              "flag"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MonsterDefinition.flag"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6958
+              }
+            ]
+          },
+          {
+            "id": "goal",
+            "cpp_members": [
+              "goal"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MonsterDefinition.goal"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6968
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "MonsterDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6954
+              }
+            ]
+          },
+          {
+            "id": "ignore_scent",
+            "cpp_members": [
+              "ignore_scent"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MonsterDefinition.ignore_scent"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6966
+              }
+            ]
+          },
+          {
+            "id": "material",
+            "cpp_members": [
+              "material"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MonsterDefinition.material"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6955
+              }
+            ]
+          },
+          {
+            "id": "melee_damage",
+            "cpp_members": [
+              "melee_damage"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MonsterDefinition.melee_damage"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6960
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3296
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3297
+              }
+            ]
+          },
+          {
+            "id": "placate_trigger",
+            "cpp_members": [
+              "placate_trigger"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MonsterDefinition.placate_trigger"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6971
+              }
+            ]
+          },
+          {
+            "id": "regeneration_modifier",
+            "cpp_members": [
+              "regeneration_modifier"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MonsterDefinition.regeneration_modifier"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6967
+              }
+            ]
+          },
+          {
+            "id": "species",
+            "cpp_members": [
+              "species"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MonsterDefinition.species"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6956
+              }
+            ]
+          },
+          {
+            "id": "starting_ammo",
+            "cpp_members": [
+              "starting_ammo"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MonsterDefinition.starting_ammo"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6964
+              }
+            ]
+          },
+          {
+            "id": "track_scent",
+            "cpp_members": [
+              "track_scent"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MonsterDefinition.track_scent"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6965
+              }
+            ]
+          },
+          {
+            "id": "weakpoint_set",
+            "cpp_members": [
+              "weakpoint_set"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MonsterDefinition.weakpoint_set"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6962
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "MonsterFactionDefinition",
+      "cpp_type": "monster_faction_definition_handle",
+      "lua_name": "MonsterFactionDefinition",
+      "registration_name": "MonsterFactionDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6993,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "attitude",
+            "cpp_members": [
+              "attitude"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MonsterFactionDefinition.attitude"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6996
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "MonsterFactionDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6995
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3669
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3670
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "MonsterFlagDefinition",
+      "cpp_type": "monster_flag_definition_handle",
+      "lua_name": "MonsterFlagDefinition",
+      "registration_name": "MonsterFlagDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6979,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "MonsterFlagDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6981
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3594
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3595
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "MoodFaceDefinition",
+      "cpp_type": "mood_face_definition_handle",
+      "lua_name": "MoodFaceDefinition",
+      "registration_name": "MoodFaceDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7015,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "MoodFaceDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7017
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3753
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3754
+              }
+            ]
+          },
+          {
+            "id": "value",
+            "cpp_members": [
+              "value"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MoodFaceDefinition.value"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7018
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "MoraleTypeDefinition",
+      "cpp_type": "morale_type_definition_handle",
+      "lua_name": "MoraleTypeDefinition",
+      "registration_name": "MoraleTypeDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6972,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "MoraleTypeDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6974
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3565
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3566
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "MovementModeDefinition",
+      "cpp_type": "movement_mode_definition_handle",
+      "lua_name": "MovementModeDefinition",
+      "registration_name": "MovementModeDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7189,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "MovementModeDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7191
+              }
+            ]
+          },
+          {
+            "id": "messages",
+            "cpp_members": [
+              "messages"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "MovementModeDefinition.messages"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7192
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2401
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2402
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "MutationCategoryDefinition",
+      "cpp_type": "mutation_category_definition_handle",
+      "lua_name": "MutationCategoryDefinition",
+      "registration_name": "MutationCategoryDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7003,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "MutationCategoryDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7005
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3713
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3714
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "MutationTypeDefinition",
+      "cpp_type": "mutation_type_definition_handle",
+      "lua_name": "MutationTypeDefinition",
+      "registration_name": "MutationTypeDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6997,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "MutationTypeDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6999
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3693
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3694
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "NamedColorDefinition",
+      "cpp_type": "named_color_definition_handle",
+      "lua_name": "NamedColorDefinition",
+      "registration_name": "NamedColorDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7026,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "name",
+            "cpp_members": [
+              "name"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "NamedColorDefinition.name"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7028
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3817
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3818
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "NestedRecipeCategoryDefinition",
+      "cpp_type": "nested_recipe_category_definition_handle",
+      "lua_name": "NestedRecipeCategoryDefinition",
+      "registration_name": "NestedRecipeCategoryDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6828,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "NestedRecipeCategoryDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6830
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 1826
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 1827
+              }
+            ]
+          },
+          {
+            "id": "recipe",
+            "cpp_members": [
+              "recipe"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "NestedRecipeCategoryDefinition.recipe"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6831
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "OverlayOrderDefinition",
+      "cpp_type": "overlay_order_definition_handle",
+      "lua_name": "OverlayOrderDefinition",
+      "registration_name": "OverlayOrderDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7136,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "OverlayOrderDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7138
+              }
+            ]
+          },
+          {
+            "id": "mutation",
+            "cpp_members": [
+              "mutation"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "OverlayOrderDefinition.mutation"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7139
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4526
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4527
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "OvermapLandUseCodeDefinition",
+      "cpp_type": "overmap_land_use_code_definition_handle",
+      "lua_name": "OvermapLandUseCodeDefinition",
+      "registration_name": "OvermapLandUseCodeDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7050,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "OvermapLandUseCodeDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7052
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3935
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3936
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "OvermapLocationDefinition",
+      "cpp_type": "overmap_location_definition_handle",
+      "lua_name": "OvermapLocationDefinition",
+      "registration_name": "OvermapLocationDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7058,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "OvermapLocationDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7060
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3980
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3981
+              }
+            ]
+          },
+          {
+            "id": "terrain",
+            "cpp_members": [
+              "terrain"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "OvermapLocationDefinition.terrain"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7061
+              }
+            ]
+          },
+          {
+            "id": "terrain_flag",
+            "cpp_members": [
+              "terrain_flag"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "OvermapLocationDefinition.terrain_flag"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7062
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "OvermapVisionDefinition",
+      "cpp_type": "overmap_vision_definition_handle",
+      "lua_name": "OvermapVisionDefinition",
+      "registration_name": "OvermapVisionDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7053,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "appearance",
+            "cpp_members": [
+              "appearance"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "OvermapVisionDefinition.appearance"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7056
+              }
+            ]
+          },
+          {
+            "id": "blend_adjacent",
+            "cpp_members": [
+              "blend_adjacent"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "OvermapVisionDefinition.blend_adjacent"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7057
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "OvermapVisionDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7055
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3945
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3946
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "PlaylistDefinition",
+      "cpp_type": "playlist_definition_handle",
+      "lua_name": "PlaylistDefinition",
+      "registration_name": "PlaylistDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7167,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "PlaylistDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7169
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4700
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4701
+              }
+            ]
+          },
+          {
+            "id": "track",
+            "cpp_members": [
+              "track"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "PlaylistDefinition.track"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7170
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "PointCoord",
+      "cpp_type": "script_point_coord",
+      "lua_name": "PointCoord",
+      "registration_name": "PointCoord",
+      "registration": {
+        "path": "src/catalua_bindings_coords.cpp",
+        "line": 947,
+        "installer": "shared.install_coordinate_value_api",
+        "namespace": "global"
+      },
+      "surfaces": [
+        "api_v5",
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "api_v5",
+          "namespace": "global",
+          "installer_chain": [
+            "api_v5.initialize_state",
+            "shared.install_value_type_api",
+            "shared.install_coordinate_value_api"
+          ]
+        },
+        {
+          "surface": "platform_v1",
+          "namespace": "global",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "shared.install_value_type_api",
+            "shared.install_coordinate_value_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "lua-owned-value",
+        "guards": []
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "__add",
+            "cpp_members": [
+              "add"
+            ],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "PointCoord.__add"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 978
+              }
+            ]
+          },
+          {
+            "id": "__eq",
+            "cpp_members": [],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "PointCoord.__eq"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 966
+              }
+            ]
+          },
+          {
+            "id": "__le",
+            "cpp_members": [],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "PointCoord.__le"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 974
+              }
+            ]
+          },
+          {
+            "id": "__lt",
+            "cpp_members": [],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "PointCoord.__lt"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 970
+              }
+            ]
+          },
+          {
+            "id": "__mul",
+            "cpp_members": [
+              "scale_by"
+            ],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "PointCoord.__mul"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 980
+              }
+            ]
+          },
+          {
+            "id": "__sub",
+            "cpp_members": [
+              "subtract"
+            ],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "PointCoord.__sub"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 979
+              }
+            ]
+          },
+          {
+            "id": "__tostring",
+            "cpp_members": [
+              "to_string"
+            ],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "PointCoord.__tostring"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 965
+              }
+            ]
+          },
+          {
+            "id": "__unm",
+            "cpp_members": [
+              "negate"
+            ],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "PointCoord.__unm"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 981
+              }
+            ]
+          },
+          {
+            "id": "add",
+            "cpp_members": [
+              "add"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "PointCoord.add"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 954
+              }
+            ]
+          },
+          {
+            "id": "compare",
+            "cpp_members": [
+              "compare"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "PointCoord.compare"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 964
+              }
+            ]
+          },
+          {
+            "id": "euclidean_distance",
+            "cpp_members": [
+              "euclidean_distance"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "PointCoord.euclidean_distance"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 963
+              }
+            ]
+          },
+          {
+            "id": "manhattan_distance",
+            "cpp_members": [
+              "manhattan_distance"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "PointCoord.manhattan_distance"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 961
+              }
+            ]
+          },
+          {
+            "id": "native.line_to",
+            "cpp_members": [
+              "line_to"
+            ],
+            "cpp_kind": "method",
+            "lua_access": [
+              "game.coords.line",
+              "ccb.services.coords.line"
+            ],
+            "disposition": "adapted",
+            "reason_code": "bounded-service-adapter",
+            "reason": "Lua reaches line generation through the bounded coordinate service so maximum output is enforced.",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.h",
+                "line": 42
+              }
+            ]
+          },
+          {
+            "id": "native.native_origin",
+            "cpp_members": [
+              "native_origin"
+            ],
+            "cpp_kind": "method",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-coordinate-bridge",
+            "reason": "Native coordinate representations are engine-only; Lua uses checked coordinate values and services.",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.h",
+                "line": 50
+              }
+            ]
+          },
+          {
+            "id": "native.native_scale",
+            "cpp_members": [
+              "native_scale"
+            ],
+            "cpp_kind": "method",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-coordinate-bridge",
+            "reason": "Native coordinate representations are engine-only; Lua uses checked coordinate values and services.",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.h",
+                "line": 51
+              }
+            ]
+          },
+          {
+            "id": "native.to_native",
+            "cpp_members": [
+              "to_native"
+            ],
+            "cpp_kind": "method",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-coordinate-bridge",
+            "reason": "Native coordinate representations are engine-only; Lua uses checked coordinate values and services.",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.h",
+                "line": 32
+              }
+            ]
+          },
+          {
+            "id": "origin",
+            "cpp_members": [
+              "origin"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "PointCoord.origin"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 951
+              }
+            ]
+          },
+          {
+            "id": "project_combine",
+            "cpp_members": [
+              "project_combine"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "PointCoord.project_combine"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 960
+              }
+            ]
+          },
+          {
+            "id": "project_remain",
+            "cpp_members": [
+              "project_remain"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "PointCoord.project_remain"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 959
+              }
+            ]
+          },
+          {
+            "id": "project_to",
+            "cpp_members": [
+              "project_to"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "PointCoord.project_to"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 958
+              }
+            ]
+          },
+          {
+            "id": "scale",
+            "cpp_members": [
+              "scale"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "PointCoord.scale"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 952
+              }
+            ]
+          },
+          {
+            "id": "scale_by",
+            "cpp_members": [
+              "scale_by"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "PointCoord.scale_by"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 956
+              }
+            ]
+          },
+          {
+            "id": "square_distance",
+            "cpp_members": [
+              "square_distance"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "PointCoord.square_distance"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 962
+              }
+            ]
+          },
+          {
+            "id": "subtract",
+            "cpp_members": [
+              "subtract"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "PointCoord.subtract"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 955
+              }
+            ]
+          },
+          {
+            "id": "to",
+            "cpp_members": [
+              "project_to"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "PointCoord.to"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 957
+              }
+            ]
+          },
+          {
+            "id": "type",
+            "cpp_members": [
+              "type_name"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "PointCoord.type"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 953
+              }
+            ]
+          },
+          {
+            "id": "x",
+            "cpp_members": [
+              "x"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "PointCoord.x"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 949
+              }
+            ]
+          },
+          {
+            "id": "y",
+            "cpp_members": [
+              "y"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "PointCoord.y"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 950
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "ProfessionGroupDefinition",
+      "cpp_type": "profession_group_definition_handle",
+      "lua_name": "ProfessionGroupDefinition",
+      "registration_name": "ProfessionGroupDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7063,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ProfessionGroupDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7065
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4008
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4009
+              }
+            ]
+          },
+          {
+            "id": "profession",
+            "cpp_members": [
+              "profession"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ProfessionGroupDefinition.profession"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7066
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "ProficiencyCategoryDefinition",
+      "cpp_type": "proficiency_category_definition_handle",
+      "lua_name": "ProficiencyCategoryDefinition",
+      "registration_name": "ProficiencyCategoryDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6795,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ProficiencyCategoryDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6797
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4837
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4838
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "ProficiencyDefinition",
+      "cpp_type": "proficiency_definition_handle",
+      "lua_name": "ProficiencyDefinition",
+      "registration_name": "ProficiencyDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6798,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "bonus",
+            "cpp_members": [
+              "bonus"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ProficiencyDefinition.bonus"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6802
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ProficiencyDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6800
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4847
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4848
+              }
+            ]
+          },
+          {
+            "id": "requires",
+            "cpp_members": [
+              "requires"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ProficiencyDefinition.requires"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6801
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "RecipeCategoryDefinition",
+      "cpp_type": "crafting_category_definition_handle",
+      "lua_name": "RecipeCategoryDefinition",
+      "registration_name": "RecipeCategoryDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6791,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "RecipeCategoryDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6793
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4818
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4819
+              }
+            ]
+          },
+          {
+            "id": "subcategory",
+            "cpp_members": [
+              "subcategory"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "RecipeCategoryDefinition.subcategory"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6794
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "RecipeDefinition",
+      "cpp_type": "recipe_definition_handle",
+      "lua_name": "RecipeDefinition",
+      "registration_name": "RecipeDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6817,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "component",
+            "cpp_members": [
+              "component"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "RecipeDefinition.component"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6821
+              }
+            ]
+          },
+          {
+            "id": "component_any",
+            "cpp_members": [
+              "component_any"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "RecipeDefinition.component_any"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6822
+              }
+            ]
+          },
+          {
+            "id": "duration_moves",
+            "cpp_members": [
+              "duration"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "RecipeDefinition.duration_moves"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6820
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "RecipeDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6819
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 1700
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 1701
+              }
+            ]
+          },
+          {
+            "id": "requirement",
+            "cpp_members": [
+              "requirement"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "RecipeDefinition.requirement"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6827
+              }
+            ]
+          },
+          {
+            "id": "requires_skill",
+            "cpp_members": [
+              "requires_skill"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "RecipeDefinition.requires_skill"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6826
+              }
+            ]
+          },
+          {
+            "id": "tool",
+            "cpp_members": [
+              "tool"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "RecipeDefinition.tool"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6823
+              }
+            ]
+          },
+          {
+            "id": "tool_any",
+            "cpp_members": [
+              "tool_any"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "RecipeDefinition.tool_any"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6825
+              }
+            ]
+          },
+          {
+            "id": "tool_charges",
+            "cpp_members": [
+              "tool_charges"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "RecipeDefinition.tool_charges"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6824
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "RecipeGroupDefinition",
+      "cpp_type": "recipe_group_definition_handle",
+      "lua_name": "RecipeGroupDefinition",
+      "registration_name": "RecipeGroupDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6842,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "RecipeGroupDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6844
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2427
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2428
+              }
+            ]
+          },
+          {
+            "id": "recipe",
+            "cpp_members": [
+              "recipe"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "RecipeGroupDefinition.recipe"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6845
+              }
+            ]
+          },
+          {
+            "id": "terrain",
+            "cpp_members": [
+              "terrain"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "RecipeGroupDefinition.terrain"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6846
+              }
+            ]
+          },
+          {
+            "id": "terrain_parameter",
+            "cpp_members": [
+              "terrain_parameter"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "RecipeGroupDefinition.terrain_parameter"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6847
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "RequirementDefinition",
+      "cpp_type": "requirement_definition_handle",
+      "lua_name": "RequirementDefinition",
+      "registration_name": "RequirementDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6832,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "component",
+            "cpp_members": [
+              "component"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "RequirementDefinition.component"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6835
+              }
+            ]
+          },
+          {
+            "id": "component_any",
+            "cpp_members": [
+              "component_any"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "RequirementDefinition.component_any"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6836
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "RequirementDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6834
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 1845
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 1846
+              }
+            ]
+          },
+          {
+            "id": "quality",
+            "cpp_members": [
+              "quality"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "RequirementDefinition.quality"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6840
+              }
+            ]
+          },
+          {
+            "id": "quality_any",
+            "cpp_members": [
+              "quality_any"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "RequirementDefinition.quality_any"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6841
+              }
+            ]
+          },
+          {
+            "id": "tool",
+            "cpp_members": [
+              "tool"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "RequirementDefinition.tool"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6837
+              }
+            ]
+          },
+          {
+            "id": "tool_any",
+            "cpp_members": [
+              "tool_any"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "RequirementDefinition.tool_any"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6839
+              }
+            ]
+          },
+          {
+            "id": "tool_charges",
+            "cpp_members": [
+              "tool_charges"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "RequirementDefinition.tool_charges"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6838
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "RotatableSymbolDefinition",
+      "cpp_type": "rotatable_symbol_definition_handle",
+      "lua_name": "RotatableSymbolDefinition",
+      "registration_name": "RotatableSymbolDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7029,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "key",
+            "cpp_members": [
+              "key"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "RotatableSymbolDefinition.key"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7031
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3827
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3828
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "ScentTypeDefinition",
+      "cpp_type": "scent_type_definition_handle",
+      "lua_name": "ScentTypeDefinition",
+      "registration_name": "ScentTypeDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6848,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ScentTypeDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6850
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2490
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2491
+              }
+            ]
+          },
+          {
+            "id": "receptive_species",
+            "cpp_members": [
+              "receptive_species"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScentTypeDefinition.receptive_species"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6851
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "ScoreDefinition",
+      "cpp_type": "score_definition_handle",
+      "lua_name": "ScoreDefinition",
+      "registration_name": "ScoreDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7133,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ScoreDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7135
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4516
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4517
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "ScriptDialogueContext",
+      "cpp_type": "script_dialogue_context",
+      "lua_name": "ScriptDialogueContext",
+      "registration_name": "ScriptDialogueContext",
+      "registration": {
+        "path": "src/catalua_ui.cpp",
+        "line": 3973,
+        "installer": "api_v5.initialize_state",
+        "namespace": "global"
+      },
+      "surfaces": [
+        "api_v5"
+      ],
+      "installations": [
+        {
+          "surface": "api_v5",
+          "namespace": "global",
+          "installer_chain": [
+            "api_v5.initialize_state"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "lua-owned-value",
+        "guards": []
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "buy_quoted_item",
+            "cpp_members": [],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptDialogueContext.buy_quoted_item"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3987
+              }
+            ]
+          },
+          {
+            "id": "get",
+            "cpp_members": [
+              "get"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptDialogueContext.get"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3977
+              }
+            ]
+          },
+          {
+            "id": "quote_trade_item",
+            "cpp_members": [],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptDialogueContext.quote_trade_item"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3980
+              }
+            ]
+          },
+          {
+            "id": "remove",
+            "cpp_members": [
+              "remove"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptDialogueContext.remove"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3979
+              }
+            ]
+          },
+          {
+            "id": "set",
+            "cpp_members": [
+              "set"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptDialogueContext.set"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3978
+              }
+            ]
+          },
+          {
+            "id": "topic",
+            "cpp_members": [
+              "topic"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptDialogueContext.topic"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3976
+              }
+            ]
+          },
+          {
+            "id": "valid",
+            "cpp_members": [
+              "valid"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptDialogueContext.valid"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3975
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "ScriptMapgenContext",
+      "cpp_type": "script_mapgen_context",
+      "lua_name": "ScriptMapgenContext",
+      "registration_name": "ScriptMapgenContext",
+      "registration": {
+        "path": "src/catalua_ui.cpp",
+        "line": 3938,
+        "installer": "api_v5.initialize_state",
+        "namespace": "global"
+      },
+      "surfaces": [
+        "api_v5"
+      ],
+      "installations": [
+        {
+          "surface": "api_v5",
+          "namespace": "global",
+          "installer_chain": [
+            "api_v5.initialize_state"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "lua-owned-value",
+        "guards": []
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "above",
+            "cpp_members": [
+              "above"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.above"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3953
+              }
+            ]
+          },
+          {
+            "id": "below",
+            "cpp_members": [
+              "below"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.below"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3954
+              }
+            ]
+          },
+          {
+            "id": "east",
+            "cpp_members": [
+              "east"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.east"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3946
+              }
+            ]
+          },
+          {
+            "id": "fill_groundcover",
+            "cpp_members": [
+              "fill_groundcover"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.fill_groundcover"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3969
+              }
+            ]
+          },
+          {
+            "id": "furniture_at",
+            "cpp_members": [
+              "furniture_at"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.furniture_at"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3964
+              }
+            ]
+          },
+          {
+            "id": "generate",
+            "cpp_members": [
+              "generate"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.generate"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3971
+              }
+            ]
+          },
+          {
+            "id": "get_direction",
+            "cpp_members": [
+              "get_direction"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.get_direction"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3957
+              }
+            ]
+          },
+          {
+            "id": "get_nesw",
+            "cpp_members": [
+              "get_nesw"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.get_nesw"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3955
+              }
+            ]
+          },
+          {
+            "id": "get_rot_suffix",
+            "cpp_members": [
+              "get_rot_suffix"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.get_rot_suffix"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3960
+              }
+            ]
+          },
+          {
+            "id": "get_rotation",
+            "cpp_members": [
+              "get_rotation"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.get_rotation"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3959
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3944
+              }
+            ]
+          },
+          {
+            "id": "neast",
+            "cpp_members": [
+              "neast"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.neast"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3949
+              }
+            ]
+          },
+          {
+            "id": "nest",
+            "cpp_members": [
+              "nest"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.nest"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3970
+              }
+            ]
+          },
+          {
+            "id": "north",
+            "cpp_members": [
+              "north"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.north"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3945
+              }
+            ]
+          },
+          {
+            "id": "nwest",
+            "cpp_members": [
+              "nwest"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.nwest"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3952
+              }
+            ]
+          },
+          {
+            "id": "operations_remaining",
+            "cpp_members": [
+              "operations_remaining"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.operations_remaining"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3942
+              }
+            ]
+          },
+          {
+            "id": "operations_used",
+            "cpp_members": [
+              "operations_used"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.operations_used"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3941
+              }
+            ]
+          },
+          {
+            "id": "random_chance",
+            "cpp_members": [
+              "random_chance"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.random_chance"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3962
+              }
+            ]
+          },
+          {
+            "id": "random_int",
+            "cpp_members": [
+              "random_int"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.random_int"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3961
+              }
+            ]
+          },
+          {
+            "id": "seast",
+            "cpp_members": [
+              "seast"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.seast"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3950
+              }
+            ]
+          },
+          {
+            "id": "set_dir",
+            "cpp_members": [
+              "set_dir"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.set_dir"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3958
+              }
+            ]
+          },
+          {
+            "id": "set_furniture",
+            "cpp_members": [
+              "set_furniture"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.set_furniture"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3967
+              }
+            ]
+          },
+          {
+            "id": "set_terrain",
+            "cpp_members": [
+              "set_terrain"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.set_terrain"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3966
+              }
+            ]
+          },
+          {
+            "id": "set_trap",
+            "cpp_members": [
+              "set_trap"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.set_trap"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3968
+              }
+            ]
+          },
+          {
+            "id": "south",
+            "cpp_members": [
+              "south"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.south"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3947
+              }
+            ]
+          },
+          {
+            "id": "swest",
+            "cpp_members": [
+              "swest"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.swest"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3951
+              }
+            ]
+          },
+          {
+            "id": "terrain_at",
+            "cpp_members": [
+              "terrain_at"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.terrain_at"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3963
+              }
+            ]
+          },
+          {
+            "id": "trap_at",
+            "cpp_members": [
+              "trap_at"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.trap_at"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3965
+              }
+            ]
+          },
+          {
+            "id": "valid",
+            "cpp_members": [
+              "valid"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.valid"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3940
+              }
+            ]
+          },
+          {
+            "id": "west",
+            "cpp_members": [
+              "west"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.west"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3948
+              }
+            ]
+          },
+          {
+            "id": "zlevel",
+            "cpp_members": [
+              "zlevel"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptMapgenContext.zlevel"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3956
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "ScriptUiContext",
+      "cpp_type": "script_ui_context",
+      "lua_name": "ScriptUiContext",
+      "registration_name": "ScriptUiContext",
+      "registration": {
+        "path": "src/catalua_ui.cpp",
+        "line": 3804,
+        "installer": "api_v5.initialize_state",
+        "namespace": "global"
+      },
+      "surfaces": [
+        "api_v5"
+      ],
+      "installations": [
+        {
+          "surface": "api_v5",
+          "namespace": "global",
+          "installer_chain": [
+            "api_v5.initialize_state"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "lua-owned-value",
+        "guards": []
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "action_slot_id",
+            "cpp_members": [],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.action_slot_id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3846
+              }
+            ]
+          },
+          {
+            "id": "backend",
+            "cpp_members": [
+              "backend"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.backend"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3806
+              }
+            ]
+          },
+          {
+            "id": "bullet_text",
+            "cpp_members": [
+              "bullet_text"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.bullet_text"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3814
+              }
+            ]
+          },
+          {
+            "id": "button",
+            "cpp_members": [
+              "button"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.button"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3825
+              }
+            ]
+          },
+          {
+            "id": "button_id",
+            "cpp_members": [
+              "button_id"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.button_id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3826
+              }
+            ]
+          },
+          {
+            "id": "checkbox",
+            "cpp_members": [
+              "checkbox"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.checkbox"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3829
+              }
+            ]
+          },
+          {
+            "id": "checkbox_id",
+            "cpp_members": [
+              "checkbox_id"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.checkbox_id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3830
+              }
+            ]
+          },
+          {
+            "id": "child",
+            "cpp_members": [
+              "child"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.child"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3852
+              }
+            ]
+          },
+          {
+            "id": "disabled_text",
+            "cpp_members": [
+              "disabled_text"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.disabled_text"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3815
+              }
+            ]
+          },
+          {
+            "id": "environment",
+            "cpp_members": [
+              "environment"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.environment"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3811
+              }
+            ]
+          },
+          {
+            "id": "grid",
+            "cpp_members": [
+              "grid"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.grid"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3855
+              }
+            ]
+          },
+          {
+            "id": "heading",
+            "cpp_members": [
+              "heading"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.heading"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3813
+              }
+            ]
+          },
+          {
+            "id": "input_float",
+            "cpp_members": [
+              "input_float"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.input_float"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3841
+              }
+            ]
+          },
+          {
+            "id": "input_float_id",
+            "cpp_members": [
+              "input_float_id"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.input_float_id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3842
+              }
+            ]
+          },
+          {
+            "id": "input_int",
+            "cpp_members": [
+              "input_int"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.input_int"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3839
+              }
+            ]
+          },
+          {
+            "id": "input_int_id",
+            "cpp_members": [
+              "input_int_id"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.input_int_id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3840
+              }
+            ]
+          },
+          {
+            "id": "input_text",
+            "cpp_members": [
+              "input_text"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.input_text"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3843
+              }
+            ]
+          },
+          {
+            "id": "input_text_id",
+            "cpp_members": [
+              "input_text_id"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.input_text_id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3844
+              }
+            ]
+          },
+          {
+            "id": "is_immediate_mode",
+            "cpp_members": [
+              "is_immediate_mode"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.is_immediate_mode"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3809
+              }
+            ]
+          },
+          {
+            "id": "item_width",
+            "cpp_members": [
+              "item_width"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.item_width"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3823
+              }
+            ]
+          },
+          {
+            "id": "modal",
+            "cpp_members": [
+              "modal"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.modal"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3861
+              }
+            ]
+          },
+          {
+            "id": "new_line",
+            "cpp_members": [
+              "new_line"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.new_line"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3820
+              }
+            ]
+          },
+          {
+            "id": "platform",
+            "cpp_members": [
+              "platform"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.platform"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3807
+              }
+            ]
+          },
+          {
+            "id": "progress_bar",
+            "cpp_members": [
+              "progress_bar"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.progress_bar"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3824
+              }
+            ]
+          },
+          {
+            "id": "radial_select_id",
+            "cpp_members": [],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.radial_select_id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3845
+              }
+            ]
+          },
+          {
+            "id": "radio_button",
+            "cpp_members": [
+              "radio_button"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.radio_button"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3831
+              }
+            ]
+          },
+          {
+            "id": "radio_button_id",
+            "cpp_members": [
+              "radio_button_id"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.radio_button_id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3832
+              }
+            ]
+          },
+          {
+            "id": "same_line",
+            "cpp_members": [
+              "same_line"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.same_line"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3819
+              }
+            ]
+          },
+          {
+            "id": "scroll",
+            "cpp_members": [
+              "scroll"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.scroll"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3853
+              }
+            ]
+          },
+          {
+            "id": "selectable",
+            "cpp_members": [
+              "selectable"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.selectable"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3833
+              }
+            ]
+          },
+          {
+            "id": "selectable_id",
+            "cpp_members": [
+              "selectable_id"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.selectable_id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3834
+              }
+            ]
+          },
+          {
+            "id": "separator",
+            "cpp_members": [
+              "separator"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.separator"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3818
+              }
+            ]
+          },
+          {
+            "id": "set_next_item_width",
+            "cpp_members": [
+              "set_next_item_width"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.set_next_item_width"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3822
+              }
+            ]
+          },
+          {
+            "id": "slider_float",
+            "cpp_members": [
+              "slider_float"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.slider_float"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3837
+              }
+            ]
+          },
+          {
+            "id": "slider_float_id",
+            "cpp_members": [
+              "slider_float_id"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.slider_float_id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3838
+              }
+            ]
+          },
+          {
+            "id": "slider_int",
+            "cpp_members": [
+              "slider_int"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.slider_int"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3835
+              }
+            ]
+          },
+          {
+            "id": "slider_int_id",
+            "cpp_members": [
+              "slider_int_id"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.slider_int_id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3836
+              }
+            ]
+          },
+          {
+            "id": "small_button",
+            "cpp_members": [
+              "small_button"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.small_button"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3827
+              }
+            ]
+          },
+          {
+            "id": "small_button_id",
+            "cpp_members": [
+              "small_button_id"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.small_button_id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3828
+              }
+            ]
+          },
+          {
+            "id": "spacing",
+            "cpp_members": [
+              "spacing"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.spacing"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3821
+              }
+            ]
+          },
+          {
+            "id": "supports",
+            "cpp_members": [
+              "supports"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.supports"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3808
+              }
+            ]
+          },
+          {
+            "id": "tab",
+            "cpp_members": [
+              "tab"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.tab"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3859
+              }
+            ]
+          },
+          {
+            "id": "table",
+            "cpp_members": [
+              "table"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.table"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3854
+              }
+            ]
+          },
+          {
+            "id": "table_next_column",
+            "cpp_members": [
+              "table_next_column"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.table_next_column"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3857
+              }
+            ]
+          },
+          {
+            "id": "table_next_row",
+            "cpp_members": [
+              "table_next_row"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.table_next_row"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3856
+              }
+            ]
+          },
+          {
+            "id": "tabs",
+            "cpp_members": [
+              "tabs"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.tabs"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3858
+              }
+            ]
+          },
+          {
+            "id": "text",
+            "cpp_members": [
+              "text"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.text"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3812
+              }
+            ]
+          },
+          {
+            "id": "text_colored",
+            "cpp_members": [
+              "text_colored"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.text_colored"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3816
+              }
+            ]
+          },
+          {
+            "id": "text_tone",
+            "cpp_members": [
+              "text_tone"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.text_tone"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3817
+              }
+            ]
+          },
+          {
+            "id": "tooltip",
+            "cpp_members": [
+              "tooltip"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.tooltip"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3862
+              }
+            ]
+          },
+          {
+            "id": "tree",
+            "cpp_members": [
+              "tree"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.tree"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3860
+              }
+            ]
+          },
+          {
+            "id": "uses_native_widgets",
+            "cpp_members": [
+              "uses_native_widgets"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.uses_native_widgets"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3810
+              }
+            ]
+          },
+          {
+            "id": "virtual_list",
+            "cpp_members": [
+              "virtual_list"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.virtual_list"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3863
+              }
+            ]
+          },
+          {
+            "id": "virtual_list_rows",
+            "cpp_members": [
+              "virtual_list_rows"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiContext.virtual_list_rows"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3864
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "ScriptUiEnvironment",
+      "cpp_type": "script_ui_environment",
+      "lua_name": "ScriptUiEnvironment",
+      "registration_name": "ScriptUiEnvironment",
+      "registration": {
+        "path": "src/catalua_ui.cpp",
+        "line": 3788,
+        "installer": "api_v5.initialize_state",
+        "namespace": "global"
+      },
+      "surfaces": [
+        "api_v5"
+      ],
+      "installations": [
+        {
+          "surface": "api_v5",
+          "namespace": "global",
+          "installer_chain": [
+            "api_v5.initialize_state"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "lua-owned-value",
+        "guards": []
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "breakpoint",
+            "cpp_members": [
+              "breakpoint"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiEnvironment.breakpoint"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3793
+              }
+            ]
+          },
+          {
+            "id": "density",
+            "cpp_members": [
+              "density"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiEnvironment.density"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3792
+              }
+            ]
+          },
+          {
+            "id": "hover",
+            "cpp_members": [
+              "hover"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiEnvironment.hover"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3796
+              }
+            ]
+          },
+          {
+            "id": "input",
+            "cpp_members": [
+              "input"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiEnvironment.input"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3791
+              }
+            ]
+          },
+          {
+            "id": "keyboard_navigation",
+            "cpp_members": [
+              "keyboard_navigation"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiEnvironment.keyboard_navigation"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3799
+              }
+            ]
+          },
+          {
+            "id": "long_press_dangerous",
+            "cpp_members": [
+              "long_press_dangerous"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiEnvironment.long_press_dangerous"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3802
+              }
+            ]
+          },
+          {
+            "id": "minimum_target",
+            "cpp_members": [
+              "minimum_target"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiEnvironment.minimum_target"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3794
+              }
+            ]
+          },
+          {
+            "id": "native_text_input",
+            "cpp_members": [
+              "native_text_input"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiEnvironment.native_text_input"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3798
+              }
+            ]
+          },
+          {
+            "id": "pointer_activation",
+            "cpp_members": [
+              "pointer_activation"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiEnvironment.pointer_activation"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3800
+              }
+            ]
+          },
+          {
+            "id": "profile",
+            "cpp_members": [
+              "profile"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiEnvironment.profile"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3790
+              }
+            ]
+          },
+          {
+            "id": "swipe_scroll",
+            "cpp_members": [
+              "swipe_scroll"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiEnvironment.swipe_scroll"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3797
+              }
+            ]
+          },
+          {
+            "id": "tap_activation",
+            "cpp_members": [
+              "tap_activation"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiEnvironment.tap_activation"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3801
+              }
+            ]
+          },
+          {
+            "id": "touch",
+            "cpp_members": [
+              "touch"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ScriptUiEnvironment.touch"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui.cpp",
+                "line": 3795
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "SkillDefinition",
+      "cpp_type": "skill_definition_handle",
+      "lua_name": "SkillDefinition",
+      "registration_name": "SkillDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6744,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "attack_time",
+            "cpp_members": [
+              "attack_time"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "SkillDefinition.attack_time"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6752
+              }
+            ]
+          },
+          {
+            "id": "companion_practice",
+            "cpp_members": [
+              "companion_practice"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "SkillDefinition.companion_practice"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6748
+              }
+            ]
+          },
+          {
+            "id": "companion_rank_factors",
+            "cpp_members": [
+              "companion_rank_factors"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "SkillDefinition.companion_rank_factors"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6753
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "SkillDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6746
+              }
+            ]
+          },
+          {
+            "id": "level_description",
+            "cpp_members": [
+              "level_description"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "SkillDefinition.level_description"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6749
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2000
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2001
+              }
+            ]
+          },
+          {
+            "id": "requires_all_trait",
+            "cpp_members": [
+              "requires_all_trait"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "SkillDefinition.requires_all_trait"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6750
+              }
+            ]
+          },
+          {
+            "id": "requires_any_trait",
+            "cpp_members": [
+              "requires_any_trait"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "SkillDefinition.requires_any_trait"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6751
+              }
+            ]
+          },
+          {
+            "id": "tag",
+            "cpp_members": [
+              "tag"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "SkillDefinition.tag"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6747
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "SkillDisplayDefinition",
+      "cpp_type": "skill_display_definition_handle",
+      "lua_name": "SkillDisplayDefinition",
+      "registration_name": "SkillDisplayDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6741,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "SkillDisplayDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6743
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 1990
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 1991
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "SnippetCategoryDefinition",
+      "cpp_type": "snippet_category_definition_handle",
+      "lua_name": "SnippetCategoryDefinition",
+      "registration_name": "SnippetCategoryDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7162,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "entry",
+            "cpp_members": [
+              "entry"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "SnippetCategoryDefinition.entry"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7166
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "SnippetCategoryDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7164
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4662
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4663
+              }
+            ]
+          },
+          {
+            "id": "text",
+            "cpp_members": [
+              "text"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "SnippetCategoryDefinition.text"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7165
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "SpeciesDefinition",
+      "cpp_type": "species_definition_handle",
+      "lua_name": "SpeciesDefinition",
+      "registration_name": "SpeciesDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6982,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "anger",
+            "cpp_members": [
+              "anger"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "SpeciesDefinition.anger"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6986
+              }
+            ]
+          },
+          {
+            "id": "fear",
+            "cpp_members": [
+              "fear"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "SpeciesDefinition.fear"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6987
+              }
+            ]
+          },
+          {
+            "id": "flag",
+            "cpp_members": [
+              "flag"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "SpeciesDefinition.flag"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6985
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "SpeciesDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6984
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3604
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3605
+              }
+            ]
+          },
+          {
+            "id": "placate",
+            "cpp_members": [
+              "placate"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "SpeciesDefinition.placate"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6988
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "SpeechPoolDefinition",
+      "cpp_type": "speech_pool_definition_handle",
+      "lua_name": "SpeechPoolDefinition",
+      "registration_name": "SpeechPoolDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7143,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "SpeechPoolDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7145
+              }
+            ]
+          },
+          {
+            "id": "line",
+            "cpp_members": [
+              "line"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "SpeechPoolDefinition.line"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7146
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4555
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4556
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "SpeedDescriptionDefinition",
+      "cpp_type": "speed_description_definition_handle",
+      "lua_name": "SpeedDescriptionDefinition",
+      "registration_name": "SpeedDescriptionDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6852,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "SpeedDescriptionDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6854
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2509
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2510
+              }
+            ]
+          },
+          {
+            "id": "value",
+            "cpp_members": [
+              "value"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "SpeedDescriptionDefinition.value"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6855
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "StartLocationDefinition",
+      "cpp_type": "start_location_definition_handle",
+      "lua_name": "StartLocationDefinition",
+      "registration_name": "StartLocationDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7110,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "city_distance",
+            "cpp_members": [
+              "city_distance"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "StartLocationDefinition.city_distance"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7116
+              }
+            ]
+          },
+          {
+            "id": "city_size",
+            "cpp_members": [
+              "city_size"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "StartLocationDefinition.city_size"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7115
+              }
+            ]
+          },
+          {
+            "id": "flag",
+            "cpp_members": [
+              "flag"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "StartLocationDefinition.flag"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7114
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "StartLocationDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7112
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4332
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4333
+              }
+            ]
+          },
+          {
+            "id": "terrain",
+            "cpp_members": [
+              "terrain"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "StartLocationDefinition.terrain"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7113
+              }
+            ]
+          },
+          {
+            "id": "z_levels",
+            "cpp_members": [
+              "z_levels"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "StartLocationDefinition.z_levels"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7117
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "SubBodyPartDefinition",
+      "cpp_type": "sub_body_part_definition_handle",
+      "lua_name": "SubBodyPartDefinition",
+      "registration_name": "SubBodyPartDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6912,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "SubBodyPartDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6914
+              }
+            ]
+          },
+          {
+            "id": "location_under",
+            "cpp_members": [
+              "location_under"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "SubBodyPartDefinition.location_under"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6915
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2905
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2906
+              }
+            ]
+          },
+          {
+            "id": "unarmed_damage",
+            "cpp_members": [
+              "unarmed_damage"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "SubBodyPartDefinition.unarmed_damage"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6916
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "TimeDuration",
+      "cpp_type": "script_time_duration",
+      "lua_name": "TimeDuration",
+      "registration_name": "TimeDuration",
+      "registration": {
+        "path": "src/catalua_bindings_values.cpp",
+        "line": 1155,
+        "installer": "shared.install_value_type_api",
+        "namespace": "global"
+      },
+      "surfaces": [
+        "api_v5",
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "api_v5",
+          "namespace": "global",
+          "installer_chain": [
+            "api_v5.initialize_state",
+            "shared.install_value_type_api"
+          ]
+        },
+        {
+          "surface": "platform_v1",
+          "namespace": "global",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "shared.install_value_type_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "lua-owned-value",
+        "guards": []
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "__add",
+            "cpp_members": [
+              "add"
+            ],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "TimeDuration.__add"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1176
+              }
+            ]
+          },
+          {
+            "id": "__div",
+            "cpp_members": [
+              "divide"
+            ],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "TimeDuration.__div"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1179
+              }
+            ]
+          },
+          {
+            "id": "__eq",
+            "cpp_members": [],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "TimeDuration.__eq"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1164
+              }
+            ]
+          },
+          {
+            "id": "__le",
+            "cpp_members": [],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "TimeDuration.__le"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1172
+              }
+            ]
+          },
+          {
+            "id": "__lt",
+            "cpp_members": [],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "TimeDuration.__lt"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1168
+              }
+            ]
+          },
+          {
+            "id": "__mul",
+            "cpp_members": [
+              "scale"
+            ],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "TimeDuration.__mul"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1178
+              }
+            ]
+          },
+          {
+            "id": "__sub",
+            "cpp_members": [
+              "subtract"
+            ],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "TimeDuration.__sub"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1177
+              }
+            ]
+          },
+          {
+            "id": "__tostring",
+            "cpp_members": [
+              "to_string"
+            ],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "TimeDuration.__tostring"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1163
+              }
+            ]
+          },
+          {
+            "id": "__unm",
+            "cpp_members": [
+              "negate"
+            ],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "TimeDuration.__unm"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1180
+              }
+            ]
+          },
+          {
+            "id": "compare",
+            "cpp_members": [
+              "compare"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TimeDuration.compare"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1160
+              }
+            ]
+          },
+          {
+            "id": "display",
+            "cpp_members": [
+              "display"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TimeDuration.display"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1159
+              }
+            ]
+          },
+          {
+            "id": "divide",
+            "cpp_members": [
+              "divide"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TimeDuration.divide"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1162
+              }
+            ]
+          },
+          {
+            "id": "scale",
+            "cpp_members": [
+              "scale"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TimeDuration.scale"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1161
+              }
+            ]
+          },
+          {
+            "id": "turns",
+            "cpp_members": [
+              "turns"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "TimeDuration.turns"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1157
+              }
+            ]
+          },
+          {
+            "id": "value",
+            "cpp_members": [
+              "value_as"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TimeDuration.value"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1158
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "TimePoint",
+      "cpp_type": "script_time_point",
+      "lua_name": "TimePoint",
+      "registration_name": "TimePoint",
+      "registration": {
+        "path": "src/catalua_bindings_values.cpp",
+        "line": 1182,
+        "installer": "shared.install_value_type_api",
+        "namespace": "global"
+      },
+      "surfaces": [
+        "api_v5",
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "api_v5",
+          "namespace": "global",
+          "installer_chain": [
+            "api_v5.initialize_state",
+            "shared.install_value_type_api"
+          ]
+        },
+        {
+          "surface": "platform_v1",
+          "namespace": "global",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "shared.install_value_type_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "lua-owned-value",
+        "guards": []
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "__add",
+            "cpp_members": [
+              "add"
+            ],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "TimePoint.__add"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1211
+              }
+            ]
+          },
+          {
+            "id": "__eq",
+            "cpp_members": [],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "TimePoint.__eq"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1199
+              }
+            ]
+          },
+          {
+            "id": "__le",
+            "cpp_members": [],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "TimePoint.__le"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1207
+              }
+            ]
+          },
+          {
+            "id": "__lt",
+            "cpp_members": [],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "TimePoint.__lt"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1203
+              }
+            ]
+          },
+          {
+            "id": "__sub",
+            "cpp_members": [],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "TimePoint.__sub"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1212
+              }
+            ]
+          },
+          {
+            "id": "__tostring",
+            "cpp_members": [
+              "to_string"
+            ],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "TimePoint.__tostring"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1198
+              }
+            ]
+          },
+          {
+            "id": "compare",
+            "cpp_members": [
+              "compare"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TimePoint.compare"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1197
+              }
+            ]
+          },
+          {
+            "id": "display",
+            "cpp_members": [
+              "display"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TimePoint.display"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1196
+              }
+            ]
+          },
+          {
+            "id": "hour_of_day",
+            "cpp_members": [
+              "hour_of_day"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TimePoint.hour_of_day"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1187
+              }
+            ]
+          },
+          {
+            "id": "is_dawn",
+            "cpp_members": [
+              "is_dawn"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TimePoint.is_dawn"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1190
+              }
+            ]
+          },
+          {
+            "id": "is_day",
+            "cpp_members": [
+              "is_day"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TimePoint.is_day"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1188
+              }
+            ]
+          },
+          {
+            "id": "is_dusk",
+            "cpp_members": [
+              "is_dusk"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TimePoint.is_dusk"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1191
+              }
+            ]
+          },
+          {
+            "id": "is_night",
+            "cpp_members": [
+              "is_night"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TimePoint.is_night"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1189
+              }
+            ]
+          },
+          {
+            "id": "minute_of_hour",
+            "cpp_members": [
+              "minute_of_hour"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TimePoint.minute_of_hour"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1186
+              }
+            ]
+          },
+          {
+            "id": "moon_phase",
+            "cpp_members": [
+              "moon_phase"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TimePoint.moon_phase"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1194
+              }
+            ]
+          },
+          {
+            "id": "season",
+            "cpp_members": [
+              "season"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TimePoint.season"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1195
+              }
+            ]
+          },
+          {
+            "id": "second_of_minute",
+            "cpp_members": [
+              "second_of_minute"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TimePoint.second_of_minute"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1185
+              }
+            ]
+          },
+          {
+            "id": "sunrise",
+            "cpp_members": [
+              "sunrise"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TimePoint.sunrise"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1192
+              }
+            ]
+          },
+          {
+            "id": "sunset",
+            "cpp_members": [
+              "sunset"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TimePoint.sunset"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1193
+              }
+            ]
+          },
+          {
+            "id": "turn",
+            "cpp_members": [
+              "turn"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "TimePoint.turn"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1184
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "ToolQualityDefinition",
+      "cpp_type": "tool_quality_definition_handle",
+      "lua_name": "ToolQualityDefinition",
+      "registration_name": "ToolQualityDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6737,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ToolQualityDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6739
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 1970
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 1971
+              }
+            ]
+          },
+          {
+            "id": "usage",
+            "cpp_members": [
+              "usage"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ToolQualityDefinition.usage"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6740
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "TripointCoord",
+      "cpp_type": "script_tripoint_coord",
+      "lua_name": "TripointCoord",
+      "registration_name": "TripointCoord",
+      "registration": {
+        "path": "src/catalua_bindings_coords.cpp",
+        "line": 983,
+        "installer": "shared.install_coordinate_value_api",
+        "namespace": "global"
+      },
+      "surfaces": [
+        "api_v5",
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "api_v5",
+          "namespace": "global",
+          "installer_chain": [
+            "api_v5.initialize_state",
+            "shared.install_value_type_api",
+            "shared.install_coordinate_value_api"
+          ]
+        },
+        {
+          "surface": "platform_v1",
+          "namespace": "global",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "shared.install_value_type_api",
+            "shared.install_coordinate_value_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "lua-owned-value",
+        "guards": []
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "__add",
+            "cpp_members": [
+              "add",
+              "add_xy"
+            ],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "TripointCoord.__add"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 1020
+              }
+            ]
+          },
+          {
+            "id": "__eq",
+            "cpp_members": [],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "TripointCoord.__eq"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 1008
+              }
+            ]
+          },
+          {
+            "id": "__le",
+            "cpp_members": [],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "TripointCoord.__le"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 1016
+              }
+            ]
+          },
+          {
+            "id": "__lt",
+            "cpp_members": [],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "TripointCoord.__lt"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 1012
+              }
+            ]
+          },
+          {
+            "id": "__mul",
+            "cpp_members": [
+              "scale_by"
+            ],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "TripointCoord.__mul"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 1028
+              }
+            ]
+          },
+          {
+            "id": "__sub",
+            "cpp_members": [
+              "subtract",
+              "subtract_xy"
+            ],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "TripointCoord.__sub"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 1024
+              }
+            ]
+          },
+          {
+            "id": "__tostring",
+            "cpp_members": [
+              "to_string"
+            ],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "TripointCoord.__tostring"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 1007
+              }
+            ]
+          },
+          {
+            "id": "__unm",
+            "cpp_members": [
+              "negate"
+            ],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "TripointCoord.__unm"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 1029
+              }
+            ]
+          },
+          {
+            "id": "add",
+            "cpp_members": [
+              "add",
+              "add_xy"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TripointCoord.add"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 992
+              }
+            ]
+          },
+          {
+            "id": "compare",
+            "cpp_members": [
+              "compare"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TripointCoord.compare"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 1006
+              }
+            ]
+          },
+          {
+            "id": "euclidean_distance",
+            "cpp_members": [
+              "euclidean_distance"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TripointCoord.euclidean_distance"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 1005
+              }
+            ]
+          },
+          {
+            "id": "manhattan_distance",
+            "cpp_members": [
+              "manhattan_distance"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TripointCoord.manhattan_distance"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 1003
+              }
+            ]
+          },
+          {
+            "id": "native.line_to",
+            "cpp_members": [
+              "line_to"
+            ],
+            "cpp_kind": "method",
+            "lua_access": [
+              "game.coords.line",
+              "ccb.services.coords.line"
+            ],
+            "disposition": "adapted",
+            "reason_code": "bounded-service-adapter",
+            "reason": "Lua reaches line generation through the bounded coordinate service so maximum output is enforced.",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.h",
+                "line": 97
+              }
+            ]
+          },
+          {
+            "id": "native.native_origin",
+            "cpp_members": [
+              "native_origin"
+            ],
+            "cpp_kind": "method",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-coordinate-bridge",
+            "reason": "Native coordinate representations are engine-only; Lua uses checked coordinate values and services.",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.h",
+                "line": 105
+              }
+            ]
+          },
+          {
+            "id": "native.native_scale",
+            "cpp_members": [
+              "native_scale"
+            ],
+            "cpp_kind": "method",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-coordinate-bridge",
+            "reason": "Native coordinate representations are engine-only; Lua uses checked coordinate values and services.",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.h",
+                "line": 106
+              }
+            ]
+          },
+          {
+            "id": "native.to_native",
+            "cpp_members": [
+              "to_native"
+            ],
+            "cpp_kind": "method",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-coordinate-bridge",
+            "reason": "Native coordinate representations are engine-only; Lua uses checked coordinate values and services.",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.h",
+                "line": 84
+              }
+            ]
+          },
+          {
+            "id": "origin",
+            "cpp_members": [
+              "origin"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "TripointCoord.origin"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 988
+              }
+            ]
+          },
+          {
+            "id": "project_combine",
+            "cpp_members": [
+              "project_combine"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TripointCoord.project_combine"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 1002
+              }
+            ]
+          },
+          {
+            "id": "project_remain",
+            "cpp_members": [
+              "project_remain"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TripointCoord.project_remain"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 1001
+              }
+            ]
+          },
+          {
+            "id": "project_to",
+            "cpp_members": [
+              "project_to"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TripointCoord.project_to"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 1000
+              }
+            ]
+          },
+          {
+            "id": "scale",
+            "cpp_members": [
+              "scale"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "TripointCoord.scale"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 989
+              }
+            ]
+          },
+          {
+            "id": "scale_by",
+            "cpp_members": [
+              "scale_by"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TripointCoord.scale_by"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 998
+              }
+            ]
+          },
+          {
+            "id": "square_distance",
+            "cpp_members": [
+              "square_distance"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TripointCoord.square_distance"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 1004
+              }
+            ]
+          },
+          {
+            "id": "subtract",
+            "cpp_members": [
+              "subtract",
+              "subtract_xy"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TripointCoord.subtract"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 995
+              }
+            ]
+          },
+          {
+            "id": "to",
+            "cpp_members": [
+              "project_to"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TripointCoord.to"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 999
+              }
+            ]
+          },
+          {
+            "id": "type",
+            "cpp_members": [
+              "type_name"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "TripointCoord.type"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 990
+              }
+            ]
+          },
+          {
+            "id": "x",
+            "cpp_members": [
+              "x"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "TripointCoord.x"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 985
+              }
+            ]
+          },
+          {
+            "id": "xy",
+            "cpp_members": [
+              "xy"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "TripointCoord.xy"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 991
+              }
+            ]
+          },
+          {
+            "id": "y",
+            "cpp_members": [
+              "y"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "TripointCoord.y"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 986
+              }
+            ]
+          },
+          {
+            "id": "z",
+            "cpp_members": [
+              "z"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "TripointCoord.z"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_coords.cpp",
+                "line": 987
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "UnitValue",
+      "cpp_type": "script_unit_value",
+      "lua_name": "UnitValue",
+      "registration_name": "UnitValue",
+      "registration": {
+        "path": "src/catalua_bindings_values.cpp",
+        "line": 1066,
+        "installer": "shared.install_value_type_api",
+        "namespace": "global"
+      },
+      "surfaces": [
+        "api_v5",
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "api_v5",
+          "namespace": "global",
+          "installer_chain": [
+            "api_v5.initialize_state",
+            "shared.install_value_type_api"
+          ]
+        },
+        {
+          "surface": "platform_v1",
+          "namespace": "global",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "shared.install_value_type_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "lua-owned-value",
+        "guards": []
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "__add",
+            "cpp_members": [
+              "add"
+            ],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "UnitValue.__add"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1081
+              }
+            ]
+          },
+          {
+            "id": "__eq",
+            "cpp_members": [],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "UnitValue.__eq"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1077
+              }
+            ]
+          },
+          {
+            "id": "__le",
+            "cpp_members": [],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "UnitValue.__le"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1087
+              }
+            ]
+          },
+          {
+            "id": "__lt",
+            "cpp_members": [],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "UnitValue.__lt"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1083
+              }
+            ]
+          },
+          {
+            "id": "__sub",
+            "cpp_members": [
+              "subtract"
+            ],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "UnitValue.__sub"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1082
+              }
+            ]
+          },
+          {
+            "id": "__tostring",
+            "cpp_members": [
+              "to_string"
+            ],
+            "cpp_kind": "operator",
+            "lua_access": [
+              "UnitValue.__tostring"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1076
+              }
+            ]
+          },
+          {
+            "id": "add",
+            "cpp_members": [
+              "add"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "UnitValue.add"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1072
+              }
+            ]
+          },
+          {
+            "id": "canonical_unit",
+            "cpp_members": [
+              "canonical_unit"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "UnitValue.canonical_unit"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1069
+              }
+            ]
+          },
+          {
+            "id": "compare",
+            "cpp_members": [
+              "compare"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "UnitValue.compare"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1075
+              }
+            ]
+          },
+          {
+            "id": "is_integral",
+            "cpp_members": [
+              "is_integral"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "UnitValue.is_integral"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1070
+              }
+            ]
+          },
+          {
+            "id": "kind",
+            "cpp_members": [
+              "kind"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "UnitValue.kind"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1068
+              }
+            ]
+          },
+          {
+            "id": "native.canonical_integer",
+            "cpp_members": [
+              "canonical_integer"
+            ],
+            "cpp_kind": "method",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "internal-canonical-storage",
+            "reason": "Canonical storage access stays native; Lua uses the unit-aware value conversion method.",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.h",
+                "line": 60
+              }
+            ]
+          },
+          {
+            "id": "native.canonical_number",
+            "cpp_members": [
+              "canonical_number"
+            ],
+            "cpp_kind": "method",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "internal-canonical-storage",
+            "reason": "Canonical storage access stays native; Lua uses the unit-aware value conversion method.",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.h",
+                "line": 61
+              }
+            ]
+          },
+          {
+            "id": "native.canonical_wide",
+            "cpp_members": [
+              "canonical_wide"
+            ],
+            "cpp_kind": "method",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "internal-canonical-storage",
+            "reason": "Canonical storage access stays native; Lua uses the unit-aware value conversion method.",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.h",
+                "line": 62
+              }
+            ]
+          },
+          {
+            "id": "scale",
+            "cpp_members": [
+              "scale"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "UnitValue.scale"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1074
+              }
+            ]
+          },
+          {
+            "id": "subtract",
+            "cpp_members": [
+              "subtract"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "UnitValue.subtract"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1073
+              }
+            ]
+          },
+          {
+            "id": "value",
+            "cpp_members": [
+              "value_as"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "UnitValue.value"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_bindings_values.cpp",
+                "line": 1071
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "VehicleGroupDefinition",
+      "cpp_type": "vehicle_group_definition_handle",
+      "lua_name": "VehicleGroupDefinition",
+      "registration_name": "VehicleGroupDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7071,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "VehicleGroupDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7073
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4047
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4048
+              }
+            ]
+          },
+          {
+            "id": "vehicle",
+            "cpp_members": [
+              "vehicle"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "VehicleGroupDefinition.vehicle"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7074
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "VehiclePartCategoryDefinition",
+      "cpp_type": "vehicle_part_category_definition_handle",
+      "lua_name": "VehiclePartCategoryDefinition",
+      "registration_name": "VehiclePartCategoryDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7023,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "VehiclePartCategoryDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7025
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3807
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3808
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "VehiclePartLocationDefinition",
+      "cpp_type": "vehicle_part_location_definition_handle",
+      "lua_name": "VehiclePartLocationDefinition",
+      "registration_name": "VehiclePartLocationDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7012,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "VehiclePartLocationDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7014
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3743
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3744
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "VitaminDefinition",
+      "cpp_type": "vitamin_definition_handle",
+      "lua_name": "VitaminDefinition",
+      "registration_name": "VitaminDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6754,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "decays_into",
+            "cpp_members": [
+              "decays_into"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "VitaminDefinition.decays_into"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6760
+              }
+            ]
+          },
+          {
+            "id": "deficiency_range",
+            "cpp_members": [
+              "deficiency_range"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "VitaminDefinition.deficiency_range"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6758
+              }
+            ]
+          },
+          {
+            "id": "excess_range",
+            "cpp_members": [
+              "excess_range"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "VitaminDefinition.excess_range"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6759
+              }
+            ]
+          },
+          {
+            "id": "flag",
+            "cpp_members": [
+              "flag"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "VitaminDefinition.flag"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6761
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "VitaminDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6756
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2090
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2091
+              }
+            ]
+          },
+          {
+            "id": "weight_micrograms",
+            "cpp_members": [
+              "weight_micrograms"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "VitaminDefinition.weight_micrograms"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6757
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "WeakpointSetDefinition",
+      "cpp_type": "weakpoint_set_definition_handle",
+      "lua_name": "WeakpointSetDefinition",
+      "registration_name": "WeakpointSetDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6891,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "armor_multiplier",
+            "cpp_members": [
+              "armor_multiplier"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "WeakpointSetDefinition.armor_multiplier"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6895
+              }
+            ]
+          },
+          {
+            "id": "armor_penalty",
+            "cpp_members": [
+              "armor_penalty"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "WeakpointSetDefinition.armor_penalty"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6896
+              }
+            ]
+          },
+          {
+            "id": "critical_multiplier",
+            "cpp_members": [
+              "critical_multiplier"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "WeakpointSetDefinition.critical_multiplier"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6898
+              }
+            ]
+          },
+          {
+            "id": "damage_multiplier",
+            "cpp_members": [
+              "damage_multiplier"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "WeakpointSetDefinition.damage_multiplier"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6897
+              }
+            ]
+          },
+          {
+            "id": "effect",
+            "cpp_members": [
+              "effect"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "WeakpointSetDefinition.effect"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6899
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "WeakpointSetDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6893
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2791
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 2792
+              }
+            ]
+          },
+          {
+            "id": "weakpoint",
+            "cpp_members": [
+              "weakpoint"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "WeakpointSetDefinition.weakpoint"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6894
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "WeaponCategoryDefinition",
+      "cpp_type": "weapon_category_definition_handle",
+      "lua_name": "WeaponCategoryDefinition",
+      "registration_name": "WeaponCategoryDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6803,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "WeaponCategoryDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6805
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4876
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4877
+              }
+            ]
+          },
+          {
+            "id": "proficiency",
+            "cpp_members": [
+              "proficiency"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "WeaponCategoryDefinition.proficiency"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6806
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "WeatherTypeDefinition",
+      "cpp_type": "weather_type_definition_handle",
+      "lua_name": "WeatherTypeDefinition",
+      "registration_name": "WeatherTypeDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7125,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "animation",
+            "cpp_members": [
+              "animation"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "WeatherTypeDefinition.animation"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7129
+              }
+            ]
+          },
+          {
+            "id": "condition",
+            "cpp_members": [
+              "condition"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "WeatherTypeDefinition.condition"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7132
+              }
+            ]
+          },
+          {
+            "id": "duration",
+            "cpp_members": [
+              "duration"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "WeatherTypeDefinition.duration"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7128
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "WeatherTypeDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7127
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4452
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4453
+              }
+            ]
+          },
+          {
+            "id": "passive_effect",
+            "cpp_members": [
+              "passive_effect"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "WeatherTypeDefinition.passive_effect"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7131
+              }
+            ]
+          },
+          {
+            "id": "requires",
+            "cpp_members": [
+              "requires"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "WeatherTypeDefinition.requires"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7130
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "WoundDefinition",
+      "cpp_type": "wound_type_definition_handle",
+      "lua_name": "WoundDefinition",
+      "registration_name": "WoundDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6917,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "damage_type",
+            "cpp_members": [
+              "damage_type"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "WoundDefinition.damage_type"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6920
+              }
+            ]
+          },
+          {
+            "id": "forbid_body_part_type",
+            "cpp_members": [
+              "forbid_body_part_type"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "WoundDefinition.forbid_body_part_type"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6924
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "WoundDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6919
+              }
+            ]
+          },
+          {
+            "id": "limb_score",
+            "cpp_members": [
+              "limb_score"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "WoundDefinition.limb_score"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6921
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3018
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3019
+              }
+            ]
+          },
+          {
+            "id": "progression",
+            "cpp_members": [
+              "progression"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "WoundDefinition.progression"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6922
+              }
+            ]
+          },
+          {
+            "id": "require_body_part_type",
+            "cpp_members": [
+              "require_body_part_type"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "WoundDefinition.require_body_part_type"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6923
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "WoundFixDefinition",
+      "cpp_type": "wound_fix_definition_handle",
+      "lua_name": "WoundFixDefinition",
+      "registration_name": "WoundFixDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 6935,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "adds",
+            "cpp_members": [
+              "adds"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "WoundFixDefinition.adds"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6941
+              }
+            ]
+          },
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "WoundFixDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6937
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3112
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 3113
+              }
+            ]
+          },
+          {
+            "id": "proficiency",
+            "cpp_members": [
+              "proficiency"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "WoundFixDefinition.proficiency"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6939
+              }
+            ]
+          },
+          {
+            "id": "removes",
+            "cpp_members": [
+              "removes"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "WoundFixDefinition.removes"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6940
+              }
+            ]
+          },
+          {
+            "id": "requires",
+            "cpp_members": [
+              "requires"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "WoundFixDefinition.requires"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6942
+              }
+            ]
+          },
+          {
+            "id": "skill",
+            "cpp_members": [
+              "skill"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "WoundFixDefinition.skill"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 6938
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "ZoneToken",
+      "cpp_type": "script_zone_token",
+      "lua_name": "ZoneToken",
+      "registration_name": "ZoneToken",
+      "registration": {
+        "path": "src/catalua_ui_zones.cpp",
+        "line": 1467,
+        "installer": "shared.install_zone_api",
+        "namespace": "global"
+      },
+      "surfaces": [
+        "api_v5",
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "api_v5",
+          "namespace": "global",
+          "installer_chain": [
+            "api_v5.initialize_state",
+            "shared.install_zone_api"
+          ]
+        },
+        {
+          "surface": "platform_v1",
+          "namespace": "global",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "shared.install_zone_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "generation-and-identity-checked-token",
+        "guards": [
+          "runtime-owner-identity",
+          "runtime-generation",
+          "world-generation",
+          "native-lifetime-identity",
+          "active-runtime-match"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "end",
+            "cpp_members": [
+              "end"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ZoneToken.end"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_zones.cpp",
+                "line": 1491
+              }
+            ]
+          },
+          {
+            "id": "faction",
+            "cpp_members": [
+              "faction"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ZoneToken.faction"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_zones.cpp",
+                "line": 1469
+              }
+            ]
+          },
+          {
+            "id": "is_valid",
+            "cpp_members": [],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ZoneToken.is_valid"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_zones.cpp",
+                "line": 1502
+              }
+            ]
+          },
+          {
+            "id": "name",
+            "cpp_members": [
+              "name"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ZoneToken.name"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_zones.cpp",
+                "line": 1480
+              }
+            ]
+          },
+          {
+            "id": "native.lifetime_identity",
+            "cpp_members": [
+              "lifetime_identity"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "identity-or-lifetime-internal",
+            "reason": "Zone identity and lifetime internals are validated by native token resolution rather than exposed to Lua.",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_zones.cpp",
+                "line": 51
+              }
+            ]
+          },
+          {
+            "id": "native.personal_end",
+            "cpp_members": [
+              "personal_end"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "identity-or-lifetime-internal",
+            "reason": "Zone identity and lifetime internals are validated by native token resolution rather than exposed to Lua.",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_zones.cpp",
+                "line": 49
+              }
+            ]
+          },
+          {
+            "id": "native.personal_start",
+            "cpp_members": [
+              "personal_start"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "identity-or-lifetime-internal",
+            "reason": "Zone identity and lifetime internals are validated by native token resolution rather than exposed to Lua.",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_zones.cpp",
+                "line": 48
+              }
+            ]
+          },
+          {
+            "id": "native.runtime",
+            "cpp_members": [
+              "runtime"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "identity-or-lifetime-internal",
+            "reason": "Zone identity and lifetime internals are validated by native token resolution rather than exposed to Lua.",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_zones.cpp",
+                "line": 41
+              }
+            ]
+          },
+          {
+            "id": "native.world_generation",
+            "cpp_members": [
+              "world_generation"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "identity-or-lifetime-internal",
+            "reason": "Zone identity and lifetime internals are validated by native token resolution rather than exposed to Lua.",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_zones.cpp",
+                "line": 42
+              }
+            ]
+          },
+          {
+            "id": "personal",
+            "cpp_members": [
+              "personal"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ZoneToken.personal"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_zones.cpp",
+                "line": 1498
+              }
+            ]
+          },
+          {
+            "id": "start",
+            "cpp_members": [
+              "start"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ZoneToken.start"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_zones.cpp",
+                "line": 1484
+              }
+            ]
+          },
+          {
+            "id": "status",
+            "cpp_members": [
+              "faction",
+              "name",
+              "type"
+            ],
+            "cpp_kind": "member",
+            "lua_access": [
+              "ZoneToken.status"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_zones.cpp",
+                "line": 1512
+              }
+            ]
+          },
+          {
+            "id": "type",
+            "cpp_members": [
+              "type"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ZoneToken.type"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_ui_zones.cpp",
+                "line": 1475
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "ZoneTypeDefinition",
+      "cpp_type": "zone_type_definition_handle",
+      "lua_name": "ZoneTypeDefinition",
+      "registration_name": "ZoneTypeDefinition",
+      "registration": {
+        "path": "src/catalua_platform_runtime.cpp",
+        "line": 7140,
+        "installer": "platform_v1.content_transaction.install_lua_api",
+        "namespace": "ccb"
+      },
+      "surfaces": [
+        "platform_v1"
+      ],
+      "installations": [
+        {
+          "surface": "platform_v1",
+          "namespace": "ccb",
+          "installer_chain": [
+            "platform_v1.initialize_state",
+            "platform_v1.install_runtime_api",
+            "platform_v1.content_transaction.install_lua_api"
+          ]
+        }
+      ],
+      "lifetime": {
+        "policy": "transaction-owned",
+        "guards": [
+          "owner-token",
+          "transaction-phase"
+        ]
+      },
+      "member_disposition": {
+        "scope": "registered Lua members plus explicitly reviewed native adaptations and exclusions",
+        "members": [
+          {
+            "id": "id",
+            "cpp_members": [
+              "id"
+            ],
+            "cpp_kind": "property",
+            "lua_access": [
+              "ZoneTypeDefinition.id"
+            ],
+            "disposition": "bound",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 7142
+              }
+            ]
+          },
+          {
+            "id": "native.definition",
+            "cpp_members": [
+              "definition"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-definition-storage",
+            "reason": "The transaction-owned definition payload is only reachable through audited builder methods.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4545
+              }
+            ]
+          },
+          {
+            "id": "native.token",
+            "cpp_members": [
+              "token"
+            ],
+            "cpp_kind": "field",
+            "lua_access": [],
+            "disposition": "unbound",
+            "reason_code": "native-owner-state",
+            "reason": "The owner token enforces transaction lifetime and is never public Lua state.",
+            "evidence": [
+              {
+                "path": "src/catalua_platform_runtime.cpp",
+                "line": 4546
+              }
+            ]
+          }
+        ]
+      }
+    }
   ]
 }

--- a/data/lua/reference/ccb_public_api_v5.json
+++ b/data/lua/reference/ccb_public_api_v5.json
@@ -19,7 +19,7 @@
     "event_specs": "src/event.h"
   },
   "parity": {
-    "native_inventory_sha256": "b43d80f924937f9f9f3e4982c15e1f3e9f87758172c6c2f5eb33fc6b34796e71",
+    "native_inventory_sha256": "f080442ccad201aa1f8ed230be7f83ce6d8b495a7fffd7e04ec5f76ffc27a1b4",
     "native_inventory_counts": {
       "id_kinds": 132,
       "json_types": 190,
@@ -37,7 +37,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3708,
+          "line": 3716,
           "authority": "native registration"
         }
       ],
@@ -53,7 +53,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3718,
+          "line": 3726,
           "authority": "native registration"
         },
         {
@@ -74,7 +74,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3727,
+          "line": 3735,
           "authority": "native registration"
         },
         {
@@ -97,7 +97,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3875,
+          "line": 3883,
           "authority": "native registration"
         }
       ],
@@ -113,7 +113,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3986,
+          "line": 3994,
           "authority": "native registration"
         }
       ],
@@ -145,7 +145,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4073,
+          "line": 4081,
           "authority": "native registration"
         }
       ],
@@ -209,7 +209,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4234,
+          "line": 4242,
           "authority": "native registration"
         }
       ],
@@ -337,7 +337,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4752,
+          "line": 4721,
           "authority": "native registration"
         }
       ],
@@ -353,7 +353,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4105,
+          "line": 4113,
           "authority": "native registration"
         }
       ],
@@ -449,7 +449,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3994,
+          "line": 4002,
           "authority": "native registration"
         }
       ],
@@ -465,7 +465,7 @@
       "sources": [
         {
           "path": "src/catalua_game_handle.cpp",
-          "line": 303,
+          "line": 361,
           "authority": "native registration"
         }
       ],
@@ -481,7 +481,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4209,
+          "line": 4217,
           "authority": "native registration"
         }
       ],
@@ -497,7 +497,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2399,
+          "line": 2409,
           "authority": "native registration"
         }
       ],
@@ -513,7 +513,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_items.cpp",
-          "line": 2427,
+          "line": 2428,
           "authority": "native registration"
         }
       ],
@@ -529,7 +529,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_items.cpp",
-          "line": 2326,
+          "line": 2327,
           "authority": "native registration"
         }
       ],
@@ -545,7 +545,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4254,
+          "line": 4262,
           "authority": "native registration"
         }
       ],
@@ -593,7 +593,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_missions.cpp",
-          "line": 1412,
+          "line": 1418,
           "authority": "native registration"
         }
       ],
@@ -625,7 +625,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4050,
+          "line": 4058,
           "authority": "native registration"
         }
       ],
@@ -785,7 +785,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4145,
+          "line": 4153,
           "authority": "native registration"
         }
       ],
@@ -945,7 +945,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_eocs.cpp",
-          "line": 781,
+          "line": 797,
           "authority": "native registration"
         }
       ],
@@ -1057,7 +1057,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3717,
+          "line": 3725,
           "authority": "native registration"
         }
       ],
@@ -1089,7 +1089,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3731,
+          "line": 3739,
           "authority": "native registration"
         }
       ],
@@ -1105,7 +1105,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3750,
+          "line": 3758,
           "authority": "native registration"
         }
       ],
@@ -1121,7 +1121,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4107,
+          "line": 4115,
           "authority": "native registration"
         }
       ],
@@ -1137,7 +1137,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4761,
+          "line": 4730,
           "authority": "native registration"
         }
       ],
@@ -1153,7 +1153,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4778,
+          "line": 4747,
           "authority": "native registration"
         }
       ],
@@ -1169,7 +1169,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4814,
+          "line": 4783,
           "authority": "native registration"
         }
       ],
@@ -1185,7 +1185,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4796,
+          "line": 4765,
           "authority": "native registration"
         }
       ],
@@ -1201,7 +1201,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3858,
+          "line": 3866,
           "authority": "native registration"
         }
       ],
@@ -1224,7 +1224,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3702,
+              "line": 3705,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1240,7 +1240,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3703,
+              "line": 3706,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1256,7 +1256,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3704,
+              "line": 3707,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1272,7 +1272,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3705,
+              "line": 3708,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1288,7 +1288,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3706,
+              "line": 3709,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1304,7 +1304,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3707,
+              "line": 3710,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1320,7 +1320,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3708,
+              "line": 3711,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1336,7 +1336,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3709,
+              "line": 3712,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1352,7 +1352,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3710,
+              "line": 3713,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1368,7 +1368,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3711,
+              "line": 3714,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1381,7 +1381,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3701,
+          "line": 3704,
           "authority": "LuaLS declaration"
         }
       ],
@@ -1402,7 +1402,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3723,
+              "line": 3726,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1418,7 +1418,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3724,
+              "line": 3727,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1434,7 +1434,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3725,
+              "line": 3728,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1450,7 +1450,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3726,
+              "line": 3729,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1463,7 +1463,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3722,
+          "line": 3725,
           "authority": "LuaLS declaration"
         }
       ],
@@ -1484,7 +1484,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3714,
+              "line": 3717,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1500,7 +1500,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3715,
+              "line": 3718,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1516,7 +1516,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3716,
+              "line": 3719,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1532,7 +1532,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3717,
+              "line": 3720,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1548,7 +1548,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3718,
+              "line": 3721,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1564,7 +1564,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3719,
+              "line": 3722,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1580,7 +1580,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3720,
+              "line": 3723,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1593,7 +1593,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3713,
+          "line": 3716,
           "authority": "LuaLS declaration"
         }
       ],
@@ -1614,7 +1614,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3696,
+              "line": 3699,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1630,7 +1630,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3697,
+              "line": 3700,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1646,7 +1646,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3698,
+              "line": 3701,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1662,7 +1662,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3699,
+              "line": 3702,
               "authority": "LuaLS declaration"
             }
           ],
@@ -1675,7 +1675,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3695,
+          "line": 3698,
           "authority": "LuaLS declaration"
         }
       ],
@@ -1692,7 +1692,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3728,
+          "line": 3731,
           "authority": "LuaLS declaration"
         }
       ],
@@ -2644,7 +2644,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3346,
+              "line": 3349,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2660,7 +2660,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3347,
+              "line": 3350,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2673,7 +2673,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3345,
+          "line": 3348,
           "authority": "LuaLS declaration"
         }
       ],
@@ -2694,7 +2694,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3326,
+              "line": 3329,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2710,7 +2710,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3327,
+              "line": 3330,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2726,7 +2726,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3328,
+              "line": 3331,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2742,7 +2742,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3329,
+              "line": 3332,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2758,7 +2758,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3330,
+              "line": 3333,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2774,7 +2774,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3331,
+              "line": 3334,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2790,7 +2790,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3332,
+              "line": 3335,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2803,7 +2803,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3325,
+          "line": 3328,
           "authority": "LuaLS declaration"
         }
       ],
@@ -2824,7 +2824,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3335,
+              "line": 3338,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2840,7 +2840,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3336,
+              "line": 3339,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2856,7 +2856,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3337,
+              "line": 3340,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2872,7 +2872,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3338,
+              "line": 3341,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2888,7 +2888,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3339,
+              "line": 3342,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2904,7 +2904,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3340,
+              "line": 3343,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2920,7 +2920,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3341,
+              "line": 3344,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2936,7 +2936,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3342,
+              "line": 3345,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2952,7 +2952,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3343,
+              "line": 3346,
               "authority": "LuaLS declaration"
             }
           ],
@@ -2965,7 +2965,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3334,
+          "line": 3337,
           "authority": "LuaLS declaration"
         }
       ],
@@ -2982,7 +2982,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3349,
+          "line": 3352,
           "authority": "LuaLS declaration"
         }
       ],
@@ -5173,7 +5173,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4203,
+              "line": 4206,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5186,7 +5186,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4202,
+          "line": 4205,
           "authority": "LuaLS declaration"
         }
       ],
@@ -5207,7 +5207,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4206,
+              "line": 4209,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5223,7 +5223,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4207,
+              "line": 4210,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5239,7 +5239,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4208,
+              "line": 4211,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5255,7 +5255,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4209,
+              "line": 4212,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5271,7 +5271,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4210,
+              "line": 4213,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5287,7 +5287,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4211,
+              "line": 4214,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5303,7 +5303,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4212,
+              "line": 4215,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5319,7 +5319,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4213,
+              "line": 4216,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5335,7 +5335,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4214,
+              "line": 4217,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5351,7 +5351,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4215,
+              "line": 4218,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5367,7 +5367,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4216,
+              "line": 4219,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5383,7 +5383,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4217,
+              "line": 4220,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5399,7 +5399,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4218,
+              "line": 4221,
               "authority": "LuaLS declaration"
             }
           ],
@@ -5412,7 +5412,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4205,
+          "line": 4208,
           "authority": "LuaLS declaration"
         }
       ],
@@ -5429,7 +5429,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4220,
+          "line": 4223,
           "authority": "LuaLS declaration"
         }
       ],
@@ -6322,7 +6322,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2774,
+              "line": 2775,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6338,7 +6338,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2775,
+              "line": 2776,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6351,7 +6351,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2773,
+          "line": 2774,
           "authority": "LuaLS declaration"
         }
       ],
@@ -6368,7 +6368,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2777,
+          "line": 2778,
           "authority": "LuaLS declaration"
         }
       ],
@@ -6568,7 +6568,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4411,
+              "line": 4414,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6584,7 +6584,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4412,
+              "line": 4415,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6600,7 +6600,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4413,
+              "line": 4416,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6616,7 +6616,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4414,
+              "line": 4417,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6632,7 +6632,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4415,
+              "line": 4418,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6648,7 +6648,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4416,
+              "line": 4419,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6664,7 +6664,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4417,
+              "line": 4420,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6680,7 +6680,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4418,
+              "line": 4421,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6696,7 +6696,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4419,
+              "line": 4422,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6712,7 +6712,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4420,
+              "line": 4423,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6728,7 +6728,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4421,
+              "line": 4424,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6744,7 +6744,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4422,
+              "line": 4425,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6760,7 +6760,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4423,
+              "line": 4426,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6776,7 +6776,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4424,
+              "line": 4427,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6789,7 +6789,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4410,
+          "line": 4413,
           "authority": "LuaLS declaration"
         }
       ],
@@ -6810,7 +6810,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3073,
+              "line": 3076,
               "authority": "LuaLS declaration"
             }
           ],
@@ -6823,7 +6823,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3072,
+          "line": 3075,
           "authority": "LuaLS declaration"
         }
       ],
@@ -8899,7 +8899,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3603,
+              "line": 3606,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8915,7 +8915,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3604,
+              "line": 3607,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8931,7 +8931,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3605,
+              "line": 3608,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8947,7 +8947,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3606,
+              "line": 3609,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8963,7 +8963,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3607,
+              "line": 3610,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8979,7 +8979,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3608,
+              "line": 3611,
               "authority": "LuaLS declaration"
             }
           ],
@@ -8995,7 +8995,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3609,
+              "line": 3612,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9011,7 +9011,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3610,
+              "line": 3613,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9027,7 +9027,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3611,
+              "line": 3614,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9043,7 +9043,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3612,
+              "line": 3615,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9056,7 +9056,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3602,
+          "line": 3605,
           "authority": "LuaLS declaration"
         }
       ],
@@ -9077,7 +9077,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3620,
+              "line": 3623,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9093,7 +9093,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3621,
+              "line": 3624,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9109,7 +9109,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3622,
+              "line": 3625,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9125,7 +9125,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3623,
+              "line": 3626,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9138,7 +9138,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3619,
+          "line": 3622,
           "authority": "LuaLS declaration"
         }
       ],
@@ -9159,7 +9159,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3615,
+              "line": 3618,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9175,7 +9175,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3616,
+              "line": 3619,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9191,7 +9191,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3617,
+              "line": 3620,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9204,7 +9204,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3614,
+          "line": 3617,
           "authority": "LuaLS declaration"
         }
       ],
@@ -9225,7 +9225,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3599,
+              "line": 3602,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9241,7 +9241,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3600,
+              "line": 3603,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9254,7 +9254,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3598,
+          "line": 3601,
           "authority": "LuaLS declaration"
         }
       ],
@@ -9271,7 +9271,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3625,
+          "line": 3628,
           "authority": "LuaLS declaration"
         }
       ],
@@ -9491,7 +9491,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4089,
+              "line": 4092,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9507,7 +9507,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4090,
+              "line": 4093,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9523,7 +9523,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4091,
+              "line": 4094,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9539,7 +9539,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4092,
+              "line": 4095,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9552,7 +9552,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4088,
+          "line": 4091,
           "authority": "LuaLS declaration"
         }
       ],
@@ -9573,7 +9573,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4119,
+              "line": 4122,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9589,7 +9589,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4120,
+              "line": 4123,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9602,7 +9602,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4118,
+          "line": 4121,
           "authority": "LuaLS declaration"
         }
       ],
@@ -9623,7 +9623,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4123,
+              "line": 4126,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9639,7 +9639,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4124,
+              "line": 4127,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9655,7 +9655,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4125,
+              "line": 4128,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9671,7 +9671,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4126,
+              "line": 4129,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9687,7 +9687,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4127,
+              "line": 4130,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9703,7 +9703,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4128,
+              "line": 4131,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9719,7 +9719,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4129,
+              "line": 4132,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9735,7 +9735,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4130,
+              "line": 4133,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9748,7 +9748,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4122,
+          "line": 4125,
           "authority": "LuaLS declaration"
         }
       ],
@@ -9769,7 +9769,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4074,
+              "line": 4077,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9785,7 +9785,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4075,
+              "line": 4078,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9801,7 +9801,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4076,
+              "line": 4079,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9817,7 +9817,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4077,
+              "line": 4080,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9833,7 +9833,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4078,
+              "line": 4081,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9846,7 +9846,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4073,
+          "line": 4076,
           "authority": "LuaLS declaration"
         }
       ],
@@ -9867,7 +9867,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4109,
+              "line": 4112,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9883,7 +9883,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4110,
+              "line": 4113,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9899,7 +9899,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4111,
+              "line": 4114,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9912,7 +9912,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4108,
+          "line": 4111,
           "authority": "LuaLS declaration"
         }
       ],
@@ -9933,7 +9933,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4114,
+              "line": 4117,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9949,7 +9949,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4115,
+              "line": 4118,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9965,7 +9965,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4116,
+              "line": 4119,
               "authority": "LuaLS declaration"
             }
           ],
@@ -9978,7 +9978,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4113,
+          "line": 4116,
           "authority": "LuaLS declaration"
         }
       ],
@@ -9999,7 +9999,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4081,
+              "line": 4084,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10015,7 +10015,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4082,
+              "line": 4085,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10031,7 +10031,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4083,
+              "line": 4086,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10047,7 +10047,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4084,
+              "line": 4087,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10063,7 +10063,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4085,
+              "line": 4088,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10079,7 +10079,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4086,
+              "line": 4089,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10092,7 +10092,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4080,
+          "line": 4083,
           "authority": "LuaLS declaration"
         }
       ],
@@ -10113,7 +10113,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4095,
+              "line": 4098,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10129,7 +10129,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4096,
+              "line": 4099,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10145,7 +10145,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4097,
+              "line": 4100,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10161,7 +10161,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4098,
+              "line": 4101,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10177,7 +10177,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4099,
+              "line": 4102,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10193,7 +10193,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4100,
+              "line": 4103,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10209,7 +10209,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4101,
+              "line": 4104,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10225,7 +10225,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4102,
+              "line": 4105,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10241,7 +10241,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4103,
+              "line": 4106,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10257,7 +10257,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4104,
+              "line": 4107,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10273,7 +10273,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4105,
+              "line": 4108,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10289,7 +10289,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4106,
+              "line": 4109,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10302,7 +10302,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4094,
+          "line": 4097,
           "authority": "LuaLS declaration"
         }
       ],
@@ -10319,7 +10319,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4132,
+          "line": 4135,
           "authority": "LuaLS declaration"
         }
       ],
@@ -10374,7 +10374,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4547,
+              "line": 4550,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10390,7 +10390,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4548,
+              "line": 4551,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10406,7 +10406,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4549,
+              "line": 4552,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10422,7 +10422,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4550,
+              "line": 4553,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10438,7 +10438,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4551,
+              "line": 4554,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10454,7 +10454,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4552,
+              "line": 4555,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10470,7 +10470,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4553,
+              "line": 4556,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10486,7 +10486,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4554,
+              "line": 4557,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10502,7 +10502,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4555,
+              "line": 4558,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10518,7 +10518,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4556,
+              "line": 4559,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10534,7 +10534,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4557,
+              "line": 4560,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10550,7 +10550,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4558,
+              "line": 4561,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10566,7 +10566,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4559,
+              "line": 4562,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10582,7 +10582,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4560,
+              "line": 4563,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10598,7 +10598,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4561,
+              "line": 4564,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10614,7 +10614,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4562,
+              "line": 4565,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10630,7 +10630,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4563,
+              "line": 4566,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10646,7 +10646,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4564,
+              "line": 4567,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10662,7 +10662,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4565,
+              "line": 4568,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10678,7 +10678,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4566,
+              "line": 4569,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10694,7 +10694,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4567,
+              "line": 4570,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10710,7 +10710,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4568,
+              "line": 4571,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10726,7 +10726,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4569,
+              "line": 4572,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10742,7 +10742,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4570,
+              "line": 4573,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10758,7 +10758,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4571,
+              "line": 4574,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10774,7 +10774,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4572,
+              "line": 4575,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10790,7 +10790,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4573,
+              "line": 4576,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10806,7 +10806,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4574,
+              "line": 4577,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10822,7 +10822,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4575,
+              "line": 4578,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10838,7 +10838,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4576,
+              "line": 4579,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10854,7 +10854,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4577,
+              "line": 4580,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10870,7 +10870,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4578,
+              "line": 4581,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10886,7 +10886,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4579,
+              "line": 4582,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10902,7 +10902,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4580,
+              "line": 4583,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10918,7 +10918,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4581,
+              "line": 4584,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10934,7 +10934,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4582,
+              "line": 4585,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10950,7 +10950,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4583,
+              "line": 4586,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10966,7 +10966,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4584,
+              "line": 4587,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10982,7 +10982,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4585,
+              "line": 4588,
               "authority": "LuaLS declaration"
             }
           ],
@@ -10998,7 +10998,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4586,
+              "line": 4589,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11014,7 +11014,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4587,
+              "line": 4590,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11030,7 +11030,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4588,
+              "line": 4591,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11046,7 +11046,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4589,
+              "line": 4592,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11062,7 +11062,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4590,
+              "line": 4593,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11078,7 +11078,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4591,
+              "line": 4594,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11094,7 +11094,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4592,
+              "line": 4595,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11110,7 +11110,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4593,
+              "line": 4596,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11126,7 +11126,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4594,
+              "line": 4597,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11142,7 +11142,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4595,
+              "line": 4598,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11158,7 +11158,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4596,
+              "line": 4599,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11174,7 +11174,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4597,
+              "line": 4600,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11190,7 +11190,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4598,
+              "line": 4601,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11206,7 +11206,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4599,
+              "line": 4602,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11222,7 +11222,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4600,
+              "line": 4603,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11238,7 +11238,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4601,
+              "line": 4604,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11254,7 +11254,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4602,
+              "line": 4605,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11270,7 +11270,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4603,
+              "line": 4606,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11286,7 +11286,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4604,
+              "line": 4607,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11299,7 +11299,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4546,
+          "line": 4549,
           "authority": "LuaLS declaration"
         }
       ],
@@ -11354,7 +11354,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3416,
+              "line": 3419,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11370,7 +11370,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3417,
+              "line": 3420,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11383,7 +11383,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3415,
+          "line": 3418,
           "authority": "LuaLS declaration"
         }
       ],
@@ -11564,7 +11564,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3669,
+          "line": 3672,
           "authority": "LuaLS declaration"
         }
       ],
@@ -11602,7 +11602,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3424,
+              "line": 3427,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11618,7 +11618,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3425,
+              "line": 3428,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11631,7 +11631,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3423,
+          "line": 3426,
           "authority": "LuaLS declaration"
         }
       ],
@@ -11652,7 +11652,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3428,
+              "line": 3431,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11668,7 +11668,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3429,
+              "line": 3432,
               "authority": "LuaLS declaration"
             }
           ],
@@ -11681,7 +11681,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3427,
+          "line": 3430,
           "authority": "LuaLS declaration"
         }
       ],
@@ -12063,7 +12063,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2965,
+              "line": 2968,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12079,7 +12079,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2966,
+              "line": 2969,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12095,7 +12095,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2967,
+              "line": 2970,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12111,7 +12111,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2968,
+              "line": 2971,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12124,7 +12124,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2964,
+          "line": 2967,
           "authority": "LuaLS declaration"
         }
       ],
@@ -12141,7 +12141,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2988,
+          "line": 2991,
           "authority": "LuaLS declaration"
         }
       ],
@@ -12834,7 +12834,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2971,
+              "line": 2974,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12850,7 +12850,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2972,
+              "line": 2975,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12866,7 +12866,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2973,
+              "line": 2976,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12879,7 +12879,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2970,
+          "line": 2973,
           "authority": "LuaLS declaration"
         }
       ],
@@ -12900,7 +12900,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2976,
+              "line": 2979,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12916,7 +12916,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2977,
+              "line": 2980,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12932,7 +12932,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2978,
+              "line": 2981,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12948,7 +12948,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2979,
+              "line": 2982,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12964,7 +12964,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2980,
+              "line": 2983,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12980,7 +12980,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2981,
+              "line": 2984,
               "authority": "LuaLS declaration"
             }
           ],
@@ -12996,7 +12996,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2982,
+              "line": 2985,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13009,7 +13009,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2975,
+          "line": 2978,
           "authority": "LuaLS declaration"
         }
       ],
@@ -13030,7 +13030,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2985,
+              "line": 2988,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13046,7 +13046,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2986,
+              "line": 2989,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13059,7 +13059,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2984,
+          "line": 2987,
           "authority": "LuaLS declaration"
         }
       ],
@@ -13080,7 +13080,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3656,
+              "line": 3659,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13096,7 +13096,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3657,
+              "line": 3660,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13112,7 +13112,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3658,
+              "line": 3661,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13128,7 +13128,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3659,
+              "line": 3662,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13144,7 +13144,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3660,
+              "line": 3663,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13160,7 +13160,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3661,
+              "line": 3664,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13176,7 +13176,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3662,
+              "line": 3665,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13192,7 +13192,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3663,
+              "line": 3666,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13208,7 +13208,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3664,
+              "line": 3667,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13224,7 +13224,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3665,
+              "line": 3668,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13240,7 +13240,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3666,
+              "line": 3669,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13256,7 +13256,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3667,
+              "line": 3670,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13269,7 +13269,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3655,
+          "line": 3658,
           "authority": "LuaLS declaration"
         }
       ],
@@ -13583,7 +13583,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3511,
+              "line": 3514,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13599,7 +13599,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3512,
+              "line": 3515,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13615,7 +13615,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3513,
+              "line": 3516,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13631,7 +13631,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3514,
+              "line": 3517,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13647,7 +13647,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3515,
+              "line": 3518,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13663,7 +13663,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3516,
+              "line": 3519,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13679,7 +13679,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3517,
+              "line": 3520,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13695,7 +13695,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3518,
+              "line": 3521,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13711,7 +13711,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3519,
+              "line": 3522,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13727,7 +13727,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3520,
+              "line": 3523,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13743,7 +13743,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3521,
+              "line": 3524,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13759,7 +13759,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3522,
+              "line": 3525,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13775,7 +13775,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3523,
+              "line": 3526,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13791,7 +13791,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3524,
+              "line": 3527,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13807,7 +13807,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3525,
+              "line": 3528,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13823,7 +13823,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3526,
+              "line": 3529,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13839,7 +13839,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3527,
+              "line": 3530,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13855,7 +13855,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3528,
+              "line": 3531,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13868,7 +13868,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3510,
+          "line": 3513,
           "authority": "LuaLS declaration"
         }
       ],
@@ -13889,7 +13889,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3543,
+              "line": 3546,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13902,7 +13902,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3542,
+          "line": 3545,
           "authority": "LuaLS declaration"
         }
       ],
@@ -13923,7 +13923,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3531,
+              "line": 3534,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13939,7 +13939,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3532,
+              "line": 3535,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13955,7 +13955,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3533,
+              "line": 3536,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13971,7 +13971,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3534,
+              "line": 3537,
               "authority": "LuaLS declaration"
             }
           ],
@@ -13987,7 +13987,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3535,
+              "line": 3538,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14003,7 +14003,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3536,
+              "line": 3539,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14019,7 +14019,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3537,
+              "line": 3540,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14035,7 +14035,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3538,
+              "line": 3541,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14051,7 +14051,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3539,
+              "line": 3542,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14067,7 +14067,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3540,
+              "line": 3543,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14080,7 +14080,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3530,
+          "line": 3533,
           "authority": "LuaLS declaration"
         }
       ],
@@ -14097,7 +14097,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3545,
+          "line": 3548,
           "authority": "LuaLS declaration"
         }
       ],
@@ -14283,7 +14283,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2631,
+              "line": 2632,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14299,7 +14299,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2632,
+              "line": 2633,
               "authority": "LuaLS declaration"
             }
           ],
@@ -14312,7 +14312,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2630,
+          "line": 2631,
           "authority": "LuaLS declaration"
         }
       ],
@@ -14539,7 +14539,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2634,
+          "line": 2635,
           "authority": "LuaLS declaration"
         }
       ],
@@ -15183,7 +15183,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3793,
+              "line": 3796,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15199,7 +15199,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3794,
+              "line": 3797,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15215,7 +15215,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3795,
+              "line": 3798,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15231,7 +15231,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3796,
+              "line": 3799,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15247,7 +15247,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3797,
+              "line": 3800,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15263,7 +15263,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3798,
+              "line": 3801,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15276,7 +15276,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3792,
+          "line": 3795,
           "authority": "LuaLS declaration"
         }
       ],
@@ -15297,7 +15297,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3076,
+              "line": 3079,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15313,7 +15313,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3077,
+              "line": 3080,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15329,7 +15329,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3078,
+              "line": 3081,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15345,7 +15345,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3079,
+              "line": 3082,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15361,7 +15361,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3080,
+              "line": 3083,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15377,7 +15377,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3081,
+              "line": 3084,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15393,7 +15393,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3082,
+              "line": 3085,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15409,7 +15409,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3083,
+              "line": 3086,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15425,7 +15425,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3084,
+              "line": 3087,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15441,7 +15441,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3085,
+              "line": 3088,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15454,7 +15454,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3075,
+          "line": 3078,
           "authority": "LuaLS declaration"
         }
       ],
@@ -15475,7 +15475,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3088,
+              "line": 3091,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15491,7 +15491,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3089,
+              "line": 3092,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15507,7 +15507,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3090,
+              "line": 3093,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15523,7 +15523,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3091,
+              "line": 3094,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15539,7 +15539,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3092,
+              "line": 3095,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15555,7 +15555,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3093,
+              "line": 3096,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15571,7 +15571,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3094,
+              "line": 3097,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15587,7 +15587,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3095,
+              "line": 3098,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15603,7 +15603,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3096,
+              "line": 3099,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15619,7 +15619,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3097,
+              "line": 3100,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15635,7 +15635,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3098,
+              "line": 3101,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15651,7 +15651,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3099,
+              "line": 3102,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15667,7 +15667,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3100,
+              "line": 3103,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15683,7 +15683,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3101,
+              "line": 3104,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15699,7 +15699,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3102,
+              "line": 3105,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15715,7 +15715,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3103,
+              "line": 3106,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15731,7 +15731,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3104,
+              "line": 3107,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15744,7 +15744,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3087,
+          "line": 3090,
           "authority": "LuaLS declaration"
         }
       ],
@@ -15863,7 +15863,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3410,
+              "line": 3413,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15879,7 +15879,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3411,
+              "line": 3414,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15895,7 +15895,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3412,
+              "line": 3415,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15911,7 +15911,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3413,
+              "line": 3416,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15924,7 +15924,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3409,
+          "line": 3412,
           "authority": "LuaLS declaration"
         }
       ],
@@ -15941,7 +15941,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3431,
+          "line": 3434,
           "authority": "LuaLS declaration"
         }
       ],
@@ -15962,7 +15962,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3393,
+              "line": 3396,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15978,7 +15978,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3394,
+              "line": 3397,
               "authority": "LuaLS declaration"
             }
           ],
@@ -15994,7 +15994,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3395,
+              "line": 3398,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16010,7 +16010,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3396,
+              "line": 3399,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16026,7 +16026,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3397,
+              "line": 3400,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16042,7 +16042,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3398,
+              "line": 3401,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16058,7 +16058,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3399,
+              "line": 3402,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16074,7 +16074,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3400,
+              "line": 3403,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16090,7 +16090,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3401,
+              "line": 3404,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16106,7 +16106,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3402,
+              "line": 3405,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16122,7 +16122,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3403,
+              "line": 3406,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16138,7 +16138,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3404,
+              "line": 3407,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16154,7 +16154,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3405,
+              "line": 3408,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16170,7 +16170,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3406,
+              "line": 3409,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16186,7 +16186,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3407,
+              "line": 3410,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16199,7 +16199,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3392,
+          "line": 3395,
           "authority": "LuaLS declaration"
         }
       ],
@@ -16220,7 +16220,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3982,
+              "line": 3985,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16236,7 +16236,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3983,
+              "line": 3986,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16252,7 +16252,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3984,
+              "line": 3987,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16268,7 +16268,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3985,
+              "line": 3988,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16284,7 +16284,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3986,
+              "line": 3989,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16300,7 +16300,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3987,
+              "line": 3990,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16316,7 +16316,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3988,
+              "line": 3991,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16332,7 +16332,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3989,
+              "line": 3992,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16348,7 +16348,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3990,
+              "line": 3993,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16364,7 +16364,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3991,
+              "line": 3994,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16380,7 +16380,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3992,
+              "line": 3995,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16393,7 +16393,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3981,
+          "line": 3984,
           "authority": "LuaLS declaration"
         }
       ],
@@ -16414,7 +16414,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3995,
+              "line": 3998,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16430,7 +16430,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3996,
+              "line": 3999,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16446,7 +16446,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3997,
+              "line": 4000,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16462,7 +16462,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3998,
+              "line": 4001,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16478,7 +16478,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3999,
+              "line": 4002,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16494,7 +16494,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4000,
+              "line": 4003,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16507,7 +16507,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3994,
+          "line": 3997,
           "authority": "LuaLS declaration"
         }
       ],
@@ -16528,7 +16528,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4032,
+              "line": 4035,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16544,7 +16544,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4033,
+              "line": 4036,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16560,7 +16560,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4034,
+              "line": 4037,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16576,7 +16576,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4035,
+              "line": 4038,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16592,7 +16592,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4036,
+              "line": 4039,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16608,7 +16608,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4037,
+              "line": 4040,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16621,7 +16621,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4031,
+          "line": 4034,
           "authority": "LuaLS declaration"
         }
       ],
@@ -16642,7 +16642,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4003,
+              "line": 4006,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16658,7 +16658,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4004,
+              "line": 4007,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16674,7 +16674,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4005,
+              "line": 4008,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16690,7 +16690,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4006,
+              "line": 4009,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16706,7 +16706,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4007,
+              "line": 4010,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16722,7 +16722,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4008,
+              "line": 4011,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16738,7 +16738,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4009,
+              "line": 4012,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16754,7 +16754,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4010,
+              "line": 4013,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16770,7 +16770,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4011,
+              "line": 4014,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16786,7 +16786,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4012,
+              "line": 4015,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16802,7 +16802,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4013,
+              "line": 4016,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16818,7 +16818,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4014,
+              "line": 4017,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16834,7 +16834,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4015,
+              "line": 4018,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16850,7 +16850,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4016,
+              "line": 4019,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16866,7 +16866,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4017,
+              "line": 4020,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16882,7 +16882,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4018,
+              "line": 4021,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16898,7 +16898,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4019,
+              "line": 4022,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16914,7 +16914,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4020,
+              "line": 4023,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16930,7 +16930,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4021,
+              "line": 4024,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16946,7 +16946,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4022,
+              "line": 4025,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16962,7 +16962,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4023,
+              "line": 4026,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16978,7 +16978,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4024,
+              "line": 4027,
               "authority": "LuaLS declaration"
             }
           ],
@@ -16994,7 +16994,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4025,
+              "line": 4028,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17010,7 +17010,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4026,
+              "line": 4029,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17026,7 +17026,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4027,
+              "line": 4030,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17042,7 +17042,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4028,
+              "line": 4031,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17058,7 +17058,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4029,
+              "line": 4032,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17071,7 +17071,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4002,
+          "line": 4005,
           "authority": "LuaLS declaration"
         }
       ],
@@ -17088,7 +17088,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4039,
+          "line": 4042,
           "authority": "LuaLS declaration"
         }
       ],
@@ -17105,7 +17105,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2878,
+          "line": 2879,
           "authority": "LuaLS declaration"
         }
       ],
@@ -17126,7 +17126,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2870,
+              "line": 2871,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17142,7 +17142,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2871,
+              "line": 2872,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17158,7 +17158,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2872,
+              "line": 2873,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17174,7 +17174,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2873,
+              "line": 2874,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17190,7 +17190,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2874,
+              "line": 2875,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17206,7 +17206,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2875,
+              "line": 2876,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17222,7 +17222,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2876,
+              "line": 2877,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17235,7 +17235,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2869,
+          "line": 2870,
           "authority": "LuaLS declaration"
         }
       ],
@@ -17256,7 +17256,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2864,
+              "line": 2865,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17272,7 +17272,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2865,
+              "line": 2866,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17285,7 +17285,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2863,
+          "line": 2864,
           "authority": "LuaLS declaration"
         }
       ],
@@ -17852,7 +17852,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3208,
+          "line": 3211,
           "authority": "LuaLS declaration"
         }
       ],
@@ -17873,7 +17873,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3168,
+              "line": 3171,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17889,7 +17889,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3169,
+              "line": 3172,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17905,7 +17905,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3170,
+              "line": 3173,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17918,7 +17918,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3167,
+          "line": 3170,
           "authority": "LuaLS declaration"
         }
       ],
@@ -17939,7 +17939,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3173,
+              "line": 3176,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17955,7 +17955,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3174,
+              "line": 3177,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17971,7 +17971,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3175,
+              "line": 3178,
               "authority": "LuaLS declaration"
             }
           ],
@@ -17987,7 +17987,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3176,
+              "line": 3179,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18003,7 +18003,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3177,
+              "line": 3180,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18019,7 +18019,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3178,
+              "line": 3181,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18035,7 +18035,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3179,
+              "line": 3182,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18051,7 +18051,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3180,
+              "line": 3183,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18067,7 +18067,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3181,
+              "line": 3184,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18083,7 +18083,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3182,
+              "line": 3185,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18099,7 +18099,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3183,
+              "line": 3186,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18115,7 +18115,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3184,
+              "line": 3187,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18131,7 +18131,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3185,
+              "line": 3188,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18144,7 +18144,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3172,
+          "line": 3175,
           "authority": "LuaLS declaration"
         }
       ],
@@ -18165,7 +18165,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3205,
+              "line": 3208,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18181,7 +18181,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3206,
+              "line": 3209,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18194,7 +18194,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3204,
+          "line": 3207,
           "authority": "LuaLS declaration"
         }
       ],
@@ -18215,7 +18215,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3200,
+              "line": 3203,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18231,7 +18231,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3201,
+              "line": 3204,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18247,7 +18247,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3202,
+              "line": 3205,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18260,7 +18260,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3199,
+          "line": 3202,
           "authority": "LuaLS declaration"
         }
       ],
@@ -18281,7 +18281,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3188,
+              "line": 3191,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18297,7 +18297,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3189,
+              "line": 3192,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18313,7 +18313,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3190,
+              "line": 3193,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18329,7 +18329,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3191,
+              "line": 3194,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18345,7 +18345,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3192,
+              "line": 3195,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18361,7 +18361,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3193,
+              "line": 3196,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18377,7 +18377,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3194,
+              "line": 3197,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18393,7 +18393,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3195,
+              "line": 3198,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18409,7 +18409,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3196,
+              "line": 3199,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18425,7 +18425,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3197,
+              "line": 3200,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18438,7 +18438,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3187,
+          "line": 3190,
           "authority": "LuaLS declaration"
         }
       ],
@@ -18704,7 +18704,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2708,
+              "line": 2709,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18720,7 +18720,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2709,
+              "line": 2710,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18736,7 +18736,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2710,
+              "line": 2711,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18752,7 +18752,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2711,
+              "line": 2712,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18768,7 +18768,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2712,
+              "line": 2713,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18784,7 +18784,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2713,
+              "line": 2714,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18800,7 +18800,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2714,
+              "line": 2715,
               "authority": "LuaLS declaration"
             }
           ],
@@ -18813,7 +18813,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2707,
+          "line": 2708,
           "authority": "LuaLS declaration"
         }
       ],
@@ -18830,7 +18830,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2716,
+          "line": 2717,
           "authority": "LuaLS declaration"
         }
       ],
@@ -19213,7 +19213,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2751,
+              "line": 2752,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19226,7 +19226,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2750,
+          "line": 2751,
           "authority": "LuaLS declaration"
         }
       ],
@@ -19243,7 +19243,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2753,
+          "line": 2754,
           "authority": "LuaLS declaration"
         }
       ],
@@ -19330,7 +19330,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4528,
+              "line": 4531,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19346,7 +19346,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4529,
+              "line": 4532,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19362,7 +19362,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4530,
+              "line": 4533,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19378,7 +19378,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4531,
+              "line": 4534,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19394,7 +19394,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4532,
+              "line": 4535,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19410,7 +19410,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4533,
+              "line": 4536,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19426,7 +19426,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4534,
+              "line": 4537,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19442,7 +19442,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4535,
+              "line": 4538,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19458,7 +19458,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4536,
+              "line": 4539,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19474,7 +19474,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4537,
+              "line": 4540,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19490,7 +19490,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4538,
+              "line": 4541,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19506,7 +19506,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4539,
+              "line": 4542,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19522,7 +19522,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4540,
+              "line": 4543,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19538,7 +19538,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4541,
+              "line": 4544,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19554,7 +19554,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4542,
+              "line": 4545,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19570,7 +19570,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4543,
+              "line": 4546,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19586,7 +19586,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4544,
+              "line": 4547,
               "authority": "LuaLS declaration"
             }
           ],
@@ -19599,7 +19599,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4527,
+          "line": 4530,
           "authority": "LuaLS declaration"
         }
       ],
@@ -20437,7 +20437,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3119,
+              "line": 3122,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20453,7 +20453,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3120,
+              "line": 3123,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20469,7 +20469,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3121,
+              "line": 3124,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20482,7 +20482,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3118,
+          "line": 3121,
           "authority": "LuaLS declaration"
         }
       ],
@@ -20503,7 +20503,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3107,
+              "line": 3110,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20519,7 +20519,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3108,
+              "line": 3111,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20535,7 +20535,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3109,
+              "line": 3112,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20551,7 +20551,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3110,
+              "line": 3113,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20567,7 +20567,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3111,
+              "line": 3114,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20583,7 +20583,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3112,
+              "line": 3115,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20596,7 +20596,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3106,
+          "line": 3109,
           "authority": "LuaLS declaration"
         }
       ],
@@ -20617,7 +20617,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3115,
+              "line": 3118,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20633,7 +20633,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3116,
+              "line": 3119,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20646,7 +20646,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3114,
+          "line": 3117,
           "authority": "LuaLS declaration"
         }
       ],
@@ -20667,7 +20667,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3124,
+              "line": 3127,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20683,7 +20683,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3125,
+              "line": 3128,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20696,7 +20696,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3123,
+          "line": 3126,
           "authority": "LuaLS declaration"
         }
       ],
@@ -20891,7 +20891,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3127,
+          "line": 3130,
           "authority": "LuaLS declaration"
         }
       ],
@@ -20912,7 +20912,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3420,
+              "line": 3423,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20928,7 +20928,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3421,
+              "line": 3424,
               "authority": "LuaLS declaration"
             }
           ],
@@ -20941,7 +20941,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3419,
+          "line": 3422,
           "authority": "LuaLS declaration"
         }
       ],
@@ -21096,7 +21096,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3767,
+              "line": 3770,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21112,7 +21112,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3768,
+              "line": 3771,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21128,7 +21128,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3769,
+              "line": 3772,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21144,7 +21144,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3770,
+              "line": 3773,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21160,7 +21160,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3771,
+              "line": 3774,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21176,7 +21176,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3772,
+              "line": 3775,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21189,7 +21189,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3766,
+          "line": 3769,
           "authority": "LuaLS declaration"
         }
       ],
@@ -21210,7 +21210,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3782,
+              "line": 3785,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21226,7 +21226,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3783,
+              "line": 3786,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21242,7 +21242,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3784,
+              "line": 3787,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21258,7 +21258,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3785,
+              "line": 3788,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21271,7 +21271,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3781,
+          "line": 3784,
           "authority": "LuaLS declaration"
         }
       ],
@@ -21292,7 +21292,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3788,
+              "line": 3791,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21308,7 +21308,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3789,
+              "line": 3792,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21324,7 +21324,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3790,
+              "line": 3793,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21337,7 +21337,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3787,
+          "line": 3790,
           "authority": "LuaLS declaration"
         }
       ],
@@ -21358,7 +21358,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3775,
+              "line": 3778,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21374,7 +21374,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3776,
+              "line": 3779,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21390,7 +21390,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3777,
+              "line": 3780,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21406,7 +21406,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3778,
+              "line": 3781,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21422,7 +21422,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3779,
+              "line": 3782,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21435,7 +21435,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3774,
+          "line": 3777,
           "authority": "LuaLS declaration"
         }
       ],
@@ -21456,7 +21456,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3761,
+              "line": 3764,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21472,7 +21472,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3762,
+              "line": 3765,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21488,7 +21488,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3763,
+              "line": 3766,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21504,7 +21504,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3764,
+              "line": 3767,
               "authority": "LuaLS declaration"
             }
           ],
@@ -21517,7 +21517,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3760,
+          "line": 3763,
           "authority": "LuaLS declaration"
         }
       ],
@@ -21534,7 +21534,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3800,
+          "line": 3803,
           "authority": "LuaLS declaration"
         }
       ],
@@ -22224,7 +22224,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3676,
+          "line": 3679,
           "authority": "LuaLS declaration"
         }
       ],
@@ -22311,7 +22311,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3870,
+              "line": 3873,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22327,7 +22327,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3871,
+              "line": 3874,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22343,7 +22343,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3872,
+              "line": 3875,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22359,7 +22359,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3873,
+              "line": 3876,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22375,7 +22375,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3874,
+              "line": 3877,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22391,7 +22391,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3875,
+              "line": 3878,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22407,7 +22407,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3876,
+              "line": 3879,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22423,7 +22423,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3877,
+              "line": 3880,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22439,7 +22439,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3878,
+              "line": 3881,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22455,7 +22455,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3879,
+              "line": 3882,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22471,7 +22471,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3880,
+              "line": 3883,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22487,7 +22487,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3881,
+              "line": 3884,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22503,7 +22503,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3882,
+              "line": 3885,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22516,7 +22516,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3869,
+          "line": 3872,
           "authority": "LuaLS declaration"
         }
       ],
@@ -22537,7 +22537,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3855,
+              "line": 3858,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22553,7 +22553,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3856,
+              "line": 3859,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22569,7 +22569,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3857,
+              "line": 3860,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22585,7 +22585,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3858,
+              "line": 3861,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22601,7 +22601,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3859,
+              "line": 3862,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22617,7 +22617,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3860,
+              "line": 3863,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22633,7 +22633,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3861,
+              "line": 3864,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22649,7 +22649,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3862,
+              "line": 3865,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22665,7 +22665,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3863,
+              "line": 3866,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22681,7 +22681,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3864,
+              "line": 3867,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22697,7 +22697,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3865,
+              "line": 3868,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22713,7 +22713,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3866,
+              "line": 3869,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22729,7 +22729,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3867,
+              "line": 3870,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22742,7 +22742,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3854,
+          "line": 3857,
           "authority": "LuaLS declaration"
         }
       ],
@@ -22763,7 +22763,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3899,
+              "line": 3902,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22779,7 +22779,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3900,
+              "line": 3903,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22795,7 +22795,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3901,
+              "line": 3904,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22811,7 +22811,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3902,
+              "line": 3905,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22827,7 +22827,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3903,
+              "line": 3906,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22843,7 +22843,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3904,
+              "line": 3907,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22859,7 +22859,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3905,
+              "line": 3908,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22875,7 +22875,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3906,
+              "line": 3909,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22891,7 +22891,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3907,
+              "line": 3910,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22907,7 +22907,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3908,
+              "line": 3911,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22923,7 +22923,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3909,
+              "line": 3912,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22939,7 +22939,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3910,
+              "line": 3913,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22955,7 +22955,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3911,
+              "line": 3914,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22971,7 +22971,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3912,
+              "line": 3915,
               "authority": "LuaLS declaration"
             }
           ],
@@ -22987,7 +22987,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3913,
+              "line": 3916,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23003,7 +23003,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3914,
+              "line": 3917,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23019,7 +23019,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3915,
+              "line": 3918,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23035,7 +23035,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3916,
+              "line": 3919,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23051,7 +23051,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3917,
+              "line": 3920,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23067,7 +23067,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3918,
+              "line": 3921,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23083,7 +23083,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3919,
+              "line": 3922,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23099,7 +23099,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3920,
+              "line": 3923,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23112,7 +23112,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3898,
+          "line": 3901,
           "authority": "LuaLS declaration"
         }
       ],
@@ -23133,7 +23133,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3923,
+              "line": 3926,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23149,7 +23149,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3924,
+              "line": 3927,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23162,7 +23162,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3922,
+          "line": 3925,
           "authority": "LuaLS declaration"
         }
       ],
@@ -23183,7 +23183,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3846,
+              "line": 3849,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23199,7 +23199,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3847,
+              "line": 3850,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23215,7 +23215,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3848,
+              "line": 3851,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23231,7 +23231,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3849,
+              "line": 3852,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23247,7 +23247,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3850,
+              "line": 3853,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23263,7 +23263,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3851,
+              "line": 3854,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23279,7 +23279,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3852,
+              "line": 3855,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23292,7 +23292,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3845,
+          "line": 3848,
           "authority": "LuaLS declaration"
         }
       ],
@@ -23313,7 +23313,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3885,
+              "line": 3888,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23329,7 +23329,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3886,
+              "line": 3889,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23345,7 +23345,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3887,
+              "line": 3890,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23361,7 +23361,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3888,
+              "line": 3891,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23377,7 +23377,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3889,
+              "line": 3892,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23393,7 +23393,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3890,
+              "line": 3893,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23409,7 +23409,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3891,
+              "line": 3894,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23425,7 +23425,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3892,
+              "line": 3895,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23441,7 +23441,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3893,
+              "line": 3896,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23457,7 +23457,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3894,
+              "line": 3897,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23473,7 +23473,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3895,
+              "line": 3898,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23489,7 +23489,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3896,
+              "line": 3899,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23502,7 +23502,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3884,
+          "line": 3887,
           "authority": "LuaLS declaration"
         }
       ],
@@ -23523,7 +23523,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3927,
+              "line": 3930,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23539,7 +23539,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3928,
+              "line": 3931,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23555,7 +23555,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3929,
+              "line": 3932,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23568,7 +23568,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3926,
+          "line": 3929,
           "authority": "LuaLS declaration"
         }
       ],
@@ -23585,7 +23585,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3931,
+          "line": 3934,
           "authority": "LuaLS declaration"
         }
       ],
@@ -23606,7 +23606,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3261,
+              "line": 3264,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23622,7 +23622,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3262,
+              "line": 3265,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23635,7 +23635,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3260,
+          "line": 3263,
           "authority": "LuaLS declaration"
         }
       ],
@@ -23656,7 +23656,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3265,
+              "line": 3268,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23672,7 +23672,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3266,
+              "line": 3269,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23688,7 +23688,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3267,
+              "line": 3270,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23704,7 +23704,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3268,
+              "line": 3271,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23720,7 +23720,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3269,
+              "line": 3272,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23736,7 +23736,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3270,
+              "line": 3273,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23752,7 +23752,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3271,
+              "line": 3274,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23768,7 +23768,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3272,
+              "line": 3275,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23784,7 +23784,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3273,
+              "line": 3276,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23800,7 +23800,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3274,
+              "line": 3277,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23813,7 +23813,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3264,
+          "line": 3267,
           "authority": "LuaLS declaration"
         }
       ],
@@ -23834,7 +23834,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3277,
+              "line": 3280,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23850,7 +23850,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3278,
+              "line": 3281,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23866,7 +23866,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3279,
+              "line": 3282,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23882,7 +23882,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3280,
+              "line": 3283,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23898,7 +23898,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3281,
+              "line": 3284,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23914,7 +23914,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3282,
+              "line": 3285,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23930,7 +23930,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3283,
+              "line": 3286,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23946,7 +23946,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3284,
+              "line": 3287,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23962,7 +23962,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 3285,
+              "line": 3288,
               "authority": "LuaLS declaration"
             }
           ],
@@ -23975,7 +23975,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3276,
+          "line": 3279,
           "authority": "LuaLS declaration"
         }
       ],
@@ -23992,7 +23992,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3287,
+          "line": 3290,
           "authority": "LuaLS declaration"
         }
       ],
@@ -24009,7 +24009,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4479,
+          "line": 4482,
           "authority": "LuaLS declaration"
         }
       ],
@@ -24030,7 +24030,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4456,
+              "line": 4459,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24046,7 +24046,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4457,
+              "line": 4460,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24062,7 +24062,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4458,
+              "line": 4461,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24078,7 +24078,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4459,
+              "line": 4462,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24094,7 +24094,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4460,
+              "line": 4463,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24110,7 +24110,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4461,
+              "line": 4464,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24126,7 +24126,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4462,
+              "line": 4465,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24139,7 +24139,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4455,
+          "line": 4458,
           "authority": "LuaLS declaration"
         }
       ],
@@ -24160,7 +24160,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4449,
+              "line": 4452,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24176,7 +24176,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4450,
+              "line": 4453,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24192,7 +24192,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4451,
+              "line": 4454,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24208,7 +24208,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4452,
+              "line": 4455,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24224,7 +24224,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4453,
+              "line": 4456,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24237,7 +24237,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4448,
+          "line": 4451,
           "authority": "LuaLS declaration"
         }
       ],
@@ -24258,7 +24258,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4431,
+              "line": 4434,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24274,7 +24274,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4432,
+              "line": 4435,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24290,7 +24290,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4433,
+              "line": 4436,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24306,7 +24306,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4434,
+              "line": 4437,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24322,7 +24322,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4435,
+              "line": 4438,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24338,7 +24338,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4436,
+              "line": 4439,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24354,7 +24354,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4437,
+              "line": 4440,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24370,7 +24370,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4438,
+              "line": 4441,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24386,7 +24386,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4439,
+              "line": 4442,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24402,7 +24402,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4440,
+              "line": 4443,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24418,7 +24418,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4441,
+              "line": 4444,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24434,7 +24434,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4442,
+              "line": 4445,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24447,7 +24447,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4430,
+          "line": 4433,
           "authority": "LuaLS declaration"
         }
       ],
@@ -24468,7 +24468,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4471,
+              "line": 4474,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24484,7 +24484,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4472,
+              "line": 4475,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24500,7 +24500,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4473,
+              "line": 4476,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24516,7 +24516,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4474,
+              "line": 4477,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24532,7 +24532,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4475,
+              "line": 4478,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24548,7 +24548,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4476,
+              "line": 4479,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24564,7 +24564,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4477,
+              "line": 4480,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24577,7 +24577,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4470,
+          "line": 4473,
           "authority": "LuaLS declaration"
         }
       ],
@@ -24598,7 +24598,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4445,
+              "line": 4448,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24614,7 +24614,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4446,
+              "line": 4449,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24627,7 +24627,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4444,
+          "line": 4447,
           "authority": "LuaLS declaration"
         }
       ],
@@ -24648,7 +24648,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4393,
+              "line": 4396,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24664,7 +24664,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4394,
+              "line": 4397,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24680,7 +24680,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4395,
+              "line": 4398,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24696,7 +24696,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4396,
+              "line": 4399,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24712,7 +24712,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4397,
+              "line": 4400,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24728,7 +24728,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4398,
+              "line": 4401,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24744,7 +24744,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4399,
+              "line": 4402,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24760,7 +24760,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4400,
+              "line": 4403,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24776,7 +24776,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4401,
+              "line": 4404,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24792,7 +24792,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4402,
+              "line": 4405,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24808,7 +24808,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4403,
+              "line": 4406,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24824,7 +24824,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4404,
+              "line": 4407,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24840,7 +24840,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4405,
+              "line": 4408,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24856,7 +24856,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4406,
+              "line": 4409,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24872,7 +24872,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4407,
+              "line": 4410,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24888,7 +24888,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4408,
+              "line": 4411,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24901,7 +24901,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4392,
+          "line": 4395,
           "authority": "LuaLS declaration"
         }
       ],
@@ -24922,7 +24922,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4427,
+              "line": 4430,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24938,7 +24938,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4428,
+              "line": 4431,
               "authority": "LuaLS declaration"
             }
           ],
@@ -24951,7 +24951,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4426,
+          "line": 4429,
           "authority": "LuaLS declaration"
         }
       ],
@@ -25134,7 +25134,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4368,
+              "line": 4371,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25150,7 +25150,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4369,
+              "line": 4372,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25166,7 +25166,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4370,
+              "line": 4373,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25182,7 +25182,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4371,
+              "line": 4374,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25198,7 +25198,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4372,
+              "line": 4375,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25214,7 +25214,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4373,
+              "line": 4376,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25230,7 +25230,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4374,
+              "line": 4377,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25246,7 +25246,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4375,
+              "line": 4378,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25262,7 +25262,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4376,
+              "line": 4379,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25278,7 +25278,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4377,
+              "line": 4380,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25294,7 +25294,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4378,
+              "line": 4381,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25310,7 +25310,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4379,
+              "line": 4382,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25326,7 +25326,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4380,
+              "line": 4383,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25342,7 +25342,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4381,
+              "line": 4384,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25358,7 +25358,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4382,
+              "line": 4385,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25374,7 +25374,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4383,
+              "line": 4386,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25390,7 +25390,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4384,
+              "line": 4387,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25406,7 +25406,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4385,
+              "line": 4388,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25422,7 +25422,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4386,
+              "line": 4389,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25438,7 +25438,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4387,
+              "line": 4390,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25454,7 +25454,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4388,
+              "line": 4391,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25470,7 +25470,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4389,
+              "line": 4392,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25486,7 +25486,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4390,
+              "line": 4393,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25499,7 +25499,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4367,
+          "line": 4370,
           "authority": "LuaLS declaration"
         }
       ],
@@ -25520,7 +25520,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4465,
+              "line": 4468,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25536,7 +25536,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4466,
+              "line": 4469,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25552,7 +25552,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4467,
+              "line": 4470,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25568,7 +25568,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4468,
+              "line": 4471,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25581,7 +25581,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4464,
+          "line": 4467,
           "authority": "LuaLS declaration"
         }
       ],
@@ -25598,7 +25598,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2797,
+          "line": 2798,
           "authority": "LuaLS declaration"
         }
       ],
@@ -25619,7 +25619,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2790,
+              "line": 2791,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25635,7 +25635,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2791,
+              "line": 2792,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25651,7 +25651,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2792,
+              "line": 2793,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25667,7 +25667,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2793,
+              "line": 2794,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25680,7 +25680,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2789,
+          "line": 2790,
           "authority": "LuaLS declaration"
         }
       ],
@@ -25701,7 +25701,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2786,
+              "line": 2787,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25717,7 +25717,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2787,
+              "line": 2788,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25730,7 +25730,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2785,
+          "line": 2786,
           "authority": "LuaLS declaration"
         }
       ],
@@ -25747,7 +25747,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2795,
+          "line": 2796,
           "authority": "LuaLS declaration"
         }
       ],
@@ -25768,7 +25768,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4300,
+              "line": 4303,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25784,7 +25784,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4301,
+              "line": 4304,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25800,7 +25800,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4302,
+              "line": 4305,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25816,7 +25816,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4303,
+              "line": 4306,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25832,7 +25832,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4304,
+              "line": 4307,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25848,7 +25848,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4305,
+              "line": 4308,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25864,7 +25864,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4306,
+              "line": 4309,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25880,7 +25880,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4307,
+              "line": 4310,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25893,7 +25893,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4299,
+          "line": 4302,
           "authority": "LuaLS declaration"
         }
       ],
@@ -25914,7 +25914,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4296,
+              "line": 4299,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25930,7 +25930,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4297,
+              "line": 4300,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25943,7 +25943,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4295,
+          "line": 4298,
           "authority": "LuaLS declaration"
         }
       ],
@@ -25964,7 +25964,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4278,
+              "line": 4281,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25980,7 +25980,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4279,
+              "line": 4282,
               "authority": "LuaLS declaration"
             }
           ],
@@ -25996,7 +25996,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4280,
+              "line": 4283,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26012,7 +26012,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4281,
+              "line": 4284,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26028,7 +26028,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4282,
+              "line": 4285,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26044,7 +26044,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4283,
+              "line": 4286,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26060,7 +26060,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4284,
+              "line": 4287,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26076,7 +26076,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4285,
+              "line": 4288,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26092,7 +26092,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4286,
+              "line": 4289,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26108,7 +26108,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4287,
+              "line": 4290,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26124,7 +26124,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4288,
+              "line": 4291,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26140,7 +26140,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4289,
+              "line": 4292,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26156,7 +26156,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4290,
+              "line": 4293,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26172,7 +26172,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4291,
+              "line": 4294,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26188,7 +26188,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4292,
+              "line": 4295,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26204,7 +26204,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4293,
+              "line": 4296,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26217,7 +26217,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4277,
+          "line": 4280,
           "authority": "LuaLS declaration"
         }
       ],
@@ -26238,7 +26238,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4268,
+              "line": 4271,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26254,7 +26254,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4269,
+              "line": 4272,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26270,7 +26270,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4270,
+              "line": 4273,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26286,7 +26286,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4271,
+              "line": 4274,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26302,7 +26302,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4272,
+              "line": 4275,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26318,7 +26318,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4273,
+              "line": 4276,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26334,7 +26334,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4274,
+              "line": 4277,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26350,7 +26350,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4275,
+              "line": 4278,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26363,7 +26363,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4267,
+          "line": 4270,
           "authority": "LuaLS declaration"
         }
       ],
@@ -26380,7 +26380,7 @@
       "sources": [
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4309,
+          "line": 4312,
           "authority": "LuaLS declaration"
         }
       ],
@@ -26485,7 +26485,7 @@
       "sources": [
         {
           "path": "src/catalua_game_handle.cpp",
-          "line": 263,
+          "line": 321,
           "authority": "native registration"
         },
         {
@@ -26566,7 +26566,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2942,
+              "line": 2944,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26582,7 +26582,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2943,
+              "line": 2945,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26598,7 +26598,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2944,
+              "line": 2946,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26614,7 +26614,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2945,
+              "line": 2947,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26627,12 +26627,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2120,
+          "line": 2130,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2941,
+          "line": 2943,
           "authority": "LuaLS declaration"
         }
       ],
@@ -26653,7 +26653,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2953,
+              "line": 2956,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26669,7 +26669,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2954,
+              "line": 2957,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26685,7 +26685,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2955,
+              "line": 2958,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26701,7 +26701,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2956,
+              "line": 2959,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26714,12 +26714,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2154,
+          "line": 2164,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2952,
+          "line": 2955,
           "authority": "LuaLS declaration"
         }
       ],
@@ -26740,7 +26740,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2622,
+              "line": 2623,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26756,7 +26756,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2623,
+              "line": 2624,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26772,7 +26772,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 2624,
+              "line": 2625,
               "authority": "LuaLS declaration"
             }
           ],
@@ -26785,12 +26785,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_missions.cpp",
-          "line": 1225,
+          "line": 1231,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2621,
+          "line": 2622,
           "authority": "LuaLS declaration"
         }
       ],
@@ -26910,7 +26910,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3965,
+          "line": 3973,
           "authority": "native registration"
         },
         {
@@ -26932,7 +26932,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3930,
+          "line": 3938,
           "authority": "native registration"
         },
         {
@@ -26954,7 +26954,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3796,
+          "line": 3804,
           "authority": "native registration"
         },
         {
@@ -27185,7 +27185,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3780,
+          "line": 3788,
           "authority": "native registration"
         },
         {
@@ -27463,7 +27463,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4253,
+              "line": 4256,
               "authority": "LuaLS declaration"
             }
           ],
@@ -27479,7 +27479,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4254,
+              "line": 4257,
               "authority": "LuaLS declaration"
             }
           ],
@@ -27495,7 +27495,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4255,
+              "line": 4258,
               "authority": "LuaLS declaration"
             }
           ],
@@ -27511,7 +27511,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4256,
+              "line": 4259,
               "authority": "LuaLS declaration"
             }
           ],
@@ -27527,7 +27527,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4257,
+              "line": 4260,
               "authority": "LuaLS declaration"
             }
           ],
@@ -27543,7 +27543,7 @@
           "sources": [
             {
               "path": "data/lua/types/ccb_api_v5.d.lua",
-              "line": 4258,
+              "line": 4261,
               "authority": "LuaLS declaration"
             }
           ],
@@ -27561,7 +27561,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4252,
+          "line": 4255,
           "authority": "LuaLS declaration"
         }
       ],
@@ -27603,7 +27603,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3912,
+          "line": 3920,
           "authority": "native registration"
         },
         {
@@ -27659,7 +27659,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3917,
+          "line": 3925,
           "authority": "native registration"
         },
         {
@@ -27710,7 +27710,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3909,
+          "line": 3917,
           "authority": "native registration"
         },
         {
@@ -27761,7 +27761,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3906,
+          "line": 3914,
           "authority": "native registration"
         },
         {
@@ -27819,7 +27819,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3876,
+          "line": 3884,
           "authority": "native registration"
         },
         {
@@ -27888,7 +27888,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3891,
+          "line": 3899,
           "authority": "native registration"
         },
         {
@@ -27944,7 +27944,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3737,
+          "line": 3740,
           "authority": "LuaLS declaration"
         }
       ],
@@ -27995,7 +27995,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3733,
+          "line": 3736,
           "authority": "LuaLS declaration"
         }
       ],
@@ -28046,7 +28046,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3745,
+          "line": 3748,
           "authority": "LuaLS declaration"
         }
       ],
@@ -28097,7 +28097,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3741,
+          "line": 3744,
           "authority": "LuaLS declaration"
         }
       ],
@@ -28153,7 +28153,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3754,
+          "line": 3757,
           "authority": "LuaLS declaration"
         }
       ],
@@ -28204,7 +28204,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3758,
+          "line": 3761,
           "authority": "LuaLS declaration"
         }
       ],
@@ -28255,7 +28255,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3749,
+          "line": 3752,
           "authority": "LuaLS declaration"
         }
       ],
@@ -28295,7 +28295,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4068,
+          "line": 4076,
           "authority": "native registration"
         },
         {
@@ -28340,7 +28340,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4063,
+          "line": 4071,
           "authority": "native registration"
         },
         {
@@ -28391,7 +28391,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4059,
+          "line": 4067,
           "authority": "native registration"
         },
         {
@@ -28447,7 +28447,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4052,
+          "line": 4060,
           "authority": "native registration"
         },
         {
@@ -28774,7 +28774,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4667,
+          "line": 4670,
           "authority": "LuaLS declaration"
         }
       ],
@@ -28816,12 +28816,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4653,
+          "line": 4624,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4608,
+          "line": 4611,
           "authority": "LuaLS declaration"
         }
       ],
@@ -28883,7 +28883,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3358,
+          "line": 3361,
           "authority": "LuaLS declaration"
         }
       ],
@@ -28934,7 +28934,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3354,
+          "line": 3357,
           "authority": "LuaLS declaration"
         }
       ],
@@ -28995,7 +28995,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3374,
+          "line": 3377,
           "authority": "LuaLS declaration"
         }
       ],
@@ -29051,7 +29051,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3368,
+          "line": 3371,
           "authority": "LuaLS declaration"
         }
       ],
@@ -29107,7 +29107,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3363,
+          "line": 3366,
           "authority": "LuaLS declaration"
         }
       ],
@@ -29163,7 +29163,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3379,
+          "line": 3382,
           "authority": "LuaLS declaration"
         }
       ],
@@ -29219,7 +29219,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3390,
+          "line": 3393,
           "authority": "LuaLS declaration"
         }
       ],
@@ -29280,7 +29280,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3385,
+          "line": 3388,
           "authority": "LuaLS declaration"
         }
       ],
@@ -29325,7 +29325,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4678,
+          "line": 4681,
           "authority": "LuaLS declaration"
         }
       ],
@@ -29376,7 +29376,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4682,
+          "line": 4685,
           "authority": "LuaLS declaration"
         }
       ],
@@ -30038,7 +30038,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4659,
+          "line": 4662,
           "authority": "LuaLS declaration"
         }
       ],
@@ -30084,7 +30084,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4223,
+          "line": 4231,
           "authority": "native registration"
         },
         {
@@ -30129,7 +30129,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4231,
+          "line": 4239,
           "authority": "native registration"
         },
         {
@@ -30174,7 +30174,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4228,
+          "line": 4236,
           "authority": "native registration"
         },
         {
@@ -30225,7 +30225,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4219,
+          "line": 4227,
           "authority": "native registration"
         },
         {
@@ -30286,7 +30286,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4211,
+          "line": 4219,
           "authority": "native registration"
         },
         {
@@ -30342,7 +30342,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4234,
+          "line": 4237,
           "authority": "LuaLS declaration"
         }
       ],
@@ -30393,7 +30393,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4225,
+          "line": 4228,
           "authority": "LuaLS declaration"
         }
       ],
@@ -30449,7 +30449,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4230,
+          "line": 4233,
           "authority": "LuaLS declaration"
         }
       ],
@@ -30505,7 +30505,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4239,
+          "line": 4242,
           "authority": "LuaLS declaration"
         }
       ],
@@ -30561,7 +30561,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4249,
+          "line": 4252,
           "authority": "LuaLS declaration"
         }
       ],
@@ -30617,7 +30617,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4244,
+          "line": 4247,
           "authority": "LuaLS declaration"
         }
       ],
@@ -33733,7 +33733,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2783,
+          "line": 2784,
           "authority": "LuaLS declaration"
         }
       ],
@@ -33982,7 +33982,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4651,
+          "line": 4654,
           "authority": "LuaLS declaration"
         }
       ],
@@ -34327,7 +34327,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4743,
+          "line": 4712,
           "authority": "native registration"
         },
         {
@@ -34372,7 +34372,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4736,
+          "line": 4705,
           "authority": "native registration"
         },
         {
@@ -34423,7 +34423,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4081,
+          "line": 4089,
           "authority": "native registration"
         },
         {
@@ -34468,7 +34468,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4086,
+          "line": 4094,
           "authority": "native registration"
         },
         {
@@ -34519,7 +34519,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4076,
+          "line": 4084,
           "authority": "native registration"
         },
         {
@@ -34941,7 +34941,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4634,
+          "line": 4637,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35266,7 +35266,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3644,
+          "line": 3647,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35317,7 +35317,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3634,
+          "line": 3637,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35362,7 +35362,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3653,
+          "line": 3656,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35413,7 +35413,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3630,
+          "line": 3633,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35474,7 +35474,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3650,
+          "line": 3653,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35530,7 +35530,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3639,
+          "line": 3642,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35581,7 +35581,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4642,
+          "line": 4645,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35637,7 +35637,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4164,
+          "line": 4167,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35688,7 +35688,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4141,
+          "line": 4144,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35739,7 +35739,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4137,
+          "line": 4140,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35795,7 +35795,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4149,
+          "line": 4152,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35851,7 +35851,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4189,
+          "line": 4192,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35907,7 +35907,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4179,
+          "line": 4182,
           "authority": "LuaLS declaration"
         }
       ],
@@ -35963,7 +35963,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4184,
+          "line": 4187,
           "authority": "LuaLS declaration"
         }
       ],
@@ -36008,7 +36008,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4144,
+          "line": 4147,
           "authority": "LuaLS declaration"
         }
       ],
@@ -36064,7 +36064,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4159,
+          "line": 4162,
           "authority": "LuaLS declaration"
         }
       ],
@@ -36120,7 +36120,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4154,
+          "line": 4157,
           "authority": "LuaLS declaration"
         }
       ],
@@ -36176,7 +36176,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4169,
+          "line": 4172,
           "authority": "LuaLS declaration"
         }
       ],
@@ -36232,7 +36232,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4174,
+          "line": 4177,
           "authority": "LuaLS declaration"
         }
       ],
@@ -36288,7 +36288,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4194,
+          "line": 4197,
           "authority": "LuaLS declaration"
         }
       ],
@@ -36349,7 +36349,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4200,
+          "line": 4203,
           "authority": "LuaLS declaration"
         }
       ],
@@ -36543,12 +36543,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3989,
+          "line": 3997,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3674,
+          "line": 3677,
           "authority": "LuaLS declaration"
         }
       ],
@@ -36588,7 +36588,7 @@
       "sources": [
         {
           "path": "src/catalua_game_handle.cpp",
-          "line": 288,
+          "line": 346,
           "authority": "native registration"
         },
         {
@@ -36639,7 +36639,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4198,
+          "line": 4206,
           "authority": "native registration"
         },
         {
@@ -36684,7 +36684,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4206,
+          "line": 4214,
           "authority": "native registration"
         },
         {
@@ -36729,7 +36729,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4203,
+          "line": 4211,
           "authority": "native registration"
         },
         {
@@ -36780,7 +36780,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4195,
+          "line": 4203,
           "authority": "native registration"
         },
         {
@@ -36838,7 +36838,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4181,
+          "line": 4189,
           "authority": "native registration"
         },
         {
@@ -36889,12 +36889,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2393,
+          "line": 2403,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3070,
+          "line": 3073,
           "authority": "LuaLS declaration"
         }
       ],
@@ -36950,12 +36950,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2314,
+          "line": 2324,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3045,
+          "line": 3048,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37006,12 +37006,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2228,
+          "line": 2238,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3012,
+          "line": 3015,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37062,12 +37062,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2205,
+          "line": 2215,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3001,
+          "line": 3004,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37113,12 +37113,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2196,
+          "line": 2206,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2996,
+          "line": 2999,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37169,12 +37169,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2237,
+          "line": 2247,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3017,
+          "line": 3020,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37220,12 +37220,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2251,
+          "line": 2261,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3021,
+          "line": 3024,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37271,12 +37271,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2278,
+          "line": 2288,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3030,
+          "line": 3033,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37327,12 +37327,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2264,
+          "line": 2274,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3026,
+          "line": 3029,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37372,12 +37372,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2190,
+          "line": 2200,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2992,
+          "line": 2995,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37433,12 +37433,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2215,
+          "line": 2225,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3007,
+          "line": 3010,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37484,12 +37484,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2330,
+          "line": 2340,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3049,
+          "line": 3052,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37535,12 +37535,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2370,
+          "line": 2380,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3062,
+          "line": 3065,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37591,12 +37591,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2383,
+          "line": 2393,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3067,
+          "line": 3070,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37647,12 +37647,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2300,
+          "line": 2310,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3039,
+          "line": 3042,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37698,12 +37698,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2343,
+          "line": 2353,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3053,
+          "line": 3056,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37749,12 +37749,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2291,
+          "line": 2301,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3034,
+          "line": 3037,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37805,12 +37805,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2356,
+          "line": 2366,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3058,
+          "line": 3061,
           "authority": "LuaLS declaration"
         }
       ],
@@ -37861,7 +37861,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_items.cpp",
-          "line": 2341,
+          "line": 2342,
           "authority": "native registration"
         },
         {
@@ -37927,7 +37927,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_items.cpp",
-          "line": 2365,
+          "line": 2366,
           "authority": "native registration"
         },
         {
@@ -37983,7 +37983,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_items.cpp",
-          "line": 2329,
+          "line": 2330,
           "authority": "native registration"
         },
         {
@@ -38044,7 +38044,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_items.cpp",
-          "line": 2379,
+          "line": 2380,
           "authority": "native registration"
         },
         {
@@ -38105,7 +38105,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_items.cpp",
-          "line": 2352,
+          "line": 2353,
           "authority": "native registration"
         },
         {
@@ -38156,7 +38156,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_items.cpp",
-          "line": 2416,
+          "line": 2417,
           "authority": "native registration"
         },
         {
@@ -38212,7 +38212,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_items.cpp",
-          "line": 2404,
+          "line": 2405,
           "authority": "native registration"
         },
         {
@@ -38268,7 +38268,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_items.cpp",
-          "line": 2392,
+          "line": 2393,
           "authority": "native registration"
         },
         {
@@ -38324,7 +38324,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4630,
+          "line": 4633,
           "authority": "LuaLS declaration"
         }
       ],
@@ -38380,7 +38380,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4647,
+          "line": 4650,
           "authority": "LuaLS declaration"
         }
       ],
@@ -38431,7 +38431,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_items.cpp",
-          "line": 2226,
+          "line": 2227,
           "authority": "native registration"
         },
         {
@@ -38487,7 +38487,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_items.cpp",
-          "line": 2271,
+          "line": 2272,
           "authority": "native registration"
         },
         {
@@ -38543,7 +38543,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_items.cpp",
-          "line": 2248,
+          "line": 2249,
           "authority": "native registration"
         },
         {
@@ -38599,7 +38599,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_items.cpp",
-          "line": 2282,
+          "line": 2283,
           "authority": "native registration"
         },
         {
@@ -38655,7 +38655,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_items.cpp",
-          "line": 2304,
+          "line": 2305,
           "authority": "native registration"
         },
         {
@@ -38711,7 +38711,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_items.cpp",
-          "line": 2215,
+          "line": 2216,
           "authority": "native registration"
         },
         {
@@ -38754,7 +38754,7 @@
       ],
       "returns": [
         {
-          "declaration": "CcbResult"
+          "declaration": "CcbResult result `value.changed` reports whether the instance-owned flag changed; effective inherited state is reported separately."
         }
       ],
       "overloads": [],
@@ -38772,7 +38772,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_items.cpp",
-          "line": 2293,
+          "line": 2294,
           "authority": "native registration"
         },
         {
@@ -38833,7 +38833,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_items.cpp",
-          "line": 2315,
+          "line": 2316,
           "authority": "native registration"
         },
         {
@@ -38894,7 +38894,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_items.cpp",
-          "line": 2259,
+          "line": 2260,
           "authority": "native registration"
         },
         {
@@ -38950,7 +38950,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_items.cpp",
-          "line": 2204,
+          "line": 2205,
           "authority": "native registration"
         },
         {
@@ -39006,7 +39006,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_items.cpp",
-          "line": 2237,
+          "line": 2238,
           "authority": "native registration"
         },
         {
@@ -39051,7 +39051,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4251,
+          "line": 4259,
           "authority": "native registration"
         },
         {
@@ -39104,7 +39104,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4248,
+          "line": 4256,
           "authority": "native registration"
         },
         {
@@ -39159,7 +39159,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4236,
+          "line": 4244,
           "authority": "native registration"
         },
         {
@@ -39217,7 +39217,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3568,
+          "line": 3571,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39268,7 +39268,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3554,
+          "line": 3557,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39319,7 +39319,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3550,
+          "line": 3553,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39375,7 +39375,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3564,
+          "line": 3567,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39431,7 +39431,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3573,
+          "line": 3576,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39487,7 +39487,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3559,
+          "line": 3562,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39543,7 +39543,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3578,
+          "line": 3581,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39599,7 +39599,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3583,
+          "line": 3586,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39655,7 +39655,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3588,
+          "line": 3591,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39711,7 +39711,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3593,
+          "line": 3596,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39860,12 +39860,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_missions.cpp",
-          "line": 1402,
+          "line": 1408,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2705,
+          "line": 2706,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39911,12 +39911,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_missions.cpp",
-          "line": 1340,
+          "line": 1346,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2679,
+          "line": 2680,
           "authority": "LuaLS declaration"
         }
       ],
@@ -39962,12 +39962,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_missions.cpp",
-          "line": 1392,
+          "line": 1398,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2701,
+          "line": 2702,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40018,12 +40018,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_missions.cpp",
-          "line": 1381,
+          "line": 1387,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2697,
+          "line": 2698,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40063,12 +40063,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_missions.cpp",
-          "line": 1285,
+          "line": 1291,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2654,
+          "line": 2655,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40114,12 +40114,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_missions.cpp",
-          "line": 1257,
+          "line": 1263,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2643,
+          "line": 2644,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40165,12 +40165,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_missions.cpp",
-          "line": 1250,
+          "line": 1256,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2639,
+          "line": 2640,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40216,12 +40216,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_missions.cpp",
-          "line": 1371,
+          "line": 1377,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2692,
+          "line": 2693,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40267,12 +40267,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_missions.cpp",
-          "line": 1275,
+          "line": 1281,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2651,
+          "line": 2652,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40323,12 +40323,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_missions.cpp",
-          "line": 1305,
+          "line": 1311,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2664,
+          "line": 2665,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40374,12 +40374,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_missions.cpp",
-          "line": 1264,
+          "line": 1270,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2647,
+          "line": 2648,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40430,12 +40430,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_missions.cpp",
-          "line": 1295,
+          "line": 1301,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2659,
+          "line": 2660,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40486,12 +40486,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_missions.cpp",
-          "line": 1316,
+          "line": 1322,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2669,
+          "line": 2670,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40547,12 +40547,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_missions.cpp",
-          "line": 1327,
+          "line": 1333,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2675,
+          "line": 2676,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40598,12 +40598,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_missions.cpp",
-          "line": 1350,
+          "line": 1356,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2683,
+          "line": 2684,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40654,12 +40654,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_missions.cpp",
-          "line": 1360,
+          "line": 1366,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2688,
+          "line": 2689,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40710,7 +40710,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4663,
+          "line": 4666,
           "authority": "LuaLS declaration"
         }
       ],
@@ -40755,7 +40755,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4620,
+          "line": 4623,
           "authority": "LuaLS declaration"
         }
       ],
@@ -41315,7 +41315,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4655,
+          "line": 4658,
           "authority": "LuaLS declaration"
         }
       ],
@@ -41361,7 +41361,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4032,
+          "line": 4040,
           "authority": "native registration"
         },
         {
@@ -41418,7 +41418,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4039,
+          "line": 4047,
           "authority": "native registration"
         },
         {
@@ -41465,7 +41465,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4027,
+          "line": 4035,
           "authority": "native registration"
         },
         {
@@ -41517,7 +41517,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4022,
+          "line": 4030,
           "authority": "native registration"
         },
         {
@@ -41576,7 +41576,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4001,
+          "line": 4009,
           "authority": "native registration"
         },
         {
@@ -41644,7 +41644,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4672,
+          "line": 4675,
           "authority": "LuaLS declaration"
         }
       ],
@@ -41695,7 +41695,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3436,
+          "line": 3439,
           "authority": "LuaLS declaration"
         }
       ],
@@ -41746,7 +41746,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3461,
+          "line": 3464,
           "authority": "LuaLS declaration"
         }
       ],
@@ -41802,7 +41802,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3476,
+          "line": 3479,
           "authority": "LuaLS declaration"
         }
       ],
@@ -41858,7 +41858,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3446,
+          "line": 3449,
           "authority": "LuaLS declaration"
         }
       ],
@@ -41919,7 +41919,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3457,
+          "line": 3460,
           "authority": "LuaLS declaration"
         }
       ],
@@ -41975,7 +41975,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3471,
+          "line": 3474,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42036,7 +42036,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3488,
+          "line": 3491,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42092,7 +42092,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3508,
+          "line": 3511,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42148,7 +42148,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3493,
+          "line": 3496,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42204,7 +42204,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3498,
+          "line": 3501,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42260,7 +42260,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3441,
+          "line": 3444,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42316,7 +42316,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3451,
+          "line": 3454,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42372,7 +42372,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3466,
+          "line": 3469,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42433,7 +42433,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3482,
+          "line": 3485,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42489,7 +42489,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3503,
+          "line": 3506,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42540,7 +42540,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4048,
+          "line": 4051,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42591,7 +42591,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4044,
+          "line": 4047,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42642,7 +42642,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4056,
+          "line": 4059,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42693,7 +42693,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4052,
+          "line": 4055,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42749,7 +42749,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4071,
+          "line": 4074,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42805,7 +42805,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4061,
+          "line": 4064,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42861,7 +42861,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4066,
+          "line": 4069,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42917,7 +42917,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2896,
+          "line": 2897,
           "authority": "LuaLS declaration"
         }
       ],
@@ -42962,7 +42962,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2882,
+          "line": 2883,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43023,7 +43023,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2907,
+          "line": 2908,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43079,7 +43079,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2901,
+          "line": 2902,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43135,7 +43135,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2938,
+          "line": 2939,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43191,7 +43191,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2891,
+          "line": 2892,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43247,7 +43247,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2922,
+          "line": 2923,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43303,7 +43303,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2927,
+          "line": 2928,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43364,7 +43364,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2933,
+          "line": 2934,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43420,7 +43420,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2917,
+          "line": 2918,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43476,7 +43476,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2912,
+          "line": 2913,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43527,7 +43527,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2886,
+          "line": 2887,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43567,12 +43567,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4657,
+          "line": 4628,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4611,
+          "line": 4614,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43623,7 +43623,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4614,
+          "line": 4617,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43668,7 +43668,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4617,
+          "line": 4620,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43719,7 +43719,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3221,
+          "line": 3224,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43770,7 +43770,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3225,
+          "line": 3228,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43821,7 +43821,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3217,
+          "line": 3220,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43872,7 +43872,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3213,
+          "line": 3216,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43928,7 +43928,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3235,
+          "line": 3238,
           "authority": "LuaLS declaration"
         }
       ],
@@ -43989,7 +43989,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3241,
+          "line": 3244,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44045,7 +44045,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3230,
+          "line": 3233,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44106,7 +44106,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3252,
+          "line": 3255,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44162,7 +44162,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3246,
+          "line": 3249,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44223,7 +44223,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3258,
+          "line": 3261,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44386,7 +44386,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2728,
+          "line": 2729,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44442,7 +44442,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2738,
+          "line": 2739,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44498,7 +44498,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2733,
+          "line": 2734,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44554,7 +44554,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2743,
+          "line": 2744,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44610,7 +44610,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2748,
+          "line": 2749,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44655,7 +44655,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2720,
+          "line": 2721,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44706,7 +44706,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2724,
+          "line": 2725,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44866,7 +44866,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2771,
+          "line": 2772,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44922,7 +44922,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2766,
+          "line": 2767,
           "authority": "LuaLS declaration"
         }
       ],
@@ -44967,7 +44967,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2757,
+          "line": 2758,
           "authority": "LuaLS declaration"
         }
       ],
@@ -45018,7 +45018,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2761,
+          "line": 2762,
           "authority": "LuaLS declaration"
         }
       ],
@@ -45058,12 +45058,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4732,
+          "line": 4701,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4675,
+          "line": 4678,
           "authority": "LuaLS declaration"
         }
       ],
@@ -45248,7 +45248,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4123,
+          "line": 4131,
           "authority": "native registration"
         },
         {
@@ -45293,7 +45293,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4137,
+          "line": 4145,
           "authority": "native registration"
         },
         {
@@ -45338,7 +45338,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4132,
+          "line": 4140,
           "authority": "native registration"
         },
         {
@@ -45383,7 +45383,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4127,
+          "line": 4135,
           "authority": "native registration"
         },
         {
@@ -45434,7 +45434,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4119,
+          "line": 4127,
           "authority": "native registration"
         },
         {
@@ -45485,7 +45485,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4114,
+          "line": 4122,
           "authority": "native registration"
         },
         {
@@ -45536,7 +45536,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4109,
+          "line": 4117,
           "authority": "native registration"
         },
         {
@@ -45592,7 +45592,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3136,
+          "line": 3139,
           "authority": "LuaLS declaration"
         }
       ],
@@ -45643,7 +45643,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3132,
+          "line": 3135,
           "authority": "LuaLS declaration"
         }
       ],
@@ -45699,7 +45699,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3146,
+          "line": 3149,
           "authority": "LuaLS declaration"
         }
       ],
@@ -45755,7 +45755,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3141,
+          "line": 3144,
           "authority": "LuaLS declaration"
         }
       ],
@@ -45821,7 +45821,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3165,
+          "line": 3168,
           "authority": "LuaLS declaration"
         }
       ],
@@ -45882,7 +45882,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3152,
+          "line": 3155,
           "authority": "LuaLS declaration"
         }
       ],
@@ -45943,7 +45943,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3158,
+          "line": 3161,
           "authority": "LuaLS declaration"
         }
       ],
@@ -45994,7 +45994,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4638,
+          "line": 4641,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47359,12 +47359,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4725,
+          "line": 4694,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4688,
+          "line": 4691,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47411,12 +47411,12 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4729,
+          "line": 4698,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4692,
+          "line": 4695,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47467,7 +47467,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3809,
+          "line": 3812,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47518,7 +47518,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3805,
+          "line": 3808,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47574,7 +47574,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3835,
+          "line": 3838,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47625,7 +47625,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3830,
+          "line": 3833,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47676,7 +47676,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3843,
+          "line": 3846,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47727,7 +47727,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3839,
+          "line": 3842,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47783,7 +47783,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3826,
+          "line": 3829,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47834,7 +47834,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3821,
+          "line": 3824,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47885,7 +47885,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3817,
+          "line": 3820,
           "authority": "LuaLS declaration"
         }
       ],
@@ -47936,7 +47936,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3813,
+          "line": 3816,
           "authority": "LuaLS declaration"
         }
       ],
@@ -48848,7 +48848,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4623,
+          "line": 4626,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49157,12 +49157,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_eocs.cpp",
-          "line": 741,
+          "line": 757,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3682,
+          "line": 3685,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49213,12 +49213,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_eocs.cpp",
-          "line": 767,
+          "line": 783,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3693,
+          "line": 3696,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49274,12 +49274,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_eocs.cpp",
-          "line": 753,
+          "line": 769,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3688,
+          "line": 3691,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49330,7 +49330,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3940,
+          "line": 3943,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49381,7 +49381,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3936,
+          "line": 3939,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49432,7 +49432,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3953,
+          "line": 3956,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49483,7 +49483,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3944,
+          "line": 3947,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49539,7 +49539,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3949,
+          "line": 3952,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49595,7 +49595,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3958,
+          "line": 3961,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49651,7 +49651,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3963,
+          "line": 3966,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49712,7 +49712,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3979,
+          "line": 3982,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49768,7 +49768,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3973,
+          "line": 3976,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49824,7 +49824,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3968,
+          "line": 3971,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49875,7 +49875,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3296,
+          "line": 3299,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49926,7 +49926,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3292,
+          "line": 3295,
           "authority": "LuaLS declaration"
         }
       ],
@@ -49982,7 +49982,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3306,
+          "line": 3309,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50038,7 +50038,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3301,
+          "line": 3304,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50099,7 +50099,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3318,
+          "line": 3321,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50155,7 +50155,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3323,
+          "line": 3326,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50216,7 +50216,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 3312,
+          "line": 3315,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50261,7 +50261,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4508,
+          "line": 4511,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50306,7 +50306,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4522,
+          "line": 4525,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50351,7 +50351,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4515,
+          "line": 4518,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50396,7 +50396,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4491,
+          "line": 4494,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50453,7 +50453,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4498,
+          "line": 4501,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50498,7 +50498,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4494,
+          "line": 4497,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50543,7 +50543,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4501,
+          "line": 4504,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50588,7 +50588,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4525,
+          "line": 4528,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50639,7 +50639,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4505,
+          "line": 4508,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50690,7 +50690,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4512,
+          "line": 4515,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50741,7 +50741,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4519,
+          "line": 4522,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50792,7 +50792,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4488,
+          "line": 4491,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50843,7 +50843,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4484,
+          "line": 4487,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50888,7 +50888,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4626,
+          "line": 4629,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50933,7 +50933,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2809,
+          "line": 2810,
           "authority": "LuaLS declaration"
         }
       ],
@@ -50999,7 +50999,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2845,
+          "line": 2846,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51055,7 +51055,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2819,
+          "line": 2820,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51111,7 +51111,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2850,
+          "line": 2851,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51167,7 +51167,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2861,
+          "line": 2862,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51223,7 +51223,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2833,
+          "line": 2834,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51279,7 +51279,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2828,
+          "line": 2829,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51335,7 +51335,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2838,
+          "line": 2839,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51396,7 +51396,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2856,
+          "line": 2857,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51452,7 +51452,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2814,
+          "line": 2815,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51503,7 +51503,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2802,
+          "line": 2803,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51554,7 +51554,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2806,
+          "line": 2807,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51605,7 +51605,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2823,
+          "line": 2824,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51661,7 +51661,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4327,
+          "line": 4330,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51717,7 +51717,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4336,
+          "line": 4339,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51768,7 +51768,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4340,
+          "line": 4343,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51819,7 +51819,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4331,
+          "line": 4334,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51870,7 +51870,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4322,
+          "line": 4325,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51921,7 +51921,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4365,
+          "line": 4368,
           "authority": "LuaLS declaration"
         }
       ],
@@ -51977,7 +51977,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4345,
+          "line": 4348,
           "authority": "LuaLS declaration"
         }
       ],
@@ -52033,7 +52033,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4350,
+          "line": 4353,
           "authority": "LuaLS declaration"
         }
       ],
@@ -52094,7 +52094,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4361,
+          "line": 4364,
           "authority": "LuaLS declaration"
         }
       ],
@@ -52150,7 +52150,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4355,
+          "line": 4358,
           "authority": "LuaLS declaration"
         }
       ],
@@ -52201,7 +52201,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4318,
+          "line": 4321,
           "authority": "LuaLS declaration"
         }
       ],
@@ -52252,7 +52252,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4314,
+          "line": 4317,
           "authority": "LuaLS declaration"
         }
       ],
@@ -52583,7 +52583,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3718,
+          "line": 3726,
           "authority": "native registration"
         },
         {
@@ -52628,7 +52628,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3727,
+          "line": 3735,
           "authority": "native registration"
         },
         {
@@ -52898,7 +52898,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3708,
+          "line": 3716,
           "authority": "native registration"
         }
       ],
@@ -52950,7 +52950,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3732,
+          "line": 3740,
           "authority": "native registration"
         },
         {
@@ -53007,7 +53007,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3742,
+          "line": 3750,
           "authority": "native registration"
         },
         {
@@ -53063,7 +53063,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3737,
+          "line": 3745,
           "authority": "native registration"
         },
         {
@@ -53108,7 +53108,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3745,
+          "line": 3753,
           "authority": "native registration"
         },
         {
@@ -53175,7 +53175,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3764,
+          "line": 3772,
           "authority": "native registration"
         },
         {
@@ -53239,7 +53239,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3756,
+          "line": 3764,
           "authority": "native registration"
         },
         {
@@ -53290,7 +53290,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3776,
+          "line": 3784,
           "authority": "native registration"
         },
         {
@@ -53340,7 +53340,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3751,
+          "line": 3759,
           "authority": "native registration"
         },
         {
@@ -53391,7 +53391,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4123,
+          "line": 4131,
           "authority": "native registration"
         },
         {
@@ -53436,7 +53436,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4137,
+          "line": 4145,
           "authority": "native registration"
         },
         {
@@ -53481,7 +53481,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4132,
+          "line": 4140,
           "authority": "native registration"
         },
         {
@@ -53526,7 +53526,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4127,
+          "line": 4135,
           "authority": "native registration"
         },
         {
@@ -53577,7 +53577,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4119,
+          "line": 4127,
           "authority": "native registration"
         },
         {
@@ -53628,7 +53628,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4114,
+          "line": 4122,
           "authority": "native registration"
         },
         {
@@ -53685,7 +53685,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4109,
+          "line": 4117,
           "authority": "native registration"
         },
         {
@@ -53747,7 +53747,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4763,
+          "line": 4732,
           "authority": "native registration"
         },
         {
@@ -53810,7 +53810,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4771,
+          "line": 4740,
           "authority": "native registration"
         },
         {
@@ -53877,7 +53877,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4799,
+          "line": 4768,
           "authority": "native registration"
         },
         {
@@ -53940,7 +53940,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4807,
+          "line": 4776,
           "authority": "native registration"
         },
         {
@@ -54007,7 +54007,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4781,
+          "line": 4750,
           "authority": "native registration"
         },
         {
@@ -54059,7 +54059,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 4789,
+          "line": 4758,
           "authority": "native registration"
         },
         {
@@ -54269,7 +54269,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3859,
+          "line": 3867,
           "authority": "native registration"
         },
         {
@@ -54327,7 +54327,7 @@
       "sources": [
         {
           "path": "src/catalua_game_handle.cpp",
-          "line": 269,
+          "line": 327,
           "authority": "native registration"
         },
         {
@@ -54369,7 +54369,7 @@
       "sources": [
         {
           "path": "src/catalua_game_handle.cpp",
-          "line": 266,
+          "line": 324,
           "authority": "native registration"
         },
         {
@@ -54411,7 +54411,7 @@
       "sources": [
         {
           "path": "src/catalua_game_handle.cpp",
-          "line": 274,
+          "line": 332,
           "authority": "native registration"
         },
         {
@@ -54537,12 +54537,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2134,
+          "line": 2144,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2949,
+          "line": 2951,
           "authority": "LuaLS declaration"
         }
       ],
@@ -54581,12 +54581,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2168,
+          "line": 2178,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2960,
+          "line": 2963,
           "authority": "LuaLS declaration"
         }
       ],
@@ -54625,12 +54625,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_missions.cpp",
-          "line": 1234,
+          "line": 1240,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2628,
+          "line": 2629,
           "authority": "LuaLS declaration"
         }
       ],
@@ -55203,7 +55203,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3979,
+          "line": 3987,
           "authority": "native registration"
         },
         {
@@ -55251,7 +55251,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3969,
+          "line": 3977,
           "authority": "native registration"
         },
         {
@@ -55309,7 +55309,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3972,
+          "line": 3980,
           "authority": "native registration"
         },
         {
@@ -55353,7 +55353,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3971,
+          "line": 3979,
           "authority": "native registration"
         },
         {
@@ -55402,7 +55402,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3970,
+          "line": 3978,
           "authority": "native registration"
         },
         {
@@ -55444,7 +55444,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3968,
+          "line": 3976,
           "authority": "native registration"
         },
         {
@@ -55486,7 +55486,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3967,
+          "line": 3975,
           "authority": "native registration"
         },
         {
@@ -55528,7 +55528,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3945,
+          "line": 3953,
           "authority": "native registration"
         },
         {
@@ -55570,7 +55570,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3946,
+          "line": 3954,
           "authority": "native registration"
         },
         {
@@ -55612,7 +55612,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3938,
+          "line": 3946,
           "authority": "native registration"
         },
         {
@@ -55650,7 +55650,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3961,
+          "line": 3969,
           "authority": "native registration"
         },
         {
@@ -55703,7 +55703,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3956,
+          "line": 3964,
           "authority": "native registration"
         },
         {
@@ -55747,7 +55747,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3963,
+          "line": 3971,
           "authority": "native registration"
         },
         {
@@ -55795,7 +55795,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3949,
+          "line": 3957,
           "authority": "native registration"
         },
         {
@@ -55843,7 +55843,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3947,
+          "line": 3955,
           "authority": "native registration"
         },
         {
@@ -55885,7 +55885,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3952,
+          "line": 3960,
           "authority": "native registration"
         },
         {
@@ -55927,7 +55927,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3951,
+          "line": 3959,
           "authority": "native registration"
         },
         {
@@ -55969,7 +55969,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3936,
+          "line": 3944,
           "authority": "native registration"
         },
         {
@@ -56011,7 +56011,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3941,
+          "line": 3949,
           "authority": "native registration"
         },
         {
@@ -56065,7 +56065,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3962,
+          "line": 3970,
           "authority": "native registration"
         },
         {
@@ -56107,7 +56107,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3937,
+          "line": 3945,
           "authority": "native registration"
         },
         {
@@ -56149,7 +56149,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3944,
+          "line": 3952,
           "authority": "native registration"
         },
         {
@@ -56191,7 +56191,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3934,
+          "line": 3942,
           "authority": "native registration"
         },
         {
@@ -56233,7 +56233,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3933,
+          "line": 3941,
           "authority": "native registration"
         },
         {
@@ -56286,7 +56286,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3954,
+          "line": 3962,
           "authority": "native registration"
         },
         {
@@ -56339,7 +56339,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3953,
+          "line": 3961,
           "authority": "native registration"
         },
         {
@@ -56381,7 +56381,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3942,
+          "line": 3950,
           "authority": "native registration"
         },
         {
@@ -56430,7 +56430,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3950,
+          "line": 3958,
           "authority": "native registration"
         },
         {
@@ -56488,7 +56488,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3959,
+          "line": 3967,
           "authority": "native registration"
         },
         {
@@ -56546,7 +56546,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3958,
+          "line": 3966,
           "authority": "native registration"
         },
         {
@@ -56604,7 +56604,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3960,
+          "line": 3968,
           "authority": "native registration"
         },
         {
@@ -56646,7 +56646,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3939,
+          "line": 3947,
           "authority": "native registration"
         },
         {
@@ -56688,7 +56688,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3943,
+          "line": 3951,
           "authority": "native registration"
         },
         {
@@ -56741,7 +56741,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3955,
+          "line": 3963,
           "authority": "native registration"
         },
         {
@@ -56794,7 +56794,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3957,
+          "line": 3965,
           "authority": "native registration"
         },
         {
@@ -56836,7 +56836,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3932,
+          "line": 3940,
           "authority": "native registration"
         },
         {
@@ -56878,7 +56878,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3940,
+          "line": 3948,
           "authority": "native registration"
         },
         {
@@ -56920,7 +56920,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3948,
+          "line": 3956,
           "authority": "native registration"
         },
         {
@@ -56983,7 +56983,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3838,
+          "line": 3846,
           "authority": "native registration"
         },
         {
@@ -57025,7 +57025,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3798,
+          "line": 3806,
           "authority": "native registration"
         },
         {
@@ -57069,7 +57069,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3806,
+          "line": 3814,
           "authority": "native registration"
         },
         {
@@ -57117,7 +57117,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3817,
+          "line": 3825,
           "authority": "native registration"
         },
         {
@@ -57170,7 +57170,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3818,
+          "line": 3826,
           "authority": "native registration"
         },
         {
@@ -57223,7 +57223,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3821,
+          "line": 3829,
           "authority": "native registration"
         },
         {
@@ -57281,7 +57281,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3822,
+          "line": 3830,
           "authority": "native registration"
         },
         {
@@ -57335,7 +57335,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3844,
+          "line": 3852,
           "authority": "native registration"
         },
         {
@@ -57379,7 +57379,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3807,
+          "line": 3815,
           "authority": "native registration"
         },
         {
@@ -57421,7 +57421,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3803,
+          "line": 3811,
           "authority": "native registration"
         },
         {
@@ -57485,7 +57485,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3847,
+          "line": 3855,
           "authority": "native registration"
         },
         {
@@ -57529,7 +57529,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3805,
+          "line": 3813,
           "authority": "native registration"
         },
         {
@@ -57582,7 +57582,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3833,
+          "line": 3841,
           "authority": "native registration"
         },
         {
@@ -57640,7 +57640,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3834,
+          "line": 3842,
           "authority": "native registration"
         },
         {
@@ -57693,7 +57693,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3831,
+          "line": 3839,
           "authority": "native registration"
         },
         {
@@ -57751,7 +57751,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3832,
+          "line": 3840,
           "authority": "native registration"
         },
         {
@@ -57804,7 +57804,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3835,
+          "line": 3843,
           "authority": "native registration"
         },
         {
@@ -57862,7 +57862,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3836,
+          "line": 3844,
           "authority": "native registration"
         },
         {
@@ -57904,7 +57904,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3801,
+          "line": 3809,
           "authority": "native registration"
         },
         {
@@ -57948,7 +57948,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3815,
+          "line": 3823,
           "authority": "native registration"
         },
         {
@@ -58011,7 +58011,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3853,
+          "line": 3861,
           "authority": "native registration"
         },
         {
@@ -58049,7 +58049,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3812,
+          "line": 3820,
           "authority": "native registration"
         },
         {
@@ -58091,7 +58091,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3799,
+          "line": 3807,
           "authority": "native registration"
         },
         {
@@ -58140,7 +58140,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3816,
+          "line": 3824,
           "authority": "native registration"
         },
         {
@@ -58198,7 +58198,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3837,
+          "line": 3845,
           "authority": "native registration"
         },
         {
@@ -58251,7 +58251,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3823,
+          "line": 3831,
           "authority": "native registration"
         },
         {
@@ -58309,7 +58309,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3824,
+          "line": 3832,
           "authority": "native registration"
         },
         {
@@ -58347,7 +58347,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3811,
+          "line": 3819,
           "authority": "native registration"
         },
         {
@@ -58401,7 +58401,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3845,
+          "line": 3853,
           "authority": "native registration"
         },
         {
@@ -58454,7 +58454,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3825,
+          "line": 3833,
           "authority": "native registration"
         },
         {
@@ -58512,7 +58512,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3826,
+          "line": 3834,
           "authority": "native registration"
         },
         {
@@ -58550,7 +58550,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3810,
+          "line": 3818,
           "authority": "native registration"
         },
         {
@@ -58594,7 +58594,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3814,
+          "line": 3822,
           "authority": "native registration"
         },
         {
@@ -58657,7 +58657,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3829,
+          "line": 3837,
           "authority": "native registration"
         },
         {
@@ -58725,7 +58725,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3830,
+          "line": 3838,
           "authority": "native registration"
         },
         {
@@ -58788,7 +58788,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3827,
+          "line": 3835,
           "authority": "native registration"
         },
         {
@@ -58856,7 +58856,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3828,
+          "line": 3836,
           "authority": "native registration"
         },
         {
@@ -58904,7 +58904,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3819,
+          "line": 3827,
           "authority": "native registration"
         },
         {
@@ -58957,7 +58957,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3820,
+          "line": 3828,
           "authority": "native registration"
         },
         {
@@ -58995,7 +58995,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3813,
+          "line": 3821,
           "authority": "native registration"
         },
         {
@@ -59043,7 +59043,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3800,
+          "line": 3808,
           "authority": "native registration"
         },
         {
@@ -59101,7 +59101,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3851,
+          "line": 3859,
           "authority": "native registration"
         },
         {
@@ -59155,7 +59155,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3846,
+          "line": 3854,
           "authority": "native registration"
         },
         {
@@ -59197,7 +59197,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3849,
+          "line": 3857,
           "authority": "native registration"
         },
         {
@@ -59235,7 +59235,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3848,
+          "line": 3856,
           "authority": "native registration"
         },
         {
@@ -59284,7 +59284,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3850,
+          "line": 3858,
           "authority": "native registration"
         },
         {
@@ -59328,7 +59328,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3804,
+          "line": 3812,
           "authority": "native registration"
         },
         {
@@ -59392,7 +59392,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3808,
+          "line": 3816,
           "authority": "native registration"
         },
         {
@@ -59441,7 +59441,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3809,
+          "line": 3817,
           "authority": "native registration"
         },
         {
@@ -59485,7 +59485,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3854,
+          "line": 3862,
           "authority": "native registration"
         },
         {
@@ -59548,7 +59548,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3852,
+          "line": 3860,
           "authority": "native registration"
         },
         {
@@ -59590,7 +59590,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3802,
+          "line": 3810,
           "authority": "native registration"
         },
         {
@@ -59644,7 +59644,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3855,
+          "line": 3863,
           "authority": "native registration"
         },
         {
@@ -59698,7 +59698,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3856,
+          "line": 3864,
           "authority": "native registration"
         },
         {
@@ -61387,7 +61387,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4262,
+          "line": 4265,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61429,7 +61429,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4265,
+          "line": 4268,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61522,7 +61522,7 @@
       "sources": [
         {
           "path": "src/catalua_game_handle.cpp",
-          "line": 265,
+          "line": 323,
           "authority": "native registration"
         },
         {
@@ -61594,12 +61594,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2125,
+          "line": 2135,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2943,
+          "line": 2945,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61618,12 +61618,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2122,
+          "line": 2132,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2942,
+          "line": 2944,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61642,12 +61642,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2128,
+          "line": 2138,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2944,
+          "line": 2946,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61666,12 +61666,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2131,
+          "line": 2141,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2945,
+          "line": 2947,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61690,12 +61690,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2159,
+          "line": 2169,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2954,
+          "line": 2957,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61714,12 +61714,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2156,
+          "line": 2166,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2953,
+          "line": 2956,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61738,12 +61738,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2162,
+          "line": 2172,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2955,
+          "line": 2958,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61762,12 +61762,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2165,
+          "line": 2175,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2956,
+          "line": 2959,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61786,12 +61786,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_missions.cpp",
-          "line": 1228,
+          "line": 1234,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2623,
+          "line": 2624,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61810,12 +61810,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_missions.cpp",
-          "line": 1227,
+          "line": 1233,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2622,
+          "line": 2623,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61834,12 +61834,12 @@
       "sources": [
         {
           "path": "src/catalua_ui_missions.cpp",
-          "line": 1231,
+          "line": 1237,
           "authority": "native registration"
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 2624,
+          "line": 2625,
           "authority": "LuaLS declaration"
         }
       ],
@@ -61978,7 +61978,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3785,
+          "line": 3793,
           "authority": "native registration"
         },
         {
@@ -62002,7 +62002,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3784,
+          "line": 3792,
           "authority": "native registration"
         },
         {
@@ -62026,7 +62026,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3788,
+          "line": 3796,
           "authority": "native registration"
         },
         {
@@ -62050,7 +62050,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3783,
+          "line": 3791,
           "authority": "native registration"
         },
         {
@@ -62074,7 +62074,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3791,
+          "line": 3799,
           "authority": "native registration"
         },
         {
@@ -62098,7 +62098,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3794,
+          "line": 3802,
           "authority": "native registration"
         },
         {
@@ -62122,7 +62122,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3786,
+          "line": 3794,
           "authority": "native registration"
         },
         {
@@ -62146,7 +62146,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3790,
+          "line": 3798,
           "authority": "native registration"
         },
         {
@@ -62170,7 +62170,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3792,
+          "line": 3800,
           "authority": "native registration"
         },
         {
@@ -62194,7 +62194,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3782,
+          "line": 3790,
           "authority": "native registration"
         },
         {
@@ -62218,7 +62218,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3789,
+          "line": 3797,
           "authority": "native registration"
         },
         {
@@ -62242,7 +62242,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3793,
+          "line": 3801,
           "authority": "native registration"
         },
         {
@@ -62266,7 +62266,7 @@
       "sources": [
         {
           "path": "src/catalua_ui.cpp",
-          "line": 3787,
+          "line": 3795,
           "authority": "native registration"
         },
         {
@@ -62535,7 +62535,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4257,
+          "line": 4260,
           "authority": "LuaLS declaration"
         }
       ],
@@ -62559,7 +62559,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4253,
+          "line": 4256,
           "authority": "LuaLS declaration"
         }
       ],
@@ -62583,7 +62583,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4255,
+          "line": 4258,
           "authority": "LuaLS declaration"
         }
       ],
@@ -62607,7 +62607,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4258,
+          "line": 4261,
           "authority": "LuaLS declaration"
         }
       ],
@@ -62631,7 +62631,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4256,
+          "line": 4259,
           "authority": "LuaLS declaration"
         }
       ],
@@ -62655,7 +62655,7 @@
         },
         {
           "path": "data/lua/types/ccb_api_v5.d.lua",
-          "line": 4254,
+          "line": 4257,
           "authority": "LuaLS declaration"
         }
       ],
@@ -62879,7 +62879,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2149,
+          "line": 2159,
           "authority": "native registration"
         }
       ],
@@ -62920,7 +62920,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2147,
+          "line": 2157,
           "authority": "native registration"
         }
       ],
@@ -62966,7 +62966,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2183,
+          "line": 2193,
           "authority": "native registration"
         }
       ],
@@ -63007,7 +63007,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_hordes.cpp",
-          "line": 2181,
+          "line": 2191,
           "authority": "native registration"
         }
       ],
@@ -63053,7 +63053,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_missions.cpp",
-          "line": 1244,
+          "line": 1250,
           "authority": "native registration"
         }
       ],
@@ -63094,7 +63094,7 @@
       "sources": [
         {
           "path": "src/catalua_ui_missions.cpp",
-          "line": 1242,
+          "line": 1248,
           "authority": "native registration"
         }
       ],

--- a/data/lua/reference/ccb_public_api_v5_coverage.json
+++ b/data/lua/reference/ccb_public_api_v5_coverage.json
@@ -10,7 +10,7 @@
       "private C++ helpers without a registered Lua access path"
     ]
   },
-  "inventory_sha256": "c9fdad677118ccefcf679e6b8244a81fb6a0ace556c4239935982491acfb31b1",
+  "inventory_sha256": "e0546335c219dc1d0eb3ec8e16bd08488683bcf9fd0d65dfb058e92c5a97410e",
   "sections": {
     "modules": 3,
     "namespaces": 70,

--- a/data/lua/templates/complete/README.md
+++ b/data/lua/templates/complete/README.md
@@ -18,6 +18,12 @@ and the gameplay random stream only when the static content fingerprint is
 unchanged.  A change to an item or recipe definition deliberately requires a
 full data reload.
 
+`runtime/behaviour.lua` also demonstrates Lua-native predicates: stable
+dimension ids come from `ccb.services.gameplay.environment`, string relations
+use the reusable `gameplay.strings` helpers, and gameplay randomness comes
+from the per-Mod `ccb.services.random` stream.  Build larger conditions as
+ordinary Lua functions and modules; do not recreate EOC key tables.
+
 The `runtime/` directory is only a suggested organization.  The loader does
 not require it, and the scaffold command never overwrites generated files.
 Likewise, `content/token.lua` is an ordinary root-local module with a

--- a/data/lua/templates/complete/content/token.lua
+++ b/data/lua/templates/complete/content/token.lua
@@ -19,8 +19,8 @@ function token_content.register(ccb)
     local recipe = ccb.content.Recipe {
         id = TOKEN_ID,
         result = TOKEN_ID,
-        category = "CC_MISC",
-        subcategory = "CSC_MISC",
+        category = "CC_OTHER",
+        subcategory = "CSC_OTHER_OTHER",
         skill = "fabrication",
         difficulty = 1,
         duration_moves = 500,

--- a/data/lua/templates/complete/runtime/behaviour.lua
+++ b/data/lua/templates/complete/runtime/behaviour.lua
@@ -10,12 +10,16 @@ function behaviour.activate(context)
 end
 
 function behaviour.world_ready(event)
+    local dimension = ccb.services.gameplay.environment.dimension()
+    assert(ccb.services.gameplay.strings.all_equal({ dimension, dimension }))
+    assert(ccb.services.random.int(1, 1) == 1)
     if not ccb.state.world.get("first_load_seen", false) then
         ccb.state.world.set("first_load_seen", true)
         ccb.tasks.after(10, "remind", { text = "Named Lua task resumed." }, 1, "world")
     end
     if event.new_game then
-        ccb.services.message("Lua-first example initialized a new world.")
+        ccb.services.message(
+            "Lua-first example initialized dimension '" .. dimension .. "'.")
     end
 end
 

--- a/data/lua/types/ccb_api_v5.d.lua
+++ b/data/lua/types/ccb_api_v5.d.lua
@@ -308,7 +308,7 @@ local GameEnum = {}
 ---@field value? any
 ---@field error? CcbError
 
----Generation-bound opaque reference to a live native game object.
+---Runtime-owner-, runtime-generation-, and world-generation-bound opaque reference to a live native game object.
 ---@class GameHandle
 ---@field kind '"creature"'|'"item"'|'"vehicle"'
 local GameHandle = {}
@@ -2392,7 +2392,7 @@ function CcbItemsApi.has_flag(handle, flag) end
 ---@param handle GameHandle
 ---@param flag GameId
 ---@param enabled boolean
----@return CcbResult
+---@return CcbResult result `value.changed` reports whether the instance-owned flag changed; effective inherited state is reported separately.
 function CcbItemsApi.set_flag(handle, flag, enabled) end
 
 ---@param handle GameHandle
@@ -2617,7 +2617,8 @@ function CcbSpellsApi.set_favorite(character, id, favorite) end
 ---@return CcbResult
 function CcbSpellsApi.queue_cast(character, id, target) end
 
----Generation-bound mission identity.
+---Runtime-owner-, generation-, and world-bound mission identity. Equality
+---includes the originating runtime owner.
 ---@class MissionToken
 ---@field uid integer
 ---@field runtime_generation integer
@@ -2937,7 +2938,8 @@ function CcbOvermapApi.set_note_danger(position, radius, dangerous) end
 ---@return CcbResult
 function CcbOvermapApi.reveal(center, radius) end
 
----Generation-bound token for an individual overmap horde entity.
+---Runtime-owner-, generation-, and world-bound token for an individual
+---overmap horde entity. Equality includes the originating runtime owner.
 ---@class HordeEntityToken
 ---@field position TripointCoord
 ---@field monster GameId
@@ -2948,7 +2950,8 @@ local HordeEntityToken = {}
 ---@return boolean
 function HordeEntityToken:is_valid() end
 
----Generation-bound token for a legacy aggregate monster group.
+---Runtime-owner-, generation-, and world-bound token for a legacy aggregate
+---monster group. Equality includes the originating runtime owner.
 ---@class LegacyHordeToken
 ---@field position TripointCoord
 ---@field group GameId
@@ -4248,7 +4251,7 @@ function CcbCampsApi.set_owner(position, owner) end
 ---@return CcbResult
 function CcbCampsApi.set_board_position(position, board_position) end
 
----Generation-bound identity of a native zone.
+---Generation- and native-lifetime-bound identity of a native zone. Recreating an identical zone does not revive an old token.
 ---@class ZoneToken
 ---@field faction GameId
 ---@field type GameId

--- a/data/lua/types/ccb_platform_v1.d.lua
+++ b/data/lua/types/ccb_platform_v1.d.lua
@@ -20,6 +20,18 @@
 ---@field core boolean
 local ModDefinition = {}
 
+---@class CcbPlatformBubbleMapSquarePayload
+---@field coordinate_space 'bub_ms' Literal native space tag.
+---@field x integer Bubble map-square x coordinate.
+---@field y integer Bubble map-square y coordinate.
+---@field z integer Bubble map-square z coordinate.
+
+---@class CcbPlatformAbsoluteMapSquarePayload
+---@field coordinate_space 'abs_ms' Literal native space tag.
+---@field x integer Absolute map-square x coordinate.
+---@field y integer Absolute map-square y coordinate.
+---@field z integer Absolute map-square z coordinate.
+
 ---@class ItemDefinitionOptions
 ---@field id string Stable item type id.
 ---@field name? string Display name; defaults to id.
@@ -569,6 +581,45 @@ function SubBodyPartDefinition:location_under(sub_body_part_id) end
 ---@return SubBodyPartDefinition self
 function SubBodyPartDefinition:unarmed_damage(damage_type, amount) end
 
+---@class WoundDefinitionOptions
+---@field id string Stable native wound-type id.
+---@field name? string Player-facing singular name; defaults to id.
+---@field plural_name? string Player-facing plural name; defaults to name.
+---@field description string Non-empty player-facing description.
+---@field pain_min? integer Minimum pain rolled when the wound is created; defaults to zero.
+---@field pain_max? integer Maximum pain no lower than pain_min; defaults to zero.
+---@field healing_min_turns? integer Positive minimum healing duration in turns; defaults to one.
+---@field healing_max_turns? integer Maximum healing duration no shorter than healing_min_turns; defaults to one.
+---@field damage_min? integer Non-negative minimum incoming damage used by natural wound candidate selection.
+---@field damage_max? integer Maximum incoming damage no lower than damage_min, used by natural candidate selection.
+---@field weight? integer Positive relative natural-selection weight; defaults to one.
+---@field per_part_limit? integer Non-negative per-body-part instance limit; zero is unlimited.
+---@field required_body_part_flag? string Existing or same-transaction JsonFlag required when natural damage selection tests a body part.
+---@field forbidden_body_part_flag? string Existing or same-transaction JsonFlag forbidden when natural damage selection tests a body part.
+
+---@class WoundDefinition
+---@field id string
+local WoundDefinition = {}
+---@param id string Existing or same-transaction DamageType id; each id may be added once and at least one is required.
+---@return WoundDefinition self
+function WoundDefinition:damage_type(id) end
+---@param id string Existing or same-transaction LimbScore id.
+---@param penalty number Finite penalty from zero through one.
+---@return WoundDefinition self
+function WoundDefinition:limb_score(id, penalty) end
+---@param id string Existing or same-transaction non-self Wound id.
+---@param chance integer Progression chance from zero through 100.
+---@return WoundDefinition self
+function WoundDefinition:progression(id, chance) end
+---Require this body-part type during natural damage-selection candidate filtering.
+---@param kind 'head'|'torso'|'sensor'|'mouth'|'arm'|'hand'|'leg'|'foot'|'wing'|'tail'|'other'
+---@return WoundDefinition self
+function WoundDefinition:require_body_part_type(kind) end
+---Forbid this body-part type during natural damage-selection candidate filtering.
+---@param kind 'head'|'torso'|'sensor'|'mouth'|'arm'|'hand'|'leg'|'foot'|'wing'|'tail'|'other'
+---@return WoundDefinition self
+function WoundDefinition:forbid_body_part_type(kind) end
+
 ---@class BodyPartDefinitionOptions
 ---@field id string Stable native body-part id.
 ---@field name string Player-facing singular name.
@@ -621,6 +672,37 @@ function BodyPartDefinition:limb_score(limb_score_id, score, maximum) end
 ---@param disable_fraction? number Fraction from zero through one.
 ---@return BodyPartDefinition self
 function BodyPartDefinition:quality(quality_id, level, disable_fraction) end
+
+---@class WoundFixDefinitionOptions
+---@field id string Stable native wound-fix id.
+---@field name? string Player-facing action name; defaults to id.
+---@field description string Non-empty player-facing treatment description.
+---@field success_message? string Player-facing successful-treatment message.
+---@field duration_turns? integer Non-negative base duration whose move cost fits the native integer range.
+---@field health_delta? integer Signed body-part HP change applied by the treatment.
+
+---@class WoundFixDefinition
+---@field id string
+local WoundFixDefinition = {}
+---@param id string Existing or same-transaction Skill id.
+---@param level integer Required level from zero through the native skill maximum.
+---@return WoundFixDefinition self
+function WoundFixDefinition:skill(id, level) end
+---@param id string Existing or same-transaction Proficiency id.
+---@param multiplier number Positive finite treatment-time multiplier that remains positive as a native float.
+---@param mandatory boolean Whether the proficiency is required to perform the treatment.
+---@return WoundFixDefinition self
+function WoundFixDefinition:proficiency(id, multiplier, mandatory) end
+---@param id string Existing or same-transaction Wound id removed by the treatment; at least one removal is required.
+---@return WoundFixDefinition self
+function WoundFixDefinition:removes(id) end
+---@param id string Existing or same-transaction Wound id added by the treatment.
+---@return WoundFixDefinition self
+function WoundFixDefinition:adds(id) end
+---@param id string Existing or same-transaction Requirement id.
+---@param count integer Positive native requirement multiplier; multiplied and subsequently consolidated component/tool counts must fit signed native integers.
+---@return WoundFixDefinition self
+function WoundFixDefinition:requires(id, count) end
 
 ---@class AnatomyDefinitionOptions
 ---@field id string Stable native anatomy id.
@@ -833,7 +915,7 @@ function SpeciesDefinition:placate(trigger) end
 
 ---@class EmissionProfilePayload
 ---@field emission_id string
----@field position CcbCoordinateTable Bubble map-square position of this emission.
+---@field position CcbPlatformBubbleMapSquarePayload Detached bubble map-square position of this emission.
 ---@field fallback EmissionProfile Immutable static fallback authored on the definition.
 
 ---@class EmissionDefinition
@@ -1238,9 +1320,9 @@ function ExplosionLightDefinition:shockwave(options) end
 ---@class AmmoImpactPolicyPayload
 ---@field ammo_effect_id string
 ---@field dealt_damage integer
----@field source CcbGameHandle|nil
----@field target CcbGameHandle|nil
----@field position CcbCoordinateTable
+---@field source GameHandle|nil Generation-checked source creature when present.
+---@field target GameHandle|nil Generation-checked target creature when present.
+---@field position CcbPlatformBubbleMapSquarePayload Detached impact position.
 
 ---@class AmmoEffectDefinition
 ---@field id string
@@ -1303,7 +1385,7 @@ function AmmoEffectDefinition:impact_policy(handler_id) end
 ---@field addiction_type_id string
 ---@field intensity integer
 ---@field sated_turns integer
----@field character CcbGameHandle Generation-checked addicted character.
+---@field character GameHandle Generation-checked addicted character.
 
 ---@class AddictionTypeDefinition
 ---@field id string
@@ -1321,7 +1403,7 @@ function AddictionTypeDefinition:tick_policy(handler_id) end
 ---@class CharacterModifierPayload
 ---@field modifier_id string
 ---@field skill_id string Empty when the consumer did not provide a skill.
----@field character CcbGameHandle Generation-checked character being evaluated.
+---@field character GameHandle Generation-checked character being evaluated.
 
 ---@class CharacterModifierDefinition
 ---@field id string
@@ -1465,7 +1547,7 @@ function ClimbingAidDefinition:deploy(furniture_id) end
 ---@field wind_description string
 ---@field wind_direction integer
 ---@field turn integer
----@field location CcbCoordinateTable Absolute map-square sample location.
+---@field location CcbPlatformAbsoluteMapSquarePayload Detached absolute map-square sample location.
 
 ---@class WeatherTypeDefinition
 ---@field id string
@@ -2103,11 +2185,13 @@ local WeaponCategoryDefinition = {}
 ---@return WeaponCategoryDefinition self
 function WeaponCategoryDefinition:proficiency(proficiency_id) end
 
+---Non-copyable borrowed callback context. Every member becomes stale after the
+---item-use handler returns or fails; saving the userdata does not extend its lease.
 ---@class ItemUseContext
 ---@field player_name string
 ---@field item_id string
----@field character GameHandle Generation-safe handle for the using character.
----@field item GameHandle Generation-safe handle for the used item instance.
+---@field character GameHandle Runtime-owner- and generation-safe handle for the using character.
+---@field item GameHandle Runtime-owner- and generation-safe handle for the used item instance.
 ---@field position TripointCoord Reality-bubble map-square (`bub`/`ms`) position of use.
 ---@field charges integer
 local ItemUseContext = {}
@@ -2234,9 +2318,17 @@ function CcbPlatformContent.ItemGroup(options) end
 ---@return SubBodyPartDefinition
 function CcbPlatformContent.SubBodyPart(options) end
 
+---@param options WoundDefinitionOptions
+---@return WoundDefinition
+function CcbPlatformContent.Wound(options) end
+
 ---@param options BodyPartDefinitionOptions
 ---@return BodyPartDefinition
 function CcbPlatformContent.BodyPart(options) end
+
+---@param options WoundFixDefinitionOptions
+---@return WoundFixDefinition
+function CcbPlatformContent.WoundFix(options) end
 
 ---@param options AnatomyDefinitionOptions
 ---@return AnatomyDefinition
@@ -2441,7 +2533,7 @@ function CcbPlatformContent.MagicType(options) end
 ---@return MovementModeDefinition
 function CcbPlatformContent.MovementMode(options) end
 
----@alias PlatformContentDefinition ItemDefinition|RecipeDefinition|NestedRecipeCategoryDefinition|ToolQualityDefinition|SkillDisplayDefinition|SkillDefinition|VitaminDefinition|JsonFlagDefinition|DamageTypeDefinition|MaterialDefinition|AmmunitionTypeDefinition|ItemCategoryDefinition|RecipeCategoryDefinition|ProficiencyCategoryDefinition|ProficiencyDefinition|WeaponCategoryDefinition|RequirementDefinition|RecipeGroupDefinition|ScentTypeDefinition|SpeedDescriptionDefinition|HarvestDropTypeDefinition|HarvestDefinition|BehaviorDefinition|MonsterAttackDefinition|EffectTypeDefinition|WeakpointSetDefinition|FieldTypeDefinition|ItemGroupDefinition|SubBodyPartDefinition|BodyPartDefinition|AnatomyDefinition|BodyGraphDefinition|MonsterDefinition|MoraleTypeDefinition|DiseaseTypeDefinition|MonsterFlagDefinition|SpeciesDefinition|EmissionDefinition|MonsterFactionDefinition|MutationTypeDefinition|ConnectGroupDefinition|MutationCategoryDefinition|ConstructionCategoryDefinition|ConstructionGroupDefinition|VehiclePartLocationDefinition|MoodFaceDefinition|DamageInfoOrderDefinition|VehiclePartCategoryDefinition|NamedColorDefinition|RotatableSymbolDefinition|AsciiArtDefinition|LimbScoreDefinition|HitRangeDefinition|BashDamageProfileDefinition|ClothingModDefinition|OvermapLandUseCodeDefinition|OvermapVisionDefinition|OvermapLocationDefinition|ProfessionGroupDefinition|MapExtraCollectionDefinition|VehicleGroupDefinition|FaultGroupDefinition|ExplosionLightDefinition|AmmoEffectDefinition|AddictionTypeDefinition|CharacterModifierDefinition|StartLocationDefinition|ClimbingAidDefinition|WeatherTypeDefinition|ScoreDefinition|OverlayOrderDefinition|ZoneTypeDefinition|SpeechPoolDefinition|EndScreenDefinition|ActivityTypeDefinition|HelpTopicDefinition|SnippetCategoryDefinition|PlaylistDefinition|AttackVectorDefinition|MagicTypeDefinition|MovementModeDefinition
+---@alias PlatformContentDefinition ItemDefinition|RecipeDefinition|NestedRecipeCategoryDefinition|ToolQualityDefinition|SkillDisplayDefinition|SkillDefinition|VitaminDefinition|JsonFlagDefinition|DamageTypeDefinition|MaterialDefinition|AmmunitionTypeDefinition|ItemCategoryDefinition|RecipeCategoryDefinition|ProficiencyCategoryDefinition|ProficiencyDefinition|WeaponCategoryDefinition|RequirementDefinition|RecipeGroupDefinition|ScentTypeDefinition|SpeedDescriptionDefinition|HarvestDropTypeDefinition|HarvestDefinition|BehaviorDefinition|MonsterAttackDefinition|EffectTypeDefinition|WeakpointSetDefinition|FieldTypeDefinition|ItemGroupDefinition|SubBodyPartDefinition|WoundDefinition|BodyPartDefinition|WoundFixDefinition|AnatomyDefinition|BodyGraphDefinition|MonsterDefinition|MoraleTypeDefinition|DiseaseTypeDefinition|MonsterFlagDefinition|SpeciesDefinition|EmissionDefinition|MonsterFactionDefinition|MutationTypeDefinition|ConnectGroupDefinition|MutationCategoryDefinition|ConstructionCategoryDefinition|ConstructionGroupDefinition|VehiclePartLocationDefinition|MoodFaceDefinition|DamageInfoOrderDefinition|VehiclePartCategoryDefinition|NamedColorDefinition|RotatableSymbolDefinition|AsciiArtDefinition|LimbScoreDefinition|HitRangeDefinition|BashDamageProfileDefinition|ClothingModDefinition|OvermapLandUseCodeDefinition|OvermapVisionDefinition|OvermapLocationDefinition|ProfessionGroupDefinition|MapExtraCollectionDefinition|VehicleGroupDefinition|FaultGroupDefinition|ExplosionLightDefinition|AmmoEffectDefinition|AddictionTypeDefinition|CharacterModifierDefinition|StartLocationDefinition|ClimbingAidDefinition|WeatherTypeDefinition|ScoreDefinition|OverlayOrderDefinition|ZoneTypeDefinition|SpeechPoolDefinition|EndScreenDefinition|ActivityTypeDefinition|HelpTopicDefinition|SnippetCategoryDefinition|PlaylistDefinition|AttackVectorDefinition|MagicTypeDefinition|MovementModeDefinition
 
 ---@param definition PlatformContentDefinition
 function CcbPlatformContent.add(definition) end
@@ -2566,9 +2658,17 @@ function CcbPlatformContent.edit_item_group(id) end
 ---@return SubBodyPartDefinition
 function CcbPlatformContent.edit_sub_body_part(id) end
 
+---@param id string Wound id staged earlier by this Mod.
+---@return WoundDefinition
+function CcbPlatformContent.edit_wound(id) end
+
 ---@param id string BodyPart id staged earlier by this Mod.
 ---@return BodyPartDefinition
 function CcbPlatformContent.edit_body_part(id) end
+
+---@param id string Wound-fix id staged earlier by this Mod.
+---@return WoundFixDefinition
+function CcbPlatformContent.edit_wound_fix(id) end
 
 ---@param id string Anatomy id staged earlier by this Mod.
 ---@return AnatomyDefinition
@@ -2769,6 +2869,35 @@ function CcbPlatformContent.edit_magic_type(id) end
 ---@return MovementModeDefinition
 function CcbPlatformContent.edit_movement_mode(id) end
 
+---@class CcbPlatformNativeEvent
+---@field type string Native event type without the `game:` prefix.
+---@field turn integer Absolute event turn.
+---@field data table<string, boolean|integer|string>
+---@field data_types table<string, string>
+---Live handles keyed by semantic native event fields. Character-id fields use
+---names such as `character`, `attacker`, `killer`, or `victim`. `item` exists
+---only for character_wields_item, character_wears_item,
+---character_takeoff_item, and character_armor_destroyed when the native event
+---actually carries an item_location talker. No positional/avatar fallback or
+---EOC alpha/beta aliases are added.
+---@field actors table<string, GameHandle>
+
+---@class CcbPlatformDialogueStartHook
+---@field avatar GameHandle The avatar starting the dialogue.
+---@field interlocutor GameHandle|table The creature/entity handle or detached non-entity talker snapshot.
+---@field initial_topic string Initial dialogue topic id.
+
+---@class CcbPlatformDialogueOptionHook
+---@field avatar GameHandle The avatar participating in the dialogue.
+---@field interlocutor GameHandle|table The creature/entity handle or detached non-entity talker snapshot.
+---@field current_topic string Topic being left.
+---@field selected_topic string Topic selected by the native dialogue response.
+
+---@class CcbPlatformDialogueEndHook
+---@field avatar GameHandle The avatar ending the dialogue.
+---@field interlocutor GameHandle|table The creature/entity handle or detached non-entity talker snapshot.
+---@field last_topic string Last processed dialogue topic id.
+
 ---@class CcbPlatformRuntime
 local CcbPlatformRuntime = {}
 
@@ -2870,9 +2999,10 @@ function CcbPlatformPresentation.choose(prompt, entries) end
 function CcbPlatformPresentation.input_text(prompt, options) end
 
 ---@class CcbPlatformServices
----@field achievements CcbAchievementsApi
+---@field achievements CcbPlatformAchievementsApi
+---@field activities CcbPlatformActivitiesApi
 ---@field addictions CcbAddictionsApi
----@field bionics CcbBionicsApi
+---@field bionics CcbPlatformBionicsApi
 ---@field camps CcbCampsApi
 ---@field characters CcbCharactersApi
 ---@field constants CcbConstantsApi
@@ -2883,20 +3013,21 @@ function CcbPlatformPresentation.input_text(prompt, options) end
 ---@field enums CcbEnumsApi
 ---@field factions CcbFactionsApi
 ---@field followers CcbFollowersApi
----@field handles CcbHandlesApi
+---@field handles CcbHandlesApi Handles are bound to the exact Platform Mod runtime owner as well as its runtime/world generations.
 ---@field hordes CcbHordesApi
----@field inventory CcbInventoryApi
+---@field inventory CcbPlatformInventoryApi
 ---@field items CcbItemsApi
----@field martial_arts CcbMartialArtsApi
+---@field martial_arts CcbPlatformMartialArtsApi
 ---@field messages CcbMessagesApi
 ---@field missions CcbMissionsApi
+---@field morale CcbPlatformMoraleApi
 ---@field mutations CcbMutationsApi
 ---@field needs CcbNeedsApi
 ---@field npcs CcbNpcsApi
 ---@field overmap CcbOvermapApi
 ---@field proficiencies CcbProficienciesApi
----@field random CcbRandomApi
----@field recipes CcbRecipesApi
+---@field random CcbPlatformRandomApi
+---@field recipes CcbPlatformRecipesApi
 ---@field relocation CcbRelocationApi
 ---@field requirements CcbRequirementsApi
 ---@field serde CcbSerdeApi
@@ -2913,9 +3044,292 @@ function CcbPlatformPresentation.input_text(prompt, options) end
 ---@field vehicles CcbVehiclesApi
 ---@field vitamins CcbVitaminsApi
 ---@field weather CcbWeatherApi
+---@field wounds CcbPlatformWoundsApi
 ---@field world CcbWorldApi
 ---@field zones CcbZonesApi
+---@field gameplay CcbPlatformGameplayApi
 local CcbPlatformServices = {}
+
+---@class CcbPlatformInventoryApi: CcbInventoryApi
+local CcbPlatformInventoryApi = {}
+
+---Return the Character's singular physical wielded item without scanning a page.
+---A force-unarmed martial-art style does not hide a physically wielded item;
+---compose that policy separately through `martial_arts.current`.
+---@param character GameHandle Character handle.
+---@return CcbResult result `value` is a live item GameHandle or nil when no item is wielded.
+function CcbPlatformInventoryApi.wielded(character) end
+
+---@class CcbPlatformAchievementsApi: CcbAchievementsApi
+local CcbPlatformAchievementsApi = {}
+
+---Complete any currently tracked pending achievement, matching native gameplay awards.
+---@param id GameId GameId<achievement>
+---@return CcbResult result `value` is true only when this call changed the completion state.
+function CcbPlatformAchievementsApi.complete(id) end
+
+---@class CcbPlatformActivitySnapshot
+---@field active boolean
+---@field id? GameId GameId<activity>; nil when no activity is active.
+---@field verb string Player-facing progressive verb, or an empty string when inactive.
+---@field moves_total integer Native total move budget.
+---@field moves_left integer Native remaining move budget.
+---@field interruptible boolean
+---@field interruptible_with_keyboard boolean
+---@field auto_resume boolean
+---@field rooted boolean
+---@field resumable boolean
+---@field progress number Clamped progress from zero through one when the move budget permits it.
+
+---@class CcbPlatformActivityMutation
+---@field changed boolean
+---@field activity CcbPlatformActivitySnapshot Resulting current activity.
+
+---@class CcbPlatformActivitiesApi
+local CcbPlatformActivitiesApi = {}
+
+---Read a detached snapshot of one Character's current native activity.
+---@param character GameHandle Character handle.
+---@return CcbResult result `value` is a CcbPlatformActivitySnapshot.
+function CcbPlatformActivitiesApi.snapshot(character) end
+
+---Assign a plain time-based activity through native Character assignment rules.
+---Native actors/handlers, EOC policies, multi-activity workflows, automatic-needs
+---activities, and speed/neither budgets require dedicated Lua-native services.
+---@param character GameHandle Character handle.
+---@param id GameId GameId<activity>
+---@param duration TimeDuration Positive duration whose move budget fits the native integer range.
+---@return CcbResult result `value` is a CcbPlatformActivityMutation.
+function CcbPlatformActivitiesApi.assign_timed(character, id, duration) end
+
+---Cancel the current activity through native cleanup, backlog, and resumption rules.
+---@param character GameHandle Character handle.
+---@return CcbResult result `value` is a CcbPlatformActivityMutation.
+function CcbPlatformActivitiesApi.cancel(character) end
+
+---@class CcbPlatformWoundSnapshot
+---@field id GameId GameId<wound>
+---@field base_pain integer Pain rolled when this wound instance was created.
+---@field current_pain integer Current pain after native healing attenuation.
+---@field healing_time TimeDuration Total native healing duration.
+---@field healing_progress TimeDuration Accumulated native healing progress.
+---@field healing_fraction number Native healing fraction from zero through one.
+
+---@class CcbPlatformWoundMutation
+---@field changed boolean Whether the exact body-part wound sequence changed.
+---@field before CcbPlatformWoundSnapshot[] Detached native-order snapshot before mutation.
+---@field after CcbPlatformWoundSnapshot[] Detached native-order snapshot after mutation.
+
+---@class CcbPlatformWoundsApi
+local CcbPlatformWoundsApi = {}
+
+---Read one Character's wounds on an exact current-anatomy body part.
+---No nearest-part or other body-part fallback is performed.
+---Wrong GameId kinds or unknown ids raise invalid_argument; handle, target,
+---and missing-part failures use the returned CcbResult error.
+---@param character GameHandle Character handle.
+---@param body_part GameId GameId<body_part>
+---@return CcbResult result `value` is a dense native-order CcbPlatformWoundSnapshot array.
+function CcbPlatformWoundsApi.snapshot(character, body_part) end
+
+---Add or worsen one typed wound on an exact body part; runtime-callback write only.
+---The Wound per-part limit is authoritative; reaching it returns `changed = false`.
+---The explicit body part is authoritative: direct add bypasses the Wound's natural
+---damage-selection body-part eligibility.  A changed add immediately resynchronizes
+---the Character's perceived-pain derived state.
+---Wrong GameId kinds or unknown ids raise invalid_argument before mutation.
+---@param character GameHandle Character handle.
+---@param body_part GameId GameId<body_part>
+---@param wound GameId GameId<wound>
+---@return CcbResult result `value` is a CcbPlatformWoundMutation with detached native-order before/after arrays.
+function CcbPlatformWoundsApi.add(character, body_part, wound) end
+
+---Remove every instance of one wound type from an exact body part; runtime-callback write only.
+---A changed removal immediately resynchronizes the Character's perceived-pain derived state.
+---Wrong GameId kinds or unknown ids raise invalid_argument before mutation.
+---@param character GameHandle Character handle.
+---@param body_part GameId GameId<body_part>
+---@param wound GameId GameId<wound>
+---@return CcbResult result `value` has detached native-order before/after arrays; absent instances produce `changed = false`.
+function CcbPlatformWoundsApi.remove(character, body_part, wound) end
+
+---@class CcbPlatformBionicsApi: CcbBionicsApi
+local CcbPlatformBionicsApi = {}
+
+---@class CcbPlatformBionicSummary
+---@field installed_count integer Number of installed bionic instances; power-storage capacity may exist without an instance.
+---@field power UnitValue Current bionic energy.
+---@field maximum_power UnitValue Maximum bionic energy.
+---@field has_capacity boolean Whether maximum bionic energy is greater than zero.
+
+---Read composable installed-count and power-capacity facts without a paginated instance scan.
+---@param character GameHandle Character handle.
+---@return CcbResult result `value` is a CcbPlatformBionicSummary.
+function CcbPlatformBionicsApi.summary(character) end
+
+---Grant a bionic through native gameplay rules without the v5 inspection-list limit.
+---@param character GameHandle Character handle.
+---@param id GameId GameId<bionic>
+---@return CcbResult result `value.changed` reports whether the character gained instances.
+function CcbPlatformBionicsApi.grant(character, id) end
+
+---Remove the first matching bionic instance through native gameplay rules.
+---@param character GameHandle Character handle.
+---@param id GameId GameId<bionic>
+---@return CcbResult result `value.changed` reports whether an instance was removed.
+function CcbPlatformBionicsApi.remove_type(character, id) end
+
+---@class CcbPlatformRecipesApi: CcbRecipesApi
+local CcbPlatformRecipesApi = {}
+
+---Query learned knowledge rather than temporary book/helper availability.
+---@param character GameHandle Character handle.
+---@param id GameId GameId<recipe>
+---@return CcbResult result `value` is true only when the Character knows this recipe.
+function CcbPlatformRecipesApi.knows(character, id) end
+
+---Teach a recipe through native character rules, including `never_learn` policy.
+---@param character GameHandle Character handle.
+---@param id GameId GameId<recipe>
+---@return CcbResult result `value.changed` reports whether learned state changed; `value.known` is the resulting state.
+function CcbPlatformRecipesApi.learn(character, id) end
+
+---Forget one learned recipe through native character rules.
+---@param character GameHandle Character handle.
+---@param id GameId GameId<recipe>
+---@return CcbResult result `value.changed` reports whether learned state changed; `value.known` is the resulting state.
+function CcbPlatformRecipesApi.forget(character, id) end
+
+---@class CcbPlatformRecipeCategoryForget
+---@field changed boolean Whether at least one learned recipe was forgotten.
+---@field forgotten_count integer Number of learned recipes removed.
+---@field known_before integer Learned-recipe count before removal.
+---@field known_after integer Learned-recipe count after removal.
+---@field category GameId GameId<crafting_category> used for selection.
+---@field subcategory? string Optional native subcategory selector.
+
+---Forget every learned recipe in one category, optionally narrowed to a subcategory.
+---This does not enumerate or mutate recipes available only from books, helpers, or other temporary sources.
+---Native CSC_ALL/FAVORITE/RECENT/HIDDEN selectors retain their engine selection rules.
+---@param character GameHandle Character handle.
+---@param category GameId GameId<crafting_category>
+---@param subcategory? string Native subcategory id; omitted or empty selects the whole category.
+---@return CcbResult result `value` is a CcbPlatformRecipeCategoryForget.
+function CcbPlatformRecipesApi.forget_category(character, category, subcategory) end
+
+---@class CcbPlatformMartialArtsApi: CcbMartialArtsApi
+local CcbPlatformMartialArtsApi = {}
+
+---Learn one martial-art style without coupling the mutation to presentation.
+---@param character GameHandle Character handle.
+---@param id GameId GameId<martial_art>
+---@return CcbResult result `value.changed` reports whether known state changed; `value.known` is the resulting state.
+function CcbPlatformMartialArtsApi.learn(character, id) end
+
+---Forget one martial-art style through the character's native style collection.
+---@param character GameHandle Character handle.
+---@param id GameId GameId<martial_art>
+---@return CcbResult result `value.changed` reports whether known state changed; `value.known` is the resulting state.
+function CcbPlatformMartialArtsApi.forget(character, id) end
+
+---@class CcbPlatformMoraleOptions
+---@field duration? TimeDuration Non-negative; defaults to one hour.
+---@field decay_start? TimeDuration Non-negative; defaults to thirty minutes.
+---@field capped? boolean Defaults to false.
+
+---@class CcbPlatformMoraleApi
+local CcbPlatformMoraleApi = {}
+
+---Add or combine one typed morale instance through native stacking rules.
+---@param character GameHandle Character handle.
+---@param id GameId GameId<morale>
+---@param bonus integer
+---@param max_bonus integer
+---@param options? CcbPlatformMoraleOptions
+---@return CcbResult result `value.before` and `value.after` are the matching net bonuses.
+function CcbPlatformMoraleApi.add(character, id, bonus, max_bonus, options) end
+
+---Remove all item-specific variants of one morale type.
+---@param character GameHandle Character handle.
+---@param id GameId GameId<morale>
+---@return CcbResult result `value.before` and `value.after` are the matching net bonuses; `value.changed` reports whether they differ.
+function CcbPlatformMoraleApi.remove(character, id) end
+
+---@class CcbPlatformRandomApi: CcbRandomApi
+local CcbPlatformRandomApi = {}
+
+---@param minimum integer Inclusive lower bound in -1000000000..1000000000.
+---@param maximum integer Inclusive upper bound in -1000000000..1000000000.
+---@return integer
+function CcbPlatformRandomApi.int(minimum, maximum) end
+
+---@param numerator integer
+---@param denominator integer Positive denominator up to 1000000000.
+---@return boolean
+function CcbPlatformRandomApi.chance(numerator, denominator) end
+
+---@param denominator number Converted to a native integer; values at or below one always succeed.
+---@return boolean
+function CcbPlatformRandomApi.one_in(denominator) end
+
+---@param numerator number
+---@param denominator number Positive finite denominator with `0 <= numerator <= denominator`.
+---@return boolean
+function CcbPlatformRandomApi.probability(numerator, denominator) end
+
+---@param minimum integer Inclusive lower bound.
+---@param maximum integer Inclusive upper bound.
+---@param count integer Number of results from 0 through 1024.
+---@param with_replacement? boolean Defaults to false.
+---@return integer[] values Dense sampled values; unique unless replacement was requested.
+function CcbPlatformRandomApi.sample_integers(minimum, maximum, count, with_replacement) end
+
+---@param check number
+---@param difficulty number
+---@param die_size? integer Defaults to 10.
+---@return boolean success True when `random(1, die_size) + check > difficulty`.
+function CcbPlatformRandomApi.contested(check, difficulty, die_size) end
+
+---@class CcbPlatformStringPredicates
+local CcbPlatformStringPredicates = {}
+
+---@param values string[] At least two strings.
+---@return boolean duplicate_found
+function CcbPlatformStringPredicates.any_equal(values) end
+
+---@param values string[] At least one string.
+---@return boolean all_match
+function CcbPlatformStringPredicates.all_equal(values) end
+
+---@class CcbPlatformModQueries
+local CcbPlatformModQueries = {}
+
+---@param mod_id string
+---@return boolean loaded Includes active Lua-first Platform Mods and the world's active Mod order.
+function CcbPlatformModQueries.is_loaded(mod_id) end
+
+---@class CcbPlatformEnvironmentQueries
+local CcbPlatformEnvironmentQueries = {}
+
+---@return string dimension_id Stable id of the currently active dimension.
+function CcbPlatformEnvironmentQueries.dimension() end
+
+---@param position TripointCoord Absolute map-square coordinate inside the active map.
+---@return boolean
+function CcbPlatformEnvironmentQueries.is_outside(position) end
+
+---@param from TripointCoord Absolute map-square coordinate inside the active map.
+---@param to TripointCoord Absolute map-square coordinate inside the active map.
+---@param range integer Non-negative maximum range.
+---@param with_fields? boolean Defaults to true.
+---@return boolean visible
+function CcbPlatformEnvironmentQueries.line_of_sight(from, to, range, with_fields) end
+
+---@class CcbPlatformGameplayApi
+---@field strings CcbPlatformStringPredicates
+---@field mods CcbPlatformModQueries
+---@field environment CcbPlatformEnvironmentQueries
+local CcbPlatformGameplayApi = {}
 
 ---@param text string
 function CcbPlatformServices.message(text) end

--- a/data/mods/Lua_First_Example/README.md
+++ b/data/mods/Lua_First_Example/README.md
@@ -1,9 +1,10 @@
 # Lua-first bundled example
 
 This optional bundled Mod contains no JSON, EOC, manifest, or required `lua/`
-directory.  The directory name supplies its default Mod id.  `main.lua`
-composes ordinary local modules that create a native item and recipe and bind
-their behaviour to named Lua functions.
+directory.  Its optional native `mod.lua` supplies display metadata and the
+core dependency without using `modinfo.json`.  `main.lua` composes ordinary
+local modules that create a native item and recipe and bind their behaviour to
+named Lua functions.
 
 The example is intentionally small.  It is an executable migration fixture
 for the implemented Platform slice, not a claim that every legacy static
@@ -13,5 +14,12 @@ generation-safe character/item handles and tagged map position exposed by
 not in live handles.
 
 Its `world_ready` handler also exercises the per-Mod random stream, stable
-dimension query, and reusable string predicates.  These are ordinary
-Lua-composition examples rather than EOC-shaped compatibility calls.
+dimension query, reusable string predicates, typed world state, and one named
+persistent task.  The task survives a save/reload cycle and emits its reminder
+after ten turns.  These are ordinary Lua-composition examples rather than
+EOC-shaped compatibility calls.
+
+The repository's `[playable_mvp]` test treats this directory as an installed
+Mod, selects it through the real Mod manager, loads and uses its item, performs
+real game saves, destroys the Lua runtime, reloads all data, and proves that
+the item behaviour, typed state, and delayed task continue correctly.

--- a/data/mods/Lua_First_Example/README.md
+++ b/data/mods/Lua_First_Example/README.md
@@ -11,3 +11,7 @@ content domain has already been replaced.  Its item callback can use the
 generation-safe character/item handles and tagged map position exposed by
 `ItemUseContext`; durable data belongs in `ccb.state` or named task payloads,
 not in live handles.
+
+Its `world_ready` handler also exercises the per-Mod random stream, stable
+dimension query, and reusable string predicates.  These are ordinary
+Lua-composition examples rather than EOC-shaped compatibility calls.

--- a/data/mods/Lua_First_Example/content/cleanwater_charm.lua
+++ b/data/mods/Lua_First_Example/content/cleanwater_charm.lua
@@ -17,8 +17,8 @@ function content.register(ccb)
     local recipe = ccb.content.Recipe {
         id = "lua_first_cleanwater_charm",
         result = "lua_first_cleanwater_charm",
-        category = "CC_MISC",
-        subcategory = "CSC_MISC",
+        category = "CC_OTHER",
+        subcategory = "CSC_OTHER_OTHER",
         skill = "fabrication",
         difficulty = 1,
         duration_moves = 500,

--- a/data/mods/Lua_First_Example/main.lua
+++ b/data/mods/Lua_First_Example/main.lua
@@ -4,6 +4,7 @@ local behaviour = require("runtime.behaviour")
 
 ccb.runtime.handler("use_cleanwater_charm", behaviour.use_charm, 1)
 ccb.runtime.handler("lua_first_example_ready", behaviour.world_ready, 1)
+ccb.runtime.handler("lua_first_example_reminder", behaviour.remind, 1)
 ccb.runtime.on("world_ready", "lua_first_example_ready")
 
 content.register(ccb)

--- a/data/mods/Lua_First_Example/mod.lua
+++ b/data/mods/Lua_First_Example/mod.lua
@@ -1,0 +1,8 @@
+local ccb = require("ccb")
+
+return ccb.ModDefinition {
+    id = "Lua_First_Example",
+    name = "Lua-first playable example",
+    version = "0.1.0",
+    dependencies = { "dda" },
+}

--- a/data/mods/Lua_First_Example/runtime/behaviour.lua
+++ b/data/mods/Lua_First_Example/runtime/behaviour.lua
@@ -10,8 +10,12 @@ function behaviour.use_charm(context)
 end
 
 function behaviour.world_ready(event)
+    local dimension = ccb.services.gameplay.environment.dimension()
+    assert(ccb.services.gameplay.strings.all_equal({ dimension, dimension }))
+    assert(ccb.services.random.int(1, 1) == 1)
     if event.new_game then
-        ccb.services.message("Lua-first bundled example is active.")
+        ccb.services.message(
+            "Lua-first bundled example is active in dimension '" .. dimension .. "'.")
     end
 end
 

--- a/data/mods/Lua_First_Example/runtime/behaviour.lua
+++ b/data/mods/Lua_First_Example/runtime/behaviour.lua
@@ -13,10 +13,22 @@ function behaviour.world_ready(event)
     local dimension = ccb.services.gameplay.environment.dimension()
     assert(ccb.services.gameplay.strings.all_equal({ dimension, dimension }))
     assert(ccb.services.random.int(1, 1) == 1)
+    if not ccb.state.world.get("cleanwater_example_initialized", false) then
+        ccb.state.world.set("cleanwater_example_initialized", true)
+        ccb.tasks.after(10, "lua_first_example_reminder", {
+            text = "The clean-water charm remembers this world after loading.",
+        }, 1, "world")
+    end
     if event.new_game then
         ccb.services.message(
             "Lua-first bundled example is active in dimension '" .. dimension .. "'.")
     end
+end
+
+function behaviour.remind(task)
+    local reminders = ccb.state.world.get("cleanwater_example_reminders", 0) + 1
+    ccb.state.world.set("cleanwater_example_reminders", reminders)
+    ccb.services.message(task.payload.text)
 end
 
 return behaviour

--- a/data/reference/json/ccb_eoc_conditions.json
+++ b/data/reference/json/ccb_eoc_conditions.json
@@ -4,7 +4,7 @@
   "inventory_kind": "eoc_conditions",
   "source": {
     "project": "Cataclysm-Cleanwater-Bomb",
-    "source_fingerprint": "sha256:3a9fb8e631868a91950ce2c4646bf101b85eb33458cfb5c71f03c58cb0d0bee4",
+    "source_fingerprint": "sha256:939c256fc667b769da6fa02c29b914a8c6ad0a087944c0923552625adaff7e48",
     "contract_roots": [
       "data/core",
       "data/json",

--- a/data/reference/json/ccb_eoc_effects.json
+++ b/data/reference/json/ccb_eoc_effects.json
@@ -4,7 +4,7 @@
   "inventory_kind": "eoc_effects",
   "source": {
     "project": "Cataclysm-Cleanwater-Bomb",
-    "source_fingerprint": "sha256:3a9fb8e631868a91950ce2c4646bf101b85eb33458cfb5c71f03c58cb0d0bee4",
+    "source_fingerprint": "sha256:939c256fc667b769da6fa02c29b914a8c6ad0a087944c0923552625adaff7e48",
     "contract_roots": [
       "data/core",
       "data/json",
@@ -21207,7 +21207,7 @@
       "contract_kind": "effect",
       "example_evidence": {
         "status": "lexical_candidate",
-        "occurrences": 1344,
+        "occurrences": 1345,
         "examples": [
           {
             "path": "data/json/effects_on_condition/addictions_eocs.json",

--- a/data/reference/json/ccb_json_object_types.json
+++ b/data/reference/json/ccb_json_object_types.json
@@ -4,7 +4,7 @@
   "inventory_kind": "json_object_types",
   "source": {
     "project": "Cataclysm-Cleanwater-Bomb",
-    "source_fingerprint": "sha256:3a9fb8e631868a91950ce2c4646bf101b85eb33458cfb5c71f03c58cb0d0bee4",
+    "source_fingerprint": "sha256:939c256fc667b769da6fa02c29b914a8c6ad0a087944c0923552625adaff7e48",
     "contract_roots": [
       "data/core",
       "data/json",
@@ -29,8 +29,8 @@
       "wound_fix"
     ],
     "observed_not_registered": [],
-    "tracked_json_files": 6729,
-    "top_level_objects": 94318,
+    "tracked_json_files": 6730,
+    "top_level_objects": 94329,
     "top_level_objects_without_string_type": 1,
     "schema_complete_types": 0
   },
@@ -3047,7 +3047,7 @@
       ],
       "compile_conditional_variants": false,
       "instance_evidence": {
-        "occurrences": 5518,
+        "occurrences": 5519,
         "examples": [
           {
             "path": "data/json/artifact/altered_object_active.json",
@@ -4676,7 +4676,7 @@
       ],
       "compile_conditional_variants": false,
       "instance_evidence": {
-        "occurrences": 911,
+        "occurrences": 912,
         "examples": [
           {
             "path": "data/json/flags.json",
@@ -5976,7 +5976,7 @@
       ],
       "compile_conditional_variants": false,
       "instance_evidence": {
-        "occurrences": 614,
+        "occurrences": 615,
         "examples": [
           {
             "path": "data/json/recipes/nested.json",
@@ -7431,7 +7431,7 @@
       ],
       "compile_conditional_variants": false,
       "instance_evidence": {
-        "occurrences": 8172,
+        "occurrences": 8177,
         "examples": [
           {
             "path": "data/json/items/armor/jewelry.json",
@@ -8429,7 +8429,7 @@
       ],
       "compile_conditional_variants": false,
       "instance_evidence": {
-        "occurrences": 757,
+        "occurrences": 760,
         "examples": [
           {
             "path": "data/json/recipes/basecamps/components.json",

--- a/src/anatomy.cpp
+++ b/src/anatomy.cpp
@@ -6,6 +6,7 @@
 #include <unordered_set>
 
 #include "ballistics.h"
+#include "catalua_platform_content.h"
 #include "character.h"
 #include "creature.h"
 #include "debug.h"
@@ -368,4 +369,3 @@ bodypart_id anatomy::select_body_part_projectile_attack( const double range_min,
     // And now, select the right body part
     return graph.select( range_min, range_max, value );
 }
-#include "catalua_platform_content.h"

--- a/src/behavior.cpp
+++ b/src/behavior.cpp
@@ -40,14 +40,6 @@ const std::vector<std::string> &node_t::child_ids() const
 {
     return authored_children;
 }
-void node_t::rebuild_children()
-{
-    children.clear();
-    children.reserve( authored_children.size() );
-    for( const std::string &child : authored_children ) {
-        children.push_back( &string_id<node_t>( child ).obj() );
-    }
-}
 void node_t::set_score_function( const score_type &func, const std::string &argument )
 {
     score_function_.emplace( func, argument );
@@ -162,6 +154,15 @@ template<>
 const node_t &string_id<node_t>::obj() const
 {
     return behavior_factory.obj( *this );
+}
+
+void node_t::rebuild_children()
+{
+    children.clear();
+    children.reserve( authored_children.size() );
+    for( const std::string &child : authored_children ) {
+        children.push_back( &string_id<node_t>( child ).obj() );
+    }
 }
 
 void behavior::load_behavior( const JsonObject &jo, const std::string &src )

--- a/src/bodygraph.cpp
+++ b/src/bodygraph.cpp
@@ -10,6 +10,7 @@
 #include "bodypart.h"
 #include "cata_utility.h"
 #include "catacharset.h"
+#include "catalua_platform_content.h"
 #include "character.h"
 #include "character_attire.h"
 #include "creature.h"
@@ -733,4 +734,3 @@ std::vector<std::string> get_bodygraph_lines( const Character &u,
     }
     return ret;
 }
-#include "catalua_platform_content.h"

--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -131,6 +131,24 @@ void cata::lua_platform::detail::refresh_body_part_similarity_cache()
     }
 }
 
+void cata::lua_platform::detail::refresh_body_part_wound_cache()
+{
+    for( body_part_type &part : body_part_factory.get_all_mod() ) {
+        part.potential_wounds.clear();
+    }
+
+    for( body_part_type &part : body_part_factory.get_all_mod() ) {
+        for( const wound_type &wound_def : wound_type::get_all() ) {
+            if( wound_def.allowed_on_bodypart( part.id ) ) {
+                const bp_wounds candidate = {
+                    wound_def.id, wound_def.damage_types, wound_def.damage_required
+                };
+                part.potential_wounds.add( candidate, wound_def.weight );
+            }
+        }
+    }
+}
+
 static body_part legacy_id_to_enum( const std::string &legacy_id )
 {
     static const std::unordered_map<std::string, body_part> body_parts = {
@@ -554,6 +572,7 @@ void body_part_type::reset()
 void body_part_type::finalize_all()
 {
     body_part_factory.finalize();
+    cata::lua_platform::detail::refresh_body_part_similarity_cache();
 }
 
 void body_part_type::finalize()
@@ -562,6 +581,7 @@ void body_part_type::finalize()
         unarmed_bonus = true;
     }
 
+    potential_wounds.clear();
     for( const wound_type &wd : wound_type::get_all() ) {
         if( wd.allowed_on_bodypart( id ) ) {
             const bp_wounds bpw = { wd.id, wd.damage_types, wd.damage_required };
@@ -1165,6 +1185,7 @@ void bodypart::add_or_worsen_wound( const wound &wd )
 
                 remove_wound( *old_wound );
                 add_wound( new_wound );
+                return;
             }
         }
 

--- a/src/catalua_game_handle.cpp
+++ b/src/catalua_game_handle.cpp
@@ -65,14 +65,54 @@ sol::table handle_value_to_lua( sol::state_view lua, const game_handle &handle )
 
 } // namespace
 
+game_handle_runtime_owner_ptr make_game_handle_runtime_owner()
+{
+    return std::make_shared<game_handle_runtime_owner>();
+}
+
+game_handle_runtime::game_handle_runtime(
+    const game_handle_runtime_owner_ptr &owner,
+    const std::size_t generation ) : owner_( owner ), generation_( generation )
+{
+}
+
+std::size_t game_handle_runtime::generation() const noexcept
+{
+    return generation_;
+}
+
+bool game_handle_runtime::has_live_owner() const noexcept
+{
+    return !owner_.expired();
+}
+
+bool game_handle_runtime::same_identity(
+    const game_handle_runtime &other ) const noexcept
+{
+    const std::weak_ptr<const game_handle_runtime_owner> empty;
+    const bool has_identity = owner_.owner_before( empty ) ||
+                              empty.owner_before( owner_ );
+    return has_identity && generation_ == other.generation_ &&
+           !owner_.owner_before( other.owner_ ) &&
+           !other.owner_.owner_before( owner_ );
+}
+
+bool game_handle_runtime::is_active_match(
+    const game_handle_runtime &other ) const noexcept
+{
+    return has_live_owner() && other.has_live_owner() &&
+           same_identity( other );
+}
+
 game_handle game_handle::from_creature(
     Creature &value, game_handle_locator locator,
-    const std::size_t runtime_generation, const std::size_t world_generation )
+    const game_handle_runtime &runtime, const std::size_t world_generation )
 {
     game_handle result;
     result.kind_ = game_handle_kind::creature;
     result.locator_ = std::move( locator );
-    result.runtime_generation_ = runtime_generation;
+    result.runtime_owner_ = runtime.owner_;
+    result.runtime_generation_ = runtime.generation_;
     result.world_generation_ = world_generation;
     result.creature_ = value.get_safe_reference();
     return result;
@@ -80,12 +120,13 @@ game_handle game_handle::from_creature(
 
 game_handle game_handle::from_item(
     item &value, game_handle_locator locator,
-    const std::size_t runtime_generation, const std::size_t world_generation )
+    const game_handle_runtime &runtime, const std::size_t world_generation )
 {
     game_handle result;
     result.kind_ = game_handle_kind::item;
     result.locator_ = std::move( locator );
-    result.runtime_generation_ = runtime_generation;
+    result.runtime_owner_ = runtime.owner_;
+    result.runtime_generation_ = runtime.generation_;
     result.world_generation_ = world_generation;
     result.item_ = value.get_safe_reference();
     return result;
@@ -93,12 +134,13 @@ game_handle game_handle::from_item(
 
 game_handle game_handle::from_vehicle(
     vehicle &value, game_handle_locator locator,
-    const std::size_t runtime_generation, const std::size_t world_generation )
+    const game_handle_runtime &runtime, const std::size_t world_generation )
 {
     game_handle result;
     result.kind_ = game_handle_kind::vehicle;
     result.locator_ = std::move( locator );
-    result.runtime_generation_ = runtime_generation;
+    result.runtime_owner_ = runtime.owner_;
+    result.runtime_generation_ = runtime.generation_;
     result.world_generation_ = world_generation;
     result.vehicle_ = value.get_safe_reference();
     return result;
@@ -130,10 +172,26 @@ std::size_t game_handle::world_generation() const noexcept
 }
 
 std::optional<game_handle_error> game_handle::validation_error(
-    const std::size_t current_runtime_generation,
+    const game_handle_runtime &current_runtime,
     const std::size_t current_world_generation ) const
 {
-    if( runtime_generation_ != current_runtime_generation ) {
+    const std::shared_ptr<const game_handle_runtime_owner> owner =
+        runtime_owner_.lock();
+    const std::shared_ptr<const game_handle_runtime_owner> current_owner =
+        current_runtime.owner_.lock();
+    if( !owner ) {
+        return game_handle_error{
+            "stale_runtime",
+            "GameHandle owner runtime is no longer alive"
+        };
+    }
+    if( !current_owner || owner != current_owner ) {
+        return game_handle_error{
+            "stale_runtime",
+            "GameHandle belongs to a different Lua runtime owner"
+        };
+    }
+    if( runtime_generation_ != current_runtime.generation_ ) {
         return game_handle_error{
             "stale_runtime",
             "GameHandle belongs to an inactive Lua runtime generation"
@@ -170,14 +228,14 @@ std::optional<game_handle_error> game_handle::validation_error(
 }
 
 native_handle_result<Creature> game_handle::resolve_creature(
-    const std::size_t current_runtime_generation,
+    const game_handle_runtime &current_runtime,
     const std::size_t current_world_generation ) const
 {
     if( kind_ != game_handle_kind::creature ) {
         return { nullptr, wrong_kind_error( game_handle_kind::creature, kind_ ) };
     }
     if( const std::optional<game_handle_error> error =
-            validation_error( current_runtime_generation, current_world_generation ) ) {
+            validation_error( current_runtime, current_world_generation ) ) {
         return { nullptr, error };
     }
     Creature *value = creature_.get();
@@ -187,14 +245,14 @@ native_handle_result<Creature> game_handle::resolve_creature(
 }
 
 native_handle_result<item> game_handle::resolve_item(
-    const std::size_t current_runtime_generation,
+    const game_handle_runtime &current_runtime,
     const std::size_t current_world_generation ) const
 {
     if( kind_ != game_handle_kind::item ) {
         return { nullptr, wrong_kind_error( game_handle_kind::item, kind_ ) };
     }
     if( const std::optional<game_handle_error> error =
-            validation_error( current_runtime_generation, current_world_generation ) ) {
+            validation_error( current_runtime, current_world_generation ) ) {
         return { nullptr, error };
     }
     item *value = item_.get();
@@ -204,14 +262,14 @@ native_handle_result<item> game_handle::resolve_item(
 }
 
 native_handle_result<vehicle> game_handle::resolve_vehicle(
-    const std::size_t current_runtime_generation,
+    const game_handle_runtime &current_runtime,
     const std::size_t current_world_generation ) const
 {
     if( kind_ != game_handle_kind::vehicle ) {
         return { nullptr, wrong_kind_error( game_handle_kind::vehicle, kind_ ) };
     }
     if( const std::optional<game_handle_error> error =
-            validation_error( current_runtime_generation, current_world_generation ) ) {
+            validation_error( current_runtime, current_world_generation ) ) {
         return { nullptr, error };
     }
     vehicle *value = vehicle_.get();
@@ -256,7 +314,7 @@ sol::table make_game_error_result( sol::state_view lua, const game_handle_error 
 
 void install_game_handle_api(
     sol::state &lua, sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read )
 {
@@ -267,17 +325,17 @@ void install_game_handle_api(
         return locator_to_lua( sol::state_view( lua_state ), self.locator() );
     },
     "is_valid",
-    [current_runtime_generation, current_world_generation]( const game_handle & self ) {
+    [current_runtime, current_world_generation]( const game_handle & self ) {
         return !self.validation_error(
-                   current_runtime_generation(), current_world_generation() );
+                   current_runtime(), current_world_generation() );
     },
     "status",
-    [current_runtime_generation, current_world_generation](
+    [current_runtime, current_world_generation](
         sol::this_state lua_state, const game_handle & self ) {
         sol::state_view state( lua_state );
         if( const std::optional<game_handle_error> error =
                 self.validation_error(
-                    current_runtime_generation(), current_world_generation() ) ) {
+                    current_runtime(), current_world_generation() ) ) {
             return make_game_error_result( state, *error );
         }
         return make_game_value_result(
@@ -286,7 +344,7 @@ void install_game_handle_api(
 
     sol::table handles = lua.create_table();
     handles.set_function( "avatar", [
-                           current_runtime_generation,
+                           current_runtime,
                            current_world_generation,
                            require_read
     ]() {
@@ -298,7 +356,7 @@ void install_game_handle_api(
             "avatar", player.getID().get_value(),
             position.x(), position.y(), position.z(), {}
         },
-        current_runtime_generation(), current_world_generation() );
+        current_runtime(), current_world_generation() );
     } );
     game["handles"] = std::move( handles );
 }

--- a/src/catalua_game_handle.h
+++ b/src/catalua_game_handle.h
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -41,6 +42,49 @@ struct game_handle_error {
     std::string message;
 };
 
+/**
+ * Opaque lifetime owner for one native-facing Lua runtime.
+ *
+ * The token itself is never registered with Lua.  A GameHandle retains only
+ * a weak reference, so keeping a handle cannot keep its originating runtime
+ * alive.
+ */
+class game_handle_runtime_owner final
+{
+};
+
+using game_handle_runtime_owner_ptr =
+    std::shared_ptr<const game_handle_runtime_owner>;
+
+game_handle_runtime_owner_ptr make_game_handle_runtime_owner();
+
+/** Explicit owner identity and generation for GameHandle validation. */
+class game_handle_runtime
+{
+    public:
+        game_handle_runtime() = default;
+        game_handle_runtime( const game_handle_runtime_owner_ptr &owner,
+                             std::size_t generation );
+
+        std::size_t generation() const noexcept;
+        bool has_live_owner() const noexcept;
+
+        // Compare the complete runtime identity without requiring either
+        // owner to still be alive.  weak_ptr ownership ordering keeps this
+        // stable for copied handles after their runtime has been destroyed.
+        bool same_identity( const game_handle_runtime &other ) const noexcept;
+
+        // True only when both contexts still have a live owner and represent
+        // the same owner plus generation.
+        bool is_active_match( const game_handle_runtime &other ) const noexcept;
+
+    private:
+        friend class game_handle;
+
+        std::weak_ptr<const game_handle_runtime_owner> owner_;
+        std::size_t generation_ = 0;
+};
+
 template<typename T>
 struct native_handle_result {
     T *value = nullptr;
@@ -58,13 +102,16 @@ class game_handle
 
         static game_handle from_creature(
             Creature &value, game_handle_locator locator,
-            std::size_t runtime_generation, std::size_t world_generation );
+            const game_handle_runtime &runtime,
+            std::size_t world_generation );
         static game_handle from_item(
             item &value, game_handle_locator locator,
-            std::size_t runtime_generation, std::size_t world_generation );
+            const game_handle_runtime &runtime,
+            std::size_t world_generation );
         static game_handle from_vehicle(
             vehicle &value, game_handle_locator locator,
-            std::size_t runtime_generation, std::size_t world_generation );
+            const game_handle_runtime &runtime,
+            std::size_t world_generation );
 
         game_handle_kind kind() const noexcept;
         std::string kind_name() const;
@@ -73,21 +120,22 @@ class game_handle
         std::size_t world_generation() const noexcept;
 
         native_handle_result<Creature> resolve_creature(
-            std::size_t current_runtime_generation,
+            const game_handle_runtime &current_runtime,
             std::size_t current_world_generation ) const;
         native_handle_result<item> resolve_item(
-            std::size_t current_runtime_generation,
+            const game_handle_runtime &current_runtime,
             std::size_t current_world_generation ) const;
         native_handle_result<vehicle> resolve_vehicle(
-            std::size_t current_runtime_generation,
+            const game_handle_runtime &current_runtime,
             std::size_t current_world_generation ) const;
         std::optional<game_handle_error> validation_error(
-            std::size_t current_runtime_generation,
+            const game_handle_runtime &current_runtime,
             std::size_t current_world_generation ) const;
 
     private:
         game_handle_kind kind_ = game_handle_kind::none;
         game_handle_locator locator_;
+        std::weak_ptr<const game_handle_runtime_owner> runtime_owner_;
         std::size_t runtime_generation_ = 0;
         std::size_t world_generation_ = 0;
         safe_reference<Creature> creature_;
@@ -104,7 +152,7 @@ sol::table make_game_error_result( sol::state_view lua, const game_handle_error 
 
 void install_game_handle_api(
     sol::state &lua, sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read );
 

--- a/src/catalua_platform.cpp
+++ b/src/catalua_platform.cpp
@@ -107,9 +107,12 @@ mod_source resolve_source( const mod_source &source )
     if( filesystem_error || !fs::is_directory( root, filesystem_error ) || filesystem_error ) {
         throw std::runtime_error( "Cannot resolve Lua-first Mod root for '" + source.id + "'" );
     }
-    const fs::path requested_entry = source.entry.is_absolute() ? source.entry :
-                                     root / source.entry;
-    const fs::path entry = fs::canonical( requested_entry, filesystem_error );
+    fs::path entry = fs::canonical( source.entry, filesystem_error );
+    if( !source.entry.is_absolute() &&
+        ( filesystem_error || !path_is_within( entry, root ) ) ) {
+        filesystem_error.clear();
+        entry = fs::canonical( root / source.entry, filesystem_error );
+    }
     if( filesystem_error || !path_is_within( entry, root ) ) {
         throw std::runtime_error( "Lua-first Mod entry for '" + source.id +
                                   "' escapes its root or cannot be resolved" );
@@ -193,10 +196,7 @@ mod_definition make_mod_definition( const sol::table &values )
 void install_mod_definition( sol::table &ccb )
 {
     ccb.new_usertype<mod_definition>(
-        "ModDefinition",
-        sol::factories( []( const sol::table & values ) {
-            return make_mod_definition( values );
-        } ),
+        "_ModDefinitionNative", sol::no_constructor,
         "id", sol::property(
     []( const mod_definition & definition ) {
         return definition.id;
@@ -245,9 +245,18 @@ void install_mod_definition( sol::table &ccb )
         definition.core = value;
         definition.core_set = true;
     } ) );
+    ccb["_ModDefinitionNative"] = sol::lua_nil;
+    ccb.set_function( "ModDefinition", []( const sol::table & values ) {
+        return make_mod_definition( values );
+    } );
 }
 
-sol::protected_function_result execute_file( sol::state &lua, const fs::path &path )
+struct file_execution_result {
+    int return_count = 0;
+    std::optional<sol::object> first;
+};
+
+file_execution_result execute_file( sol::state &lua, const fs::path &path )
 {
     sol::load_result loaded = lua.load_file( path.string() );
     if( !loaded.valid() ) {
@@ -260,7 +269,14 @@ sol::protected_function_result execute_file( sol::state &lua, const fs::path &pa
         const sol::error error = result;
         throw std::runtime_error( path.string() + ": " + error.what() );
     }
-    return result;
+    file_execution_result snapshot;
+    snapshot.return_count = result.return_count();
+    if( snapshot.return_count > 0 ) {
+        // protected_function_result owns stack slots that cannot safely cross
+        // this helper boundary.  Preserve the first return in the registry.
+        snapshot.first = result.get<sol::object>();
+    }
+    return snapshot;
 }
 
 sol::object require_local_module( sol::state &lua, const fs::path &root,
@@ -286,10 +302,10 @@ sol::object require_local_module( sol::state &lua, const fs::path &root,
     // independent from author-mutated package.path/searchers.
     loaded_modules[module_name] = true;
     try {
-        sol::protected_function_result execution = execute_file( lua, *path );
+        const file_execution_result execution = execute_file( lua, *path );
         sol::object exported = loaded_modules.raw_get<sol::object>( module_name );
-        if( execution.return_count() > 0 && execution.get_type() != sol::type::nil ) {
-            exported = execution.get<sol::object>();
+        if( execution.first && execution.first->get_type() != sol::type::nil ) {
+            exported = *execution.first;
         } else if( !exported.valid() || exported.get_type() == sol::type::nil ) {
             exported = sol::make_object( lua, true );
         }
@@ -328,7 +344,7 @@ void initialize_state( sol::state &lua, const fs::path &requested_root,
     package["path"] = ( root / "?.lua" ).generic_u8string() + ";" +
                       ( root / "?" / "init.lua" ).generic_u8string();
     package["cpath"] = std::string();
-    lua.set_function( "require", [&lua, root]( const std::string &module_name ) {
+    lua.set_function( "require", [&lua, root]( const std::string & module_name ) {
         return require_local_module( lua, root, module_name );
     } );
 }
@@ -373,13 +389,13 @@ bool read_mod_definition( const fs::path &root, mod_definition &result, std::str
                 << path.generic_u8string();
         sol::state lua;
         initialize_state( lua, canonical_root );
-        sol::protected_function_result execution = execute_file( lua, path );
-        if( execution.return_count() != 1 ) {
+        const file_execution_result execution = execute_file( lua, path );
+        if( execution.return_count != 1 ) {
             error = path.generic_u8string() +
                     ": expected exactly one ccb.ModDefinition return value";
             return false;
         }
-        sol::object value = execution.get<sol::object>();
+        const sol::object &value = *execution.first;
         if( !value.is<mod_definition>() ) {
             error = path.generic_u8string() +
                     ": expected a native ccb.ModDefinition return value";

--- a/src/catalua_platform_content.h
+++ b/src/catalua_platform_content.h
@@ -70,6 +70,8 @@ class VehicleGroup;
 struct species_type;
 struct sub_body_part_type;
 struct weakpoints;
+class wound_fix;
+class wound_type;
 
 namespace behavior
 {
@@ -121,8 +123,12 @@ generic_factory<behavior::node_t> &behavior_registry();
 generic_factory<weakpoints> &weakpoint_set_registry();
 generic_factory<body_part_type> &body_part_registry();
 void refresh_body_part_similarity_cache();
+void refresh_body_part_wound_cache();
 generic_factory<sub_body_part_type> &sub_body_part_registry();
 void refresh_sub_body_part_similarity_cache();
+generic_factory<wound_type> &wound_type_registry();
+generic_factory<wound_fix> &wound_fix_registry();
+void refresh_wound_fix_links();
 generic_factory<anatomy> &anatomy_registry();
 generic_factory<bodygraph> &bodygraph_registry();
 generic_factory<morale_type_data> &morale_type_registry();

--- a/src/catalua_platform_runtime.cpp
+++ b/src/catalua_platform_runtime.cpp
@@ -3,6 +3,7 @@
 #if defined(CATA_ENABLE_LUA_UI) && CATA_ENABLE_LUA_UI
 
 #include <algorithm>
+#include <array>
 #include <cctype>
 #include <cmath>
 #include <cstdint>
@@ -19,11 +20,13 @@
 #include <tuple>
 #include <type_traits>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <variant>
 
 #include "calendar.h"
 #include "addiction.h"
+#include "achievement.h"
 #include "activity_actor.h"
 #include "activity_handlers.h"
 #include "activity_type.h"
@@ -31,11 +34,13 @@
 #include "ammo_effect.h"
 #include "anatomy.h"
 #include "ascii_art.h"
+#include "avatar.h"
 #include "behavior.h"
 #include "behavior_oracle.h"
 #include "behavior_strategy.h"
 #include "bodypart.h"
 #include "bodygraph.h"
+#include "bionics.h"
 #include "butchery_requirements.h"
 #include "cata_path.h"
 #include "catacharset.h"
@@ -78,6 +83,7 @@
 #include "catalua_ui_world_services.h"
 #include "catalua_ui_zones.h"
 #include "character.h"
+#include "character_martial_arts.h"
 #include "character_modifier.h"
 #include "climbing.h"
 #include "clothing_mod.h"
@@ -105,17 +111,20 @@
 #include "flag.h"
 #include "flexbuffer_json.h"
 #include "generic_factory.h"
-#include "item.h"
-#include "item_group.h"
+#include "game.h"
 #include "harvest.h"
 #include "help.h"
 #include "hsv_color.h"
+#include "init.h"
+#include "item.h"
+#include "item_group.h"
 #include "item_category.h"
 #include "item_factory.h"
 #include "item_location.h"
 #include "itype.h"
 #include "iuse.h"
 #include "json.h"
+#include "json_loader.h"
 #include "map.h"
 #include "map_accessories.h"
 #include "mapdata.h"
@@ -135,6 +144,7 @@
 #include "move_mode.h"
 #include "mtype.h"
 #include "mutation.h"
+#include "npc.h"
 #include "omdata.h"
 #include "overmap_location.h"
 #include "output.h"
@@ -172,6 +182,7 @@
 #include "weather_gen.h"
 #include "weather_type.h"
 #include "weakpoint.h"
+#include "wound.h"
 #include "worldfactory.h"
 
 namespace cata::lua_platform
@@ -269,8 +280,8 @@ struct recipe_definition_data {
     std::string result;
     std::string name;
     std::string description;
-    std::string category = "CC_MISC";
-    std::string subcategory = "CSC_MISC";
+    std::string category = "CC_OTHER";
+    std::string subcategory = "CSC_OTHER_OTHER";
     double activity_level = NO_EXERCISE;
     std::set<std::string> nested_recipes;
     std::string skill;
@@ -595,6 +606,65 @@ struct body_part_definition_data {
     std::set<std::string> flags;
     std::map<std::string, body_part_limb_score_definition_data> limb_scores;
     std::vector<body_part_quality_definition_data> qualities;
+    bool registered = false;
+};
+
+struct wound_limb_score_definition_data {
+    std::string id;
+    double penalty = 0.0;
+};
+
+struct wound_progression_definition_data {
+    std::string id;
+    std::int64_t chance = 0;
+};
+
+struct wound_type_definition_data {
+    std::string id;
+    std::string name;
+    std::string plural_name;
+    std::string description;
+    std::int64_t pain_min = 0;
+    std::int64_t pain_max = 0;
+    std::int64_t healing_min_turns = 1;
+    std::int64_t healing_max_turns = 1;
+    std::int64_t damage_min = 0;
+    std::int64_t damage_max = 0;
+    std::int64_t weight = 1;
+    std::int64_t per_part_limit = 0;
+    std::string required_body_part_flag;
+    std::string forbidden_body_part_flag;
+    std::vector<std::string> damage_types;
+    std::vector<wound_limb_score_definition_data> limb_scores;
+    std::vector<wound_progression_definition_data> progressions;
+    std::vector<std::string> required_body_part_types;
+    std::vector<std::string> forbidden_body_part_types;
+    bool registered = false;
+};
+
+struct wound_fix_proficiency_definition_data {
+    std::string id;
+    double multiplier = 1.0;
+    bool mandatory = false;
+};
+
+struct wound_fix_requirement_definition_data {
+    std::string id;
+    std::int64_t count = 1;
+};
+
+struct wound_fix_definition_data {
+    std::string id;
+    std::string name;
+    std::string description;
+    std::string success_message;
+    std::int64_t duration_turns = 0;
+    std::int64_t health_delta = 0;
+    std::map<std::string, std::int64_t> skills;
+    std::vector<wound_fix_proficiency_definition_data> proficiencies;
+    std::set<std::string> wounds_removed;
+    std::set<std::string> wounds_added;
+    std::vector<wound_fix_requirement_definition_data> requirements;
     bool registered = false;
 };
 
@@ -1854,7 +1924,7 @@ struct requirement_definition_handle {
     }
 
     requirement_definition_handle &quality( const std::string &id,
-            std::int64_t level, std::int64_t count ) {
+                                            std::int64_t level, std::int64_t count ) {
         require_building_handle( token, *definition, "requirement" );
         if( id.empty() || level <= 0 || count <= 0 ||
             level > std::numeric_limits<int>::max() ||
@@ -2358,7 +2428,7 @@ struct recipe_group_definition_handle {
     std::shared_ptr<owner_token> token;
 
     recipe_group_definition_handle &recipe( const std::string &id,
-                                             const std::string &description ) {
+                                            const std::string &description ) {
         require_building_handle( token, *definition, "recipe group" );
         if( id.empty() || description.empty() ) {
             throw std::runtime_error( "recipe-group entry needs an id and description" );
@@ -2488,57 +2558,57 @@ struct harvest_drop_type_definition_handle {
 };
 
 struct harvest_definition_handle {
-    std::shared_ptr<harvest_definition_data> definition;
-    std::shared_ptr<owner_token> token;
+        std::shared_ptr<harvest_definition_data> definition;
+        std::shared_ptr<owner_token> token;
 
-    harvest_definition_handle &drop( const sol::table &options ) {
-        require_building_handle( token, *definition, "harvest" );
-        harvest_entry_definition_data entry;
-        entry.output = options.get_or( "output", std::string() );
-        entry.category = options.get_or( "category", std::string() );
-        entry.base_minimum = options.get_or( "base_minimum", 1.0 );
-        entry.base_maximum = options.get_or( "base_maximum", entry.base_minimum );
-        entry.skill_minimum = options.get_or( "skill_minimum", 0.0 );
-        entry.skill_maximum = options.get_or( "skill_maximum", entry.skill_minimum );
-        entry.maximum = options.get_or<std::int64_t>( "maximum", 1000 );
-        entry.mass_ratio = options.get_or( "mass_ratio", 0.0 );
-        if( entry.output.empty() || std::any_of(
-                definition->entries.begin(), definition->entries.end(),
-        [&entry]( const harvest_entry_definition_data & existing ) {
-        return existing.output == entry.output;
+        harvest_definition_handle &drop( const sol::table &options ) {
+            require_building_handle( token, *definition, "harvest" );
+            harvest_entry_definition_data entry;
+            entry.output = options.get_or( "output", std::string() );
+            entry.category = options.get_or( "category", std::string() );
+            entry.base_minimum = options.get_or( "base_minimum", 1.0 );
+            entry.base_maximum = options.get_or( "base_maximum", entry.base_minimum );
+            entry.skill_minimum = options.get_or( "skill_minimum", 0.0 );
+            entry.skill_maximum = options.get_or( "skill_maximum", entry.skill_minimum );
+            entry.maximum = options.get_or<std::int64_t>( "maximum", 1000 );
+            entry.mass_ratio = options.get_or( "mass_ratio", 0.0 );
+            if( entry.output.empty() || std::any_of(
+                    definition->entries.begin(), definition->entries.end(),
+            [&entry]( const harvest_entry_definition_data & existing ) {
+            return existing.output == entry.output;
         } ) ) {
-            throw std::runtime_error( "harvest drop needs a unique non-empty output id" );
+                throw std::runtime_error( "harvest drop needs a unique non-empty output id" );
+            }
+            definition->entries.push_back( std::move( entry ) );
+            return *this;
         }
-        definition->entries.push_back( std::move( entry ) );
-        return *this;
-    }
 
-    harvest_definition_handle &item_flag( const std::string &output,
-                                           const std::string &flag ) {
-        require_building_handle( token, *definition, "harvest" );
-        harvest_entry_definition_data &entry = require_drop( output );
-        if( flag.empty() ) {
-            throw std::runtime_error( "harvest item flag cannot be empty" );
+        harvest_definition_handle &item_flag( const std::string &output,
+                                              const std::string &flag ) {
+            require_building_handle( token, *definition, "harvest" );
+            harvest_entry_definition_data &entry = require_drop( output );
+            if( flag.empty() ) {
+                throw std::runtime_error( "harvest item flag cannot be empty" );
+            }
+            entry.flags.insert( flag );
+            return *this;
         }
-        entry.flags.insert( flag );
-        return *this;
-    }
 
-    harvest_definition_handle &item_fault( const std::string &output,
-                                            const std::string &fault ) {
-        require_building_handle( token, *definition, "harvest" );
-        harvest_entry_definition_data &entry = require_drop( output );
-        if( fault.empty() ) {
-            throw std::runtime_error( "harvest item fault cannot be empty" );
+        harvest_definition_handle &item_fault( const std::string &output,
+                                               const std::string &fault ) {
+            require_building_handle( token, *definition, "harvest" );
+            harvest_entry_definition_data &entry = require_drop( output );
+            if( fault.empty() ) {
+                throw std::runtime_error( "harvest item fault cannot be empty" );
+            }
+            entry.faults.insert( fault );
+            return *this;
         }
-        entry.faults.insert( fault );
-        return *this;
-    }
 
-    std::string id() const {
-        require_readable_handle( token, *definition, "harvest" );
-        return definition->id;
-    }
+        std::string id() const {
+            require_readable_handle( token, *definition, "harvest" );
+            return definition->id;
+        }
 
     private:
         harvest_entry_definition_data &require_drop( const std::string &output ) {
@@ -2556,48 +2626,48 @@ struct harvest_definition_handle {
 };
 
 struct behavior_definition_handle {
-    std::shared_ptr<behavior_definition_data> definition;
-    std::shared_ptr<owner_token> token;
+        std::shared_ptr<behavior_definition_data> definition;
+        std::shared_ptr<owner_token> token;
 
-    behavior_definition_handle &child( const std::string &id ) {
-        require_building_handle( token, *definition, "behavior" );
-        if( id.empty() || std::find( definition->children.begin(),
-                                     definition->children.end(), id ) !=
-            definition->children.end() ) {
-            throw std::runtime_error( "behavior child needs a unique non-empty id" );
+        behavior_definition_handle &child( const std::string &id ) {
+            require_building_handle( token, *definition, "behavior" );
+            if( id.empty() || std::find( definition->children.begin(),
+                                         definition->children.end(), id ) !=
+                definition->children.end() ) {
+                throw std::runtime_error( "behavior child needs a unique non-empty id" );
+            }
+            definition->children.push_back( id );
+            return *this;
         }
-        definition->children.push_back( id );
-        return *this;
-    }
 
-    behavior_definition_handle &when( const std::string &handler,
-                                      const sol::optional<std::string> &argument,
-                                      const sol::optional<bool> &inverted ) {
-        return add_condition( handler, argument.value_or( std::string() ), false,
-                              inverted.value_or( false ) );
-    }
+        behavior_definition_handle &when( const std::string &handler,
+                                          const sol::optional<std::string> &argument,
+                                          const sol::optional<bool> &inverted ) {
+            return add_condition( handler, argument.value_or( std::string() ), false,
+                                  inverted.value_or( false ) );
+        }
 
-    behavior_definition_handle &when_native(
-        const std::string &predicate, const sol::optional<std::string> &argument,
-        const sol::optional<bool> &inverted ) {
-        return add_condition( predicate, argument.value_or( std::string() ), true,
-                              inverted.value_or( false ) );
-    }
+        behavior_definition_handle &when_native(
+            const std::string &predicate, const sol::optional<std::string> &argument,
+            const sol::optional<bool> &inverted ) {
+            return add_condition( predicate, argument.value_or( std::string() ), true,
+                                  inverted.value_or( false ) );
+        }
 
-    behavior_definition_handle &score( const std::string &handler,
-                                       const sol::optional<std::string> &argument ) {
-        return set_score( handler, argument.value_or( std::string() ), false );
-    }
+        behavior_definition_handle &score( const std::string &handler,
+                                           const sol::optional<std::string> &argument ) {
+            return set_score( handler, argument.value_or( std::string() ), false );
+        }
 
-    behavior_definition_handle &score_native(
-        const std::string &predicate, const sol::optional<std::string> &argument ) {
-        return set_score( predicate, argument.value_or( std::string() ), true );
-    }
+        behavior_definition_handle &score_native(
+            const std::string &predicate, const sol::optional<std::string> &argument ) {
+            return set_score( predicate, argument.value_or( std::string() ), true );
+        }
 
-    std::string id() const {
-        require_readable_handle( token, *definition, "behavior" );
-        return definition->id;
-    }
+        std::string id() const {
+            require_readable_handle( token, *definition, "behavior" );
+            return definition->id;
+        }
 
     private:
         behavior_definition_handle &add_condition( const std::string &policy,
@@ -2611,8 +2681,8 @@ struct behavior_definition_handle {
         }
 
         behavior_definition_handle &set_score( const std::string &policy,
-                                                const std::string &argument,
-                                                const bool native ) {
+                                               const std::string &argument,
+                                               const bool native ) {
             require_building_handle( token, *definition, "behavior" );
             if( policy.empty() ) {
                 throw std::runtime_error( "behavior score policy cannot be empty" );
@@ -2623,56 +2693,56 @@ struct behavior_definition_handle {
 };
 
 struct effect_type_definition_handle {
-    std::shared_ptr<effect_type_definition_data> definition;
-    std::shared_ptr<owner_token> token;
+        std::shared_ptr<effect_type_definition_data> definition;
+        std::shared_ptr<owner_token> token;
 
-    effect_type_definition_handle &name( const std::string &text ) {
-        return append_text( definition->names, text, "effect name" );
-    }
+        effect_type_definition_handle &name( const std::string &text ) {
+            return append_text( definition->names, text, "effect name" );
+        }
 
-    effect_type_definition_handle &description( const std::string &text ) {
-        return append_text( definition->descriptions, text, "effect description" );
-    }
+        effect_type_definition_handle &description( const std::string &text ) {
+            return append_text( definition->descriptions, text, "effect description" );
+        }
 
-    effect_type_definition_handle &reduced_description( const std::string &text ) {
-        return append_text( definition->reduced_descriptions, text,
-                            "reduced effect description" );
-    }
+        effect_type_definition_handle &reduced_description( const std::string &text ) {
+            return append_text( definition->reduced_descriptions, text,
+                                "reduced effect description" );
+        }
 
-    effect_type_definition_handle &flag( const std::string &id ) {
-        return insert_id( definition->flags, id, "effect flag" );
-    }
+        effect_type_definition_handle &flag( const std::string &id ) {
+            return insert_id( definition->flags, id, "effect flag" );
+        }
 
-    effect_type_definition_handle &immune_character_flag( const std::string &id ) {
-        return insert_id( definition->immune_character_flags, id,
-                          "effect immunity character flag" );
-    }
+        effect_type_definition_handle &immune_character_flag( const std::string &id ) {
+            return insert_id( definition->immune_character_flags, id,
+                              "effect immunity character flag" );
+        }
 
-    effect_type_definition_handle &immune_bodypart_flag( const std::string &id ) {
-        return insert_id( definition->immune_bodypart_flags, id,
-                          "effect immunity body-part flag" );
-    }
+        effect_type_definition_handle &immune_bodypart_flag( const std::string &id ) {
+            return insert_id( definition->immune_bodypart_flags, id,
+                              "effect immunity body-part flag" );
+        }
 
-    effect_type_definition_handle &resist_trait( const std::string &id ) {
-        return insert_id( definition->resist_traits, id, "effect resistance trait" );
-    }
+        effect_type_definition_handle &resist_trait( const std::string &id ) {
+            return insert_id( definition->resist_traits, id, "effect resistance trait" );
+        }
 
-    effect_type_definition_handle &resist_effect( const std::string &id ) {
-        return insert_id( definition->resist_effects, id, "resistance effect" );
-    }
+        effect_type_definition_handle &resist_effect( const std::string &id ) {
+            return insert_id( definition->resist_effects, id, "resistance effect" );
+        }
 
-    effect_type_definition_handle &removes_effect( const std::string &id ) {
-        return insert_id( definition->removes_effects, id, "removed effect" );
-    }
+        effect_type_definition_handle &removes_effect( const std::string &id ) {
+            return insert_id( definition->removes_effects, id, "removed effect" );
+        }
 
-    effect_type_definition_handle &blocks_effect( const std::string &id ) {
-        return insert_id( definition->blocks_effects, id, "blocked effect" );
-    }
+        effect_type_definition_handle &blocks_effect( const std::string &id ) {
+            return insert_id( definition->blocks_effects, id, "blocked effect" );
+        }
 
-    std::string id() const {
-        require_readable_handle( token, *definition, "effect type" );
-        return definition->id;
-    }
+        std::string id() const {
+            require_readable_handle( token, *definition, "effect type" );
+            return definition->id;
+        }
 
     private:
         effect_type_definition_handle &append_text( std::vector<std::string> &target,
@@ -2716,90 +2786,92 @@ struct monster_attack_definition_handle {
 };
 
 struct weakpoint_set_definition_handle {
-    std::shared_ptr<weakpoint_set_definition_data> definition;
-    std::shared_ptr<owner_token> token;
+        using damage_value_map = std::map<std::string, double>;
 
-    weakpoint_set_definition_handle &weakpoint( const sol::table &options ) {
-        require_building_handle( token, *definition, "weakpoint set" );
-        weakpoint_definition_data value;
-        value.id = options.get_or( "id", std::string() );
-        value.name = options.get_or( "name", std::string() );
-        value.coverage = options.get_or( "coverage", 100.0 );
-        value.good = options.get_or( "good", true );
-        value.head = options.get_or( "head", false );
-        if( value.id.empty() || std::any_of(
-                definition->weakpoints.begin(), definition->weakpoints.end(),
-        [&value]( const weakpoint_definition_data & existing ) {
+        std::shared_ptr<weakpoint_set_definition_data> definition;
+        std::shared_ptr<owner_token> token;
+
+        weakpoint_set_definition_handle &weakpoint( const sol::table &options ) {
+            require_building_handle( token, *definition, "weakpoint set" );
+            weakpoint_definition_data value;
+            value.id = options.get_or( "id", std::string() );
+            value.name = options.get_or( "name", std::string() );
+            value.coverage = options.get_or( "coverage", 100.0 );
+            value.good = options.get_or( "good", true );
+            value.head = options.get_or( "head", false );
+            if( value.id.empty() || std::any_of(
+                    definition->weakpoints.begin(), definition->weakpoints.end(),
+            [&value]( const weakpoint_definition_data & existing ) {
             return existing.id == value.id;
         } ) ) {
-            throw std::runtime_error( "weakpoint needs a unique non-empty id" );
+                throw std::runtime_error( "weakpoint needs a unique non-empty id" );
+            }
+            definition->weakpoints.push_back( std::move( value ) );
+            return *this;
         }
-        definition->weakpoints.push_back( std::move( value ) );
-        return *this;
-    }
 
-    weakpoint_set_definition_handle &armor_multiplier(
-        const std::string &weakpoint_id, const std::string &damage_type,
-        const double value ) {
-        return set_damage_value( weakpoint_id, damage_type, value,
-        []( weakpoint_definition_data & point ) -> std::map<std::string, double> & {
-            return point.armor_multipliers;
-        }, "armor multiplier" );
-    }
+        weakpoint_set_definition_handle &armor_multiplier(
+            const std::string &weakpoint_id, const std::string &damage_type,
+            const double value ) {
+            return set_damage_value( weakpoint_id, damage_type, value,
+            []( weakpoint_definition_data & point ) -> damage_value_map & {
+                return point.armor_multipliers;
+            }, "armor multiplier" );
+        }
 
-    weakpoint_set_definition_handle &armor_penalty(
-        const std::string &weakpoint_id, const std::string &damage_type,
-        const double value ) {
-        return set_damage_value( weakpoint_id, damage_type, value,
-        []( weakpoint_definition_data & point ) -> std::map<std::string, double> & {
-            return point.armor_penalties;
-        }, "armor penalty" );
-    }
+        weakpoint_set_definition_handle &armor_penalty(
+            const std::string &weakpoint_id, const std::string &damage_type,
+            const double value ) {
+            return set_damage_value( weakpoint_id, damage_type, value,
+            []( weakpoint_definition_data & point ) -> damage_value_map & {
+                return point.armor_penalties;
+            }, "armor penalty" );
+        }
 
-    weakpoint_set_definition_handle &damage_multiplier(
-        const std::string &weakpoint_id, const std::string &damage_type,
-        const double value ) {
-        return set_damage_value( weakpoint_id, damage_type, value,
-        []( weakpoint_definition_data & point ) -> std::map<std::string, double> & {
-            return point.damage_multipliers;
-        }, "damage multiplier" );
-    }
+        weakpoint_set_definition_handle &damage_multiplier(
+            const std::string &weakpoint_id, const std::string &damage_type,
+            const double value ) {
+            return set_damage_value( weakpoint_id, damage_type, value,
+            []( weakpoint_definition_data & point ) -> damage_value_map & {
+                return point.damage_multipliers;
+            }, "damage multiplier" );
+        }
 
-    weakpoint_set_definition_handle &critical_multiplier(
-        const std::string &weakpoint_id, const std::string &damage_type,
-        const double value ) {
-        return set_damage_value( weakpoint_id, damage_type, value,
-        []( weakpoint_definition_data & point ) -> std::map<std::string, double> & {
-            return point.critical_multipliers;
-        }, "critical multiplier" );
-    }
+        weakpoint_set_definition_handle &critical_multiplier(
+            const std::string &weakpoint_id, const std::string &damage_type,
+            const double value ) {
+            return set_damage_value( weakpoint_id, damage_type, value,
+            []( weakpoint_definition_data & point ) -> damage_value_map & {
+                return point.critical_multipliers;
+            }, "critical multiplier" );
+        }
 
-    weakpoint_set_definition_handle &effect( const std::string &weakpoint_id,
-            const sol::table &options ) {
-        require_building_handle( token, *definition, "weakpoint set" );
-        weakpoint_effect_definition_data value;
-        value.effect = options.get_or( "effect", std::string() );
-        value.chance = options.get_or( "chance", 100.0 );
-        value.permanent = options.get_or( "permanent", false );
-        value.duration_min_turns = options.get_or<std::int64_t>(
-                                       "duration_min_turns", 0 );
-        value.duration_max_turns = options.get_or<std::int64_t>(
-                                       "duration_max_turns", value.duration_min_turns );
-        value.intensity_min = options.get_or<std::int64_t>( "intensity_min", 1 );
-        value.intensity_max = options.get_or<std::int64_t>(
-                                  "intensity_max", value.intensity_min );
-        value.damage_required_min = options.get_or( "damage_required_min", 0.0 );
-        value.damage_required_max = options.get_or(
-                                        "damage_required_max", 100.0 );
-        value.message = options.get_or( "message", std::string() );
-        require_weakpoint( weakpoint_id ).effects.push_back( std::move( value ) );
-        return *this;
-    }
+        weakpoint_set_definition_handle &effect( const std::string &weakpoint_id,
+                const sol::table &options ) {
+            require_building_handle( token, *definition, "weakpoint set" );
+            weakpoint_effect_definition_data value;
+            value.effect = options.get_or( "effect", std::string() );
+            value.chance = options.get_or( "chance", 100.0 );
+            value.permanent = options.get_or( "permanent", false );
+            value.duration_min_turns = options.get_or<std::int64_t>(
+                                           "duration_min_turns", 0 );
+            value.duration_max_turns = options.get_or<std::int64_t>(
+                                           "duration_max_turns", value.duration_min_turns );
+            value.intensity_min = options.get_or<std::int64_t>( "intensity_min", 1 );
+            value.intensity_max = options.get_or<std::int64_t>(
+                                      "intensity_max", value.intensity_min );
+            value.damage_required_min = options.get_or( "damage_required_min", 0.0 );
+            value.damage_required_max = options.get_or(
+                                            "damage_required_max", 100.0 );
+            value.message = options.get_or( "message", std::string() );
+            require_weakpoint( weakpoint_id ).effects.push_back( std::move( value ) );
+            return *this;
+        }
 
-    std::string id() const {
-        require_readable_handle( token, *definition, "weakpoint set" );
-        return definition->id;
-    }
+        std::string id() const {
+            require_readable_handle( token, *definition, "weakpoint set" );
+            return definition->id;
+        }
 
     private:
         weakpoint_definition_data &require_weakpoint( const std::string &id ) {
@@ -2859,75 +2931,75 @@ struct sub_body_part_definition_handle {
 };
 
 struct body_part_definition_handle {
-    std::shared_ptr<body_part_definition_data> definition;
-    std::shared_ptr<owner_token> token;
+        std::shared_ptr<body_part_definition_data> definition;
+        std::shared_ptr<owner_token> token;
 
-    body_part_definition_handle &sub_part( const std::string &id ) {
-        require_building_handle( token, *definition, "body part" );
-        if( id.empty() ) {
-            throw std::runtime_error( "body-part sub location cannot be empty" );
+        body_part_definition_handle &sub_part( const std::string &id ) {
+            require_building_handle( token, *definition, "body part" );
+            if( id.empty() ) {
+                throw std::runtime_error( "body-part sub location cannot be empty" );
+            }
+            definition->sub_parts.push_back( id );
+            return *this;
         }
-        definition->sub_parts.push_back( id );
-        return *this;
-    }
 
-    body_part_definition_handle &limb_type( const std::string &kind,
-                                            const sol::optional<double> &weight ) {
-        require_building_handle( token, *definition, "body part" );
-        const double value = weight.value_or( 1.0 );
-        if( kind.empty() || !std::isfinite( value ) || value <= 0.0 ) {
-            throw std::runtime_error( "body-part limb type is invalid" );
+        body_part_definition_handle &limb_type( const std::string &kind,
+                                                const sol::optional<double> &weight ) {
+            require_building_handle( token, *definition, "body part" );
+            const double value = weight.value_or( 1.0 );
+            if( kind.empty() || !std::isfinite( value ) || value <= 0.0 ) {
+                throw std::runtime_error( "body-part limb type is invalid" );
+            }
+            definition->limb_types[kind] = value;
+            return *this;
         }
-        definition->limb_types[kind] = value;
-        return *this;
-    }
 
-    body_part_definition_handle &armor( const std::string &damage_type,
-                                        const double amount ) {
-        return set_damage( definition->armor, damage_type, amount, "armor" );
-    }
-
-    body_part_definition_handle &unarmed_damage( const std::string &damage_type,
-            const double amount ) {
-        return set_damage( definition->unarmed_damage, damage_type, amount,
-                           "unarmed damage" );
-    }
-
-    body_part_definition_handle &flag( const std::string &id ) {
-        require_building_handle( token, *definition, "body part" );
-        if( id.empty() ) {
-            throw std::runtime_error( "body-part flag cannot be empty" );
+        body_part_definition_handle &armor( const std::string &damage_type,
+                                            const double amount ) {
+            return set_damage( definition->armor, damage_type, amount, "armor" );
         }
-        definition->flags.insert( id );
-        return *this;
-    }
 
-    body_part_definition_handle &limb_score( const std::string &id,
-            const double score, const sol::optional<double> &maximum ) {
-        require_building_handle( token, *definition, "body part" );
-        const double maximum_value = maximum.value_or( score );
-        if( id.empty() || !std::isfinite( score ) || !std::isfinite( maximum_value ) ||
-            score < 0.0 || maximum_value < score ) {
-            throw std::runtime_error( "body-part limb score is invalid" );
+        body_part_definition_handle &unarmed_damage( const std::string &damage_type,
+                const double amount ) {
+            return set_damage( definition->unarmed_damage, damage_type, amount,
+                               "unarmed damage" );
         }
-        definition->limb_scores[id] = { score, maximum_value };
-        return *this;
-    }
 
-    body_part_definition_handle &quality( const std::string &id,
-                                          const std::int64_t level,
-                                          const sol::optional<double> &disable_fraction ) {
-        require_building_handle( token, *definition, "body part" );
-        definition->qualities.push_back( {
-            id, level, disable_fraction.value_or( 0.0 )
-        } );
-        return *this;
-    }
+        body_part_definition_handle &flag( const std::string &id ) {
+            require_building_handle( token, *definition, "body part" );
+            if( id.empty() ) {
+                throw std::runtime_error( "body-part flag cannot be empty" );
+            }
+            definition->flags.insert( id );
+            return *this;
+        }
 
-    std::string id() const {
-        require_readable_handle( token, *definition, "body part" );
-        return definition->id;
-    }
+        body_part_definition_handle &limb_score( const std::string &id,
+                const double score, const sol::optional<double> &maximum ) {
+            require_building_handle( token, *definition, "body part" );
+            const double maximum_value = maximum.value_or( score );
+            if( id.empty() || !std::isfinite( score ) || !std::isfinite( maximum_value ) ||
+                score < 0.0 || maximum_value < score ) {
+                throw std::runtime_error( "body-part limb score is invalid" );
+            }
+            definition->limb_scores[id] = { score, maximum_value };
+            return *this;
+        }
+
+        body_part_definition_handle &quality( const std::string &id,
+                                              const std::int64_t level,
+                                              const sol::optional<double> &disable_fraction ) {
+            require_building_handle( token, *definition, "body part" );
+            definition->qualities.push_back( {
+                id, level, disable_fraction.value_or( 0.0 )
+            } );
+            return *this;
+        }
+
+        std::string id() const {
+            require_readable_handle( token, *definition, "body part" );
+            return definition->id;
+        }
 
     private:
         body_part_definition_handle &set_damage( std::map<std::string, double> &target,
@@ -2938,6 +3010,190 @@ struct body_part_definition_handle {
                 throw std::runtime_error( "body-part " + std::string( label ) + " is invalid" );
             }
             target[damage_type] = amount;
+            return *this;
+        }
+};
+
+struct wound_type_definition_handle {
+        std::shared_ptr<wound_type_definition_data> definition;
+        std::shared_ptr<owner_token> token;
+
+        wound_type_definition_handle &damage_type( const std::string &id ) {
+            require_building_handle( token, *definition, "wound" );
+            require_reference( id, "damage type" );
+            if( std::find( definition->damage_types.begin(), definition->damage_types.end(), id ) !=
+                definition->damage_types.end() ) {
+                throw std::runtime_error( "wound damage type must be unique" );
+            }
+            definition->damage_types.push_back( id );
+            return *this;
+        }
+
+        wound_type_definition_handle &limb_score( const std::string &id,
+                const double penalty ) {
+            require_building_handle( token, *definition, "wound" );
+            require_reference( id, "limb score" );
+            if( !std::isfinite( penalty ) || penalty < 0.0 || penalty > 1.0 ||
+                std::any_of( definition->limb_scores.begin(), definition->limb_scores.end(),
+            [&id]( const wound_limb_score_definition_data & value ) {
+            return value.id == id;
+        } ) ) {
+                throw std::runtime_error(
+                    "wound limb score requires a unique id and finite 0..1 penalty" );
+            }
+            definition->limb_scores.push_back( { id, penalty } );
+            return *this;
+        }
+
+        wound_type_definition_handle &progression( const std::string &id,
+                const std::int64_t chance ) {
+            require_building_handle( token, *definition, "wound" );
+            require_reference( id, "progression wound" );
+            if( id == definition->id || chance < 0 || chance > 100 ||
+                std::any_of( definition->progressions.begin(), definition->progressions.end(),
+            [&id]( const wound_progression_definition_data & value ) {
+            return value.id == id;
+        } ) ) {
+                throw std::runtime_error(
+                    "wound progression requires a unique non-self id and integer 0..100 chance" );
+            }
+            definition->progressions.push_back( { id, chance } );
+            return *this;
+        }
+
+        wound_type_definition_handle &require_body_part_type( const std::string &kind ) {
+            return body_part_type( kind, true );
+        }
+
+        wound_type_definition_handle &forbid_body_part_type( const std::string &kind ) {
+            return body_part_type( kind, false );
+        }
+
+        std::string id() const {
+            require_readable_handle( token, *definition, "wound" );
+            return definition->id;
+        }
+
+    private:
+        static void require_reference( const std::string &id, const char *kind ) {
+            if( id.empty() || id.size() > 256 || id.find( '\0' ) != std::string::npos ) {
+                throw std::runtime_error( std::string( "wound " ) + kind +
+                                          " id is invalid" );
+            }
+        }
+
+        wound_type_definition_handle &body_part_type( const std::string &kind,
+                const bool required ) {
+            require_building_handle( token, *definition, "wound" );
+            if( kind.empty() || kind.size() > 64 ||
+                kind.find( '\0' ) != std::string::npos ||
+                !io::string_to_enum_optional<bp_type>( kind ) ) {
+                throw std::runtime_error( "wound body-part type is invalid" );
+            }
+            std::vector<std::string> &target = required ?
+                                               definition->required_body_part_types :
+                                               definition->forbidden_body_part_types;
+            const std::vector<std::string> &opposite = required ?
+                    definition->forbidden_body_part_types :
+                    definition->required_body_part_types;
+            if( std::find( target.begin(), target.end(), kind ) != target.end() ) {
+                throw std::runtime_error( "wound body-part type must be unique" );
+            }
+            if( std::find( opposite.begin(), opposite.end(), kind ) != opposite.end() ) {
+                throw std::runtime_error(
+                    "wound cannot both require and forbid one body-part type" );
+            }
+            target.push_back( kind );
+            return *this;
+        }
+};
+
+struct wound_fix_definition_handle {
+        std::shared_ptr<wound_fix_definition_data> definition;
+        std::shared_ptr<owner_token> token;
+
+        wound_fix_definition_handle &skill( const std::string &id,
+                                            const std::int64_t level ) {
+            require_building_handle( token, *definition, "wound fix" );
+            require_reference( id, "skill" );
+            if( level < 0 || level > MAX_SKILL ||
+                !definition->skills.emplace( id, level ).second ) {
+                throw std::runtime_error(
+                    "wound-fix skill requires a unique id and level within the native range" );
+            }
+            return *this;
+        }
+
+        wound_fix_definition_handle &proficiency( const std::string &id,
+                const double multiplier, const bool mandatory ) {
+            require_building_handle( token, *definition, "wound fix" );
+            require_reference( id, "proficiency" );
+            if( !std::isfinite( multiplier ) || multiplier <= 0.0 ||
+                multiplier > std::numeric_limits<float>::max() ||
+                static_cast<float>( multiplier ) <= 0.0f ||
+                std::any_of( definition->proficiencies.begin(), definition->proficiencies.end(),
+            [&id]( const wound_fix_proficiency_definition_data & value ) {
+            return value.id == id;
+        } ) ) {
+                throw std::runtime_error(
+                    "wound-fix proficiency requires a unique id and positive finite multiplier" );
+            }
+            definition->proficiencies.push_back( { id, multiplier, mandatory } );
+            return *this;
+        }
+
+        wound_fix_definition_handle &removes( const std::string &id ) {
+            return wound_reference( id, true );
+        }
+
+        wound_fix_definition_handle &adds( const std::string &id ) {
+            return wound_reference( id, false );
+        }
+
+        wound_fix_definition_handle &requires( const std::string &id,
+                                               const std::int64_t count ) {
+            require_building_handle( token, *definition, "wound fix" );
+            require_reference( id, "requirement" );
+            if( count <= 0 || count > std::numeric_limits<int>::max() ||
+                std::any_of( definition->requirements.begin(), definition->requirements.end(),
+            [&id]( const wound_fix_requirement_definition_data & value ) {
+            return value.id == id;
+        } ) ) {
+                throw std::runtime_error(
+                    "wound-fix requirement requires a unique id and positive native count" );
+            }
+            definition->requirements.push_back( { id, count } );
+            return *this;
+        }
+
+        std::string id() const {
+            require_readable_handle( token, *definition, "wound fix" );
+            return definition->id;
+        }
+
+    private:
+        static void require_reference( const std::string &id, const char *kind ) {
+            if( id.empty() || id.size() > 256 || id.find( '\0' ) != std::string::npos ) {
+                throw std::runtime_error( std::string( "wound-fix " ) + kind +
+                                          " id is invalid" );
+            }
+        }
+
+        wound_fix_definition_handle &wound_reference( const std::string &id,
+                const bool removed ) {
+            require_building_handle( token, *definition, "wound fix" );
+            require_reference( id, "wound" );
+            std::set<std::string> &target = removed ? definition->wounds_removed :
+                                            definition->wounds_added;
+            const std::set<std::string> &opposite = removed ? definition->wounds_added :
+                                                    definition->wounds_removed;
+            if( opposite.count( id ) != 0 ) {
+                throw std::runtime_error(
+                    "wound fix cannot both remove and add one wound type" );
+            }
+            if( !target.insert( id ).second ) {
+                throw std::runtime_error( "wound-fix wound reference must be unique" );
+            }
             return *this;
         }
 };
@@ -3020,10 +3276,10 @@ struct body_graph_definition_handle {
                                    options.get<sol::optional<sol::table>>( "sub_body_parts" ),
                                    "body graph sub body parts" );
         if( symbol.empty() || std::any_of( definition->parts.begin(),
-                                          definition->parts.end(),
+                                           definition->parts.end(),
         [&symbol]( const body_graph_part_definition_data & existing ) {
-            return existing.symbol == symbol;
-        } ) ) {
+        return existing.symbol == symbol;
+    } ) ) {
             throw std::runtime_error( "body-graph part needs a unique symbol" );
         }
         definition->parts.push_back( std::move( value ) );
@@ -3037,149 +3293,154 @@ struct body_graph_definition_handle {
 };
 
 struct monster_definition_handle {
-    std::shared_ptr<monster_definition_data> definition;
-    std::shared_ptr<owner_token> token;
+        std::shared_ptr<monster_definition_data> definition;
+        std::shared_ptr<owner_token> token;
 
-    monster_definition_handle &material( const std::string &id,
-                                         const sol::optional<std::int64_t> &portions ) {
-        require_building_handle( token, *definition, "monster" );
-        const std::int64_t value = portions.value_or( 1 );
-        if( id.empty() || value <= 0 ) {
-            throw std::runtime_error( "monster material needs an id and positive portions" );
+        monster_definition_handle &material( const std::string &id,
+                                             const sol::optional<std::int64_t> &portions ) {
+            require_building_handle( token, *definition, "monster" );
+            const std::int64_t value = portions.value_or( 1 );
+            if( id.empty() || value <= 0 ) {
+                throw std::runtime_error( "monster material needs an id and positive portions" );
+            }
+            definition->materials[id] = value;
+            return *this;
         }
-        definition->materials[id] = value;
-        return *this;
-    }
 
-    monster_definition_handle &species( const std::string &id ) {
-        return insert_id( definition->species, id, "species" );
-    }
-
-    monster_definition_handle &category( const std::string &id ) {
-        return insert_id( definition->categories, id, "category" );
-    }
-
-    monster_definition_handle &flag( const std::string &id ) {
-        return insert_id( definition->flags, id, "flag" );
-    }
-
-    monster_definition_handle &armor( const std::string &damage_type,
-                                      const double amount ) {
-        require_building_handle( token, *definition, "monster" );
-        if( damage_type.empty() || !std::isfinite( amount ) || amount < 0.0 ) {
-            throw std::runtime_error( "monster armor is invalid" );
+        monster_definition_handle &species( const std::string &id ) {
+            return insert_id( definition->species, id, "species" );
         }
-        definition->armor[damage_type] = amount;
-        return *this;
-    }
 
-    monster_definition_handle &melee_damage(
-        const std::string &damage_type, const double amount,
-        const sol::optional<double> &armor_penetration ) {
-        require_building_handle( token, *definition, "monster" );
-        const double penetration = armor_penetration.value_or( 0.0 );
-        if( damage_type.empty() || !std::isfinite( amount ) || amount < 0.0 ||
-            !std::isfinite( penetration ) || penetration < 0.0 ) {
-            throw std::runtime_error( "monster melee damage is invalid" );
+        monster_definition_handle &category( const std::string &id ) {
+            return insert_id( definition->categories, id, "category" );
         }
-        definition->melee_damage[damage_type] = { amount, penetration };
-        return *this;
-    }
 
-    monster_definition_handle &attack( const std::string &id,
-                                       const sol::optional<double> &cooldown ) {
-        require_building_handle( token, *definition, "monster" );
-        if( id.empty() || std::any_of( definition->attacks.begin(),
-                                      definition->attacks.end(),
-        [&id]( const monster_attack_reference_definition_data & value ) {
+        monster_definition_handle &flag( const std::string &id ) {
+            return insert_id( definition->flags, id, "flag" );
+        }
+
+        monster_definition_handle &armor( const std::string &damage_type,
+                                          const double amount ) {
+            require_building_handle( token, *definition, "monster" );
+            if( damage_type.empty() || !std::isfinite( amount ) || amount < 0.0 ) {
+                throw std::runtime_error( "monster armor is invalid" );
+            }
+            definition->armor[damage_type] = amount;
+            return *this;
+        }
+
+        monster_definition_handle &melee_damage(
+            const std::string &damage_type, const double amount,
+            const sol::optional<double> &armor_penetration ) {
+            require_building_handle( token, *definition, "monster" );
+            const double penetration = armor_penetration.value_or( 0.0 );
+            if( damage_type.empty() || !std::isfinite( amount ) || amount < 0.0 ||
+                !std::isfinite( penetration ) || penetration < 0.0 ) {
+                throw std::runtime_error( "monster melee damage is invalid" );
+            }
+            definition->melee_damage[damage_type] = { amount, penetration };
+            return *this;
+        }
+
+        monster_definition_handle &attack( const std::string &id,
+                                           const sol::optional<double> &cooldown ) {
+            require_building_handle( token, *definition, "monster" );
+            if( id.empty() || std::any_of( definition->attacks.begin(),
+                                           definition->attacks.end(),
+            [&id]( const monster_attack_reference_definition_data & value ) {
             return value.id == id;
         } ) ) {
-            throw std::runtime_error( "monster attack reference needs a unique id" );
+                throw std::runtime_error( "monster attack reference needs a unique id" );
+            }
+            monster_attack_reference_definition_data attack;
+            attack.id = id;
+            if( cooldown ) {
+                attack.cooldown = *cooldown;
+            }
+            definition->attacks.push_back( std::move( attack ) );
+            return *this;
         }
-        definition->attacks.push_back( { id, cooldown } );
-        return *this;
-    }
 
-    monster_definition_handle &weakpoint_set( const std::string &id ) {
-        require_building_handle( token, *definition, "monster" );
-        if( id.empty() || std::find( definition->weakpoint_sets.begin(),
-                                     definition->weakpoint_sets.end(), id ) !=
-            definition->weakpoint_sets.end() ) {
-            throw std::runtime_error( "monster weakpoint set needs a unique id" );
+        monster_definition_handle &weakpoint_set( const std::string &id ) {
+            require_building_handle( token, *definition, "monster" );
+            if( id.empty() || std::find( definition->weakpoint_sets.begin(),
+                                         definition->weakpoint_sets.end(), id ) !=
+                definition->weakpoint_sets.end() ) {
+                throw std::runtime_error( "monster weakpoint set needs a unique id" );
+            }
+            definition->weakpoint_sets.push_back( id );
+            return *this;
         }
-        definition->weakpoint_sets.push_back( id );
-        return *this;
-    }
 
-    monster_definition_handle &emission( const std::string &id,
-                                         const std::int64_t interval_turns ) {
-        require_building_handle( token, *definition, "monster" );
-        if( id.empty() || interval_turns <= 0 ) {
-            throw std::runtime_error( "monster emission needs an id and positive interval" );
+        monster_definition_handle &emission( const std::string &id,
+                                             const std::int64_t interval_turns ) {
+            require_building_handle( token, *definition, "monster" );
+            if( id.empty() || interval_turns <= 0 ) {
+                throw std::runtime_error( "monster emission needs an id and positive interval" );
+            }
+            definition->emissions[id] = interval_turns;
+            return *this;
         }
-        definition->emissions[id] = interval_turns;
-        return *this;
-    }
 
-    monster_definition_handle &starting_ammo( const std::string &id,
-            const std::int64_t amount ) {
-        require_building_handle( token, *definition, "monster" );
-        if( id.empty() || amount <= 0 ) {
-            throw std::runtime_error( "monster starting ammo needs an id and positive amount" );
+        monster_definition_handle &starting_ammo( const std::string &id,
+                const std::int64_t amount ) {
+            require_building_handle( token, *definition, "monster" );
+            if( id.empty() || amount <= 0 ) {
+                throw std::runtime_error( "monster starting ammo needs an id and positive amount" );
+            }
+            definition->starting_ammo[id] = amount;
+            return *this;
         }
-        definition->starting_ammo[id] = amount;
-        return *this;
-    }
 
-    monster_definition_handle &track_scent( const std::string &id ) {
-        return insert_id( definition->tracked_scents, id, "tracked scent" );
-    }
-
-    monster_definition_handle &ignore_scent( const std::string &id ) {
-        return insert_id( definition->ignored_scents, id, "ignored scent" );
-    }
-
-    monster_definition_handle &regeneration_modifier( const std::string &effect,
-            const std::int64_t amount ) {
-        require_building_handle( token, *definition, "monster" );
-        if( effect.empty() || amount < std::numeric_limits<int>::min() ||
-            amount > std::numeric_limits<int>::max() ) {
-            throw std::runtime_error( "monster regeneration modifier is invalid" );
+        monster_definition_handle &track_scent( const std::string &id ) {
+            return insert_id( definition->tracked_scents, id, "tracked scent" );
         }
-        definition->regeneration_modifiers[effect] = amount;
-        return *this;
-    }
 
-    monster_definition_handle &goal( const std::string &id ) {
-        require_building_handle( token, *definition, "monster" );
-        if( id.empty() || std::find( definition->goals.begin(), definition->goals.end(), id ) !=
-            definition->goals.end() ) {
-            throw std::runtime_error( "monster behavior goal needs a unique id" );
+        monster_definition_handle &ignore_scent( const std::string &id ) {
+            return insert_id( definition->ignored_scents, id, "ignored scent" );
         }
-        definition->goals.push_back( id );
-        return *this;
-    }
 
-    monster_definition_handle &anger_trigger( const std::string &id ) {
-        return insert_id( definition->anger_triggers, id, "anger trigger" );
-    }
+        monster_definition_handle &regeneration_modifier( const std::string &effect,
+                const std::int64_t amount ) {
+            require_building_handle( token, *definition, "monster" );
+            if( effect.empty() || amount < std::numeric_limits<int>::min() ||
+                amount > std::numeric_limits<int>::max() ) {
+                throw std::runtime_error( "monster regeneration modifier is invalid" );
+            }
+            definition->regeneration_modifiers[effect] = amount;
+            return *this;
+        }
 
-    monster_definition_handle &fear_trigger( const std::string &id ) {
-        return insert_id( definition->fear_triggers, id, "fear trigger" );
-    }
+        monster_definition_handle &goal( const std::string &id ) {
+            require_building_handle( token, *definition, "monster" );
+            if( id.empty() || std::find( definition->goals.begin(), definition->goals.end(), id ) !=
+                definition->goals.end() ) {
+                throw std::runtime_error( "monster behavior goal needs a unique id" );
+            }
+            definition->goals.push_back( id );
+            return *this;
+        }
 
-    monster_definition_handle &placate_trigger( const std::string &id ) {
-        return insert_id( definition->placate_triggers, id, "placate trigger" );
-    }
+        monster_definition_handle &anger_trigger( const std::string &id ) {
+            return insert_id( definition->anger_triggers, id, "anger trigger" );
+        }
 
-    std::string id() const {
-        require_readable_handle( token, *definition, "monster" );
-        return definition->id;
-    }
+        monster_definition_handle &fear_trigger( const std::string &id ) {
+            return insert_id( definition->fear_triggers, id, "fear trigger" );
+        }
+
+        monster_definition_handle &placate_trigger( const std::string &id ) {
+            return insert_id( definition->placate_triggers, id, "placate trigger" );
+        }
+
+        std::string id() const {
+            require_readable_handle( token, *definition, "monster" );
+            return definition->id;
+        }
 
     private:
         monster_definition_handle &insert_id( std::set<std::string> &target,
-                const std::string &id, const std::string_view label ) {
+                                              const std::string &id, const std::string_view label ) {
             require_building_handle( token, *definition, "monster" );
             if( id.empty() ) {
                 throw std::runtime_error( "monster " + std::string( label ) +
@@ -3191,25 +3452,25 @@ struct monster_definition_handle {
 };
 
 struct item_group_definition_handle {
-    std::shared_ptr<item_group_definition_data> definition;
-    std::shared_ptr<owner_token> token;
+        std::shared_ptr<item_group_definition_data> definition;
+        std::shared_ptr<owner_token> token;
 
-    item_group_definition_handle &item( const std::string &id,
-                                        const sol::optional<std::int64_t> &probability,
-                                        const sol::optional<std::string> &variant ) {
-        return add_entry( id, false, probability.value_or( 100 ),
-                          variant.value_or( std::string() ) );
-    }
+        item_group_definition_handle &item( const std::string &id,
+                                            const sol::optional<std::int64_t> &probability,
+                                            const sol::optional<std::string> &variant ) {
+            return add_entry( id, false, probability.value_or( 100 ),
+                              variant.value_or( std::string() ) );
+        }
 
-    item_group_definition_handle &group( const std::string &id,
-                                         const sol::optional<std::int64_t> &probability ) {
-        return add_entry( id, true, probability.value_or( 100 ), std::string() );
-    }
+        item_group_definition_handle &group( const std::string &id,
+                                             const sol::optional<std::int64_t> &probability ) {
+            return add_entry( id, true, probability.value_or( 100 ), std::string() );
+        }
 
-    std::string id() const {
-        require_readable_handle( token, *definition, "item group" );
-        return definition->id;
-    }
+        std::string id() const {
+            require_readable_handle( token, *definition, "item group" );
+            return definition->id;
+        }
 
     private:
         item_group_definition_handle &add_entry( const std::string &id, const bool group,
@@ -3224,69 +3485,69 @@ struct item_group_definition_handle {
 };
 
 struct field_type_definition_handle {
-    std::shared_ptr<field_type_definition_data> definition;
-    std::shared_ptr<owner_token> token;
+        std::shared_ptr<field_type_definition_data> definition;
+        std::shared_ptr<owner_token> token;
 
-    field_type_definition_handle &intensity( const sol::table &options ) {
-        require_building_handle( token, *definition, "field type" );
-        field_intensity_definition_data value;
-        value.name = options.get_or( "name", std::string() );
-        value.symbol = options.get_or( "symbol", std::string( "%" ) );
-        value.color = options.get_or( "color", std::string( "white" ) );
-        value.dangerous = options.get_or( "dangerous", false );
-        value.transparent = options.get_or( "transparent", true );
-        value.move_cost = options.get_or<std::int64_t>( "move_cost", 0 );
-        value.upgrade_chance = options.get_or<std::int64_t>( "upgrade_chance", 0 );
-        value.upgrade_duration_turns = options.get_or<std::int64_t>(
-                                           "upgrade_duration_turns", 0 );
-        value.light_emitted = options.get_or( "light_emitted", 0.0 );
-        value.local_light_override = options.get_or( "local_light_override", -1.0 );
-        value.translucency = options.get_or( "translucency", 0.0 );
-        value.concentration = options.get_or<std::int64_t>( "concentration", 1 );
-        value.convection_temperature_modifier = options.get_or<std::int64_t>(
+        field_type_definition_handle &intensity( const sol::table &options ) {
+            require_building_handle( token, *definition, "field type" );
+            field_intensity_definition_data value;
+            value.name = options.get_or( "name", std::string() );
+            value.symbol = options.get_or( "symbol", std::string( "%" ) );
+            value.color = options.get_or( "color", std::string( "white" ) );
+            value.dangerous = options.get_or( "dangerous", false );
+            value.transparent = options.get_or( "transparent", true );
+            value.move_cost = options.get_or<std::int64_t>( "move_cost", 0 );
+            value.upgrade_chance = options.get_or<std::int64_t>( "upgrade_chance", 0 );
+            value.upgrade_duration_turns = options.get_or<std::int64_t>(
+                                               "upgrade_duration_turns", 0 );
+            value.light_emitted = options.get_or( "light_emitted", 0.0 );
+            value.local_light_override = options.get_or( "local_light_override", -1.0 );
+            value.translucency = options.get_or( "translucency", 0.0 );
+            value.concentration = options.get_or<std::int64_t>( "concentration", 1 );
+            value.convection_temperature_modifier = options.get_or<std::int64_t>(
                     "convection_temperature_modifier", 0 );
-        value.scent_neutralization = options.get_or<std::int64_t>(
-                                         "scent_neutralization", 0 );
-        definition->intensity_levels.push_back( std::move( value ) );
-        return *this;
-    }
-
-    field_type_definition_handle &effect( const std::int64_t intensity_index,
-                                          const sol::table &options ) {
-        require_building_handle( token, *definition, "field type" );
-        if( intensity_index <= 0 ||
-            static_cast<std::size_t>( intensity_index ) >
-            definition->intensity_levels.size() ) {
-            throw std::runtime_error( "field effect needs an existing one-based intensity" );
+            value.scent_neutralization = options.get_or<std::int64_t>(
+                                             "scent_neutralization", 0 );
+            definition->intensity_levels.push_back( std::move( value ) );
+            return *this;
         }
-        field_effect_definition_data value;
-        value.effect = options.get_or( "effect", std::string() );
-        value.duration_min_turns = options.get_or<std::int64_t>(
-                                       "duration_min_turns", 0 );
-        value.duration_max_turns = options.get_or<std::int64_t>(
-                                       "duration_max_turns", value.duration_min_turns );
-        value.intensity = options.get_or<std::int64_t>( "intensity", 1 );
-        value.body_part = options.get_or( "body_part", std::string() );
-        value.environmental = options.get_or( "environmental", true );
-        value.message = options.get_or( "message", std::string() );
-        value.npc_message = options.get_or( "npc_message", std::string() );
-        definition->intensity_levels[static_cast<std::size_t>( intensity_index - 1 )].
-        effects.push_back( std::move( value ) );
-        return *this;
-    }
 
-    field_type_definition_handle &immune_monster( const std::string &id ) {
-        return insert_monster( definition->immune_monsters, id, "immune monster" );
-    }
+        field_type_definition_handle &effect( const std::int64_t intensity_index,
+                                              const sol::table &options ) {
+            require_building_handle( token, *definition, "field type" );
+            if( intensity_index <= 0 ||
+                static_cast<std::size_t>( intensity_index ) >
+                definition->intensity_levels.size() ) {
+                throw std::runtime_error( "field effect needs an existing one-based intensity" );
+            }
+            field_effect_definition_data value;
+            value.effect = options.get_or( "effect", std::string() );
+            value.duration_min_turns = options.get_or<std::int64_t>(
+                                           "duration_min_turns", 0 );
+            value.duration_max_turns = options.get_or<std::int64_t>(
+                                           "duration_max_turns", value.duration_min_turns );
+            value.intensity = options.get_or<std::int64_t>( "intensity", 1 );
+            value.body_part = options.get_or( "body_part", std::string() );
+            value.environmental = options.get_or( "environmental", true );
+            value.message = options.get_or( "message", std::string() );
+            value.npc_message = options.get_or( "npc_message", std::string() );
+            definition->intensity_levels[static_cast<std::size_t>( intensity_index - 1 )].
+            effects.push_back( std::move( value ) );
+            return *this;
+        }
 
-    field_type_definition_handle &block_monster( const std::string &id ) {
-        return insert_monster( definition->blocked_monsters, id, "blocked monster" );
-    }
+        field_type_definition_handle &immune_monster( const std::string &id ) {
+            return insert_monster( definition->immune_monsters, id, "immune monster" );
+        }
 
-    std::string id() const {
-        require_readable_handle( token, *definition, "field type" );
-        return definition->id;
-    }
+        field_type_definition_handle &block_monster( const std::string &id ) {
+            return insert_monster( definition->blocked_monsters, id, "blocked monster" );
+        }
+
+        std::string id() const {
+            require_readable_handle( token, *definition, "field type" );
+            return definition->id;
+        }
 
     private:
         field_type_definition_handle &insert_monster( std::set<std::string> &target,
@@ -3841,7 +4102,8 @@ struct explosion_light_definition_handle {
         value.color = { {
                 component( red, "red" ), component( green, "green" ),
                 component( blue, "blue" )
-            } };
+            }
+        };
         value.alpha = component( alpha, "alpha" );
         definition->stops.push_back( value );
         return *this;
@@ -3855,9 +4117,9 @@ struct explosion_light_definition_handle {
         definition->fade = options.get_or( "fade", definition->fade );
         definition->blend = options.get_or( "blend", definition->blend );
         definition->spread_jitter = options.get_or(
-                                         "spread_jitter", definition->spread_jitter );
+                                        "spread_jitter", definition->spread_jitter );
         definition->color_jitter = options.get_or(
-                                        "color_jitter", definition->color_jitter );
+                                       "color_jitter", definition->color_jitter );
         definition->flicker = options.get_or( "flicker", definition->flicker );
         definition->easing = options.get_or( "easing", definition->easing );
         return *this;
@@ -4151,9 +4413,9 @@ struct climbing_aid_definition_handle {
         require_building_handle( token, *definition, "climbing aid" );
         definition->max_height = options.get_or<std::int64_t>( "max_height", 1 );
         definition->easy_climb_back_up = options.get_or<std::int64_t>(
-                                               "easy_climb_back_up", 0 );
+                                             "easy_climb_back_up", 0 );
         definition->allow_remaining_height = options.get_or(
-                                                 "allow_remaining_height", true );
+                "allow_remaining_height", true );
         definition->menu_text = options.get_or( "menu_text", std::string() );
         definition->unavailable_text = options.get_or(
                                            "unavailable_text", std::string() );
@@ -4655,7 +4917,8 @@ using damage_type_registration = catalog_registration<damage_type_definition_dat
 using ammunition_type_registration = catalog_registration<ammunition_type_definition_data>;
 using item_category_registration = catalog_registration<item_category_definition_data>;
 using crafting_category_registration = catalog_registration<crafting_category_definition_data>;
-using proficiency_category_registration = catalog_registration<proficiency_category_definition_data>;
+using proficiency_category_registration =
+    catalog_registration<proficiency_category_definition_data>;
 using proficiency_registration = catalog_registration<proficiency_definition_data>;
 using weapon_category_registration = catalog_registration<weapon_category_definition_data>;
 using requirement_registration = catalog_registration<requirement_definition_data>;
@@ -4672,6 +4935,8 @@ using field_type_registration = catalog_registration<field_type_definition_data>
 using item_group_registration = catalog_registration<item_group_definition_data>;
 using sub_body_part_registration = catalog_registration<sub_body_part_definition_data>;
 using body_part_registration = catalog_registration<body_part_definition_data>;
+using wound_type_registration = catalog_registration<wound_type_definition_data>;
+using wound_fix_registration = catalog_registration<wound_fix_definition_data>;
 using anatomy_registration = catalog_registration<anatomy_definition_data>;
 using body_graph_registration = catalog_registration<body_graph_definition_data>;
 using monster_registration = catalog_registration<monster_definition_data>;
@@ -4932,7 +5197,8 @@ std::optional<weather_sound_category> platform_weather_sound_category( std::stri
         { "cloudy", weather_sound_category::cloudy },
     };
     const auto found = values.find( value );
-    return found == values.end() ? std::nullopt : std::optional<weather_sound_category>( found->second );
+    return found == values.end() ? std::nullopt : std::optional<weather_sound_category>
+           ( found->second );
 }
 
 std::uint64_t fnv1a( std::string_view value, std::uint64_t state = 1469598103934665603ULL )
@@ -5067,10 +5333,16 @@ std::vector<presentation_choice> presentation_choices_from_lua(
 }
 
 struct use_context_data {
+    use_context_data() = default;
+    use_context_data( const use_context_data & ) = delete;
+    use_context_data &operator=( const use_context_data & ) = delete;
+    use_context_data( use_context_data && ) = delete;
+    use_context_data &operator=( use_context_data && ) = delete;
+
     Character *character = nullptr;
     item *used_item = nullptr;
     tripoint_bub_ms position;
-    std::size_t runtime_generation = 0;
+    cata::lua_ui::game_handle_runtime handle_runtime;
     std::size_t world_generation = 0;
     bool active = true;
 
@@ -5114,14 +5386,14 @@ struct use_context_data {
         return cata::lua_ui::game_handle::from_creature( *character, {
             "platform_item_use_character", character->getID().get_value(),
             absolute.x(), absolute.y(), absolute.z(), {}
-        }, runtime_generation, world_generation );
+        }, handle_runtime, world_generation );
     }
 
     cata::lua_ui::game_handle item_handle() const {
         require_active();
         return cata::lua_ui::game_handle::from_item( *used_item, {
             "platform_item_use_item", used_item->uid().get_value(), 0, 0, 0, {}
-        }, runtime_generation, world_generation );
+        }, handle_runtime, world_generation );
     }
 
     cata::lua_ui::script_tripoint_coord use_position() const {
@@ -5130,6 +5402,24 @@ struct use_context_data {
                    coords::origin::reality_bubble, coords::scale::map_square,
                    position.raw() );
     }
+};
+
+class use_context_lease
+{
+    public:
+        explicit use_context_lease( use_context_data &context ) : context_( context ) {}
+
+        use_context_lease( const use_context_lease & ) = delete;
+        use_context_lease &operator=( const use_context_lease & ) = delete;
+
+        ~use_context_lease() noexcept {
+            context_.active = false;
+            context_.character = nullptr;
+            context_.used_item = nullptr;
+        }
+
+    private:
+        use_context_data &context_;
 };
 
 std::int64_t nonnegative_turn_difference( const std::int64_t later,
@@ -5189,7 +5479,7 @@ sol::object get_persistent_value( const persistent_state &store,
         }
         return fallback.value_or( sol::make_object( lua, sol::lua_nil ) );
     }
-    return std::visit( [lua]( const auto &entry ) {
+    return std::visit( [lua]( const auto & entry ) {
         return sol::make_object( lua, entry );
     }, found->second );
 }
@@ -5198,7 +5488,7 @@ sol::table persistent_table( sol::state &lua, const persistent_state &values )
 {
     sol::table result = lua.create_table();
     for( const auto &[key, value] : values ) {
-        std::visit( [&result, &key]( const auto &entry ) {
+        std::visit( [&result, &key]( const auto & entry ) {
             result[key] = entry;
         }, value );
     }
@@ -5241,7 +5531,7 @@ void write_typed_values( JsonOut &json, const persistent_state &values )
     for( const std::string &key : keys ) {
         json.member( key );
         json.start_object();
-        std::visit( [&json]( const auto &value ) {
+        std::visit( [&json]( const auto & value ) {
             using value_type = std::decay_t<decltype( value )>;
             if constexpr( std::is_same_v<value_type, bool> ) {
                 json.member( "type", "boolean" );
@@ -5300,6 +5590,8 @@ class runtime : public std::enable_shared_from_this<runtime>
 
         std::string mod_id;
         std::size_t generation = 0;
+        cata::lua_ui::game_handle_runtime_owner_ptr game_handle_owner =
+            cata::lua_ui::make_game_handle_runtime_owner();
         sol::state *lua = nullptr;
         content_transaction content;
         std::unordered_map<std::string, handler_definition> handlers;
@@ -5315,13 +5607,17 @@ class runtime : public std::enable_shared_from_this<runtime>
         std::mt19937_64 random_engine;
         int callback_depth = 0;
         bool world_is_ready = false;
+
+        cata::lua_ui::game_handle_runtime handle_runtime() const {
+            return cata::lua_ui::game_handle_runtime( game_handle_owner, generation );
+        }
 };
 
 struct content_transaction::impl {
     impl( std::string owner_id, std::size_t owner_generation ) :
         owner( std::move( owner_id ) ), generation( owner_generation ),
         token( std::make_shared<owner_token>( owner_token{ owner, generation,
-                handle_lifecycle::building } ) ) {}
+                                              handle_lifecycle::building } ) ) {}
 
     std::string owner;
     std::size_t generation = 0;
@@ -5352,7 +5648,9 @@ struct content_transaction::impl {
     std::vector<field_type_registration> field_types;
     std::vector<item_group_registration> item_groups;
     std::vector<sub_body_part_registration> sub_body_parts;
+    std::vector<wound_type_registration> wound_types;
     std::vector<body_part_registration> body_parts;
+    std::vector<wound_fix_registration> wound_fixes;
     std::vector<anatomy_registration> anatomies;
     std::vector<body_graph_registration> body_graphs;
     std::vector<monster_registration> monsters;
@@ -5408,7 +5706,7 @@ struct content_transaction::impl {
     std::vector<recipe_registration> recipes;
     std::vector<std::pair<quality_id, std::optional<quality>>> tool_quality_undo;
     std::vector<std::pair<skill_displayType_id, std::optional<SkillDisplayType>>>
-            skill_display_undo;
+    skill_display_undo;
     std::vector<std::pair<skill_id, std::optional<Skill>>> skill_undo;
     std::vector<std::pair<vitamin_id, std::optional<vitamin>>> vitamin_undo;
     std::vector<std::pair<flag_id, std::optional<json_flag>>> json_flag_undo;
@@ -5418,32 +5716,34 @@ struct content_transaction::impl {
     std::vector<std::tuple<item_category_id, std::optional<item_category>, float>>
             item_category_undo;
     std::vector<std::pair<crafting_category_id, std::optional<crafting_category>>>
-            crafting_category_undo;
+    crafting_category_undo;
     std::vector<std::pair<proficiency_category_id, std::optional<proficiency_category>>>
-            proficiency_category_undo;
+    proficiency_category_undo;
     std::vector<std::pair<proficiency_id, std::optional<proficiency>>> proficiency_undo;
     std::vector<std::pair<weapon_category_id, std::optional<weapon_category>>>
-            weapon_category_undo;
+    weapon_category_undo;
     std::vector<std::pair<requirement_id, std::optional<requirement_data>>> requirement_undo;
     std::vector<std::pair<std::string,
         std::optional<detail::recipe_group_native_definition>>> recipe_group_undo;
     std::vector<std::pair<scenttype_id, std::optional<scent_type>>> scent_type_undo;
     std::vector<std::pair<speed_description_id, std::optional<speed_description>>>
-            speed_description_undo;
+    speed_description_undo;
     std::vector<std::pair<harvest_drop_type_id, std::optional<harvest_drop_type>>>
-            harvest_drop_type_undo;
+    harvest_drop_type_undo;
     std::vector<std::pair<harvest_id, std::optional<harvest_list>>> harvest_undo;
     std::vector<std::pair<string_id<behavior::node_t>,
         std::optional<behavior::node_t>>> behavior_undo;
     std::vector<std::pair<std::string, std::optional<effect_type>>> effect_type_undo;
     std::vector<std::pair<std::string, std::optional<mtype_special_attack>>>
-            monster_attack_undo;
+    monster_attack_undo;
     std::vector<std::pair<weakpoints_id, std::optional<weakpoints>>> weakpoint_set_undo;
     std::vector<std::pair<field_type_str_id, std::optional<field_type>>> field_type_undo;
     std::vector<std::pair<item_group_id, std::unique_ptr<Item_spawn_data>>> item_group_undo;
     std::vector<std::pair<sub_bodypart_str_id, std::optional<sub_body_part_type>>>
-            sub_body_part_undo;
+    sub_body_part_undo;
+    std::vector<std::pair<wound_type_id, std::optional<wound_type>>> wound_type_undo;
     std::vector<std::pair<bodypart_str_id, std::optional<body_part_type>>> body_part_undo;
+    std::vector<std::pair<wound_fix_id, std::optional<wound_fix>>> wound_fix_undo;
     std::vector<std::pair<anatomy_id, std::optional<anatomy>>> anatomy_undo;
     std::vector<std::pair<bodygraph_id, std::optional<bodygraph>>> body_graph_undo;
     std::vector<std::pair<mtype_id, std::optional<mtype>>> monster_undo;
@@ -5453,11 +5753,11 @@ struct content_transaction::impl {
     std::vector<std::pair<species_id, std::optional<species_type>>> species_undo;
     std::vector<std::pair<std::string, std::optional<emit>>> emission_undo;
     std::vector<std::pair<mfaction_str_id, std::optional<monfaction>>>
-            monster_faction_undo;
+    monster_faction_undo;
     std::vector<std::pair<std::string, bool>> mutation_type_undo;
     std::vector<std::pair<std::string, std::optional<connect_group>>> connect_group_undo;
     std::vector<std::pair<std::string, std::optional<mutation_category_trait>>>
-            mutation_category_undo;
+    mutation_category_undo;
     std::vector<std::pair<construction_category_id,
         std::optional<construction_category>>> construction_category_undo;
     std::vector<std::pair<construction_group_str_id,
@@ -5503,13 +5803,13 @@ struct content_transaction::impl {
     std::vector<std::pair<std::string, std::optional<int>>> overlay_order_undo;
     std::vector<std::pair<zone_type_id, std::optional<zone_type>>> zone_type_undo;
     std::vector<std::pair<std::string, std::optional<std::vector<SpeechBubble>>>>
-            speech_pool_undo;
+    speech_pool_undo;
     std::vector<std::pair<end_screen_id, std::optional<end_screen>>> end_screen_undo;
     std::vector<std::pair<activity_id, std::optional<activity_type>>> activity_type_undo;
     std::optional<help> help_undo;
     std::optional<snippet_library> snippet_library_undo;
     std::vector<std::pair<std::string, std::optional<sfx::playlist_definition>>>
-            playlist_undo;
+    playlist_undo;
     std::vector<std::pair<attack_vector_id, std::optional<attack_vector>>>
     attack_vector_undo;
     std::vector<std::pair<magic_type_id, std::optional<magic_type>>> magic_type_undo;
@@ -5524,6 +5824,7 @@ namespace
 
 std::vector<std::shared_ptr<runtime>> active_runtimes;
 std::size_t active_world_generation = 0;
+int platform_event_dispatch_depth = 0;
 std::map<std::string, persistent_scope_record> orphan_character_records;
 std::map<std::string, persistent_scope_record> orphan_world_records;
 
@@ -5559,6 +5860,21 @@ class callback_scope
         runtime &owner_;
 };
 
+class platform_event_dispatch_scope
+{
+    public:
+        platform_event_dispatch_scope() {
+            ++platform_event_dispatch_depth;
+        }
+
+        platform_event_dispatch_scope( const platform_event_dispatch_scope & ) = delete;
+        platform_event_dispatch_scope &operator=( const platform_event_dispatch_scope & ) = delete;
+
+        ~platform_event_dispatch_scope() {
+            --platform_event_dispatch_depth;
+        }
+};
+
 void require_live_runtime( const std::weak_ptr<runtime> &weak,
                            const std::string_view api_name )
 {
@@ -5585,11 +5901,71 @@ void report_callback_error( const runtime &owner, std::string_view handler,
     ::add_msg( m_bad, message );
 }
 
-sol::table event_to_lua( runtime &owner, const cata::event &event )
+cata::lua_ui::game_handle platform_creature_handle( const runtime &owner,
+        const Creature &creature );
+
+Character *platform_event_character( const character_id &id )
+{
+    avatar &player = get_avatar();
+    if( player.getID() == id ) {
+        return &player;
+    }
+    return g == nullptr ? nullptr : g->find_npc( id );
+}
+
+bool platform_event_contract_exists( const std::string_view name )
+{
+    for( int raw = 0; raw < static_cast<int>( event_type::num_event_types ); ++raw ) {
+        if( io::enum_to_string( static_cast<event_type>( raw ) ) == name ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+std::map<std::string, Character *> platform_event_characters( const cata::event &event )
+{
+    std::map<std::string, Character *> result;
+    for( const auto &[name, value] : event.data() ) {
+        if( value.type() != cata_variant_type::character_id ) {
+            continue;
+        }
+        const character_id id = value.get<cata_variant_type::character_id>();
+        if( Character *character = platform_event_character( id ) ) {
+            result.emplace( name, character );
+        }
+    }
+    return result;
+}
+
+const item *platform_event_item( const cata::event &event, const talker *item_actor )
+{
+    if( item_actor == nullptr ) {
+        return nullptr;
+    }
+    // These native producers explicitly attach their semantic item_location as
+    // the second talker.  Do not treat that position as a generic actor fallback.
+    switch( event.type() ) {
+        case event_type::character_wields_item:
+        case event_type::character_wears_item:
+        case event_type::character_takeoff_item:
+        case event_type::character_armor_destroyed:
+            break;
+        default:
+            return nullptr;
+    }
+    const item_location *location = item_actor->get_const_item();
+    return location == nullptr ? nullptr : location->get_item();
+}
+
+sol::table event_to_lua( runtime &owner, const cata::event &event,
+                         const std::map<std::string, Character *> &characters,
+                         const item *event_item )
 {
     sol::table result = owner.lua->create_table();
     sol::table data = owner.lua->create_table();
     sol::table data_types = owner.lua->create_table();
+    sol::table actors = owner.lua->create_table();
     result["type"] = io::enum_to_string( event.type() );
     result["turn"] = to_turn<std::int64_t>( event.time() );
     for( const auto &[name, value] : event.data() ) {
@@ -5600,9 +5976,16 @@ sol::table event_to_lua( runtime &owner, const cata::event &event )
             case cata_variant_type::int_:
                 data[name] = value.get<cata_variant_type::int_>();
                 break;
-            case cata_variant_type::character_id:
-                data[name] = value.get<cata_variant_type::character_id>().get_value();
-                break;
+            case cata_variant_type::character_id: {
+                const character_id id =
+                    value.get<cata_variant_type::character_id>();
+                data[name] = id.get_value();
+                const auto character = characters.find( name );
+                if( character != characters.end() ) {
+                    actors[name] = platform_creature_handle( owner, *character->second );
+                }
+            }
+            break;
             case cata_variant_type::chrono_seconds:
                 data[name] = value.get<cata_variant_type::chrono_seconds>().count();
                 break;
@@ -5612,9 +5995,39 @@ sol::table event_to_lua( runtime &owner, const cata::event &event )
         }
         data_types[name] = io::enum_to_string( value.type() );
     }
+    if( event_item != nullptr ) {
+        actors["item"] = cata::lua_ui::game_handle::from_item(
+        const_cast<item &>( *event_item ), {
+            "platform_event_item", event_item->uid().get_value(), 0, 0, 0, {}
+        }, owner.handle_runtime(), active_world_generation );
+    }
     result["data"] = std::move( data );
     result["data_types"] = std::move( data_types );
+    result["actors"] = std::move( actors );
     return result;
+}
+
+void dispatch_event_handler( runtime &owner, const std::string &name,
+                             const std::string &handler_id, const sol::object &payload )
+{
+    if( owner.callback_depth >= 16 ) {
+        DebugLog( D_ERROR, D_MAIN ) << "Lua-first event recursion limit reached for '"
+                                    << owner.mod_id << ':' << name << "'";
+        return;
+    }
+    const auto handler = owner.handlers.find( handler_id );
+    if( handler == owner.handlers.end() ) {
+        DebugLog( D_ERROR, D_MAIN ) << "Lua-first event '" << name
+                                    << "' references missing handler '"
+                                    << owner.mod_id << ":" << handler_id << "'";
+        return;
+    }
+    sol::protected_function callback = handler->second.callback;
+    callback_scope scope( owner );
+    const sol::protected_function_result result = callback( payload );
+    if( !result.valid() ) {
+        report_callback_error( owner, handler_id, result );
+    }
 }
 
 void dispatch_event( runtime &owner, const std::string &name, sol::object payload )
@@ -5623,21 +6036,14 @@ void dispatch_event( runtime &owner, const std::string &name, sol::object payloa
     if( subscription == owner.subscriptions.end() ) {
         return;
     }
+    if( owner.callback_depth >= 16 ) {
+        DebugLog( D_ERROR, D_MAIN ) << "Lua-first event recursion limit reached for '"
+                                    << owner.mod_id << ':' << name << "'";
+        return;
+    }
     const std::vector<std::string> handler_ids = subscription->second;
     for( const std::string &handler_id : handler_ids ) {
-        const auto handler = owner.handlers.find( handler_id );
-        if( handler == owner.handlers.end() ) {
-            DebugLog( D_ERROR, D_MAIN ) << "Lua-first event '" << name
-                                        << "' references missing handler '"
-                                        << owner.mod_id << ":" << handler_id << "'";
-            continue;
-        }
-        sol::protected_function callback = handler->second.callback;
-        callback_scope scope( owner );
-        const sol::protected_function_result result = callback( payload );
-        if( !result.valid() ) {
-            report_callback_error( owner, handler_id, result );
-        }
+        dispatch_event_handler( owner, name, handler_id, payload );
     }
 }
 
@@ -5725,7 +6131,7 @@ cata::lua_ui::game_handle platform_creature_handle( const runtime &owner,
         locator.stable_id = character->getID().get_value();
     }
     return cata::lua_ui::game_handle::from_creature(
-               mutable_creature, std::move( locator ), owner.generation,
+               mutable_creature, std::move( locator ), owner.handle_runtime(),
                active_world_generation );
 }
 
@@ -5738,18 +6144,18 @@ sol::object platform_talker_to_lua( runtime &owner, const const_talker &talker )
     if( const item_location *location = talker.get_const_item() ) {
         if( const item *value = location->get_item() ) {
             return sol::make_object( lua, cata::lua_ui::game_handle::from_item(
-                                         const_cast<item &>( *value ), {
+            const_cast<item &>( *value ), {
                 "platform_callback_talker_item", value->uid().get_value(), 0, 0, 0, {}
-            }, owner.generation, active_world_generation ) );
+            }, owner.handle_runtime(), active_world_generation ) );
         }
     }
     if( const vehicle *value = talker.get_const_vehicle() ) {
         const tripoint_abs_ms position = value->pos_abs();
         return sol::make_object( lua, cata::lua_ui::game_handle::from_vehicle(
-                                     const_cast<vehicle &>( *value ), {
-                "platform_callback_talker_vehicle", 0,
-                position.x(), position.y(), position.z(), {}
-            }, owner.generation, active_world_generation ) );
+        const_cast<vehicle &>( *value ), {
+            "platform_callback_talker_vehicle", 0,
+            position.x(), position.y(), position.z(), {}
+        }, owner.handle_runtime(), active_world_generation ) );
     }
 
     sol::table snapshot = owner.lua->create_table();
@@ -5777,24 +6183,27 @@ sol::object platform_callback_value_to_lua(
     runtime &owner, const cata::lua_ui::native_callback_value &value )
 {
     sol::state_view lua( *owner.lua );
-    return std::visit( [&owner, lua]( const auto &entry ) -> sol::object {
+    return std::visit( [&owner, lua]( const auto & entry ) -> sol::object {
         using value_type = std::decay_t<decltype( entry )>;
         if constexpr( std::is_same_v<value_type, const Character *> ||
-                      std::is_same_v<value_type, const Creature *> ) {
+                      std::is_same_v<value_type, const Creature *> )
+        {
             if( entry == nullptr ) {
                 return sol::make_object( lua, sol::lua_nil );
             }
             return sol::make_object( lua, platform_creature_handle( owner, *entry ) );
-        } else if constexpr( std::is_same_v<value_type, const item *> ) {
+        } else if constexpr( std::is_same_v<value_type, const item *> )
+        {
             if( entry == nullptr ) {
                 return sol::make_object( lua, sol::lua_nil );
             }
             return sol::make_object( lua, cata::lua_ui::game_handle::from_item(
-                                         const_cast<item &>( *entry ), {
+            const_cast<item &>( *entry ), {
                 "platform_callback_item", entry->uid().get_value(), 0, 0, 0, {}
-            }, owner.generation, active_world_generation ) );
+            }, owner.handle_runtime(), active_world_generation ) );
         } else if constexpr( std::is_same_v<value_type,
-                             cata::lua_ui::native_callback_point> ) {
+                             cata::lua_ui::native_callback_point> )
+        {
             sol::table point = owner.lua->create_table();
             point["coordinate_space"] = entry.coordinate_space;
             point["x"] = entry.pos.x();
@@ -5802,24 +6211,29 @@ sol::object platform_callback_value_to_lua(
             point["z"] = entry.pos.z();
             return sol::make_object( lua, std::move( point ) );
         } else if constexpr( std::is_same_v<value_type,
-                             cata::lua_ui::native_callback_id> ) {
+                             cata::lua_ui::native_callback_id> )
+        {
             return sol::make_object( lua,
                                      cata::lua_ui::script_game_id( entry.kind, entry.value ) );
-        } else if constexpr( std::is_same_v<value_type, std::vector<std::string>> ) {
+        } else if constexpr( std::is_same_v<value_type, std::vector<std::string>> )
+        {
             sol::table strings = owner.lua->create_table();
             for( std::size_t index = 0; index < entry.size(); ++index ) {
                 strings[index + 1] = entry[index];
             }
             return sol::make_object( lua, std::move( strings ) );
-        } else if constexpr( std::is_same_v<value_type, const const_talker *> ) {
+        } else if constexpr( std::is_same_v<value_type, const const_talker *> )
+        {
             return entry == nullptr ? sol::make_object( lua, sol::lua_nil ) :
                    platform_talker_to_lua( owner, *entry );
         } else if constexpr( std::is_same_v<value_type,
-                             cata::lua_ui::native_callback_mission> ) {
+                             cata::lua_ui::native_callback_mission> )
+        {
             return sol::make_object( lua, cata::lua_ui::mission_token(
-                                         entry.uid, owner.generation,
+                                         entry.uid, owner.handle_runtime(),
                                          active_world_generation ) );
-        } else {
+        } else
+        {
             return sol::make_object( lua, entry );
         }
     }, value );
@@ -5839,6 +6253,36 @@ sol::table platform_callback_payload(
             throw std::invalid_argument( "Platform native hook payload has an invalid field name" );
         }
         result[argument.name] = platform_callback_value_to_lua( owner, argument.value );
+    }
+    return result;
+}
+
+cata::lua_ui::native_callback_arguments platform_callback_arguments(
+    const std::string_view hook_name,
+    const cata::lua_ui::native_callback_arguments &arguments )
+{
+    cata::lua_ui::native_callback_arguments result = arguments;
+    const auto rename = [&result]( const std::string_view from,
+    const std::string_view to ) {
+        for( cata::lua_ui::native_callback_argument &argument : result ) {
+            if( argument.name == from ) {
+                argument.name = to;
+            }
+        }
+    };
+    if( hook_name == "on_dialogue_start" ) {
+        rename( "alpha", "avatar" );
+        rename( "beta", "interlocutor" );
+        rename( "topic", "initial_topic" );
+    } else if( hook_name == "on_dialogue_option" ) {
+        rename( "alpha", "avatar" );
+        rename( "beta", "interlocutor" );
+        rename( "topic", "current_topic" );
+        rename( "option", "selected_topic" );
+    } else if( hook_name == "on_dialogue_end" ) {
+        rename( "alpha", "avatar" );
+        rename( "beta", "interlocutor" );
+        rename( "topic", "last_topic" );
     }
     return result;
 }
@@ -6000,20 +6444,82 @@ void apply_platform_hook_table( const std::string_view name, const sol::table &t
     stop = stop || platform_hook_bool( table, "stop" ).value_or( false );
 }
 
+void dispatch_platform_event( const cata::event &event, const item *event_item )
+{
+    if( g == nullptr || event.type() == event_type::num_event_types ) {
+        return;
+    }
+    const std::string event_name = "game:" + io::enum_to_string( event.type() );
+    const bool has_subscriber = std::any_of(
+                                    active_runtimes.begin(), active_runtimes.end(),
+    [&event_name]( const std::shared_ptr<runtime> &owner ) {
+        return owner && owner->world_is_ready &&
+               owner->subscriptions.find( event_name ) != owner->subscriptions.end();
+    } );
+    if( !has_subscriber ) {
+        return;
+    }
+    if( platform_event_dispatch_depth >= 16 ) {
+        DebugLog( D_WARNING, D_MAIN ) << "Lua-first global event recursion limit reached for '"
+                                      << event_name << "'";
+        return;
+    }
+    platform_event_dispatch_scope event_scope;
+    const std::map<std::string, Character *> characters =
+        platform_event_characters( event );
+    struct pending_callback {
+        std::shared_ptr<runtime> owner;
+        std::string handler_id;
+        sol::object payload;
+    };
+    std::vector<pending_callback> pending;
+    for( const std::shared_ptr<runtime> &owner : active_runtimes ) {
+        if( !owner || !owner->world_is_ready ) {
+            continue;
+        }
+        const auto subscription = owner->subscriptions.find( event_name );
+        if( subscription == owner->subscriptions.end() ) {
+            continue;
+        }
+        if( owner->callback_depth >= 16 ) {
+            DebugLog( D_ERROR, D_MAIN ) << "Lua-first event recursion limit reached for '"
+                                        << owner->mod_id << ':' << event_name << "'";
+            continue;
+        }
+        const std::vector<std::string> handler_ids = subscription->second;
+        for( const std::string &handler_id : handler_ids ) {
+            try {
+                pending.push_back( {
+                    owner,
+                    handler_id,
+                    sol::make_object(
+                        *owner->lua, event_to_lua( *owner, event, characters,
+                                                   event_item ) )
+                } );
+            } catch( const std::exception &exception ) {
+                DebugLog( D_ERROR, D_MAIN ) << "Lua-first event payload for '"
+                                            << owner->mod_id << ':' << event_name << ':'
+                                            << handler_id << "' failed: " << exception.what();
+            }
+        }
+    }
+    for( const pending_callback &callback : pending ) {
+        dispatch_event_handler( *callback.owner, event_name, callback.handler_id,
+                                callback.payload );
+    }
+}
+
 class platform_event_bridge : public event_subscriber
 {
     public:
-        using event_subscriber::notify;
-
         void notify( const cata::event &event ) override {
-            const std::string event_name = "game:" + io::enum_to_string( event.type() );
-            for( const std::shared_ptr<runtime> &owner : active_runtimes ) {
-                if( owner && owner->world_is_ready ) {
-                    dispatch_event( *owner, event_name,
-                                    sol::make_object( *owner->lua,
-                                            event_to_lua( *owner, event ) ) );
-                }
-            }
+            dispatch_platform_event( event, nullptr );
+        }
+
+        void notify( const cata::event &event, std::unique_ptr<talker>,
+                     std::unique_ptr<talker> item_actor ) override {
+            dispatch_platform_event(
+                event, platform_event_item( event, item_actor.get() ) );
         }
 };
 
@@ -6211,7 +6717,7 @@ void write_scope( const cata_path &path, const std::string &scope )
     if( serialized.size() > maximum_platform_state_file_bytes ) {
         throw std::runtime_error( "Platform state file exceeds 16 MiB" );
     }
-    write_to_file( path, [&serialized]( std::ostream &output ) {
+    write_to_file( path, [&serialized]( std::ostream & output ) {
         output << serialized;
     } );
 }
@@ -6408,6 +6914,14 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         "id", sol::property( &sub_body_part_definition_handle::id ),
         "location_under", &sub_body_part_definition_handle::location_under,
         "unarmed_damage", &sub_body_part_definition_handle::unarmed_damage );
+    ccb.new_usertype<wound_type_definition_handle>(
+        "WoundDefinition", sol::no_constructor,
+        "id", sol::property( &wound_type_definition_handle::id ),
+        "damage_type", &wound_type_definition_handle::damage_type,
+        "limb_score", &wound_type_definition_handle::limb_score,
+        "progression", &wound_type_definition_handle::progression,
+        "require_body_part_type", &wound_type_definition_handle::require_body_part_type,
+        "forbid_body_part_type", &wound_type_definition_handle::forbid_body_part_type );
     ccb.new_usertype<body_part_definition_handle>(
         "BodyPartDefinition", sol::no_constructor,
         "id", sol::property( &body_part_definition_handle::id ),
@@ -6418,6 +6932,14 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         "flag", &body_part_definition_handle::flag,
         "limb_score", &body_part_definition_handle::limb_score,
         "quality", &body_part_definition_handle::quality );
+    ccb.new_usertype<wound_fix_definition_handle>(
+        "WoundFixDefinition", sol::no_constructor,
+        "id", sol::property( &wound_fix_definition_handle::id ),
+        "skill", &wound_fix_definition_handle::skill,
+        "proficiency", &wound_fix_definition_handle::proficiency,
+        "removes", &wound_fix_definition_handle::removes,
+        "adds", &wound_fix_definition_handle::adds,
+        "requires", &wound_fix_definition_handle::requires );
     ccb.new_usertype<anatomy_definition_handle>(
         "AnatomyDefinition", sol::no_constructor,
         "id", sol::property( &anatomy_definition_handle::id ),
@@ -6671,7 +7193,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
 
     impl *const transaction = pimpl_.get();
     sol::table content = lua.create_table();
-    content.set_function( "ToolQuality", [transaction]( const sol::table &options ) {
+    content.set_function( "ToolQuality", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -6680,7 +7202,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->name = options.get_or( "name", definition->id );
         return tool_quality_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "SkillDisplay", [transaction]( const sol::table &options ) {
+    content.set_function( "SkillDisplay", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -6689,7 +7211,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->label = options.get_or( "label", definition->id );
         return skill_display_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "Skill", [transaction]( const sol::table &options ) {
+    content.set_function( "Skill", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -6704,7 +7226,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->consumes_focus = options.get_or( "consumes_focus", true );
         return skill_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "Vitamin", [transaction]( const sol::table &options ) {
+    content.set_function( "Vitamin", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -6719,7 +7241,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->rate_turns = options.get_or<std::int64_t>( "rate_turns", 1 );
         return vitamin_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "JsonFlag", [transaction]( const sol::table &options ) {
+    content.set_function( "JsonFlag", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -6736,7 +7258,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->craft_inherit = options.get_or( "craft_inherit", false );
         return json_flag_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "DamageType", [transaction]( const sol::table &options ) {
+    content.set_function( "DamageType", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -6752,11 +7274,11 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->edged = options.get_or( "edged", false );
         definition->environmental = options.get_or( "environmental", false );
         definition->material_required = options.get_or( "material_required", false );
-        definition->bash_conversion_factor = options.get_or<double>(
-                    "bash_conversion_factor", definition->physical ? 0.5 : 0.1 );
+        definition->bash_conversion_factor = options.get_or(
+                "bash_conversion_factor", definition->physical ? 0.5 : 0.1 );
         return damage_type_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "Material", [transaction]( const sol::table &options ) {
+    content.set_function( "Material", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -6770,12 +7292,12 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->chip_resistance = options.get_or<std::int64_t>( "chip_resistance", 0 );
         definition->breathability = options.get_or<std::int64_t>( "breathability", 0 );
         definition->repair_difficulty = options.get_or<std::int64_t>( "repair_difficulty", 10 );
-        definition->density = options.get_or<double>( "density", 1.0 );
-        definition->sheet_thickness = options.get_or<double>( "sheet_thickness", 0.0 );
-        definition->specific_heat_liquid = options.get_or<double>( "specific_heat_liquid", 4.186 );
-        definition->specific_heat_solid = options.get_or<double>( "specific_heat_solid", 2.108 );
-        definition->latent_heat = options.get_or<double>( "latent_heat", 334.0 );
-        definition->freezing_point = options.get_or<double>( "freezing_point", 0.0 );
+        definition->density = options.get_or( "density", 1.0 );
+        definition->sheet_thickness = options.get_or( "sheet_thickness", 0.0 );
+        definition->specific_heat_liquid = options.get_or( "specific_heat_liquid", 4.186 );
+        definition->specific_heat_solid = options.get_or( "specific_heat_solid", 2.108 );
+        definition->latent_heat = options.get_or( "latent_heat", 334.0 );
+        definition->freezing_point = options.get_or( "freezing_point", 0.0 );
         definition->rotting = options.get_or( "rotting", false );
         definition->soft = options.get_or( "soft", false );
         definition->uncomfortable = options.get_or( "uncomfortable", false );
@@ -6786,7 +7308,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         }
         return material_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "AmmunitionType", [transaction]( const sol::table &options ) {
+    content.set_function( "AmmunitionType", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -6796,7 +7318,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->default_item = options.get_or( "default_item", std::string() );
         return ammunition_type_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "ItemCategory", [transaction]( const sol::table &options ) {
+    content.set_function( "ItemCategory", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -6805,11 +7327,11 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->header = options.get_or( "header", definition->id );
         definition->noun = options.get_or( "noun", definition->header );
         definition->sort_rank = options.get_or<std::int64_t>( "sort_rank", 0 );
-        definition->spawn_rate = options.get_or<double>( "spawn_rate", 1.0 );
+        definition->spawn_rate = options.get_or( "spawn_rate", 1.0 );
         definition->zone = options.get_or( "zone", std::string() );
         return item_category_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "RecipeCategory", [transaction]( const sol::table &options ) {
+    content.set_function( "RecipeCategory", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -6821,7 +7343,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->wildcard = options.get_or( "wildcard", false );
         return crafting_category_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "ProficiencyCategory", [transaction]( const sol::table &options ) {
+    content.set_function( "ProficiencyCategory", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -6831,7 +7353,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->description = options.get_or( "description", std::string() );
         return proficiency_category_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "Proficiency", [transaction]( const sol::table &options ) {
+    content.set_function( "Proficiency", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -6841,17 +7363,17 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->description = options.get_or( "description", std::string() );
         definition->category = options.get_or( "category", std::string() );
         definition->time_to_learn_turns = options.get_or<std::int64_t>(
-                                                "time_to_learn_turns", 35996400 );
-        definition->time_multiplier = options.get_or<double>( "time_multiplier", 2.0 );
-        definition->skill_penalty = options.get_or<double>( "skill_penalty", 1.0 );
-        definition->weakpoint_bonus = options.get_or<double>( "weakpoint_bonus", 0.0 );
-        definition->weakpoint_penalty = options.get_or<double>( "weakpoint_penalty", 0.0 );
+                                              "time_to_learn_turns", 35996400 );
+        definition->time_multiplier = options.get_or( "time_multiplier", 2.0 );
+        definition->skill_penalty = options.get_or( "skill_penalty", 1.0 );
+        definition->weakpoint_bonus = options.get_or( "weakpoint_bonus", 0.0 );
+        definition->weakpoint_penalty = options.get_or( "weakpoint_penalty", 0.0 );
         definition->can_learn = options.get_or( "can_learn", false );
         definition->ignore_focus = options.get_or( "ignore_focus", false );
         definition->teachable = options.get_or( "teachable", true );
         return proficiency_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "WeaponCategory", [transaction]( const sol::table &options ) {
+    content.set_function( "WeaponCategory", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -6860,7 +7382,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->name = options.get_or( "name", definition->id );
         return weapon_category_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "Item", [transaction]( const sol::table &options ) {
+    content.set_function( "Item", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -6871,15 +7393,16 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->symbol = options.get_or( "symbol", std::string( "?" ) );
         return item_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "Recipe", [transaction]( const sol::table &options ) {
+    content.set_function( "Recipe", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
         auto definition = std::make_shared<recipe_definition_data>();
         definition->id = options.get_or( "id", std::string() );
         definition->result = options.get_or( "result", std::string() );
-        definition->category = options.get_or( "category", std::string( "CC_MISC" ) );
-        definition->subcategory = options.get_or( "subcategory", std::string( "CSC_MISC" ) );
+        definition->category = options.get_or( "category", std::string( "CC_OTHER" ) );
+        definition->subcategory = options.get_or(
+                                      "subcategory", std::string( "CSC_OTHER_OTHER" ) );
         definition->skill = options.get_or( "skill", std::string() );
         definition->difficulty = options.get_or<std::int64_t>( "difficulty", 0 );
         definition->time_moves = options.get_or<std::int64_t>( "duration_moves", 100 );
@@ -6887,7 +7410,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->reversible = options.get_or( "reversible", false );
         return recipe_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "NestedRecipeCategory", [transaction]( const sol::table &options ) {
+    content.set_function( "NestedRecipeCategory", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -6903,7 +7426,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "Requirement", [transaction]( const sol::table &options ) {
+    content.set_function( "Requirement", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -6912,7 +7435,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->name = options.get_or( "name", std::string() );
         return requirement_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "RecipeGroup", [transaction]( const sol::table &options ) {
+    content.set_function( "RecipeGroup", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -6921,7 +7444,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->building_type = options.get_or( "building_type", std::string( "NONE" ) );
         return recipe_group_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "ScentType", [transaction]( const sol::table &options ) {
+    content.set_function( "ScentType", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -6929,7 +7452,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->id = options.get_or( "id", std::string() );
         return scent_type_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "SpeedDescription", [transaction]( const sol::table &options ) {
+    content.set_function( "SpeedDescription", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -6937,7 +7460,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->id = options.get_or( "id", std::string() );
         return speed_description_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "HarvestDropType", [transaction]( const sol::table &options ) {
+    content.set_function( "HarvestDropType", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -6957,7 +7480,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "Harvest", [transaction]( const sol::table &options ) {
+    content.set_function( "Harvest", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -6970,7 +7493,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
                                                 "butchery_requirements", std::string( "default" ) );
         return harvest_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "Behavior", [transaction]( const sol::table &options ) {
+    content.set_function( "Behavior", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -6980,7 +7503,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->goal = options.get_or( "goal", std::string() );
         return behavior_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "MonsterAttack", [transaction]( const sol::table &options ) {
+    content.set_function( "MonsterAttack", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -6992,7 +7515,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "EffectType", [transaction]( const sol::table &options ) {
+    content.set_function( "EffectType", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7003,7 +7526,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             definition->names.push_back( name );
         }
         if( const std::string description = options.get_or(
-                    "description", std::string() ); !description.empty() ) {
+                                                "description", std::string() ); !description.empty() ) {
             definition->descriptions.push_back( description );
         }
         definition->remove_message = options.get_or( "remove_message", std::string() );
@@ -7016,9 +7539,9 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->maximum_intensity = options.get_or<std::int64_t>(
                                             "maximum_intensity", 1 );
         definition->maximum_duration_turns = options.get_or<std::int64_t>(
-                    "maximum_duration_turns", 31536000 );
+                "maximum_duration_turns", 31536000 );
         definition->intensity_duration_turns = options.get_or<std::int64_t>(
-                    "intensity_duration_turns", 0 );
+                "intensity_duration_turns", 0 );
         definition->duration_add_percent = options.get_or<std::int64_t>(
                                                "duration_add_percent", 100 );
         definition->intensity_add_value = options.get_or<std::int64_t>(
@@ -7028,7 +7551,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->intensity_decay_tick = options.get_or<std::int64_t>(
                                                "intensity_decay_tick", 0 );
         definition->intensity_decay_removes = options.get_or(
-                    "intensity_decay_removes", false );
+                "intensity_decay_removes", false );
         definition->main_parts_only = options.get_or( "main_parts_only", false );
         definition->show_in_info = options.get_or( "show_in_info", false );
         definition->show_intensity = options.get_or( "show_intensity", true );
@@ -7037,7 +7560,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "WeakpointSet", [transaction]( const sol::table &options ) {
+    content.set_function( "WeakpointSet", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7047,7 +7570,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "FieldType", [transaction]( const sol::table &options ) {
+    content.set_function( "FieldType", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7056,7 +7579,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->underwater_age_speedup_turns = options.get_or<std::int64_t>(
                     "underwater_age_speedup_turns", 0 );
         definition->outdoor_age_speedup_turns = options.get_or<std::int64_t>(
-                                                   "outdoor_age_speedup_turns", 0 );
+                "outdoor_age_speedup_turns", 0 );
         definition->decay_amount_factor = options.get_or<std::int64_t>(
                                               "decay_amount_factor", 0 );
         definition->percent_spread = options.get_or<std::int64_t>( "percent_spread", 0 );
@@ -7087,7 +7610,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "ItemGroup", [transaction]( const sol::table &options ) {
+    content.set_function( "ItemGroup", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7100,7 +7623,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "SubBodyPart", [transaction]( const sol::table &options ) {
+    content.set_function( "SubBodyPart", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7120,7 +7643,45 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "BodyPart", [transaction]( const sol::table &options ) {
+    content.set_function( "Wound", [transaction]( const sol::table & options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<wound_type_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->name = options.get_or( "name", definition->id );
+        definition->plural_name = options.get_or( "plural_name", definition->name );
+        definition->description = options.get_or( "description", std::string() );
+        definition->pain_min = options.get_or<std::int64_t>( "pain_min", 0 );
+        definition->pain_max = options.get_or<std::int64_t>( "pain_max", 0 );
+        definition->healing_min_turns = options.get_or<std::int64_t>(
+                                            "healing_min_turns", 1 );
+        definition->healing_max_turns = options.get_or<std::int64_t>(
+                                            "healing_max_turns", 1 );
+        definition->damage_min = options.get_or<std::int64_t>( "damage_min", 0 );
+        definition->damage_max = options.get_or<std::int64_t>( "damage_max", 0 );
+        definition->weight = options.get_or<std::int64_t>( "weight", 1 );
+        definition->per_part_limit = options.get_or<std::int64_t>( "per_part_limit", 0 );
+        definition->required_body_part_flag = options.get_or(
+                "required_body_part_flag", std::string() );
+        definition->forbidden_body_part_flag = options.get_or(
+                "forbidden_body_part_flag", std::string() );
+        return wound_type_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "WoundFix", [transaction]( const sol::table & options ) {
+        if( transaction->token->lifecycle != handle_lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto definition = std::make_shared<wound_fix_definition_data>();
+        definition->id = options.get_or( "id", std::string() );
+        definition->name = options.get_or( "name", definition->id );
+        definition->description = options.get_or( "description", std::string() );
+        definition->success_message = options.get_or( "success_message", std::string() );
+        definition->duration_turns = options.get_or<std::int64_t>( "duration_turns", 0 );
+        definition->health_delta = options.get_or<std::int64_t>( "health_delta", 0 );
+        return wound_fix_definition_handle{ std::move( definition ), transaction->token };
+    } );
+    content.set_function( "BodyPart", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7153,7 +7714,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "Anatomy", [transaction]( const sol::table &options ) {
+    content.set_function( "Anatomy", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7161,7 +7722,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->id = options.get_or( "id", std::string() );
         return anatomy_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "BodyGraph", [transaction]( const sol::table &options ) {
+    content.set_function( "BodyGraph", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7177,7 +7738,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "Monster", [transaction]( const sol::table &options ) {
+    content.set_function( "Monster", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7223,17 +7784,17 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->regenerates = options.get_or<std::int64_t>( "regenerates", 0 );
         definition->bleed_rate = options.get_or<std::int64_t>( "bleed_rate", 100 );
         definition->status_chance_multiplier = options.get_or(
-                    "status_chance_multiplier", 1.0 );
+                "status_chance_multiplier", 1.0 );
         definition->luminance = options.get_or( "luminance", 0.0 );
         definition->regenerates_in_dark = options.get_or(
                                               "regenerates_in_dark", false );
         definition->regenerates_morale = options.get_or(
                                              "regenerates_morale", false );
         definition->aggressive_to_characters = options.get_or(
-                    "aggressive_to_characters", true );
+                "aggressive_to_characters", true );
         return monster_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "MoraleType", [transaction]( const sol::table &options ) {
+    content.set_function( "MoraleType", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7243,7 +7804,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->permanent = options.get_or( "permanent", false );
         return morale_type_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "DiseaseType", [transaction]( const sol::table &options ) {
+    content.set_function( "DiseaseType", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7251,9 +7812,9 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->id = options.get_or( "id", std::string() );
         definition->symptoms = options.get_or( "symptoms", std::string() );
         definition->minimum_duration_turns = options.get_or<std::int64_t>(
-                                                 "minimum_duration_turns", 1 );
+                "minimum_duration_turns", 1 );
         definition->maximum_duration_turns = options.get_or<std::int64_t>(
-                                                 "maximum_duration_turns", 1 );
+                "maximum_duration_turns", 1 );
         definition->minimum_intensity = options.get_or<std::int64_t>(
                                             "minimum_intensity", 1 );
         definition->maximum_intensity = options.get_or<std::int64_t>(
@@ -7264,7 +7825,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         }
         return disease_type_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "MonsterFlag", [transaction]( const sol::table &options ) {
+    content.set_function( "MonsterFlag", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7272,7 +7833,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->id = options.get_or( "id", std::string() );
         return monster_flag_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "Species", [transaction]( const sol::table &options ) {
+    content.set_function( "Species", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7283,7 +7844,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->bleeds = options.get_or( "bleeds", std::string( "fd_null" ) );
         return species_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "Emission", [transaction]( const sol::table &options ) {
+    content.set_function( "Emission", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7295,7 +7856,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->chance = options.get_or<std::int64_t>( "chance", 100 );
         return emission_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "MonsterFaction", [transaction]( const sol::table &options ) {
+    content.set_function( "MonsterFaction", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7304,7 +7865,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->base = options.get_or( "base", std::string() );
         return monster_faction_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "MutationType", [transaction]( const sol::table &options ) {
+    content.set_function( "MutationType", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7312,7 +7873,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->id = options.get_or( "id", std::string() );
         return mutation_type_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "ConnectGroup", [transaction]( const sol::table &options ) {
+    content.set_function( "ConnectGroup", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7320,7 +7881,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->id = options.get_or( "id", std::string() );
         return connect_group_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "MutationCategory", [transaction]( const sol::table &options ) {
+    content.set_function( "MutationCategory", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7345,7 +7906,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "ConstructionCategory", [transaction]( const sol::table &options ) {
+    content.set_function( "ConstructionCategory", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7356,7 +7917,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "ConstructionGroup", [transaction]( const sol::table &options ) {
+    content.set_function( "ConstructionGroup", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7367,7 +7928,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "VehiclePartLocation", [transaction]( const sol::table &options ) {
+    content.set_function( "VehiclePartLocation", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7381,7 +7942,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "MoodFace", [transaction]( const sol::table &options ) {
+    content.set_function( "MoodFace", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7389,7 +7950,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->id = options.get_or( "id", std::string() );
         return mood_face_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "DamageInfoOrder", [transaction]( const sol::table &options ) {
+    content.set_function( "DamageInfoOrder", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7401,7 +7962,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "VehiclePartCategory", [transaction]( const sol::table &options ) {
+    content.set_function( "VehiclePartCategory", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7414,7 +7975,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "NamedColor", [transaction]( const sol::table &options ) {
+    content.set_function( "NamedColor", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7427,7 +7988,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->alpha = options.get_or<std::int64_t>( "alpha", 255 );
         return named_color_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "RotatableSymbol", [transaction]( const sol::table &options ) {
+    content.set_function( "RotatableSymbol", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7459,7 +8020,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "AsciiArt", [transaction]( const sol::table &options ) {
+    content.set_function( "AsciiArt", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7467,7 +8028,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->id = options.get_or( "id", std::string() );
         return ascii_art_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "LimbScore", [transaction]( const sol::table &options ) {
+    content.set_function( "LimbScore", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7479,7 +8040,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
                 "affected_by_encumbrance", true );
         return limb_score_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "HitRange", [transaction]( const sol::table &options ) {
+    content.set_function( "HitRange", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7498,7 +8059,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         }
         return hit_range_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "BashDamageProfile", [transaction]( const sol::table &options ) {
+    content.set_function( "BashDamageProfile", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7508,7 +8069,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "ClothingMod", [transaction]( const sol::table &options ) {
+    content.set_function( "ClothingMod", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7523,7 +8084,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "OvermapLandUseCode", [transaction]( const sol::table &options ) {
+    content.set_function( "OvermapLandUseCode", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7543,7 +8104,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "OvermapVision", [transaction]( const sol::table &options ) {
+    content.set_function( "OvermapVision", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7553,7 +8114,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "OvermapLocation", [transaction]( const sol::table &options ) {
+    content.set_function( "OvermapLocation", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7563,7 +8124,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "ProfessionGroup", [transaction]( const sol::table &options ) {
+    content.set_function( "ProfessionGroup", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7573,7 +8134,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "MapExtraCollection", [transaction]( const sol::table &options ) {
+    content.set_function( "MapExtraCollection", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7584,7 +8145,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "VehicleGroup", [transaction]( const sol::table &options ) {
+    content.set_function( "VehicleGroup", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7594,7 +8155,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "FaultGroup", [transaction]( const sol::table &options ) {
+    content.set_function( "FaultGroup", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7604,7 +8165,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "ExplosionLight", [transaction]( const sol::table &options ) {
+    content.set_function( "ExplosionLight", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7614,7 +8175,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "AmmoEffect", [transaction]( const sol::table &options ) {
+    content.set_function( "AmmoEffect", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7625,7 +8186,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "AddictionType", [transaction]( const sol::table &options ) {
+    content.set_function( "AddictionType", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7639,7 +8200,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "CharacterModifier", [transaction]( const sol::table &options ) {
+    content.set_function( "CharacterModifier", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7651,7 +8212,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "StartLocation", [transaction]( const sol::table &options ) {
+    content.set_function( "StartLocation", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7662,7 +8223,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "ClimbingAid", [transaction]( const sol::table &options ) {
+    content.set_function( "ClimbingAid", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7674,7 +8235,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "WeatherType", [transaction]( const sol::table &options ) {
+    content.set_function( "WeatherType", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7702,7 +8263,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "Score", [transaction]( const sol::table &options ) {
+    content.set_function( "Score", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7722,7 +8283,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::make_shared<overlay_order_definition_data>(), transaction->token
         };
     } );
-    content.set_function( "ZoneType", [transaction]( const sol::table &options ) {
+    content.set_function( "ZoneType", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7737,7 +8298,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "SpeechPool", [transaction]( const sol::table &options ) {
+    content.set_function( "SpeechPool", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7747,7 +8308,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "EndScreen", [transaction]( const sol::table &options ) {
+    content.set_function( "EndScreen", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7761,7 +8322,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "ActivityType", [transaction]( const sol::table &options ) {
+    content.set_function( "ActivityType", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7783,7 +8344,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "HelpTopic", [transaction]( const sol::table &options ) {
+    content.set_function( "HelpTopic", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7798,7 +8359,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "SnippetCategory", [transaction]( const sol::table &options ) {
+    content.set_function( "SnippetCategory", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7808,7 +8369,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "Playlist", [transaction]( const sol::table &options ) {
+    content.set_function( "Playlist", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7819,7 +8380,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "AttackVector", [transaction]( const sol::table &options ) {
+    content.set_function( "AttackVector", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7836,7 +8397,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "MagicType", [transaction]( const sol::table &options ) {
+    content.set_function( "MagicType", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7853,15 +8414,15 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
                 options.get<sol::optional<std::int64_t>>( "max_book_level" ) ) {
             definition->max_book_level = *maximum;
         }
-        definition->failure_cost_fraction = options.get_or<double>(
-                    "failure_cost_fraction", 0.0 );
-        definition->failure_experience_fraction = options.get_or<double>(
+        definition->failure_cost_fraction = options.get_or(
+                                                "failure_cost_fraction", 0.0 );
+        definition->failure_experience_fraction = options.get_or(
                     "failure_experience_fraction", 0.2 );
         return magic_type_definition_handle{
             std::move( definition ), transaction->token
         };
     } );
-    content.set_function( "MovementMode", [transaction]( const sol::table &options ) {
+    content.set_function( "MovementMode", [transaction]( const sol::table & options ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -7871,18 +8432,18 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->kind = options.get_or( "kind", std::string( "walking" ) );
         definition->panel_color = options.get_or( "panel_color", std::string( "white" ) );
         definition->symbol_color = options.get_or( "symbol_color", std::string( "white" ) );
-        definition->exertion = options.get_or<double>( "exertion", 1.0 );
-        definition->riding_exertion = options.get_or<double>( "riding_exertion", 0.0 );
-        definition->stamina_multiplier = options.get_or<double>(
-                    "stamina_multiplier", 1.0 );
-        definition->sound_multiplier = options.get_or<double>(
-                                          "sound_multiplier", 1.0 );
-        definition->speed_multiplier = options.get_or<double>(
-                                          "speed_multiplier", 1.0 );
+        definition->exertion = options.get_or( "exertion", 1.0 );
+        definition->riding_exertion = options.get_or( "riding_exertion", 0.0 );
+        definition->stamina_multiplier = options.get_or(
+                                             "stamina_multiplier", 1.0 );
+        definition->sound_multiplier = options.get_or(
+                                           "sound_multiplier", 1.0 );
+        definition->speed_multiplier = options.get_or(
+                                           "speed_multiplier", 1.0 );
         definition->mech_power_kilojoules = options.get_or<std::int64_t>(
-                    "mech_power_kilojoules", 2 );
+                                                "mech_power_kilojoules", 2 );
         definition->swim_speed_modifier = options.get_or<std::int64_t>(
-                    "swim_speed_modifier", 0 );
+                                              "swim_speed_modifier", 0 );
         definition->stop_hauling = options.get_or( "stop_hauling", false );
         const auto read_symbol = [&options]( const char *name ) {
             const std::string symbol = options.get_or( name, std::string() );
@@ -7900,7 +8461,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         };
     } );
 
-    auto register_catalog = [transaction]( auto handle, auto &registrations,
+    auto register_catalog = [transaction]( auto handle, auto & registrations,
     const definition_operation operation, const char *kind ) {
         if( handle.token != transaction->token ) {
             throw std::runtime_error( std::string( "cannot register a " ) + kind +
@@ -7925,7 +8486,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         registrations.push_back( { operation, handle.definition } );
     };
 
-    auto register_definition = [transaction, register_catalog]( const sol::object &value,
+    auto register_definition = [transaction, register_catalog]( const sol::object & value,
     definition_operation operation ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
@@ -8088,9 +8649,19 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
                               transaction->sub_body_parts, operation, "sub body part" );
             return;
         }
+        if( value.is<wound_type_definition_handle>() ) {
+            register_catalog( value.as<wound_type_definition_handle>(),
+                              transaction->wound_types, operation, "wound" );
+            return;
+        }
         if( value.is<body_part_definition_handle>() ) {
             register_catalog( value.as<body_part_definition_handle>(),
                               transaction->body_parts, operation, "body part" );
+            return;
+        }
+        if( value.is<wound_fix_definition_handle>() ) {
+            register_catalog( value.as<wound_fix_definition_handle>(),
+                              transaction->wound_fixes, operation, "wound fix" );
             return;
         }
         if( value.is<anatomy_definition_handle>() ) {
@@ -8407,16 +8978,16 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         throw std::runtime_error(
             "content registration requires a native Platform definition" );
     };
-    content.set_function( "add", [register_definition]( const sol::object &value ) {
+    content.set_function( "add", [register_definition]( const sol::object & value ) {
         register_definition( value, definition_operation::add );
     } );
-    content.set_function( "replace", [register_definition]( const sol::object &value ) {
+    content.set_function( "replace", [register_definition]( const sol::object & value ) {
         register_definition( value, definition_operation::replace );
     } );
-    content.set_function( "edit", [register_definition]( const sol::object &value ) {
+    content.set_function( "edit", [register_definition]( const sol::object & value ) {
         register_definition( value, definition_operation::edit );
     } );
-    auto edit_catalog = [transaction]( const std::string &id, auto &registrations,
+    auto edit_catalog = [transaction]( const std::string & id, auto & registrations,
     const char *kind ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
@@ -8430,435 +9001,447 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             throw std::runtime_error( std::string( "edit_" ) + kind +
                                       " requires a definition staged earlier by this Mod" );
         }
-        auto definition = std::make_shared<std::decay_t<decltype( *found->definition )>>(
+        auto definition = std::make_shared < std::decay_t < decltype( *found->definition ) >> (
                               *found->definition );
         definition->registered = false;
         return definition;
     };
-    content.set_function( "edit_tool_quality", [transaction, edit_catalog]( const std::string &id ) {
+    content.set_function( "edit_tool_quality", [transaction, edit_catalog]( const std::string & id ) {
         return tool_quality_definition_handle{
             edit_catalog( id, transaction->tool_qualities, "tool_quality" ), transaction->token
         };
     } );
-    content.set_function( "edit_skill_display", [transaction, edit_catalog]( const std::string &id ) {
+    content.set_function( "edit_skill_display", [transaction, edit_catalog]( const std::string & id ) {
         return skill_display_definition_handle{
             edit_catalog( id, transaction->skill_displays, "skill_display" ), transaction->token
         };
     } );
-    content.set_function( "edit_skill", [transaction, edit_catalog]( const std::string &id ) {
+    content.set_function( "edit_skill", [transaction, edit_catalog]( const std::string & id ) {
         return skill_definition_handle{
             edit_catalog( id, transaction->skills, "skill" ), transaction->token
         };
     } );
-    content.set_function( "edit_vitamin", [transaction, edit_catalog]( const std::string &id ) {
+    content.set_function( "edit_vitamin", [transaction, edit_catalog]( const std::string & id ) {
         return vitamin_definition_handle{
             edit_catalog( id, transaction->vitamins, "vitamin" ), transaction->token
         };
     } );
-    content.set_function( "edit_json_flag", [transaction, edit_catalog]( const std::string &id ) {
+    content.set_function( "edit_json_flag", [transaction, edit_catalog]( const std::string & id ) {
         return json_flag_definition_handle{
             edit_catalog( id, transaction->json_flags, "json_flag" ), transaction->token
         };
     } );
-    content.set_function( "edit_damage_type", [transaction, edit_catalog]( const std::string &id ) {
+    content.set_function( "edit_damage_type", [transaction, edit_catalog]( const std::string & id ) {
         return damage_type_definition_handle{
             edit_catalog( id, transaction->damage_types, "damage_type" ), transaction->token
         };
     } );
-    content.set_function( "edit_material", [transaction, edit_catalog]( const std::string &id ) {
+    content.set_function( "edit_material", [transaction, edit_catalog]( const std::string & id ) {
         return material_definition_handle{
             edit_catalog( id, transaction->materials, "material" ), transaction->token
         };
     } );
     content.set_function( "edit_ammunition_type", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return ammunition_type_definition_handle{
             edit_catalog( id, transaction->ammunition_types, "ammunition_type" ),
             transaction->token
         };
     } );
     content.set_function( "edit_item_category", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return item_category_definition_handle{
             edit_catalog( id, transaction->item_categories, "item_category" ), transaction->token
         };
     } );
     content.set_function( "edit_recipe_category", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return crafting_category_definition_handle{
             edit_catalog( id, transaction->crafting_categories, "recipe_category" ),
             transaction->token
         };
     } );
     content.set_function( "edit_proficiency_category", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return proficiency_category_definition_handle{
             edit_catalog( id, transaction->proficiency_categories, "proficiency_category" ),
             transaction->token
         };
     } );
     content.set_function( "edit_proficiency", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return proficiency_definition_handle{
             edit_catalog( id, transaction->proficiencies, "proficiency" ), transaction->token
         };
     } );
     content.set_function( "edit_weapon_category", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return weapon_category_definition_handle{
             edit_catalog( id, transaction->weapon_categories, "weapon_category" ),
             transaction->token
         };
     } );
     content.set_function( "edit_requirement", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return requirement_definition_handle{
             edit_catalog( id, transaction->requirements, "requirement" ), transaction->token
         };
     } );
     content.set_function( "edit_recipe_group", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return recipe_group_definition_handle{
             edit_catalog( id, transaction->recipe_groups, "recipe_group" ), transaction->token
         };
     } );
     content.set_function( "edit_scent_type", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return scent_type_definition_handle{
             edit_catalog( id, transaction->scent_types, "scent_type" ), transaction->token
         };
     } );
     content.set_function( "edit_speed_description", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return speed_description_definition_handle{
             edit_catalog( id, transaction->speed_descriptions, "speed_description" ),
             transaction->token
         };
     } );
     content.set_function( "edit_harvest_drop_type", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return harvest_drop_type_definition_handle{
             edit_catalog( id, transaction->harvest_drop_types, "harvest_drop_type" ),
             transaction->token
         };
     } );
     content.set_function( "edit_harvest", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return harvest_definition_handle{
             edit_catalog( id, transaction->harvests, "harvest" ), transaction->token
         };
     } );
     content.set_function( "edit_behavior", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return behavior_definition_handle{
             edit_catalog( id, transaction->behaviors, "behavior" ), transaction->token
         };
     } );
     content.set_function( "edit_monster_attack", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return monster_attack_definition_handle{
             edit_catalog( id, transaction->monster_attacks, "monster_attack" ),
             transaction->token
         };
     } );
     content.set_function( "edit_effect_type", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return effect_type_definition_handle{
             edit_catalog( id, transaction->effect_types, "effect_type" ),
             transaction->token
         };
     } );
     content.set_function( "edit_weakpoint_set", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return weakpoint_set_definition_handle{
             edit_catalog( id, transaction->weakpoint_sets, "weakpoint_set" ),
             transaction->token
         };
     } );
     content.set_function( "edit_field_type", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return field_type_definition_handle{
             edit_catalog( id, transaction->field_types, "field_type" ),
             transaction->token
         };
     } );
     content.set_function( "edit_item_group", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return item_group_definition_handle{
             edit_catalog( id, transaction->item_groups, "item_group" ),
             transaction->token
         };
     } );
     content.set_function( "edit_sub_body_part", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return sub_body_part_definition_handle{
             edit_catalog( id, transaction->sub_body_parts, "sub_body_part" ),
             transaction->token
         };
     } );
+    content.set_function( "edit_wound", [transaction, edit_catalog](
+    const std::string & id ) {
+        return wound_type_definition_handle{
+            edit_catalog( id, transaction->wound_types, "wound" ), transaction->token
+        };
+    } );
     content.set_function( "edit_body_part", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return body_part_definition_handle{
             edit_catalog( id, transaction->body_parts, "body_part" ),
             transaction->token
         };
     } );
+    content.set_function( "edit_wound_fix", [transaction, edit_catalog](
+    const std::string & id ) {
+        return wound_fix_definition_handle{
+            edit_catalog( id, transaction->wound_fixes, "wound_fix" ), transaction->token
+        };
+    } );
     content.set_function( "edit_anatomy", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return anatomy_definition_handle{
             edit_catalog( id, transaction->anatomies, "anatomy" ), transaction->token
         };
     } );
     content.set_function( "edit_body_graph", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return body_graph_definition_handle{
             edit_catalog( id, transaction->body_graphs, "body_graph" ),
             transaction->token
         };
     } );
     content.set_function( "edit_monster", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return monster_definition_handle{
             edit_catalog( id, transaction->monsters, "monster" ), transaction->token
         };
     } );
     content.set_function( "edit_morale_type", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return morale_type_definition_handle{
             edit_catalog( id, transaction->morale_types, "morale_type" ), transaction->token
         };
     } );
     content.set_function( "edit_disease_type", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return disease_type_definition_handle{
             edit_catalog( id, transaction->disease_types, "disease_type" ), transaction->token
         };
     } );
     content.set_function( "edit_monster_flag", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return monster_flag_definition_handle{
             edit_catalog( id, transaction->monster_flags, "monster_flag" ), transaction->token
         };
     } );
     content.set_function( "edit_species", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return species_definition_handle{
             edit_catalog( id, transaction->species, "species" ), transaction->token
         };
     } );
     content.set_function( "edit_emission", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return emission_definition_handle{
             edit_catalog( id, transaction->emissions, "emission" ), transaction->token
         };
     } );
     content.set_function( "edit_monster_faction", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return monster_faction_definition_handle{
             edit_catalog( id, transaction->monster_factions, "monster_faction" ),
             transaction->token
         };
     } );
     content.set_function( "edit_mutation_type", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return mutation_type_definition_handle{
             edit_catalog( id, transaction->mutation_types, "mutation_type" ), transaction->token
         };
     } );
     content.set_function( "edit_connect_group", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return connect_group_definition_handle{
             edit_catalog( id, transaction->connect_groups, "connect_group" ),
             transaction->token
         };
     } );
     content.set_function( "edit_mutation_category", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return mutation_category_definition_handle{
             edit_catalog( id, transaction->mutation_categories, "mutation_category" ),
             transaction->token
         };
     } );
     content.set_function( "edit_construction_category", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return construction_category_definition_handle{
             edit_catalog( id, transaction->construction_categories, "construction_category" ),
             transaction->token
         };
     } );
     content.set_function( "edit_construction_group", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return construction_group_definition_handle{
             edit_catalog( id, transaction->construction_groups, "construction_group" ),
             transaction->token
         };
     } );
     content.set_function( "edit_vehicle_part_location", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return vehicle_part_location_definition_handle{
             edit_catalog( id, transaction->vehicle_part_locations, "vehicle_part_location" ),
             transaction->token
         };
     } );
     content.set_function( "edit_mood_face", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return mood_face_definition_handle{
             edit_catalog( id, transaction->mood_faces, "mood_face" ), transaction->token
         };
     } );
     content.set_function( "edit_damage_info_order", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return damage_info_order_definition_handle{
             edit_catalog( id, transaction->damage_info_orders, "damage_info_order" ),
             transaction->token
         };
     } );
     content.set_function( "edit_vehicle_part_category", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return vehicle_part_category_definition_handle{
             edit_catalog( id, transaction->vehicle_part_categories,
                           "vehicle_part_category" ), transaction->token
         };
     } );
     content.set_function( "edit_named_color", [transaction, edit_catalog](
-    const std::string &name ) {
+    const std::string & name ) {
         return named_color_definition_handle{
             edit_catalog( name, transaction->named_colors, "named_color" ),
             transaction->token
         };
     } );
     content.set_function( "edit_rotatable_symbol", [transaction, edit_catalog](
-    const std::string &key ) {
+    const std::string & key ) {
         return rotatable_symbol_definition_handle{
             edit_catalog( key, transaction->rotatable_symbols, "rotatable_symbol" ),
             transaction->token
         };
     } );
     content.set_function( "edit_ascii_art", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return ascii_art_definition_handle{
             edit_catalog( id, transaction->ascii_arts, "ascii_art" ), transaction->token
         };
     } );
     content.set_function( "edit_limb_score", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return limb_score_definition_handle{
             edit_catalog( id, transaction->limb_scores, "limb_score" ), transaction->token
         };
     } );
     content.set_function( "edit_bash_damage_profile", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return bash_damage_profile_definition_handle{
             edit_catalog( id, transaction->bash_damage_profiles, "bash_damage_profile" ),
             transaction->token
         };
     } );
     content.set_function( "edit_clothing_mod", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return clothing_mod_definition_handle{
             edit_catalog( id, transaction->clothing_mods, "clothing_mod" ), transaction->token
         };
     } );
     content.set_function( "edit_overmap_land_use_code", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return overmap_land_use_code_definition_handle{
             edit_catalog( id, transaction->overmap_land_use_codes,
                           "overmap_land_use_code" ), transaction->token
         };
     } );
     content.set_function( "edit_overmap_vision", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return overmap_vision_definition_handle{
             edit_catalog( id, transaction->overmap_visions, "overmap_vision" ),
             transaction->token
         };
     } );
     content.set_function( "edit_overmap_location", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return overmap_location_definition_handle{
             edit_catalog( id, transaction->overmap_locations, "overmap_location" ),
             transaction->token
         };
     } );
     content.set_function( "edit_profession_group", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return profession_group_definition_handle{
             edit_catalog( id, transaction->profession_groups, "profession_group" ),
             transaction->token
         };
     } );
     content.set_function( "edit_map_extra_collection", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return map_extra_collection_definition_handle{
             edit_catalog( id, transaction->map_extra_collections, "map_extra_collection" ),
             transaction->token
         };
     } );
     content.set_function( "edit_vehicle_group", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return vehicle_group_definition_handle{
             edit_catalog( id, transaction->vehicle_groups, "vehicle_group" ),
             transaction->token
         };
     } );
     content.set_function( "edit_fault_group", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return fault_group_definition_handle{
             edit_catalog( id, transaction->fault_groups, "fault_group" ),
             transaction->token
         };
     } );
     content.set_function( "edit_explosion_light", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return explosion_light_definition_handle{
             edit_catalog( id, transaction->explosion_lights, "explosion_light" ),
             transaction->token
         };
     } );
     content.set_function( "edit_ammo_effect", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return ammo_effect_definition_handle{
             edit_catalog( id, transaction->ammo_effects, "ammo_effect" ),
             transaction->token
         };
     } );
     content.set_function( "edit_addiction_type", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return addiction_type_definition_handle{
             edit_catalog( id, transaction->addiction_types, "addiction_type" ),
             transaction->token
         };
     } );
     content.set_function( "edit_character_modifier", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return character_modifier_definition_handle{
             edit_catalog( id, transaction->character_modifiers, "character_modifier" ),
             transaction->token
         };
     } );
     content.set_function( "edit_start_location", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return start_location_definition_handle{
             edit_catalog( id, transaction->start_locations, "start_location" ),
             transaction->token
         };
     } );
     content.set_function( "edit_climbing_aid", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return climbing_aid_definition_handle{
             edit_catalog( id, transaction->climbing_aids, "climbing_aid" ),
             transaction->token
         };
     } );
     content.set_function( "edit_weather_type", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return weather_type_definition_handle{
             edit_catalog( id, transaction->weather_types, "weather_type" ),
             transaction->token
         };
     } );
     content.set_function( "edit_score", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return score_definition_handle{
             edit_catalog( id, transaction->scores, "score" ), transaction->token
         };
@@ -8870,70 +9453,70 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         };
     } );
     content.set_function( "edit_zone_type", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return zone_type_definition_handle{
             edit_catalog( id, transaction->zone_types, "zone_type" ), transaction->token
         };
     } );
     content.set_function( "edit_speech_pool", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return speech_pool_definition_handle{
             edit_catalog( id, transaction->speech_pools, "speech_pool" ), transaction->token
         };
     } );
     content.set_function( "edit_end_screen", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return end_screen_definition_handle{
             edit_catalog( id, transaction->end_screens, "end_screen" ), transaction->token
         };
     } );
     content.set_function( "edit_activity_type", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return activity_type_definition_handle{
             edit_catalog( id, transaction->activity_types, "activity_type" ), transaction->token
         };
     } );
     content.set_function( "edit_help_topic", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return help_topic_definition_handle{
             edit_catalog( id, transaction->help_topics, "help_topic" ), transaction->token
         };
     } );
     content.set_function( "edit_snippet_category", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return snippet_category_definition_handle{
             edit_catalog( id, transaction->snippet_categories, "snippet_category" ),
             transaction->token
         };
     } );
     content.set_function( "edit_playlist", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return playlist_definition_handle{
             edit_catalog( id, transaction->playlists, "playlist" ), transaction->token
         };
     } );
     content.set_function( "edit_attack_vector", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return attack_vector_definition_handle{
             edit_catalog( id, transaction->attack_vectors, "attack_vector" ),
             transaction->token
         };
     } );
     content.set_function( "edit_magic_type", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return magic_type_definition_handle{
             edit_catalog( id, transaction->magic_types, "magic_type" ),
             transaction->token
         };
     } );
     content.set_function( "edit_movement_mode", [transaction, edit_catalog](
-    const std::string &id ) {
+    const std::string & id ) {
         return movement_mode_definition_handle{
             edit_catalog( id, transaction->movement_modes, "movement_mode" ),
             transaction->token
         };
     } );
-    content.set_function( "edit_item", [transaction]( const std::string &id ) {
+    content.set_function( "edit_item", [transaction]( const std::string & id ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -8950,7 +9533,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->registered = false;
         return item_definition_handle{ std::move( definition ), transaction->token };
     } );
-    content.set_function( "edit_recipe", [transaction]( const std::string &id ) {
+    content.set_function( "edit_recipe", [transaction]( const std::string & id ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -8972,7 +9555,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         return recipe_definition_handle{ std::move( definition ), transaction->token };
     } );
     content.set_function( "edit_nested_recipe_category", [transaction](
-    const std::string &id ) {
+    const std::string & id ) {
         if( transaction->token->lifecycle != handle_lifecycle::building ) {
             throw std::runtime_error( "content transaction is no longer building" );
         }
@@ -9001,13 +9584,13 @@ bool content_transaction::validate( const runtime &owner_runtime,
                                     std::string &error ) const
 {
     try {
-        const auto require_valid_id = []( const std::string &id, const char *kind ) {
+        const auto require_valid_id = []( const std::string & id, const char *kind ) {
             if( id.empty() || id.find( '#' ) != std::string::npos || id.size() > 256 ) {
                 throw std::runtime_error( std::string( "invalid " ) + kind + " id '" + id + "'" );
             }
         };
         const auto validate_operation = [check_engine_state]( const definition_operation operation,
-        const bool exists, const std::string &id, const char *kind ) {
+        const bool exists, const std::string & id, const char *kind ) {
             if( !check_engine_state ) {
                 return;
             }
@@ -9221,6 +9804,10 @@ bool content_transaction::validate( const runtime &owner_runtime,
         std::set<std::string> declared_recipe_ids;
         for( const recipe_registration &entry : pimpl_->recipes ) {
             declared_recipe_ids.insert( entry.definition->id );
+        }
+        std::set<std::string> declared_morale_type_ids;
+        for( const morale_type_registration &entry : pimpl_->morale_types ) {
+            declared_morale_type_ids.insert( entry.definition->id );
         }
 
         std::set<std::string> clothing_mod_ids;
@@ -9487,7 +10074,7 @@ bool content_transaction::validate( const runtime &owner_runtime,
                 throw std::runtime_error( "ammo effect '" + definition.id +
                                           "' has a duplicate id or invalid trigger chance" );
             }
-            const auto validate_field = [&]( const ammo_field_definition_data &field,
+            const auto validate_field = [&]( const ammo_field_definition_data & field,
             const bool trail ) {
                 if( field.field.empty() || !native_int( field.intensity_min ) ||
                     field.intensity_max < field.intensity_min ||
@@ -9508,7 +10095,7 @@ bool content_transaction::validate( const runtime &owner_runtime,
                 validate_field( field, true );
             }
             const auto validate_character_effect = [&](
-            const ammo_character_effect_definition_data &effect, const bool area ) {
+            const ammo_character_effect_definition_data & effect, const bool area ) {
                 if( effect.effect.empty() || effect.duration_turns <= 0 ||
                     effect.duration_turns > std::numeric_limits<int>::max() ||
                     effect.intensity_min <= 0 ||
@@ -9543,8 +10130,10 @@ bool content_transaction::validate( const runtime &owner_runtime,
                   definition.fragment_mass <= 0.0 ||
                   !percent( definition.fragment_recovery ) ||
                   ( check_engine_state && !definition.explosion_light.empty() &&
+                    explosion_light_ids.count( definition.explosion_light ) == 0 &&
                     !explosion_light_str_id( definition.explosion_light ).is_valid() ) ||
                   ( check_engine_state && definition.fragment_drop != "null" &&
+                    declared_item_ids.count( definition.fragment_drop ) == 0 &&
                     !itype_id( definition.fragment_drop ).is_valid() ) ) ) {
                 throw std::runtime_error( "ammo effect '" + definition.id +
                                           "' has invalid explosion or shrapnel values" );
@@ -9580,6 +10169,7 @@ bool content_transaction::validate( const runtime &owner_runtime,
                 definition.name.empty() || definition.type_name.empty() ||
                 definition.description.empty() || definition.tick_handler.empty() ||
                 ( check_engine_state && !definition.craving_morale.empty() &&
+                  declared_morale_type_ids.count( definition.craving_morale ) == 0 &&
                   !morale_type( definition.craving_morale ).is_valid() ) ) {
                 throw std::runtime_error( "addiction type '" + definition.id +
                                           "' needs unique text, an optional valid craving morale, and a tick policy" );
@@ -9720,7 +10310,7 @@ bool content_transaction::validate( const runtime &owner_runtime,
                 return std::isfinite( value ) &&
                        std::abs( value ) <= std::numeric_limits<float>::max();
             };
-            const auto single_codepoint = []( const std::string &symbol ) {
+            const auto single_codepoint = []( const std::string & symbol ) {
                 if( symbol.empty() ) {
                     return false;
                 }
@@ -9969,7 +10559,7 @@ bool content_transaction::validate( const runtime &owner_runtime,
             }
             if( std::any_of( definition.paragraphs.begin(), definition.paragraphs.end(),
             []( const std::string & paragraph ) {
-                return paragraph.empty();
+            return paragraph.empty();
             } ) ) {
                 throw std::runtime_error( "help topic '" + definition.id +
                                           "' has an empty paragraph" );
@@ -10063,7 +10653,7 @@ bool content_transaction::validate( const runtime &owner_runtime,
             for( const auto &[file, volume] : definition.tracks ) {
                 const std::filesystem::path path( file );
                 const bool traverses_parent = std::any_of(
-                                                  path.begin(), path.end(), []( const auto & part ) {
+                path.begin(), path.end(), []( const auto & part ) {
                     return part == "..";
                 } );
                 if( file.empty() || file.size() > 4096 ||
@@ -10187,7 +10777,8 @@ bool content_transaction::validate( const runtime &owner_runtime,
                     { "failure-cost", &definition.failure_cost_handler },
                     { "failure-experience", &definition.failure_experience_handler },
                     { "failure", &definition.failure_handler },
-                } };
+                }
+            };
             for( const auto &[label, handler_id] : handlers ) {
                 if( !handler_id->empty() && owner_runtime.handlers.count( *handler_id ) == 0 ) {
                     throw std::runtime_error( "magic type '" + definition.id +
@@ -10342,7 +10933,7 @@ bool content_transaction::validate( const runtime &owner_runtime,
         for( const monster_faction_registration &entry : pimpl_->monster_factions ) {
             const monster_faction_definition_data &definition = *entry.definition;
             if( check_engine_state ) {
-                const auto known_faction = [&monster_faction_ids]( const std::string &id ) {
+                const auto known_faction = [&monster_faction_ids]( const std::string & id ) {
                     return mfaction_str_id( id ).is_valid() || monster_faction_ids.count( id );
                 };
                 if( !known_faction( definition.base ) ) {
@@ -10580,7 +11171,7 @@ bool content_transaction::validate( const runtime &owner_runtime,
         for( const rotatable_symbol_registration &entry : pimpl_->rotatable_symbols ) {
             const rotatable_symbol_definition_data &definition = *entry.definition;
             std::set<std::uint32_t> candidate( definition.symbols.begin(),
-                                              definition.symbols.end() );
+                                               definition.symbols.end() );
             if( definition.key.empty() ||
                 ( definition.symbols.size() != 2 && definition.symbols.size() != 4 ) ||
                 candidate.size() != definition.symbols.size() ) {
@@ -10644,6 +11235,120 @@ bool content_transaction::validate( const runtime &owner_runtime,
                                 definition.id, "limb score" );
         }
 
+        std::set<std::string> wound_type_ids;
+        for( const wound_type_registration &entry : pimpl_->wound_types ) {
+            const wound_type_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "wound" );
+            if( definition.id.find( '\0' ) != std::string::npos ||
+                !wound_type_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "wound '" + definition.id +
+                                          "' is registered more than once per transaction" );
+            }
+            validate_operation( entry.operation, wound_type_id( definition.id ).is_valid(),
+                                definition.id, "wound" );
+        }
+        const auto valid_wound_text = []( const std::string & value,
+        const std::size_t maximum ) {
+            return !value.empty() && value.size() <= maximum &&
+                   value.find( '\0' ) == std::string::npos;
+        };
+        for( const wound_type_registration &entry : pimpl_->wound_types ) {
+            const wound_type_definition_data &definition = *entry.definition;
+            if( !valid_wound_text( definition.name, 1024 ) ||
+                !valid_wound_text( definition.plural_name, 1024 ) ||
+                !valid_wound_text( definition.description, 32768 ) ||
+                definition.pain_min < 0 || definition.pain_max < definition.pain_min ||
+                definition.pain_max > std::numeric_limits<int>::max() ||
+                definition.healing_min_turns <= 0 ||
+                definition.healing_max_turns < definition.healing_min_turns ||
+                definition.healing_max_turns > std::numeric_limits<int>::max() ||
+                definition.damage_min < 0 || definition.damage_max < definition.damage_min ||
+                definition.damage_max > std::numeric_limits<int>::max() ||
+                definition.weight <= 0 || definition.weight > std::numeric_limits<int>::max() ||
+                definition.per_part_limit < 0 ||
+                definition.per_part_limit > std::numeric_limits<int>::max() ||
+                definition.damage_types.empty() ) {
+                throw std::runtime_error( "wound '" + definition.id +
+                                          "' has invalid text, bounds, weight, limit, or no damage type" );
+            }
+            if( definition.required_body_part_flag.size() > 256 ||
+                definition.required_body_part_flag.find( '\0' ) != std::string::npos ||
+                definition.forbidden_body_part_flag.size() > 256 ||
+                definition.forbidden_body_part_flag.find( '\0' ) != std::string::npos ||
+                ( !definition.required_body_part_flag.empty() &&
+                  definition.required_body_part_flag == definition.forbidden_body_part_flag ) ) {
+                throw std::runtime_error( "wound '" + definition.id +
+                                          "' has invalid or contradictory body-part flags" );
+            }
+            const auto known_character_flag = [&json_flag_ids]( const std::string & id ) {
+                return id.empty() || json_flag_ids.count( id ) != 0 ||
+                       json_character_flag( id ).is_valid();
+            };
+            if( !known_character_flag( definition.required_body_part_flag ) ||
+                !known_character_flag( definition.forbidden_body_part_flag ) ) {
+                throw std::runtime_error( "wound '" + definition.id +
+                                          "' references an unknown body-part flag" );
+            }
+            std::set<std::string> damage_types;
+            for( const std::string &damage_id : definition.damage_types ) {
+                if( damage_id.empty() || damage_id.size() > 256 ||
+                    damage_id.find( '\0' ) != std::string::npos ||
+                    !damage_types.insert( damage_id ).second ||
+                    ( damage_type_ids.count( damage_id ) == 0 &&
+                      !damage_type_id( damage_id ).is_valid() ) ) {
+                    throw std::runtime_error( "wound '" + definition.id +
+                                              "' has invalid or duplicate damage type '" +
+                                              damage_id + "'" );
+                }
+            }
+            std::set<std::string> scores;
+            for( const wound_limb_score_definition_data &score : definition.limb_scores ) {
+                if( score.id.empty() || score.id.size() > 256 ||
+                    score.id.find( '\0' ) != std::string::npos ||
+                    !scores.insert( score.id ).second || !std::isfinite( score.penalty ) ||
+                    score.penalty < 0.0 || score.penalty > 1.0 ||
+                    ( limb_score_ids.count( score.id ) == 0 &&
+                      !limb_score_id( score.id ).is_valid() ) ) {
+                    throw std::runtime_error( "wound '" + definition.id +
+                                              "' has invalid limb score '" + score.id + "'" );
+                }
+            }
+            std::set<std::string> progressions;
+            for( const wound_progression_definition_data &progression :
+                 definition.progressions ) {
+                if( progression.id.empty() || progression.id.size() > 256 ||
+                    progression.id.find( '\0' ) != std::string::npos ||
+                    progression.id == definition.id ||
+                    !progressions.insert( progression.id ).second ||
+                    progression.chance < 0 || progression.chance > 100 ||
+                    ( wound_type_ids.count( progression.id ) == 0 &&
+                      !wound_type_id( progression.id ).is_valid() ) ) {
+                    throw std::runtime_error( "wound '" + definition.id +
+                                              "' has invalid progression '" +
+                                              progression.id + "'" );
+                }
+            }
+            std::set<std::string> required_types;
+            std::set<std::string> forbidden_types;
+            for( const std::string &kind : definition.required_body_part_types ) {
+                if( kind.empty() || kind.size() > 64 || kind.find( '\0' ) != std::string::npos ||
+                    !io::string_to_enum_optional<bp_type>( kind ) ||
+                    !required_types.insert( kind ).second ) {
+                    throw std::runtime_error( "wound '" + definition.id +
+                                              "' has invalid required body-part type '" + kind + "'" );
+                }
+            }
+            for( const std::string &kind : definition.forbidden_body_part_types ) {
+                if( kind.empty() || kind.size() > 64 || kind.find( '\0' ) != std::string::npos ||
+                    !io::string_to_enum_optional<bp_type>( kind ) ||
+                    !forbidden_types.insert( kind ).second || required_types.count( kind ) != 0 ) {
+                    throw std::runtime_error( "wound '" + definition.id +
+                                              "' has invalid or contradictory forbidden body-part type '" +
+                                              kind + "'" );
+                }
+            }
+        }
+
         if( pimpl_->hit_ranges.size() > 1 ) {
             throw std::runtime_error( "hit range is a singleton and may be registered once" );
         }
@@ -10652,7 +11357,7 @@ bool content_transaction::validate( const runtime &owner_runtime,
             if( definition.id != "global" || definition.even_good.empty() ) {
                 throw std::runtime_error( "hit range requires the global singleton and values" );
             }
-            if( entry.operation != definition_operation::replace ) {
+            if( check_engine_state && entry.operation != definition_operation::replace ) {
                 throw std::runtime_error( "hit range is a global singleton and must use replace" );
             }
             for( const std::int64_t value : definition.even_good ) {
@@ -10762,7 +11467,7 @@ bool content_transaction::validate( const runtime &owner_runtime,
         std::set<std::string> visiting_item_groups;
         std::set<std::string> visited_item_groups;
         std::function<void( const std::string & )> visit_item_group;
-        visit_item_group = [&]( const std::string &id ) {
+        visit_item_group = [&]( const std::string & id ) {
             if( visited_item_groups.count( id ) != 0 ) {
                 return;
             }
@@ -10790,7 +11495,8 @@ bool content_transaction::validate( const runtime &owner_runtime,
                                           "' is registered more than once per transaction" );
             }
             const std::vector<std::string> skills = definition.skills.empty() ?
-                    std::vector<std::string>{ "survival" } : definition.skills;
+                                                    std::vector<std::string> { "survival" } :
+                                                    definition.skills;
             for( const std::string &skill : skills ) {
                 if( skill_ids.count( skill ) == 0 && !skill_id( skill ).is_valid() ) {
                     throw std::runtime_error( "harvest drop type '" + definition.id +
@@ -10974,7 +11680,7 @@ bool content_transaction::validate( const runtime &owner_runtime,
         std::set<std::string> visiting_behaviors;
         std::set<std::string> visited_behaviors;
         std::function<void( const std::string & )> visit_behavior;
-        visit_behavior = [&]( const std::string &id ) {
+        visit_behavior = [&]( const std::string & id ) {
             if( visited_behaviors.count( id ) != 0 ) {
                 return;
             }
@@ -11048,11 +11754,11 @@ bool content_transaction::validate( const runtime &owner_runtime,
         }
 
         const std::set<std::string> body_sides = { "left", "right", "both" };
-        const auto known_body_part = [&]( const std::string &id ) {
+        const auto known_body_part = [&]( const std::string & id ) {
             return body_part_ids.count( id ) != 0 || !check_engine_state ||
                    bodypart_str_id( id ).is_valid();
         };
-        const auto known_sub_body_part = [&]( const std::string &id ) {
+        const auto known_sub_body_part = [&]( const std::string & id ) {
             return sub_body_part_ids.count( id ) != 0 || !check_engine_state ||
                    sub_bodypart_str_id( id ).is_valid();
         };
@@ -11112,22 +11818,22 @@ bool content_transaction::validate( const runtime &owner_runtime,
                 definition.plural_heading, definition.encumbrance_text,
                 definition.hp_bar_text, definition.id
             };
-            if( std::any_of( labels.begin(), labels.end(), []( const std::string &value ) {
+            if( std::any_of( labels.begin(), labels.end(), []( const std::string & value ) {
             return value.empty() || value.size() > 1024 ||
-                   value.find( '\0' ) != std::string::npos;
+                       value.find( '\0' ) != std::string::npos;
             } ) || definition.main_part.empty() ||
-                !known_body_part( definition.main_part ) ||
-                definition.connected_to.empty() ||
-                !known_body_part( definition.connected_to ) ||
-                definition.opposite.empty() || !known_body_part( definition.opposite ) ||
-                body_sides.count( definition.side ) == 0 ||
-                !finite_native_float( definition.hit_size ) || definition.hit_size <= 0.0 ||
-                !finite_native_float( definition.hit_difficulty ) ||
-                definition.hit_difficulty < 0.0 || definition.base_health <= 0 ||
-                definition.base_health > std::numeric_limits<int>::max() ||
-                definition.drench_capacity < 0 ||
-                definition.drench_capacity > std::numeric_limits<int>::max() ||
-                definition.limb_types.empty() ) {
+            !known_body_part( definition.main_part ) ||
+            definition.connected_to.empty() ||
+            !known_body_part( definition.connected_to ) ||
+            definition.opposite.empty() || !known_body_part( definition.opposite ) ||
+            body_sides.count( definition.side ) == 0 ||
+            !finite_native_float( definition.hit_size ) || definition.hit_size <= 0.0 ||
+            !finite_native_float( definition.hit_difficulty ) ||
+            definition.hit_difficulty < 0.0 || definition.base_health <= 0 ||
+            definition.base_health > std::numeric_limits<int>::max() ||
+            definition.drench_capacity < 0 ||
+            definition.drench_capacity > std::numeric_limits<int>::max() ||
+            definition.limb_types.empty() ) {
                 throw std::runtime_error( "body part '" + definition.id +
                                           "' has invalid text, links, geometry, or health" );
             }
@@ -11308,7 +12014,7 @@ bool content_transaction::validate( const runtime &owner_runtime,
         std::set<std::string> visiting_body_graphs;
         std::set<std::string> visited_body_graphs;
         std::function<void( const std::string & )> visit_body_graph;
-        visit_body_graph = [&]( const std::string &id ) {
+        visit_body_graph = [&]( const std::string & id ) {
             if( visited_body_graphs.count( id ) != 0 ) {
                 return;
             }
@@ -11344,7 +12050,7 @@ bool content_transaction::validate( const runtime &owner_runtime,
             require_valid_id( definition.id, "effect type" );
             const auto bounded_texts = []( const std::vector<std::string> &values ) {
                 return !values.empty() && std::all_of(
-                           values.begin(), values.end(), []( const std::string & value ) {
+                values.begin(), values.end(), []( const std::string & value ) {
                     return !value.empty() && value.size() <= 4096 &&
                            value.find( '\0' ) == std::string::npos;
                 } );
@@ -11541,8 +12247,8 @@ bool content_transaction::validate( const runtime &owner_runtime,
                                               "' contains an invalid weakpoint" );
                 }
                 const auto validate_damage_map = [&](
-                    const std::map<std::string, double> &values,
-                    const bool non_negative, const std::string_view label ) {
+                                                     const std::map<std::string, double> &values,
+                const bool non_negative, const std::string_view label ) {
                     for( const auto &[damage_id, value] : values ) {
                         if( ( damage_type_ids.count( damage_id ) == 0 &&
                               !damage_type_id( damage_id ).is_valid() ) ||
@@ -11785,6 +12491,7 @@ bool content_transaction::validate( const runtime &owner_runtime,
         }
 
         std::set<std::string> requirement_ids;
+        std::map<std::string, const requirement_definition_data *> staged_requirements;
         for( const requirement_registration &entry : pimpl_->requirements ) {
             const requirement_definition_data &definition = *entry.definition;
             require_valid_id( definition.id, "requirement" );
@@ -11794,6 +12501,7 @@ bool content_transaction::validate( const runtime &owner_runtime,
                 throw std::runtime_error( "requirement '" + definition.id +
                                           "' must contain native requirements and be registered once per transaction" );
             }
+            staged_requirements.emplace( definition.id, &definition );
             const auto validate_item_groups = [&declared_item_ids, &definition](
             const std::vector<std::vector<component_requirement>> &groups, const char *kind ) {
                 for( const std::vector<component_requirement> &group : groups ) {
@@ -11832,6 +12540,263 @@ bool content_transaction::validate( const runtime &owner_runtime,
                                 requirement_data::registry().count(
                                     requirement_id( definition.id ) ) != 0,
                                 definition.id, "requirement" );
+        }
+
+        std::set<std::string> wound_fix_ids;
+        for( const wound_fix_registration &entry : pimpl_->wound_fixes ) {
+            const wound_fix_definition_data &definition = *entry.definition;
+            require_valid_id( definition.id, "wound fix" );
+            if( definition.id.find( '\0' ) != std::string::npos ||
+                !wound_fix_ids.insert( definition.id ).second ) {
+                throw std::runtime_error( "wound fix '" + definition.id +
+                                          "' is registered more than once per transaction" );
+            }
+            validate_operation( entry.operation, wound_fix_id( definition.id ).is_valid(),
+                                definition.id, "wound fix" );
+        }
+        for( const wound_fix_registration &entry : pimpl_->wound_fixes ) {
+            const wound_fix_definition_data &definition = *entry.definition;
+            if( !valid_wound_text( definition.name, 1024 ) ||
+                !valid_wound_text( definition.description, 32768 ) ||
+                definition.success_message.size() > 32768 ||
+                definition.success_message.find( '\0' ) != std::string::npos ||
+                definition.duration_turns < 0 ||
+                definition.duration_turns > std::numeric_limits<int>::max() / 100 ||
+                definition.health_delta < std::numeric_limits<int>::min() ||
+                definition.health_delta > std::numeric_limits<int>::max() ||
+                definition.wounds_removed.empty() ) {
+                throw std::runtime_error( "wound fix '" + definition.id +
+                                          "' has invalid text, duration, health delta, or removes no wounds" );
+            }
+            for( const auto &[skill, level] : definition.skills ) {
+                if( skill.empty() || skill.size() > 256 ||
+                    skill.find( '\0' ) != std::string::npos || level < 0 || level > MAX_SKILL ||
+                    ( skill_ids.count( skill ) == 0 && !skill_id( skill ).is_valid() ) ) {
+                    throw std::runtime_error( "wound fix '" + definition.id +
+                                              "' has invalid skill '" + skill + "'" );
+                }
+            }
+            std::set<std::string> proficiencies;
+            for( const wound_fix_proficiency_definition_data &proficiency :
+                 definition.proficiencies ) {
+                if( proficiency.id.empty() || proficiency.id.size() > 256 ||
+                    proficiency.id.find( '\0' ) != std::string::npos ||
+                    !proficiencies.insert( proficiency.id ).second ||
+                    !std::isfinite( proficiency.multiplier ) ||
+                    proficiency.multiplier <= 0.0 ||
+                    proficiency.multiplier > std::numeric_limits<float>::max() ||
+                    static_cast<float>( proficiency.multiplier ) <= 0.0f ||
+                    ( proficiency_ids.count( proficiency.id ) == 0 &&
+                      !proficiency_id( proficiency.id ).is_valid() ) ) {
+                    throw std::runtime_error( "wound fix '" + definition.id +
+                                              "' has invalid proficiency '" +
+                                              proficiency.id + "'" );
+                }
+            }
+            const auto known_wound = [&wound_type_ids]( const std::string & id ) {
+                return wound_type_ids.count( id ) != 0 || wound_type_id( id ).is_valid();
+            };
+            for( const std::string &wound_id : definition.wounds_removed ) {
+                if( wound_id.empty() || wound_id.size() > 256 ||
+                    wound_id.find( '\0' ) != std::string::npos || !known_wound( wound_id ) ||
+                    definition.wounds_added.count( wound_id ) != 0 ) {
+                    throw std::runtime_error( "wound fix '" + definition.id +
+                                              "' has invalid or contradictory removed wound '" +
+                                              wound_id + "'" );
+                }
+            }
+            for( const std::string &wound_id : definition.wounds_added ) {
+                if( wound_id.empty() || wound_id.size() > 256 ||
+                    wound_id.find( '\0' ) != std::string::npos || !known_wound( wound_id ) ||
+                    definition.wounds_removed.count( wound_id ) != 0 ) {
+                    throw std::runtime_error( "wound fix '" + definition.id +
+                                              "' has invalid or contradictory added wound '" +
+                                              wound_id + "'" );
+                }
+            }
+            struct scaled_requirement_component {
+                std::string type;
+                bool is_requirement = false;
+                std::int64_t count = 0;
+            };
+            using scaled_requirement_groups =
+                std::vector<std::vector<scaled_requirement_component>>;
+            scaled_requirement_groups scaled_component_groups;
+            scaled_requirement_groups scaled_tool_groups;
+            std::set<std::string> requirements;
+            for( const wound_fix_requirement_definition_data &requirement :
+                 definition.requirements ) {
+                if( requirement.id.empty() || requirement.id.size() > 256 ||
+                    requirement.id.find( '\0' ) != std::string::npos ||
+                    !requirements.insert( requirement.id ).second || requirement.count <= 0 ||
+                    requirement.count > std::numeric_limits<int>::max() ||
+                    ( requirement_ids.count( requirement.id ) == 0 &&
+                      requirement_data::registry().count( requirement_id( requirement.id ) ) == 0 ) ) {
+                    throw std::runtime_error( "wound fix '" + definition.id +
+                                              "' has invalid requirement '" +
+                                              requirement.id + "'" );
+                }
+                const auto scaled_counts_fit = [&requirement]( const auto & groups ) {
+                    constexpr std::int64_t native_min =
+                        std::numeric_limits<int>::min();
+                    constexpr std::int64_t native_max =
+                        std::numeric_limits<int>::max();
+                    for( const auto &group : groups ) {
+                        for( const auto &component : group ) {
+                            const std::int64_t count = component.count;
+                            if( ( count < 0 &&
+                                  count < native_min / requirement.count ) ||
+                                ( count > 0 &&
+                                  count > native_max / requirement.count ) ) {
+                                return false;
+                            }
+                        }
+                    }
+                    return true;
+                };
+                const auto append_scaled_groups = [&requirement](
+                                                      const auto & groups, scaled_requirement_groups & target,
+                const auto & type_of, const auto & is_requirement ) {
+                    for( const auto &group : groups ) {
+                        std::vector<scaled_requirement_component> scaled_group;
+                        scaled_group.reserve( group.size() );
+                        for( const auto &component : group ) {
+                            const std::int64_t scaled_count =
+                                static_cast<std::int64_t>( component.count ) *
+                                requirement.count;
+                            scaled_group.push_back( {
+                                type_of( component ), is_requirement( component ),
+                                std::max<std::int64_t>( scaled_count, -1 )
+                            } );
+                        }
+                        target.push_back( std::move( scaled_group ) );
+                    }
+                };
+                bool counts_fit = false;
+                const auto staged = staged_requirements.find( requirement.id );
+                if( staged != staged_requirements.end() ) {
+                    counts_fit = scaled_counts_fit( staged->second->components ) &&
+                                 scaled_counts_fit( staged->second->tools );
+                    if( counts_fit ) {
+                        append_scaled_groups(
+                            staged->second->components, scaled_component_groups,
+                        []( const component_requirement & component ) {
+                            return component.id;
+                        }, []( const component_requirement & ) {
+                            return false;
+                        } );
+                        append_scaled_groups(
+                            staged->second->tools, scaled_tool_groups,
+                        []( const component_requirement & component ) {
+                            return component.id;
+                        }, []( const component_requirement & ) {
+                            return false;
+                        } );
+                    }
+                } else {
+                    const auto existing = requirement_data::registry().find(
+                                              requirement_id( requirement.id ) );
+                    counts_fit = existing != requirement_data::registry().end() &&
+                                 scaled_counts_fit( existing->second.get_components() ) &&
+                                 scaled_counts_fit( existing->second.get_tools() );
+                    if( counts_fit ) {
+                        append_scaled_groups(
+                            existing->second.get_components(), scaled_component_groups,
+                        []( const item_comp & component ) {
+                            return component.type.str();
+                        }, []( const item_comp & component ) {
+                            return component.requirement;
+                        } );
+                        append_scaled_groups(
+                            existing->second.get_tools(), scaled_tool_groups,
+                        []( const tool_comp & component ) {
+                            return component.type.str();
+                        }, []( const tool_comp & component ) {
+                            return component.requirement;
+                        } );
+                    }
+                }
+                if( !counts_fit ) {
+                    throw std::runtime_error( "wound fix '" + definition.id +
+                                              "' requirement '" + requirement.id +
+                                              "' exceeds the native component/tool count range when scaled" );
+                }
+            }
+            const auto consolidated_counts_fit = []( scaled_requirement_groups old_groups,
+            const bool tools ) {
+                const auto type_less = []( const scaled_requirement_component & lhs,
+                const scaled_requirement_component & rhs ) {
+                    return std::tie( lhs.type, lhs.is_requirement ) <
+                           std::tie( rhs.type, rhs.is_requirement );
+                };
+                for( std::vector<scaled_requirement_component> &group : old_groups ) {
+                    std::sort( group.begin(), group.end(), type_less );
+                }
+                std::sort( old_groups.begin(), old_groups.end(),
+                           [&type_less]( const std::vector<scaled_requirement_component> &lhs,
+                const std::vector<scaled_requirement_component> &rhs ) {
+                    return std::lexicographical_compare(
+                               lhs.begin(), lhs.end(), rhs.begin(), rhs.end(), type_less );
+                } );
+
+                std::vector<std::vector<scaled_requirement_component>> consolidated;
+                for( std::vector<scaled_requirement_component> &old_group : old_groups ) {
+                    bool match = false;
+                    for( std::vector<scaled_requirement_component> &new_group : consolidated ) {
+                        if( std::includes( new_group.begin(), new_group.end(),
+                                           old_group.begin(), old_group.end(), type_less ) ) {
+                            match = true;
+                            std::swap( old_group, new_group );
+                        } else if( std::includes( old_group.begin(), old_group.end(),
+                                                  new_group.begin(), new_group.end(), type_less ) ) {
+                            match = true;
+                        }
+                        if( !match ) {
+                            continue;
+                        }
+                        auto old_component = old_group.begin();
+                        for( auto new_component = new_group.begin();
+                             new_component != new_group.end(); ++old_component ) {
+                            if( !type_less( *old_component, *new_component ) ) {
+                                if( tools ) {
+                                    if( new_component->count < 0 && old_component->count < 0 ) {
+                                        new_component->count = std::min(
+                                                                   new_component->count,
+                                                                   old_component->count );
+                                    } else if( new_component->count > 0 &&
+                                               old_component->count > 0 ) {
+                                        const std::int64_t sum = new_component->count +
+                                                                 old_component->count;
+                                        if( sum > std::numeric_limits<int>::max() ) {
+                                            return false;
+                                        }
+                                        new_component->count = sum;
+                                    }
+                                } else {
+                                    const std::int64_t sum = new_component->count +
+                                                             old_component->count;
+                                    if( sum < std::numeric_limits<int>::min() ||
+                                        sum > std::numeric_limits<int>::max() ) {
+                                        return false;
+                                    }
+                                    new_component->count = sum;
+                                }
+                                ++new_component;
+                            }
+                        }
+                        break;
+                    }
+                    if( !match ) {
+                        consolidated.push_back( std::move( old_group ) );
+                    }
+                }
+                return true;
+            };
+            if( !consolidated_counts_fit( std::move( scaled_component_groups ), false ) ||
+                !consolidated_counts_fit( std::move( scaled_tool_groups ), true ) ) {
+                throw std::runtime_error( "wound fix '" + definition.id +
+                                          "' combined requirements exceed the native count range during consolidation" );
+            }
         }
 
         std::set<std::string> recipe_group_ids;
@@ -11931,7 +12896,7 @@ bool content_transaction::validate( const runtime &owner_runtime,
                                               "' references unknown vitamin '" + vitamin_key + "'" );
                 }
             }
-            const auto item_exists = [&declared_item_ids]( const std::string &id ) {
+            const auto item_exists = [&declared_item_ids]( const std::string & id ) {
                 return id.empty() || declared_item_ids.count( id ) != 0 ||
                        item::type_is_defined( itype_id( id ) );
             };
@@ -11961,7 +12926,8 @@ bool content_transaction::validate( const runtime &owner_runtime,
                 throw std::runtime_error( "item '" + definition.id + "' requires a name and symbol" );
             }
             if( !item_ids.insert( definition.id ).second ) {
-                throw std::runtime_error( "item '" + definition.id + "' is registered more than once in one transaction" );
+                throw std::runtime_error( "item '" + definition.id +
+                                          "' is registered more than once in one transaction" );
             }
             std::int64_t material_portions = 0;
             std::map<std::string, std::int64_t> portions_by_material;
@@ -11994,7 +12960,8 @@ bool content_transaction::validate( const runtime &owner_runtime,
             }
             const bool exists = item_controller->has_template( itype_id( definition.id ) );
             if( check_engine_state && entry.operation == definition_operation::add && exists ) {
-                throw std::runtime_error( "add would overwrite existing item '" + definition.id + "'; use replace explicitly" );
+                throw std::runtime_error( "add would overwrite existing item '" + definition.id +
+                                          "'; use replace explicitly" );
             }
             if( check_engine_state && entry.operation == definition_operation::replace && !exists ) {
                 throw std::runtime_error( operation_name( entry.operation ) +
@@ -12599,7 +13566,7 @@ bool content_transaction::apply( std::string &error )
             }
             for( const auto &[product, efficiency] : source.burn_products ) {
                 native._burn_products.emplace_back( itype_id( product ),
-                                                     static_cast<float>( efficiency ) );
+                                                    static_cast<float>( efficiency ) );
             }
             if( source.has_fuel ) {
                 native.fuel.energy = units::from_kilojoule<std::int64_t>(
@@ -12632,7 +13599,7 @@ bool content_transaction::apply( std::string &error )
             detail::proficiency_category_registry().insert( native );
         }
 
-        const auto proficiency_attribute = []( const std::string &attribute ) {
+        const auto proficiency_attribute = []( const std::string & attribute ) {
             if( attribute == "strength" ) {
                 return proficiency_bonus_type::strength;
             }
@@ -12954,7 +13921,7 @@ bool content_transaction::apply( std::string &error )
                 native.values_.push_back( std::move( value ) );
             }
             std::sort( native.values_.begin(), native.values_.end(),
-            []( const mood_face_value &left, const mood_face_value &right ) {
+            []( const mood_face_value & left, const mood_face_value & right ) {
                 return left.value() > right.value();
             } );
             detail::mood_face_registry().insert( native );
@@ -13232,7 +14199,8 @@ bool content_transaction::apply( std::string &error )
                 value.chance = static_cast<int>( effect.chance );
                 value.radius = static_cast<int>( effect.radius );
                 value.hits_amount = { static_cast<int>( effect.hits_min ),
-                                      static_cast<int>( effect.hits_max ) };
+                                      static_cast<int>( effect.hits_max )
+                                    };
                 value.all_bp = effect.all_body_parts;
                 native.aoe_effects.push_back( std::move( value ) );
             }
@@ -13420,7 +14388,7 @@ bool content_transaction::apply( std::string &error )
             if( source.has_animation ) {
                 native.weather_animation.factor = static_cast<float>( source.animation_factor );
                 native.weather_animation.color = color_from_string(
-                        source.animation_color, report_color_error::no );
+                                                     source.animation_color, report_color_error::no );
                 native.weather_animation.symbol = UTF8_getch( source.animation_symbol );
             }
             for( const std::string &weather : source.required_weathers ) {
@@ -13612,8 +14580,8 @@ bool content_transaction::apply( std::string &error )
                 order = registry.help_texts.crbegin()->first + 1;
             }
             registry.help_texts[order] = std::make_pair(
-                                            no_translation( source.title ),
-                                            std::move( paragraphs ) );
+                                             no_translation( source.title ),
+                                             std::move( paragraphs ) );
             registry.platform_help_topic_orders[source.id] = order;
         }
 
@@ -13653,7 +14621,7 @@ bool content_transaction::apply( std::string &error )
                     category.ids.push_back( snippet_library::weighted_id{ accumulated, id } );
                     SNIPPET.snippets_by_id[id] = no_translation( snippet.text );
                     SNIPPET.name_by_id[id] = snippet.name.empty() ? translation() :
-                                                  no_translation( snippet.name );
+                                             no_translation( snippet.name );
                     // Lua-authored snippets deliberately do not populate EOC_by_id.
                     SNIPPET.EOC_by_id.erase( id );
                 }
@@ -13863,7 +14831,8 @@ bool content_transaction::apply( std::string &error )
             native.msg_dissect_success = source.dissect_success;
             native.msg_dissect_fail = source.dissect_failure;
             const std::vector<std::string> skills = source.skills.empty() ?
-                    std::vector<std::string>{ "survival" } : source.skills;
+                                                    std::vector<std::string> { "survival" } :
+                                                    source.skills;
             for( const std::string &skill : skills ) {
                 native.harvest_skills.emplace_back( skill );
             }
@@ -13939,11 +14908,11 @@ bool content_transaction::apply( std::string &error )
                     const std::string behavior_id = source.id;
                     const std::string handler_id = condition.policy;
                     native.add_predicate(
-                    [owner, behavior_id, handler_id]( const behavior::oracle_t *oracle,
-                            const std::string &argument ) {
+                        [owner, behavior_id, handler_id]( const behavior::oracle_t *oracle,
+                    const std::string & argument ) {
                         const Creature *subject = oracle == nullptr ? nullptr : oracle->get_subject();
                         const std::optional<bool> result = invoke_behavior_condition_handler(
-                                owner, behavior_id, handler_id, subject, argument );
+                                                               owner, behavior_id, handler_id, subject, argument );
                         return result.value_or( false ) ? behavior::status_t::running :
                                behavior::status_t::failure;
                     }, condition.argument, condition.inverted );
@@ -13959,8 +14928,8 @@ bool content_transaction::apply( std::string &error )
                     const std::string behavior_id = source.id;
                     const std::string handler_id = score.policy;
                     native.set_score_function(
-                    [owner, behavior_id, handler_id]( const behavior::oracle_t *oracle,
-                            const std::string_view argument ) {
+                        [owner, behavior_id, handler_id]( const behavior::oracle_t *oracle,
+                    const std::string_view argument ) {
                         const Creature *subject = oracle == nullptr ? nullptr : oracle->get_subject();
                         return static_cast<float>( invoke_behavior_score_handler(
                                                        owner, behavior_id, handler_id, subject,
@@ -14021,10 +14990,10 @@ bool content_transaction::apply( std::string &error )
                 native.flags.emplace( id );
             }
             for( const std::string &id : source.immune_character_flags ) {
-                native.immune_flags.emplace( id );
+                native.immune_flags.insert( json_character_flag( id ) );
             }
             for( const std::string &id : source.immune_bodypart_flags ) {
-                native.immune_bp_flags.emplace( id );
+                native.immune_bp_flags.insert( json_character_flag( id ) );
             }
             for( const std::string &id : source.resist_traits ) {
                 native.resist_traits.emplace_back( id );
@@ -14079,6 +15048,60 @@ bool content_transaction::apply( std::string &error )
         }
         if( !pimpl_->sub_body_parts.empty() ) {
             detail::refresh_sub_body_part_similarity_cache();
+        }
+
+        for( const wound_type_registration &entry : pimpl_->wound_types ) {
+            const wound_type_id id( entry.definition->id );
+            pimpl_->wound_type_undo.emplace_back(
+                id, id.is_valid() ? std::optional<wound_type>( id.obj() ) : std::nullopt );
+            const wound_type_definition_data &source = *entry.definition;
+            wound_type native;
+            native.id = id;
+            native.was_loaded = true;
+            native.name_ = pl_translation( source.name, source.plural_name );
+            native.description_ = no_translation( source.description );
+            native.pain_ = {
+                static_cast<int>( source.pain_min ), static_cast<int>( source.pain_max )
+            };
+            native.healing_time_ = {
+                time_duration::from_turns( static_cast<int>( source.healing_min_turns ) ),
+                time_duration::from_turns( static_cast<int>( source.healing_max_turns ) )
+            };
+            native.damage_required = {
+                static_cast<int>( source.damage_min ), static_cast<int>( source.damage_max )
+            };
+            native.weight = static_cast<int>( source.weight );
+            native.limit = static_cast<unsigned int>( source.per_part_limit );
+            if( !source.required_body_part_flag.empty() ) {
+                native.whitelist_bp_with_flag =
+                    json_character_flag( source.required_body_part_flag );
+            }
+            if( !source.forbidden_body_part_flag.empty() ) {
+                native.blacklist_bp_with_flag =
+                    json_character_flag( source.forbidden_body_part_flag );
+            }
+            for( const std::string &damage_id : source.damage_types ) {
+                native.damage_types.emplace_back( damage_id );
+            }
+            for( const wound_limb_score_definition_data &score : source.limb_scores ) {
+                native.limb_scores.push_back( {
+                    limb_score_id( score.id ), static_cast<float>( score.penalty )
+                } );
+            }
+            for( const wound_progression_definition_data &progression : source.progressions ) {
+                native.wound_progression.push_back( {
+                    wound_type_id( progression.id ), static_cast<int>( progression.chance )
+                } );
+            }
+            for( const std::string &kind : source.required_body_part_types ) {
+                native.whitelist_body_part_types.push_back(
+                    io::string_to_enum<bp_type>( kind ) );
+            }
+            for( const std::string &kind : source.forbidden_body_part_types ) {
+                native.blacklist_body_part_types.push_back(
+                    io::string_to_enum<bp_type>( kind ) );
+            }
+            detail::wound_type_registry().insert( native ).finalize();
         }
 
         static const std::map<std::string, bp_type> platform_body_part_types = {
@@ -14139,7 +15162,7 @@ bool content_transaction::apply( std::string &error )
                     damage_type_id( damage_id ), static_cast<float>( amount ) );
             }
             for( const std::string &flag : source.flags ) {
-                native.flags.emplace( flag );
+                native.flags.insert( json_character_flag( flag ) );
             }
             for( const auto &[score_id, score] : source.limb_scores ) {
                 native.limb_scores[limb_score_id( score_id )] = {
@@ -14246,7 +15269,7 @@ bool content_transaction::apply( std::string &error )
                 level.translucency = static_cast<float>( source_level.translucency );
                 level.concentration = static_cast<int>( source_level.concentration );
                 level.convection_temperature_mod = static_cast<int>(
-                        source_level.convection_temperature_modifier );
+                                                       source_level.convection_temperature_modifier );
                 level.scent_neutralization = static_cast<int>(
                                                  source_level.scent_neutralization );
                 for( const field_effect_definition_data &source_effect :
@@ -14319,7 +15342,7 @@ bool content_transaction::apply( std::string &error )
             for( const std::string &monster_id : source.blocked_monsters ) {
                 native.block_mtypes.emplace( monster_id );
             }
-            get_all_field_types().insert( native ).finalize();
+            get_all_field_types().insert( native );
         }
 
         for( const monster_attack_registration &entry : pimpl_->monster_attacks ) {
@@ -14474,6 +15497,43 @@ bool content_transaction::apply( std::string &error )
             native.id_ = id;
             native.name_ = no_translation( source.name );
             requirement_data::registry()[id] = std::move( native );
+        }
+
+        for( const wound_fix_registration &entry : pimpl_->wound_fixes ) {
+            const wound_fix_id id( entry.definition->id );
+            pimpl_->wound_fix_undo.emplace_back(
+                id, id.is_valid() ? std::optional<wound_fix>( id.obj() ) : std::nullopt );
+            const wound_fix_definition_data &source = *entry.definition;
+            wound_fix native;
+            native.id = id;
+            native.was_loaded = true;
+            native.name = no_translation( source.name );
+            native.description = no_translation( source.description );
+            native.success_msg = no_translation( source.success_message );
+            native.time = time_duration::from_turns( static_cast<int>( source.duration_turns ) );
+            native.mod_hp = static_cast<int>( source.health_delta );
+            for( const auto &[skill, level] : source.skills ) {
+                native.skills.emplace( skill_id( skill ), static_cast<int>( level ) );
+            }
+            for( const wound_fix_proficiency_definition_data &proficiency :
+                 source.proficiencies ) {
+                native.proficiencies.push_back( {
+                    proficiency_id( proficiency.id ),
+                    static_cast<float>( proficiency.multiplier ), proficiency.mandatory
+                } );
+            }
+            for( const std::string &wound_id : source.wounds_removed ) {
+                native.wounds_removed.emplace( wound_id );
+            }
+            for( const std::string &wound_id : source.wounds_added ) {
+                native.wounds_added.emplace( wound_id );
+            }
+            for( const wound_fix_requirement_definition_data &requirement :
+                 source.requirements ) {
+                native.requirement_refs.emplace_back(
+                    requirement_id( requirement.id ), static_cast<int>( requirement.count ) );
+            }
+            detail::wound_fix_registry().insert( native ).finalize();
         }
 
         for( const recipe_group_registration &entry : pimpl_->recipe_groups ) {
@@ -14791,12 +15851,44 @@ bool content_transaction::apply( std::string &error )
                 native.placate.set( monster_triggers.at( trigger ) );
             }
             mtype &inserted = detail::monster_type_registry().insert( native );
-            MonsterGenerator::generator().finalize_lua_first_mtype( inserted );
+            MonsterGenerator::generator().finalize_lua_first_mtype_if_ready(
+                inserted, DynamicDataLoader::get_instance().is_data_finalized() );
         }
         if( !pimpl_->monsters.empty() ) {
             MonsterGenerator::generator().refresh_hallucination_monsters();
         }
+        for( const field_type_registration &entry : pimpl_->field_types ) {
+            field_type &native = const_cast<field_type &>(
+                                     field_type_str_id( entry.definition->id ).obj() );
+            native.finalize();
+        }
 
+        if( !pimpl_->requirements.empty() || !pimpl_->wound_fixes.empty() ) {
+            detail::wound_fix_registry().finalize();
+        }
+        for( const wound_fix_registration &entry : pimpl_->wound_fixes ) {
+            const wound_fix &native = wound_fix_id( entry.definition->id ).obj();
+            if( native.requirement_refs.size() != entry.definition->requirements.size() ) {
+                throw std::runtime_error(
+                    "wound fix '" + entry.definition->id +
+                    "' changed its requirement references while being applied" );
+            }
+            for( std::size_t index = 0; index < native.requirement_refs.size(); ++index ) {
+                if( native.requirement_refs[index].first !=
+                    requirement_id( entry.definition->requirements[index].id ) ||
+                    native.requirement_refs[index].second !=
+                    entry.definition->requirements[index].count ) {
+                    throw std::runtime_error(
+                        "wound fix '" + entry.definition->id +
+                        "' changed a requirement reference while being applied" );
+                }
+            }
+        }
+        if( !pimpl_->wound_types.empty() || !pimpl_->wound_fixes.empty() ||
+            !pimpl_->body_parts.empty() ) {
+            detail::refresh_wound_fix_links();
+            detail::refresh_body_part_wound_cache();
+        }
         pimpl_->applied = true;
         error.clear();
         return true;
@@ -15315,6 +16407,13 @@ bool content_transaction::validate_finalized( std::string &error ) const
             return false;
         }
     }
+    for( const wound_type_registration &entry : pimpl_->wound_types ) {
+        if( !wound_type_id( entry.definition->id ).is_valid() ) {
+            error = "Lua-first wound '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
     for( const body_part_registration &entry : pimpl_->body_parts ) {
         if( !bodypart_str_id( entry.definition->id ).is_valid() ) {
             error = "Lua-first body part '" + entry.definition->id +
@@ -15392,6 +16491,55 @@ bool content_transaction::validate_finalized( std::string &error ) const
             return false;
         }
     }
+    for( const wound_fix_registration &entry : pimpl_->wound_fixes ) {
+        const wound_fix_id id( entry.definition->id );
+        if( !id.is_valid() ) {
+            error = "Lua-first wound fix '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    for( const wound_type &wound_definition : detail::wound_type_registry().get_all() ) {
+        for( const wound_fix_id &fix_id : wound_definition.fixes ) {
+            if( !fix_id.is_valid() ||
+                fix_id->wounds_removed.count( wound_definition.id ) == 0 ) {
+                error = "wound '" + wound_definition.id.str() +
+                        "' retained an invalid wound-fix reverse link";
+                return false;
+            }
+        }
+    }
+    for( const wound_fix &fix : detail::wound_fix_registry().get_all() ) {
+        for( const wound_type_id &wound_id : fix.wounds_removed ) {
+            if( !wound_id.is_valid() || wound_id->fixes.count( fix.id ) == 0 ) {
+                error = "wound fix '" + fix.id.str() +
+                        "' is missing a wound reverse link";
+                return false;
+            }
+        }
+    }
+    for( const body_part_type &part : detail::body_part_registry().get_all() ) {
+        std::set<wound_type_id> cached_ids;
+        for( const auto &[candidate, weight] : part.potential_wounds ) {
+            if( !candidate.id.is_valid() || !cached_ids.insert( candidate.id ).second ||
+                !candidate.id->allowed_on_bodypart( part.id ) ||
+                candidate.damage_type != candidate.id->damage_types ||
+                candidate.damage_required != candidate.id->damage_required ||
+                weight != candidate.id->weight ) {
+                error = "body part '" + part.id.str() +
+                        "' retained an invalid or duplicate wound-cache entry";
+                return false;
+            }
+        }
+        for( const wound_type &wound_definition : detail::wound_type_registry().get_all() ) {
+            if( wound_definition.allowed_on_bodypart( part.id ) !=
+                ( cached_ids.count( wound_definition.id ) != 0 ) ) {
+                error = "body part '" + part.id.str() +
+                        "' has an incomplete wound cache";
+                return false;
+            }
+        }
+    }
     for( const recipe_group_registration &entry : pimpl_->recipe_groups ) {
         if( !detail::recipe_group_exists( entry.definition->id ) ) {
             error = "Lua-first recipe group '" + entry.definition->id +
@@ -15426,6 +16574,11 @@ bool content_transaction::validate_finalized( std::string &error ) const
 
 void content_transaction::rollback()
 {
+    const bool rebuild_wound_fixes = !pimpl_->requirement_undo.empty() ||
+                                     !pimpl_->wound_fix_undo.empty();
+    const bool refresh_wound_derived = !pimpl_->wound_type_undo.empty() ||
+                                       !pimpl_->wound_fix_undo.empty() ||
+                                       !pimpl_->body_part_undo.empty();
     for( auto it = pimpl_->monster_undo.rbegin();
          it != pimpl_->monster_undo.rend(); ++it ) {
         if( it->second ) {
@@ -15485,6 +16638,16 @@ void content_transaction::rollback()
         }
     }
     pimpl_->recipe_group_undo.clear();
+
+    for( auto it = pimpl_->wound_fix_undo.rbegin();
+         it != pimpl_->wound_fix_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::wound_fix_registry().restore( *it->second );
+        } else {
+            detail::wound_fix_registry().erase( it->first );
+        }
+    }
+    pimpl_->wound_fix_undo.clear();
 
     for( auto it = pimpl_->requirement_undo.rbegin();
          it != pimpl_->requirement_undo.rend(); ++it ) {
@@ -15577,6 +16740,16 @@ void content_transaction::rollback()
         detail::refresh_body_part_similarity_cache();
     }
     pimpl_->body_part_undo.clear();
+
+    for( auto it = pimpl_->wound_type_undo.rbegin();
+         it != pimpl_->wound_type_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::wound_type_registry().restore( *it->second );
+        } else {
+            detail::wound_type_registry().erase( it->first );
+        }
+    }
+    pimpl_->wound_type_undo.clear();
 
     for( auto it = pimpl_->sub_body_part_undo.rbegin();
          it != pimpl_->sub_body_part_undo.rend(); ++it ) {
@@ -16293,6 +17466,13 @@ void content_transaction::rollback()
         }
     }
     pimpl_->json_flag_undo.clear();
+    if( rebuild_wound_fixes ) {
+        detail::wound_fix_registry().finalize();
+    }
+    if( refresh_wound_derived ) {
+        detail::refresh_wound_fix_links();
+        detail::refresh_body_part_wound_cache();
+    }
     pimpl_->applied = false;
 }
 
@@ -16318,6 +17498,7 @@ void content_transaction::commit()
     pimpl_->proficiency_undo.clear();
     pimpl_->weapon_category_undo.clear();
     pimpl_->requirement_undo.clear();
+    pimpl_->wound_fix_undo.clear();
     pimpl_->recipe_group_undo.clear();
     pimpl_->scent_type_undo.clear();
     pimpl_->speed_description_undo.clear();
@@ -16327,6 +17508,7 @@ void content_transaction::commit()
     pimpl_->behavior_undo.clear();
     pimpl_->effect_type_undo.clear();
     pimpl_->sub_body_part_undo.clear();
+    pimpl_->wound_type_undo.clear();
     pimpl_->body_part_undo.clear();
     pimpl_->anatomy_undo.clear();
     pimpl_->body_graph_undo.clear();
@@ -16984,7 +18166,7 @@ std::string content_transaction::fingerprint() const
             hash_part( state, "trail" );
             hash_field( field );
         }
-        const auto hash_character_effect = [&] (
+        const auto hash_character_effect = [&](
         const ammo_character_effect_definition_data & effect ) {
             hash_part( state, effect.effect );
             hash_part( state, std::to_string( effect.duration_turns ) );
@@ -17505,6 +18687,47 @@ std::string content_transaction::fingerprint() const
             hash_part( state, std::to_string( amount ) );
         }
     }
+    for( const wound_type_registration &entry : pimpl_->wound_types ) {
+        hash_part( state, "wound" );
+        hash_part( state, operation_name( entry.operation ) );
+        const wound_type_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.name );
+        hash_part( state, value.plural_name );
+        hash_part( state, value.description );
+        hash_part( state, std::to_string( value.pain_min ) );
+        hash_part( state, std::to_string( value.pain_max ) );
+        hash_part( state, std::to_string( value.healing_min_turns ) );
+        hash_part( state, std::to_string( value.healing_max_turns ) );
+        hash_part( state, std::to_string( value.damage_min ) );
+        hash_part( state, std::to_string( value.damage_max ) );
+        hash_part( state, std::to_string( value.weight ) );
+        hash_part( state, std::to_string( value.per_part_limit ) );
+        hash_part( state, value.required_body_part_flag );
+        hash_part( state, value.forbidden_body_part_flag );
+        for( const std::string &damage_type : value.damage_types ) {
+            hash_part( state, "damage_type" );
+            hash_part( state, damage_type );
+        }
+        for( const wound_limb_score_definition_data &score : value.limb_scores ) {
+            hash_part( state, "limb_score" );
+            hash_part( state, score.id );
+            hash_part( state, std::to_string( score.penalty ) );
+        }
+        for( const wound_progression_definition_data &progression : value.progressions ) {
+            hash_part( state, "progression" );
+            hash_part( state, progression.id );
+            hash_part( state, std::to_string( progression.chance ) );
+        }
+        for( const std::string &kind : value.required_body_part_types ) {
+            hash_part( state, "require_body_part_type" );
+            hash_part( state, kind );
+        }
+        for( const std::string &kind : value.forbidden_body_part_types ) {
+            hash_part( state, "forbid_body_part_type" );
+            hash_part( state, kind );
+        }
+    }
     for( const body_part_registration &entry : pimpl_->body_parts ) {
         hash_part( state, "body_part" );
         hash_part( state, operation_name( entry.operation ) );
@@ -17861,6 +19084,41 @@ std::string content_transaction::fingerprint() const
             }
         }
     }
+    for( const wound_fix_registration &entry : pimpl_->wound_fixes ) {
+        hash_part( state, "wound_fix" );
+        hash_part( state, operation_name( entry.operation ) );
+        const wound_fix_definition_data &value = *entry.definition;
+        hash_part( state, value.id );
+        hash_part( state, value.name );
+        hash_part( state, value.description );
+        hash_part( state, value.success_message );
+        hash_part( state, std::to_string( value.duration_turns ) );
+        hash_part( state, std::to_string( value.health_delta ) );
+        for( const auto &[skill, level] : value.skills ) {
+            hash_part( state, "skill" );
+            hash_part( state, skill );
+            hash_part( state, std::to_string( level ) );
+        }
+        for( const wound_fix_proficiency_definition_data &proficiency : value.proficiencies ) {
+            hash_part( state, "proficiency" );
+            hash_part( state, proficiency.id );
+            hash_part( state, std::to_string( proficiency.multiplier ) );
+            hash_part( state, proficiency.mandatory ? "mandatory" : "optional" );
+        }
+        for( const std::string &wound_id : value.wounds_removed ) {
+            hash_part( state, "removes" );
+            hash_part( state, wound_id );
+        }
+        for( const std::string &wound_id : value.wounds_added ) {
+            hash_part( state, "adds" );
+            hash_part( state, wound_id );
+        }
+        for( const wound_fix_requirement_definition_data &requirement : value.requirements ) {
+            hash_part( state, "requires" );
+            hash_part( state, requirement.id );
+            hash_part( state, std::to_string( requirement.count ) );
+        }
+    }
     for( const recipe_group_registration &entry : pimpl_->recipe_groups ) {
         hash_part( state, "recipe_group" );
         hash_part( state, operation_name( entry.operation ) );
@@ -18164,8 +19422,8 @@ bool content_transaction::find_emission_handler(
 }
 
 std::shared_ptr<runtime> make_runtime( const std::string &mod_id,
-                                      std::size_t generation,
-                                      sol::state &lua )
+                                       std::size_t generation,
+                                       sol::state &lua )
 {
     return std::make_shared<runtime>( mod_id, generation, lua );
 }
@@ -18188,8 +19446,8 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
 
     const std::weak_ptr<runtime> weak = value;
     sol::table runtime_api = lua.create_table();
-    runtime_api.set_function( "handler", [weak]( const std::string &id,
-    const sol::object &callback, const sol::optional<std::int64_t> &payload_version ) {
+    runtime_api.set_function( "handler", [weak]( const std::string & id,
+    const sol::object & callback, const sol::optional<std::int64_t> &payload_version ) {
         const std::shared_ptr<runtime> owner = weak.lock();
         if( !owner ) {
             throw std::runtime_error( "stale Platform runtime" );
@@ -18206,13 +19464,13 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
         }
         const int version = static_cast<int>( requested_version );
         if( !owner->handlers.emplace( id, handler_definition{
-            version, callback.as<sol::protected_function>()
+        version, callback.as<sol::protected_function>()
         } ).second ) {
             throw std::runtime_error( "duplicate handler id '" + id + "'" );
         }
     } );
-    runtime_api.set_function( "on", [weak]( const std::string &event_name,
-    const std::string &handler_id ) {
+    runtime_api.set_function( "on", [weak]( const std::string & event_name,
+    const std::string & handler_id ) {
         const std::shared_ptr<runtime> owner = weak.lock();
         if( !owner ) {
             throw std::runtime_error( "stale Platform runtime" );
@@ -18225,6 +19483,10 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
         if( !lifecycle && ( event_name.size() <= 5 || event_name.compare( 0, 5, "game:" ) != 0 ) ) {
             throw std::runtime_error( "event must be a lifecycle name or game:<event>" );
         }
+        if( !lifecycle && !platform_event_contract_exists(
+                std::string_view( event_name ).substr( 5 ) ) ) {
+            throw std::runtime_error( "unknown native event '" + event_name + "'" );
+        }
         std::vector<std::string> &subscriptions = owner->subscriptions[event_name];
         if( std::find( subscriptions.begin(), subscriptions.end(), handler_id ) !=
             subscriptions.end() ) {
@@ -18234,8 +19496,8 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
         subscriptions.push_back( handler_id );
     } );
     runtime_api.set_function( "migrate_task_payload", [weak](
-    const std::string &handler_id, const std::int64_t from_version,
-    const std::int64_t to_version, const sol::object &callback ) {
+                                  const std::string & handler_id, const std::int64_t from_version,
+    const std::int64_t to_version, const sol::object & callback ) {
         const std::shared_ptr<runtime> owner = weak.lock();
         if( !owner ) {
             throw std::runtime_error( "stale Platform runtime" );
@@ -18264,8 +19526,8 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
                 "' from version " + std::to_string( from_version ) );
         }
     } );
-    runtime_api.set_function( "hook", [weak]( const std::string &hook_name,
-    const std::string &handler_id ) {
+    runtime_api.set_function( "hook", [weak]( const std::string & hook_name,
+    const std::string & handler_id ) {
         const std::shared_ptr<runtime> owner = weak.lock();
         if( !owner ) {
             throw std::runtime_error( "stale Platform runtime" );
@@ -18286,18 +19548,18 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
     ccb["runtime"] = std::move( runtime_api );
 
     auto install_state_scope = [&lua, weak]( persistent_state runtime::*member,
-    const std::string &name ) {
+    const std::string & name ) {
         sol::table scope = lua.create_table();
         scope.set_function( "get", [weak, member, name]( sol::this_state state,
-        const std::string &key, const sol::optional<sol::object> &fallback ) {
+        const std::string & key, const sol::optional<sol::object> &fallback ) {
             const std::shared_ptr<runtime> owner = weak.lock();
             if( !owner || !owner->world_is_ready ) {
                 throw std::runtime_error( "state." + name + " is only available after world_ready" );
             }
             return get_persistent_value( owner.get()->*member, state, key, fallback );
         } );
-        scope.set_function( "set", [weak, member, name]( const std::string &key,
-        const sol::object &entry ) {
+        scope.set_function( "set", [weak, member, name]( const std::string & key,
+        const sol::object & entry ) {
             const std::shared_ptr<runtime> owner = weak.lock();
             if( !owner || !owner->world_is_ready ) {
                 throw std::runtime_error( "state." + name + " is only available after world_ready" );
@@ -18314,8 +19576,8 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
 
     sol::table tasks = lua.create_table();
     tasks.set_function( "after", [weak]( std::int64_t turns,
-    const std::string &handler_id, const sol::optional<sol::table> &payload,
-    const sol::optional<std::int64_t> &payload_version,
+                                         const std::string & handler_id, const sol::optional<sol::table> &payload,
+                                         const sol::optional<std::int64_t> &payload_version,
     const sol::optional<std::string> &scope ) {
         const std::shared_ptr<runtime> owner = weak.lock();
         if( !owner || !owner->world_is_ready ) {
@@ -18389,18 +19651,18 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
         }
     };
     sol::table presentation = lua.create_table();
-    presentation.set_function( "notice", [require_presentation]( const std::string &message ) {
+    presentation.set_function( "notice", [require_presentation]( const std::string & message ) {
         require_presentation();
         require_presentation_text( message, "notice" );
         ::popup( message );
     } );
-    presentation.set_function( "confirm", [require_presentation]( const std::string &question ) {
+    presentation.set_function( "confirm", [require_presentation]( const std::string & question ) {
         require_presentation();
         require_presentation_text( question, "confirmation question" );
         return query_yn( question );
     } );
     presentation.set_function( "choose", [require_presentation](
-    sol::this_state state, const std::string &prompt, const sol::table &entries ) {
+    sol::this_state state, const std::string & prompt, const sol::table & entries ) {
         require_presentation();
         require_presentation_text( prompt, "choice prompt" );
         const std::vector<presentation_choice> choices =
@@ -18424,7 +19686,7 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
         return sol::make_object( lua_state, choices[menu.ret].id );
     } );
     presentation.set_function( "input_text", [require_presentation](
-    sol::this_state state, const std::string &prompt,
+                                   sol::this_state state, const std::string & prompt,
     const sol::optional<sol::table> &options ) {
         require_presentation();
         require_presentation_text( prompt, "input prompt", 4096 );
@@ -18459,7 +19721,7 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
     ccb["presentation"] = std::move( presentation );
 
     sol::table services = lua.create_table();
-    services.set_function( "message", [weak]( const std::string &message ) {
+    services.set_function( "message", [weak]( const std::string & message ) {
         const std::shared_ptr<runtime> owner = weak.lock();
         if( !owner || !owner->world_is_ready ) {
             throw std::runtime_error( "game services are only available after world_ready" );
@@ -18480,7 +19742,8 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
     // legacy EOC bridge, JSON registry, and v5 capability tables.
     const auto runtime_generation = [weak]() {
         const std::shared_ptr<runtime> owner = weak.lock();
-        return owner ? owner->generation : std::numeric_limits<std::size_t>::max();
+        return owner ? owner->handle_runtime() :
+               cata::lua_ui::game_handle_runtime();
     };
     const auto world_generation = []() {
         return active_world_generation;
@@ -18528,6 +19791,272 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
                                       require_read, require_write );
     cata::lua_ui::install_bionic_api( services, runtime_generation, world_generation,
                                       require_read, require_write );
+    sol::table bionics = services["bionics"];
+    bionics.set_function( "summary", [require_read, runtime_generation, world_generation](
+    sol::this_state state, const cata::lua_ui::game_handle & handle ) {
+        require_read();
+        sol::state_view lua_state( state );
+        const cata::lua_ui::native_handle_result<Creature> resolved =
+            handle.resolve_creature( runtime_generation(), world_generation() );
+        if( !resolved ) {
+            return cata::lua_ui::make_game_error_result( lua_state, *resolved.error );
+        }
+        Character *character = dynamic_cast<Character *>( resolved.value );
+        if( character == nullptr ) {
+            return cata::lua_ui::make_game_error_result( lua_state, {
+                "wrong_target", "services.bionics.summary requires a character handle"
+            } );
+        }
+        const auto energy_value = []( const units::energy & value ) {
+            return cata::lua_ui::script_unit_value::from_canonical_integer(
+                       "energy", "millijoule", value.value() );
+        };
+        sol::table value = lua_state.create_table();
+        value["installed_count"] = character->num_bionics();
+        value["power"] = energy_value( character->get_power_level() );
+        value["maximum_power"] = energy_value( character->get_max_power_level() );
+        value["has_capacity"] = character->has_max_power();
+        return cata::lua_ui::make_game_value_result(
+                   lua_state, sol::make_object( lua_state, std::move( value ) ) );
+    } );
+    bionics.set_function( "grant", [require_write, runtime_generation, world_generation](
+                              sol::this_state state, const cata::lua_ui::game_handle & handle,
+    const cata::lua_ui::script_game_id & id ) {
+        require_write();
+        if( id.kind() != "bionic" || !id.is_valid() ) {
+            throw std::invalid_argument(
+                "services.bionics.grant requires a valid GameId<bionic>" );
+        }
+        sol::state_view lua_state( state );
+        const cata::lua_ui::native_handle_result<Creature> resolved =
+            handle.resolve_creature( runtime_generation(), world_generation() );
+        if( !resolved ) {
+            return cata::lua_ui::make_game_error_result( lua_state, *resolved.error );
+        }
+        Character *character = dynamic_cast<Character *>( resolved.value );
+        if( character == nullptr ) {
+            return cata::lua_ui::make_game_error_result( lua_state, {
+                "wrong_target", "services.bionics.grant requires a character handle"
+            } );
+        }
+        const int before = character->num_bionics();
+        const bionic_uid uid = character->add_bionic( bionic_id( id.value() ) );
+        sol::table value = lua_state.create_table();
+        value["changed"] = character->num_bionics() != before;
+        value["uid"] = static_cast<std::uint64_t>( uid );
+        value["count"] = character->num_bionics();
+        return cata::lua_ui::make_game_value_result(
+                   lua_state, sol::make_object( lua_state, std::move( value ) ) );
+    } );
+    bionics.set_function( "remove_type", [require_write, runtime_generation, world_generation](
+                              sol::this_state state, const cata::lua_ui::game_handle & handle,
+    const cata::lua_ui::script_game_id & id ) {
+        require_write();
+        if( id.kind() != "bionic" || !id.is_valid() ) {
+            throw std::invalid_argument(
+                "services.bionics.remove_type requires a valid GameId<bionic>" );
+        }
+        sol::state_view lua_state( state );
+        const cata::lua_ui::native_handle_result<Creature> resolved =
+            handle.resolve_creature( runtime_generation(), world_generation() );
+        if( !resolved ) {
+            return cata::lua_ui::make_game_error_result( lua_state, *resolved.error );
+        }
+        Character *character = dynamic_cast<Character *>( resolved.value );
+        if( character == nullptr ) {
+            return cata::lua_ui::make_game_error_result( lua_state, {
+                "wrong_target", "services.bionics.remove_type requires a character handle"
+            } );
+        }
+        bool changed = false;
+        if( const std::optional<bionic *> installed =
+                character->find_bionic_by_type( bionic_id( id.value() ) ) ) {
+            character->remove_bionic( **installed );
+            changed = true;
+        }
+        sol::table value = lua_state.create_table();
+        value["changed"] = changed;
+        value["count"] = character->num_bionics();
+        return cata::lua_ui::make_game_value_result(
+                   lua_state, sol::make_object( lua_state, std::move( value ) ) );
+    } );
+    services["bionics"] = std::move( bionics );
+    const auto make_wound_snapshot = []( sol::state_view lua_state,
+    const bodypart & part ) {
+        sol::table snapshot = lua_state.create_table();
+        const std::vector<wound> &native_wounds = part.get_wounds();
+        for( std::size_t index = 0; index < native_wounds.size(); ++index ) {
+            const wound &entry = native_wounds[index];
+            double healing_fraction = static_cast<double>( entry.healing_percentage() );
+            if( !std::isfinite( healing_fraction ) ) {
+                healing_fraction = 0.0;
+            }
+            healing_fraction = std::clamp( healing_fraction, 0.0, 1.0 );
+            sol::table value = lua_state.create_table();
+            value["id"] = cata::lua_ui::script_game_id( "wound", entry.type.str() );
+            value["base_pain"] = entry.get_base_pain();
+            value["current_pain"] = entry.get_pain();
+            value["healing_time"] =
+                cata::lua_ui::script_time_duration::from_native( entry.get_healing_time() );
+            value["healing_progress"] =
+                cata::lua_ui::script_time_duration::from_native( entry.get_healing_progress() );
+            value["healing_fraction"] = healing_fraction;
+            snapshot[index + 1] = std::move( value );
+        }
+        return snapshot;
+    };
+    const auto same_wounds = []( const std::vector<wound> &lhs,
+    const std::vector<wound> &rhs ) {
+        if( lhs.size() != rhs.size() ) {
+            return false;
+        }
+        for( std::size_t index = 0; index < lhs.size(); ++index ) {
+            if( lhs[index].type != rhs[index].type ||
+                lhs[index].get_base_pain() != rhs[index].get_base_pain() ||
+                lhs[index].get_pain() != rhs[index].get_pain() ||
+                lhs[index].get_healing_time() != rhs[index].get_healing_time() ||
+                lhs[index].get_healing_progress() != rhs[index].get_healing_progress() ) {
+                return false;
+            }
+        }
+        return true;
+    };
+    sol::table wounds = lua.create_table();
+    wounds.set_function( "snapshot", [require_read, runtime_generation, world_generation,
+                                                    make_wound_snapshot]( sol::this_state state,
+                                              const cata::lua_ui::game_handle & handle,
+    const cata::lua_ui::script_game_id & body_part_id ) {
+        require_read();
+        if( body_part_id.kind() != "body_part" || !body_part_id.is_valid() ) {
+            throw std::invalid_argument(
+                "services.wounds.snapshot requires a valid GameId<body_part>" );
+        }
+        sol::state_view lua_state( state );
+        const cata::lua_ui::native_handle_result<Creature> resolved =
+            handle.resolve_creature( runtime_generation(), world_generation() );
+        if( !resolved ) {
+            return cata::lua_ui::make_game_error_result( lua_state, *resolved.error );
+        }
+        Character *character = dynamic_cast<Character *>( resolved.value );
+        if( character == nullptr ) {
+            return cata::lua_ui::make_game_error_result( lua_state, {
+                "wrong_target", "services.wounds.snapshot requires a character handle"
+            } );
+        }
+        const bodypart_id native_part_id = bodypart_str_id( body_part_id.value() ).id();
+        if( !character->has_part( native_part_id, body_part_filter::strict ) ) {
+            return cata::lua_ui::make_game_error_result( lua_state, {
+                "missing_part", "services.wounds.snapshot requires an exact character body part"
+            } );
+        }
+        const bodypart *part = character->get_part( native_part_id );
+        return cata::lua_ui::make_game_value_result(
+                   lua_state, sol::make_object( lua_state,
+                                                make_wound_snapshot( lua_state, *part ) ) );
+    } );
+    wounds.set_function( "add", [require_write, runtime_generation, world_generation,
+                                                make_wound_snapshot, same_wounds]( sol::this_state state,
+                                         const cata::lua_ui::game_handle & handle,
+                                         const cata::lua_ui::script_game_id & body_part_id,
+    const cata::lua_ui::script_game_id & wound_id ) {
+        require_write();
+        if( body_part_id.kind() != "body_part" || !body_part_id.is_valid() ) {
+            throw std::invalid_argument(
+                "services.wounds.add requires a valid GameId<body_part>" );
+        }
+        if( wound_id.kind() != "wound" || !wound_id.is_valid() ) {
+            throw std::invalid_argument(
+                "services.wounds.add requires a valid GameId<wound>" );
+        }
+        sol::state_view lua_state( state );
+        const cata::lua_ui::native_handle_result<Creature> resolved =
+            handle.resolve_creature( runtime_generation(), world_generation() );
+        if( !resolved ) {
+            return cata::lua_ui::make_game_error_result( lua_state, *resolved.error );
+        }
+        Character *character = dynamic_cast<Character *>( resolved.value );
+        if( character == nullptr ) {
+            return cata::lua_ui::make_game_error_result( lua_state, {
+                "wrong_target", "services.wounds.add requires a character handle"
+            } );
+        }
+        const bodypart_id native_part_id = bodypart_str_id( body_part_id.value() ).id();
+        if( !character->has_part( native_part_id, body_part_filter::strict ) ) {
+            return cata::lua_ui::make_game_error_result( lua_state, {
+                "missing_part", "services.wounds.add requires an exact character body part"
+            } );
+        }
+        bodypart *part = character->get_part( native_part_id );
+        const std::vector<wound> before_native = part->get_wounds();
+        sol::table before = make_wound_snapshot( lua_state, *part );
+        const wound_type_id native_wound_id( wound_id.value() );
+        const int limit = native_wound_id->get_limit();
+        const std::size_t existing_count = std::count_if(
+                                               before_native.begin(), before_native.end(),
+        [&native_wound_id]( const wound & existing ) {
+            return existing.type == native_wound_id;
+        } );
+        if( limit == 0 || existing_count < static_cast<std::size_t>( limit ) ) {
+            character->apply_wound( native_part_id, native_wound_id );
+        }
+        sol::table after = make_wound_snapshot( lua_state, *part );
+        sol::table value = lua_state.create_table();
+        value["changed"] = !same_wounds( before_native, part->get_wounds() );
+        value["before"] = std::move( before );
+        value["after"] = std::move( after );
+        return cata::lua_ui::make_game_value_result(
+                   lua_state, sol::make_object( lua_state, std::move( value ) ) );
+    } );
+    wounds.set_function( "remove", [require_write, runtime_generation, world_generation,
+                                                   make_wound_snapshot]( sol::this_state state,
+                                            const cata::lua_ui::game_handle & handle,
+                                            const cata::lua_ui::script_game_id & body_part_id,
+    const cata::lua_ui::script_game_id & wound_id ) {
+        require_write();
+        if( body_part_id.kind() != "body_part" || !body_part_id.is_valid() ) {
+            throw std::invalid_argument(
+                "services.wounds.remove requires a valid GameId<body_part>" );
+        }
+        if( wound_id.kind() != "wound" || !wound_id.is_valid() ) {
+            throw std::invalid_argument(
+                "services.wounds.remove requires a valid GameId<wound>" );
+        }
+        sol::state_view lua_state( state );
+        const cata::lua_ui::native_handle_result<Creature> resolved =
+            handle.resolve_creature( runtime_generation(), world_generation() );
+        if( !resolved ) {
+            return cata::lua_ui::make_game_error_result( lua_state, *resolved.error );
+        }
+        Character *character = dynamic_cast<Character *>( resolved.value );
+        if( character == nullptr ) {
+            return cata::lua_ui::make_game_error_result( lua_state, {
+                "wrong_target", "services.wounds.remove requires a character handle"
+            } );
+        }
+        const bodypart_id native_part_id = bodypart_str_id( body_part_id.value() ).id();
+        if( !character->has_part( native_part_id, body_part_filter::strict ) ) {
+            return cata::lua_ui::make_game_error_result( lua_state, {
+                "missing_part", "services.wounds.remove requires an exact character body part"
+            } );
+        }
+        bodypart *part = character->get_part( native_part_id );
+        sol::table before = make_wound_snapshot( lua_state, *part );
+        const std::size_t count_before = part->get_wounds().size();
+        part->remove_all_wounds_of_type( wound_type_id( wound_id.value() ) );
+        sol::table after = make_wound_snapshot( lua_state, *part );
+        sol::table value = lua_state.create_table();
+        const bool changed = part->get_wounds().size() != count_before;
+        if( changed ) {
+            character->on_stat_change(
+                "perceived_pain", character->get_perceived_pain() );
+        }
+        value["changed"] = changed;
+        value["before"] = std::move( before );
+        value["after"] = std::move( after );
+        return cata::lua_ui::make_game_value_result(
+                   lua_state, sol::make_object( lua_state, std::move( value ) ) );
+    } );
+    services["wounds"] = std::move( wounds );
     cata::lua_ui::install_mutation_api( services, runtime_generation, world_generation,
                                         require_read, require_write );
     cata::lua_ui::install_skill_api( services, runtime_generation, world_generation,
@@ -18540,8 +20069,342 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
                                          require_read, require_write );
     cata::lua_ui::install_need_api( services, runtime_generation, world_generation,
                                     require_read, require_write );
+    const auto make_activity_snapshot = []( sol::state_view lua_state,
+    const player_activity & current ) {
+        sol::table snapshot = lua_state.create_table();
+        const bool active = static_cast<bool>( current );
+        snapshot["active"] = active;
+        if( active ) {
+            snapshot["id"] = cata::lua_ui::script_game_id(
+                                 "activity", current.id().str() );
+        } else {
+            snapshot["id"] = sol::nil;
+        }
+        snapshot["verb"] = active ? current.get_verb().translated() : std::string();
+        snapshot["moves_total"] = current.moves_total;
+        snapshot["moves_left"] = current.moves_left;
+        snapshot["interruptible"] = current.is_interruptible();
+        snapshot["interruptible_with_keyboard"] = current.is_interruptible_with_kb();
+        snapshot["auto_resume"] = current.auto_resume;
+        snapshot["rooted"] = active && current.rooted();
+        snapshot["resumable"] = active && current.can_resume();
+        if( active && current.moves_total > 0 && current.moves_left >= 0 ) {
+            snapshot["progress"] = std::clamp(
+                                       static_cast<double>( current.moves_total - current.moves_left ) /
+                                       current.moves_total, 0.0, 1.0 );
+        } else {
+            snapshot["progress"] = 0.0;
+        }
+        return snapshot;
+    };
+    sol::table activities = lua.create_table();
+    activities.set_function( "snapshot", [require_read, runtime_generation, world_generation,
+                                                        make_activity_snapshot]( sol::this_state state,
+    const cata::lua_ui::game_handle & handle ) {
+        require_read();
+        sol::state_view lua_state( state );
+        const cata::lua_ui::native_handle_result<Creature> resolved =
+            handle.resolve_creature( runtime_generation(), world_generation() );
+        if( !resolved ) {
+            return cata::lua_ui::make_game_error_result( lua_state, *resolved.error );
+        }
+        Character *character = dynamic_cast<Character *>( resolved.value );
+        if( character == nullptr ) {
+            return cata::lua_ui::make_game_error_result( lua_state, {
+                "wrong_target", "services.activities.snapshot requires a character handle"
+            } );
+        }
+        return cata::lua_ui::make_game_value_result(
+                   lua_state, sol::make_object( lua_state,
+                                                make_activity_snapshot( lua_state, character->activity ) ) );
+    } );
+    activities.set_function( "assign_timed",
+                             [require_write, runtime_generation, world_generation, make_activity_snapshot](
+                                 sol::this_state state, const cata::lua_ui::game_handle & handle,
+                                 const cata::lua_ui::script_game_id & id,
+    const cata::lua_ui::script_time_duration & duration ) {
+        require_write();
+        if( id.kind() != "activity" || !id.is_valid() ) {
+            throw std::invalid_argument(
+                "services.activities.assign_timed requires a valid GameId<activity>" );
+        }
+        const std::int64_t turns = duration.turns();
+        constexpr std::int64_t maximum_turns =
+            std::numeric_limits<int>::max() / 100;
+        if( turns <= 0 || turns > maximum_turns ) {
+            throw std::invalid_argument(
+                "services.activities.assign_timed duration must resolve to 1.." +
+                std::to_string( maximum_turns ) + " turns" );
+        }
+        sol::state_view lua_state( state );
+        const cata::lua_ui::native_handle_result<Creature> resolved =
+            handle.resolve_creature( runtime_generation(), world_generation() );
+        if( !resolved ) {
+            return cata::lua_ui::make_game_error_result( lua_state, *resolved.error );
+        }
+        Character *character = dynamic_cast<Character *>( resolved.value );
+        if( character == nullptr ) {
+            return cata::lua_ui::make_game_error_result( lua_state, {
+                "wrong_target", "services.activities.assign_timed requires a character handle"
+            } );
+        }
+        const activity_id native_id( id.value() );
+        if( activity_actors::deserialize_functions.count( native_id ) != 0 ) {
+            return cata::lua_ui::make_game_error_result( lua_state, {
+                "specialized_activity",
+                "services.activities.assign_timed cannot construct an activity that requires a native actor"
+            } );
+        }
+        const activity_type &activity_definition = native_id.obj();
+        if( activity_handlers::do_turn_functions.count( native_id ) != 0 ||
+            activity_handlers::finish_functions.count( native_id ) != 0 ) {
+            return cata::lua_ui::make_game_error_result( lua_state, {
+                "specialized_activity",
+                "services.activities.assign_timed cannot construct an activity with native turn or completion handlers"
+            } );
+        }
+        if( !activity_definition.do_turn_EOC.is_null() ||
+            !activity_definition.completion_EOC.is_null() ) {
+            return cata::lua_ui::make_game_error_result( lua_state, {
+                "legacy_activity_policy",
+                "services.activities.assign_timed never enters an EOC-backed activity policy"
+            } );
+        }
+        if( activity_definition.based_on() != based_on_type::TIME ) {
+            return cata::lua_ui::make_game_error_result( lua_state, {
+                "not_timed_activity",
+                "services.activities.assign_timed requires a time-based activity"
+            } );
+        }
+        if( activity_definition.multi_activity() ) {
+            return cata::lua_ui::make_game_error_result( lua_state, {
+                "specialized_activity",
+                "services.activities.assign_timed cannot construct a multi-activity workflow"
+            } );
+        }
+        if( activity_definition.valid_auto_needs() ) {
+            return cata::lua_ui::make_game_error_result( lua_state, {
+                "specialized_activity",
+                "services.activities.assign_timed cannot construct an automatic-needs activity"
+            } );
+        }
+        const int moves = static_cast<int>( turns * 100 );
+        character->assign_activity( native_id, moves );
+        if( !character->activity || character->activity.id() != native_id ) {
+            return cata::lua_ui::make_game_error_result( lua_state, {
+                "assignment_rejected", "native character rules rejected the requested activity"
+            } );
+        }
+        sol::table value = lua_state.create_table();
+        value["changed"] = true;
+        value["activity"] = make_activity_snapshot( lua_state, character->activity );
+        return cata::lua_ui::make_game_value_result(
+                   lua_state, sol::make_object( lua_state, std::move( value ) ) );
+    } );
+    activities.set_function( "cancel", [require_write, runtime_generation, world_generation,
+                                                       make_activity_snapshot]( sol::this_state state,
+    const cata::lua_ui::game_handle & handle ) {
+        require_write();
+        sol::state_view lua_state( state );
+        const cata::lua_ui::native_handle_result<Creature> resolved =
+            handle.resolve_creature( runtime_generation(), world_generation() );
+        if( !resolved ) {
+            return cata::lua_ui::make_game_error_result( lua_state, *resolved.error );
+        }
+        Character *character = dynamic_cast<Character *>( resolved.value );
+        if( character == nullptr ) {
+            return cata::lua_ui::make_game_error_result( lua_state, {
+                "wrong_target", "services.activities.cancel requires a character handle"
+            } );
+        }
+        const bool changed = static_cast<bool>( character->activity );
+        if( changed ) {
+            character->cancel_activity();
+        }
+        sol::table value = lua_state.create_table();
+        value["changed"] = changed;
+        value["activity"] = make_activity_snapshot( lua_state, character->activity );
+        return cata::lua_ui::make_game_value_result(
+                   lua_state, sol::make_object( lua_state, std::move( value ) ) );
+    } );
+    services["activities"] = std::move( activities );
+    sol::table morale = lua.create_table();
+    morale.set_function( "add", [require_write, runtime_generation, world_generation](
+                             sol::this_state state, const cata::lua_ui::game_handle & handle,
+                             const cata::lua_ui::script_game_id & id, const std::int64_t bonus,
+    const std::int64_t max_bonus, const sol::optional<sol::table> &options ) {
+        require_write();
+        if( id.kind() != "morale" || !id.is_valid() ) {
+            throw std::invalid_argument(
+                "services.morale.add requires a valid GameId<morale>" );
+        }
+        if( bonus < std::numeric_limits<int>::min() ||
+            bonus > std::numeric_limits<int>::max() ||
+            max_bonus < std::numeric_limits<int>::min() ||
+            max_bonus > std::numeric_limits<int>::max() ) {
+            throw std::invalid_argument(
+                "services.morale.add bonus values exceed native integer bounds" );
+        }
+        time_duration duration = 1_hours;
+        time_duration decay_start = 30_minutes;
+        bool capped = false;
+        if( options ) {
+            for( const auto &entry : *options ) {
+                const sol::object key_object = entry.first;
+                if( key_object.get_type() != sol::type::string ) {
+                    throw std::invalid_argument(
+                        "services.morale.add option keys must be strings" );
+                }
+                const std::string key = key_object.as<std::string>();
+                const sol::object value = entry.second;
+                if( key == "duration" || key == "decay_start" ) {
+                    if( !value.is<cata::lua_ui::script_time_duration>() ) {
+                        throw std::invalid_argument(
+                            "services.morale.add time options must be TimeDuration values" );
+                    }
+                    const time_duration native =
+                        value.as<cata::lua_ui::script_time_duration>().to_native();
+                    if( native < 0_turns ) {
+                        throw std::invalid_argument(
+                            "services.morale.add time options cannot be negative" );
+                    }
+                    if( key == "duration" ) {
+                        duration = native;
+                    } else {
+                        decay_start = native;
+                    }
+                } else if( key == "capped" ) {
+                    if( !value.is<bool>() ) {
+                        throw std::invalid_argument(
+                            "services.morale.add capped must be a boolean" );
+                    }
+                    capped = value.as<bool>();
+                } else {
+                    throw std::invalid_argument(
+                        "services.morale.add received unknown option '" + key + "'" );
+                }
+            }
+        }
+        sol::state_view lua_state( state );
+        const cata::lua_ui::native_handle_result<Creature> resolved =
+            handle.resolve_creature( runtime_generation(), world_generation() );
+        if( !resolved ) {
+            return cata::lua_ui::make_game_error_result( lua_state, *resolved.error );
+        }
+        Character *character = dynamic_cast<Character *>( resolved.value );
+        if( character == nullptr ) {
+            return cata::lua_ui::make_game_error_result( lua_state, {
+                "wrong_target", "services.morale.add requires a character handle"
+            } );
+        }
+        const morale_type native_id( id.value() );
+        const int before = character->has_morale( native_id );
+        character->add_morale( native_id, static_cast<int>( bonus ),
+                               static_cast<int>( max_bonus ), duration, decay_start, capped );
+        const int after = character->has_morale( native_id );
+        sol::table result = lua_state.create_table();
+        result["changed"] = after != before;
+        result["before"] = before;
+        result["after"] = after;
+        return cata::lua_ui::make_game_value_result(
+                   lua_state, sol::make_object( lua_state, std::move( result ) ) );
+    } );
+    morale.set_function( "remove", [require_write, runtime_generation, world_generation](
+                             sol::this_state state, const cata::lua_ui::game_handle & handle,
+    const cata::lua_ui::script_game_id & id ) {
+        require_write();
+        if( id.kind() != "morale" || !id.is_valid() ) {
+            throw std::invalid_argument(
+                "services.morale.remove requires a valid GameId<morale>" );
+        }
+        sol::state_view lua_state( state );
+        const cata::lua_ui::native_handle_result<Creature> resolved =
+            handle.resolve_creature( runtime_generation(), world_generation() );
+        if( !resolved ) {
+            return cata::lua_ui::make_game_error_result( lua_state, *resolved.error );
+        }
+        Character *character = dynamic_cast<Character *>( resolved.value );
+        if( character == nullptr ) {
+            return cata::lua_ui::make_game_error_result( lua_state, {
+                "wrong_target", "services.morale.remove requires a character handle"
+            } );
+        }
+        const morale_type native_id( id.value() );
+        const int before = character->has_morale( native_id );
+        character->rem_morale( native_id );
+        const int after = character->has_morale( native_id );
+        sol::table result = lua_state.create_table();
+        result["changed"] = after != before;
+        result["before"] = before;
+        result["after"] = after;
+        return cata::lua_ui::make_game_value_result(
+                   lua_state, sol::make_object( lua_state, std::move( result ) ) );
+    } );
+    services["morale"] = std::move( morale );
     cata::lua_ui::install_martial_art_api( services, runtime_generation, world_generation,
                                            require_read, require_write );
+    sol::table martial_arts = services["martial_arts"];
+    martial_arts.set_function( "learn", [require_write, runtime_generation, world_generation](
+                                   sol::this_state state, const cata::lua_ui::game_handle & handle,
+    const cata::lua_ui::script_game_id & id ) {
+        require_write();
+        if( id.kind() != "martial_art" || !id.is_valid() ) {
+            throw std::invalid_argument(
+                "services.martial_arts.learn requires a valid GameId<martial_art>" );
+        }
+        sol::state_view lua_state( state );
+        const cata::lua_ui::native_handle_result<Creature> resolved =
+            handle.resolve_creature( runtime_generation(), world_generation() );
+        if( !resolved ) {
+            return cata::lua_ui::make_game_error_result( lua_state, *resolved.error );
+        }
+        Character *character = dynamic_cast<Character *>( resolved.value );
+        if( character == nullptr ) {
+            return cata::lua_ui::make_game_error_result( lua_state, {
+                "wrong_target", "services.martial_arts.learn requires a character handle"
+            } );
+        }
+        const matype_id native_id( id.value() );
+        const bool before = character->has_martialart( native_id );
+        character->martial_arts_data->add_martialart( native_id );
+        const bool known = character->has_martialart( native_id );
+        sol::table value = lua_state.create_table();
+        value["changed"] = known != before;
+        value["known"] = known;
+        return cata::lua_ui::make_game_value_result(
+                   lua_state, sol::make_object( lua_state, std::move( value ) ) );
+    } );
+    martial_arts.set_function( "forget", [require_write, runtime_generation, world_generation](
+                                   sol::this_state state, const cata::lua_ui::game_handle & handle,
+    const cata::lua_ui::script_game_id & id ) {
+        require_write();
+        if( id.kind() != "martial_art" || !id.is_valid() ) {
+            throw std::invalid_argument(
+                "services.martial_arts.forget requires a valid GameId<martial_art>" );
+        }
+        sol::state_view lua_state( state );
+        const cata::lua_ui::native_handle_result<Creature> resolved =
+            handle.resolve_creature( runtime_generation(), world_generation() );
+        if( !resolved ) {
+            return cata::lua_ui::make_game_error_result( lua_state, *resolved.error );
+        }
+        Character *character = dynamic_cast<Character *>( resolved.value );
+        if( character == nullptr ) {
+            return cata::lua_ui::make_game_error_result( lua_state, {
+                "wrong_target", "services.martial_arts.forget requires a character handle"
+            } );
+        }
+        const matype_id native_id( id.value() );
+        const bool before = character->has_martialart( native_id );
+        character->martial_arts_data->clear_style( native_id );
+        const bool known = character->has_martialart( native_id );
+        sol::table value = lua_state.create_table();
+        value["changed"] = known != before;
+        value["known"] = known;
+        return cata::lua_ui::make_game_value_result(
+                   lua_state, sol::make_object( lua_state, std::move( value ) ) );
+    } );
+    services["martial_arts"] = std::move( martial_arts );
     cata::lua_ui::install_vehicle_api( services, runtime_generation, world_generation,
                                        require_read, require_write );
     cata::lua_ui::install_npc_api( services, runtime_generation, world_generation,
@@ -18556,20 +20419,450 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
                                      require_read, require_write );
     cata::lua_ui::install_item_api( services, runtime_generation, world_generation,
                                     require_read, require_write );
+    sol::table inventory = services["inventory"];
+    inventory.set_function( "wielded", [require_read, runtime_generation,
+                                                      world_generation]( sol::this_state state,
+    const cata::lua_ui::game_handle & handle ) {
+        require_read();
+        sol::state_view lua_state( state );
+        const cata::lua_ui::native_handle_result<Creature> resolved =
+            handle.resolve_creature( runtime_generation(), world_generation() );
+        if( !resolved ) {
+            return cata::lua_ui::make_game_error_result( lua_state, *resolved.error );
+        }
+        Character *character = dynamic_cast<Character *>( resolved.value );
+        if( character == nullptr ) {
+            return cata::lua_ui::make_game_error_result( lua_state, {
+                "wrong_target", "services.inventory.wielded requires a character handle"
+            } );
+        }
+        item_location wielded = character->get_wielded_item();
+        if( !wielded ) {
+            return cata::lua_ui::make_game_value_result(
+                       lua_state, sol::make_object( lua_state, sol::lua_nil ) );
+        }
+        const tripoint_abs_ms position = character->pos_abs();
+        cata::lua_ui::game_handle_locator locator;
+        locator.scope = "character_wielded";
+        locator.stable_id = wielded->uid().get_value();
+        locator.x = position.x();
+        locator.y = position.y();
+        locator.z = position.z();
+        return cata::lua_ui::make_game_value_result(
+                   lua_state, sol::make_object(
+                       lua_state, cata::lua_ui::game_handle::from_item(
+                           *wielded, std::move( locator ), runtime_generation(),
+                           world_generation() ) ) );
+    } );
+    services["inventory"] = std::move( inventory );
     cata::lua_ui::install_zone_api( lua, services, runtime_generation, world_generation,
                                     require_read, require_write );
     cata::lua_ui::install_achievement_api( services, require_read, require_write );
+    sol::table achievements = services["achievements"];
+    achievements.set_function( "complete", [require_write](
+    sol::this_state state, const cata::lua_ui::script_game_id & id ) {
+        require_write();
+        if( id.kind() != "achievement" || !id.is_valid() ) {
+            throw std::invalid_argument(
+                "services.achievements.complete requires a valid GameId<achievement>" );
+        }
+        const achievement_id native_id( id.value() );
+        achievements_tracker &tracker = get_achievements();
+        const std::vector<const achievement *> valid = tracker.valid_achievements();
+        const auto found = std::find_if( valid.begin(), valid.end(), [&native_id](
+        const achievement * entry ) {
+            return entry != nullptr && entry->id == native_id;
+        } );
+        bool changed = false;
+        if( found != valid.end() &&
+            tracker.is_completed( native_id ) == achievement_completion::pending ) {
+            tracker.report_achievement( *found, achievement_completion::completed );
+            changed = true;
+        }
+        sol::state_view lua_state( state );
+        return cata::lua_ui::make_game_value_result(
+                   lua_state, sol::make_object( lua_state, changed ) );
+    } );
+    services["achievements"] = std::move( achievements );
     cata::lua_ui::install_statistics_api( services, require_read );
     cata::lua_ui::install_faction_api( services, require_read, require_write );
     cata::lua_ui::install_camp_api( services, require_read, require_write );
     cata::lua_ui::install_weather_api( services, require_read, require_write );
     cata::lua_ui::install_crafting_api( services, require_read, require_write,
                                         has_callback, source_id );
+    sol::table recipes = services["recipes"];
+    recipes.set_function( "knows", [require_read, runtime_generation, world_generation](
+                              sol::this_state state, const cata::lua_ui::game_handle & handle,
+    const cata::lua_ui::script_game_id & id ) {
+        require_read();
+        if( id.kind() != "recipe" || !id.is_valid() ) {
+            throw std::invalid_argument(
+                "services.recipes.knows requires a valid GameId<recipe>" );
+        }
+        sol::state_view lua_state( state );
+        const cata::lua_ui::native_handle_result<Creature> resolved =
+            handle.resolve_creature( runtime_generation(), world_generation() );
+        if( !resolved ) {
+            return cata::lua_ui::make_game_error_result( lua_state, *resolved.error );
+        }
+        Character *character = dynamic_cast<Character *>( resolved.value );
+        if( character == nullptr ) {
+            return cata::lua_ui::make_game_error_result( lua_state, {
+                "wrong_target", "services.recipes.knows requires a character handle"
+            } );
+        }
+        const bool known = character->knows_recipe( &recipe_id( id.value() ).obj() );
+        return cata::lua_ui::make_game_value_result(
+                   lua_state, sol::make_object( lua_state, known ) );
+    } );
+    recipes.set_function( "learn", [require_write, runtime_generation, world_generation](
+                              sol::this_state state, const cata::lua_ui::game_handle & handle,
+    const cata::lua_ui::script_game_id & id ) {
+        require_write();
+        if( id.kind() != "recipe" || !id.is_valid() ) {
+            throw std::invalid_argument(
+                "services.recipes.learn requires a valid GameId<recipe>" );
+        }
+        sol::state_view lua_state( state );
+        const cata::lua_ui::native_handle_result<Creature> resolved =
+            handle.resolve_creature( runtime_generation(), world_generation() );
+        if( !resolved ) {
+            return cata::lua_ui::make_game_error_result( lua_state, *resolved.error );
+        }
+        Character *character = dynamic_cast<Character *>( resolved.value );
+        if( character == nullptr ) {
+            return cata::lua_ui::make_game_error_result( lua_state, {
+                "wrong_target", "services.recipes.learn requires a character handle"
+            } );
+        }
+        const recipe *target = &recipe_id( id.value() ).obj();
+        const bool before = character->knows_recipe( target );
+        character->learn_recipe( target );
+        const bool known = character->knows_recipe( target );
+        sol::table value = lua_state.create_table();
+        value["changed"] = known != before;
+        value["known"] = known;
+        return cata::lua_ui::make_game_value_result(
+                   lua_state, sol::make_object( lua_state, std::move( value ) ) );
+    } );
+    recipes.set_function( "forget", [require_write, runtime_generation, world_generation](
+                              sol::this_state state, const cata::lua_ui::game_handle & handle,
+    const cata::lua_ui::script_game_id & id ) {
+        require_write();
+        if( id.kind() != "recipe" || !id.is_valid() ) {
+            throw std::invalid_argument(
+                "services.recipes.forget requires a valid GameId<recipe>" );
+        }
+        sol::state_view lua_state( state );
+        const cata::lua_ui::native_handle_result<Creature> resolved =
+            handle.resolve_creature( runtime_generation(), world_generation() );
+        if( !resolved ) {
+            return cata::lua_ui::make_game_error_result( lua_state, *resolved.error );
+        }
+        Character *character = dynamic_cast<Character *>( resolved.value );
+        if( character == nullptr ) {
+            return cata::lua_ui::make_game_error_result( lua_state, {
+                "wrong_target", "services.recipes.forget requires a character handle"
+            } );
+        }
+        const recipe *target = &recipe_id( id.value() ).obj();
+        const bool before = character->knows_recipe( target );
+        character->forget_recipe( target );
+        const bool known = character->knows_recipe( target );
+        sol::table value = lua_state.create_table();
+        value["changed"] = known != before;
+        value["known"] = known;
+        return cata::lua_ui::make_game_value_result(
+                   lua_state, sol::make_object( lua_state, std::move( value ) ) );
+    } );
+    recipes.set_function( "forget_category", [require_write, runtime_generation,
+                                         world_generation]( sol::this_state state,
+                                  const cata::lua_ui::game_handle & handle,
+                                  const cata::lua_ui::script_game_id & category,
+    const sol::optional<std::string> &subcategory ) {
+        require_write();
+        if( category.kind() != "crafting_category" || !category.is_valid() ) {
+            throw std::invalid_argument(
+                "services.recipes.forget_category requires a valid "
+                "GameId<crafting_category>" );
+        }
+        const std::string native_subcategory = subcategory.value_or( std::string() );
+        if( native_subcategory.size() > 256 ||
+            native_subcategory.find( '\0' ) != std::string::npos ) {
+            throw std::invalid_argument(
+                "services.recipes.forget_category subcategory exceeds its native limit" );
+        }
+        sol::state_view lua_state( state );
+        const cata::lua_ui::native_handle_result<Creature> resolved =
+            handle.resolve_creature( runtime_generation(), world_generation() );
+        if( !resolved ) {
+            return cata::lua_ui::make_game_error_result( lua_state, *resolved.error );
+        }
+        Character *character = dynamic_cast<Character *>( resolved.value );
+        if( character == nullptr ) {
+            return cata::lua_ui::make_game_error_result( lua_state, {
+                "wrong_target",
+                "services.recipes.forget_category requires a character handle"
+            } );
+        }
+        const recipe_subset &known_recipes = character->get_learned_recipes();
+        const std::size_t known_before = known_recipes.size();
+        const std::vector<const recipe *> recipes_to_forget =
+            recipes_from_cat( known_recipes, crafting_category_id( category.value() ),
+                              native_subcategory ).first;
+        for( const recipe *entry : recipes_to_forget ) {
+            character->forget_recipe( entry );
+        }
+        const std::size_t known_after = character->get_learned_recipes().size();
+        const std::size_t forgotten_count = known_before > known_after ?
+                                            known_before - known_after : 0;
+        sol::table value = lua_state.create_table();
+        value["changed"] = forgotten_count > 0;
+        value["forgotten_count"] = forgotten_count;
+        value["known_before"] = known_before;
+        value["known_after"] = known_after;
+        value["category"] = cata::lua_ui::script_game_id(
+                                "crafting_category", category.value() );
+        if( subcategory ) {
+            value["subcategory"] = *subcategory;
+        } else {
+            value["subcategory"] = sol::nil;
+        }
+        return cata::lua_ui::make_game_value_result(
+                   lua_state, sol::make_object( lua_state, std::move( value ) ) );
+    } );
+    services["recipes"] = std::move( recipes );
     cata::lua_ui::install_overmap_api( services, require_read, require_write,
                                        random_index );
     cata::lua_ui::install_game_snapshot_api( services, require_read );
     cata::lua_ui::install_game_info_api( services, require_read, require_write,
                                          has_callback );
+
+    // Platform owns an isolated gameplay random stream.  The shared v5
+    // implementation above intentionally uses the engine stream, so replace
+    // only the Platform table with callbacks backed by runtime::random_engine.
+    // This keeps ordinary Lua composition deterministic across runtime-only
+    // hot reloads without changing the v5 contract.
+    sol::table random = services["random"];
+    const auto require_random_runtime = [weak]() {
+        const std::shared_ptr<runtime> owner = weak.lock();
+        if( !owner || !owner->world_is_ready || owner->callback_depth <= 0 ) {
+            throw std::runtime_error(
+                "Platform gameplay randomness is only available inside a runtime callback" );
+        }
+        return owner;
+    };
+    const auto random_integer = [require_random_runtime]( const std::int64_t minimum,
+    const std::int64_t maximum ) {
+        if( minimum < -1000000000LL || maximum > 1000000000LL || minimum > maximum ) {
+            throw std::invalid_argument(
+                "services.random.int requires an ordered range within -1000000000..1000000000" );
+        }
+        const std::shared_ptr<runtime> owner = require_random_runtime();
+        std::uniform_int_distribution<std::int64_t> distribution( minimum, maximum );
+        return distribution( owner->random_engine );
+    };
+    random.set_function( "int", random_integer );
+    random.set_function( "chance", [require_random_runtime]( const std::int64_t numerator,
+    const std::int64_t denominator ) {
+        const std::shared_ptr<runtime> owner = require_random_runtime();
+        if( denominator <= 0 || denominator > 1000000000LL || numerator < 0 ||
+            numerator > denominator ) {
+            throw std::invalid_argument(
+                "services.random.chance requires 0 <= numerator <= denominator <= 1000000000" );
+        }
+        if( numerator == 0 ) {
+            return false;
+        }
+        if( numerator == denominator ) {
+            return true;
+        }
+        std::uniform_int_distribution<std::int64_t> distribution( 1, denominator );
+        return distribution( owner->random_engine ) <= numerator;
+    } );
+    random.set_function( "one_in", [require_random_runtime]( const double raw_denominator ) {
+        const std::shared_ptr<runtime> owner = require_random_runtime();
+        if( !std::isfinite( raw_denominator ) || raw_denominator < -1000000000.0 ||
+            raw_denominator > 1000000000.0 ) {
+            throw std::invalid_argument(
+                "services.random.one_in requires a finite denominator within native bounds" );
+        }
+        const std::int64_t denominator = static_cast<std::int64_t>( raw_denominator );
+        if( denominator <= 1 ) {
+            return true;
+        }
+        std::uniform_int_distribution<std::int64_t> distribution( 0, denominator - 1 );
+        return distribution( owner->random_engine ) == 0;
+    } );
+    random.set_function( "probability", [require_random_runtime]( const double numerator,
+    const double denominator ) {
+        const std::shared_ptr<runtime> owner = require_random_runtime();
+        if( !std::isfinite( numerator ) || !std::isfinite( denominator ) ||
+            denominator <= 0.0 || numerator < 0.0 || numerator > denominator ) {
+            throw std::invalid_argument(
+                "services.random.probability requires finite 0 <= numerator <= denominator" );
+        }
+        if( numerator == 0.0 ) {
+            return false;
+        }
+        if( numerator == denominator ) {
+            return true;
+        }
+        std::uniform_real_distribution<double> distribution( 0.0, 1.0 );
+        return distribution( owner->random_engine ) <= numerator / denominator;
+    } );
+    random.set_function( "sample_integers", [require_random_runtime](
+                             sol::this_state state, const std::int64_t minimum, const std::int64_t maximum,
+    const std::int64_t requested_count, const sol::optional<bool> &with_replacement ) {
+        if( minimum < -1000000000LL || maximum > 1000000000LL || minimum > maximum ||
+            requested_count < 0 || requested_count > 1024 ) {
+            throw std::invalid_argument(
+                "services.random.sample_integers requires an ordered bounded range and 0..1024 samples" );
+        }
+        const bool replace = with_replacement.value_or( false );
+        const std::uint64_t population = static_cast<std::uint64_t>( maximum - minimum ) + 1;
+        if( !replace && static_cast<std::uint64_t>( requested_count ) > population ) {
+            throw std::invalid_argument(
+                "services.random.sample_integers cannot exceed the range without replacement" );
+        }
+        const std::shared_ptr<runtime> owner = require_random_runtime();
+        std::uniform_int_distribution<std::int64_t> distribution( minimum, maximum );
+        sol::state_view lua_state( state );
+        sol::table result = lua_state.create_table( requested_count, 0 );
+        std::unordered_set<std::int64_t> selected;
+        for( std::int64_t index = 1; index <= requested_count; ++index ) {
+            std::int64_t value = distribution( owner->random_engine );
+            if( !replace ) {
+                while( !selected.insert( value ).second ) {
+                    value = distribution( owner->random_engine );
+                }
+            }
+            result[index] = value;
+        }
+        return result;
+    } );
+    random.set_function( "contested", [random_integer]( const double check,
+    const double difficulty, const sol::optional<std::int64_t> &optional_die_size ) {
+        const std::int64_t die_size = optional_die_size.value_or( 10 );
+        if( !std::isfinite( check ) || !std::isfinite( difficulty ) ||
+            die_size <= 0 || die_size > 1000000000LL ) {
+            throw std::invalid_argument(
+                "services.random.contested requires finite values and a die size within 1..1000000000" );
+        }
+        return static_cast<double>( random_integer( 1, die_size ) ) + check > difficulty;
+    } );
+    services["random"] = std::move( random );
+
+    sol::table gameplay = lua.create_table();
+    sol::table strings = lua.create_table();
+    strings.set_function( "any_equal", []( const sol::table & values ) {
+        const std::size_t count = require_dense_array(
+                                      values, "services.gameplay.strings.any_equal values", 2, 1024 );
+        std::unordered_set<std::string> seen;
+        for( std::size_t index = 1; index <= count; ++index ) {
+            const sol::object value = values[index];
+            if( !value.is<std::string>() ) {
+                throw std::invalid_argument(
+                    "services.gameplay.strings.any_equal accepts only strings" );
+            }
+            if( !seen.insert( value.as<std::string>() ).second ) {
+                return true;
+            }
+        }
+        return false;
+    } );
+    strings.set_function( "all_equal", []( const sol::table & values ) {
+        const std::size_t count = require_dense_array(
+                                      values, "services.gameplay.strings.all_equal values", 1, 1024 );
+        const sol::object first = values[1];
+        if( !first.is<std::string>() ) {
+            throw std::invalid_argument(
+                "services.gameplay.strings.all_equal accepts only strings" );
+        }
+        const std::string expected = first.as<std::string>();
+        for( std::size_t index = 2; index <= count; ++index ) {
+            const sol::object value = values[index];
+            if( !value.is<std::string>() ) {
+                throw std::invalid_argument(
+                    "services.gameplay.strings.all_equal accepts only strings" );
+            }
+            if( value.as<std::string>() != expected ) {
+                return false;
+            }
+        }
+        return true;
+    } );
+    gameplay["strings"] = std::move( strings );
+
+    sol::table mods = lua.create_table();
+    mods.set_function( "is_loaded", [require_read]( const std::string & id ) {
+        require_read();
+        if( id.empty() || id.size() > 256 || id.find( '\0' ) != std::string::npos ) {
+            throw std::invalid_argument(
+                "services.gameplay.mods.is_loaded requires a bounded non-empty Mod id" );
+        }
+        if( find_active_runtime( id ) ) {
+            return true;
+        }
+        if( !world_generator || world_generator->active_world == nullptr ) {
+            return false;
+        }
+        const mod_id requested( id );
+        const std::vector<mod_id> &order = world_generator->active_world->active_mod_order;
+        return std::find( order.begin(), order.end(), requested ) != order.end();
+    } );
+    gameplay["mods"] = std::move( mods );
+
+    sol::table environment = lua.create_table();
+    environment.set_function( "dimension", [require_read]() {
+        require_read();
+        if( g == nullptr ) {
+            throw std::runtime_error(
+                "services.gameplay.environment.dimension requires an active game" );
+        }
+        return g->get_dimension_prefix().str();
+    } );
+    const auto require_environment_position = []( const cata::lua_ui::script_tripoint_coord &
+    position, const std::string & api_name ) {
+        if( position.native_origin() != coords::origin::abs ||
+            position.native_scale() != coords::scale::map_square ) {
+            throw std::invalid_argument(
+                api_name + " requires an absolute map-square Tripoint" );
+        }
+        map &here = get_map();
+        const tripoint_abs_ms absolute( position.to_native() );
+        if( !here.inbounds( absolute ) ) {
+            throw std::invalid_argument( api_name + " position is outside the active map" );
+        }
+        return here.get_bub( absolute );
+    };
+    environment.set_function( "is_outside", [require_read, require_environment_position](
+    const cata::lua_ui::script_tripoint_coord & position ) {
+        require_read();
+        map &here = get_map();
+        return here.is_outside( require_environment_position(
+                                    position, "services.gameplay.environment.is_outside" ) );
+    } );
+    environment.set_function( "line_of_sight", [require_read, require_environment_position](
+                                  const cata::lua_ui::script_tripoint_coord & from,
+                                  const cata::lua_ui::script_tripoint_coord & to, const std::int64_t range,
+    const sol::optional<bool> &with_fields ) {
+        require_read();
+        if( range < 0 || range > 100000 ) {
+            throw std::invalid_argument(
+                "services.gameplay.environment.line_of_sight range must be within 0..100000" );
+        }
+        map &here = get_map();
+        const tripoint_bub_ms first = require_environment_position(
+                                          from, "services.gameplay.environment.line_of_sight" );
+        const tripoint_bub_ms second = require_environment_position(
+                                           to, "services.gameplay.environment.line_of_sight" );
+        return here.sees( first, second, static_cast<int>( range ),
+                          with_fields.value_or( true ) );
+    } );
+    gameplay["environment"] = std::move( environment );
+    services["gameplay"] = std::move( gameplay );
+
     cata::lua_ui::install_game_interaction_api( services, require_write, has_callback );
     cata::lua_ui::install_game_world_service_api(
         services, runtime_generation, world_generation, require_read, require_write,
@@ -18783,6 +21076,8 @@ cata::lua_ui::native_hook_result dispatch_runtime_hook(
     const cata::lua_ui::native_hook_result &initial )
 {
     cata::lua_ui::native_hook_result aggregate = initial;
+    const cata::lua_ui::native_callback_arguments platform_arguments =
+        platform_callback_arguments( name, arguments );
     if( cata::lua_ui::native_hook_supports_result_field( name, "allow" ) &&
         !aggregate.allowed ) {
         return aggregate;
@@ -18807,7 +21102,7 @@ cata::lua_ui::native_hook_result dispatch_runtime_hook(
                                             << owner->mod_id << ':' << name << "'";
                 continue;
             }
-            sol::table payload = platform_callback_payload( *owner, arguments );
+            sol::table payload = platform_callback_payload( *owner, platform_arguments );
             payload["hook"] = std::string( name );
             payload["cancellable"] =
                 cata::lua_ui::native_hook_supports_result_field( name, "allow" );
@@ -18922,12 +21217,12 @@ std::optional<int> invoke_use_handler( std::string_view mod_id,
     context->character = character;
     context->used_item = &used_item;
     context->position = position;
-    context->runtime_generation = owner->generation;
+    context->handle_runtime = owner->handle_runtime();
     context->world_generation = active_world_generation;
+    use_context_lease context_lease( *context );
     sol::protected_function callback = handler->second.callback;
     callback_scope scope( *owner );
     const sol::protected_function_result result = callback( context );
-    context->active = false;
     if( !result.valid() ) {
         report_callback_error( *owner, handler_id, result );
         return std::nullopt;
@@ -19459,7 +21754,7 @@ bool invoke_activity_type_handler(
 
         try {
             const sol::table returned = result.get<sol::table>();
-            const auto integer_field = [&returned]( const std::string &field,
+            const auto integer_field = [&returned]( const std::string & field,
             const int fallback ) {
                 const sol::optional<sol::object> candidate =
                     returned.get<sol::optional<sol::object>>( field );
@@ -19890,9 +22185,9 @@ void runtime_process_tasks()
             const auto handler = owner->handlers.find( task.handler_id );
             if( handler == owner->handlers.end() ) {
                 if( owner->reported_task_migration_failures.insert( task.id ).second ) {
-                    DebugLog( D_ERROR, D_MAIN ) << "Keeping Lua-first task " << task.id
-                                                << " for missing handler '" << owner->mod_id
-                                                << ':' << task.handler_id << "'";
+                    DebugLog( D_WARNING, D_MAIN ) << "Keeping Lua-first task " << task.id
+                                                  << " for missing handler '" << owner->mod_id
+                                                  << ':' << task.handler_id << "'";
                 }
                 continue;
             }
@@ -19903,10 +22198,10 @@ void runtime_process_tasks()
             std::string migration_error;
             if( !migrate_task_payload( *owner, task, migration_error ) ) {
                 if( owner->reported_task_migration_failures.insert( task.id ).second ) {
-                    DebugLog( D_ERROR, D_MAIN ) << "Keeping Lua-first task " << task.id
-                                                << " with unmigrated payload for '"
-                                                << owner->mod_id << ':' << task.handler_id
-                                                << "': " << migration_error;
+                    DebugLog( D_WARNING, D_MAIN ) << "Keeping Lua-first task " << task.id
+                                                  << " with unmigrated payload for '"
+                                                  << owner->mod_id << ':' << task.handler_id
+                                                  << "': " << migration_error;
                 }
             } else {
                 owner->reported_task_migration_failures.erase( task.id );
@@ -19926,8 +22221,8 @@ void runtime_process_tasks()
         for( const persistent_task &task : due ) {
             owner->reported_task_migration_failures.erase( task.id );
         }
-        std::sort( due.begin(), due.end(), []( const persistent_task &lhs,
-        const persistent_task &rhs ) {
+        std::sort( due.begin(), due.end(), []( const persistent_task & lhs,
+        const persistent_task & rhs ) {
             return std::tie( lhs.due_turn, lhs.id ) < std::tie( rhs.due_turn, rhs.id );
         } );
         for( const persistent_task &task : due ) {
@@ -20002,8 +22297,14 @@ void content_transaction::rollback() {}
 void content_transaction::commit() {}
 void content_transaction::seal() {}
 void content_transaction::discard() {}
-std::string content_transaction::fingerprint() const { return {}; }
-bool content_transaction::was_applied() const { return false; }
+std::string content_transaction::fingerprint() const
+{
+    return {};
+}
+bool content_transaction::was_applied() const
+{
+    return false;
+}
 bool content_transaction::find_damage_handler( std::string_view, std::string_view,
         std::string &handler_id ) const
 {

--- a/src/catalua_platform_runtime.h
+++ b/src/catalua_platform_runtime.h
@@ -10,6 +10,8 @@
 #include <string_view>
 #include <vector>
 
+#include "coords_fwd.h"
+
 class Character;
 class Creature;
 class item;
@@ -17,12 +19,11 @@ class map;
 class player_activity;
 class recipe;
 struct itype;
-struct tripoint_bub_ms;
 struct w_point;
 
 #if defined(CATA_ENABLE_LUA_UI) && CATA_ENABLE_LUA_UI
-#include "catalua_sol.h"
-#include "catalua_ui.h"
+    #include "catalua_sol.h"
+    #include "catalua_ui.h"
 #endif
 
 namespace cata::lua_platform
@@ -117,8 +118,8 @@ class content_transaction
 #if defined(CATA_ENABLE_LUA_UI) && CATA_ENABLE_LUA_UI
 
 std::shared_ptr<runtime> make_runtime( const std::string &mod_id,
-                                      std::size_t generation,
-                                      sol::state &lua );
+                                       std::size_t generation,
+                                       sol::state &lua );
 void install_runtime_api( const std::shared_ptr<runtime> &value,
                           sol::state &lua, sol::table &ccb );
 

--- a/src/catalua_ui.cpp
+++ b/src/catalua_ui.cpp
@@ -458,6 +458,8 @@ class runtime_state : public event_subscriber
         int mapgen_dispatch_depth = 0;
         std::size_t generation = 0;
         std::size_t world_generation = 0;
+        game_handle_runtime_owner_ptr game_handle_owner =
+            make_game_handle_runtime_owner();
         bool accept_actions = false;
         std::optional<std::size_t> current_source;
         std::optional<std::string> current_page;
@@ -467,6 +469,11 @@ class runtime_state : public event_subscriber
         std::uint64_t slow_callback_count = 0;
         std::string last_slow_callback;
 };
+
+game_handle_runtime current_game_handle_runtime( const runtime_state &state )
+{
+    return game_handle_runtime( state.game_handle_owner, state.generation );
+}
 
 struct runtime_diagnostic_record {
     std::uint64_t sequence = 0;
@@ -4253,11 +4260,12 @@ void initialize_state( runtime_state &state )
         return mapgen_limits( state, lua );
     } );
     game["mapgen"] = std::move( mapgen );
+    const auto current_handle_runtime = [&state]() {
+        return current_game_handle_runtime( state );
+    };
     install_game_handle_api(
         state.lua, game,
-    [&state]() {
-        return state.generation;
-    },
+        current_handle_runtime,
     [&state]() {
         return state.world_generation;
     },
@@ -4267,9 +4275,7 @@ void initialize_state( runtime_state &state )
     } );
     install_creature_api(
         game,
-    [&state]() {
-        return state.generation;
-    },
+        current_handle_runtime,
     [&state]() {
         return state.world_generation;
     },
@@ -4283,9 +4289,7 @@ void initialize_state( runtime_state &state )
     } );
     install_effect_api(
         game,
-    [&state]() {
-        return state.generation;
-    },
+        current_handle_runtime,
     [&state]() {
         return state.world_generation;
     },
@@ -4299,9 +4303,7 @@ void initialize_state( runtime_state &state )
     } );
     install_eoc_api(
         game,
-    [&state]() {
-        return state.generation;
-    },
+        current_handle_runtime,
     [&state]() {
         return state.world_generation;
     },
@@ -4319,9 +4321,7 @@ void initialize_state( runtime_state &state )
     } );
     install_bionic_api(
         game,
-    [&state]() {
-        return state.generation;
-    },
+        current_handle_runtime,
     [&state]() {
         return state.world_generation;
     },
@@ -4335,9 +4335,7 @@ void initialize_state( runtime_state &state )
     } );
     install_mutation_api(
         game,
-    [&state]() {
-        return state.generation;
-    },
+        current_handle_runtime,
     [&state]() {
         return state.world_generation;
     },
@@ -4351,9 +4349,7 @@ void initialize_state( runtime_state &state )
     } );
     install_skill_api(
         game,
-    [&state]() {
-        return state.generation;
-    },
+        current_handle_runtime,
     [&state]() {
         return state.world_generation;
     },
@@ -4367,9 +4363,7 @@ void initialize_state( runtime_state &state )
     } );
     install_proficiency_api(
         game,
-    [&state]() {
-        return state.generation;
-    },
+        current_handle_runtime,
     [&state]() {
         return state.world_generation;
     },
@@ -4383,9 +4377,7 @@ void initialize_state( runtime_state &state )
     } );
     install_vitamin_api(
         game,
-    [&state]() {
-        return state.generation;
-    },
+        current_handle_runtime,
     [&state]() {
         return state.world_generation;
     },
@@ -4399,9 +4391,7 @@ void initialize_state( runtime_state &state )
     } );
     install_addiction_api(
         game,
-    [&state]() {
-        return state.generation;
-    },
+        current_handle_runtime,
     [&state]() {
         return state.world_generation;
     },
@@ -4440,9 +4430,7 @@ void initialize_state( runtime_state &state )
     } );
     install_need_api(
         game,
-    [&state]() {
-        return state.generation;
-    },
+        current_handle_runtime,
     [&state]() {
         return state.world_generation;
     },
@@ -4456,9 +4444,7 @@ void initialize_state( runtime_state &state )
     } );
     install_martial_art_api(
         game,
-    [&state]() {
-        return state.generation;
-    },
+        current_handle_runtime,
     [&state]() {
         return state.world_generation;
     },
@@ -4472,9 +4458,7 @@ void initialize_state( runtime_state &state )
     } );
     install_vehicle_api(
         game,
-    [&state]() {
-        return state.generation;
-    },
+        current_handle_runtime,
     [&state]() {
         return state.world_generation;
     },
@@ -4488,9 +4472,7 @@ void initialize_state( runtime_state &state )
     } );
     install_npc_api(
         game,
-    [&state]() {
-        return state.generation;
-    },
+        current_handle_runtime,
     [&state]() {
         return state.world_generation;
     },
@@ -4524,9 +4506,7 @@ void initialize_state( runtime_state &state )
     } );
     install_zone_api(
         state.lua, game,
-    [&state]() {
-        return state.generation;
-    },
+        current_handle_runtime,
     [&state]() {
         return state.world_generation;
     },
@@ -4540,9 +4520,7 @@ void initialize_state( runtime_state &state )
     } );
     install_magic_api(
         game,
-    [&state]() {
-        return state.generation;
-    },
+        current_handle_runtime,
     [&state]() {
         return state.world_generation;
     },
@@ -4556,9 +4534,7 @@ void initialize_state( runtime_state &state )
     } );
     install_mission_api(
         game,
-    [&state]() {
-        return state.generation;
-    },
+        current_handle_runtime,
     [&state]() {
         return state.world_generation;
     },
@@ -4588,9 +4564,7 @@ void initialize_state( runtime_state &state )
     } );
     install_world_api(
         game,
-    [&state]() {
-        return state.generation;
-    },
+        current_handle_runtime,
     [&state]() {
         return state.world_generation;
     },
@@ -4617,9 +4591,7 @@ void initialize_state( runtime_state &state )
     } );
     install_horde_api(
         game,
-    [&state]() {
-        return state.generation;
-    },
+        current_handle_runtime,
     [&state]() {
         return state.world_generation;
     },
@@ -4633,9 +4605,7 @@ void initialize_state( runtime_state &state )
     } );
     install_item_api(
         game,
-    [&state]() {
-        return state.generation;
-    },
+        current_handle_runtime,
     [&state]() {
         return state.world_generation;
     },
@@ -4688,9 +4658,7 @@ void initialize_state( runtime_state &state )
     } );
     install_game_world_service_api(
         game,
-    [&state]() {
-        return state.generation;
-    },
+        current_handle_runtime,
     [&state]() {
         return state.world_generation;
     },
@@ -5292,7 +5260,7 @@ game_handle native_creature_handle(
     }
     return game_handle::from_creature(
                mutable_creature, std::move( locator ),
-               state.generation, state.world_generation );
+               current_game_handle_runtime( state ), state.world_generation );
 }
 
 sol::object native_talker_to_lua(
@@ -5311,7 +5279,7 @@ sol::object native_talker_to_lua(
             mutable_item, {
                 "callback_talker_item",
                 value->uid().get_value(), 0, 0, 0, {}
-            }, state.generation, state.world_generation ) );
+            }, current_game_handle_runtime( state ), state.world_generation ) );
         }
     }
     if( const vehicle *value = talker.get_const_vehicle() ) {
@@ -5323,7 +5291,7 @@ sol::object native_talker_to_lua(
         mutable_vehicle, {
             "callback_talker_vehicle", 0,
             position.x(), position.y(), position.z(), {}
-        }, state.generation, state.world_generation ) );
+        }, current_game_handle_runtime( state ), state.world_generation ) );
     }
 
     sol::table snapshot = state.lua.create_table();
@@ -5378,7 +5346,7 @@ sol::object native_callback_value_to_lua(
             mutable_item, {
                 "callback_item",
                 entry->uid().get_value(), 0, 0, 0, {}
-            }, state.generation, state.world_generation ) );
+            }, current_game_handle_runtime( state ), state.world_generation ) );
         } else if constexpr( std::is_same_v<value_type, native_callback_point> )
         {
             sol::table point = state.lua.create_table();
@@ -5411,7 +5379,7 @@ sol::object native_callback_value_to_lua(
         {
             return sol::make_object(
                        lua, mission_token(
-                           entry.uid, state.generation,
+                           entry.uid, current_game_handle_runtime( state ),
                            state.world_generation ) );
         } else
         {

--- a/src/catalua_ui_addictions.cpp
+++ b/src/catalua_ui_addictions.cpp
@@ -196,7 +196,7 @@ sol::table get_definition(
 }
 
 Character *resolve_character(
-    const game_handle &handle, const std::size_t runtime_generation,
+    const game_handle &handle, const game_handle_runtime &runtime_generation,
     const std::size_t world_generation,
     std::optional<game_handle_error> &error )
 {
@@ -308,7 +308,7 @@ std::vector<const addiction *> sorted_addictions(
 sol::table list_states(
     sol::this_state lua, const game_handle &handle,
     const sol::optional<sol::table> &requested,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const state_list_options options =
@@ -349,7 +349,7 @@ sol::table list_states(
 sol::table get_state(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_addiction_id(
@@ -373,7 +373,7 @@ sol::table get_state(
 sol::table expose_state(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id, const int strength,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_addiction_id(
@@ -422,7 +422,7 @@ sol::table expose_state(
 sol::table remove_state(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_addiction_id(
@@ -507,7 +507,7 @@ sol::table set_state(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
     const sol::table &requested_adjustments,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_addiction_id(
@@ -568,7 +568,7 @@ sol::table set_state(
 sol::table run_effect_state(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_addiction_id(
@@ -605,7 +605,7 @@ sol::table run_effect_state(
 
 void install_addiction_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write )

--- a/src/catalua_ui_addictions.h
+++ b/src/catalua_ui_addictions.h
@@ -10,10 +10,12 @@
 namespace cata::lua_ui
 {
 
+class game_handle_runtime;
+
 // Install native addiction definition and character state services.
 void install_addiction_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write );

--- a/src/catalua_ui_bionics.cpp
+++ b/src/catalua_ui_bionics.cpp
@@ -55,7 +55,7 @@ void require_id_kind( const script_game_id &id, const std::string &kind,
 }
 
 Character *resolve_character(
-    const game_handle &handle, const std::size_t runtime_generation,
+    const game_handle &handle, const game_handle_runtime &runtime_generation,
     const std::size_t world_generation,
     std::optional<game_handle_error> &error )
 {
@@ -542,7 +542,7 @@ int instance_limit( const sol::optional<int> &requested )
 sol::table list_instances(
     sol::this_state lua, const game_handle &handle,
     const sol::optional<int> &requested_limit,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const int limit = instance_limit( requested_limit );
@@ -594,7 +594,7 @@ std::optional<bionic *> find_instance(
 sol::table get_instance(
     sol::this_state lua, const game_handle &handle,
     const std::uint64_t uid,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -622,7 +622,7 @@ sol::table get_instance(
 sol::table has_instance(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_id_kind(
@@ -644,7 +644,7 @@ sol::table has_instance(
 sol::table install_instance(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_id_kind(
@@ -692,7 +692,7 @@ sol::table install_instance(
 sol::table remove_instance(
     sol::this_state lua, const game_handle &handle,
     const std::uint64_t uid,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -732,7 +732,7 @@ sol::table remove_instance(
 sol::table set_power(
     sol::this_state lua, const game_handle &handle,
     const script_unit_value &requested_power,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const units::energy power = native_energy(
@@ -764,7 +764,7 @@ sol::table set_power(
 sol::table set_activation(
     sol::this_state lua, const game_handle &handle,
     const std::uint64_t uid, const bool active,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -880,7 +880,7 @@ configuration read_configuration( const sol::table &requested )
 sol::table configure_instance(
     sol::this_state lua, const game_handle &handle,
     const std::uint64_t uid, const sol::table &requested,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const configuration options =
@@ -928,7 +928,7 @@ sol::table configure_instance(
 
 void install_bionic_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write )

--- a/src/catalua_ui_bionics.h
+++ b/src/catalua_ui_bionics.h
@@ -10,11 +10,13 @@
 namespace cata::lua_ui
 {
 
+class game_handle_runtime;
+
 // Install detached bionic definition/instance snapshots and generation-safe,
 // capability-gated bionic operations.
 void install_bionic_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write );

--- a/src/catalua_ui_creatures.cpp
+++ b/src/catalua_ui_creatures.cpp
@@ -136,7 +136,7 @@ game_handle_locator creature_locator( Creature &creature )
 }
 
 game_handle make_creature_handle(
-    Creature &creature, const std::size_t runtime_generation,
+    Creature &creature, const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     return game_handle::from_creature(
@@ -196,7 +196,7 @@ sol::table snapshot_creature(
 
 sol::table creature_snapshot_result(
     sol::this_state lua, const game_handle &handle,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -212,7 +212,7 @@ sol::table creature_snapshot_result(
 
 sol::table nearby_creatures(
     sol::this_state lua, const sol::optional<sol::table> &requested,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const creature_query_options options = read_query_options( requested );
@@ -280,7 +280,7 @@ sol::table nearby_creatures(
 
 sol::table creature_at(
     sol::this_state lua, const script_tripoint_coord &position,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     if( position.native_origin() != coords::origin::abs ||
@@ -306,7 +306,7 @@ sol::table creature_at(
 }
 
 const Character *character_from_handle(
-    const game_handle &handle, const std::size_t runtime_generation,
+    const game_handle &handle, const game_handle_runtime &runtime_generation,
     const std::size_t world_generation,
     std::optional<game_handle_error> &error )
 {
@@ -327,7 +327,7 @@ const Character *character_from_handle(
 }
 
 Character *mutable_character_from_handle(
-    const game_handle &handle, const std::size_t runtime_generation,
+    const game_handle &handle, const game_handle_runtime &runtime_generation,
     const std::size_t world_generation,
     std::optional<game_handle_error> &error )
 {
@@ -469,7 +469,7 @@ sol::table character_mutable_state(
 sol::table adjust_character(
     sol::this_state lua, const game_handle &handle,
     const sol::table &requested,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const character_adjustments adjustments =
@@ -525,7 +525,7 @@ sol::table adjust_character(
 sol::table heal_character(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &body_part, const int amount,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     if( amount <= 0 || amount > maximum_character_healing ) {
@@ -561,7 +561,7 @@ sol::table heal_character(
 sol::table set_character_movement_mode(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_mode,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_id_kind(
@@ -759,7 +759,7 @@ sol::table snapshot_character(
 sol::table character_snapshot_result(
     sol::this_state lua, const game_handle &handle,
     const sol::optional<int> &requested_body_part_limit,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -779,7 +779,7 @@ sol::table character_snapshot_result(
 
 sol::table character_by_id(
     sol::this_state lua, const std::int64_t id,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -808,7 +808,7 @@ sol::table character_by_id(
 
 sol::table nearby_characters(
     sol::this_state lua, const sol::optional<sol::table> &requested,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const creature_query_options options = read_query_options( requested );
@@ -871,7 +871,7 @@ sol::table nearby_characters(
 
 void install_creature_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write )

--- a/src/catalua_ui_creatures.h
+++ b/src/catalua_ui_creatures.h
@@ -10,11 +10,13 @@
 namespace cata::lua_ui
 {
 
+class game_handle_runtime;
+
 // Install bounded creature queries and detached snapshots.  Live game objects
 // cross the Lua boundary only through generation-checked GameHandle values.
 void install_creature_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write );

--- a/src/catalua_ui_effects.cpp
+++ b/src/catalua_ui_effects.cpp
@@ -45,7 +45,7 @@ void require_id_kind( const script_game_id &id, const std::string &kind,
 }
 
 Creature *resolve_creature(
-    const game_handle &handle, const std::size_t runtime_generation,
+    const game_handle &handle, const game_handle_runtime &runtime_generation,
     const std::size_t world_generation,
     std::optional<game_handle_error> &error )
 {
@@ -202,7 +202,7 @@ effect *find_effect(
 sol::table list_effects(
     sol::this_state lua, const game_handle &handle,
     const sol::optional<int> &requested_limit,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const int limit = effect_limit(
@@ -240,7 +240,7 @@ sol::table has_effect(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
     const std::optional<script_game_id> &requested_body_part,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_id_kind(
@@ -269,7 +269,7 @@ sol::table get_effect(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
     const std::optional<script_game_id> &requested_body_part,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_id_kind(
@@ -382,7 +382,7 @@ sol::table add_effect(
     const script_game_id &requested_id,
     const script_time_duration &duration,
     const sol::optional<sol::table> &requested_options,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_id_kind(
@@ -431,7 +431,7 @@ sol::table remove_effect(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
     const std::optional<script_game_id> &requested_body_part,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_id_kind(
@@ -522,7 +522,7 @@ sol::table update_effect(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
     const sol::table &requested_options,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_id_kind(
@@ -582,7 +582,7 @@ sol::table update_effect(
 
 void install_effect_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write )

--- a/src/catalua_ui_effects.h
+++ b/src/catalua_ui_effects.h
@@ -10,11 +10,13 @@
 namespace cata::lua_ui
 {
 
+class game_handle_runtime;
+
 // Install bounded, detached effect inspection and capability-gated mutation.
 // Effect instances never cross the Lua boundary as native references.
 void install_effect_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write );

--- a/src/catalua_ui_eocs.cpp
+++ b/src/catalua_ui_eocs.cpp
@@ -343,7 +343,7 @@ std::unique_ptr<talker> resolve_talker_option(
     const sol::optional<sol::table> &options,
     const std::string &field,
     const bool default_avatar,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation,
     std::optional<game_handle_error> &error )
 {
@@ -398,7 +398,7 @@ struct prepared_eoc_dialogue {
 
 prepared_eoc_dialogue prepare_eoc_dialogue(
     const sol::optional<sol::table> &options,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     validate_eoc_options( options );
@@ -438,7 +438,7 @@ prepared_eoc_dialogue prepare_eoc_dialogue(
 sol::table test_eoc(
     sol::this_state lua, const script_game_id &id,
     const sol::optional<sol::table> &options,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_eoc_id( id, "game.eocs.test" );
@@ -463,7 +463,7 @@ sol::table test_eoc(
 sol::table activate_eoc(
     sol::this_state lua, const script_game_id &id,
     const sol::optional<sol::table> &options,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_eoc_id( id, "game.eocs.activate" );
@@ -489,7 +489,7 @@ sol::table queue_eoc(
     sol::this_state lua, const script_game_id &id,
     const script_time_duration &delay,
     const sol::optional<sol::table> &options,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_eoc_id( id, "game.eocs.queue" );
@@ -533,7 +533,7 @@ struct resolved_variable_talker {
 
 resolved_variable_talker resolve_variable_talker(
     const game_handle &handle,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     resolved_variable_talker result;
@@ -569,7 +569,7 @@ resolved_variable_talker resolve_variable_talker(
 sol::table get_variable(
     sol::this_state lua, const game_handle &handle,
     const std::string &key,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     validate_context_key( key );
@@ -597,7 +597,7 @@ sol::table get_variable(
 sol::table set_variable(
     sol::this_state lua, const game_handle &handle,
     const std::string &key, const sol::object &requested,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     validate_context_key( key );
@@ -631,7 +631,7 @@ sol::table set_variable(
 sol::table remove_variable(
     sol::this_state lua, const game_handle &handle,
     const std::string &key,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     validate_context_key( key );
@@ -661,7 +661,7 @@ sol::table remove_variable(
 
 void install_eoc_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write,
@@ -745,7 +745,7 @@ void install_eoc_api(
 
 void install_variable_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write,

--- a/src/catalua_ui_eocs.h
+++ b/src/catalua_ui_eocs.h
@@ -10,12 +10,14 @@
 namespace cata::lua_ui
 {
 
+class game_handle_runtime;
+
 // Install generation-safe variables attached to creature and vehicle talkers.
 // This domain service is independent from EOC execution and is shared with
 // the Lua-first Platform.
 void install_variable_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write,
@@ -25,7 +27,7 @@ void install_variable_api(
 // Lua receives detached metadata and invokes them through bounded contexts.
 void install_eoc_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write,

--- a/src/catalua_ui_hordes.cpp
+++ b/src/catalua_ui_hordes.cpp
@@ -95,11 +95,11 @@ class horde_entity_token
         horde_entity_token(
             const tripoint_abs_ms &position,
             const horde_entity &entry,
-            const std::size_t runtime_generation,
+            const game_handle_runtime &runtime_generation,
             const std::size_t world_generation )
             : position_( position ),
               monster_( entry.get_type()->id.str() ),
-              runtime_generation_( runtime_generation ),
+              runtime_( runtime_generation ),
               world_generation_( world_generation ),
               identity_( entry.lua_identity() ) {
         }
@@ -116,7 +116,7 @@ class horde_entity_token
         }
 
         std::size_t runtime_generation() const noexcept {
-            return runtime_generation_;
+            return runtime_.generation();
         }
 
         std::size_t world_generation() const noexcept {
@@ -142,12 +142,17 @@ class horde_entity_token
             return identity_;
         }
 
+        bool belongs_to(
+            const game_handle_runtime &runtime ) const noexcept {
+            return runtime_.is_active_match( runtime );
+        }
+
         friend bool operator==(
             const horde_entity_token &lhs,
             const horde_entity_token &rhs ) {
             return lhs.position_ == rhs.position_ &&
                    lhs.monster_ == rhs.monster_ &&
-                   lhs.runtime_generation_ == rhs.runtime_generation_ &&
+                   lhs.runtime_.same_identity( rhs.runtime_ ) &&
                    lhs.world_generation_ == rhs.world_generation_ &&
                    lhs.identity_ == rhs.identity_;
         }
@@ -155,7 +160,7 @@ class horde_entity_token
     private:
         tripoint_abs_ms position_;
         std::string monster_;
-        std::size_t runtime_generation_ = 0;
+        game_handle_runtime runtime_;
         std::size_t world_generation_ = 0;
         std::uint64_t identity_ = 0;
 };
@@ -165,11 +170,11 @@ class legacy_horde_token
     public:
         legacy_horde_token(
             const mongroup &group,
-            const std::size_t runtime_generation,
+            const game_handle_runtime &runtime_generation,
             const std::size_t world_generation )
             : position_( group.abs_pos ),
               group_( group.type.str() ),
-              runtime_generation_( runtime_generation ),
+              runtime_( runtime_generation ),
               world_generation_( world_generation ),
               identity_( group.lua_identity() ) {
         }
@@ -186,7 +191,7 @@ class legacy_horde_token
         }
 
         std::size_t runtime_generation() const noexcept {
-            return runtime_generation_;
+            return runtime_.generation();
         }
 
         std::size_t world_generation() const noexcept {
@@ -212,12 +217,17 @@ class legacy_horde_token
             return identity_;
         }
 
+        bool belongs_to(
+            const game_handle_runtime &runtime ) const noexcept {
+            return runtime_.is_active_match( runtime );
+        }
+
         friend bool operator==(
             const legacy_horde_token &lhs,
             const legacy_horde_token &rhs ) {
             return lhs.position_ == rhs.position_ &&
                    lhs.group_ == rhs.group_ &&
-                   lhs.runtime_generation_ == rhs.runtime_generation_ &&
+                   lhs.runtime_.same_identity( rhs.runtime_ ) &&
                    lhs.world_generation_ == rhs.world_generation_ &&
                    lhs.identity_ == rhs.identity_;
         }
@@ -225,7 +235,7 @@ class legacy_horde_token
     private:
         tripoint_abs_sm position_;
         std::string group_;
-        std::size_t runtime_generation_ = 0;
+        game_handle_runtime runtime_;
         std::size_t world_generation_ = 0;
         std::uint64_t identity_ = 0;
 };
@@ -1066,7 +1076,7 @@ bool group_contains(
 sol::table snapshot_entity(
     sol::state_view lua,
     const entity_match &match,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const horde_entity &entry = *match.entry;
@@ -1113,7 +1123,7 @@ sol::table snapshot_entity(
 sol::table snapshot_legacy_group(
     sol::state_view lua,
     const mongroup &group,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::table result = lua.create_table();
@@ -1201,14 +1211,14 @@ sol::table snapshot_legacy_group(
 
 std::optional<entity_match> resolve_entity_token(
     const horde_entity_token &token,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation,
     std::optional<game_handle_error> &error )
 {
-    if( token.runtime_generation() != runtime_generation ) {
+    if( !token.belongs_to( runtime_generation ) ) {
         error = game_handle_error{
             "stale_runtime",
-            "HordeEntityToken belongs to an inactive Lua runtime generation"
+            "HordeEntityToken belongs to an inactive or different Lua runtime"
         };
         return std::nullopt;
     }
@@ -1260,14 +1270,14 @@ std::optional<entity_match> resolve_entity_token(
 
 mongroup *resolve_legacy_token(
     const legacy_horde_token &token,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation,
     std::optional<game_handle_error> &error )
 {
-    if( token.runtime_generation() != runtime_generation ) {
+    if( !token.belongs_to( runtime_generation ) ) {
         error = game_handle_error{
             "stale_runtime",
-            "LegacyHordeToken belongs to an inactive Lua runtime generation"
+            "LegacyHordeToken belongs to an inactive or different Lua runtime"
         };
         return nullptr;
     }
@@ -1302,7 +1312,7 @@ sol::table list_entities(
     sol::this_state lua,
     const script_tripoint_coord &center,
     const sol::optional<sol::table> &requested,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     constexpr std::string_view api_name =
@@ -1360,7 +1370,7 @@ sol::table list_legacy_groups(
     sol::this_state lua,
     const script_tripoint_coord &center,
     const sol::optional<sol::table> &requested,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     constexpr std::string_view api_name =
@@ -1417,7 +1427,7 @@ sol::table list_legacy_groups(
 sol::table get_entity(
     sol::this_state lua,
     const horde_entity_token &token,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -1443,7 +1453,7 @@ sol::table get_entity(
 sol::table get_legacy_group(
     sol::this_state lua,
     const legacy_horde_token &token,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -1470,7 +1480,7 @@ sol::table spawn_entity(
     sol::this_state lua,
     const script_tripoint_coord &position,
     const script_game_id &requested_monster,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     constexpr std::string_view api_name =
@@ -1562,7 +1572,7 @@ sol::table alert_entity(
     const horde_entity_token &token,
     const script_tripoint_coord &destination,
     const int intensity,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     constexpr std::string_view api_name =
@@ -1623,7 +1633,7 @@ sol::table alert_entity(
 sol::table remove_entity(
     sol::this_state lua,
     const horde_entity_token &token,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -1795,7 +1805,7 @@ void apply_legacy_settings(
 sol::table spawn_legacy_group(
     sol::this_state lua,
     const sol::table &requested,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     constexpr std::string_view api_name =
@@ -1882,7 +1892,7 @@ sol::table update_legacy_group(
     sol::this_state lua,
     const legacy_horde_token &token,
     const sol::table &requested,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     constexpr std::string_view api_name =
@@ -1923,7 +1933,7 @@ sol::table update_legacy_group(
 sol::table remove_legacy_group(
     sol::this_state lua,
     const legacy_horde_token &token,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -2111,7 +2121,7 @@ sol::table horde_limits( sol::this_state lua )
 
 void install_horde_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write )

--- a/src/catalua_ui_hordes.h
+++ b/src/catalua_ui_hordes.h
@@ -10,12 +10,14 @@
 namespace cata::lua_ui
 {
 
+class game_handle_runtime;
+
 // Install detached monster-group definitions plus bounded, existing-overmap
 // horde observation and mutation APIs.  Native horde_entity and mongroup
 // pointers never cross into Lua; live entries use generation-bound tokens.
 void install_horde_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write );

--- a/src/catalua_ui_items.cpp
+++ b/src/catalua_ui_items.cpp
@@ -177,7 +177,7 @@ inventory_query_options read_inventory_options(
 }
 
 Character *resolve_character(
-    const game_handle &handle, const std::size_t runtime_generation,
+    const game_handle &handle, const game_handle_runtime &runtime_generation,
     const std::size_t world_generation,
     std::optional<game_handle_error> &error )
 {
@@ -329,7 +329,7 @@ std::vector<inventory_item_entry> collect_inventory(
 
 game_handle make_item_handle(
     Character &character, const inventory_item_entry &entry,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const tripoint_abs_ms position = character.pos_abs();
@@ -348,7 +348,7 @@ game_handle make_item_handle(
 sol::table inventory_entry_to_lua(
     sol::state_view lua, Character &character,
     const inventory_item_entry &entry,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::table result = lua.create_table();
@@ -370,7 +370,7 @@ sol::table inventory_entry_to_lua(
 sol::table list_inventory(
     sol::this_state lua, const game_handle &character_handle,
     const sol::optional<sol::table> &requested,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const inventory_query_options options =
@@ -427,7 +427,7 @@ sol::table list_inventory(
 sol::table find_inventory_item(
     sol::this_state lua, const game_handle &character_handle,
     const std::int64_t uid,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     if( uid <= 0 ) {
@@ -753,7 +753,7 @@ sol::table snapshot_item(
 sol::table item_snapshot_result(
     sol::this_state lua, const game_handle &handle,
     const sol::optional<int> &requested_relation_limit,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const int relation_limit =
@@ -917,7 +917,7 @@ sol::table snapshot_pocket(
 sol::table item_pockets_result(
     sol::this_state lua, const game_handle &handle,
     const sol::optional<sol::table> &requested,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const pocket_query_options options =
@@ -1110,7 +1110,7 @@ void collect_item_contents(
 game_handle make_contained_item_handle(
     const game_handle &root,
     const contained_item_entry &entry,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     game_handle_locator locator = root.locator();
@@ -1126,7 +1126,7 @@ game_handle make_contained_item_handle(
 sol::table contained_item_to_lua(
     sol::state_view lua, const game_handle &root,
     const contained_item_entry &entry,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::table result = lua.create_table();
@@ -1148,7 +1148,7 @@ sol::table contained_item_to_lua(
 sol::table item_contents_result(
     sol::this_state lua, const game_handle &handle,
     const sol::optional<sol::table> &requested,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const contents_query_options options =
@@ -1298,7 +1298,7 @@ sol::table mutable_item_state(
 sol::table update_item(
     sol::this_state lua, const game_handle &handle,
     const sol::table &requested,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -1380,7 +1380,7 @@ sol::table item_var_to_lua(
 sol::table get_item_var(
     sol::this_state lua, const game_handle &handle,
     const std::string &key,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     validate_item_var_key( key, "game.items.get_var" );
@@ -1457,7 +1457,7 @@ void set_item_var_value(
 sol::table set_item_var(
     sol::this_state lua, const game_handle &handle,
     const std::string &key, const sol::object &requested,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     validate_item_var_key( key, "game.items.set_var" );
@@ -1490,7 +1490,7 @@ sol::table set_item_var(
 sol::table erase_item_var(
     sol::this_state lua, const game_handle &handle,
     const std::string &key,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     validate_item_var_key( key, "game.items.erase_var" );
@@ -1514,7 +1514,7 @@ sol::table erase_item_var(
 sol::table item_has_flag(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &flag,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_id_kind(
@@ -1536,7 +1536,7 @@ sol::table item_has_flag(
 sol::table set_item_flag(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &flag, const bool enabled,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_id_kind(
@@ -1553,8 +1553,8 @@ sol::table set_item_flag(
     sol::table value = state.create_table();
     value["effective_before"] =
         resolved.value->has_flag( native );
-    value["own_before"] =
-        resolved.value->has_own_flag( native );
+    const bool own_before = resolved.value->has_own_flag( native );
+    value["own_before"] = own_before;
     if( enabled ) {
         resolved.value->set_flag( native );
     } else {
@@ -1562,8 +1562,9 @@ sol::table set_item_flag(
     }
     value["effective_after"] =
         resolved.value->has_flag( native );
-    value["own_after"] =
-        resolved.value->has_own_flag( native );
+    const bool own_after = resolved.value->has_own_flag( native );
+    value["own_after"] = own_after;
+    value["changed"] = own_before != own_after;
     return make_game_value_result(
                state, sol::make_object(
                    state, std::move( value ) ) );
@@ -1572,7 +1573,7 @@ sol::table set_item_flag(
 sol::table item_has_technique(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &technique,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_id_kind(
@@ -1595,7 +1596,7 @@ sol::table item_has_technique(
 sol::table set_item_technique(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &technique, const bool enabled,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_id_kind(
@@ -1659,7 +1660,7 @@ inventory_give_options read_inventory_give_options(
 
 sol::table character_item_to_lua(
     sol::state_view lua, Character &character, item &entry,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const std::vector<item *> parents =
@@ -1703,7 +1704,7 @@ sol::table character_item_to_lua(
 bool resolve_owned_item(
     const game_handle &character_handle,
     const game_handle &item_handle,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation,
     Character *&character, item *&entry,
     std::optional<game_handle_error> &error )
@@ -1735,7 +1736,7 @@ bool resolve_owned_item(
 sol::table inventory_resources(
     sol::this_state lua, const game_handle &character_handle,
     const script_game_id &type, const std::int64_t quantity,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_id_kind(
@@ -1783,7 +1784,7 @@ sol::table give_inventory_items(
     sol::this_state lua, const game_handle &character_handle,
     const script_game_id &type, const std::int64_t quantity,
     const sol::optional<sol::table> &requested,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_id_kind(
@@ -1860,7 +1861,7 @@ sol::table remove_inventory_item(
     sol::this_state lua, const game_handle &character_handle,
     const game_handle &item_handle,
     const sol::optional<std::int64_t> &requested_quantity,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -1964,7 +1965,7 @@ sol::table remove_inventory_item(
 sol::table wield_inventory_item(
     sol::this_state lua, const game_handle &character_handle,
     const game_handle &item_handle,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -2030,7 +2031,7 @@ sol::table wield_inventory_item(
 sol::table wear_inventory_item(
     sol::this_state lua, const game_handle &character_handle,
     const game_handle &item_handle,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -2122,7 +2123,7 @@ sol::table wear_inventory_item(
 
 sol::table stash_wielded_item(
     sol::this_state lua, const game_handle &character_handle,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -2194,7 +2195,7 @@ sol::table stash_wielded_item(
 
 void install_item_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write )

--- a/src/catalua_ui_items.h
+++ b/src/catalua_ui_items.h
@@ -10,11 +10,13 @@
 namespace cata::lua_ui
 {
 
+class game_handle_runtime;
+
 // Install bounded inventory traversal and item operations.  Native items
 // cross the Lua boundary only through generation-checked GameHandle values.
 void install_item_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write );

--- a/src/catalua_ui_magic.cpp
+++ b/src/catalua_ui_magic.cpp
@@ -58,7 +58,7 @@ void require_spell_id(
 }
 
 Character *resolve_character(
-    const game_handle &handle, const std::size_t runtime_generation,
+    const game_handle &handle, const game_handle_runtime &runtime_generation,
     const std::size_t world_generation,
     std::optional<game_handle_error> &error )
 {
@@ -655,7 +655,7 @@ sol::table snapshot_known_spell(
 sol::table list_known(
     sol::this_state lua, const game_handle &handle,
     const sol::optional<sol::table> &requested_options,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const page_options options = read_page_options(
@@ -707,7 +707,7 @@ sol::table list_known(
 sol::table knows_spell(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_spell_id(
@@ -729,7 +729,7 @@ sol::table knows_spell(
 sol::table get_known(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_spell_id(
@@ -761,7 +761,7 @@ sol::table get_known(
 sol::table can_learn_spell(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_spell_id(
@@ -856,7 +856,7 @@ sol::table learn_spell(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
     const sol::optional<sol::table> &requested_options,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_spell_id(
@@ -917,7 +917,7 @@ sol::table learn_spell(
 sol::table forget_spell(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_spell_id(
@@ -962,7 +962,7 @@ sol::table adjust_spell(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id, const int amount,
     const spell_adjustment adjustment,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const std::string api_name =
@@ -1062,7 +1062,7 @@ sol::table mana_snapshot(
 
 sol::table get_mana(
     sol::this_state lua, const game_handle &handle,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -1083,7 +1083,7 @@ sol::table get_mana(
 sol::table change_mana(
     sol::this_state lua, const game_handle &handle,
     const int amount, const bool relative,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const std::string api_name = relative ?
@@ -1126,7 +1126,7 @@ sol::table change_mana(
 sol::table set_casting_ignore(
     sol::this_state lua, const game_handle &handle,
     const bool enabled,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -1152,7 +1152,7 @@ sol::table set_casting_ignore(
 sol::table set_favorite(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id, const bool favorite,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_spell_id(
@@ -1203,7 +1203,7 @@ sol::table queue_cast(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
     const script_tripoint_coord &requested_target,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_spell_id(
@@ -1297,7 +1297,7 @@ sol::table queue_cast(
 
 void install_magic_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write )

--- a/src/catalua_ui_magic.h
+++ b/src/catalua_ui_magic.h
@@ -10,11 +10,13 @@
 namespace cata::lua_ui
 {
 
+class game_handle_runtime;
+
 // Install detached spell definition and known-spell snapshots.  Native spell
 // and known_magic instances never cross the Lua boundary.
 void install_magic_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write );

--- a/src/catalua_ui_martial_arts.cpp
+++ b/src/catalua_ui_martial_arts.cpp
@@ -235,7 +235,7 @@ sol::table get_definition(
 }
 
 Character *resolve_character(
-    const game_handle &handle, const std::size_t runtime_generation,
+    const game_handle &handle, const game_handle_runtime &runtime_generation,
     const std::size_t world_generation,
     std::optional<game_handle_error> &error )
 {
@@ -318,7 +318,7 @@ state_list_options read_state_list_options(
 sol::table list_states(
     sol::this_state lua, const game_handle &handle,
     const sol::optional<sol::table> &requested,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const state_list_options options =
@@ -364,7 +364,7 @@ sol::table list_states(
 sol::table get_state(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_style_id(
@@ -387,7 +387,7 @@ sol::table get_state(
 
 sol::table get_current_state(
     sol::this_state lua, const game_handle &handle,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -409,7 +409,7 @@ sol::table get_current_state(
 sol::table learn_state(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_style_id(
@@ -445,7 +445,7 @@ sol::table learn_state(
 sol::table remove_state(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_style_id(
@@ -500,7 +500,7 @@ sol::table remove_state(
 sol::table select_state(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_style_id(
@@ -545,7 +545,7 @@ sol::table select_state(
 sol::table set_hands_free_state(
     sol::this_state lua, const game_handle &handle,
     const bool keep_hands_free,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -572,7 +572,7 @@ sol::table set_hands_free_state(
 sol::table trigger_state(
     sol::this_state lua, const game_handle &handle,
     const std::string &trigger,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -627,7 +627,7 @@ sol::table trigger_state(
 
 void install_martial_art_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write )

--- a/src/catalua_ui_martial_arts.h
+++ b/src/catalua_ui_martial_arts.h
@@ -10,10 +10,12 @@
 namespace cata::lua_ui
 {
 
+class game_handle_runtime;
+
 // Install native martial-art definitions and character style services.
 void install_martial_art_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write );

--- a/src/catalua_ui_missions.cpp
+++ b/src/catalua_ui_missions.cpp
@@ -54,13 +54,13 @@ void require_mission_id(
 
 std::optional<game_handle_error> mission_token_error(
     const mission_token &token,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
-    if( token.runtime_generation() != runtime_generation ) {
+    if( !token.belongs_to( runtime_generation ) ) {
         return game_handle_error{
             "stale_runtime",
-            "MissionToken belongs to an inactive Lua runtime generation"
+            "MissionToken belongs to an inactive or different Lua runtime"
         };
     }
     if( token.world_generation() != world_generation ) {
@@ -80,7 +80,7 @@ std::optional<game_handle_error> mission_token_error(
 
 mission *resolve_mission(
     const mission_token &token,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation,
     std::optional<game_handle_error> &error )
 {
@@ -493,7 +493,7 @@ std::string mission_status_name( const mission &entry )
 
 sol::table snapshot_instance(
     sol::state_view lua, const mission &entry,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const avatar &player = get_avatar();
@@ -653,7 +653,7 @@ instance_options read_instance_options(
 sol::table list_instances(
     sol::this_state lua,
     const sol::optional<sol::table> &requested_options,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const instance_options options =
@@ -714,7 +714,7 @@ sol::table list_instances(
 
 sol::table get_instance(
     sol::this_state lua, const mission_token &token,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -736,7 +736,7 @@ sol::table get_instance(
 
 sol::table current_instance(
     sol::this_state lua,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -830,7 +830,7 @@ character_id requested_npc_id(
 sol::table reserve_instance(
     sol::this_state lua, const script_game_id &requested_id,
     const sol::optional<int> &npc_id,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_mission_id(
@@ -860,7 +860,7 @@ sol::table reserve_random_instance(
     sol::this_state lua, const script_enum_value &origin,
     const script_tripoint_coord &position,
     const sol::optional<int> &npc_id,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const mission_origin native_origin =
@@ -891,7 +891,7 @@ sol::table reserve_random_instance(
 
 sol::table assign_instance(
     sol::this_state lua, const mission_token &token,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -934,7 +934,7 @@ bool assigned_to_avatar( const mission &entry )
 
 sol::table select_instance(
     sol::this_state lua, const mission_token &token,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -966,7 +966,7 @@ sol::table select_instance(
 sol::table is_complete_instance(
     sol::this_state lua, const mission_token &token,
     const sol::optional<int> &npc_id,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -987,7 +987,7 @@ sol::table is_complete_instance(
 sol::table step_instance(
     sol::this_state lua, const mission_token &token,
     const int step,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     if( step < 0 || step > maximum_mission_step ) {
@@ -1029,7 +1029,7 @@ sol::table step_instance(
 
 sol::table fail_instance(
     sol::this_state lua, const mission_token &token,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -1067,7 +1067,7 @@ sol::table fail_instance(
 sol::table complete_instance(
     sol::this_state lua, const mission_token &token,
     const sol::optional<bool> &force,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -1116,7 +1116,7 @@ sol::table complete_instance(
 
 sol::table cancel_reserved_instance(
     sol::this_state lua, const mission_token &token,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -1150,7 +1150,7 @@ sol::table cancel_reserved_instance(
 
 sol::table abandon_instance(
     sol::this_state lua, const mission_token &token,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -1186,10 +1186,10 @@ sol::table abandon_instance(
 } // namespace
 
 mission_token::mission_token(
-    const int uid, const std::size_t runtime_generation,
+    const int uid, const game_handle_runtime &runtime,
     const std::size_t world_generation )
     : uid_( uid ),
-      runtime_generation_( runtime_generation ),
+      runtime_( runtime ),
       world_generation_( world_generation )
 {
 }
@@ -1201,12 +1201,18 @@ int mission_token::uid() const noexcept
 
 std::size_t mission_token::runtime_generation() const noexcept
 {
-    return runtime_generation_;
+    return runtime_.generation();
 }
 
 std::size_t mission_token::world_generation() const noexcept
 {
     return world_generation_;
+}
+
+bool mission_token::belongs_to(
+    const game_handle_runtime &runtime ) const noexcept
+{
+    return runtime_.is_active_match( runtime );
 }
 
 std::string mission_token::to_string() const
@@ -1216,7 +1222,7 @@ std::string mission_token::to_string() const
 
 void install_mission_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write )

--- a/src/catalua_ui_missions.h
+++ b/src/catalua_ui_missions.h
@@ -6,6 +6,7 @@
 #include <functional>
 #include <string>
 
+#include "catalua_game_handle.h"
 #include "catalua_sol.h"
 
 namespace cata::lua_ui
@@ -15,34 +16,35 @@ class mission_token
 {
     public:
         mission_token(
-            int uid, std::size_t runtime_generation,
+            int uid, const game_handle_runtime &runtime,
             std::size_t world_generation );
 
         int uid() const noexcept;
         std::size_t runtime_generation() const noexcept;
         std::size_t world_generation() const noexcept;
+        bool belongs_to( const game_handle_runtime &runtime ) const noexcept;
         std::string to_string() const;
 
         friend bool operator==(
             const mission_token &lhs, const mission_token &rhs ) {
             return lhs.uid_ == rhs.uid_ &&
-                   lhs.runtime_generation_ ==
-                   rhs.runtime_generation_ &&
+                   lhs.runtime_.same_identity( rhs.runtime_ ) &&
                    lhs.world_generation_ ==
                    rhs.world_generation_;
         }
 
     private:
         int uid_ = 0;
-        std::size_t runtime_generation_ = 0;
+        game_handle_runtime runtime_;
         std::size_t world_generation_ = 0;
 };
 
-// Install detached mission definitions plus generation-bound mission tokens.
+// Install detached mission definitions plus runtime-owner- and generation-bound
+// mission tokens.
 // Mission pointers and mutable mission_type objects never cross into Lua.
 void install_mission_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write );

--- a/src/catalua_ui_mutations.cpp
+++ b/src/catalua_ui_mutations.cpp
@@ -50,7 +50,7 @@ void require_mutation_id(
 }
 
 Character *resolve_character(
-    const game_handle &handle, const std::size_t runtime_generation,
+    const game_handle &handle, const game_handle_runtime &runtime_generation,
     const std::size_t world_generation,
     std::optional<game_handle_error> &error )
 {
@@ -588,7 +588,7 @@ sol::table snapshot_state(
 sol::table list_states(
     sol::this_state lua, const game_handle &handle,
     const sol::optional<sol::table> &requested_options,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const state_options options =
@@ -646,7 +646,7 @@ sol::table list_states(
 sol::table has_state(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_mutation_id(
@@ -668,7 +668,7 @@ sol::table has_state(
 sol::table get_state(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_mutation_id(
@@ -729,7 +729,7 @@ sol::table grant_state(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
     const sol::optional<std::string> &requested_variant_id,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_mutation_id(
@@ -777,7 +777,7 @@ sol::table grant_state(
 sol::table remove_state(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_mutation_id(
@@ -822,7 +822,7 @@ sol::table remove_state(
 sol::table set_active_state(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id, const bool desired,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_mutation_id(
@@ -887,7 +887,7 @@ sol::table set_variant_state(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
     const std::string &requested_variant_id,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_mutation_id(
@@ -931,7 +931,7 @@ sol::table set_variant_state(
 
 void install_mutation_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write )

--- a/src/catalua_ui_mutations.h
+++ b/src/catalua_ui_mutations.h
@@ -10,11 +10,13 @@
 namespace cata::lua_ui
 {
 
+class game_handle_runtime;
+
 // Install detached, paginated mutation definition snapshots.  Character
 // mutation state and write operations are added by the same namespace.
 void install_mutation_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write );

--- a/src/catalua_ui_needs.cpp
+++ b/src/catalua_ui_needs.cpp
@@ -27,7 +27,7 @@ constexpr int maximum_stored_kcal = 2000000;
 constexpr std::int64_t maximum_sleep_adjustment_turns = 31622400;
 
 Character *resolve_character(
-    const game_handle &handle, const std::size_t runtime_generation,
+    const game_handle &handle, const game_handle_runtime &runtime_generation,
     const std::size_t world_generation,
     std::optional<game_handle_error> &error )
 {
@@ -81,7 +81,7 @@ sol::table snapshot_needs(
 
 sol::table get_needs(
     sol::this_state lua, const game_handle &handle,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -155,7 +155,7 @@ need_adjustments read_need_adjustments(
 sol::table set_needs(
     sol::this_state lua, const game_handle &handle,
     const sol::table &requested_adjustments,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const need_adjustments adjustments =
@@ -196,7 +196,7 @@ sol::table set_needs(
 sol::table modify_needs(
     sol::this_state lua, const game_handle &handle,
     const sol::table &requested_deltas,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const need_adjustments deltas =
@@ -237,7 +237,7 @@ sol::table modify_needs(
 sol::table set_calories(
     sol::this_state lua, const game_handle &handle,
     const int requested_kcal,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     if( requested_kcal < 0 ||
@@ -270,7 +270,7 @@ sol::table set_calories(
 sol::table modify_calories(
     sol::this_state lua, const game_handle &handle,
     const int requested_delta, const bool ignore_weariness,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     if( requested_delta < -maximum_need_magnitude ||
@@ -326,7 +326,7 @@ sol::table snapshot_gut_vitamin(
 
 sol::table get_gut_calories(
     sol::this_state lua, const game_handle &handle,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -345,7 +345,7 @@ sol::table get_gut_calories(
 sol::table set_gut_calories(
     sol::this_state lua, const game_handle &handle,
     const int requested_kcal,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     if( requested_kcal < 0 ) {
@@ -373,7 +373,7 @@ sol::table set_gut_calories(
 sol::table modify_gut_calories(
     sol::this_state lua, const game_handle &handle,
     const int requested_delta,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -399,7 +399,7 @@ sol::table modify_gut_calories(
 sol::table get_gut_vitamin(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &id,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_vitamin_id( id, "game.needs.get_gut_vitamin" );
@@ -420,7 +420,7 @@ sol::table get_gut_vitamin(
 sol::table set_gut_vitamin(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &id, const int requested_amount,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_vitamin_id( id, "game.needs.set_gut_vitamin" );
@@ -450,7 +450,7 @@ sol::table set_gut_vitamin(
 sol::table modify_gut_vitamin(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &id, const int requested_delta,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_vitamin_id( id, "game.needs.modify_gut_vitamin" );
@@ -527,7 +527,7 @@ sleep_adjustments read_sleep_adjustments(
 sol::table modify_sleep(
     sol::this_state lua, const game_handle &handle,
     const sol::table &requested_adjustments,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const sleep_adjustments adjustments =
@@ -562,7 +562,7 @@ sol::table modify_sleep(
 sol::table reset_sleep(
     sol::this_state lua, const game_handle &handle,
     const std::string &scope,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     if( scope != "daily" && scope != "continuous" &&
@@ -645,7 +645,7 @@ health_adjustments read_health_adjustments(
 sol::table set_health(
     sol::this_state lua, const game_handle &handle,
     const sol::table &requested_adjustments,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const health_adjustments adjustments =
@@ -743,7 +743,7 @@ health_deltas read_health_deltas(
 sol::table modify_health(
     sol::this_state lua, const game_handle &handle,
     const sol::table &requested_deltas,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const health_deltas deltas =
@@ -783,7 +783,7 @@ sol::table modify_health(
 
 void install_need_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write )

--- a/src/catalua_ui_needs.h
+++ b/src/catalua_ui_needs.h
@@ -10,10 +10,12 @@
 namespace cata::lua_ui
 {
 
+class game_handle_runtime;
+
 // Install generation-safe character need and health services.
 void install_need_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write );

--- a/src/catalua_ui_npcs.cpp
+++ b/src/catalua_ui_npcs.cpp
@@ -267,7 +267,7 @@ sol::table get_class(
 }
 
 game_handle make_npc_handle(
-    npc &entry, const std::size_t runtime_generation,
+    npc &entry, const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const tripoint_abs_ms position =
@@ -281,7 +281,7 @@ game_handle make_npc_handle(
 }
 
 npc *resolve_npc(
-    const game_handle &handle, const std::size_t runtime_generation,
+    const game_handle &handle, const game_handle_runtime &runtime_generation,
     const std::size_t world_generation,
     std::optional<game_handle_error> &error )
 {
@@ -317,7 +317,7 @@ sol::table snapshot_opinion(
 
 sol::table snapshot_npc(
     sol::state_view lua, npc &entry,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const tripoint_abs_ms position =
@@ -470,7 +470,7 @@ std::vector<npc *> matching_npcs(
 sol::table list_npcs(
     sol::this_state lua,
     const sol::optional<sol::table> &requested,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const state_options options =
@@ -512,7 +512,7 @@ sol::table list_npcs(
 
 sol::table get_npc(
     sol::this_state lua, const game_handle &handle,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -553,7 +553,7 @@ void validate_npc_name( const std::string &name )
 sol::table rename_npc(
     sol::this_state lua, const game_handle &handle,
     const std::string &requested_name,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     validate_npc_name( requested_name );
@@ -608,7 +608,7 @@ std::optional<npc_attitude> parse_attitude(
 sol::table set_npc_attitude(
     sol::this_state lua, const game_handle &handle,
     const std::string &requested_attitude,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const std::optional<npc_attitude> attitude =
@@ -721,7 +721,7 @@ int adjusted_opinion_value(
 sol::table modify_npc_opinion(
     sol::this_state lua, const game_handle &handle,
     const sol::table &requested,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const opinion_deltas deltas =
@@ -791,7 +791,7 @@ sol::table modify_npc_opinion(
 
 void install_npc_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write )

--- a/src/catalua_ui_npcs.h
+++ b/src/catalua_ui_npcs.h
@@ -10,10 +10,12 @@
 namespace cata::lua_ui
 {
 
+class game_handle_runtime;
+
 // Install native NPC class catalogs and generation-safe NPC services.
 void install_npc_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write );

--- a/src/catalua_ui_proficiencies.cpp
+++ b/src/catalua_ui_proficiencies.cpp
@@ -314,7 +314,7 @@ sol::table get_definition(
 }
 
 Character *resolve_character(
-    const game_handle &handle, const std::size_t runtime_generation,
+    const game_handle &handle, const game_handle_runtime &runtime_generation,
     const std::size_t world_generation,
     std::optional<game_handle_error> &error )
 {
@@ -445,7 +445,7 @@ std::vector<const proficiency *> character_definitions(
 sol::table list_states(
     sol::this_state lua, const game_handle &handle,
     const sol::optional<sol::table> &requested,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const state_list_options options =
@@ -486,7 +486,7 @@ sol::table list_states(
 sol::table get_state(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_proficiency_id(
@@ -550,7 +550,7 @@ sol::table grant_state(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
     const sol::optional<sol::table> &requested_options,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_proficiency_id(
@@ -593,7 +593,7 @@ sol::table grant_state(
 sol::table remove_state(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_proficiency_id(
@@ -631,7 +631,7 @@ sol::table practice_state(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
     const script_time_duration &requested_amount,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_proficiency_id(
@@ -672,7 +672,7 @@ sol::table set_progress_state(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
     const script_time_duration &requested_progress,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_proficiency_id(
@@ -724,7 +724,7 @@ sol::table set_progress_state(
 
 void install_proficiency_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write )

--- a/src/catalua_ui_proficiencies.h
+++ b/src/catalua_ui_proficiencies.h
@@ -10,10 +10,12 @@
 namespace cata::lua_ui
 {
 
+class game_handle_runtime;
+
 // Install the native proficiency definition and character learning service.
 void install_proficiency_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write );

--- a/src/catalua_ui_skills.cpp
+++ b/src/catalua_ui_skills.cpp
@@ -169,7 +169,7 @@ sol::table get_definition(
 }
 
 Character *resolve_character(
-    const game_handle &handle, const std::size_t runtime_generation,
+    const game_handle &handle, const game_handle_runtime &runtime_generation,
     const std::size_t world_generation,
     std::optional<game_handle_error> &error )
 {
@@ -284,7 +284,7 @@ std::vector<const Skill *> character_skill_definitions(
 sol::table list_states(
     sol::this_state lua, const game_handle &handle,
     const sol::optional<sol::table> &requested,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const state_list_options options =
@@ -325,7 +325,7 @@ sol::table list_states(
 sol::table get_state(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_skill_id( requested_id, "game.skills.get" );
@@ -403,7 +403,7 @@ sol::table set_state(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
     const sol::table &requested_adjustments,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_skill_id( requested_id, "game.skills.set" );
@@ -455,7 +455,7 @@ sol::table set_state(
 sol::table set_training_state(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id, const bool training,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_skill_id( requested_id, "game.skills.set_training" );
@@ -534,7 +534,7 @@ sol::table practice_state(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id, const int amount,
     const sol::optional<sol::table> &requested_options,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_skill_id( requested_id, "game.skills.practice" );
@@ -576,7 +576,7 @@ sol::table practice_state(
 
 void install_skill_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write )

--- a/src/catalua_ui_skills.h
+++ b/src/catalua_ui_skills.h
@@ -10,10 +10,12 @@
 namespace cata::lua_ui
 {
 
+class game_handle_runtime;
+
 // Install the native skill definition and character skill service.
 void install_skill_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write );

--- a/src/catalua_ui_vehicles.cpp
+++ b/src/catalua_ui_vehicles.cpp
@@ -236,7 +236,7 @@ sol::table get_definition(
 }
 
 vehicle *resolve_vehicle(
-    const game_handle &handle, const std::size_t runtime_generation,
+    const game_handle &handle, const game_handle_runtime &runtime_generation,
     const std::size_t world_generation,
     std::optional<game_handle_error> &error )
 {
@@ -407,7 +407,7 @@ sol::table snapshot_live_vehicle(
 
 sol::table get_live_vehicle(
     sol::this_state lua, const game_handle &handle,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -545,7 +545,7 @@ sol::table snapshot_live_part(
 sol::table list_live_parts(
     sol::this_state lua, const game_handle &handle,
     const sol::optional<sol::table> &requested,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const part_options options =
@@ -604,7 +604,7 @@ sol::table list_live_parts(
 
 sol::table list_vehicle_fuels(
     sol::this_state lua, const game_handle &handle,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -685,7 +685,7 @@ void validate_vehicle_name( const std::string &name )
 sol::table rename_vehicle(
     sol::this_state lua, const game_handle &handle,
     const std::string &requested_name,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     validate_vehicle_name( requested_name );
@@ -710,7 +710,7 @@ sol::table rename_vehicle(
 sol::table set_cruise_velocity(
     sol::this_state lua, const game_handle &handle,
     const int requested_velocity,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     if( requested_velocity < -maximum_requested_velocity ||
@@ -801,7 +801,7 @@ stop_options read_stop_options(
 sol::table stop_vehicle(
     sol::this_state lua, const game_handle &handle,
     const sol::optional<sol::table> &requested,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const stop_options options =
@@ -844,7 +844,7 @@ sol::table stop_vehicle(
 sol::table set_vehicle_tracking(
     sol::this_state lua, const game_handle &handle,
     const bool enabled,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -871,7 +871,7 @@ sol::table set_vehicle_tracking(
 sol::table set_vehicle_part_enabled(
     sol::this_state lua, const game_handle &handle,
     const int part_index, const bool enabled,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -952,7 +952,7 @@ sol::table set_vehicle_part_enabled(
 
 void install_vehicle_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write )

--- a/src/catalua_ui_vehicles.h
+++ b/src/catalua_ui_vehicles.h
@@ -10,10 +10,12 @@
 namespace cata::lua_ui
 {
 
+class game_handle_runtime;
+
 // Install native vehicle definitions and generation-safe live services.
 void install_vehicle_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write );

--- a/src/catalua_ui_vitamins.cpp
+++ b/src/catalua_ui_vitamins.cpp
@@ -225,7 +225,7 @@ sol::table get_definition(
 }
 
 Character *resolve_character(
-    const game_handle &handle, const std::size_t runtime_generation,
+    const game_handle &handle, const game_handle_runtime &runtime_generation,
     const std::size_t world_generation,
     std::optional<game_handle_error> &error )
 {
@@ -317,7 +317,7 @@ std::vector<const vitamin *> sorted_vitamins()
 sol::table list_states(
     sol::this_state lua, const game_handle &handle,
     const sol::optional<sol::table> &requested,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const state_list_options options =
@@ -358,7 +358,7 @@ sol::table list_states(
 sol::table get_state(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_vitamin_id(
@@ -382,7 +382,7 @@ sol::table get_state(
 sol::table set_state(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id, const int requested_amount,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_vitamin_id(
@@ -421,7 +421,7 @@ sol::table set_state(
 sol::table modify_state(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id, const int requested_delta,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_vitamin_id(
@@ -463,7 +463,7 @@ sol::table modify_state(
 sol::table reset_daily_state(
     sol::this_state lua, const game_handle &handle,
     const script_game_id &requested_id,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     require_vitamin_id(
@@ -494,7 +494,7 @@ sol::table reset_daily_state(
 
 void install_vitamin_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write )

--- a/src/catalua_ui_vitamins.h
+++ b/src/catalua_ui_vitamins.h
@@ -10,10 +10,12 @@
 namespace cata::lua_ui
 {
 
+class game_handle_runtime;
+
 // Install native vitamin definition and character pool services.
 void install_vitamin_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write );

--- a/src/catalua_ui_world.cpp
+++ b/src/catalua_ui_world.cpp
@@ -316,7 +316,7 @@ vehicle_options read_vehicle_options(
 
 game_handle make_map_item_handle(
     item &entry, const tripoint_abs_ms &position,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     game_handle_locator locator;
@@ -332,7 +332,7 @@ game_handle make_map_item_handle(
 
 game_handle make_vehicle_handle(
     vehicle &entry, const tripoint_abs_ms &position,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     game_handle_locator locator;
@@ -396,7 +396,7 @@ sol::table snapshot_fields(
 sol::table snapshot_items(
     sol::state_view lua, map_stack entries,
     const tripoint_abs_ms &position, const int limit,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const std::size_t total = entries.size();
@@ -438,7 +438,7 @@ sol::table snapshot_items(
 sol::table snapshot_vehicle_at(
     sol::state_view lua, map &here,
     const tripoint_bub_ms &position,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::table result = lua.create_table();
@@ -480,7 +480,7 @@ sol::table snapshot_tile(
     sol::state_view lua, map &here,
     const tripoint_bub_ms &position,
     const tile_options &options,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const tripoint_abs_ms absolute =
@@ -581,7 +581,7 @@ sol::table world_tile(
     sol::this_state lua,
     const script_tripoint_coord &position,
     const sol::optional<sol::table> &requested_options,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     map &here = get_map();
@@ -600,7 +600,7 @@ sol::table world_region(
     sol::this_state lua,
     const script_tripoint_coord &center,
     const sol::optional<sol::table> &requested_options,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     map &here = get_map();
@@ -665,7 +665,7 @@ sol::table world_region(
 sol::table world_vehicles(
     sol::this_state lua,
     const sol::optional<sol::table> &requested_options,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const vehicle_options options =
@@ -978,7 +978,7 @@ sol::table spawn_item(
     const script_tripoint_coord &position,
     const script_game_id &requested,
     const std::int64_t quantity,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     constexpr std::string_view api_name =
@@ -1057,7 +1057,7 @@ sol::table remove_item(
     sol::this_state lua,
     const script_tripoint_coord &position,
     const game_handle &handle,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     constexpr std::string_view api_name =
@@ -1105,7 +1105,7 @@ sol::table remove_item(
 
 void install_world_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write )

--- a/src/catalua_ui_world.h
+++ b/src/catalua_ui_world.h
@@ -10,12 +10,14 @@
 namespace cata::lua_ui
 {
 
+class game_handle_runtime;
+
 // Install bounded active-map observation and mutation APIs.  Map, item and
 // vehicle pointers never cross into Lua; live objects use generation-bound
 // GameHandle values and all coordinates are explicitly typed.
 void install_world_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write );

--- a/src/catalua_ui_world_services.cpp
+++ b/src/catalua_ui_world_services.cpp
@@ -122,7 +122,7 @@ std::string creature_scope( const Creature &creature )
 
 game_handle make_creature_handle(
     Creature &creature,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const tripoint_abs_ms position = creature.pos_abs();
@@ -153,7 +153,7 @@ sol::table spawn_monster(
     sol::this_state lua, const script_game_id &requested_type,
     const script_tripoint_coord &requested_position,
     const sol::optional<int> &requested_radius,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     constexpr std::string_view api_name = "game.spawns.monster";
@@ -253,7 +253,7 @@ sol::table spawn_hallucination(
     sol::this_state lua,
     const script_tripoint_coord &requested_position,
     const sol::optional<sol::table> &requested_options,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     constexpr std::string_view api_name =
@@ -293,7 +293,7 @@ sol::table spawn_hallucination(
 
 npc *resolve_npc(
     const game_handle &handle,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation,
     std::optional<game_handle_error> &error )
 {
@@ -317,7 +317,7 @@ npc *resolve_npc(
 sol::table follower_mutation(
     sol::this_state lua, const game_handle &handle,
     const bool add,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -359,7 +359,7 @@ sol::table follower_mutation(
 
 sol::table follower_list(
     sol::this_state lua,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -525,7 +525,7 @@ sol::table relocate_overmap(
 
 void install_game_world_service_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write,

--- a/src/catalua_ui_world_services.h
+++ b/src/catalua_ui_world_services.h
@@ -10,12 +10,14 @@
 namespace cata::lua_ui
 {
 
+class game_handle_runtime;
+
 // Install generation-bound spawning, follower, and avatar relocation
 // services.  Mutations require game.write and an active callback.  Relocation
 // additionally requires game.actions.dangerous.
 void install_game_world_service_api(
     sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write,

--- a/src/catalua_ui_zones.cpp
+++ b/src/catalua_ui_zones.cpp
@@ -6,6 +6,7 @@
 #include <cctype>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -37,7 +38,7 @@ constexpr std::int64_t maximum_zone_axis_length = 256;
 constexpr std::int64_t maximum_zone_volume = 65536;
 
 struct script_zone_token {
-    std::size_t runtime_generation = 0;
+    game_handle_runtime runtime;
     std::size_t world_generation = 0;
     std::string faction;
     std::string type;
@@ -47,7 +48,7 @@ struct script_zone_token {
     tripoint_rel_ms personal_start = tripoint_rel_ms::zero;
     tripoint_rel_ms personal_end = tripoint_rel_ms::zero;
     bool personal = false;
-    std::size_t ordinal = 0;
+    std::weak_ptr<const void> lifetime_identity;
 };
 
 std::string lowercase_ascii( std::string value )
@@ -188,17 +189,29 @@ bool token_matches_zone(
            token.end;
 }
 
+bool token_owns_zone(
+    const script_zone_token &token,
+    const zone_data &entry )
+{
+    const std::weak_ptr<const void> identity =
+        entry.get_lifetime_identity();
+    return !token.lifetime_identity.owner_before(
+               identity ) &&
+           !identity.owner_before(
+               token.lifetime_identity );
+}
+
 zone_data *resolve_zone(
     const script_zone_token &token,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation,
     std::optional<game_handle_error> &error )
 {
-    if( token.runtime_generation !=
-        runtime_generation ) {
+    if( !token.runtime.is_active_match(
+            runtime_generation ) ) {
         error = game_handle_error{
             "stale_runtime",
-            "The ZoneToken belongs to a previous Lua runtime"
+            "The ZoneToken belongs to an inactive or different Lua runtime"
         };
         return nullptr;
     }
@@ -213,16 +226,15 @@ zone_data *resolve_zone(
     std::vector<zone_manager::ref_zone_data> zones =
         zone_manager::get_manager().get_zones(
             faction_id( token.faction ) );
-    std::size_t ordinal = 0;
     for( zone_data &entry : zones ) {
         if( !token_matches_zone(
                 token, entry ) ) {
             continue;
         }
-        if( ordinal == token.ordinal ) {
+        if( token_owns_zone(
+                token, entry ) ) {
             return &entry;
         }
-        ++ordinal;
     }
     error = game_handle_error{
         "not_found",
@@ -233,12 +245,11 @@ zone_data *resolve_zone(
 
 script_zone_token make_zone_token(
     zone_data &entry,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     script_zone_token result;
-    result.runtime_generation =
-        runtime_generation;
+    result.runtime = runtime_generation;
     result.world_generation =
         world_generation;
     result.faction =
@@ -253,23 +264,13 @@ script_zone_token make_zone_token(
         entry.get_end_point();
     result.personal =
         entry.get_is_personal();
+    result.lifetime_identity =
+        entry.get_lifetime_identity();
     if( result.personal ) {
         result.personal_start =
             entry.get_personal_start_point();
         result.personal_end =
             entry.get_personal_end_point();
-    }
-    std::vector<zone_manager::ref_zone_data> zones =
-        zone_manager::get_manager().get_zones(
-            entry.get_faction() );
-    for( zone_data &candidate : zones ) {
-        if( &candidate == &entry ) {
-            break;
-        }
-        if( token_matches_zone(
-                result, candidate ) ) {
-            ++result.ordinal;
-        }
     }
     return result;
 }
@@ -743,7 +744,7 @@ sol::table snapshot_option_descriptions(
 
 sol::table snapshot_zone(
     sol::state_view lua, zone_data &entry,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::table result = lua.create_table();
@@ -800,14 +801,13 @@ sol::table snapshot_zone(
 sol::table create_zone(
     sol::this_state lua,
     const sol::table &requested,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const zone_create_options options =
         read_zone_create_options( requested );
     script_zone_token identity;
-    identity.runtime_generation =
-        runtime_generation;
+    identity.runtime = runtime_generation;
     identity.world_generation =
         world_generation;
     identity.faction =
@@ -946,7 +946,7 @@ sol::table rename_zone(
     sol::this_state lua,
     const script_zone_token &token,
     const std::string &requested_name,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     validate_zone_name(
@@ -996,7 +996,7 @@ sol::table set_zone_enabled(
     sol::this_state lua,
     const script_zone_token &token,
     const bool enabled,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -1045,7 +1045,7 @@ sol::table set_zone_temporary_disabled(
     sol::this_state lua,
     const script_zone_token &token,
     const bool disabled,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -1097,7 +1097,7 @@ sol::table set_zone_position(
     const script_zone_token &token,
     const script_tripoint_coord &requested_start,
     const script_tripoint_coord &requested_end,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -1240,7 +1240,7 @@ sol::table set_zone_position(
 sol::table remove_zone(
     sol::this_state lua,
     const script_zone_token &token,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -1324,7 +1324,7 @@ sol::table list_zone_matches(
     sol::this_state lua,
     const zone_list_options &options,
     const std::optional<tripoint_abs_ms> &position,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const std::vector<zone_match> matches =
@@ -1375,7 +1375,7 @@ sol::table list_zone_matches(
 sol::table list_zones(
     sol::this_state lua,
     const sol::optional<sol::table> &requested,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     return list_zone_matches(
@@ -1391,7 +1391,7 @@ sol::table zones_at(
     sol::this_state lua,
     const script_tripoint_coord &position,
     const sol::optional<sol::table> &requested,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     return list_zone_matches(
@@ -1407,7 +1407,7 @@ sol::table zones_at(
 sol::table get_zone(
     sol::this_state lua,
     const script_zone_token &token,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     sol::state_view state( lua );
@@ -1432,7 +1432,7 @@ sol::table zone_contains(
     sol::this_state lua,
     const script_zone_token &token,
     const script_tripoint_coord &position,
-    const std::size_t runtime_generation,
+    const game_handle_runtime &runtime_generation,
     const std::size_t world_generation )
 {
     const tripoint_abs_ms native_position =
@@ -1459,7 +1459,7 @@ sol::table zone_contains(
 
 void install_zone_api(
     sol::state &lua, sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write )

--- a/src/catalua_ui_zones.h
+++ b/src/catalua_ui_zones.h
@@ -10,10 +10,12 @@
 namespace cata::lua_ui
 {
 
+class game_handle_runtime;
+
 // Install generation-safe native zone catalogs and live zone services.
 void install_zone_api(
     sol::state &lua, sol::table &game,
-    std::function<std::size_t()> current_runtime_generation,
+    std::function<game_handle_runtime()> current_runtime_generation,
     std::function<std::size_t()> current_world_generation,
     std::function<void()> require_read,
     std::function<void()> require_write );

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -1869,6 +1869,7 @@ void zone_data::serialize( JsonOut &json ) const
 
 void zone_data::deserialize( const JsonObject &data )
 {
+    lifetime_identity = std::make_shared<unsigned char>( 0 );
     data.allow_omitted_members();
     data.read( "name", name );
     // handle legacy zone types

--- a/src/clzones.h
+++ b/src/clzones.h
@@ -419,6 +419,11 @@ class zone_data
         tripoint_abs_ms cached_shift;
         shared_ptr_fast<zone_options> options;
         bool is_displayed;
+        // Transient object identity for generation-safe native handles.  Copies
+        // and moves of the same logical zone retain the anchor, while a newly
+        // constructed or deserialized zone receives a distinct identity.
+        std::shared_ptr<const void> lifetime_identity =
+            std::make_shared<unsigned char>( 0 ); // NOLINT(cata-serialize)
 
     public:
         zone_data() {
@@ -549,6 +554,9 @@ class zone_data
         }
         bool get_is_personal() const {
             return is_personal;
+        }
+        std::weak_ptr<const void> get_lifetime_identity() const {
+            return lifetime_identity;
         }
         tripoint_abs_ms get_start_point() const {
             if( is_personal ) {

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -75,6 +75,11 @@ generic_factory<ma_buff> ma_buffs( "martial art buff" );
 generic_factory<attack_vector> attack_vector_factory( "attack vector" );
 } // namespace
 
+generic_factory<weapon_category> &cata::lua_platform::detail::weapon_category_registry()
+{
+    return weapon_category_factory;
+}
+
 generic_factory<attack_vector> &cata::lua_platform::detail::attack_vector_registry()
 {
     return attack_vector_factory;

--- a/src/mod_manager.cpp
+++ b/src/mod_manager.cpp
@@ -353,9 +353,9 @@ void mod_manager::load_lua_platform_mod( const cata_path &root )
         }
     }
 
-    const auto record_rejection = [&]( const std::string &unbounded_reason ) {
+    const auto record_rejection = [&]( const std::string & unbounded_reason ) {
         const std::string reason = bounded_lua_platform_diagnostic( unbounded_reason );
-        DebugLog( D_ERROR, D_MAIN ) << "Rejected Lua-first Mod at " << root << ": " << reason;
+        DebugLog( D_WARNING, D_MAIN ) << "Rejected Lua-first Mod at " << root << ": " << reason;
         if( legacy_mods.size() == 1 ) {
             MOD_INFORMATION &hybrid = *legacy_mods.front();
             // Keep a legacy hybrid usable when its optional Platform entry is
@@ -386,7 +386,8 @@ void mod_manager::load_lua_platform_mod( const cata_path &root )
                                            " (rejected Lua-first candidate)" );
         const size_t default_category = get_mod_list_categories().size() - 1;
         diagnostic.category = { static_cast<int>( default_category ),
-                                get_mod_list_categories()[default_category].second };
+                                get_mod_list_categories()[default_category].second
+                              };
         diagnostic.path = root;
         diagnostic.mod_root_path = root;
         diagnostic.lua_platform_entry = root / "main.lua";
@@ -530,7 +531,8 @@ void mod_manager::load_lua_platform_mod( const cata_path &root )
     mod.name_ = no_translation( definition.name_set ? definition.name : ident_string );
     const size_t default_category = get_mod_list_categories().size() - 1;
     mod.category = { static_cast<int>( default_category ),
-                     get_mod_list_categories()[default_category].second };
+                     get_mod_list_categories()[default_category].second
+                   };
     mod.version = definition.version_set ? definition.version : std::string();
     mod.dependencies = std::move( dependencies );
     mod.core = definition.core_set && definition.core;

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -83,7 +83,7 @@ const mtype_special_attack *cata::lua_platform::detail::monster_attack_registry_
 void cata::lua_platform::detail::monster_attack_registry_set(
     const mtype_special_attack &value )
 {
-    MonsterGenerator::generator().attack_map[value->id] = value;
+    MonsterGenerator::generator().attack_map.insert_or_assign( value->id, value );
 }
 
 void cata::lua_platform::detail::monster_attack_registry_erase( const std::string &id )
@@ -521,8 +521,13 @@ void MonsterGenerator::finalize_mtypes()
     }
 }
 
-void MonsterGenerator::finalize_lua_first_mtype( mtype &mon )
+void MonsterGenerator::finalize_lua_first_mtype_if_ready( mtype &mon,
+        const bool data_is_finalized )
 {
+    if( !data_is_finalized ) {
+        return;
+    }
+
     mon.flags.clear();
     for( const mon_flag_str_id &flag : mon.pre_flags_ ) {
         mon.flags.emplace( flag );

--- a/src/monstergenerator.h
+++ b/src/monstergenerator.h
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "catalua_platform_content.h"
 #include "enum_bitset.h"
 #include "mattack_common.h"
 #include "mtype.h"
@@ -53,15 +54,6 @@ struct species_type {
     static void finalize_all();
 };
 
-namespace cata::lua_platform::detail
-{
-generic_factory<species_type> &species_registry();
-generic_factory<mtype> &monster_type_registry();
-const mtype_special_attack *monster_attack_registry_find( const std::string &id );
-void monster_attack_registry_set( const mtype_special_attack &value );
-void monster_attack_registry_erase( const std::string &id );
-} // namespace cata::lua_platform::detail
-
 class MonsterGenerator
 {
     public:
@@ -83,8 +75,12 @@ class MonsterGenerator
         // combines mtype and species information, sets bitflags
         void finalize_mtypes();
 
-        /** Finalize one freshly constructed Lua-first mtype exactly once. */
-        void finalize_lua_first_mtype( mtype &mon );
+        /**
+         * Finalize one freshly constructed Lua-first mtype when the global
+         * data set was already finalized.  During initial data loading the
+         * normal global monster finalizer owns this work instead.
+         */
+        void finalize_lua_first_mtype_if_ready( mtype &mon, bool data_is_finalized );
 
         /** Rebuild the derived hallucination candidate list after a transaction. */
         void refresh_hallucination_monsters();

--- a/src/subbodypart.cpp
+++ b/src/subbodypart.cpp
@@ -3,6 +3,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "catalua_platform_content.h"
 #include "flexbuffer_json.h"
 #include "generic_factory.h"
 #include "type_id.h"
@@ -116,6 +117,7 @@ void sub_body_part_type::reset()
 void sub_body_part_type::finalize_all()
 {
     sub_body_part_factory.finalize();
+    cata::lua_platform::detail::refresh_sub_body_part_similarity_cache();
 }
 
 void sub_body_part_type::finalize()
@@ -139,4 +141,3 @@ std::vector<sub_bodypart_str_id> sub_body_part_type::get_all_combined_similar_su
 
     return std::vector<sub_bodypart_str_id>();
 }
-#include "catalua_platform_content.h"

--- a/src/weakpoint.cpp
+++ b/src/weakpoint.cpp
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "calendar.h"
+#include "catalua_platform_content.h"
 #include "character.h"
 #include "condition.h"
 #include "creature.h"
@@ -789,4 +790,3 @@ void weakpoints::del_from_set( const weakpoints &set )
         }
     }
 }
-#include "catalua_platform_content.h"

--- a/src/wound.cpp
+++ b/src/wound.cpp
@@ -1,9 +1,13 @@
 #include "wound.h"
 
+#include <algorithm>
+#include <cstddef>
+#include <limits>
 #include <memory>
 #include <set>
 
 #include "bodypart.h"
+#include "catalua_platform_content.h"
 #include "debug.h"
 #include "flexbuffer_json.h"
 #include "generic_factory.h"
@@ -43,10 +47,12 @@ wound::wound( wound_type_id wd ) :
 namespace
 {
 generic_factory<wound_type> wound_type_factory( "wound" );
-
-// we'll store requirement_ids here and wait for requirements to load in, then we can actualize them
-std::multimap<wound_fix_id, std::pair<std::string, int>> reqs_temp_storage;
 } // namespace
+
+generic_factory<wound_type> &cata::lua_platform::detail::wound_type_registry()
+{
+    return wound_type_factory;
+}
 
 void wound_type::load_wounds( const JsonObject &jo, const std::string &src )
 {
@@ -70,6 +76,7 @@ bool string_id<wound_type>::is_valid() const
 void wound_type::reset()
 {
     wound_type_factory.reset();
+    cata::lua_platform::detail::refresh_body_part_wound_cache();
 }
 
 void wound_type::check_consistency()
@@ -90,6 +97,7 @@ const std::vector<wound_type> &wound_type::get_all()
 void wound_type::finalize_all()
 {
     wound_type_factory.finalize();
+    cata::lua_platform::detail::refresh_body_part_wound_cache();
 }
 
 void wound_type::finalize()
@@ -101,6 +109,26 @@ namespace
 {
 generic_factory<wound_fix> wound_fix_factory( "wound_fix" );
 } // namespace
+
+generic_factory<wound_fix> &cata::lua_platform::detail::wound_fix_registry()
+{
+    return wound_fix_factory;
+}
+
+void cata::lua_platform::detail::refresh_wound_fix_links()
+{
+    for( wound_type &wound_def : wound_type_factory.get_all_mod() ) {
+        wound_def.fixes.clear();
+    }
+
+    for( const wound_fix &fix : wound_fix_factory.get_all() ) {
+        for( const wound_type_id &wound_id : fix.wounds_removed ) {
+            if( wound_id.is_valid() ) {
+                const_cast<wound_type &>( *wound_id ).fixes.emplace( fix.id );
+            }
+        }
+    }
+}
 
 void wound_fix::load_wound_fixes( const JsonObject &jo, const std::string &src )
 {
@@ -134,7 +162,7 @@ bool string_id<wound_fix>::is_valid() const
 void wound_fix::reset()
 {
     wound_fix_factory.reset();
-    reqs_temp_storage.clear();
+    cata::lua_platform::detail::refresh_wound_fix_links();
 }
 
 void wound_fix::check_consistency()
@@ -173,14 +201,13 @@ void wound_fix::check() const
 void wound_fix::finalize_all()
 {
     wound_fix_factory.finalize();
+    cata::lua_platform::detail::refresh_wound_fix_links();
 }
 
 void wound_fix::finalize()
 {
-    const auto range = reqs_temp_storage.equal_range( id );
-    for( auto it = range.first; it != range.second; ++it ) {
-        const requirement_id req_id( it->second.first );
-        const int amount = it->second.second;
+    requirements = cata::make_value<requirement_data>();
+    for( const auto &[req_id, amount] : requirement_refs ) {
         if( !req_id.is_valid() ) {
             debugmsg( "wound_fix '%s' has invalid requirement_id '%s'", id.str(), req_id.str() );
             continue;
@@ -188,10 +215,6 @@ void wound_fix::finalize()
         *requirements = *requirements + ( *req_id ) * amount;
     }
     requirements->consolidate();
-    for( const wound_type_id &fid : wounds_removed ) {
-        const_cast<wound_type &>( *fid ).fixes.emplace( id );
-    }
-    requirement_data::finalize();
 }
 
 void wound_limb_score::deserialize( const JsonObject &jo )
@@ -234,19 +257,26 @@ void wound_fix::load( const JsonObject &jo, const std::string_view & )
     }
 
     if( jo.has_array( "requirements" ) ) {
+        requirement_refs.clear();
+        std::size_t inline_requirement_index = 0;
         for( const JsonValue &jv : jo.get_array( "requirements" ) ) {
             if( jv.test_array() ) {
                 // array of 2 elements filled with [requirement_id, count]
                 const JsonArray &req = static_cast<JsonArray>( jv );
-                const std::string req_id = req.get_string( 0 );
+                const requirement_id req_id( req.get_string( 0 ) );
                 const int req_amount = req.get_int( 1 );
-                reqs_temp_storage.emplace( id, std::make_pair( req_id, req_amount ) );
+                requirement_refs.emplace_back( req_id, req_amount );
             } else if( jv.test_object() ) {
                 // defining single requirement inline
                 const JsonObject &req = static_cast<JsonObject>( jv );
-                const requirement_id req_id( "wound_fix_" + id.str() + "_inline_req" );
+                std::string inline_requirement_id = "wound_fix_" + id.str() + "_inline_req";
+                if( inline_requirement_index > 0 ) {
+                    inline_requirement_id += "_" + std::to_string( inline_requirement_index + 1 );
+                }
+                ++inline_requirement_index;
+                const requirement_id req_id( inline_requirement_id );
                 requirement_data::load_requirement( req, req_id );
-                reqs_temp_storage.emplace( id, std::make_pair( req_id.str(), 1 ) );
+                requirement_refs.emplace_back( req_id, 1 );
             } else {
                 debugmsg( "wound_fix '%s' has has invalid requirement element", id.str() );
             }
@@ -340,17 +370,36 @@ void wound::deserialize( const JsonObject &jsin )
 
 float wound::healing_percentage() const
 {
-    return healing_progress / healing_time;
+    if( healing_time <= 0_seconds ) {
+        return healing_progress <= 0_seconds ? 0.0f : 1.0f;
+    }
+    const float progress = healing_progress / healing_time;
+    return std::clamp( progress, 0.0f, 1.0f );
 }
 
 int wound::get_pain() const
 {
-    return pain * ( 1 - healing_percentage() );
+    const double current_pain = static_cast<double>( pain ) *
+                                ( 1.0 - static_cast<double>( healing_percentage() ) );
+    return static_cast<int>( std::clamp(
+                                 current_pain,
+                                 static_cast<double>( std::numeric_limits<int>::min() ),
+                                 static_cast<double>( std::numeric_limits<int>::max() ) ) );
+}
+
+int wound::get_base_pain() const
+{
+    return pain;
 }
 
 time_duration wound::get_healing_time() const
 {
     return healing_time;
+}
+
+time_duration wound::get_healing_progress() const
+{
+    return healing_progress;
 }
 
 bool wound::update_wound( const time_duration time_passed )

--- a/src/wound.h
+++ b/src/wound.h
@@ -18,6 +18,11 @@
 class JsonObject;
 class JsonOut;
 
+namespace cata::lua_platform
+{
+class content_transaction;
+} // namespace cata::lua_platform
+
 enum class bp_type;
 
 struct wound_progress {
@@ -78,6 +83,8 @@ class wound_type
         // list of wounds this wound can lead to
         std::vector<wound_progress> wound_progression;
     private:
+        friend class cata::lua_platform::content_transaction;
+
         translation name_;
         translation description_;
 
@@ -103,12 +110,16 @@ class wound
 
         void serialize( JsonOut &jsout ) const;
         void deserialize( const JsonObject &jsin );
-        // returns the wound healing progress divided by healing time
+        // returns the wound healing progress divided by healing time, clamped to [0, 1]
         float healing_percentage() const;
         // return how much pain this specific wound gives you, reduced depending on how long the wound presented.
         int get_pain() const;
+        // exposes the unadjusted pain assigned when the wound was created
+        int get_base_pain() const;
         // exposes healing_time
         time_duration get_healing_time() const;
+        // exposes the accumulated healing progress
+        time_duration get_healing_progress() const;
         // update the wound healing progress, if it's healed, return true
         bool update_wound( time_duration time_passed );
 
@@ -176,6 +187,8 @@ class wound_fix
     private:
 
         friend class wound;
+        friend class cata::lua_platform::content_transaction;
+        std::vector<std::pair<requirement_id, int>> requirement_refs;
         cata::value_ptr<requirement_data> requirements = cata::make_value<requirement_data>();
 };
 

--- a/tests/catalua_ui_test.cpp
+++ b/tests/catalua_ui_test.cpp
@@ -29,6 +29,7 @@
 #include "catalua_ui_i18n.h"
 #include "catalua_ui_manifest.h"
 #include "catalua_ui_mapgen.h"
+#include "catalua_ui_missions.h"
 #include "catalua_ui_modules.h"
 #include "catalua_ui_navigation.h"
 #include "catalua_ui_navigation_internal.h"
@@ -47,6 +48,7 @@
 #include "construction_group.h"
 #include "crafting_gui.h"
 #include "damage.h"
+#include "debug.h"
 #include "dialogue.h"
 #include "disease.h"
 #include "effect.h"
@@ -62,6 +64,7 @@
 #include "fault.h"
 #include "field_type.h"
 #include "game.h"
+#include "generic_factory.h"
 #include "harvest.h"
 #include "help.h"
 #include "hsv_color.h"
@@ -98,6 +101,7 @@
 #include "overmap_location.h"
 #include "overmapbuffer.h"
 #include "overlay_ordering.h"
+#include "options_helpers.h"
 #include "panels.h"
 #include "path_info.h"
 #include "player_activity.h"
@@ -134,6 +138,7 @@
 #include "weather_gen.h"
 #include "weather_type.h"
 #include "weakpoint.h"
+#include "wound.h"
 #include "worldfactory.h"
 
 #include <algorithm>
@@ -147,6 +152,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <set>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -924,17 +930,18 @@ return ccb.ModDefinition {
     dependencies = { "ccb_platform_self_dependency_test" },
 }
         )lua" );
-        test_mod.refresh();
-        const mod_id rejected( test_mod.root_name() );
-        REQUIRE( rejected.is_valid() );
-        CHECK( rejected->lua_platform_error.find( "itself as a dependency" ) !=
-               std::string::npos );
-    }
+    test_mod.refresh();
+    const mod_id rejected( test_mod.root_name() );
+    REQUIRE( rejected.is_valid() );
+    CHECK( rejected->lua_platform_error.find( "itself as a dependency" ) !=
+           std::string::npos );
+}
 
-    SECTION( "dependency metadata must be a unique dense array" ) {
-        scoped_platform_test_mod sparse( "ccb_platform_sparse_dependencies" );
-        sparse.write( "main.lua", "return true\n" );
-        sparse.write( "mod.lua", R"lua(
+SECTION( "dependency metadata must be a unique dense array" )
+{
+    scoped_platform_test_mod sparse( "ccb_platform_sparse_dependencies" );
+    sparse.write( "main.lua", "return true\n" );
+    sparse.write( "mod.lua", R"lua(
 local ccb = require("ccb")
 return ccb.ModDefinition {
     dependencies = { [1] = "dda", [3] = "aftershock" },
@@ -972,44 +979,47 @@ return ccb.ModDefinition { id = "" }
 local ccb = require("ccb")
 return ccb.ModDefinition { id = "reserved#id" }
         )lua" );
-        empty_id.refresh();
-        REQUIRE( mod_id( empty_id.root_name() ).is_valid() );
-        REQUIRE( mod_id( reserved_id.root_name() ).is_valid() );
-        CHECK_FALSE( mod_id( empty_id.root_name() )->lua_platform_error.empty() );
-        CHECK_FALSE( mod_id( reserved_id.root_name() )->lua_platform_error.empty() );
-    }
+    empty_id.refresh();
+    REQUIRE( mod_id( empty_id.root_name() ).is_valid() );
+    REQUIRE( mod_id( reserved_id.root_name() ).is_valid() );
+    CHECK_FALSE( mod_id( empty_id.root_name() )->lua_platform_error.empty() );
+    CHECK_FALSE( mod_id( reserved_id.root_name() )->lua_platform_error.empty() );
+}
 
-    SECTION( "absolute entries are rejected" ) {
-        scoped_platform_test_mod test_mod( "ccb_platform_absolute_entry_test" );
-        test_mod.write( "mod.lua", R"lua(
+SECTION( "absolute entries are rejected" )
+{
+    scoped_platform_test_mod test_mod( "ccb_platform_absolute_entry_test" );
+    test_mod.write( "mod.lua", R"lua(
 local ccb = require("ccb")
 return ccb.ModDefinition { entry = "/outside.lua" }
         )lua" );
-        test_mod.refresh();
-        REQUIRE( mod_id( test_mod.root_name() ).is_valid() );
-        CHECK( mod_id( test_mod.root_name() )->lua_platform_error.find( "relative path" ) !=
-               std::string::npos );
-    }
+    test_mod.refresh();
+    REQUIRE( mod_id( test_mod.root_name() ).is_valid() );
+    CHECK( mod_id( test_mod.root_name() )->lua_platform_error.find( "relative path" ) !=
+           std::string::npos );
+}
 
-    SECTION( "parent traversal entries are rejected" ) {
-        scoped_platform_test_mod target( "ccb_platform_escape_target" );
-        scoped_platform_test_mod test_mod( "ccb_platform_escape_test" );
-        target.write( "main.lua", "return true\n" );
-        test_mod.write( "mod.lua", R"lua(
+SECTION( "parent traversal entries are rejected" )
+{
+    scoped_platform_test_mod target( "ccb_platform_escape_target" );
+    scoped_platform_test_mod test_mod( "ccb_platform_escape_test" );
+    target.write( "main.lua", "return true\n" );
+    test_mod.write( "mod.lua", R"lua(
 local ccb = require("ccb")
 return ccb.ModDefinition { entry = "../ccb_platform_escape_target/main.lua" }
         )lua" );
-        test_mod.refresh();
-        REQUIRE( mod_id( test_mod.root_name() ).is_valid() );
-        CHECK( mod_id( test_mod.root_name() )->lua_platform_error.find( "escapes" ) !=
-               std::string::npos );
-        CHECK( mod_id( target.root_name() ).is_valid() );
-    }
+    test_mod.refresh();
+    REQUIRE( mod_id( test_mod.root_name() ).is_valid() );
+    CHECK( mod_id( test_mod.root_name() )->lua_platform_error.find( "escapes" ) !=
+           std::string::npos );
+    CHECK( mod_id( target.root_name() ).is_valid() );
+}
 
-    SECTION( "the first deterministically discovered duplicate id wins" ) {
-        scoped_platform_test_mod first( "ccb_platform_duplicate_a" );
-        scoped_platform_test_mod second( "ccb_platform_duplicate_b" );
-        const std::string metadata = R"lua(
+SECTION( "the first deterministically discovered duplicate id wins" )
+{
+    scoped_platform_test_mod first( "ccb_platform_duplicate_a" );
+    scoped_platform_test_mod second( "ccb_platform_duplicate_b" );
+    const std::string metadata = R"lua(
 local ccb = require("ccb")
 return ccb.ModDefinition { id = "ccb_platform_duplicate_test" }
 )lua";
@@ -1166,7 +1176,9 @@ assert(package.loaded.helper == nil)
         second.source( "ccb_platform_runtime_second" )
     };
     std::string error;
-    REQUIRE( cata::lua_platform::prepare_mods( sources, error ) );
+    const bool prepared = cata::lua_platform::prepare_mods( sources, error );
+    INFO( error );
+    REQUIRE( prepared );
     CHECK( error.empty() );
     REQUIRE( cata::lua_platform::apply_prepared_content( error ) );
     REQUIRE( cata::lua_platform::validate_finalized_prepared_content( error ) );
@@ -1219,8 +1231,10 @@ ccb.content.add(recipe)
 )lua" );
 
     std::string error;
-    REQUIRE( cata::lua_platform::prepare_mods(
-                 { test_mod.source( "ccb_platform_native_content" ) }, error ) );
+    const bool prepared = cata::lua_platform::prepare_mods(
+                              { test_mod.source( "ccb_platform_native_content" ) }, error );
+    INFO( error );
+    REQUIRE( prepared );
     CHECK_FALSE( cata::lua_platform::prepared_content_fingerprint().empty() );
     REQUIRE( cata::lua_platform::apply_prepared_content( error ) );
     CHECK( item_controller->has_template( itype_id( "ccb_platform_native_item" ) ) );
@@ -1990,7 +2004,9 @@ ccb.content.add(recipe_group)
     std::string error;
     REQUIRE( cata::lua_platform::prepare_mods(
                  { test_mod.source( "ccb_platform_native_catalogs" ) }, error ) );
-    REQUIRE( cata::lua_platform::apply_prepared_content( error ) );
+    const bool applied = cata::lua_platform::apply_prepared_content( error );
+    INFO( error );
+    REQUIRE( applied );
 
     CHECK( quality_id( "CCB_PLATFORM_TEST_QUALITY" ).is_valid() );
     CHECK( skill_displayType_id( "ccb_platform_test_skill_display" ).is_valid() );
@@ -2411,6 +2427,67 @@ ccb.content.add(behavior)
     cata::lua_platform::shutdown();
 }
 
+TEST_CASE( "lua_first_monster_finalization_waits_for_the_global_data_pass",
+           "[lua][platform][content][monster][finalize]" )
+{
+    override_option monster_speed( "MONSTER_SPEED", "50%" );
+    override_option monster_resilience( "MONSTER_RESILIENCE", "200%" );
+
+    mtype candidate;
+    candidate.id = mtype_id( "mon_ccb_platform_finalize_once" );
+    candidate.hp = 100;
+    candidate.speed = 100;
+
+    MonsterGenerator &generator = MonsterGenerator::generator();
+    generator.finalize_lua_first_mtype_if_ready( candidate, false );
+    CHECK( candidate.hp == 100 );
+    CHECK( candidate.speed == 100 );
+
+    generator.finalize_lua_first_mtype_if_ready( candidate, true );
+    CHECK( candidate.hp == 200 );
+    CHECK( candidate.speed == 50 );
+}
+
+TEST_CASE( "lua_first_body_similarity_caches_survive_the_global_finalize_pass",
+           "[lua][platform][content][bodypart][finalize]" )
+{
+    body_part_type &body = const_cast<body_part_type &>( body_part_arm_l.obj() );
+    const std::optional<bodypart_str_id> previous_body_similarity = body.similar_bodypart;
+    const bodypart_str_id body_peer = body_part_arm_r;
+
+    const sub_bodypart_str_id sub_id( "hand_palm_l" );
+    const sub_bodypart_str_id sub_peer( "hand_palm_r" );
+    REQUIRE( sub_id.is_valid() );
+    REQUIRE( sub_peer.is_valid() );
+    sub_body_part_type &sub = const_cast<sub_body_part_type &>( sub_id.obj() );
+    const std::optional<sub_bodypart_str_id> previous_sub_similarity = sub.similar_bodypart;
+
+    on_out_of_scope restore_similarity( [&]() {
+        body.similar_bodypart = previous_body_similarity;
+        sub.similar_bodypart = previous_sub_similarity;
+        cata::lua_platform::detail::refresh_body_part_similarity_cache();
+        cata::lua_platform::detail::refresh_sub_body_part_similarity_cache();
+    } );
+
+    body.similar_bodypart = body_peer;
+    sub.similar_bodypart = sub_peer;
+    cata::lua_platform::detail::refresh_body_part_similarity_cache();
+    cata::lua_platform::detail::refresh_sub_body_part_similarity_cache();
+
+    // Lua-first insertion refreshes these caches before the normal global
+    // finalization pass.  Re-running the native finalizers must not append the
+    // same relationship a second time.
+    body_part_type::finalize_all();
+    sub_body_part_type::finalize_all();
+
+    const std::vector<bodypart_str_id> body_similar =
+        body.get_all_combined_similar_bodyparts();
+    CHECK( std::count( body_similar.begin(), body_similar.end(), body_peer ) == 1 );
+    const std::vector<sub_bodypart_str_id> sub_similar =
+        sub.get_all_combined_similar_sub_bodyparts();
+    CHECK( std::count( sub_similar.begin(), sub_similar.end(), sub_peer ) == 1 );
+}
+
 TEST_CASE( "lua_first_creature_catalogs_are_native_and_transactional",
            "[lua][platform][content][monster][body]" )
 {
@@ -2600,6 +2677,1349 @@ ccb.content.add(monster)
     CHECK( cata::lua_platform::detail::monster_attack_registry_find(
                "ccb_platform_creature_attack" ) == nullptr );
     CHECK_FALSE( mtype_id( "mon_ccb_platform_creature" ).is_valid() );
+}
+
+TEST_CASE( "lua_first_wound_content_adds_replaces_edits_and_refreshes_derived_state",
+           "[lua][platform][content][wound]" )
+{
+    cata::lua_platform::shutdown();
+    on_out_of_scope reset_platform( []() {
+        cata::lua_platform::shutdown();
+    } );
+    scoped_platform_test_mod provider( "ccb_platform_wound_provider" );
+    scoped_platform_test_mod consumer( "ccb_platform_wound_consumer" );
+    provider.write( "main.lua", R"lua(
+local ccb = require("ccb")
+
+local requirement = ccb.content.Requirement {
+    id = "ccb_platform_wound_provider_requirement",
+    name = "Provider wound requirement",
+}
+requirement:component("rock", 1)
+ccb.content.add(requirement)
+
+local wound = ccb.content.Wound {
+    id = "ccb_platform_layered_wound",
+    name = "Provider wound",
+    plural_name = "Provider wounds",
+    description = "The provider definition.",
+    pain_min = 1,
+    pain_max = 1,
+    healing_min_turns = 10,
+    healing_max_turns = 10,
+    damage_min = 1,
+    damage_max = 2,
+    weight = 2,
+    per_part_limit = 1,
+}
+wound:damage_type("bash")
+wound:require_body_part_type("arm")
+ccb.content.add(wound)
+
+local target = ccb.content.Wound {
+    id = "ccb_platform_provider_wound_target",
+    name = "Provider target wound",
+    plural_name = "Provider target wounds",
+    description = "The provider treatment target.",
+    healing_min_turns = 5,
+    healing_max_turns = 5,
+    damage_min = 1,
+    damage_max = 1,
+}
+target:damage_type("bash")
+target:require_body_part_type("hand")
+ccb.content.add(target)
+
+local fix = ccb.content.WoundFix {
+    id = "ccb_platform_layered_wound_fix",
+    name = "Provider treatment",
+    description = "The provider treatment definition.",
+    success_message = "Provider treatment succeeded.",
+    duration_turns = 10,
+    health_delta = 1,
+}
+fix:removes("ccb_platform_layered_wound")
+fix:adds("ccb_platform_provider_wound_target")
+fix:requires("ccb_platform_wound_provider_requirement", 1)
+ccb.content.add(fix)
+)lua" );
+    consumer.write( "main.lua", R"lua(
+local ccb = require("ccb")
+
+ccb.content.add(ccb.content.SkillDisplay {
+    id = "ccb_platform_wound_skill_display",
+    label = "Wound test skills",
+})
+ccb.content.add(ccb.content.Skill {
+    id = "ccb_platform_wound_skill",
+    name = "Wound testing",
+    description = "Tests same-transaction wound-fix skill references.",
+    display_category = "ccb_platform_wound_skill_display",
+    sort_rank = 30000,
+})
+ccb.content.add(ccb.content.DamageType {
+    id = "ccb_platform_wound_damage_a",
+    name = "Wound test damage A",
+    skill = "ccb_platform_wound_skill",
+    physical = true,
+})
+ccb.content.add(ccb.content.DamageType {
+    id = "ccb_platform_wound_damage_b",
+    name = "Wound test damage B",
+    skill = "ccb_platform_wound_skill",
+    physical = true,
+})
+ccb.content.add(ccb.content.ProficiencyCategory {
+    id = "ccb_platform_wound_proficiency_category",
+    name = "Wound test proficiencies",
+    description = "Same-transaction wound-fix proficiency references.",
+})
+ccb.content.add(ccb.content.Proficiency {
+    id = "ccb_platform_wound_proficiency",
+    name = "Wound treatment testing",
+    description = "A same-transaction wound treatment proficiency.",
+    category = "ccb_platform_wound_proficiency_category",
+    time_to_learn_turns = 100,
+    can_learn = true,
+})
+ccb.content.add(ccb.content.LimbScore {
+    id = "ccb_platform_wound_limb_score",
+    name = "Wound test limb score",
+    affected_by_wounds = true,
+})
+
+local primary_requirement = ccb.content.Requirement {
+    id = "ccb_platform_wound_primary_requirement",
+    name = "Primary wound requirement",
+}
+primary_requirement:component("scrap", 2)
+ccb.content.add(primary_requirement)
+local edited_requirement = ccb.content.Requirement {
+    id = "ccb_platform_wound_edited_requirement",
+    name = "Edited wound requirement",
+}
+edited_requirement:component("rock", 1)
+ccb.content.add(edited_requirement)
+
+local first_target = ccb.content.Wound {
+    id = "ccb_platform_wound_progression_first",
+    name = "First progression target",
+    plural_name = "First progression targets",
+    description = "The first deterministic progression target.",
+    pain_min = 1,
+    pain_max = 1,
+    healing_min_turns = 5,
+    healing_max_turns = 5,
+    damage_min = 1,
+    damage_max = 1,
+}
+first_target:damage_type("ccb_platform_wound_damage_a")
+first_target:require_body_part_type("hand")
+ccb.content.add(first_target)
+local second_target = ccb.content.Wound {
+    id = "ccb_platform_wound_progression_second",
+    name = "Second progression target",
+    plural_name = "Second progression targets",
+    description = "The second deterministic progression target.",
+    pain_min = 1,
+    pain_max = 1,
+    healing_min_turns = 5,
+    healing_max_turns = 5,
+    damage_min = 1,
+    damage_max = 1,
+}
+second_target:damage_type("ccb_platform_wound_damage_b")
+second_target:require_body_part_type("hand")
+ccb.content.add(second_target)
+
+local wound = ccb.content.Wound {
+    id = "ccb_platform_layered_wound",
+    name = "Consumer wound",
+    plural_name = "Consumer wounds",
+    description = "The consumer replacement definition.",
+    pain_min = 6,
+    pain_max = 6,
+    healing_min_turns = 30,
+    healing_max_turns = 30,
+    damage_min = 3,
+    damage_max = 11,
+    weight = 13,
+    per_part_limit = 4,
+}
+wound:damage_type("ccb_platform_wound_damage_a")
+wound:limb_score("ccb_platform_wound_limb_score", 0.35)
+wound:progression("ccb_platform_wound_progression_first", 100)
+wound:require_body_part_type("arm")
+ccb.content.replace(wound)
+
+local edited_wound = ccb.content.edit_wound("ccb_platform_layered_wound")
+edited_wound:damage_type("ccb_platform_wound_damage_b")
+edited_wound:progression("ccb_platform_wound_progression_second", 100)
+ccb.content.edit(edited_wound)
+assert(not pcall(ccb.content.edit_wound, "not_staged_by_this_mod"))
+
+local fix = ccb.content.WoundFix {
+    id = "ccb_platform_layered_wound_fix",
+    name = "Consumer treatment",
+    description = "The consumer replacement treatment.",
+    success_message = "Consumer treatment succeeded.",
+    duration_turns = 45,
+    health_delta = 3,
+}
+fix:skill("ccb_platform_wound_skill", 2)
+fix:proficiency("ccb_platform_wound_proficiency", 0.4, true)
+fix:removes("ccb_platform_layered_wound")
+fix:adds("ccb_platform_wound_progression_first")
+fix:requires("ccb_platform_wound_primary_requirement", 2)
+ccb.content.replace(fix)
+
+local edited_fix = ccb.content.edit_wound_fix("ccb_platform_layered_wound_fix")
+edited_fix:adds("ccb_platform_wound_progression_second")
+edited_fix:requires("ccb_platform_wound_edited_requirement", 3)
+ccb.content.edit(edited_fix)
+assert(not pcall(ccb.content.edit_wound_fix, "not_staged_by_this_mod"))
+)lua" );
+
+    std::string error;
+    REQUIRE( cata::lua_platform::prepare_mods( {
+        provider.source( "ccb_platform_wound_provider" ),
+        consumer.source( "ccb_platform_wound_consumer" )
+    }, error ) );
+    REQUIRE( cata::lua_platform::apply_prepared_content( error ) );
+    REQUIRE( cata::lua_platform::validate_finalized_prepared_content( error ) );
+
+    const wound_type_id wound_id( "ccb_platform_layered_wound" );
+    const wound_type_id provider_target_id( "ccb_platform_provider_wound_target" );
+    const wound_type_id first_target_id( "ccb_platform_wound_progression_first" );
+    const wound_type_id second_target_id( "ccb_platform_wound_progression_second" );
+    const wound_fix_id fix_id( "ccb_platform_layered_wound_fix" );
+    const requirement_id provider_requirement_id(
+        "ccb_platform_wound_provider_requirement" );
+    const requirement_id primary_requirement_id(
+        "ccb_platform_wound_primary_requirement" );
+    const requirement_id edited_requirement_id(
+        "ccb_platform_wound_edited_requirement" );
+    REQUIRE( wound_id.is_valid() );
+    REQUIRE( provider_target_id.is_valid() );
+    REQUIRE( first_target_id.is_valid() );
+    REQUIRE( second_target_id.is_valid() );
+    REQUIRE( fix_id.is_valid() );
+    REQUIRE( skill_id( "ccb_platform_wound_skill" ).is_valid() );
+    REQUIRE( damage_type_id( "ccb_platform_wound_damage_a" ).is_valid() );
+    REQUIRE( damage_type_id( "ccb_platform_wound_damage_b" ).is_valid() );
+    REQUIRE( proficiency_id( "ccb_platform_wound_proficiency" ).is_valid() );
+    REQUIRE( limb_score_id( "ccb_platform_wound_limb_score" ).is_valid() );
+    CHECK( requirement_data::all().count( primary_requirement_id ) == 1 );
+    CHECK( requirement_data::all().count( edited_requirement_id ) == 1 );
+
+    CHECK( wound_id->get_name() == "Consumer wound" );
+    CHECK( wound_id->get_description() == "The consumer replacement definition." );
+    CHECK( wound_id->damage_required == ( std::pair<int, int>{ 3, 11 } ) );
+    CHECK( wound_id->damage_types ==
+           ( std::vector<damage_type_id>{
+        damage_type_id( "ccb_platform_wound_damage_a" ),
+        damage_type_id( "ccb_platform_wound_damage_b" )
+    } ) );
+    CHECK( wound_id->weight == 13 );
+    CHECK( wound_id->get_limit() == 4 );
+    CHECK( wound_id->allowed_on_bodypart( body_part_arm_l ) );
+    CHECK_FALSE( wound_id->allowed_on_bodypart( body_part_hand_l ) );
+    REQUIRE( wound_id->get_limb_scores().size() == 1 );
+    CHECK( wound_id->get_limb_scores().front().score ==
+           limb_score_id( "ccb_platform_wound_limb_score" ) );
+    CHECK( wound_id->get_limb_scores().front().value == Approx( 0.35f ) );
+    REQUIRE( wound_id->wound_progression.size() == 2 );
+    CHECK( wound_id->wound_progression[0].id == first_target_id );
+    CHECK( wound_id->wound_progression[0].chance == 100 );
+    CHECK( wound_id->wound_progression[1].id == second_target_id );
+    CHECK( wound_id->wound_progression[1].chance == 100 );
+
+    wound wound_snapshot( wound_id );
+    CHECK( wound_snapshot.get_base_pain() == 6 );
+    CHECK( wound_snapshot.get_healing_time() == 30_turns );
+    CHECK( wound_snapshot.get_healing_progress() == 0_turns );
+
+    CHECK( fix_id->get_name() == "Consumer treatment" );
+    CHECK( fix_id->get_description() == "The consumer replacement treatment." );
+    CHECK( fix_id->success_msg.translated() == "Consumer treatment succeeded." );
+    CHECK( fix_id->time == 45_turns );
+    CHECK( fix_id->mod_hp == 3 );
+    CHECK( fix_id->skills ==
+           ( std::map<skill_id, int>{ { skill_id( "ccb_platform_wound_skill" ), 2 } } ) );
+    REQUIRE( fix_id->proficiencies.size() == 1 );
+    CHECK( fix_id->proficiencies.front().prof ==
+           proficiency_id( "ccb_platform_wound_proficiency" ) );
+    CHECK( fix_id->proficiencies.front().time_save == Approx( 0.4f ) );
+    CHECK( fix_id->proficiencies.front().is_mandatory );
+    CHECK( fix_id->wounds_removed == ( std::set<wound_type_id>{ wound_id } ) );
+    CHECK( fix_id->wounds_added ==
+           ( std::set<wound_type_id>{ first_target_id, second_target_id } ) );
+    CHECK( wound_id->fixes == ( std::set<wound_fix_id>{ fix_id } ) );
+    CHECK( provider_target_id->fixes.empty() );
+    CHECK( first_target_id->fixes.empty() );
+    CHECK( second_target_id->fixes.empty() );
+
+    const auto component_count = []( const requirement_data &requirements,
+                                     const itype_id &item_id ) {
+        int result = 0;
+        for( const std::vector<item_comp> &group : requirements.get_components() ) {
+            for( const item_comp &component : group ) {
+                if( component.type == item_id ) {
+                    result += component.count;
+                }
+            }
+        }
+        return result;
+    };
+    CHECK( component_count( fix_id->get_requirements(), itype_id( "scrap" ) ) == 4 );
+    CHECK( component_count( fix_id->get_requirements(), itype_id( "rock" ) ) == 3 );
+
+    const auto cached_count = []( const bodypart_str_id &part_id,
+                                  const wound_type_id &candidate_id ) {
+        const body_part_type &part = part_id.obj();
+        return std::count_if( part.potential_wounds.begin(), part.potential_wounds.end(),
+        [&candidate_id]( const std::pair<bp_wounds, int> &entry ) {
+            return entry.first.id == candidate_id;
+        } );
+    };
+    CHECK( cached_count( body_part_arm_l, wound_id ) == 1 );
+    CHECK( cached_count( body_part_hand_l, wound_id ) == 0 );
+    CHECK( cached_count( body_part_hand_l, first_target_id ) == 1 );
+    CHECK( cached_count( body_part_arm_l, first_target_id ) == 0 );
+
+    cata::lua_platform::detail::refresh_wound_fix_links();
+    cata::lua_platform::detail::refresh_wound_fix_links();
+    cata::lua_platform::detail::refresh_body_part_wound_cache();
+    cata::lua_platform::detail::refresh_body_part_wound_cache();
+    CHECK( wound_id->fixes == ( std::set<wound_fix_id>{ fix_id } ) );
+    CHECK( first_target_id->fixes.empty() );
+    CHECK( second_target_id->fixes.empty() );
+    CHECK( cached_count( body_part_arm_l, wound_id ) == 1 );
+    CHECK( cached_count( body_part_hand_l, first_target_id ) == 1 );
+
+    INFO( "wound progression RNG seed: 42424242" );
+    // NOLINTNEXTLINE(cata-determinism)
+    const cata_default_random_engine saved_engine = rng_get_engine();
+    on_out_of_scope restore_rng( [saved_engine]() {
+        rng_get_engine() = saved_engine;
+    } );
+    rng_set_engine_seed( 42424242 );
+    bodypart part( body_part_arm_l );
+    part.add_wound( wound_id );
+    for( int attempt = 0; attempt < 1000 &&
+         !part.has_wound( first_target_id ); ++attempt ) {
+        part.add_or_worsen_wound( wound_id );
+    }
+    REQUIRE( part.has_wound( first_target_id ) );
+    CHECK_FALSE( part.has_wound( second_target_id ) );
+
+    cata::lua_platform::discard_prepared_mods();
+    CHECK_FALSE( wound_id.is_valid() );
+    CHECK_FALSE( provider_target_id.is_valid() );
+    CHECK_FALSE( first_target_id.is_valid() );
+    CHECK_FALSE( second_target_id.is_valid() );
+    CHECK_FALSE( fix_id.is_valid() );
+    CHECK_FALSE( skill_id( "ccb_platform_wound_skill" ).is_valid() );
+    CHECK_FALSE( damage_type_id( "ccb_platform_wound_damage_a" ).is_valid() );
+    CHECK_FALSE( damage_type_id( "ccb_platform_wound_damage_b" ).is_valid() );
+    CHECK_FALSE( proficiency_id( "ccb_platform_wound_proficiency" ).is_valid() );
+    CHECK_FALSE( limb_score_id( "ccb_platform_wound_limb_score" ).is_valid() );
+    CHECK( requirement_data::all().count( provider_requirement_id ) == 0 );
+    CHECK( requirement_data::all().count( primary_requirement_id ) == 0 );
+    CHECK( requirement_data::all().count( edited_requirement_id ) == 0 );
+    CHECK( cached_count( body_part_arm_l, wound_id ) == 0 );
+    CHECK( cached_count( body_part_hand_l, first_target_id ) == 0 );
+    cata::lua_platform::shutdown();
+}
+
+TEST_CASE( "lua_first_wound_content_validates_native_numeric_composition",
+           "[lua][platform][content][wound][validation]" )
+{
+    cata::lua_platform::shutdown();
+    on_out_of_scope reset_platform( []() {
+        cata::lua_platform::shutdown();
+    } );
+
+    const requirement_id existing_requirement_id( "welding_standard" );
+    REQUIRE( requirement_data::all().count( existing_requirement_id ) == 1 );
+    const uint64_t existing_requirement_hash =
+        requirement_data::all().at( existing_requirement_id ).make_hash();
+
+    SECTION( "a same-transaction requirement must remain representable after scaling" ) {
+        scoped_platform_test_mod test_mod( "ccb_wound_staged_requirement_overflow" );
+        test_mod.write( "main.lua", R"lua(
+local ccb = require("ccb")
+
+local requirement = ccb.content.Requirement {
+    id = "ccb_wound_staged_overflow_requirement",
+    name = "Staged overflow requirement",
+}
+requirement:component("rock", 1073741824)
+ccb.content.add(requirement)
+
+local wound = ccb.content.Wound {
+    id = "ccb_wound_staged_overflow_target",
+    name = "Staged overflow wound",
+    plural_name = "Staged overflow wounds",
+    description = "A validation-only treatment target.",
+    healing_min_turns = 1,
+    healing_max_turns = 1,
+    damage_min = 1,
+    damage_max = 1,
+}
+wound:damage_type("bash")
+ccb.content.add(wound)
+
+local fix = ccb.content.WoundFix {
+    id = "ccb_wound_staged_overflow_fix",
+    name = "Staged overflow treatment",
+    description = "Must fail before native integer multiplication.",
+}
+fix:removes("ccb_wound_staged_overflow_target")
+fix:requires("ccb_wound_staged_overflow_requirement", 2)
+ccb.content.add(fix)
+)lua" );
+
+        std::string error;
+        CHECK_FALSE( cata::lua_platform::prepare_mods( {
+            test_mod.source( "ccb_wound_staged_requirement_overflow" )
+        }, error ) );
+        CHECK( error.find( "exceeds the native component/tool count range when scaled" ) !=
+               std::string::npos );
+        CHECK( requirement_data::all().count(
+                   requirement_id( "ccb_wound_staged_overflow_requirement" ) ) == 0 );
+        CHECK_FALSE( wound_type_id( "ccb_wound_staged_overflow_target" ).is_valid() );
+        CHECK_FALSE( wound_fix_id( "ccb_wound_staged_overflow_fix" ).is_valid() );
+    }
+
+    SECTION( "an exact native integer minimum product clamps a negative tool count" ) {
+        scoped_platform_test_mod test_mod( "ccb_wound_tool_integer_minimum" );
+        test_mod.write( "main.lua", R"lua(
+local ccb = require("ccb")
+
+local requirement = ccb.content.Requirement {
+    id = "ccb_wound_tool_integer_minimum_requirement",
+    name = "Native integer minimum tool requirement",
+}
+requirement:tool("rock", 1073741824)
+ccb.content.add(requirement)
+
+local wound = ccb.content.Wound {
+    id = "ccb_wound_tool_integer_minimum_target",
+    name = "Native integer minimum wound",
+    plural_name = "Native integer minimum wounds",
+    description = "A treatment target for exact signed multiplication.",
+    healing_min_turns = 1,
+    healing_max_turns = 1,
+    damage_min = 1,
+    damage_max = 1,
+}
+wound:damage_type("bash")
+ccb.content.add(wound)
+
+local fix = ccb.content.WoundFix {
+    id = "ccb_wound_tool_integer_minimum_fix",
+    name = "Native integer minimum treatment",
+    description = "Safely multiplies to INT_MIN before the native negative-tool clamp.",
+}
+fix:removes("ccb_wound_tool_integer_minimum_target")
+fix:requires("ccb_wound_tool_integer_minimum_requirement", 2)
+ccb.content.add(fix)
+)lua" );
+
+        std::string error;
+        REQUIRE( cata::lua_platform::prepare_mods( {
+            test_mod.source( "ccb_wound_tool_integer_minimum" )
+        }, error ) );
+        REQUIRE( cata::lua_platform::apply_prepared_content( error ) );
+        REQUIRE( cata::lua_platform::validate_finalized_prepared_content( error ) );
+
+        const requirement_id requirement_id_value(
+            "ccb_wound_tool_integer_minimum_requirement" );
+        const wound_fix_id fix_id( "ccb_wound_tool_integer_minimum_fix" );
+        REQUIRE( requirement_data::all().count( requirement_id_value ) == 1 );
+        REQUIRE( fix_id.is_valid() );
+        const requirement_data::alter_tool_comp_vector &tools =
+            fix_id->get_requirements().get_tools();
+        REQUIRE( tools.size() == 1 );
+        REQUIRE( tools.front().size() == 1 );
+        CHECK( tools.front().front().type == itype_id( "rock" ) );
+        CHECK( tools.front().front().count == -1 );
+
+        cata::lua_platform::discard_prepared_mods();
+        CHECK( requirement_data::all().count( requirement_id_value ) == 0 );
+        CHECK_FALSE( fix_id.is_valid() );
+    }
+
+    SECTION( "non-subset alternatives retain independent maximum component counts" ) {
+        scoped_platform_test_mod test_mod( "ccb_wound_non_subset_requirements" );
+        test_mod.write( "main.lua", R"lua(
+local ccb = require("ccb")
+
+local first = ccb.content.Requirement {
+    id = "ccb_wound_non_subset_requirement_a",
+    name = "First non-subset requirement",
+}
+first:component_any({
+    { id = "rock", count = 2147483647 },
+    { id = "scrap", count = 1 },
+})
+ccb.content.add(first)
+
+local second = ccb.content.Requirement {
+    id = "ccb_wound_non_subset_requirement_b",
+    name = "Second non-subset requirement",
+}
+second:component_any({
+    { id = "rock", count = 2147483647 },
+    { id = "stick", count = 1 },
+})
+ccb.content.add(second)
+
+local wound = ccb.content.Wound {
+    id = "ccb_wound_non_subset_target",
+    name = "Non-subset wound",
+    plural_name = "Non-subset wounds",
+    description = "A treatment target for independent alternative groups.",
+    healing_min_turns = 1,
+    healing_max_turns = 1,
+    damage_min = 1,
+    damage_max = 1,
+}
+wound:damage_type("bash")
+ccb.content.add(wound)
+
+local fix = ccb.content.WoundFix {
+    id = "ccb_wound_non_subset_fix",
+    name = "Non-subset treatment",
+    description = "Keeps alternative groups that are not subsets independent.",
+}
+fix:removes("ccb_wound_non_subset_target")
+fix:requires("ccb_wound_non_subset_requirement_a", 1)
+fix:requires("ccb_wound_non_subset_requirement_b", 1)
+ccb.content.add(fix)
+)lua" );
+
+        std::string error;
+        REQUIRE( cata::lua_platform::prepare_mods( {
+            test_mod.source( "ccb_wound_non_subset_requirements" )
+        }, error ) );
+        REQUIRE( cata::lua_platform::apply_prepared_content( error ) );
+        REQUIRE( cata::lua_platform::validate_finalized_prepared_content( error ) );
+
+        const wound_fix_id fix_id( "ccb_wound_non_subset_fix" );
+        REQUIRE( fix_id.is_valid() );
+        const requirement_data::alter_item_comp_vector &components =
+            fix_id->get_requirements().get_components();
+        REQUIRE( components.size() == 2 );
+        int maximum_rock_groups = 0;
+        std::set<std::string> companions;
+        for( const std::vector<item_comp> &group : components ) {
+            CHECK( group.size() == 2 );
+            bool has_maximum_rock = false;
+            for( const item_comp &component : group ) {
+                if( component.type == itype_id( "rock" ) ) {
+                    has_maximum_rock =
+                        component.count == std::numeric_limits<int>::max();
+                } else {
+                    companions.insert( component.type.str() );
+                }
+            }
+            if( has_maximum_rock ) {
+                ++maximum_rock_groups;
+            }
+        }
+        CHECK( maximum_rock_groups == 2 );
+        CHECK( companions == ( std::set<std::string>{ "scrap", "stick" } ) );
+
+        cata::lua_platform::discard_prepared_mods();
+        CHECK_FALSE( fix_id.is_valid() );
+        CHECK( requirement_data::all().count(
+                   requirement_id( "ccb_wound_non_subset_requirement_a" ) ) == 0 );
+        CHECK( requirement_data::all().count(
+                   requirement_id( "ccb_wound_non_subset_requirement_b" ) ) == 0 );
+    }
+
+    SECTION( "components merged from separate requirements must remain representable" ) {
+        scoped_platform_test_mod test_mod( "ccb_wound_component_consolidation_overflow" );
+        test_mod.write( "main.lua", R"lua(
+local ccb = require("ccb")
+
+local function add_requirement(id)
+    local requirement = ccb.content.Requirement {
+        id = id,
+        name = id,
+    }
+    requirement:component("rock", 2147483647)
+    ccb.content.add(requirement)
+end
+add_requirement("ccb_wound_component_overflow_a")
+add_requirement("ccb_wound_component_overflow_b")
+
+local wound = ccb.content.Wound {
+    id = "ccb_wound_component_overflow_target",
+    name = "Component consolidation wound",
+    plural_name = "Component consolidation wounds",
+    description = "A validation-only treatment target.",
+    healing_min_turns = 1,
+    healing_max_turns = 1,
+    damage_min = 1,
+    damage_max = 1,
+}
+wound:damage_type("bash")
+ccb.content.add(wound)
+
+local fix = ccb.content.WoundFix {
+    id = "ccb_wound_component_overflow_fix",
+    name = "Component consolidation treatment",
+    description = "Must fail before native requirement consolidation.",
+}
+fix:removes("ccb_wound_component_overflow_target")
+fix:requires("ccb_wound_component_overflow_a", 1)
+fix:requires("ccb_wound_component_overflow_b", 1)
+ccb.content.add(fix)
+)lua" );
+
+        std::string error;
+        CHECK_FALSE( cata::lua_platform::prepare_mods( {
+            test_mod.source( "ccb_wound_component_consolidation_overflow" )
+        }, error ) );
+        CHECK( error.find( "during consolidation" ) != std::string::npos );
+        CHECK( requirement_data::all().count(
+                   requirement_id( "ccb_wound_component_overflow_a" ) ) == 0 );
+        CHECK( requirement_data::all().count(
+                   requirement_id( "ccb_wound_component_overflow_b" ) ) == 0 );
+        CHECK_FALSE( wound_type_id( "ccb_wound_component_overflow_target" ).is_valid() );
+        CHECK_FALSE( wound_fix_id( "ccb_wound_component_overflow_fix" ).is_valid() );
+    }
+
+    SECTION( "positive tool charges merged from separate requirements must remain representable" ) {
+        scoped_platform_test_mod test_mod( "ccb_wound_tool_consolidation_overflow" );
+        test_mod.write( "main.lua", R"lua(
+local ccb = require("ccb")
+
+local function add_requirement(id)
+    local requirement = ccb.content.Requirement {
+        id = id,
+        name = id,
+    }
+    requirement:tool_charges("rock", 2147483647)
+    ccb.content.add(requirement)
+end
+add_requirement("ccb_wound_tool_overflow_a")
+add_requirement("ccb_wound_tool_overflow_b")
+
+local wound = ccb.content.Wound {
+    id = "ccb_wound_tool_overflow_target",
+    name = "Tool consolidation wound",
+    plural_name = "Tool consolidation wounds",
+    description = "A validation-only treatment target.",
+    healing_min_turns = 1,
+    healing_max_turns = 1,
+    damage_min = 1,
+    damage_max = 1,
+}
+wound:damage_type("bash")
+ccb.content.add(wound)
+
+local fix = ccb.content.WoundFix {
+    id = "ccb_wound_tool_overflow_fix",
+    name = "Tool consolidation treatment",
+    description = "Must fail before native tool-charge consolidation.",
+}
+fix:removes("ccb_wound_tool_overflow_target")
+fix:requires("ccb_wound_tool_overflow_a", 1)
+fix:requires("ccb_wound_tool_overflow_b", 1)
+ccb.content.add(fix)
+)lua" );
+
+        std::string error;
+        CHECK_FALSE( cata::lua_platform::prepare_mods( {
+            test_mod.source( "ccb_wound_tool_consolidation_overflow" )
+        }, error ) );
+        CHECK( error.find( "during consolidation" ) != std::string::npos );
+        CHECK( requirement_data::all().count(
+                   requirement_id( "ccb_wound_tool_overflow_a" ) ) == 0 );
+        CHECK( requirement_data::all().count(
+                   requirement_id( "ccb_wound_tool_overflow_b" ) ) == 0 );
+        CHECK_FALSE( wound_type_id( "ccb_wound_tool_overflow_target" ).is_valid() );
+        CHECK_FALSE( wound_fix_id( "ccb_wound_tool_overflow_fix" ).is_valid() );
+    }
+
+    SECTION( "mergeable groups inside one requirement must remain representable" ) {
+        scoped_platform_test_mod test_mod( "ccb_wound_internal_consolidation_overflow" );
+        test_mod.write( "main.lua", R"lua(
+local ccb = require("ccb")
+
+local requirement = ccb.content.Requirement {
+    id = "ccb_wound_internal_overflow_requirement",
+    name = "Internal consolidation overflow requirement",
+}
+requirement:component("rock", 2147483647)
+requirement:component("rock", 1)
+ccb.content.add(requirement)
+
+local wound = ccb.content.Wound {
+    id = "ccb_wound_internal_overflow_target",
+    name = "Internal consolidation wound",
+    plural_name = "Internal consolidation wounds",
+    description = "A validation-only treatment target.",
+    healing_min_turns = 1,
+    healing_max_turns = 1,
+    damage_min = 1,
+    damage_max = 1,
+}
+wound:damage_type("bash")
+ccb.content.add(wound)
+
+local fix = ccb.content.WoundFix {
+    id = "ccb_wound_internal_overflow_fix",
+    name = "Internal consolidation treatment",
+    description = "Must fail before consolidating one requirement's groups.",
+}
+fix:removes("ccb_wound_internal_overflow_target")
+fix:requires("ccb_wound_internal_overflow_requirement", 1)
+ccb.content.add(fix)
+)lua" );
+
+        std::string error;
+        CHECK_FALSE( cata::lua_platform::prepare_mods( {
+            test_mod.source( "ccb_wound_internal_consolidation_overflow" )
+        }, error ) );
+        CHECK( error.find( "during consolidation" ) != std::string::npos );
+        CHECK( requirement_data::all().count(
+                   requirement_id( "ccb_wound_internal_overflow_requirement" ) ) == 0 );
+        CHECK_FALSE( wound_type_id( "ccb_wound_internal_overflow_target" ).is_valid() );
+        CHECK_FALSE( wound_fix_id( "ccb_wound_internal_overflow_fix" ).is_valid() );
+    }
+
+    SECTION( "an existing requirement must remain representable after scaling" ) {
+        scoped_platform_test_mod test_mod( "ccb_wound_existing_requirement_overflow" );
+        test_mod.write( "main.lua", R"lua(
+local ccb = require("ccb")
+
+local wound = ccb.content.Wound {
+    id = "ccb_wound_existing_overflow_target",
+    name = "Existing overflow wound",
+    plural_name = "Existing overflow wounds",
+    description = "A validation-only treatment target.",
+    healing_min_turns = 1,
+    healing_max_turns = 1,
+    damage_min = 1,
+    damage_max = 1,
+}
+wound:damage_type("bash")
+ccb.content.add(wound)
+
+local fix = ccb.content.WoundFix {
+    id = "ccb_wound_existing_overflow_fix",
+    name = "Existing overflow treatment",
+    description = "Must fail before native integer multiplication.",
+}
+fix:removes("ccb_wound_existing_overflow_target")
+fix:requires("welding_standard", 2147483647)
+ccb.content.add(fix)
+)lua" );
+
+        std::string error;
+        CHECK_FALSE( cata::lua_platform::prepare_mods( {
+            test_mod.source( "ccb_wound_existing_requirement_overflow" )
+        }, error ) );
+        CHECK( error.find( "exceeds the native component/tool count range when scaled" ) !=
+               std::string::npos );
+        REQUIRE( requirement_data::all().count( existing_requirement_id ) == 1 );
+        CHECK( requirement_data::all().at( existing_requirement_id ).make_hash() ==
+               existing_requirement_hash );
+        CHECK_FALSE( wound_type_id( "ccb_wound_existing_overflow_target" ).is_valid() );
+        CHECK_FALSE( wound_fix_id( "ccb_wound_existing_overflow_fix" ).is_valid() );
+    }
+
+    SECTION( "a positive proficiency multiplier must remain positive as a native float" ) {
+        scoped_platform_test_mod test_mod( "ccb_wound_proficiency_underflow" );
+        test_mod.write( "main.lua", R"lua(
+local ccb = require("ccb")
+
+local wound = ccb.content.Wound {
+    id = "ccb_wound_proficiency_underflow_target",
+    name = "Proficiency underflow wound",
+    plural_name = "Proficiency underflow wounds",
+    description = "A validation-only treatment target.",
+    healing_min_turns = 1,
+    healing_max_turns = 1,
+    damage_min = 1,
+    damage_max = 1,
+}
+wound:damage_type("bash")
+ccb.content.add(wound)
+
+local fix = ccb.content.WoundFix {
+    id = "ccb_wound_proficiency_underflow_fix",
+    name = "Proficiency underflow treatment",
+    description = "Must reject a native zero time multiplier.",
+}
+fix:proficiency("prof_knapping", 1e-100, false)
+fix:removes("ccb_wound_proficiency_underflow_target")
+ccb.content.add(fix)
+)lua" );
+
+        std::string error;
+        CHECK_FALSE( cata::lua_platform::prepare_mods( {
+            test_mod.source( "ccb_wound_proficiency_underflow" )
+        }, error ) );
+        CHECK( error.find( "positive finite multiplier" ) != std::string::npos );
+        CHECK_FALSE( wound_type_id( "ccb_wound_proficiency_underflow_target" ).is_valid() );
+        CHECK_FALSE( wound_fix_id( "ccb_wound_proficiency_underflow_fix" ).is_valid() );
+    }
+}
+
+TEST_CASE( "wound_pain_preserves_the_native_integer_maximum_at_zero_progress",
+           "[wound][lua][platform][content]" )
+{
+    cata::lua_platform::shutdown();
+    on_out_of_scope reset_platform( []() {
+        cata::lua_platform::shutdown();
+    } );
+    scoped_platform_test_mod test_mod( "ccb_wound_maximum_pain" );
+    test_mod.write( "main.lua", R"lua(
+local ccb = require("ccb")
+local wound = ccb.content.Wound {
+    id = "ccb_wound_maximum_pain",
+    name = "Maximum pain wound",
+    plural_name = "Maximum pain wounds",
+    description = "Exercises native integer pain without float rounding.",
+    pain_min = 2147483647,
+    pain_max = 2147483647,
+    healing_min_turns = 1,
+    healing_max_turns = 1,
+    damage_min = 1,
+    damage_max = 1,
+}
+wound:damage_type("bash")
+ccb.content.add(wound)
+)lua" );
+
+    std::string error;
+    REQUIRE( cata::lua_platform::prepare_mods( {
+        test_mod.source( "ccb_wound_maximum_pain" )
+    }, error ) );
+    REQUIRE( cata::lua_platform::apply_prepared_content( error ) );
+    REQUIRE( cata::lua_platform::validate_finalized_prepared_content( error ) );
+
+    const wound_type_id type( "ccb_wound_maximum_pain" );
+    REQUIRE( type.is_valid() );
+    wound current( type );
+    CHECK( current.get_base_pain() == std::numeric_limits<int>::max() );
+    CHECK( current.get_healing_progress() == 0_turns );
+    CHECK( current.get_pain() == std::numeric_limits<int>::max() );
+
+    cata::lua_platform::discard_prepared_mods();
+    CHECK_FALSE( type.is_valid() );
+}
+
+TEST_CASE( "lua_first_wound_content_fingerprint_tracks_every_public_input",
+           "[lua][platform][content][wound][fingerprint]" )
+{
+    cata::lua_platform::shutdown();
+    on_out_of_scope reset_platform( []() {
+        cata::lua_platform::shutdown();
+    } );
+    scoped_platform_test_mod test_mod( "ccb_platform_wound_fingerprint" );
+    const auto source_for = []( const std::string &changed_field ) {
+        std::string source = R"lua(
+local ccb = require("ccb")
+local changed_field = "@@FIELD@@"
+local function pick(field, baseline, changed)
+    if changed_field == field then
+        return changed
+    end
+    return baseline
+end
+
+local function add_flag(id)
+    ccb.content.add(ccb.content.JsonFlag {
+        id = id,
+        name = id,
+        info = "Wound fingerprint flag.",
+    })
+end
+add_flag("CCB_WOUND_FP_REQUIRED_A")
+add_flag("CCB_WOUND_FP_REQUIRED_B")
+add_flag("CCB_WOUND_FP_FORBIDDEN_A")
+add_flag("CCB_WOUND_FP_FORBIDDEN_B")
+
+ccb.content.add(ccb.content.SkillDisplay {
+    id = "ccb_wound_fp_skill_display",
+    label = "Wound fingerprint skills",
+})
+local function add_skill(id, name, rank)
+    ccb.content.add(ccb.content.Skill {
+        id = id,
+        name = name,
+        description = "A WoundFix fingerprint dependency.",
+        display_category = "ccb_wound_fp_skill_display",
+        sort_rank = rank,
+    })
+end
+add_skill("ccb_wound_fp_skill_a", "Wound fingerprint skill A", 31000)
+add_skill("ccb_wound_fp_skill_b", "Wound fingerprint skill B", 31001)
+
+ccb.content.add(ccb.content.ProficiencyCategory {
+    id = "ccb_wound_fp_proficiency_category",
+    name = "Wound fingerprint proficiencies",
+    description = "WoundFix fingerprint dependencies.",
+})
+local function add_proficiency(id, name)
+    ccb.content.add(ccb.content.Proficiency {
+        id = id,
+        name = name,
+        description = "A WoundFix fingerprint proficiency.",
+        category = "ccb_wound_fp_proficiency_category",
+        time_to_learn_turns = 100,
+        can_learn = true,
+    })
+end
+add_proficiency("ccb_wound_fp_proficiency_a", "Wound fingerprint proficiency A")
+add_proficiency("ccb_wound_fp_proficiency_b", "Wound fingerprint proficiency B")
+
+local function add_requirement(id, item)
+    local requirement = ccb.content.Requirement {
+        id = id,
+        name = id,
+    }
+    requirement:component(item, 1)
+    ccb.content.add(requirement)
+end
+add_requirement("ccb_wound_fp_requirement_a", "rock")
+add_requirement("ccb_wound_fp_requirement_b", "scrap")
+
+ccb.content.add(ccb.content.LimbScore {
+    id = "ccb_wound_fp_limb_score_a",
+    name = "Wound fingerprint limb score A",
+    affected_by_wounds = true,
+})
+ccb.content.add(ccb.content.LimbScore {
+    id = "ccb_wound_fp_limb_score_b",
+    name = "Wound fingerprint limb score B",
+    affected_by_wounds = true,
+})
+
+local function add_simple_wound(id)
+    local wound = ccb.content.Wound {
+        id = id,
+        name = id,
+        plural_name = id .. "s",
+        description = "A Wound fingerprint dependency.",
+        healing_min_turns = 1,
+        healing_max_turns = 1,
+        damage_min = 1,
+        damage_max = 1,
+    }
+    wound:damage_type("bash")
+    ccb.content.add(wound)
+end
+add_simple_wound("ccb_wound_fp_progression_a")
+add_simple_wound("ccb_wound_fp_progression_b")
+add_simple_wound("ccb_wound_fp_removed_a")
+add_simple_wound("ccb_wound_fp_removed_b")
+add_simple_wound("ccb_wound_fp_added_a")
+add_simple_wound("ccb_wound_fp_added_b")
+
+local wound = ccb.content.Wound {
+    id = pick("wound.id", "ccb_wound_fp_primary_a", "ccb_wound_fp_primary_b"),
+    name = pick("wound.name", "Fingerprint wound A", "Fingerprint wound B"),
+    plural_name = pick("wound.plural_name", "Fingerprint wounds A", "Fingerprint wounds B"),
+    description = pick("wound.description", "Fingerprint description A", "Fingerprint description B"),
+    pain_min = pick("wound.pain_min", 1, 2),
+    pain_max = pick("wound.pain_max", 5, 6),
+    healing_min_turns = pick("wound.healing_min_turns", 10, 11),
+    healing_max_turns = pick("wound.healing_max_turns", 20, 21),
+    damage_min = pick("wound.damage_min", 2, 3),
+    damage_max = pick("wound.damage_max", 8, 9),
+    weight = pick("wound.weight", 3, 4),
+    per_part_limit = pick("wound.per_part_limit", 1, 2),
+    required_body_part_flag = pick("wound.required_body_part_flag",
+                                   "CCB_WOUND_FP_REQUIRED_A", "CCB_WOUND_FP_REQUIRED_B"),
+    forbidden_body_part_flag = pick("wound.forbidden_body_part_flag",
+                                    "CCB_WOUND_FP_FORBIDDEN_A", "CCB_WOUND_FP_FORBIDDEN_B"),
+}
+wound:damage_type(pick("wound.damage_type.id", "bash", "cut"))
+wound:limb_score(pick("wound.limb_score.id", "ccb_wound_fp_limb_score_a",
+                      "ccb_wound_fp_limb_score_b"),
+                 pick("wound.limb_score.penalty", 0.2, 0.3))
+wound:progression(pick("wound.progression.id", "ccb_wound_fp_progression_a",
+                       "ccb_wound_fp_progression_b"),
+                  pick("wound.progression.chance", 40, 41))
+wound:require_body_part_type(pick("wound.require_body_part_type", "arm", "leg"))
+wound:forbid_body_part_type(pick("wound.forbid_body_part_type", "hand", "foot"))
+ccb.content.add(wound)
+
+local fix = ccb.content.WoundFix {
+    id = pick("fix.id", "ccb_wound_fp_fix_a", "ccb_wound_fp_fix_b"),
+    name = pick("fix.name", "Fingerprint fix A", "Fingerprint fix B"),
+    description = pick("fix.description", "Fingerprint fix description A",
+                       "Fingerprint fix description B"),
+    success_message = pick("fix.success_message", "Fingerprint success A",
+                           "Fingerprint success B"),
+    duration_turns = pick("fix.duration_turns", 30, 31),
+    health_delta = pick("fix.health_delta", 2, 3),
+}
+fix:skill(pick("fix.skill.id", "ccb_wound_fp_skill_a", "ccb_wound_fp_skill_b"),
+          pick("fix.skill.level", 1, 2))
+fix:proficiency(pick("fix.proficiency.id", "ccb_wound_fp_proficiency_a",
+                     "ccb_wound_fp_proficiency_b"),
+                pick("fix.proficiency.multiplier", 0.4, 0.5),
+                pick("fix.proficiency.mandatory", false, true))
+fix:removes(pick("fix.removes.id", "ccb_wound_fp_removed_a", "ccb_wound_fp_removed_b"))
+fix:adds(pick("fix.adds.id", "ccb_wound_fp_added_a", "ccb_wound_fp_added_b"))
+fix:requires(pick("fix.requires.id", "ccb_wound_fp_requirement_a",
+                  "ccb_wound_fp_requirement_b"),
+             pick("fix.requires.count", 2, 3))
+ccb.content.add(fix)
+)lua";
+        const std::string marker = "@@FIELD@@";
+        source.replace( source.find( marker ), marker.size(), changed_field );
+        return source;
+    };
+    const auto fingerprint_for = [&test_mod, &source_for]( const std::string &field ) {
+        test_mod.write( "main.lua", source_for( field ) );
+        std::string error;
+        const bool prepared = cata::lua_platform::prepare_mods(
+                                  { test_mod.source( "ccb_platform_wound_fingerprint" ) }, error );
+        INFO( error );
+        REQUIRE( prepared );
+        const std::string fingerprint =
+            cata::lua_platform::prepared_content_fingerprint();
+        REQUIRE_FALSE( fingerprint.empty() );
+        cata::lua_platform::discard_prepared_mods();
+        return fingerprint;
+    };
+
+    const std::string baseline = fingerprint_for( "" );
+    const std::vector<std::string> fields = {
+        "wound.id",
+        "wound.name",
+        "wound.plural_name",
+        "wound.description",
+        "wound.pain_min",
+        "wound.pain_max",
+        "wound.healing_min_turns",
+        "wound.healing_max_turns",
+        "wound.damage_min",
+        "wound.damage_max",
+        "wound.weight",
+        "wound.per_part_limit",
+        "wound.required_body_part_flag",
+        "wound.forbidden_body_part_flag",
+        "wound.damage_type.id",
+        "wound.limb_score.id",
+        "wound.limb_score.penalty",
+        "wound.progression.id",
+        "wound.progression.chance",
+        "wound.require_body_part_type",
+        "wound.forbid_body_part_type",
+        "fix.id",
+        "fix.name",
+        "fix.description",
+        "fix.success_message",
+        "fix.duration_turns",
+        "fix.health_delta",
+        "fix.skill.id",
+        "fix.skill.level",
+        "fix.proficiency.id",
+        "fix.proficiency.multiplier",
+        "fix.proficiency.mandatory",
+        "fix.removes.id",
+        "fix.adds.id",
+        "fix.requires.id",
+        "fix.requires.count",
+    };
+    for( const std::string &field : fields ) {
+        CAPTURE( field );
+        const std::string fingerprint = fingerprint_for( field );
+        CHECK( fingerprint != baseline );
+    }
+}
+
+TEST_CASE( "lua_first_wound_content_rolls_back_apply_and_finalized_failures",
+           "[lua][platform][content][wound][rollback]" )
+{
+    cata::lua_platform::shutdown();
+    const requirement_id rollback_requirement_id( "ccb_wound_rollback_requirement" );
+    const wound_type_id wound_id( "ccb_wound_rollback_baseline" );
+    const wound_type_id target_id( "ccb_wound_rollback_target" );
+    const wound_fix_id fix_id( "ccb_wound_rollback_fix" );
+    const wound_type_id transient_wound_id( "ccb_wound_rollback_transient" );
+    const wound_fix_id transient_fix_id( "ccb_wound_rollback_transient_fix" );
+    auto &all_requirements = const_cast<
+                             std::map<requirement_id, requirement_data> &>(
+                                 requirement_data::all() );
+    REQUIRE( all_requirements.count( rollback_requirement_id ) == 0 );
+    on_out_of_scope cleanup( [=, &all_requirements]() {
+        cata::lua_platform::shutdown();
+        cata::lua_platform::detail::wound_fix_registry().erase( transient_fix_id );
+        cata::lua_platform::detail::wound_fix_registry().erase( fix_id );
+        all_requirements.erase( rollback_requirement_id );
+        cata::lua_platform::detail::wound_type_registry().erase( transient_wound_id );
+        cata::lua_platform::detail::wound_type_registry().erase( wound_id );
+        cata::lua_platform::detail::wound_type_registry().erase( target_id );
+        cata::lua_platform::detail::refresh_wound_fix_links();
+        cata::lua_platform::detail::refresh_body_part_wound_cache();
+    } );
+
+    const auto component_count = []( const requirement_data &requirements,
+                                     const itype_id &item_id ) {
+        int result = 0;
+        for( const std::vector<item_comp> &group : requirements.get_components() ) {
+            for( const item_comp &component : group ) {
+                if( component.type == item_id ) {
+                    result += component.count;
+                }
+            }
+        }
+        return result;
+    };
+    const auto cached_count = []( const bodypart_str_id &part_id,
+                                  const wound_type_id &candidate_id ) {
+        const body_part_type &part = part_id.obj();
+        return std::count_if( part.potential_wounds.begin(), part.potential_wounds.end(),
+        [&candidate_id]( const std::pair<bp_wounds, int> &entry ) {
+            return entry.first.id == candidate_id;
+        } );
+    };
+
+    scoped_platform_test_mod baseline( "ccb_wound_rollback_baseline_mod" );
+    baseline.write( "main.lua", R"lua(
+local ccb = require("ccb")
+
+local requirement = ccb.content.Requirement {
+    id = "ccb_wound_rollback_requirement",
+    name = "Rollback baseline requirement",
+}
+requirement:component("rock", 1)
+ccb.content.add(requirement)
+
+local wound = ccb.content.Wound {
+    id = "ccb_wound_rollback_baseline",
+    name = "Rollback baseline wound",
+    plural_name = "Rollback baseline wounds",
+    description = "The definition that failed candidates must restore.",
+    pain_min = 2,
+    pain_max = 2,
+    healing_min_turns = 20,
+    healing_max_turns = 20,
+    damage_min = 2,
+    damage_max = 4,
+    weight = 5,
+}
+wound:damage_type("bash")
+wound:require_body_part_type("arm")
+ccb.content.add(wound)
+
+local target = ccb.content.Wound {
+    id = "ccb_wound_rollback_target",
+    name = "Rollback target wound",
+    plural_name = "Rollback target wounds",
+    description = "The stable treatment target.",
+    healing_min_turns = 5,
+    healing_max_turns = 5,
+    damage_min = 1,
+    damage_max = 1,
+}
+target:damage_type("cut")
+target:require_body_part_type("hand")
+ccb.content.add(target)
+
+local fix = ccb.content.WoundFix {
+    id = "ccb_wound_rollback_fix",
+    name = "Rollback baseline treatment",
+    description = "The treatment whose derived requirements must be restored.",
+    success_message = "Rollback baseline treatment succeeded.",
+    duration_turns = 20,
+    health_delta = 1,
+}
+fix:removes("ccb_wound_rollback_baseline")
+fix:adds("ccb_wound_rollback_target")
+fix:requires("ccb_wound_rollback_requirement", 2)
+ccb.content.add(fix)
+)lua" );
+
+    std::string error;
+    REQUIRE( cata::lua_platform::prepare_mods(
+                 { baseline.source( "ccb_wound_rollback_baseline_mod" ) }, error ) );
+    REQUIRE( cata::lua_platform::apply_prepared_content( error ) );
+    REQUIRE( cata::lua_platform::validate_finalized_prepared_content( error ) );
+    cata::lua_platform::commit_prepared_mods();
+
+    REQUIRE( wound_id.is_valid() );
+    REQUIRE( target_id.is_valid() );
+    REQUIRE( fix_id.is_valid() );
+    REQUIRE( requirement_data::all().count( rollback_requirement_id ) == 1 );
+    CHECK( wound_id->get_name() == "Rollback baseline wound" );
+    CHECK( wound_id->fixes == ( std::set<wound_fix_id>{ fix_id } ) );
+    CHECK( target_id->fixes.empty() );
+    CHECK( component_count( fix_id->get_requirements(), itype_id( "rock" ) ) == 2 );
+    CHECK( component_count( fix_id->get_requirements(), itype_id( "scrap" ) ) == 0 );
+    CHECK( component_count( requirement_data::all().at( rollback_requirement_id ),
+                            itype_id( "rock" ) ) == 1 );
+    CHECK( cached_count( body_part_arm_l, wound_id ) == 1 );
+    CHECK( cached_count( body_part_hand_l, wound_id ) == 0 );
+    CHECK( cached_count( body_part_hand_l, target_id ) == 1 );
+    CHECK( cached_count( body_part_arm_l, target_id ) == 0 );
+
+    scoped_platform_test_mod apply_provider( "ccb_wound_rollback_apply_provider" );
+    scoped_platform_test_mod apply_consumer( "ccb_wound_rollback_apply_consumer" );
+    apply_provider.write( "main.lua", R"lua(
+local ccb = require("ccb")
+
+local requirement = ccb.content.Requirement {
+    id = "ccb_wound_rollback_requirement",
+    name = "Temporary apply requirement",
+}
+requirement:component("scrap", 3)
+ccb.content.replace(requirement)
+
+local wound = ccb.content.Wound {
+    id = "ccb_wound_rollback_transient",
+    name = "Transient apply wound",
+    plural_name = "Transient apply wounds",
+    description = "Must disappear when the later Mod fails to apply.",
+    healing_min_turns = 10,
+    healing_max_turns = 10,
+    damage_min = 1,
+    damage_max = 2,
+}
+wound:damage_type("bash")
+wound:require_body_part_type("hand")
+ccb.content.add(wound)
+
+local fix = ccb.content.WoundFix {
+    id = "ccb_wound_rollback_transient_fix",
+    name = "Transient apply treatment",
+    description = "Must leave no reverse-link residue.",
+    success_message = "Transient treatment succeeded.",
+    duration_turns = 5,
+}
+fix:removes("ccb_wound_rollback_transient")
+fix:requires("ccb_wound_rollback_requirement", 1)
+ccb.content.add(fix)
+)lua" );
+    apply_consumer.write( "main.lua", R"lua(
+local ccb = require("ccb")
+local duplicate = ccb.content.Wound {
+    id = "ccb_wound_rollback_transient",
+    name = "Conflicting transient wound",
+    plural_name = "Conflicting transient wounds",
+    description = "The duplicate add fails after the provider was applied.",
+    healing_min_turns = 1,
+    healing_max_turns = 1,
+    damage_min = 1,
+    damage_max = 1,
+}
+duplicate:damage_type("bash")
+ccb.content.add(duplicate)
+)lua" );
+
+    REQUIRE( cata::lua_platform::prepare_mods( {
+        apply_provider.source( "ccb_wound_rollback_apply_provider" ),
+        apply_consumer.source( "ccb_wound_rollback_apply_consumer" )
+    }, error ) );
+    CHECK_FALSE( cata::lua_platform::apply_prepared_content( error ) );
+    CHECK( error.find( "add would overwrite existing wound" ) != std::string::npos );
+    CHECK_FALSE( transient_wound_id.is_valid() );
+    CHECK_FALSE( transient_fix_id.is_valid() );
+    REQUIRE( wound_id.is_valid() );
+    REQUIRE( fix_id.is_valid() );
+    REQUIRE( requirement_data::all().count( rollback_requirement_id ) == 1 );
+    CHECK( wound_id->fixes == ( std::set<wound_fix_id>{ fix_id } ) );
+    CHECK( target_id->fixes.empty() );
+    CHECK( component_count( fix_id->get_requirements(), itype_id( "rock" ) ) == 2 );
+    CHECK( component_count( fix_id->get_requirements(), itype_id( "scrap" ) ) == 0 );
+    CHECK( component_count( requirement_data::all().at( rollback_requirement_id ),
+                            itype_id( "rock" ) ) == 1 );
+    CHECK( cached_count( body_part_arm_l, wound_id ) == 1 );
+    CHECK( cached_count( body_part_hand_l, transient_wound_id ) == 0 );
+    CHECK( cached_count( body_part_hand_l, target_id ) == 1 );
+    cata::lua_platform::discard_prepared_mods();
+
+    scoped_platform_test_mod finalized_candidate(
+        "ccb_wound_rollback_finalized_candidate" );
+    finalized_candidate.write( "main.lua", R"lua(
+local ccb = require("ccb")
+
+local requirement = ccb.content.Requirement {
+    id = "ccb_wound_rollback_requirement",
+    name = "Temporary finalized requirement",
+}
+requirement:component("scrap", 4)
+ccb.content.replace(requirement)
+
+local wound = ccb.content.Wound {
+    id = "ccb_wound_rollback_baseline",
+    name = "Temporary finalized wound",
+    plural_name = "Temporary finalized wounds",
+    description = "Must roll back after finalized validation fails.",
+    pain_min = 7,
+    pain_max = 7,
+    healing_min_turns = 70,
+    healing_max_turns = 70,
+    damage_min = 7,
+    damage_max = 8,
+    weight = 9,
+}
+wound:damage_type("cut")
+wound:require_body_part_type("hand")
+ccb.content.replace(wound)
+
+local fix = ccb.content.WoundFix {
+    id = "ccb_wound_rollback_fix",
+    name = "Temporary finalized treatment",
+    description = "Its requirement cache must not survive rollback.",
+    success_message = "Temporary finalized treatment succeeded.",
+    duration_turns = 70,
+    health_delta = 7,
+}
+fix:removes("ccb_wound_rollback_baseline")
+fix:adds("ccb_wound_rollback_target")
+fix:requires("ccb_wound_rollback_requirement", 3)
+ccb.content.replace(fix)
+)lua" );
+
+    REQUIRE( cata::lua_platform::prepare_mods( {
+        finalized_candidate.source( "ccb_wound_rollback_finalized_candidate" )
+    }, error ) );
+    REQUIRE( cata::lua_platform::apply_prepared_content( error ) );
+    REQUIRE( wound_id.is_valid() );
+    REQUIRE( fix_id.is_valid() );
+    REQUIRE( requirement_data::all().count( rollback_requirement_id ) == 1 );
+    CHECK( wound_id->get_name() == "Temporary finalized wound" );
+    CHECK( fix_id->get_name() == "Temporary finalized treatment" );
+    CHECK( component_count( fix_id->get_requirements(), itype_id( "rock" ) ) == 0 );
+    CHECK( component_count( fix_id->get_requirements(), itype_id( "scrap" ) ) == 12 );
+    CHECK( component_count( requirement_data::all().at( rollback_requirement_id ),
+                            itype_id( "scrap" ) ) == 4 );
+    CHECK( cached_count( body_part_arm_l, wound_id ) == 0 );
+    CHECK( cached_count( body_part_hand_l, wound_id ) == 1 );
+
+    const_cast<wound_type &>( wound_id.obj() ).fixes.clear();
+    CHECK_FALSE( cata::lua_platform::validate_finalized_prepared_content( error ) );
+    CHECK( error.find( "missing a wound reverse link" ) != std::string::npos );
+    cata::lua_platform::discard_prepared_mods();
+
+    REQUIRE( wound_id.is_valid() );
+    REQUIRE( target_id.is_valid() );
+    REQUIRE( fix_id.is_valid() );
+    REQUIRE( requirement_data::all().count( rollback_requirement_id ) == 1 );
+    CHECK( wound_id->get_name() == "Rollback baseline wound" );
+    CHECK( fix_id->get_name() == "Rollback baseline treatment" );
+    CHECK( wound_id->fixes == ( std::set<wound_fix_id>{ fix_id } ) );
+    CHECK( target_id->fixes.empty() );
+    CHECK( component_count( fix_id->get_requirements(), itype_id( "rock" ) ) == 2 );
+    CHECK( component_count( fix_id->get_requirements(), itype_id( "scrap" ) ) == 0 );
+    CHECK( component_count( requirement_data::all().at( rollback_requirement_id ),
+                            itype_id( "rock" ) ) == 1 );
+    CHECK( cached_count( body_part_arm_l, wound_id ) == 1 );
+    CHECK( cached_count( body_part_hand_l, wound_id ) == 0 );
+    CHECK( cached_count( body_part_hand_l, target_id ) == 1 );
 }
 
 TEST_CASE( "lua_first_monster_attack_policy_receives_generation_safe_handles",
@@ -2882,6 +4302,216 @@ ccb.content.add(activity)
     cata::lua_platform::shutdown();
 }
 
+TEST_CASE( "lua_first_activity_services_use_native_character_rules",
+           "[lua][platform][runtime][services][activity]" )
+{
+    cata::lua_platform::shutdown();
+    clear_avatar();
+    on_out_of_scope reset_platform( []() {
+        avatar &player = get_avatar();
+        if( player.activity ) {
+            player.cancel_activity();
+        }
+        cata::lua_platform::shutdown();
+        clear_avatar();
+    } );
+    scoped_platform_test_mod test_mod( "ccb_platform_activity_services" );
+    const fs::path marker = test_mod.root() / "activity-services.txt";
+    test_mod.write( "main.lua", string_format( R"lua(
+local ccb = require("ccb")
+
+local activity = ccb.content.ActivityType {
+    id = "ACT_CCB_PLATFORM_TIMED_SERVICE",
+    verb = "testing a native timed service",
+    based_on = "time",
+    activity_level = 1,
+}
+ccb.content.add(activity)
+ccb.content.add(ccb.content.ActivityType {
+    id = "ACT_CCB_PLATFORM_MAXIMUM_SERVICE",
+    verb = "testing a maximum native timed service",
+    based_on = "time",
+    can_resume = false,
+    activity_level = 1,
+})
+ccb.content.add(ccb.content.ActivityType {
+    id = "ACT_CCB_PLATFORM_AUTOMATIC_NEEDS",
+    verb = "testing rejected automatic needs",
+    based_on = "time",
+    auto_needs = true,
+    activity_level = 1,
+})
+ccb.content.add(ccb.content.ActivityType {
+    id = "ACT_CCB_PLATFORM_MULTI_SERVICE",
+    verb = "testing rejected multi activity",
+    based_on = "time",
+    multi_activity = true,
+    activity_level = 1,
+})
+
+ccb.runtime.handler("exercise_activity_services", function()
+    local character = ccb.services.creatures.avatar()
+    local activity_id = ccb.services.types.id(
+        "activity", "ACT_CCB_PLATFORM_TIMED_SERVICE")
+
+    local initial = ccb.services.activities.snapshot(character)
+    assert(initial.ok and not initial.value.active)
+    assert(initial.value.id == nil)
+    assert(not pcall(function()
+        ccb.services.activities.assign_timed(
+            character, activity_id,
+            ccb.services.time.duration(0, "turn"))
+    end))
+    assert(not pcall(function()
+        ccb.services.activities.assign_timed(
+            character, activity_id,
+            ccb.services.time.duration(21474837, "turn"))
+    end))
+    assert(not pcall(function()
+        ccb.services.activities.assign_timed(
+            character, ccb.services.types.id("item", "rock"),
+            ccb.services.time.duration(1, "turn"))
+    end))
+
+    local specialized_id = ccb.services.types.id(
+        "activity", "ACT_TARGET_PRACTICE")
+    local specialized = ccb.services.activities.assign_timed(
+        character, specialized_id,
+        ccb.services.time.duration(1, "turn"))
+    assert(not specialized.ok)
+    assert(specialized.error.code == "specialized_activity")
+
+    local native_handler = ccb.services.activities.assign_timed(
+        character,
+        ccb.services.types.id("activity", "ACT_FILL_LIQUID"),
+        ccb.services.time.duration(1, "turn"))
+    assert(not native_handler.ok)
+    assert(native_handler.error.code == "specialized_activity")
+
+    local legacy_policy = ccb.services.activities.assign_timed(
+        character,
+        ccb.services.types.id("activity", "ACT_PHONE_RECOVERY_BASIC"),
+        ccb.services.time.duration(1, "turn"))
+    assert(not legacy_policy.ok)
+    assert(legacy_policy.error.code == "legacy_activity_policy")
+
+    local speed_budget = ccb.services.activities.assign_timed(
+        character,
+        ccb.services.types.id("activity", "ACT_MORTAR_AIMING"),
+        ccb.services.time.duration(1, "turn"))
+    assert(not speed_budget.ok)
+    assert(speed_budget.error.code == "not_timed_activity")
+
+    local automatic_needs = ccb.services.activities.assign_timed(
+        character,
+        ccb.services.types.id("activity", "ACT_CCB_PLATFORM_AUTOMATIC_NEEDS"),
+        ccb.services.time.duration(21474836, "turn"))
+    assert(not automatic_needs.ok)
+    assert(automatic_needs.error.code == "specialized_activity")
+
+    local multi_activity = ccb.services.activities.assign_timed(
+        character,
+        ccb.services.types.id("activity", "ACT_CCB_PLATFORM_MULTI_SERVICE"),
+        ccb.services.time.duration(1, "turn"))
+    assert(not multi_activity.ok)
+    assert(multi_activity.error.code == "specialized_activity")
+
+    local assigned = ccb.services.activities.assign_timed(
+        character, activity_id,
+        ccb.services.time.duration(2, "turn"))
+    assert(assigned.ok and assigned.value.changed)
+    assert(assigned.value.activity.active)
+    assert(assigned.value.activity.id == activity_id)
+    assert(assigned.value.activity.moves_total == 200)
+    assert(assigned.value.activity.moves_left == 200)
+    assert(assigned.value.activity.progress == 0)
+
+    local observed = ccb.services.activities.snapshot(character)
+    assert(observed.ok and observed.value.active)
+    assert(observed.value.id == activity_id)
+    assert(observed.value.verb == "testing a native timed service")
+    assert(observed.value.rooted == false)
+    assert(observed.value.resumable == true)
+
+    local cancelled = ccb.services.activities.cancel(character)
+    assert(cancelled.ok and cancelled.value.changed)
+    assert(not cancelled.value.activity.active)
+    assert(cancelled.value.activity.id == nil)
+
+    local maximum = ccb.services.activities.assign_timed(
+        character,
+        ccb.services.types.id("activity", "ACT_CCB_PLATFORM_MAXIMUM_SERVICE"),
+        ccb.services.time.duration(21474836, "turn"))
+    assert(maximum.ok and maximum.value.changed)
+    assert(maximum.value.activity.moves_total == 2147483600)
+    assert(maximum.value.activity.moves_left == 2147483600)
+    local maximum_cancelled = ccb.services.activities.cancel(character)
+    assert(maximum_cancelled.ok and maximum_cancelled.value.changed)
+
+    local unchanged = ccb.services.activities.cancel(character)
+    assert(unchanged.ok and not unchanged.value.changed)
+
+    local output = assert(io.open([[%s]], "wb"))
+    output:write("native")
+    output:close()
+end)
+ccb.runtime.on("world_ready", "exercise_activity_services")
+)lua", marker.generic_u8string() ) );
+
+    std::string error;
+    REQUIRE( cata::lua_platform::prepare_mods(
+                 { test_mod.source( "ccb_platform_activity_services" ) }, error ) );
+    REQUIRE( cata::lua_platform::apply_prepared_content( error ) );
+    REQUIRE( cata::lua_platform::validate_finalized_prepared_content( error ) );
+    cata::lua_platform::commit_prepared_mods();
+    cata::lua_platform::on_world_ready( true );
+
+    REQUIRE( fs::is_regular_file( marker ) );
+    std::ifstream input( marker );
+    std::string text;
+    input >> text;
+    CHECK( text == "native" );
+    CHECK_FALSE( get_avatar().activity );
+}
+
+TEST_CASE( "lua_first_activity_cancel_is_side_effect_free_without_a_current_activity",
+           "[lua][platform][runtime][services][activity]" )
+{
+    cata::lua_platform::shutdown();
+    clear_avatar();
+    on_out_of_scope reset_platform( []() {
+        cata::lua_platform::shutdown();
+        clear_avatar();
+    } );
+    avatar &player = get_avatar();
+    player_activity queued( activity_id( "ACT_GENERIC_EOC" ), 100 );
+    queued.auto_resume = true;
+    player.backlog.push_back( queued );
+
+    scoped_platform_test_mod test_mod( "ccb_platform_activity_noop_cancel" );
+    test_mod.write( "main.lua", R"lua(
+local ccb = require("ccb")
+ccb.runtime.handler("cancel_inactive", function()
+    local result = ccb.services.activities.cancel(ccb.services.creatures.avatar())
+    assert(result.ok and not result.value.changed)
+    assert(not result.value.activity.active)
+end)
+ccb.runtime.on("world_ready", "cancel_inactive")
+)lua" );
+
+    std::string error;
+    REQUIRE( cata::lua_platform::prepare_mods(
+                 { test_mod.source( "ccb_platform_activity_noop_cancel" ) }, error ) );
+    REQUIRE( cata::lua_platform::apply_prepared_content( error ) );
+    REQUIRE( cata::lua_platform::validate_finalized_prepared_content( error ) );
+    cata::lua_platform::commit_prepared_mods();
+    cata::lua_platform::on_world_ready( true );
+
+    CHECK_FALSE( player.activity );
+    REQUIRE( player.backlog.size() == 1 );
+    CHECK( player.backlog.front().auto_resume );
+}
+
 TEST_CASE( "lua_first_help_snippets_and_playlists_use_native_domain_models",
            "[lua][platform][content][presentation]" )
 {
@@ -2974,8 +4604,10 @@ ccb.content.add(ccb.content.HitRange {
 )lua" );
 
     std::string error;
-    REQUIRE( cata::lua_platform::prepare_mods(
-                 { test_mod.source( "ccb_platform_hit_range_replace_only" ) }, error ) );
+    const bool prepared = cata::lua_platform::prepare_mods(
+                              { test_mod.source( "ccb_platform_hit_range_replace_only" ) }, error );
+    INFO( error );
+    REQUIRE( prepared );
     CHECK_FALSE( cata::lua_platform::apply_prepared_content( error ) );
     CHECK( error.find( "must use replace" ) != std::string::npos );
     CHECK( Creature::dispersion_for_even_chance_of_good_hit == previous_hit_range );
@@ -3139,12 +4771,20 @@ ccb.runtime.handler("inspect_use_context", function(context)
     context.charges = 7
     return 17
 end)
+ccb.runtime.handler("fail_use_context", function(context)
+    failed_use_context = context
+    error("intentional item-use failure")
+end)
 ccb.runtime.handler("assert_use_context_expired", function()
-    local readable, failure = pcall(function()
-        return saved_use_context.item_id
-    end)
-    assert(not readable)
-    assert(string.find(failure, "stale item-use context", 1, true))
+    local function assert_expired(context)
+        local readable, failure = pcall(function()
+            return context.item_id
+        end)
+        assert(not readable)
+        assert(string.find(failure, "stale item-use context", 1, true))
+    end
+    assert_expired(saved_use_context)
+    assert_expired(failed_use_context)
 end)
 ccb.runtime.on("before_save", "assert_use_context_expired")
 )lua", position.x(), position.y(), position.z() ) );
@@ -3165,7 +4805,14 @@ ccb.runtime.on("before_save", "assert_use_context_expired")
     REQUIRE( result );
     CHECK( *result == 17 );
     CHECK( used.charges == 7 );
+    REQUIRE_FALSE( debug_has_error_been_observed() );
+    CHECK_FALSE( cata::lua_platform::invoke_use_handler(
+                     "ccb_platform_item_use_context", "fail_use_context",
+                     &player, used, &get_map(), position ) );
+    REQUIRE( debug_has_error_been_observed() );
+    debug_reset_error_observed();
     cata::lua_platform::before_save();
+    CHECK_FALSE( debug_has_error_been_observed() );
     cata::lua_platform::shutdown();
 }
 
@@ -3254,8 +4901,10 @@ assert(not pcall(ccb.content.edit, ccb.content.Item {
 )lua" );
 
     std::string error;
-    REQUIRE( cata::lua_platform::prepare_mods(
-                 { test_mod.source( "ccb_platform_content_edit" ) }, error ) );
+    const bool prepared = cata::lua_platform::prepare_mods(
+                              { test_mod.source( "ccb_platform_content_edit" ) }, error );
+    INFO( error );
+    REQUIRE( prepared );
     REQUIRE( cata::lua_platform::apply_prepared_content( error ) );
     const itype *edited = item_controller->find_template(
                               itype_id( "ccb_platform_edited_item" ) );
@@ -3605,6 +5254,16 @@ TEST_CASE( "lua_first_platform_exposes_shared_domains_and_synchronous_hooks",
            "[lua][platform][runtime][services][hooks]" )
 {
     cata::lua_platform::shutdown();
+    const achievement_id shared_achievement( "lua_test_manual_achievement" );
+    REQUIRE( shared_achievement.is_valid() );
+    achievements_tracker &achievement_tracker = get_achievements();
+    if( achievement_tracker.valid_achievements().empty() ) {
+        get_event_bus().send<event_type::game_start>( "lua-platform-shared-domains-test" );
+    }
+    REQUIRE( achievement_tracker.reset_manual_achievement( shared_achievement.obj() ) );
+    on_out_of_scope reset_achievement( [&achievement_tracker, shared_achievement]() {
+        achievement_tracker.reset_manual_achievement( shared_achievement.obj() );
+    } );
     scoped_platform_test_mod test_mod( "ccb_platform_shared_domains" );
     const fs::path marker = test_mod.root() / "shared-domains.txt";
     test_mod.write( "main.lua", string_format( R"lua(
@@ -3617,13 +5276,32 @@ assert(string.find(early_prompt_error, "inside a runtime callback", 1, true) or
        string.find(early_prompt_error, "after world_ready", 1, true))
 
 local required_domains = {
-    "achievements", "addictions", "bionics", "camps", "characters",
+    "achievements", "activities", "addictions", "bionics", "camps", "characters",
     "crafting", "creatures", "effects", "factions", "handles", "hordes",
-    "inventory", "items", "martial_arts", "missions", "mutations", "needs",
+    "gameplay", "inventory", "items", "martial_arts", "missions", "morale", "mutations", "needs",
     "npcs", "overmap", "proficiencies", "recipes", "skills", "spells",
     "statistics", "time", "types", "units", "variables", "vehicles",
-    "vitamins", "weather", "world", "zones",
+    "vitamins", "weather", "world", "wounds", "zones",
 }
+
+assert(not pcall(function()
+    ccb.services.random.int(1, 1)
+end))
+assert(not pcall(function()
+    ccb.services.random.chance(0, 1)
+end))
+assert(not pcall(function()
+    ccb.services.random.chance(1, 1)
+end))
+assert(not pcall(function()
+    ccb.services.random.one_in(1)
+end))
+assert(not pcall(function()
+    ccb.services.random.probability(0, 1)
+end))
+assert(not pcall(function()
+    ccb.services.random.probability(1, 1)
+end))
 
 ccb.runtime.handler("ready", function()
     for _, name in ipairs(required_domains) do
@@ -3631,6 +5309,133 @@ ccb.runtime.handler("ready", function()
     end
     local avatar = ccb.services.creatures.avatar()
     assert(avatar.kind == "creature")
+    assert(ccb.services.gameplay.strings.any_equal({ "a", "b", "a" }))
+    assert(not ccb.services.gameplay.strings.any_equal({ "a", "b" }))
+    assert(ccb.services.gameplay.strings.all_equal({ "same", "same" }))
+    assert(not ccb.services.gameplay.strings.all_equal({ "same", "different" }))
+    assert(not pcall(function()
+        ccb.services.gameplay.strings.any_equal({ "only-one" })
+    end))
+    assert(ccb.services.gameplay.mods.is_loaded("ccb_platform_shared_domains"))
+    assert(not ccb.services.gameplay.mods.is_loaded("missing-platform-mod"))
+    local dimension = ccb.services.gameplay.environment.dimension()
+    assert(type(dimension) == "string" and #dimension > 0)
+    local locator = avatar:locator()
+    local avatar_position = ccb.services.coords.tripoint_abs_ms(
+        locator.position.x, locator.position.y, locator.position.z)
+    assert(type(ccb.services.gameplay.environment.is_outside(avatar_position)) == "boolean")
+    assert(ccb.services.gameplay.environment.line_of_sight(
+        avatar_position, avatar_position, 0))
+    assert(not pcall(function()
+        ccb.services.gameplay.environment.line_of_sight(
+            avatar_position, avatar_position, -1)
+    end))
+    local achievement_id = ccb.services.types.id(
+        "achievement", "lua_test_manual_achievement")
+    local completed = ccb.services.achievements.complete(achievement_id)
+    assert(completed.ok and completed.value)
+    local reset = ccb.services.achievements.reset(achievement_id)
+    assert(reset.ok)
+
+    local bionic_id = ccb.services.types.id("bionic", "bio_earplugs")
+    while true do
+        local initially_removed_bionic = ccb.services.bionics.remove_type(
+            avatar, bionic_id)
+        assert(initially_removed_bionic.ok)
+        if not initially_removed_bionic.value.changed then
+            break
+        end
+    end
+    local installed_bionic = ccb.services.bionics.grant(avatar, bionic_id)
+    assert(installed_bionic.ok)
+    assert(installed_bionic.value.changed)
+    local has_installed_bionic = ccb.services.bionics.has(avatar, bionic_id)
+    assert(has_installed_bionic.ok and has_installed_bionic.value)
+    local removed_bionic = ccb.services.bionics.remove_type(avatar, bionic_id)
+    assert(removed_bionic.ok and removed_bionic.value.changed)
+    local has_removed_bionic = ccb.services.bionics.has(avatar, bionic_id)
+    assert(has_removed_bionic.ok and not has_removed_bionic.value)
+    local absent_bionic = ccb.services.bionics.remove_type(avatar, bionic_id)
+    assert(absent_bionic.ok and not absent_bionic.value.changed)
+
+    local recipe_id = ccb.services.types.id("recipe", "cudgel_test_no_tools")
+    local initially_forgotten = ccb.services.recipes.forget(avatar, recipe_id)
+    assert(initially_forgotten.ok and not initially_forgotten.value.known)
+    local learned_recipe = ccb.services.recipes.learn(avatar, recipe_id)
+    assert(learned_recipe.ok and learned_recipe.value.changed)
+    assert(learned_recipe.value.known)
+    local duplicate_recipe = ccb.services.recipes.learn(avatar, recipe_id)
+    assert(duplicate_recipe.ok and not duplicate_recipe.value.changed)
+    local forgotten_recipe = ccb.services.recipes.forget(avatar, recipe_id)
+    assert(forgotten_recipe.ok and forgotten_recipe.value.changed)
+    assert(not forgotten_recipe.value.known)
+    local absent_recipe = ccb.services.recipes.forget(avatar, recipe_id)
+    assert(absent_recipe.ok and not absent_recipe.value.changed)
+
+    local martial_art_id = ccb.services.types.id("martial_art", "style_karate")
+    local initially_forgotten_style = ccb.services.martial_arts.forget(
+        avatar, martial_art_id)
+    assert(initially_forgotten_style.ok and not initially_forgotten_style.value.known)
+    local learned_style = ccb.services.martial_arts.learn(avatar, martial_art_id)
+    assert(learned_style.ok and learned_style.value.changed)
+    assert(learned_style.value.known)
+    local known_style = ccb.services.martial_arts.get(avatar, martial_art_id)
+    assert(known_style.ok and known_style.value.known)
+    local duplicate_style = ccb.services.martial_arts.learn(avatar, martial_art_id)
+    assert(duplicate_style.ok and not duplicate_style.value.changed)
+    local forgotten_style = ccb.services.martial_arts.forget(avatar, martial_art_id)
+    assert(forgotten_style.ok and forgotten_style.value.changed)
+    assert(not forgotten_style.value.known)
+    local absent_style = ccb.services.martial_arts.forget(avatar, martial_art_id)
+    assert(absent_style.ok and not absent_style.value.changed)
+
+    local mutation_id = ccb.services.types.id("mutation", "TOUGH")
+    local has_mutation = ccb.services.mutations.has(avatar, mutation_id)
+    assert(has_mutation.ok and type(has_mutation.value) == "boolean")
+    local proficiency_id = ccb.services.types.id("proficiency", "prof_knapping")
+    local proficiency = ccb.services.proficiencies.get(avatar, proficiency_id)
+    assert(proficiency.ok and type(proficiency.value.known) == "boolean")
+
+    local morale_id = ccb.services.types.id("morale", "morale_feeling_good")
+    local initial_morale = ccb.services.morale.remove(avatar, morale_id)
+    assert(initial_morale.ok and initial_morale.value.after == 0)
+    local default_morale = ccb.services.morale.add(avatar, morale_id, 10, 50)
+    assert(default_morale.ok and default_morale.value.changed)
+    assert(default_morale.value.before == 0 and default_morale.value.after == 10)
+    local cleared_default_morale = ccb.services.morale.remove(avatar, morale_id)
+    assert(cleared_default_morale.ok and cleared_default_morale.value.changed)
+    assert(cleared_default_morale.value.before == 10)
+    assert(cleared_default_morale.value.after == 0)
+    local added_morale = ccb.services.morale.add(avatar, morale_id, 10, 50, {
+        duration = ccb.services.time.duration(2, "hour"),
+        decay_start = ccb.services.time.duration(1, "hour"),
+        capped = false,
+    })
+    assert(added_morale.ok and added_morale.value.changed)
+    assert(added_morale.value.before == 0 and added_morale.value.after == 10)
+    local removed_morale = ccb.services.morale.remove(avatar, morale_id)
+    assert(removed_morale.ok and removed_morale.value.changed)
+    assert(removed_morale.value.after == 0)
+    assert(not pcall(function()
+        ccb.services.morale.add(avatar, morale_id, 1, 10, { unknown = true })
+    end))
+
+    assert(ccb.services.random.int(37, 37) == 37)
+    assert(not ccb.services.random.chance(0, 1))
+    assert(ccb.services.random.chance(1, 1))
+    assert(ccb.services.random.one_in(1))
+    assert(not ccb.services.random.probability(0, 1))
+    assert(ccb.services.random.probability(1, 1))
+    assert(ccb.services.random.contested(1, 1, 1))
+    assert(not ccb.services.random.contested(0, 1, 1))
+    local repeated = ccb.services.random.sample_integers(7, 7, 3, true)
+    assert(#repeated == 3 and repeated[1] == 7 and repeated[3] == 7)
+    local unique = ccb.services.random.sample_integers(1, 3, 3)
+    assert(#unique == 3)
+    assert(unique[1] ~= unique[2] and unique[1] ~= unique[3] and unique[2] ~= unique[3])
+    assert(not pcall(function()
+        ccb.services.random.sample_integers(1, 2, 3)
+    end))
 end)
 
 ccb.runtime.handler("deny_move", function(payload)
@@ -3660,6 +5465,602 @@ ccb.runtime.hook("on_player_try_move", "deny_move")
     input >> text;
     CHECK( text == "denied" );
     cata::lua_platform::shutdown();
+}
+
+TEST_CASE( "lua_first_bionic_and_recipe_services_expose_composable_character_facts",
+           "[lua][platform][runtime][services][bionics][recipes]" )
+{
+    cata::lua_platform::shutdown();
+    clear_avatar();
+    clear_map_without_vision();
+    avatar &player = get_avatar();
+    player.clear_bionics();
+    player.set_max_power_level( 1_kJ );
+    player.set_power_level( 0_kJ );
+    const recipe &target_recipe = recipe_id( "cudgel_test_no_tools" ).obj();
+    REQUIRE( target_recipe.category.is_valid() );
+    REQUIRE_FALSE( target_recipe.subcategory.empty() );
+    player.forget_recipe( &target_recipe );
+    on_out_of_scope cleanup( [&player, &target_recipe]() {
+        player.clear_bionics();
+        player.set_max_power_level( 0_kJ );
+        player.set_power_level( 0_kJ );
+        player.forget_recipe( &target_recipe );
+        cata::lua_platform::shutdown();
+        clear_avatar();
+        clear_map_without_vision();
+    } );
+
+    scoped_platform_test_mod test_mod( "ccb_platform_bionic_recipe_facts" );
+    const fs::path marker = test_mod.root() / "bionic-recipe-facts.txt";
+    test_mod.write( "main.lua", string_format( R"lua(
+local ccb = require("ccb")
+local services = ccb.services
+
+local function value(result)
+    assert(result.ok, result.error and result.error.message)
+    return result.value
+end
+
+ccb.runtime.handler("ready", function()
+    local character = services.creatures.avatar()
+    local initial_bionics = value(services.bionics.summary(character))
+    assert(initial_bionics.installed_count == 0)
+    assert(initial_bionics.power:value("millijoule") == 0)
+    assert(initial_bionics.maximum_power:value("millijoule") > 0)
+    assert(initial_bionics.has_capacity)
+    local initial_maximum = initial_bionics.maximum_power:value("millijoule")
+
+    local storage = services.types.id("bionic", "bio_power_storage")
+    value(services.bionics.grant(character, storage))
+    local stored_power = value(services.bionics.summary(character))
+    assert(stored_power.installed_count == 1)
+    assert(stored_power.maximum_power:value("millijoule") > initial_maximum)
+    assert(stored_power.has_capacity)
+
+    local earplugs = services.types.id("bionic", "bio_earplugs")
+    value(services.bionics.grant(character, earplugs))
+    local installed = value(services.bionics.summary(character))
+    assert(installed.installed_count == 2)
+    assert(installed.has_capacity)
+    assert(value(services.bionics.remove_type(character, earplugs)).changed)
+    assert(value(services.bionics.summary(character)).installed_count == 1)
+    assert(not pcall(function()
+        services.bionics.summary(services.types.id("bionic", "bio_earplugs"))
+    end))
+
+    local recipe = services.types.id("recipe", "cudgel_test_no_tools")
+    local category = services.types.id("crafting_category", "%s")
+    local subcategory = "%s"
+    assert(not value(services.recipes.knows(character, recipe)))
+    value(services.recipes.learn(character, recipe))
+    assert(value(services.recipes.knows(character, recipe)))
+
+    local subcategory_result = value(services.recipes.forget_category(
+        character, category, subcategory))
+    assert(subcategory_result.changed)
+    assert(subcategory_result.forgotten_count >= 1)
+    assert(subcategory_result.known_before ==
+        subcategory_result.known_after + subcategory_result.forgotten_count)
+    assert(subcategory_result.category == category)
+    assert(subcategory_result.subcategory == subcategory)
+    assert(not value(services.recipes.knows(character, recipe)))
+
+    value(services.recipes.learn(character, recipe))
+    local category_result = value(services.recipes.forget_category(
+        character, category))
+    assert(category_result.changed and category_result.forgotten_count >= 1)
+    assert(category_result.subcategory == nil)
+    assert(not value(services.recipes.knows(character, recipe)))
+
+    local empty_result = value(services.recipes.forget_category(
+        character, category, "CSC_NOT_A_REAL_SUBCATEGORY"))
+    assert(not empty_result.changed and empty_result.forgotten_count == 0)
+    assert(not pcall(function()
+        services.recipes.knows(character, category)
+    end))
+    assert(not pcall(function()
+        services.recipes.forget_category(character, recipe)
+    end))
+    assert(not pcall(function()
+        services.recipes.forget_category(character, category, string.rep("x", 257))
+    end))
+
+    local output = assert(io.open([[%s]], "wb"))
+    output:write("ok")
+    output:close()
+end)
+ccb.runtime.on("world_ready", "ready")
+)lua", target_recipe.category.str(), target_recipe.subcategory,
+                                      marker.generic_u8string() ) );
+
+    std::string error;
+    REQUIRE( cata::lua_platform::prepare_mods(
+                 { test_mod.source( "ccb_platform_bionic_recipe_facts" ) }, error ) );
+    REQUIRE( cata::lua_platform::apply_prepared_content( error ) );
+    REQUIRE( cata::lua_platform::validate_finalized_prepared_content( error ) );
+    cata::lua_platform::commit_prepared_mods();
+    cata::lua_platform::on_world_ready( true );
+
+    std::ifstream input( marker, std::ios::binary );
+    std::string contents;
+    input >> contents;
+    REQUIRE( input );
+    CHECK( contents == "ok" );
+}
+
+TEST_CASE( "lua_first_wielded_service_reports_physical_item_without_policy_aliases",
+           "[lua][platform][runtime][services][inventory][wielded]" )
+{
+    cata::lua_platform::shutdown();
+    clear_avatar();
+    clear_map_without_vision();
+    on_out_of_scope restore_map( []() {
+        clear_map_without_vision();
+    } );
+    avatar &player = get_avatar();
+    map &here = get_map();
+    player.setpos( here, tripoint_bub_ms( 30, 30, 0 ) );
+    player.remove_weapon();
+    const auto storage = player.worn.wear_item(
+                             player, item( itype_id( "debug_backpack" ) ),
+                             false, false );
+    REQUIRE( storage );
+    const std::int64_t storage_uid =
+        ( **storage ).uid().get_value();
+    const std::vector<matype_id> original_styles = player.known_styles( false );
+    const matype_id original_selected =
+        player.martial_arts_data->selected_style();
+    const bool original_hands_free =
+        player.martial_arts_data->keep_hands_free;
+    on_out_of_scope cleanup( [&player, storage_uid, original_styles,
+    original_selected, original_hands_free]() {
+        player.remove_weapon();
+        player.remove_items_with( [storage_uid]( const item &candidate ) {
+            return candidate.uid().get_value() == storage_uid ||
+                   candidate.typeId() == itype_id( "rock" );
+        }, 100 );
+        player.clear_bionics();
+        player.martial_arts_data->clear_styles();
+        for( const matype_id &style : original_styles ) {
+            player.martial_arts_data->add_martialart( style );
+        }
+        player.martial_arts_data->set_style( original_selected, true );
+        player.martial_arts_data->keep_hands_free = original_hands_free;
+        cata::lua_platform::shutdown();
+    } );
+
+    npc &native_npc = spawn_npc(
+                          ( player.pos_bub( here ) +
+                            tripoint_rel_ms::east * 3 ).xy(),
+                          "test_talker" );
+    native_npc.name = "Lua wielded service NPC";
+    item_location npc_weapon = native_npc.i_add( item( itype_id( "rock" ) ) );
+    REQUIRE( npc_weapon );
+    REQUIRE( native_npc.wield( npc_weapon ) );
+    const character_id native_npc_id = native_npc.getID();
+    on_out_of_scope cleanup_npc( [native_npc_id]() {
+        g->remove_npc_follower( native_npc_id );
+        g->remove_npc( native_npc_id );
+        overmap_buffer.remove_npc( native_npc_id );
+    } );
+
+    scoped_platform_test_mod test_mod( "ccb_platform_wielded_service" );
+    const fs::path marker = test_mod.root() / "wielded-service.txt";
+    test_mod.write( "main.lua", string_format( R"lua(
+local ccb = require("ccb")
+local services = ccb.services
+
+local function value(result)
+    assert(result.ok, result.error and result.error.message)
+    return result.value
+end
+
+ccb.runtime.handler("ready", function()
+    local character = services.creatures.avatar()
+    assert(value(services.inventory.wielded(character)) == nil)
+
+    local npc_page = value(services.npcs.list({
+        query = "Lua wielded service NPC", limit = 2,
+    }))
+    assert(npc_page.total == 1 and npc_page.returned == 1)
+    local npc_item = value(services.inventory.wielded(
+        npc_page.items[1].handle))
+    assert(npc_item.kind == "item")
+    assert(value(services.items.snapshot(npc_item)).id ==
+           services.types.id("item", "rock"))
+
+    local created = value(services.inventory.give(
+        character, services.types.id("item", "rock"), 1,
+        { allow_wield = false }))
+    assert(created.instances == 1)
+    local item = created.items[1].handle
+    local wrong_kind = services.inventory.wielded(item)
+    assert(not wrong_kind.ok and wrong_kind.error.code == "wrong_kind")
+
+    local source_uid = item:locator().stable_id
+    local wield_result = value(services.inventory.wield(character, item))
+    assert(wield_result.accepted)
+    local physical = value(services.inventory.wielded(character))
+    assert(physical.kind == "item")
+    local physical_locator = physical:locator()
+    assert(physical_locator.scope == "character_wielded")
+    assert(physical_locator.stable_id == wield_result.uid)
+    if wield_result.previous_uid ~= nil then
+        assert(wield_result.previous_uid == source_uid)
+    else
+        assert(wield_result.uid == source_uid)
+    end
+
+    local locked = services.types.id("json_flag", "NO_UNWIELD")
+    assert(value(services.items.set_flag(physical, locked, true)).changed)
+    assert(value(services.items.has_flag(physical, locked)))
+    assert(value(services.inventory.wielded(character)):locator().stable_id ==
+           physical_locator.stable_id)
+
+    local forced = services.types.id("martial_art", "style_taekwondo")
+    value(services.martial_arts.learn(character, forced))
+    value(services.martial_arts.select(character, forced))
+    assert(value(services.martial_arts.current(character)).force_unarmed)
+    assert(value(services.inventory.wielded(character)):locator().stable_id ==
+           physical_locator.stable_id)
+
+    assert(value(services.items.set_flag(physical, locked, false)).changed)
+    local stashed = value(services.inventory.stash_wielded(character))
+    assert(stashed.accepted)
+    assert(value(services.inventory.wielded(character)) == nil)
+    local removed = value(services.inventory.remove(
+        character, stashed.item.handle))
+    assert(removed.removed == 1)
+    assert(services.items.snapshot(physical).error.code == "destroyed")
+
+    local storage = services.types.id("bionic", "bio_power_storage")
+    value(services.bionics.grant(character, storage))
+    value(services.bionics.grant(character, storage))
+    value(services.bionics.set_power(
+        character, services.units.new("energy", 200, "kilojoule")))
+    local blade = value(services.bionics.grant(
+        character, services.types.id("bionic", "bio_blade")))
+    value(services.bionics.activate(character, blade.uid))
+    local bionic_item = value(services.inventory.wielded(character))
+    assert(bionic_item.kind == "item")
+    assert(value(services.items.snapshot(bionic_item)).id ==
+           services.types.id("item", "bio_blade_weapon"))
+    assert(value(services.items.has_flag(bionic_item, locked)))
+    value(services.bionics.deactivate(character, blade.uid))
+    assert(value(services.inventory.wielded(character)) == nil)
+    assert(services.items.snapshot(bionic_item).error.code == "destroyed")
+
+    local output = assert(io.open([[%s]], "wb"))
+    output:write("ok")
+    output:close()
+end)
+ccb.runtime.on("world_ready", "ready")
+)lua", marker.generic_u8string() ) );
+
+    std::string error;
+    REQUIRE( cata::lua_platform::prepare_mods(
+                 { test_mod.source( "ccb_platform_wielded_service" ) }, error ) );
+    REQUIRE( cata::lua_platform::apply_prepared_content( error ) );
+    REQUIRE( cata::lua_platform::validate_finalized_prepared_content( error ) );
+    cata::lua_platform::commit_prepared_mods();
+    cata::lua_platform::on_world_ready( true );
+
+    std::ifstream input( marker, std::ios::binary );
+    std::string contents;
+    input >> contents;
+    REQUIRE( input );
+    CHECK( contents == "ok" );
+
+}
+
+TEST_CASE( "lua_first_wound_services_preserve_native_character_and_handle_rules",
+           "[lua][platform][runtime][services][wound]" )
+{
+    cata::lua_platform::shutdown();
+    clear_avatar();
+    clear_map_without_vision();
+    on_out_of_scope reset_platform( []() {
+        avatar &player = get_avatar();
+        player.get_part( bodypart_str_id( "torso" ).id() )->remove_all_wounds_of_type(
+            wound_type_id( "ccb_platform_service_wound" ) );
+        player.get_part( bodypart_str_id( "torso" ).id() )->remove_all_wounds_of_type(
+            wound_type_id( "ccb_platform_service_ordered_wound" ) );
+        const trait_id masochist( "MASOCHIST" );
+        if( player.has_permanent_trait( masochist ) ) {
+            player.on_mutation_loss( masochist );
+            player.unset_mutation( masochist );
+        }
+        cata::lua_platform::shutdown();
+        clear_avatar();
+        clear_map_without_vision();
+    } );
+
+    avatar &player = get_avatar();
+    const trait_id masochist( "MASOCHIST" );
+    const morale_type masochist_morale( "morale_perm_masochist" );
+    REQUIRE_FALSE( player.has_permanent_trait( masochist ) );
+    player.set_pain( 0 );
+    player.set_painkiller( 0 );
+    player.set_mutation( masochist );
+    player.on_mutation_gain( masochist );
+    REQUIRE( player.has_morale( masochist_morale ) == 0 );
+    map &here = get_map();
+    player.setpos( here, tripoint_bub_ms( 30, 30, 0 ) );
+    const tripoint_bub_ms npc_position =
+        player.pos_bub( here ) + tripoint_rel_ms::west * 3;
+    const tripoint_bub_ms monster_position =
+        player.pos_bub( here ) + tripoint_rel_ms::east * 3;
+    npc &native_npc = spawn_npc( npc_position.xy(), "test_talker" );
+    native_npc.name = "Lua wound service NPC";
+    const character_id native_npc_id = native_npc.getID();
+    monster &native_monster = spawn_test_monster( "mon_zombie", monster_position );
+    REQUIRE( native_monster.pos_bub( here ) == monster_position );
+    on_out_of_scope cleanup_creatures( [native_npc_id, monster_position]() {
+        if( monster *placed = get_creature_tracker().creature_at<monster>(
+                                  monster_position, true ) ) {
+            g->remove_zombie( *placed );
+        }
+        g->remove_npc_follower( native_npc_id );
+        g->remove_npc( native_npc_id );
+        overmap_buffer.remove_npc( native_npc_id );
+    } );
+
+    const tripoint_abs_ms npc_absolute = native_npc.pos_abs();
+    const tripoint_abs_ms monster_absolute = here.get_abs( monster_position );
+    scoped_platform_test_mod test_mod( "ccb_platform_wound_services" );
+    const fs::path marker = test_mod.root() / "wound-services.txt";
+    test_mod.write( "main.lua", string_format( R"lua(
+local ccb = require("ccb")
+local services = ccb.services
+
+local wound_definition = ccb.content.Wound {
+    id = "ccb_platform_service_wound",
+    name = "Platform service wound",
+    plural_name = "Platform service wounds",
+    description = "A deterministic wound used by the native service test.",
+    pain_min = 4,
+    pain_max = 4,
+    healing_min_turns = 10,
+    healing_max_turns = 10,
+    per_part_limit = 2,
+}
+wound_definition:damage_type("bash")
+wound_definition:require_body_part_type("hand")
+ccb.content.add(wound_definition)
+
+local ordered_wound_definition = ccb.content.Wound {
+    id = "ccb_platform_service_ordered_wound",
+    name = "Platform ordered wound",
+    plural_name = "Platform ordered wounds",
+    description = "A second deterministic wound used to prove native order.",
+    pain_min = 7,
+    pain_max = 7,
+    healing_min_turns = 20,
+    healing_max_turns = 20,
+    per_part_limit = 1,
+}
+ordered_wound_definition:damage_type("bash")
+ordered_wound_definition:require_body_part_type("hand")
+ccb.content.add(ordered_wound_definition)
+
+local torso = nil
+local debug_tail = nil
+local wound_id = nil
+local saved_avatar = nil
+local saved_monster = nil
+local ready_count = 0
+local destroyed_checked = false
+
+local function value(result)
+    assert(result.ok, result.error and result.error.message)
+    return result.value
+end
+
+local function same_snapshot(lhs, rhs)
+    if #lhs ~= #rhs then
+        return false
+    end
+    for index = 1, #lhs do
+        local a = lhs[index]
+        local b = rhs[index]
+        if a.id ~= b.id or
+           a.base_pain ~= b.base_pain or
+           a.current_pain ~= b.current_pain or
+           a.healing_time ~= b.healing_time or
+           a.healing_progress ~= b.healing_progress or
+           a.healing_fraction ~= b.healing_fraction then
+            return false
+        end
+    end
+    return true
+end
+
+local function assert_derived(character, expected)
+    local creature_state = value(services.creatures.snapshot(character))
+    local character_state = value(services.characters.snapshot(character, 1))
+    assert(creature_state.pain == expected)
+    assert(creature_state.perceived_pain == expected)
+    assert(character_state.creature.perceived_pain == expected)
+    assert(character_state.needs.morale == expected)
+end
+
+ccb.runtime.handler("ready", function()
+    ready_count = ready_count + 1
+    if ready_count == 2 then
+        local stale = services.wounds.snapshot(saved_avatar, torso)
+        assert(not stale.ok and stale.error.code == "stale_world")
+        assert(destroyed_checked)
+        local output = assert(io.open([[%s]], "wb"))
+        output:write("ok")
+        output:close()
+        return
+    end
+    assert(ready_count == 1)
+
+    local avatar = services.creatures.avatar()
+    saved_avatar = avatar
+    torso = services.types.id("body_part", "torso")
+    debug_tail = services.types.id("body_part", "debug_tail")
+    wound_id = services.types.id("wound", "ccb_platform_service_wound")
+    local ordered_wound_id = services.types.id(
+        "wound", "ccb_platform_service_ordered_wound")
+    assert(#value(services.wounds.snapshot(avatar, torso)) == 0)
+
+    local first = value(services.wounds.add(avatar, torso, wound_id))
+    assert(first.changed and #first.before == 0 and #first.after == 1)
+    local first_wound = first.after[1]
+    assert(first_wound.id == wound_id)
+    assert(first_wound.base_pain == 4 and first_wound.current_pain == 4)
+    assert(first_wound.healing_time.turns == 10)
+    assert(first_wound.healing_progress.turns == 0)
+    assert(first_wound.healing_fraction == 0)
+    assert_derived(avatar, 4)
+
+    local second = value(services.wounds.add(avatar, torso, ordered_wound_id))
+    assert(second.changed and #second.before == 1 and #second.after == 2)
+    assert(second.after[1].id == wound_id)
+    assert(second.after[2].id == ordered_wound_id)
+    assert_derived(avatar, 11)
+
+    local third = value(services.wounds.add(avatar, torso, wound_id))
+    assert(third.changed and #third.before == 2 and #third.after == 3)
+    assert(third.after[1].id == wound_id)
+    assert(third.after[2].id == ordered_wound_id)
+    assert(third.after[3].id == wound_id)
+    assert_derived(avatar, 15)
+
+    local limited = value(services.wounds.add(avatar, torso, wound_id))
+    assert(not limited.changed)
+    assert(#limited.before == 3 and #limited.after == 3)
+    assert(same_snapshot(limited.before, limited.after))
+    assert_derived(avatar, 15)
+
+    local removed = value(services.wounds.remove(avatar, torso, wound_id))
+    assert(removed.changed and #removed.before == 3 and #removed.after == 1)
+    assert(removed.after[1].id == ordered_wound_id)
+    assert_derived(avatar, 7)
+    local absent = value(services.wounds.remove(avatar, torso, wound_id))
+    assert(not absent.changed and #absent.before == 1 and #absent.after == 1)
+    assert(absent.after[1].id == ordered_wound_id)
+    assert_derived(avatar, 7)
+    local last = value(services.wounds.remove(avatar, torso, ordered_wound_id))
+    assert(last.changed and #last.after == 0)
+    assert_derived(avatar, 0)
+
+    local npc_position = services.coords.tripoint_abs_ms(%d, %d, %d)
+    local npc_handle = value(services.creatures.at(npc_position))
+    assert(value(services.creatures.snapshot(npc_handle)).kind == "npc")
+    local npc_added = value(services.wounds.add(npc_handle, torso, wound_id))
+    assert(npc_added.changed and #npc_added.after == 1)
+    local npc_snapshot = value(services.wounds.snapshot(npc_handle, torso))
+    assert(#npc_snapshot == 1 and npc_snapshot[1].id == wound_id)
+    local npc_removed = value(services.wounds.remove(npc_handle, torso, wound_id))
+    assert(npc_removed.changed and #npc_removed.after == 0)
+
+    local monster_position = services.coords.tripoint_abs_ms(%d, %d, %d)
+    saved_monster = value(services.creatures.at(monster_position))
+    assert(value(services.creatures.snapshot(saved_monster)).kind == "monster")
+    local wrong_target = services.wounds.add(saved_monster, torso, wound_id)
+    assert(not wrong_target.ok and wrong_target.error.code == "wrong_target")
+
+    assert(debug_tail:is_valid())
+    local missing_part = services.wounds.snapshot(avatar, debug_tail)
+    assert(not missing_part.ok and missing_part.error.code == "missing_part")
+
+    local rock = services.types.id("item", "rock")
+    local missing_body_part = services.types.id(
+        "body_part", "__missing_platform_service_body_part__")
+    local missing_wound = services.types.id(
+        "wound", "__missing_platform_service_wound__")
+    assert(not missing_body_part:is_valid() and not missing_wound:is_valid())
+    assert(not pcall(services.wounds.snapshot, avatar, rock))
+    assert(not pcall(services.wounds.snapshot, avatar, missing_body_part))
+    assert(not pcall(services.wounds.add, avatar, torso, rock))
+    assert(not pcall(services.wounds.add, avatar, torso, missing_wound))
+end)
+
+ccb.runtime.handler("destroyed", function()
+    local destroyed = services.wounds.snapshot(saved_monster, torso)
+    assert(not destroyed.ok and destroyed.error.code == "destroyed")
+    destroyed_checked = true
+    return true
+end)
+
+ccb.runtime.on("world_ready", "ready")
+ccb.runtime.hook("on_player_try_move", "destroyed")
+)lua",
+                    marker.generic_u8string(),
+                    npc_absolute.x(), npc_absolute.y(), npc_absolute.z(),
+                    monster_absolute.x(), monster_absolute.y(), monster_absolute.z() ) );
+
+    std::string error;
+    REQUIRE( cata::lua_platform::prepare_mods(
+                 { test_mod.source( "ccb_platform_wound_services" ) }, error ) );
+    REQUIRE( cata::lua_platform::apply_prepared_content( error ) );
+    REQUIRE( cata::lua_platform::validate_finalized_prepared_content( error ) );
+    cata::lua_platform::commit_prepared_mods();
+    cata::lua_platform::on_world_ready( true );
+
+    if( monster *placed = get_creature_tracker().creature_at<monster>(
+                              monster_position, true ) ) {
+        g->remove_zombie( *placed );
+    }
+    g->clear_zombies();
+    CHECK( cata::lua_ui::dispatch_native_hook( "on_player_try_move" ) );
+    cata::lua_platform::on_world_ready( false );
+
+    std::ifstream input( marker, std::ios::binary );
+    std::string contents;
+    input >> contents;
+    REQUIRE( input );
+    CHECK( contents == "ok" );
+
+    cata::lua_platform::clear_active_runtimes();
+    sol::state gate_lua;
+    gate_lua.open_libraries(
+        sol::lib::base, sol::lib::string, sol::lib::table );
+    sol::table gate_ccb = gate_lua.create_named_table( "ccb" );
+    const std::shared_ptr<cata::lua_platform::runtime> gate_runtime =
+        cata::lua_platform::make_runtime(
+            "ccb_platform_wound_write_gate", 424242, gate_lua );
+    cata::lua_platform::install_runtime_api(
+        gate_runtime, gate_lua, gate_ccb );
+    cata::lua_platform::set_active_runtimes( { gate_runtime } );
+    on_out_of_scope clear_gate_runtime( []() {
+        cata::lua_platform::clear_active_runtimes();
+    } );
+    cata::lua_platform::runtime_world_ready( true );
+
+    const sol::protected_function_result gate_result = gate_lua.safe_script( R"lua(
+local services = ccb.services
+local function value(result)
+    assert(result.ok, result.error and result.error.message)
+    return result.value
+end
+
+local avatar = services.creatures.avatar()
+local torso = services.types.id("body_part", "torso")
+local wound = services.types.id("wound", "ccb_platform_service_wound")
+assert(#value(services.wounds.snapshot(avatar, torso)) == 0)
+
+local add_ok, add_error = pcall(function()
+    services.wounds.add(avatar, torso, wound)
+end)
+assert(not add_ok)
+assert(string.find(tostring(add_error),
+    "only available inside a runtime callback", 1, true) ~= nil)
+
+local remove_ok, remove_error = pcall(function()
+    services.wounds.remove(avatar, torso, wound)
+end)
+assert(not remove_ok)
+assert(string.find(tostring(remove_error),
+    "only available inside a runtime callback", 1, true) ~= nil)
+
+assert(#value(services.wounds.snapshot(avatar, torso)) == 0)
+)lua" );
+    REQUIRE( gate_result.valid() );
 }
 
 TEST_CASE( "lua_first_hooks_preserve_and_deduplicate_cross_runtime_results",
@@ -3903,6 +6304,384 @@ ccb.runtime.on("world_ready", "ready")
     CHECK( ( cata::lua_platform::loaded_mod_ids() == std::vector<std::string> {
         "ccb_platform_runtime_reload"
     } ) );
+    cata::lua_platform::shutdown();
+}
+
+TEST_CASE( "lua_first_native_events_expose_named_character_actors_without_eoc_aliases",
+           "[lua][platform][runtime][events][actors]" )
+{
+    cata::lua_platform::shutdown();
+    scoped_platform_test_mod test_mod( "ccb_platform_event_actors" );
+    const fs::path marker = test_mod.root() / "event-actors.txt";
+    test_mod.write( "main.lua", string_format( R"lua(
+local ccb = require("ccb")
+ccb.runtime.handler("event_actors", function(event)
+    assert(event.type == "character_heals_damage")
+    assert(event.alpha == nil and event.beta == nil)
+    assert(event.data_types.character == "character_id")
+    assert(event.actors.character.kind == "creature")
+    local character = ccb.services.creatures.snapshot(event.actors.character)
+    assert(character.ok and character.value.kind == "avatar")
+    local output = assert(io.open([[%s]], "ab"))
+    output:write("A")
+    output:close()
+end)
+ccb.runtime.on("game:character_heals_damage", "event_actors")
+)lua", marker.generic_u8string() ) );
+
+    std::string error;
+    REQUIRE( cata::lua_platform::prepare_mods(
+                 { test_mod.source( "ccb_platform_event_actors" ) }, error ) );
+    REQUIRE( cata::lua_platform::apply_prepared_content( error ) );
+    REQUIRE( cata::lua_platform::validate_finalized_prepared_content( error ) );
+    cata::lua_platform::commit_prepared_mods();
+    cata::lua_platform::on_world_ready( true );
+
+    const cata::event event = cata::event::make<event_type::character_heals_damage>(
+                                  get_avatar().getID(), 1 );
+    get_event_bus().send_with_talker( &get_avatar(), &get_avatar(), event );
+
+    std::ifstream input( marker, std::ios::binary );
+    const std::string contents{
+        std::istreambuf_iterator<char>( input ),
+        std::istreambuf_iterator<char>()
+    };
+    REQUIRE( input );
+    CHECK( contents == "A" );
+    cata::lua_platform::shutdown();
+}
+
+TEST_CASE( "lua_first_native_event_actor_snapshots_are_semantic_and_handler_isolated",
+           "[lua][platform][runtime][events][actors]" )
+{
+    cata::lua_platform::shutdown();
+    REQUIRE_FALSE( debug_has_error_been_observed() );
+    scoped_platform_test_mod test_mod( "ccb_platform_event_actor_snapshots" );
+    const fs::path marker = test_mod.root() / "event-actor-snapshots.txt";
+    test_mod.write( "main.lua", string_format( R"lua(
+local ccb = require("ccb")
+assert(not pcall(function()
+    ccb.runtime.on("game:not_a_native_event", "observe_independent_copy")
+end))
+
+ccb.runtime.handler("mutate_then_fail", function(event)
+    assert(event.alpha == nil and event.beta == nil)
+    assert(event.actors.killer.kind == "creature")
+    assert(event.actors.victim.kind == "creature")
+    event.data.killer = -1
+    event.data_types.killer = "mutated"
+    event.actors.killer = nil
+    error("intentional event payload mutation")
+end)
+
+ccb.runtime.handler("observe_independent_copy", function(event)
+    assert(event.data.killer ~= -1)
+    assert(event.data_types.killer == "character_id")
+    assert(event.actors.killer.kind == "creature")
+    assert(event.actors.victim.kind == "creature")
+    local killer = ccb.services.creatures.snapshot(event.actors.killer)
+    local victim = ccb.services.creatures.snapshot(event.actors.victim)
+    assert(killer.ok and killer.value.kind == "avatar")
+    assert(victim.ok and victim.value.kind == "avatar")
+    local output = assert(io.open([[%s]], "ab"))
+    output:write("K")
+    output:close()
+end)
+
+ccb.runtime.handler("observe_actor_free_event", function(event)
+    assert(event.type == "game_begin")
+    assert(event.data.cdda_version == "event-contract-test")
+    assert(event.alpha == nil and event.beta == nil)
+    assert(next(event.actors) == nil)
+    local output = assert(io.open([[%s]], "ab"))
+    output:write("E")
+    output:close()
+end)
+
+ccb.runtime.handler("observe_unresolved_character", function(event)
+    assert(event.type == "character_heals_damage")
+    assert(event.data.character == -31337)
+    assert(event.data_types.character == "character_id")
+    assert(event.actors.character == nil)
+    local output = assert(io.open([[%s]], "ab"))
+    output:write("U")
+    output:close()
+end)
+
+ccb.runtime.on("game:character_kills_character", "mutate_then_fail")
+ccb.runtime.on("game:character_kills_character", "observe_independent_copy")
+ccb.runtime.on("game:game_begin", "observe_actor_free_event")
+ccb.runtime.on("game:character_heals_damage", "observe_unresolved_character")
+)lua", marker.generic_u8string(), marker.generic_u8string(),
+    marker.generic_u8string() ) );
+
+    std::string error;
+    REQUIRE( cata::lua_platform::prepare_mods(
+                 { test_mod.source( "ccb_platform_event_actor_snapshots" ) }, error ) );
+    REQUIRE( cata::lua_platform::apply_prepared_content( error ) );
+    REQUIRE( cata::lua_platform::validate_finalized_prepared_content( error ) );
+    cata::lua_platform::commit_prepared_mods();
+    cata::lua_platform::on_world_ready( true );
+
+    get_event_bus().send<event_type::character_kills_character>(
+        get_avatar().getID(), get_avatar().getID(), "avatar", "test" );
+    get_event_bus().send<event_type::game_begin>( "event-contract-test" );
+    get_event_bus().send<event_type::character_heals_damage>(
+        character_id( -31337 ), 1 );
+
+    std::ifstream input( marker, std::ios::binary );
+    const std::string contents{
+        std::istreambuf_iterator<char>( input ),
+        std::istreambuf_iterator<char>()
+    };
+    REQUIRE( input );
+    CHECK( contents == "KEU" );
+    cata::lua_platform::shutdown();
+    REQUIRE( debug_has_error_been_observed() );
+    debug_reset_error_observed();
+}
+
+TEST_CASE( "lua_first_native_item_event_actors_require_named_item_semantics",
+           "[lua][platform][runtime][events][actors][items]" )
+{
+    cata::lua_platform::shutdown();
+    scoped_platform_test_mod test_mod( "ccb_platform_event_item_actors" );
+    const fs::path marker = test_mod.root() / "event-item-actors.txt";
+    test_mod.write( "main.lua", string_format( R"lua(
+local ccb = require("ccb")
+local wield_calls = 0
+local markers = {
+    character_wields_item = "W",
+    character_wears_item = "R",
+    character_takeoff_item = "T",
+    character_armor_destroyed = "D",
+}
+
+local function append(value)
+    local output = assert(io.open([[%s]], "ab"))
+    output:write(value)
+    output:close()
+end
+
+ccb.runtime.handler("observe_item_event", function(event)
+    assert(event.alpha == nil and event.beta == nil)
+    assert(event.data_types.character == "character_id")
+    assert(event.data_types.itype == "itype_id")
+    assert(event.actors.character.kind == "creature")
+    if event.type == "character_wields_item" then
+        wield_calls = wield_calls + 1
+        if wield_calls == 2 then
+            assert(event.actors.item == nil)
+            append("P")
+            return
+        end
+    end
+    local item = assert(event.actors.item)
+    assert(item.kind == "item")
+    assert(item:locator().scope == "platform_event_item")
+    assert(item:is_valid())
+    append(assert(markers[event.type]))
+end)
+
+ccb.runtime.handler("reject_positional_item_fallback", function(event)
+    assert(event.type == "game_begin")
+    assert(event.alpha == nil and event.beta == nil)
+    assert(next(event.actors) == nil)
+    append("G")
+end)
+
+ccb.runtime.on("game:character_wields_item", "observe_item_event")
+ccb.runtime.on("game:character_wears_item", "observe_item_event")
+ccb.runtime.on("game:character_takeoff_item", "observe_item_event")
+ccb.runtime.on("game:character_armor_destroyed", "observe_item_event")
+ccb.runtime.on("game:game_begin", "reject_positional_item_fallback")
+)lua", marker.generic_u8string() ) );
+
+    std::string error;
+    REQUIRE( cata::lua_platform::prepare_mods(
+                 { test_mod.source( "ccb_platform_event_item_actors" ) }, error ) );
+    REQUIRE( cata::lua_platform::apply_prepared_content( error ) );
+    REQUIRE( cata::lua_platform::validate_finalized_prepared_content( error ) );
+    cata::lua_platform::commit_prepared_mods();
+    cata::lua_platform::on_world_ready( true );
+
+    avatar &player = get_avatar();
+    item_location event_item = player.i_add(
+                                   item( itype_id( "rock" ) ), true, nullptr,
+                                   nullptr, true, false );
+    REQUIRE( event_item );
+    on_out_of_scope cleanup( [event_item]() mutable {
+        if( event_item ) {
+            event_item.remove_item();
+        }
+    } );
+    const character_id player_id = player.getID();
+    const itype_id item_type = event_item->typeId();
+
+    get_event_bus().send_with_talker(
+        &player, &event_item,
+        cata::event::make<event_type::character_wields_item>( player_id, item_type ) );
+    get_event_bus().send_with_talker(
+        &player, &event_item,
+        cata::event::make<event_type::character_wears_item>( player_id, item_type ) );
+    get_event_bus().send_with_talker(
+        &player, &event_item,
+        cata::event::make<event_type::character_takeoff_item>( player_id, item_type ) );
+    get_event_bus().send_with_talker(
+        &player, &event_item,
+        cata::event::make<event_type::character_armor_destroyed>( player_id, item_type ) );
+    get_event_bus().send<event_type::character_wields_item>( player_id, item_type );
+    get_event_bus().send_with_talker(
+        &player, &event_item,
+        cata::event::make<event_type::game_begin>( "event-item-fallback-test" ) );
+
+    std::ifstream input( marker, std::ios::binary );
+    const std::string contents{
+        std::istreambuf_iterator<char>( input ),
+        std::istreambuf_iterator<char>()
+    };
+    REQUIRE( input );
+    CHECK( contents == "WRTDPG" );
+    cata::lua_platform::shutdown();
+}
+
+TEST_CASE( "lua_first_native_event_recursion_is_globally_bounded_across_mods",
+           "[lua][platform][runtime][events][recursion]" )
+{
+    cata::lua_platform::shutdown();
+    scoped_platform_test_mod gains_mod( "ccb_platform_event_recursion_gains" );
+    scoped_platform_test_mod losses_mod( "ccb_platform_event_recursion_losses" );
+    const fs::path marker = gains_mod.root() / "event-recursion.txt";
+    gains_mod.write( "main.lua", string_format( R"lua(
+local ccb = require("ccb")
+
+for index = 1, 9 do
+    ccb.content.add(ccb.content.EffectType {
+        id = "ccb_platform_recursion_gain_" .. index,
+        name = "Platform recursion gain " .. index,
+        description = "Exercises the global native-event recursion guard.",
+    })
+end
+for index = 1, 8 do
+    ccb.content.add(ccb.content.EffectType {
+        id = "ccb_platform_recursion_loss_" .. index,
+        name = "Platform recursion loss " .. index,
+        description = "Exercises the global native-event recursion guard.",
+    })
+end
+
+local running = false
+local next_loss = 1
+local function append(value)
+    local output = assert(io.open([[%s]], "ab"))
+    output:write(value)
+    output:close()
+end
+
+ccb.runtime.handler("gain", function(event)
+    if not running then
+        return
+    end
+    local loss_index = next_loss
+    assert(event.type == "character_gains_effect")
+    assert(event.data.effect == "ccb_platform_recursion_gain_" .. loss_index)
+    append("A")
+    next_loss = loss_index + 1
+    local removed = ccb.services.effects.remove(
+        event.actors.character,
+        ccb.services.types.id(
+            "effect", "ccb_platform_recursion_loss_" .. loss_index))
+    assert(removed.ok and removed.value)
+end)
+
+ccb.runtime.handler("ready", function()
+    local character = ccb.services.creatures.avatar()
+    local duration = ccb.services.time.duration(1, "hour")
+    for index = 1, 8 do
+        local added = ccb.services.effects.add(
+            character,
+            ccb.services.types.id(
+                "effect", "ccb_platform_recursion_loss_" .. index),
+            duration)
+        assert(added.ok)
+    end
+    running = true
+    local started = ccb.services.effects.add(
+        character,
+        ccb.services.types.id("effect", "ccb_platform_recursion_gain_1"),
+        duration)
+    assert(started.ok)
+end)
+
+ccb.runtime.on("game:character_gains_effect", "gain")
+ccb.runtime.on("world_ready", "ready")
+)lua", marker.generic_u8string() ) );
+
+    losses_mod.write( "main.lua", string_format( R"lua(
+local ccb = require("ccb")
+local next_gain = 2
+
+local function append(value)
+    local output = assert(io.open([[%s]], "ab"))
+    output:write(value)
+    output:close()
+end
+
+ccb.runtime.handler("loss", function(event)
+    local gain_index = next_gain
+    assert(event.type == "character_loses_effect")
+    assert(event.data.effect == "ccb_platform_recursion_loss_" .. (gain_index - 1))
+    append("B")
+    next_gain = gain_index + 1
+    local added = ccb.services.effects.add(
+        event.actors.character,
+        ccb.services.types.id(
+            "effect", "ccb_platform_recursion_gain_" .. gain_index),
+        ccb.services.time.duration(1, "hour"))
+    assert(added.ok)
+end)
+
+ccb.runtime.on("game:character_loses_effect", "loss")
+)lua", marker.generic_u8string() ) );
+
+    gains_mod.refresh();
+    const mod_id gains_id( gains_mod.root_name() );
+    const mod_id losses_id( losses_mod.root_name() );
+    REQUIRE( gains_id.is_valid() );
+    REQUIRE( losses_id.is_valid() );
+    CHECK( gains_id->mod_root_path.get_unrelative_path() == gains_mod.root() );
+    CHECK( losses_id->mod_root_path.get_unrelative_path() == losses_mod.root() );
+
+    std::string error;
+    REQUIRE( cata::lua_platform::prepare_mods( {
+        gains_mod.source( "ccb_platform_event_recursion_gains" ),
+        losses_mod.source( "ccb_platform_event_recursion_losses" )
+    }, error ) );
+    REQUIRE( cata::lua_platform::apply_prepared_content( error ) );
+    REQUIRE( cata::lua_platform::validate_finalized_prepared_content( error ) );
+    cata::lua_platform::commit_prepared_mods();
+
+    avatar &player = get_avatar();
+    on_out_of_scope cleanup( [&player]() {
+        for( int index = 1; index <= 9; ++index ) {
+            player.remove_effect( efftype_id(
+                                      "ccb_platform_recursion_gain_" + std::to_string( index ) ) );
+        }
+        for( int index = 1; index <= 8; ++index ) {
+            player.remove_effect( efftype_id(
+                                      "ccb_platform_recursion_loss_" + std::to_string( index ) ) );
+        }
+    } );
+    cata::lua_platform::on_world_ready( true );
+
+    std::ifstream input( marker, std::ios::binary );
+    const std::string contents{
+        std::istreambuf_iterator<char>( input ),
+        std::istreambuf_iterator<char>()
+    };
+    REQUIRE( input );
+    CHECK( contents == "ABABABABABABABAB" );
+    CHECK( player.has_effect( efftype_id( "ccb_platform_recursion_gain_9" ) ) );
     cata::lua_platform::shutdown();
 }
 
@@ -4647,7 +7426,7 @@ TEST_CASE( "lua_v5_registered_handlers_accept_native_context",
         "id": "user",
         "version": "5.0.0",
         "api_version": 5,
-        "capabilities": [ "game.write", "state.character" ],
+        "capabilities": [ "game.read", "game.write", "state.character" ],
         "dependencies": [ "builtin" ]
     })json" );
     script.write( R"lua(
@@ -5011,42 +7790,56 @@ TEST_CASE( "lua_binding_catalog_is_unique_capability_scoped_and_detached",
     CHECK_FALSE( api_supports( "missing" ).get<bool>() );
 }
 
-TEST_CASE( "lua_game_handles_reject_stale_destroyed_and_wrong_kind_references",
+TEST_CASE( "lua_game_handles_reject_foreign_stale_destroyed_and_wrong_kind_references",
            "[lua][bindings][handles]" )
 {
     using namespace cata::lua_ui;
 
     constexpr std::size_t runtime_generation = 17;
     constexpr std::size_t world_generation = 23;
+    const game_handle_runtime_owner_ptr runtime_owner =
+        make_game_handle_runtime_owner();
+    const game_handle_runtime runtime_context( runtime_owner, runtime_generation );
     game_handle_locator locator{ "test", 42, 1, 2, 3, { 4, 5 } };
     auto value = std::make_unique<item>();
     game_handle handle = game_handle::from_item(
-                             *value, locator, runtime_generation, world_generation );
+                             *value, locator, runtime_context, world_generation );
 
     native_handle_result<item> resolved =
-        handle.resolve_item( runtime_generation, world_generation );
+        handle.resolve_item( runtime_context, world_generation );
     REQUIRE( resolved );
     CHECK( resolved.value == value.get() );
     CHECK_FALSE( resolved.error );
 
     const native_handle_result<Creature> wrong =
-        handle.resolve_creature( runtime_generation, world_generation );
+        handle.resolve_creature( runtime_context, world_generation );
     REQUIRE_FALSE( wrong );
     REQUIRE( wrong.error );
     CHECK( wrong.error->code == "wrong_kind" );
 
-    resolved = handle.resolve_item( runtime_generation + 1, world_generation );
+    resolved = handle.resolve_item(
+                   game_handle_runtime( runtime_owner, runtime_generation + 1 ),
+                   world_generation );
     REQUIRE_FALSE( resolved );
     REQUIRE( resolved.error );
     CHECK( resolved.error->code == "stale_runtime" );
 
-    resolved = handle.resolve_item( runtime_generation, world_generation + 1 );
+    resolved = handle.resolve_item( runtime_context, world_generation + 1 );
     REQUIRE_FALSE( resolved );
     REQUIRE( resolved.error );
     CHECK( resolved.error->code == "stale_world" );
 
+    const game_handle_runtime_owner_ptr foreign_owner =
+        make_game_handle_runtime_owner();
+    resolved = handle.resolve_item(
+                   game_handle_runtime( foreign_owner, runtime_generation ),
+                   world_generation );
+    REQUIRE_FALSE( resolved );
+    REQUIRE( resolved.error );
+    CHECK( resolved.error->code == "stale_runtime" );
+
     value.reset();
-    resolved = handle.resolve_item( runtime_generation, world_generation );
+    resolved = handle.resolve_item( runtime_context, world_generation );
     REQUIRE_FALSE( resolved );
     REQUIRE( resolved.error );
     CHECK( resolved.error->code == "destroyed" );
@@ -5058,8 +7851,8 @@ TEST_CASE( "lua_game_handles_reject_stale_destroyed_and_wrong_kind_references",
     std::size_t current_world = world_generation;
     install_game_handle_api(
         lua, game,
-    [&current_runtime]() {
-        return current_runtime;
+    [&runtime_owner, &current_runtime]() {
+        return game_handle_runtime( runtime_owner, current_runtime );
     },
     [&current_world]() {
         return current_world;
@@ -5068,7 +7861,9 @@ TEST_CASE( "lua_game_handles_reject_stale_destroyed_and_wrong_kind_references",
 
     auto live_value = std::make_unique<item>();
     lua["test_handle"] = game_handle::from_item(
-                             *live_value, locator, runtime_generation, world_generation );
+                             *live_value, locator,
+                             game_handle_runtime( runtime_owner, runtime_generation ),
+                             world_generation );
     sol::protected_function_result script = lua.safe_script( R"lua(
 assert(test_handle.kind == "item")
 local locator = test_handle:locator()
@@ -5096,6 +7891,172 @@ assert(status.error.code == "stale_runtime")
 assert(type(status.error.message) == "string")
 )lua" );
     REQUIRE( script.valid() );
+
+    const game_handle_runtime_owner_ptr boundary_owner =
+        make_game_handle_runtime_owner();
+    const game_handle_runtime boundary_runtime(
+        boundary_owner, std::numeric_limits<std::size_t>::max() );
+    auto boundary_value = std::make_unique<item>();
+    const game_handle boundary_handle = game_handle::from_item(
+                                            *boundary_value, locator,
+                                            boundary_runtime, world_generation );
+    CHECK( boundary_handle.resolve_item( boundary_runtime, world_generation ) );
+    const native_handle_result<item> inactive_boundary =
+        boundary_handle.resolve_item( game_handle_runtime(), world_generation );
+    REQUIRE_FALSE( inactive_boundary );
+    REQUIRE( inactive_boundary.error );
+    CHECK( inactive_boundary.error->code == "stale_runtime" );
+
+    game_handle_runtime_owner_ptr expiring_owner =
+        make_game_handle_runtime_owner();
+    const game_handle_runtime expiring_runtime(
+        expiring_owner, runtime_generation );
+    auto expiring_value = std::make_unique<item>();
+    const game_handle expiring_handle = game_handle::from_item(
+                                            *expiring_value, locator,
+                                            expiring_runtime, world_generation );
+    REQUIRE( expiring_runtime.has_live_owner() );
+    expiring_owner.reset();
+    CHECK_FALSE( expiring_runtime.has_live_owner() );
+    const native_handle_result<item> expired = expiring_handle.resolve_item(
+                game_handle_runtime( make_game_handle_runtime_owner(), runtime_generation ),
+                world_generation );
+    REQUIRE_FALSE( expired );
+    REQUIRE( expired.error );
+    CHECK( expired.error->code == "stale_runtime" );
+}
+
+TEST_CASE( "lua_native_tokens_bind_owner_identity_and_keep_expired_equality_stable",
+           "[lua][bindings][tokens][owner]" )
+{
+    using namespace cata::lua_ui;
+
+    constexpr std::size_t runtime_generation = 41;
+    constexpr std::size_t world_generation = 73;
+    game_handle_runtime_owner_ptr first_owner =
+        make_game_handle_runtime_owner();
+    const game_handle_runtime_owner_ptr foreign_owner =
+        make_game_handle_runtime_owner();
+    const game_handle_runtime first_runtime(
+        first_owner, runtime_generation );
+    const game_handle_runtime first_runtime_copy(
+        first_owner, runtime_generation );
+    const game_handle_runtime next_generation(
+        first_owner, runtime_generation + 1 );
+    const game_handle_runtime foreign_runtime(
+        foreign_owner, runtime_generation );
+
+    CHECK( first_runtime.same_identity( first_runtime_copy ) );
+    CHECK( first_runtime.is_active_match( first_runtime_copy ) );
+    CHECK_FALSE( game_handle_runtime().same_identity(
+                     game_handle_runtime() ) );
+    CHECK_FALSE( first_runtime.same_identity( next_generation ) );
+    CHECK_FALSE( first_runtime.is_active_match( foreign_runtime ) );
+
+    const mission_token token(
+        123456, first_runtime, world_generation );
+    const mission_token token_copy = token;
+    const mission_token foreign_token(
+        123456, foreign_runtime, world_generation );
+    const mission_token next_generation_token(
+        123456, next_generation, world_generation );
+
+    CHECK( token.runtime_generation() == runtime_generation );
+    CHECK( token == token_copy );
+    CHECK_FALSE( token == foreign_token );
+    CHECK_FALSE( token == next_generation_token );
+    CHECK( token.belongs_to( first_runtime_copy ) );
+    CHECK_FALSE( token.belongs_to( foreign_runtime ) );
+
+    game_handle_runtime active_runtime = foreign_runtime;
+    sol::state lua;
+    lua.open_libraries( sol::lib::base, sol::lib::table );
+    sol::table game = lua.create_named_table( "game" );
+    install_mission_api(
+        game,
+    [&active_runtime]() {
+        return active_runtime;
+    }, [world_generation]() {
+        return world_generation;
+    }, []() {}, []() {} );
+    lua["origin_token"] = token;
+    lua["same_token"] = token_copy;
+    lua["foreign_token"] = foreign_token;
+    sol::protected_function_result result = lua.safe_script( R"lua(
+assert(origin_token == same_token)
+assert(origin_token ~= foreign_token)
+local resolved = game.missions.get(origin_token)
+assert(resolved.ok == false)
+assert(resolved.error.code == "stale_runtime")
+)lua" );
+    REQUIRE( result.valid() );
+
+    first_owner.reset();
+    CHECK_FALSE( first_runtime.has_live_owner() );
+    CHECK( first_runtime.same_identity( first_runtime_copy ) );
+    CHECK_FALSE( first_runtime.is_active_match( first_runtime_copy ) );
+    CHECK( token == token_copy );
+    CHECK_FALSE( token == foreign_token );
+    CHECK_FALSE( token.belongs_to( first_runtime_copy ) );
+    result = lua.safe_script( R"lua(
+assert(origin_token == same_token)
+assert(origin_token ~= foreign_token)
+)lua" );
+    REQUIRE( result.valid() );
+}
+
+TEST_CASE( "lua_first_game_handles_reject_same_generation_foreign_runtime_owners",
+           "[lua][platform][runtime][handles][owner]" )
+{
+    using cata::lua_platform::runtime;
+    using cata::lua_ui::game_handle;
+
+    cata::lua_platform::clear_active_runtimes();
+    sol::state first_lua;
+    sol::state second_lua;
+    first_lua.open_libraries( sol::lib::base, sol::lib::table );
+    second_lua.open_libraries( sol::lib::base, sol::lib::table );
+    sol::table first_ccb = first_lua.create_named_table( "ccb" );
+    sol::table second_ccb = second_lua.create_named_table( "ccb" );
+    constexpr std::size_t shared_generation =
+        std::numeric_limits<std::size_t>::max();
+    const std::shared_ptr<runtime> first =
+        cata::lua_platform::make_runtime(
+            "ccb_platform_handle_owner_first", shared_generation, first_lua );
+    const std::shared_ptr<runtime> second =
+        cata::lua_platform::make_runtime(
+            "ccb_platform_handle_owner_second", shared_generation, second_lua );
+    cata::lua_platform::install_runtime_api( first, first_lua, first_ccb );
+    cata::lua_platform::install_runtime_api( second, second_lua, second_ccb );
+    cata::lua_platform::set_active_runtimes( { first, second } );
+    on_out_of_scope clear_runtimes( []() {
+        cata::lua_platform::clear_active_runtimes();
+    } );
+    cata::lua_platform::runtime_world_ready( true );
+
+    sol::protected_function_result created = first_lua.safe_script( R"lua(
+return ccb.services.creatures.avatar()
+)lua" );
+    REQUIRE( created.valid() );
+    const game_handle first_handle = created.get<game_handle>();
+    first_lua["same_owner"] = first_handle;
+    sol::protected_function_result local_result = first_lua.safe_script( R"lua(
+local result = ccb.services.creatures.snapshot(same_owner)
+assert(result.ok and result.value.kind == "avatar")
+return true
+)lua" );
+    REQUIRE( local_result.valid() );
+    CHECK( local_result.get<bool>() );
+
+    second_lua["foreign_owner"] = first_handle;
+    sol::protected_function_result foreign_result = second_lua.safe_script( R"lua(
+local result = ccb.services.creatures.snapshot(foreign_owner)
+assert(not result.ok)
+assert(result.error.code == "stale_runtime")
+return true
+)lua" );
+    REQUIRE( foreign_result.valid() );
+    CHECK( foreign_result.get<bool>() );
 }
 
 TEST_CASE( "lua_top_level_handles_use_the_committed_runtime_generation",
@@ -6430,6 +9391,11 @@ TEST_CASE( "lua_v5_gut_nutrients_are_generation_safe_and_bounded",
     const vitamin_id vitamin_c( "vitC" );
     const int original_calories = player.guts.get_calories();
     const int original_vitamin = player.guts.get_vitamin( vitamin_c );
+    on_out_of_scope restore_gut_nutrients( [&player, vitamin_c, original_calories,
+    original_vitamin]() {
+        player.guts.mod_calories( original_calories - player.guts.get_calories() );
+        player.guts.set_vitamin( vitamin_c, original_vitamin );
+    } );
 
     scoped_lua_user_script script;
     script.write_manifest( R"json({
@@ -6453,7 +9419,7 @@ assert(large_calories.value.after == 2000001)
 
 local assigned_calories = game.needs.set_gut_calories(avatar, 100)
 assert(assigned_calories.ok == true)
-assert(assigned_calories.value.before == calories.value)
+assert(assigned_calories.value.before == large_calories.value.after)
 assert(assigned_calories.value.after == 100)
 
 local modified_calories = game.needs.modify_gut_calories(avatar, -25)
@@ -6493,8 +9459,6 @@ end) == false)
     CHECK( error.empty() );
     CHECK( player.guts.get_calories() == std::numeric_limits<int>::max() );
     CHECK( player.guts.get_vitamin( vitamin_c ) == 15 );
-    player.guts.mod_calories( original_calories - std::numeric_limits<int>::max() );
-    player.guts.set_vitamin( vitamin_c, original_vitamin );
 }
 
 TEST_CASE( "lua_v5_calorie_sleep_and_health_services_use_native_rules",
@@ -8445,6 +11409,24 @@ assert(removed.value.zone.personal == true)
 assert(personal_token:is_valid() == false)
 assert(game.zones.get(
     personal_token).error.code == "not_found")
+
+local recreated_personal = game.zones.create({
+    name = "Lua personal zone",
+    type = zone_id,
+    start = game.coords.tripoint_rel_ms(
+        -2, -1, 0),
+    ["end"] = game.coords.tripoint_rel_ms(
+        2, 1, 0),
+    personal = true
+})
+assert(recreated_personal.ok == true)
+assert(recreated_personal.value.token:is_valid() == true)
+assert(personal_token:is_valid() == false)
+assert(game.zones.get(
+    personal_token).error.code == "not_found")
+local removed_recreated = game.zones.remove(
+    recreated_personal.value.token)
+assert(removed_recreated.ok == true)
 
 assert(pcall(function()
     game.zones.create({
@@ -11560,12 +14542,45 @@ assert(game.items.get_var(
     rock.handle, "ccb_lua_text").error.code == "not_found")
 
 local pseudo = game.types.id("json_flag", "PSEUDO")
+local added_pseudo = game.items.set_flag(
+    rock.handle, pseudo, true)
+assert(added_pseudo.value.own_before == false)
+assert(added_pseudo.value.own_after == true)
+assert(added_pseudo.value.changed == true)
 assert(game.items.set_flag(
-    rock.handle, pseudo, true).value.own_after == true)
+    rock.handle, pseudo, true).value.changed == false)
 assert(game.items.has_flag(
     rock.handle, pseudo).value == true)
+local removed_pseudo = game.items.set_flag(
+    rock.handle, pseudo, false)
+assert(removed_pseudo.value.own_before == true)
+assert(removed_pseudo.value.own_after == false)
+assert(removed_pseudo.value.changed == true)
 assert(game.items.set_flag(
-    rock.handle, pseudo, false).value.own_after == false)
+    rock.handle, pseudo, false).value.changed == false)
+
+local inherited = game.types.id("json_flag", "TRADER_AVOID")
+local inherited_before = game.items.set_flag(
+    rock.handle, inherited, false)
+assert(inherited_before.value.effective_before == true)
+assert(inherited_before.value.effective_after == true)
+assert(inherited_before.value.own_before == false)
+assert(inherited_before.value.own_after == false)
+assert(inherited_before.value.changed == false)
+local inherited_added = game.items.set_flag(
+    rock.handle, inherited, true)
+assert(inherited_added.value.effective_before == true)
+assert(inherited_added.value.effective_after == true)
+assert(inherited_added.value.own_before == false)
+assert(inherited_added.value.own_after == true)
+assert(inherited_added.value.changed == true)
+local inherited_removed = game.items.set_flag(
+    rock.handle, inherited, false)
+assert(inherited_removed.value.effective_before == true)
+assert(inherited_removed.value.effective_after == true)
+assert(inherited_removed.value.own_before == true)
+assert(inherited_removed.value.own_after == false)
+assert(inherited_removed.value.changed == true)
 
 local feint = game.types.id(
     "martial_art_technique", "tec_feint")
@@ -13017,7 +16032,7 @@ assert(string.find(error, "nesting limit", 1, true) ~= nil)
     local ok, error = pcall(
         require, "test_limits.budget_" .. tostring(index))
     if index < )lua" +
-                  std::to_string( maximum_modules_per_source ) + R"lua( then
+                                 std::to_string( maximum_modules_per_source ) + R"lua( then
         assert(ok)
     else
         assert(ok == false)
@@ -15499,6 +18514,7 @@ TEST_CASE( "lua_v5_dialogue_and_interaction_hooks_run_from_native_bridges",
 {
     using namespace cata::lua_ui;
 
+    cata::lua_platform::shutdown();
     clear_avatar();
     clear_map_without_vision();
     avatar &player = get_avatar();
@@ -15512,6 +18528,51 @@ TEST_CASE( "lua_v5_dialogue_and_interaction_hooks_run_from_native_bridges",
         player.pos_bub( here ) + tripoint_rel_ms::west * 2 );
     std::unique_ptr<talker> alpha = get_talker_for( player );
     std::unique_ptr<talker> beta = get_talker_for( test_npc );
+
+    scoped_platform_test_mod platform_mod( "ccb_platform_dialogue_projection" );
+    const fs::path platform_marker = platform_mod.root() / "dialogue-projection.txt";
+    platform_mod.write( "main.lua", string_format( R"lua(
+local ccb = require("ccb")
+local function append(value)
+    local output = assert(io.open([[%s]], "ab"))
+    output:write(value)
+    output:close()
+end
+
+ccb.runtime.handler("dialogue_start", function(payload)
+    assert(payload.alpha == nil and payload.beta == nil and payload.topic == nil)
+    assert(payload.avatar.kind == "creature")
+    assert(payload.interlocutor.kind == "creature")
+    assert(payload.initial_topic == "TALK_TEST_START")
+    assert(payload.results.result == "TALK_LUA_START")
+    append("S")
+    return { result = "TALK_PLATFORM_START" }
+end)
+
+ccb.runtime.handler("dialogue_option", function(payload)
+    assert(payload.alpha == nil and payload.beta == nil)
+    assert(payload.topic == nil and payload.option == nil)
+    assert(payload.avatar.kind == "creature")
+    assert(payload.interlocutor.kind == "creature")
+    assert(payload.current_topic == "TALK_PLATFORM_START")
+    assert(payload.selected_topic == "TALK_TEST_OPTION")
+    assert(payload.results.result == "TALK_LUA_OPTION")
+    append("O")
+    return { result = "TALK_PLATFORM_OPTION" }
+end)
+
+ccb.runtime.handler("dialogue_end", function(payload)
+    assert(payload.alpha == nil and payload.beta == nil and payload.topic == nil)
+    assert(payload.avatar.kind == "creature")
+    assert(payload.interlocutor.kind == "creature")
+    assert(payload.last_topic == "TALK_PLATFORM_OPTION")
+    append("E")
+end)
+
+ccb.runtime.hook("on_dialogue_start", "dialogue_start")
+ccb.runtime.hook("on_dialogue_option", "dialogue_option")
+ccb.runtime.hook("on_dialogue_end", "dialogue_end")
+)lua", platform_marker.generic_u8string() ) );
 
     scoped_lua_user_script script;
     script.write_manifest( R"json({
@@ -15542,7 +18603,7 @@ end)
 game.hooks.on("on_dialogue_option", function(payload)
     assert(payload.alpha.kind == "creature")
     assert(payload.beta.kind == "creature")
-    assert(payload.topic == "TALK_LUA_START")
+    assert(payload.topic == "TALK_PLATFORM_START")
     assert(payload.option == "TALK_TEST_OPTION")
     count("dialogue_option")
     return { result = "TALK_LUA_OPTION" }
@@ -15550,7 +18611,7 @@ end)
 game.hooks.on("on_dialogue_end", function(payload)
     assert(payload.alpha.kind == "creature")
     assert(payload.beta.kind == "creature")
-    assert(payload.topic == "TALK_LUA_OPTION")
+    assert(payload.topic == "TALK_PLATFORM_OPTION")
     count("dialogue_end")
 end)
 game.hooks.on("on_try_npc_interaction", function(payload)
@@ -15584,22 +18645,36 @@ end)
 
     std::string error;
     REQUIRE( reload_scripts( error ) );
+    REQUIRE( cata::lua_platform::prepare_mods(
+                 { platform_mod.source( "ccb_platform_dialogue_projection" ) }, error ) );
+    REQUIRE( cata::lua_platform::apply_prepared_content( error ) );
+    REQUIRE( cata::lua_platform::validate_finalized_prepared_content( error ) );
+    cata::lua_platform::commit_prepared_mods();
+    cata::lua_platform::on_world_ready( true );
 
     const native_hook_result start =
         dispatch_native_dialogue_hook(
             "on_dialogue_start", *alpha, *beta,
             "TALK_TEST_START" );
     REQUIRE( start.result );
-    CHECK( *start.result == "TALK_LUA_START" );
+    CHECK( *start.result == "TALK_PLATFORM_START" );
 
     const native_hook_result option =
         dispatch_native_dialogue_hook(
             "on_dialogue_option", *alpha, *beta,
             *start.result, "TALK_TEST_OPTION" );
     REQUIRE( option.result );
-    CHECK( *option.result == "TALK_LUA_OPTION" );
+    CHECK( *option.result == "TALK_PLATFORM_OPTION" );
     dispatch_native_dialogue_hook(
         "on_dialogue_end", *alpha, *beta, *option.result );
+
+    std::ifstream platform_input( platform_marker, std::ios::binary );
+    const std::string platform_calls{
+        std::istreambuf_iterator<char>( platform_input ),
+        std::istreambuf_iterator<char>()
+    };
+    REQUIRE( platform_input );
+    CHECK( platform_calls == "SOE" );
 
     CHECK( begin_native_npc_interaction( player, test_npc ) );
     CHECK_FALSE( allow_native_monster_interaction(
@@ -15641,6 +18716,7 @@ TEST_CASE( "lua_v5_dialogue_topics_extend_json_without_replacing_it",
             { "text": "<end_talking_leave>", "topic": "TALK_DONE" }
         ]
     })json" );
+    CHECK( base_topic.get_string( "type" ) == "talk_topic" );
     load_talk_topic( base_topic, "lua dialogue test" );
 
     clear_avatar();
@@ -15714,8 +18790,10 @@ game.dialogue.register_topic({
     CHECK( base_dialogue.dynamic_line( base_topic_id ) == "Base JSON line." );
     base_dialogue.gen_responses( base_topic_id );
     REQUIRE( base_dialogue.responses.size() == 3 );
-    CHECK( base_dialogue.responses[0].success.next_topic.id == "TALK_NONE" );
-    CHECK( base_dialogue.responses[1].success.next_topic.id == "TALK_LUA_DIALOGUE_TOPIC" );
+    // insert_before_standard_exits places the extension before both TALK_NONE
+    // and TALK_DONE, matching the JSON dialogue extension contract.
+    CHECK( base_dialogue.responses[0].success.next_topic.id == "TALK_LUA_DIALOGUE_TOPIC" );
+    CHECK( base_dialogue.responses[1].success.next_topic.id == "TALK_NONE" );
     CHECK( base_dialogue.responses[2].success.next_topic.id == "TALK_DONE" );
 
     dialogue lua_dialogue( get_talker_for( player ), get_talker_for( test_npc ) );

--- a/tests/catalua_ui_test.cpp
+++ b/tests/catalua_ui_test.cpp
@@ -5090,6 +5090,180 @@ ccb.runtime.on("world_ready", "ready")
     cata::lua_platform::shutdown();
 }
 
+TEST_CASE( "lua_first_bundled_mod_completes_a_playable_save_reload_loop",
+           "[lua][platform][integration][playable_mvp]" )
+{
+    REQUIRE( world_generator != nullptr );
+    REQUIRE( world_generator->active_world != nullptr );
+    REQUIRE( g != nullptr );
+
+    cata::lua_platform::shutdown();
+    mod_manager &manager = world_generator->get_mod_manager();
+    manager.refresh_mod_list();
+    const mod_id example_id( "Lua_First_Example" );
+    REQUIRE( example_id.is_valid() );
+    CHECK( example_id->name() == "Lua-first playable example" );
+    CHECK( example_id->version == "0.1.0" );
+    CHECK( ( example_id->dependencies == std::vector<mod_id> { mod_id( "dda" ) } ) );
+    CHECK( example_id->mod_root_path.get_unrelative_path() ==
+           PATH_INFO::moddir().get_unrelative_path() / "Lua_First_Example" );
+
+    std::vector<mod_id> &active_mods =
+        world_generator->active_world->active_mod_order;
+    const std::vector<mod_id> original_mods = active_mods;
+    std::vector<mod_id> selected_mods = original_mods;
+    mod_ui selector( manager );
+    selector.try_add( example_id, selected_mods, false );
+    CHECK( std::find( selected_mods.begin(), selected_mods.end(), mod_id( "dda" ) ) !=
+           selected_mods.end() );
+    CHECK( std::count( selected_mods.begin(), selected_mods.end(), example_id ) == 1 );
+
+    const auto reset_playable_avatar = []() {
+        get_avatar() = avatar();
+        get_avatar().create( character_type::NOW );
+        get_avatar().setID( g->assign_npc_id(), false );
+        get_avatar().set_save_id( "Lua-first playable MVP" );
+        get_avatar().setpos( get_map(), tripoint_bub_ms( 30, 30, 0 ) );
+    };
+    bool restored_original_mods = false;
+    on_out_of_scope restore_mods( [&]() {
+        if( restored_original_mods ) {
+            return;
+        }
+        try {
+            cata::lua_platform::shutdown();
+            active_mods = original_mods;
+            g->load_core_data();
+            g->load_world_modfiles();
+            reset_playable_avatar();
+        } catch( ... ) {
+            // Preserve the original test failure; this process-level fixture is
+            // reinitialized by the next cata_test invocation.
+        }
+    } );
+    active_mods = selected_mods;
+
+    scoped_calendar_turn turn;
+    const auto load_selected_mods = [&]() {
+        cata::lua_platform::shutdown();
+        g->load_core_data();
+        g->load_world_modfiles();
+        CHECK( ( cata::lua_platform::loaded_mod_ids() ==
+                 std::vector<std::string> { "Lua_First_Example" } ) );
+    };
+    load_selected_mods();
+    reset_playable_avatar();
+
+    scoped_lua_state_file character_sidecar(
+        ( PATH_INFO::player_base_save_path() +
+          ".lua_platform.json" ).get_unrelative_path() );
+    scoped_lua_state_file world_sidecar(
+        ( world_generator->active_world->folder_path() /
+          "lua_platform_world.json" ).get_unrelative_path() );
+    character_sidecar.write( R"json({
+  "version": 1,
+  "scope": "character",
+  "mods": {}
+})json" );
+    world_sidecar.write( R"json({
+  "version": 1,
+  "scope": "world",
+  "mods": {}
+})json" );
+
+    const auto platform_record = []( const std::string &contents ) {
+        JsonObject root = json_loader::from_string( contents ).get_object();
+        root.allow_omitted_members();
+        JsonObject mods = root.get_object( "mods" );
+        mods.allow_omitted_members();
+        JsonObject record = mods.get_object( "Lua_First_Example" );
+        record.allow_omitted_members();
+        return record;
+    };
+    const auto platform_integer = [&platform_record]( const std::string &contents,
+    const std::string &key ) {
+        JsonObject record = platform_record( contents );
+        JsonObject values = record.get_object( "values" );
+        values.allow_omitted_members();
+        JsonObject value = values.get_object( key );
+        value.allow_omitted_members();
+        return value.get_int64( "value" );
+    };
+    const auto platform_boolean = [&platform_record]( const std::string &contents,
+    const std::string &key ) {
+        JsonObject record = platform_record( contents );
+        JsonObject values = record.get_object( "values" );
+        values.allow_omitted_members();
+        JsonObject value = values.get_object( key );
+        value.allow_omitted_members();
+        return value.get_bool( "value" );
+    };
+    const auto platform_task_handlers = [&platform_record]( const std::string &contents ) {
+        JsonObject record = platform_record( contents );
+        JsonArray tasks = record.get_array( "tasks" );
+        std::vector<std::string> handlers;
+        handlers.reserve( tasks.size() );
+        while( tasks.has_more() ) {
+            JsonObject task = tasks.next_object();
+            task.allow_omitted_members();
+            handlers.push_back( task.get_string( "handler" ) );
+        }
+        return handlers;
+    };
+
+    cata::lua_platform::on_world_ready( true );
+    REQUIRE( item_controller->has_template(
+                 itype_id( "lua_first_cleanwater_charm" ) ) );
+    REQUIRE( recipe_id( "lua_first_cleanwater_charm" ).is_valid() );
+
+    avatar &player = get_avatar();
+    item first_charm( itype_id( "lua_first_cleanwater_charm" ) );
+    const std::optional<int> first_use = first_charm.type->invoke(
+            &player, first_charm, &get_map(), player.pos_bub() );
+    REQUIRE( first_use );
+    CHECK( *first_use == 0 );
+
+    REQUIRE( g->save() );
+    CHECK_FALSE( world_generator->active_world->world_saves.empty() );
+    CHECK( platform_integer( character_sidecar.read(), "cleanwater_charm_uses" ) == 1 );
+    CHECK( platform_boolean( world_sidecar.read(),
+                             "cleanwater_example_initialized" ) );
+    const std::vector<std::string> first_tasks =
+        platform_task_handlers( world_sidecar.read() );
+    REQUIRE( first_tasks.size() == 1 );
+    CHECK( first_tasks.front() == "lua_first_example_reminder" );
+
+    load_selected_mods();
+    reset_playable_avatar();
+    cata::lua_platform::on_world_ready( false );
+    REQUIRE( item_controller->has_template(
+                 itype_id( "lua_first_cleanwater_charm" ) ) );
+    REQUIRE( recipe_id( "lua_first_cleanwater_charm" ).is_valid() );
+
+    item restored_charm( itype_id( "lua_first_cleanwater_charm" ) );
+    const std::optional<int> restored_use = restored_charm.type->invoke(
+            &player, restored_charm, &get_map(), player.pos_bub() );
+    REQUIRE( restored_use );
+    CHECK( *restored_use == 0 );
+    REQUIRE( g->save() );
+    CHECK( platform_integer( character_sidecar.read(), "cleanwater_charm_uses" ) == 2 );
+    CHECK( platform_task_handlers( world_sidecar.read() ).size() == 1 );
+
+    calendar::turn += 11_turns;
+    cata::lua_platform::on_turn();
+    REQUIRE( g->save() );
+    CHECK( platform_integer( world_sidecar.read(),
+                             "cleanwater_example_reminders" ) == 1 );
+    CHECK( platform_task_handlers( world_sidecar.read() ).empty() );
+
+    cata::lua_platform::shutdown();
+    active_mods = original_mods;
+    g->load_core_data();
+    g->load_world_modfiles();
+    reset_playable_avatar();
+    restored_original_mods = true;
+}
+
 TEST_CASE( "lua_first_corrupt_duplicate_task_ids_clear_the_scope",
            "[lua][platform][runtime][state]" )
 {

--- a/tests/magic_spell_test.cpp
+++ b/tests/magic_spell_test.cpp
@@ -884,19 +884,24 @@ TEST_CASE( "spell_lua_effect_copy_from_inheritance", "[magic][spell][lua]" )
 {
     using namespace cata::lua_ui;
 
-    const auto load_spell = []( const std::string & json ) {
-        spell_type spell;
-        spell.load( json_loader::from_string( json ).get_object(), "dda" );
-        return spell;
+    const auto load_spell = []( spell_type & spell, const std::string & json ) {
+        JsonObject object = json_loader::from_string( json ).get_object();
+        object.get_string( "id" );
+        if( object.has_string( "copy-from" ) ) {
+            object.get_string( "copy-from" );
+        }
+        spell.load( object, "dda" );
     };
 
-    const spell_type base = load_spell( R"json({
+    spell_type base;
+    load_spell( base, R"json({
         "id": "test_lua_base",
         "name": { "str": "base" },
         "description": "base lua spell",
         "effect": "lua",
         "lua": { "handler": "test.lua_base" },
-        "shape": "blast"
+        "shape": "blast",
+        "valid_targets": [ "self" ]
     })json" );
     REQUIRE( base.effect_name == "lua" );
     REQUIRE( base.lua_effect.has_value() );
@@ -906,12 +911,12 @@ TEST_CASE( "spell_lua_effect_copy_from_inheritance", "[magic][spell][lua]" )
     // omit both "effect" and "lua"; it must keep the inherited descriptor.
     spell_type child = base;
     child.was_loaded = true;
-    child.load( json_loader::from_string( R"json({
+    load_spell( child, R"json({
         "id": "test_lua_child",
         "copy-from": "test_lua_base",
         "name": { "str": "child" },
         "description": "child lua spell"
-    })json" ).get_object(), "dda" );
+    })json" );
     CHECK( child.effect_name == "lua" );
     CHECK( child.lua_effect.has_value() );
     CHECK( child.lua_effect->handler == "test.lua_base" );
@@ -919,13 +924,13 @@ TEST_CASE( "spell_lua_effect_copy_from_inheritance", "[magic][spell][lua]" )
     // A child that supplies its own "lua" descriptor replaces the base one.
     spell_type overridden = base;
     overridden.was_loaded = true;
-    overridden.load( json_loader::from_string( R"json({
+    load_spell( overridden, R"json({
         "id": "test_lua_child_override",
         "copy-from": "test_lua_base",
         "name": { "str": "override" },
         "description": "override lua spell",
         "lua": { "handler": "test.lua_override", "args": { "rate": 2 } }
-    })json" ).get_object(), "dda" );
+    })json" );
     CHECK( overridden.lua_effect.has_value() );
     CHECK( overridden.lua_effect->handler == "test.lua_override" );
     CHECK( overridden.lua_effect->args.at( "rate" ) ==
@@ -934,14 +939,13 @@ TEST_CASE( "spell_lua_effect_copy_from_inheritance", "[magic][spell][lua]" )
     // A child that changes "effect" drops the inherited Lua descriptor.
     spell_type reclassified = base;
     reclassified.was_loaded = true;
-    reclassified.load( json_loader::from_string( R"json({
+    load_spell( reclassified, R"json({
         "id": "test_lua_child_other",
         "copy-from": "test_lua_base",
         "name": { "str": "other" },
         "description": "other spell",
         "effect": "attack"
-    })json" ).get_object(), "dda" );
+    })json" );
     CHECK( reclassified.effect_name == "attack" );
     CHECK( !reclassified.lua_effect.has_value() );
 }
-

--- a/tests/mod_manager_test.cpp
+++ b/tests/mod_manager_test.cpp
@@ -5,6 +5,7 @@
 #include "catalua_platform.h"
 #include "mod_manager.h"
 #include "path_info.h"
+#include "worldfactory.h"
 
 #include <string>
 #include <vector>
@@ -56,6 +57,20 @@ TEST_CASE( "lua_first_platform_disabled_build_rejects_runtime_sources",
            "[mod_manager][lua][platform]" )
 {
     CHECK_FALSE( cata::lua_platform::is_enabled() );
+
+    REQUIRE( world_generator != nullptr );
+    mod_manager &manager = world_generator->get_mod_manager();
+    manager.refresh_mod_list();
+    const mod_id bundled_example( "Lua_First_Example" );
+    REQUIRE( bundled_example.is_valid() );
+    CHECK( bundled_example->lua_platform_version ==
+           cata::lua_platform::platform_version );
+    CHECK( bundled_example->lua_platform_error.find( "not enabled" ) !=
+           std::string::npos );
+    CHECK( bundled_example->lua_platform_entry.get_unrelative_path() ==
+           PATH_INFO::moddir().get_unrelative_path() /
+           "Lua_First_Example" / "main.lua" );
+
     const std::vector<cata::lua_platform::mod_source> sources = {
         { "disabled_test", "disabled_test", "disabled_test/main.lua" }
     };

--- a/tools/agent/check_lua_first_replacement_ledger.py
+++ b/tools/agent/check_lua_first_replacement_ledger.py
@@ -21,10 +21,17 @@ def check() -> dict[str, int]:
     schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
     jsonschema.Draft202012Validator(schema).validate(ledger)
     entries = ledger["entries"]
-    identities = [(entry["inventory"], entry["selector"]) for entry in entries]
-    duplicates = sorted(key for key, count in Counter(identities).items() if count != 1)
+    identities = [
+        (entry["inventory"], entry["selector"]) for entry in entries
+    ]
+    duplicates = sorted(
+        key for key, count in Counter(identities).items() if count != 1
+    )
     if duplicates:
-        raise RuntimeError(f"replacement ledger has duplicate selectors: {duplicates[:20]}")
+        raise RuntimeError(
+            "replacement ledger has duplicate selectors: "
+            f"{duplicates[:20]}"
+        )
 
     source_ids = [source["id"] for source in ledger["sources"]]
     if len(source_ids) != len(set(source_ids)):
@@ -32,9 +39,16 @@ def check() -> dict[str, int]:
 
     expected: set[tuple[str, str]] = set()
     for source in ledger["sources"]:
-        document = json.loads((ROOT / source["path"]).read_text(encoding="utf-8"))
-        if source["source_fingerprint"] != document["source"]["source_fingerprint"]:
-            raise RuntimeError(f"inventory fingerprint changed for {source['id']}")
+        document = json.loads(
+            (ROOT / source["path"]).read_text(encoding="utf-8")
+        )
+        if (
+            source["source_fingerprint"] !=
+            document["source"]["source_fingerprint"]
+        ):
+            raise RuntimeError(
+                f"inventory fingerprint changed for {source['id']}"
+            )
         values = {entry[source["selector"]] for entry in document["entries"]}
         if len(values) != source["entry_count"]:
             raise RuntimeError(f"inventory count changed for {source['id']}")
@@ -44,25 +58,33 @@ def check() -> dict[str, int]:
     extra = sorted(actual - expected)
     if missing or extra:
         raise RuntimeError(
-            f"replacement ledger coverage differs: missing={missing[:20]}, extra={extra[:20]}"
+            "replacement ledger coverage differs: "
+            f"missing={missing[:20]}, extra={extra[:20]}"
         )
     expected_summary = {"total": len(entries)}
     for status in (
         "implemented_unverified",
+        "bounded_implemented_unverified",
         "primitive_available_unverified",
         "planned",
         "private_adapter",
         "reviewed_not_applicable",
     ):
-        expected_summary[status] = sum(entry["status"] == status for entry in entries)
+        expected_summary[status] = sum(
+            entry["status"] == status for entry in entries
+        )
     if ledger["summary"] != expected_summary:
         raise RuntimeError("replacement ledger status summary is stale")
 
+    implemented_statuses = {
+        "implemented_unverified",
+        "bounded_implemented_unverified",
+    }
+    evidenced_statuses = implemented_statuses | {
+        "primitive_available_unverified",
+    }
     for entry in entries:
-        if entry["status"] in {
-            "implemented_unverified",
-            "primitive_available_unverified",
-        }:
+        if entry["status"] in evidenced_statuses:
             evidence = entry["evidence"]
             required_kinds = (
                 "src/",
@@ -73,32 +95,46 @@ def check() -> dict[str, int]:
             if any(not any(value.startswith(kind) for value in evidence)
                    for kind in required_kinds):
                 raise RuntimeError(
-                    "implemented selector or primitive lacks source, declaration, test, or "
-                    f"documentation evidence: {entry['inventory']}:{entry['selector']}"
+                    "implemented selector or primitive lacks source, "
+                    "declaration, test, or "
+                    "documentation evidence: "
+                    f"{entry['inventory']}:{entry['selector']}"
+                )
+            if (
+                entry["status"] in implemented_statuses and
+                "tools/migrate_lua_first.py" not in evidence
+            ):
+                raise RuntimeError(
+                    "implemented selector lacks migration evidence: "
+                    f"{entry['inventory']}:{entry['selector']}"
                 )
             if entry["legacy_dependency"] != "none":
                 raise RuntimeError(
-                    "implemented selector has an unresolved public legacy dependency: "
+                    "implemented selector has an unresolved public legacy "
+                    "dependency: "
                     f"{entry['inventory']}:{entry['selector']}"
                 )
         for evidence in entry["evidence"]:
-            if evidence.startswith(("src/", "data/", "tests/", "tools/", "ai/")) and not (
-                ROOT / evidence
-            ).exists():
-                raise RuntimeError(f"replacement evidence path does not exist: {evidence}")
-    return {
-        "total": len(entries),
-        "implemented_unverified": sum(
-            entry["status"] == "implemented_unverified" for entry in entries
-        ),
-    }
+            if (
+                evidence.startswith(
+                    ("src/", "data/", "tests/", "tools/", "ai/")
+                ) and not (ROOT / evidence).exists()
+            ):
+                raise RuntimeError(
+                    "replacement evidence path does not exist: "
+                    f"{evidence}"
+                )
+    return expected_summary
 
 
 def main() -> int:
     result = check()
     print(
         f"Lua-first replacement ledger covers {result['total']} selectors; "
-        f"{result['implemented_unverified']} are implemented but not yet verified."
+        f"{result['implemented_unverified']} have full unverified coverage "
+        "and "
+        f"{result['bounded_implemented_unverified']} have bounded unverified "
+        "coverage."
     )
     return 0
 

--- a/tools/agent/check_project_metadata.py
+++ b/tools/agent/check_project_metadata.py
@@ -15,6 +15,7 @@ import jsonschema
 import yaml
 
 from audit_repository_governance import validate_repository, validate_target
+from check_lua_first_replacement_ledger import check as check_lua_first_replacement_ledger
 from generate_markdown_inventory import contributor_rejection_reason
 
 
@@ -171,6 +172,7 @@ def validate_context() -> None:
     schema_path = ROOT / "ai/context.schema.json"
     schema = json.loads(schema_path.read_text(encoding="utf-8"))
     documents = {path.name: load_yaml(path) for path in CONTEXT_FILES}
+    check_lua_first_replacement_ledger()
     known = tracked_paths()
     for path in CONTEXT_FILES:
         jsonschema.Draft202012Validator(schema).validate(documents[path.name])

--- a/tools/agent/check_project_metadata.py
+++ b/tools/agent/check_project_metadata.py
@@ -15,7 +15,9 @@ import jsonschema
 import yaml
 
 from audit_repository_governance import validate_repository, validate_target
-from check_lua_first_replacement_ledger import check as check_lua_first_replacement_ledger
+from check_lua_first_replacement_ledger import (
+    check as check_lua_first_replacement_ledger,
+)
 from generate_markdown_inventory import contributor_rejection_reason
 
 
@@ -159,8 +161,8 @@ def validate_lua_first_roadmap(roadmap: dict | None = None) -> None:
         raise ValueError("duplicate capability id in Lua-first roadmap")
     for capability in roadmap["capabilities"]:
         if (
-            capability["status"] == "available"
-            and capability["legacy_dependency"] == "public_legacy"
+            capability["status"] == "available" and
+            capability["legacy_dependency"] == "public_legacy"
         ):
             raise ValueError(
                 f"available Lua-first capability exposes public legacy "

--- a/tools/agent/generate_documentation_registry.py
+++ b/tools/agent/generate_documentation_registry.py
@@ -39,6 +39,8 @@ AGENT_METADATA = {
     "ai/documentation-registry.yml",
     "ai/docs-impact.yml",
     "ai/generated-files.yml",
+    "ai/lua-first-replacement-ledger.schema.json",
+    "ai/lua-first-replacement-ledger.yml",
     "ai/lua-first-roadmap.schema.json",
     "ai/lua-first-roadmap.yml",
     "ai/project-map.yml",
@@ -53,6 +55,7 @@ API_CONTRACTS = {
     "data/lua/reference/ccb_public_api_v5.schema.json",
     "data/lua/reference/ccb_public_api_v5_coverage.schema.json",
     "data/lua/types/ccb_api_v5.d.lua",
+    "data/lua/types/ccb_platform_v1.d.lua",
     "tools/json_api/contract-inventory.schema.json",
 }
 ARCHITECTURE_CONTRACTS = {
@@ -124,6 +127,8 @@ def generated_by(path: str) -> str | None:
         return "python3 tools/agent/generate_documentation_registry.py"
     if path == "ai/agent-benchmark-baseline.json":
         return "python3 tools/agent/benchmark_context_pack.py"
+    if path == "ai/lua-first-replacement-ledger.yml":
+        return "python3 tools/agent/generate_lua_first_replacement_ledger.py"
     if path in {
         "doc/migration/contributor-anomalies.yml",
         "doc/migration/markdown-inventory.yml",
@@ -182,6 +187,11 @@ def classify(path: str, legacy: dict[str, dict]) -> dict:
         status = "active"
         authority = "api_contract"
         source_of_truth = True
+    elif path.startswith("data/lua/templates/") and path.endswith(".md"):
+        category = "maintained_document"
+        status = "active"
+        authority = "explanatory"
+        source_of_truth = False
     elif generator:
         category = "generated_document"
         status = "generated"

--- a/tools/agent/generate_lua_first_replacement_ledger.py
+++ b/tools/agent/generate_lua_first_replacement_ledger.py
@@ -29,15 +29,22 @@ INVENTORIES = {
 
 CONTROL_FLOW = {
     "and",
+    "get_condition",
     "or",
     "not",
     "if",
     "foreach",
+    "nothing",
+    "run_eoc_selector",
+    "run_eocs",
+    "run_lua",
+    "set_condition",
     "switch",
+    "test_eoc",
     "weighted_list_eocs",
 }
 
-IMPLEMENTED_JSON = {
+BOUNDED_IMPLEMENTED_JSON = {
     "MOD_INFO": {
         "target": "platform.mod-metadata",
         "evidence": [
@@ -45,6 +52,7 @@ IMPLEMENTED_JSON = {
             "src/mod_manager.cpp",
             "data/lua/types/ccb_platform_v1.d.lua",
             "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
             "data/lua/LUA_FIRST_PLATFORM.md",
         ],
     },
@@ -54,6 +62,7 @@ IMPLEMENTED_JSON = {
             "src/catalua_platform_runtime.cpp",
             "data/lua/types/ccb_platform_v1.d.lua",
             "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
             "data/lua/LUA_FIRST_PLATFORM.md",
         ],
     },
@@ -63,6 +72,7 @@ IMPLEMENTED_JSON = {
             "src/catalua_platform_runtime.cpp",
             "data/lua/types/ccb_platform_v1.d.lua",
             "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
             "data/lua/LUA_FIRST_PLATFORM.md",
         ],
     },
@@ -948,7 +958,33 @@ IMPLEMENTED_JSON = {
             "data/lua/LUA_FIRST_PLATFORM.md",
         ],
     },
+    "wound": {
+        "target": "content.wounds",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/wound.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "tools/test_migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
+    "wound_fix": {
+        "target": "content.wound-fixes",
+        "evidence": [
+            "src/catalua_platform_runtime.cpp",
+            "src/wound.cpp",
+            "data/lua/types/ccb_platform_v1.d.lua",
+            "tests/catalua_ui_test.cpp",
+            "tools/migrate_lua_first.py",
+            "tools/test_migrate_lua_first.py",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        ],
+    },
 }
+
+PLANNED_JSON = {}
 
 NATIVE_PRIMITIVE_DOMAINS = {
     "items",
@@ -977,6 +1013,503 @@ NATIVE_PRIMITIVE_EVIDENCE = [
     "tests/catalua_ui_test.cpp",
     "data/lua/LUA_FIRST_PLATFORM.md",
 ]
+
+BOUNDED_IMPLEMENTED_EOC = {
+    ("eoc-conditions", "compare_string"): "services.gameplay.strings",
+    ("eoc-conditions", "compare_string_match_all"): (
+        "services.gameplay.strings"
+    ),
+    ("eoc-conditions", "current_dimension"): "services.gameplay.environment",
+    ("eoc-conditions", "mod_is_loaded"): "services.gameplay.mods",
+    ("eoc-conditions", "one_in_chance"): "services.random",
+    ("eoc-conditions", "roll_contested"): "services.random",
+    ("eoc-conditions", "u_has_bionics"): "services.bionics",
+    ("eoc-conditions", "u_has_activity"): "services.activities",
+    ("eoc-conditions", "u_can_drop_weapon"): (
+        "services.inventory-and-martial-arts"
+    ),
+    ("eoc-conditions", "u_has_item"): "services.inventory",
+    ("eoc-conditions", "u_has_move_mode"): "services.characters.movement",
+    ("eoc-conditions", "u_has_weapon"): "services.inventory-and-martial-arts",
+    ("eoc-conditions", "u_has_wielded_with_flag"): (
+        "services.inventory-and-items"
+    ),
+    ("eoc-conditions", "u_has_any_trait"): "services.mutations",
+    ("eoc-conditions", "u_has_martial_art"): "services.martial_arts",
+    ("eoc-conditions", "u_has_proficiency"): "services.proficiencies",
+    ("eoc-conditions", "u_has_trait"): "services.mutations",
+    ("eoc-conditions", "u_know_recipe"): "services.recipes",
+    ("eoc-conditions", "u_using_martial_art"): "services.martial_arts",
+    ("eoc-conditions", "x_in_y_chance"): "services.random",
+    ("eoc-effects", "give_achievement"): "services.achievements",
+    ("eoc-effects", "message"): "services.message",
+    ("eoc-effects", "npc_set_flag"): "services.items",
+    ("eoc-effects", "npc_unset_flag"): "services.items",
+    ("eoc-effects", "u_add_bionic"): "services.bionics",
+    ("eoc-effects", "u_cancel_activity"): "services.activities",
+    ("eoc-effects", "u_add_effect"): "services.effects",
+    ("eoc-effects", "u_forget_martial_art"): "services.martial_arts",
+    ("eoc-effects", "u_forget_recipe"): "services.recipes",
+    ("eoc-effects", "u_learn_martial_art"): "services.martial_arts",
+    ("eoc-effects", "u_learn_recipe"): "services.recipes",
+    ("eoc-effects", "u_lose_bionic"): "services.bionics",
+    ("eoc-effects", "u_lose_effect"): "services.effects",
+    ("eoc-effects", "u_add_morale"): "services.morale",
+    ("eoc-effects", "u_lose_morale"): "services.morale",
+}
+
+BOUNDED_IMPLEMENTED_EOC_EVIDENCE = [
+    "src/catalua_platform_runtime.cpp",
+    "data/lua/types/ccb_platform_v1.d.lua",
+    "tests/catalua_ui_test.cpp",
+    "tools/migrate_lua_first.py",
+    "tools/test_migrate_lua_first.py",
+    "data/lua/LUA_FIRST_PLATFORM.md",
+]
+
+BOUNDED_IMPLEMENTED_EOC_EXTRA_EVIDENCE = {
+    ("eoc-conditions", "u_can_drop_weapon"): [
+        "src/condition.cpp",
+        "src/melee.cpp",
+        "src/catalua_ui_items.cpp",
+        "src/catalua_ui_martial_arts.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-conditions", "u_has_bionics"): [
+        "src/condition.cpp",
+        "src/catalua_ui_bionics.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-conditions", "u_has_activity"): [
+        "src/condition.cpp",
+        "src/player_activity.cpp",
+    ],
+    ("eoc-conditions", "u_has_item"): [
+        "src/condition.cpp",
+        "src/catalua_ui_items.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-conditions", "u_has_move_mode"): [
+        "src/condition.cpp",
+        "src/catalua_ui_creatures.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-conditions", "u_has_weapon"): [
+        "src/condition.cpp",
+        "src/melee.cpp",
+        "src/catalua_ui_items.cpp",
+        "src/catalua_ui_martial_arts.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-conditions", "u_has_wielded_with_flag"): [
+        "src/condition.cpp",
+        "src/talker_character.cpp",
+        "src/catalua_ui_items.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-conditions", "u_has_any_trait"): [
+        "src/condition.cpp",
+        "src/catalua_ui_mutations.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-conditions", "u_has_martial_art"): [
+        "src/condition.cpp",
+        "src/catalua_ui_martial_arts.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-conditions", "u_using_martial_art"): [
+        "src/condition.cpp",
+        "src/catalua_ui_martial_arts.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-conditions", "u_has_proficiency"): [
+        "src/condition.cpp",
+        "src/catalua_ui_proficiencies.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-conditions", "u_has_trait"): [
+        "src/condition.cpp",
+        "src/catalua_ui_mutations.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-conditions", "u_know_recipe"): [
+        "src/condition.cpp",
+        "src/character_crafting.cpp",
+        "src/catalua_ui_crafting.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "u_add_bionic"): [
+        "src/bionics.cpp",
+        "src/catalua_ui_bionics.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "npc_set_flag"): [
+        "src/effect_on_condition.cpp",
+        "src/event_bus.cpp",
+        "src/npctalk.cpp",
+        "src/catalua_ui_items.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "npc_unset_flag"): [
+        "src/effect_on_condition.cpp",
+        "src/event_bus.cpp",
+        "src/npctalk.cpp",
+        "src/catalua_ui_items.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "u_cancel_activity"): [
+        "src/npctalk.cpp",
+        "src/character.cpp",
+        "src/player_activity.cpp",
+    ],
+    ("eoc-effects", "u_add_effect"): [
+        "src/npctalk.cpp",
+        "src/creature.cpp",
+        "src/catalua_ui_effects.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "u_lose_bionic"): [
+        "src/bionics.cpp",
+        "src/catalua_ui_bionics.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "u_lose_effect"): [
+        "src/npctalk.cpp",
+        "src/creature.cpp",
+        "src/catalua_ui_effects.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "u_learn_recipe"): [
+        "src/character_crafting.cpp",
+        "src/catalua_ui_crafting.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "u_forget_recipe"): [
+        "src/character_crafting.cpp",
+        "src/catalua_ui_crafting.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "u_learn_martial_art"): [
+        "src/character_martial_arts.cpp",
+        "src/catalua_ui_martial_arts.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "u_forget_martial_art"): [
+        "src/character_martial_arts.cpp",
+        "src/catalua_ui_martial_arts.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "u_add_morale"): [
+        "src/npctalk.cpp",
+        "src/talker_character.cpp",
+        "src/character_morale.cpp",
+        "src/morale.cpp",
+        "src/morale_types.cpp",
+    ],
+    ("eoc-effects", "u_lose_morale"): [
+        "src/npctalk.cpp",
+        "src/talker_character.cpp",
+        "src/character_morale.cpp",
+        "src/morale.cpp",
+        "src/morale_types.cpp",
+    ],
+}
+
+EXPLICIT_PRIMITIVE_EOC = {
+    ("eoc-conditions", "follower_present"): "services.followers",
+    ("eoc-conditions", "is_outside"): "services.gameplay.environment",
+    ("eoc-conditions", "line_of_sight"): "services.gameplay.environment",
+    ("eoc-conditions", "npc_can_drop_weapon"): (
+        "services.inventory-and-martial-arts"
+    ),
+    ("eoc-conditions", "npc_has_activity"): "services.activities",
+    ("eoc-conditions", "npc_has_item"): "services.inventory",
+    ("eoc-conditions", "npc_has_move_mode"): "services.characters.movement",
+    ("eoc-conditions", "npc_has_weapon"): (
+        "services.inventory-and-martial-arts"
+    ),
+    ("eoc-conditions", "npc_has_wielded_with_flag"): (
+        "services.inventory-and-items"
+    ),
+    ("eoc-effects", "closest_city"): "services.overmap",
+    ("eoc-effects", "assign_mission"): "services.missions-and-dialogue",
+    ("eoc-effects", "dimension_name"): "services.gameplay.environment",
+    ("eoc-effects", "follow"): "services.followers-and-npcs",
+    ("eoc-effects", "give_aid"): "services.characters-and-effects",
+    ("eoc-effects", "give_equipment"): "services.inventory-and-presentation",
+    ("eoc-effects", "hostile"): "services.npcs",
+    ("eoc-effects", "mirror_coordinates"): "services.coords",
+    ("eoc-effects", "map_spawn_item"): "services.world",
+    ("eoc-effects", "npc_cancel_activity"): "services.activities",
+    ("eoc-effects", "npc_set_fac_relation"): "services.factions",
+    ("eoc-effects", "reveal_route"): "services.overmap",
+    ("eoc-effects", "sample_range"): "services.random",
+    ("eoc-effects", "set_trap"): "services.world-and-coords",
+    ("eoc-effects", "signal_hordes"): "services.hordes",
+    ("eoc-effects", "stop_following"): "services.followers-and-npcs",
+    ("eoc-effects", "stranger_neutral"): "services.npcs",
+    ("eoc-effects", "turn_cost"): "services.characters-and-time",
+    ("eoc-effects", "u_add_faction_trust"): "services.factions",
+    ("eoc-effects", "u_set_flag"): "services.items",
+    ("eoc-effects", "u_set_fac_relation"): "services.factions",
+    ("eoc-effects", "u_spawn_item"): "services.inventory",
+    ("eoc-effects", "u_unset_flag"): "services.items",
+}
+
+EXPLICIT_PRIMITIVE_EOC_EXTRA_EVIDENCE = {
+    ("eoc-conditions", "follower_present"): [
+        "src/catalua_ui_game_info.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-conditions", "npc_can_drop_weapon"): [
+        "src/melee.cpp", "src/catalua_ui_items.cpp",
+        "src/catalua_ui_martial_arts.cpp", "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-conditions", "npc_has_activity"): [
+        "src/condition.cpp", "src/player_activity.cpp",
+    ],
+    ("eoc-conditions", "npc_has_item"): [
+        "src/condition.cpp", "src/catalua_ui_items.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-conditions", "npc_has_move_mode"): [
+        "src/condition.cpp", "src/catalua_ui_creatures.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-conditions", "npc_has_weapon"): [
+        "src/melee.cpp", "src/catalua_ui_items.cpp",
+        "src/catalua_ui_martial_arts.cpp", "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-conditions", "npc_has_wielded_with_flag"): [
+        "src/talker_character.cpp", "src/catalua_ui_items.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "closest_city"): [
+        "src/catalua_ui_overmap.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "assign_mission"): [
+        "src/npctalk.cpp", "src/catalua_ui_missions.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "follow"): [
+        "src/catalua_ui_game_info.cpp",
+        "src/catalua_ui_npcs.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "give_aid"): [
+        "src/catalua_ui_creatures.cpp",
+        "src/catalua_ui_effects.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "give_equipment"): [
+        "src/catalua_ui_items.cpp",
+        "src/catalua_ui_interaction.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "hostile"): [
+        "src/catalua_ui_npcs.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "map_spawn_item"): [
+        "src/npctalk.cpp", "src/catalua_ui_world.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "npc_cancel_activity"): [
+        "src/npctalk.cpp", "src/character.cpp", "src/player_activity.cpp",
+    ],
+    ("eoc-effects", "npc_set_fac_relation"): [
+        "src/npctalk.cpp",
+        "src/talker_character.cpp",
+        "src/catalua_ui_factions.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "reveal_route"): [
+        "src/catalua_ui_overmap.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "set_trap"): [
+        "src/catalua_ui_world.cpp",
+        "src/catalua_bindings_coords.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "signal_hordes"): [
+        "src/catalua_ui_hordes.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "stop_following"): [
+        "src/catalua_ui_game_info.cpp",
+        "src/catalua_ui_npcs.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "stranger_neutral"): [
+        "src/catalua_ui_npcs.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "turn_cost"): [
+        "src/catalua_ui_creatures.cpp",
+        "src/catalua_ui_time.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "u_add_faction_trust"): [
+        "src/npctalk.cpp",
+        "src/talker_character.cpp",
+        "src/catalua_ui_factions.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "u_set_flag"): [
+        "src/npctalk.cpp", "src/catalua_ui_items.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "u_set_fac_relation"): [
+        "src/npctalk.cpp",
+        "src/talker_character.cpp",
+        "src/catalua_ui_factions.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "u_spawn_item"): [
+        "src/npctalk.cpp", "src/catalua_ui_items.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+    ("eoc-effects", "u_unset_flag"): [
+        "src/npctalk.cpp", "src/catalua_ui_items.cpp",
+        "data/lua/types/ccb_api_v5.d.lua",
+    ],
+}
+
+EXPLICIT_PLANNED_EOC = {
+    ("eoc-conditions", "npc_is_travelling"): "services.character-navigation",
+    ("eoc-conditions", "u_is_travelling"): "services.character-navigation",
+    ("eoc-effects", "goto_location"): "workflows.npc-navigation",
+    ("eoc-effects", "morale_chat_activity"): "workflows.socialize",
+    ("eoc-effects", "npc_activate"): "services.items-and-characters",
+    ("eoc-effects", "npc_add_wet"): "services.wetness",
+    ("eoc-effects", "npc_add_wound"): "services.wounds",
+    ("eoc-effects", "npc_deal_damage"): "services.combat",
+    ("eoc-effects", "npc_pick_bodypart"): "services.body-parts-and-wounds",
+    ("eoc-effects", "npc_remove_wound"): "services.wounds",
+    ("eoc-effects", "npc_assign_activity"): "services.activities",
+    ("eoc-effects", "npc_set_goal"): "services.npc-navigation",
+    ("eoc-effects", "npc_set_guard_pos"): "services.npc-navigation",
+    ("eoc-effects", "npc_set_fault"): "services.items",
+    ("eoc-effects", "npc_set_random_fault_of_type"): "services.items",
+    ("eoc-effects", "set_browsed"): "services.items",
+    ("eoc-effects", "transform_item"): "services.items",
+    ("eoc-effects", "u_activate"): "services.items-and-characters",
+    ("eoc-effects", "u_assign_activity"): "services.activities",
+    ("eoc-effects", "u_add_wet"): "services.wetness",
+    ("eoc-effects", "u_add_wound"): "services.wounds",
+    ("eoc-effects", "u_deal_damage"): "services.combat",
+    ("eoc-effects", "u_pick_bodypart"): "services.body-parts-and-wounds",
+    ("eoc-effects", "u_remove_wound"): "services.wounds",
+    ("eoc-effects", "u_set_goal"): "services.npc-navigation",
+    ("eoc-effects", "u_set_guard_pos"): "services.npc-navigation",
+    ("eoc-effects", "u_set_fault"): "services.items",
+    ("eoc-effects", "u_set_random_fault_of_type"): "services.items",
+    ("eoc-effects", "npc_teleport"): "services.relocation",
+    ("eoc-effects", "revert_activity"): "services.npc-work",
+    ("eoc-effects", "u_teleport"): "services.relocation",
+    ("eoc-effects", "u_travel_to_dimension"): "workflows.dimension-travel",
+}
+
+EXPLICIT_PLANNED_EOC_EXTRA_EVIDENCE = {
+    ("eoc-conditions", "npc_is_travelling"): [
+        "src/condition.cpp", "src/character.h",
+    ],
+    ("eoc-conditions", "u_is_travelling"): [
+        "src/condition.cpp", "src/character.h",
+    ],
+    ("eoc-effects", "goto_location"): ["src/npctalk_funcs.cpp"],
+    ("eoc-effects", "morale_chat_activity"): ["src/npctalk_funcs.cpp"],
+    ("eoc-effects", "npc_activate"): [
+        "src/npctalk.cpp", "src/catalua_ui_items.cpp",
+    ],
+    ("eoc-effects", "u_activate"): [
+        "src/npctalk.cpp", "src/catalua_ui_items.cpp",
+    ],
+    ("eoc-effects", "npc_assign_activity"): [
+        "src/npctalk.cpp", "src/character.cpp",
+    ],
+    ("eoc-effects", "u_assign_activity"): [
+        "src/npctalk.cpp", "src/character.cpp",
+    ],
+    ("eoc-effects", "npc_add_wet"): ["src/weather.cpp", "src/suffer.cpp"],
+    ("eoc-effects", "u_add_wet"): ["src/weather.cpp", "src/suffer.cpp"],
+    ("eoc-effects", "npc_add_wound"): [
+        "src/npctalk.cpp",
+        "src/bodypart.cpp",
+        "src/wound.cpp",
+        "src/catalua_platform_runtime.cpp",
+        "data/lua/types/ccb_platform_v1.d.lua",
+        "data/lua/LUA_FIRST_PLATFORM.md",
+    ],
+    ("eoc-effects", "npc_remove_wound"): [
+        "src/npctalk.cpp",
+        "src/bodypart.cpp",
+        "src/wound.cpp",
+        "src/catalua_platform_runtime.cpp",
+        "data/lua/types/ccb_platform_v1.d.lua",
+        "data/lua/LUA_FIRST_PLATFORM.md",
+    ],
+    ("eoc-effects", "u_add_wound"): [
+        "src/npctalk.cpp",
+        "src/bodypart.cpp",
+        "src/wound.cpp",
+        "src/catalua_platform_runtime.cpp",
+        "data/lua/types/ccb_platform_v1.d.lua",
+        "data/lua/LUA_FIRST_PLATFORM.md",
+    ],
+    ("eoc-effects", "u_remove_wound"): [
+        "src/npctalk.cpp",
+        "src/bodypart.cpp",
+        "src/wound.cpp",
+        "src/catalua_platform_runtime.cpp",
+        "data/lua/types/ccb_platform_v1.d.lua",
+        "data/lua/LUA_FIRST_PLATFORM.md",
+    ],
+    ("eoc-effects", "npc_deal_damage"): [
+        "src/creature.cpp", "src/character_health.cpp",
+    ],
+    ("eoc-effects", "u_deal_damage"): [
+        "src/creature.cpp", "src/character_health.cpp",
+    ],
+    ("eoc-effects", "npc_pick_bodypart"): [
+        "src/bodypart.cpp", "src/npctalk.cpp",
+    ],
+    ("eoc-effects", "u_pick_bodypart"): [
+        "src/bodypart.cpp", "src/npctalk.cpp",
+    ],
+    ("eoc-effects", "npc_set_fault"): [
+        "src/npctalk.cpp", "src/catalua_ui_items.cpp",
+    ],
+    ("eoc-effects", "u_set_fault"): [
+        "src/npctalk.cpp", "src/catalua_ui_items.cpp",
+    ],
+    ("eoc-effects", "npc_set_random_fault_of_type"): [
+        "src/npctalk.cpp", "src/catalua_ui_items.cpp",
+    ],
+    ("eoc-effects", "u_set_random_fault_of_type"): [
+        "src/npctalk.cpp", "src/catalua_ui_items.cpp",
+    ],
+    ("eoc-effects", "npc_set_goal"): ["src/npctalk.cpp"],
+    ("eoc-effects", "u_set_goal"): ["src/npctalk.cpp"],
+    ("eoc-effects", "npc_set_guard_pos"): ["src/npctalk.cpp"],
+    ("eoc-effects", "u_set_guard_pos"): ["src/npctalk.cpp"],
+    ("eoc-effects", "npc_teleport"): [
+        "src/npctalk.cpp", "src/catalua_ui_world_services.cpp",
+    ],
+    ("eoc-effects", "u_teleport"): [
+        "src/npctalk.cpp", "src/catalua_ui_world_services.cpp",
+    ],
+    ("eoc-effects", "revert_activity"): ["src/npc.cpp"],
+    ("eoc-effects", "u_travel_to_dimension"): ["src/npctalk.cpp"],
+    ("eoc-effects", "set_browsed"): [
+        "src/npctalk.cpp", "src/catalua_ui_items.cpp",
+    ],
+    ("eoc-effects", "transform_item"): [
+        "src/npctalk.cpp", "src/catalua_ui_items.cpp",
+    ],
+}
 
 
 def service_for(selector: str) -> str:
@@ -1020,18 +1553,31 @@ def legacy_evidence(entry: dict) -> list[str]:
 
 def disposition(inventory: str, selector: str, entry: dict) -> dict:
     if inventory == "json-object-types":
-        if selector in IMPLEMENTED_JSON:
-            implemented = IMPLEMENTED_JSON[selector]
+        if selector in BOUNDED_IMPLEMENTED_JSON:
+            implemented = BOUNDED_IMPLEMENTED_JSON[selector]
             return {
                 "inventory": inventory,
                 "selector": selector,
                 "target_kind": "platform_domain",
                 "target": implemented["target"],
-                "status": "implemented_unverified",
+                "status": "bounded_implemented_unverified",
                 "legacy_dependency": "none",
                 "evidence": implemented["evidence"],
             }
-        if selector in {"EXTERNAL_OPTION", "WORLD_OPTION", "colordef", "test_data"}:
+        if selector in PLANNED_JSON:
+            planned = PLANNED_JSON[selector]
+            return {
+                "inventory": inventory,
+                "selector": selector,
+                "target_kind": "platform_domain",
+                "target": planned["target"],
+                "status": "planned",
+                "legacy_dependency": "public_legacy",
+                "evidence": planned["evidence"],
+            }
+        if selector in {
+            "EXTERNAL_OPTION", "WORLD_OPTION", "colordef", "test_data"
+        }:
             return {
                 "inventory": inventory,
                 "selector": selector,
@@ -1051,6 +1597,54 @@ def disposition(inventory: str, selector: str, entry: dict) -> dict:
             "evidence": legacy_evidence(entry),
         }
 
+    bounded_target = BOUNDED_IMPLEMENTED_EOC.get((inventory, selector))
+    if bounded_target:
+        return {
+            "inventory": inventory,
+            "selector": selector,
+            "target_kind": "shared_service",
+            "target": bounded_target,
+            "status": "bounded_implemented_unverified",
+            "legacy_dependency": "none",
+            "evidence": (
+                BOUNDED_IMPLEMENTED_EOC_EVIDENCE +
+                BOUNDED_IMPLEMENTED_EOC_EXTRA_EVIDENCE.get(
+                    (inventory, selector), []
+                )
+            ),
+        }
+    planned_target = EXPLICIT_PLANNED_EOC.get((inventory, selector))
+    if planned_target:
+        return {
+            "inventory": inventory,
+            "selector": selector,
+            "target_kind": "shared_service",
+            "target": planned_target,
+            "status": "planned",
+            "legacy_dependency": "public_legacy",
+            "evidence": (
+                legacy_evidence(entry) +
+                EXPLICIT_PLANNED_EOC_EXTRA_EVIDENCE.get(
+                    (inventory, selector), []
+                )
+            ),
+        }
+    primitive_target = EXPLICIT_PRIMITIVE_EOC.get((inventory, selector))
+    if primitive_target:
+        return {
+            "inventory": inventory,
+            "selector": selector,
+            "target_kind": "shared_service",
+            "target": primitive_target,
+            "status": "primitive_available_unverified",
+            "legacy_dependency": "none",
+            "evidence": (
+                NATIVE_PRIMITIVE_EVIDENCE +
+                EXPLICIT_PRIMITIVE_EOC_EXTRA_EVIDENCE.get(
+                    (inventory, selector), []
+                )
+            ),
+        }
     if selector in CONTROL_FLOW:
         return {
             "inventory": inventory,
@@ -1094,7 +1688,9 @@ def build_ledger() -> dict:
                 "id": inventory,
                 "path": str(path.relative_to(ROOT)),
                 "selector": selector_field,
-                "source_fingerprint": document["source"]["source_fingerprint"],
+                "source_fingerprint": document["source"][
+                    "source_fingerprint"
+                ],
                 "entry_count": len(source_entries),
             }
         )
@@ -1107,15 +1703,23 @@ def build_ledger() -> dict:
         "schema_version": 1,
         "kind": "lua_first_replacement_ledger",
         "contract": (
-            "Every checked legacy selector appears exactly once. Planned entries are "
-            "migration work, not shipped Platform APIs. Primitive-available entries "
-            "have native composition building blocks but are not claims of selector-level parity."
+            "Every checked legacy selector appears exactly once. Planned "
+            "entries are migration work, not shipped Platform APIs. Bounded "
+            "entries cover named real shapes without claiming full selector "
+            "parity. "
+            "Primitive-available entries have native composition building "
+            "blocks but are not claims of selector-level parity."
         ),
         "sources": sources,
         "summary": {
             "total": len(entries),
             "implemented_unverified": sum(
-                entry["status"] == "implemented_unverified" for entry in entries
+                entry["status"] == "implemented_unverified"
+                for entry in entries
+            ),
+            "bounded_implemented_unverified": sum(
+                entry["status"] == "bounded_implemented_unverified"
+                for entry in entries
             ),
             "primitive_available_unverified": sum(
                 entry["status"] == "primitive_available_unverified"
@@ -1126,7 +1730,8 @@ def build_ledger() -> dict:
                 entry["status"] == "private_adapter" for entry in entries
             ),
             "reviewed_not_applicable": sum(
-                entry["status"] == "reviewed_not_applicable" for entry in entries
+                entry["status"] == "reviewed_not_applicable"
+                for entry in entries
             ),
         },
         "entries": entries,
@@ -1134,7 +1739,9 @@ def build_ledger() -> dict:
 
 
 def render(ledger: dict) -> str:
-    return yaml.safe_dump(ledger, sort_keys=False, allow_unicode=True, width=100)
+    return yaml.safe_dump(
+        ledger, sort_keys=False, allow_unicode=True, width=100
+    )
 
 
 def main() -> int:
@@ -1143,7 +1750,10 @@ def main() -> int:
     args = parser.parse_args()
     expected = render(build_ledger())
     if args.check:
-        if not OUTPUT.exists() or OUTPUT.read_text(encoding="utf-8") != expected:
+        if (
+            not OUTPUT.exists() or
+            OUTPUT.read_text(encoding="utf-8") != expected
+        ):
             print(f"stale generated ledger: {OUTPUT.relative_to(ROOT)}")
             return 1
         return 0

--- a/tools/agent/test_lua_first_replacement_ledger.py
+++ b/tools/agent/test_lua_first_replacement_ledger.py
@@ -7,15 +7,25 @@ from generate_lua_first_replacement_ledger import OUTPUT, build_ledger, render
 class LuaFirstReplacementLedgerTest(unittest.TestCase):
     def test_committed_ledger_covers_every_selector_once(self):
         result = check()
-        self.assertEqual(result["total"], 775)
-        self.assertEqual(result["implemented_unverified"], 82)
-        self.assertGreater(
-            build_ledger()["summary"]["primitive_available_unverified"], 0
+        self.assertEqual(
+            result,
+            {
+                "total": 775,
+                "implemented_unverified": 0,
+                "bounded_implemented_unverified": 119,
+                "primitive_available_unverified": 440,
+                "planned": 198,
+                "private_adapter": 0,
+                "reviewed_not_applicable": 18,
+            },
         )
 
     def test_generator_preserves_the_three_inventory_denominators(self):
         generated = build_ledger()
-        counts = {source["id"]: source["entry_count"] for source in generated["sources"]}
+        counts = {
+            source["id"]: source["entry_count"]
+            for source in generated["sources"]
+        }
         self.assertEqual(
             counts,
             {
@@ -33,18 +43,401 @@ class LuaFirstReplacementLedgerTest(unittest.TestCase):
             if entry["inventory"] == "json-object-types"
         }
         for selector in {
-            "monster_attack", "effect_type", "weakpoint_set", "field_type",
-            "item_group", "sub_body_part", "body_part", "anatomy",
+            "monster_attack", "effect_type", "weakpoint_set",
+            "field_type", "item_group", "sub_body_part", "body_part",
+            "wound", "wound_fix", "anatomy",
             "body_graph", "MONSTER",
         }:
-            self.assertEqual(entries[selector]["status"], "implemented_unverified")
-            self.assertIn("tools/migrate_lua_first.py", entries[selector]["evidence"])
+            self.assertEqual(
+                entries[selector]["status"],
+                "bounded_implemented_unverified",
+            )
+            self.assertIn(
+                "tools/migrate_lua_first.py",
+                entries[selector]["evidence"],
+            )
 
     def test_committed_ledger_matches_the_generator(self):
         self.assertEqual(
             OUTPUT.read_text(encoding="utf-8"),
             render(build_ledger()),
         )
+
+    def test_coverage_statuses_have_status_specific_evidence(self):
+        generated = build_ledger()
+        implemented_statuses = {
+            "implemented_unverified",
+            "bounded_implemented_unverified",
+        }
+        evidenced_statuses = implemented_statuses | {
+            "primitive_available_unverified",
+        }
+        required_prefixes = (
+            "src/",
+            "data/lua/types/",
+            "tests/",
+            "data/lua/LUA_FIRST_PLATFORM.md",
+        )
+        for entry in generated["entries"]:
+            if entry["status"] not in evidenced_statuses:
+                continue
+            for prefix in required_prefixes:
+                self.assertTrue(
+                    any(
+                        value.startswith(prefix)
+                        for value in entry["evidence"]
+                    ),
+                    f"{entry['inventory']}:{entry['selector']} lacks "
+                    f"{prefix} evidence",
+                )
+            if entry["status"] in implemented_statuses:
+                self.assertIn(
+                    "tools/migrate_lua_first.py",
+                    entry["evidence"],
+                    f"{entry['inventory']}:{entry['selector']} lacks "
+                    "migration evidence",
+                )
+
+    def test_lua_native_eoc_shapes_remain_bounded_until_full_parity(self):
+        generated = build_ledger()
+        entries = {
+            (entry["inventory"], entry["selector"]): entry
+            for entry in generated["entries"]
+        }
+        for selector in {
+            "compare_string",
+            "compare_string_match_all",
+            "current_dimension",
+            "mod_is_loaded",
+            "one_in_chance",
+            "roll_contested",
+            "u_can_drop_weapon",
+            "u_has_activity",
+            "u_has_bionics",
+            "u_has_item",
+            "u_has_move_mode",
+            "u_has_weapon",
+            "u_has_wielded_with_flag",
+            "u_has_any_trait",
+            "u_has_martial_art",
+            "u_has_proficiency",
+            "u_has_trait",
+            "u_know_recipe",
+            "u_using_martial_art",
+            "x_in_y_chance",
+        }:
+            entry = entries[("eoc-conditions", selector)]
+            self.assertEqual(entry["status"], "bounded_implemented_unverified")
+            self.assertEqual(entry["legacy_dependency"], "none")
+            self.assertIn("tools/migrate_lua_first.py", entry["evidence"])
+
+        achievement = entries[("eoc-effects", "give_achievement")]
+        self.assertEqual(
+            achievement["status"], "bounded_implemented_unverified"
+        )
+        self.assertEqual(achievement["target"], "services.achievements")
+
+        message = entries[("eoc-effects", "message")]
+        self.assertEqual(message["status"], "bounded_implemented_unverified")
+        self.assertEqual(message["target"], "services.message")
+
+        for selector in {"npc_set_flag", "npc_unset_flag"}:
+            item_flag = entries[("eoc-effects", selector)]
+            self.assertEqual(
+                item_flag["status"], "bounded_implemented_unverified"
+            )
+            self.assertEqual(item_flag["target"], "services.items")
+            self.assertIn("src/event_bus.cpp", item_flag["evidence"])
+
+        bionic = entries[("eoc-effects", "u_add_bionic")]
+        self.assertEqual(bionic["status"], "bounded_implemented_unverified")
+        self.assertEqual(bionic["target"], "services.bionics")
+        self.assertIn("src/catalua_ui_bionics.cpp", bionic["evidence"])
+
+        bionic_removal = entries[("eoc-effects", "u_lose_bionic")]
+        self.assertEqual(
+            bionic_removal["status"], "bounded_implemented_unverified"
+        )
+        self.assertEqual(bionic_removal["target"], "services.bionics")
+
+        learned_recipe = entries[("eoc-effects", "u_learn_recipe")]
+        self.assertEqual(
+            learned_recipe["status"], "bounded_implemented_unverified"
+        )
+        self.assertEqual(learned_recipe["target"], "services.recipes")
+        self.assertIn("src/character_crafting.cpp", learned_recipe["evidence"])
+
+        forgotten_recipe = entries[("eoc-effects", "u_forget_recipe")]
+        self.assertEqual(
+            forgotten_recipe["status"], "bounded_implemented_unverified"
+        )
+        self.assertEqual(forgotten_recipe["target"], "services.recipes")
+
+        known_recipe = entries[("eoc-conditions", "u_know_recipe")]
+        self.assertEqual(
+            known_recipe["status"], "bounded_implemented_unverified"
+        )
+        self.assertEqual(known_recipe["target"], "services.recipes")
+        self.assertIn("src/condition.cpp", known_recipe["evidence"])
+        self.assertIn(
+            "src/character_crafting.cpp", known_recipe["evidence"]
+        )
+
+        learned_style = entries[("eoc-effects", "u_learn_martial_art")]
+        self.assertEqual(
+            learned_style["status"], "bounded_implemented_unverified"
+        )
+        self.assertEqual(learned_style["target"], "services.martial_arts")
+        self.assertIn(
+            "src/character_martial_arts.cpp", learned_style["evidence"]
+        )
+
+        forgotten_style = entries[("eoc-effects", "u_forget_martial_art")]
+        self.assertEqual(
+            forgotten_style["status"], "bounded_implemented_unverified"
+        )
+        self.assertEqual(forgotten_style["target"], "services.martial_arts")
+
+        added_morale = entries[("eoc-effects", "u_add_morale")]
+        self.assertEqual(
+            added_morale["status"], "bounded_implemented_unverified"
+        )
+        self.assertEqual(added_morale["target"], "services.morale")
+        self.assertIn("src/morale.cpp", added_morale["evidence"])
+        self.assertIn("src/npctalk.cpp", added_morale["evidence"])
+        self.assertIn("src/talker_character.cpp", added_morale["evidence"])
+
+        removed_morale = entries[("eoc-effects", "u_lose_morale")]
+        self.assertEqual(
+            removed_morale["status"], "bounded_implemented_unverified"
+        )
+        self.assertEqual(removed_morale["target"], "services.morale")
+        self.assertIn("src/npctalk.cpp", removed_morale["evidence"])
+        self.assertIn("src/talker_character.cpp", removed_morale["evidence"])
+
+        added_effect = entries[("eoc-effects", "u_add_effect")]
+        self.assertEqual(
+            added_effect["status"], "bounded_implemented_unverified"
+        )
+        self.assertEqual(added_effect["target"], "services.effects")
+        self.assertIn("src/catalua_ui_effects.cpp", added_effect["evidence"])
+
+        removed_effect = entries[("eoc-effects", "u_lose_effect")]
+        self.assertEqual(
+            removed_effect["status"], "bounded_implemented_unverified"
+        )
+        self.assertEqual(removed_effect["target"], "services.effects")
+
+        cancelled_activity = entries[("eoc-effects", "u_cancel_activity")]
+        self.assertEqual(
+            cancelled_activity["status"],
+            "bounded_implemented_unverified",
+        )
+        self.assertEqual(cancelled_activity["target"], "services.activities")
+
+        for selector in {"u_add_wound", "u_remove_wound"}:
+            wound_effect = entries[("eoc-effects", selector)]
+            self.assertEqual(
+                wound_effect["status"],
+                "planned",
+            )
+            self.assertEqual(wound_effect["target"], "services.wounds")
+            self.assertEqual(
+                wound_effect["legacy_dependency"], "public_legacy"
+            )
+            self.assertIn("src/npctalk.cpp", wound_effect["evidence"])
+            self.assertIn("src/bodypart.cpp", wound_effect["evidence"])
+            self.assertIn("src/wound.cpp", wound_effect["evidence"])
+            self.assertIn(
+                "src/catalua_platform_runtime.cpp", wound_effect["evidence"]
+            )
+
+        for selector in {
+            "npc_set_fac_relation",
+            "u_add_faction_trust",
+            "u_set_fac_relation",
+        }:
+            faction_effect = entries[("eoc-effects", selector)]
+            self.assertEqual(
+                faction_effect["status"],
+                "primitive_available_unverified",
+            )
+            self.assertEqual(faction_effect["target"], "services.factions")
+            self.assertIn(
+                "src/catalua_ui_factions.cpp",
+                faction_effect["evidence"],
+            )
+
+        for selector, target in {
+            "npc_add_wet": "services.wetness",
+            "npc_add_wound": "services.wounds",
+            "npc_deal_damage": "services.combat",
+            "npc_pick_bodypart": "services.body-parts-and-wounds",
+            "npc_remove_wound": "services.wounds",
+            "u_add_wet": "services.wetness",
+            "u_deal_damage": "services.combat",
+            "u_pick_bodypart": "services.body-parts-and-wounds",
+        }.items():
+            wound_effect = entries[("eoc-effects", selector)]
+            self.assertEqual(wound_effect["status"], "planned")
+            self.assertEqual(wound_effect["target"], target)
+
+        wound = entries[("json-object-types", "wound")]
+        self.assertEqual(
+            wound["status"], "bounded_implemented_unverified"
+        )
+        self.assertEqual(wound["target"], "content.wounds")
+        self.assertEqual(wound["legacy_dependency"], "none")
+        self.assertIn("tools/migrate_lua_first.py", wound["evidence"])
+        wound_fix = entries[("json-object-types", "wound_fix")]
+        self.assertEqual(
+            wound_fix["status"], "bounded_implemented_unverified"
+        )
+        self.assertEqual(wound_fix["target"], "content.wound-fixes")
+        self.assertEqual(wound_fix["legacy_dependency"], "none")
+        self.assertIn("tools/migrate_lua_first.py", wound_fix["evidence"])
+
+        for inventory, selector, target in {
+            (
+                "eoc-conditions",
+                "npc_can_drop_weapon",
+                "services.inventory-and-martial-arts",
+            ),
+            ("eoc-conditions", "npc_has_activity", "services.activities"),
+            ("eoc-conditions", "npc_has_item", "services.inventory"),
+            (
+                "eoc-conditions",
+                "npc_has_move_mode",
+                "services.characters.movement",
+            ),
+            (
+                "eoc-conditions",
+                "npc_has_weapon",
+                "services.inventory-and-martial-arts",
+            ),
+            (
+                "eoc-conditions",
+                "npc_has_wielded_with_flag",
+                "services.inventory-and-items",
+            ),
+            ("eoc-effects", "map_spawn_item", "services.world"),
+            ("eoc-effects", "npc_cancel_activity", "services.activities"),
+            (
+                "eoc-effects",
+                "assign_mission",
+                "services.missions-and-dialogue",
+            ),
+            ("eoc-effects", "u_set_flag", "services.items"),
+            ("eoc-effects", "u_spawn_item", "services.inventory"),
+            ("eoc-effects", "u_unset_flag", "services.items"),
+        }:
+            item_entry = entries[(inventory, selector)]
+            self.assertEqual(
+                item_entry["status"],
+                "primitive_available_unverified",
+            )
+            self.assertEqual(item_entry["target"], target)
+
+        for selector, target in {
+            "npc_activate": "services.items-and-characters",
+            "npc_set_fault": "services.items",
+            "npc_set_random_fault_of_type": "services.items",
+            "set_browsed": "services.items",
+            "transform_item": "services.items",
+            "u_activate": "services.items-and-characters",
+            "u_set_fault": "services.items",
+            "u_set_random_fault_of_type": "services.items",
+        }.items():
+            item_entry = entries[("eoc-effects", selector)]
+            self.assertEqual(item_entry["status"], "planned")
+            self.assertEqual(item_entry["target"], target)
+
+        for inventory, selector, target in {
+            (
+                "eoc-conditions",
+                "npc_is_travelling",
+                "services.character-navigation",
+            ),
+            (
+                "eoc-conditions",
+                "u_is_travelling",
+                "services.character-navigation",
+            ),
+            ("eoc-effects", "goto_location", "workflows.npc-navigation"),
+            ("eoc-effects", "morale_chat_activity", "workflows.socialize"),
+            ("eoc-effects", "npc_assign_activity", "services.activities"),
+            ("eoc-effects", "npc_set_goal", "services.npc-navigation"),
+            ("eoc-effects", "npc_set_guard_pos", "services.npc-navigation"),
+            ("eoc-effects", "npc_teleport", "services.relocation"),
+            ("eoc-effects", "revert_activity", "services.npc-work"),
+            ("eoc-effects", "u_assign_activity", "services.activities"),
+            ("eoc-effects", "u_set_goal", "services.npc-navigation"),
+            ("eoc-effects", "u_set_guard_pos", "services.npc-navigation"),
+            ("eoc-effects", "u_teleport", "services.relocation"),
+            (
+                "eoc-effects",
+                "u_travel_to_dimension",
+                "workflows.dimension-travel",
+            ),
+        }:
+            activity_entry = entries[(inventory, selector)]
+            self.assertEqual(activity_entry["status"], "planned")
+            self.assertEqual(activity_entry["target"], target)
+
+        for selector in {
+            "get_condition",
+            "nothing",
+            "run_eoc_selector",
+            "run_eocs",
+            "run_lua",
+            "set_condition",
+            "test_eoc",
+        }:
+            matches = [
+                entry for entry in generated["entries"]
+                if entry["selector"] == selector
+            ]
+            self.assertTrue(matches)
+            self.assertTrue(
+                all(
+                    entry["status"] == "reviewed_not_applicable"
+                    for entry in matches
+                )
+            )
+
+        for inventory, selector in {
+            ("eoc-conditions", "is_outside"),
+            ("eoc-conditions", "line_of_sight"),
+            ("eoc-effects", "dimension_name"),
+            ("eoc-effects", "mirror_coordinates"),
+            ("eoc-effects", "sample_range"),
+        }:
+            self.assertEqual(
+                entries[(inventory, selector)]["status"],
+                "primitive_available_unverified",
+            )
+
+        primitive_targets = {
+            ("eoc-conditions", "follower_present"): "services.followers",
+            ("eoc-effects", "closest_city"): "services.overmap",
+            ("eoc-effects", "follow"): "services.followers-and-npcs",
+            ("eoc-effects", "give_aid"): "services.characters-and-effects",
+            ("eoc-effects", "give_equipment"): (
+                "services.inventory-and-presentation"
+            ),
+            ("eoc-effects", "hostile"): "services.npcs",
+            ("eoc-effects", "reveal_route"): "services.overmap",
+            ("eoc-effects", "set_trap"): "services.world-and-coords",
+            ("eoc-effects", "signal_hordes"): "services.hordes",
+            ("eoc-effects", "stop_following"): "services.followers-and-npcs",
+            ("eoc-effects", "stranger_neutral"): "services.npcs",
+            ("eoc-effects", "turn_cost"): "services.characters-and-time",
+        }
+        for key, target in primitive_targets.items():
+            self.assertEqual(
+                entries[key]["status"], "primitive_available_unverified"
+            )
+            self.assertEqual(entries[key]["target"], target)
 
 
 if __name__ == "__main__":

--- a/tools/agent/test_project_metadata.py
+++ b/tools/agent/test_project_metadata.py
@@ -89,6 +89,7 @@ class ProjectMetadataTest(unittest.TestCase):
         roadmap = yaml.safe_load(path.read_text(encoding="utf-8"))
         roadmap = copy.deepcopy(roadmap)
         roadmap["capabilities"][0]["status"] = "available"
+        roadmap["capabilities"][0]["legacy_dependency"] = "public_legacy"
 
         with self.assertRaisesRegex(ValueError, "public legacy"):
             validate_lua_first_roadmap(roadmap)

--- a/tools/agent/test_project_metadata.py
+++ b/tools/agent/test_project_metadata.py
@@ -13,6 +13,7 @@ from check_project_metadata import (
     validate_lua_first_roadmap,
     validate_repository_settings,
 )
+from check_lua_first_replacement_ledger import check as check_lua_first_replacement_ledger
 
 
 class ProjectMetadataTest(unittest.TestCase):
@@ -67,6 +68,10 @@ class ProjectMetadataTest(unittest.TestCase):
 
     def test_lua_first_roadmap_is_valid(self):
         validate_lua_first_roadmap()
+
+    def test_lua_first_replacement_ledger_is_exact(self):
+        result = check_lua_first_replacement_ledger()
+        self.assertEqual(result["total"], 775)
 
     def test_lua_first_roadmap_rejects_dependency_cycles(self):
         path = ROOT / "ai/lua-first-roadmap.yml"

--- a/tools/create_lua_mod.py
+++ b/tools/create_lua_mod.py
@@ -17,9 +17,9 @@ MOD_ID_TOKEN = "__CCB_LUA_FIRST_MOD_ID__"
 def normalized_mod_id(target: Path) -> str:
     candidate = target.name
     if (
-        not candidate
-        or "#" in candidate
-        or any(character.isspace() for character in candidate)
+        not candidate or
+        "#" in candidate or
+        any(character.isspace() for character in candidate)
     ):
         raise ValueError(
             "target directory name becomes the Mod id and must be non-empty "
@@ -91,12 +91,14 @@ def create_mod(target: Path, template: str) -> None:
         if target.exists() or target.is_symlink():
             if target.is_symlink() or not had_empty_target:
                 raise FileExistsError(
-                    f"target appeared while the scaffold was being prepared: {target}"
+                    "target appeared while the scaffold was being prepared: "
+                    f"{target}"
                 )
             current_stat = target.stat()
             if (current_stat.st_dev, current_stat.st_ino) != target_identity:
                 raise FileExistsError(
-                    f"target changed while the scaffold was being prepared: {target}"
+                    "target changed while the scaffold was being prepared: "
+                    f"{target}"
                 )
             # The target was proven empty above.  If an author or another
             # process adds a file meanwhile, rmdir fails and preserves it.
@@ -109,10 +111,10 @@ def create_mod(target: Path, template: str) -> None:
             # final same-filesystem installation itself fails.  Never replace
             # a path concurrently recreated by somebody else.
             if (
-                had_empty_target
-                and removed_empty_target
-                and not target.exists()
-                and not target.is_symlink()
+                had_empty_target and
+                removed_empty_target and
+                not target.exists() and
+                not target.is_symlink()
             ):
                 target.mkdir()
             raise

--- a/tools/generate_builtin_mods.py
+++ b/tools/generate_builtin_mods.py
@@ -116,9 +116,9 @@ def find_mod_roots(source: Path) -> set[str]:
         if not child.is_dir():
             continue
         if (
-            (child / "main.lua").is_file()
-            or (child / "mod.lua").is_file()
-            or any(child.rglob("modinfo.json"))
+            (child / "main.lua").is_file() or
+            (child / "mod.lua").is_file() or
+            any(child.rglob("modinfo.json"))
         ):
             result.add(child.relative_to(source).as_posix())
     return result

--- a/tools/lua_api/check_ccb_inventory.py
+++ b/tools/lua_api/check_ccb_inventory.py
@@ -8,9 +8,17 @@ import json
 from pathlib import Path
 
 try:
-    from .generate_ccb_inventory import DEFAULT_OUTPUT, build_inventory
+    from .generate_ccb_inventory import (
+        DEFAULT_OUTPUT,
+        build_inventory,
+        validate_export_contract,
+    )
 except ImportError:
-    from generate_ccb_inventory import DEFAULT_OUTPUT, build_inventory
+    from generate_ccb_inventory import (  # type: ignore
+        DEFAULT_OUTPUT,
+        build_inventory,
+        validate_export_contract,
+    )
 
 
 def load_inventory(path: Path) -> dict[str, object]:
@@ -23,16 +31,32 @@ def load_inventory(path: Path) -> dict[str, object]:
 def check(path: Path) -> dict[str, int]:
     expected = build_inventory()
     actual = load_inventory(path)
+    validate_export_contract(actual)
     if actual != expected:
         raise RuntimeError(
             "CCB native Lua inventory is stale; run "
             "python3 tools/lua_api/generate_ccb_inventory.py"
         )
+    surfaces = {
+        str(surface["id"]): surface
+        for surface in expected["export_surfaces"]
+    }
+    api_v5_roots = set(surfaces["api_v5"]["roots"])
+    platform_v1_roots = set(surfaces["platform_v1"]["roots"])
+    member_dispositions = sum(
+        len(root["member_disposition"]["members"])
+        for root in expected["export_roots"]
+    )
     return {
         "id_kinds": len(expected["id_kinds"]),
         "json_types": len(expected["json_types"]),
         "event_types": len(expected["event_types"]),
         "native_domains": len(expected["native_domains"]),
+        "export_roots": len(expected["export_roots"]),
+        "api_v5_roots": len(api_v5_roots),
+        "platform_v1_roots": len(platform_v1_roots),
+        "shared_roots": len(api_v5_roots & platform_v1_roots),
+        "member_dispositions": member_dispositions,
     }
 
 
@@ -51,7 +75,12 @@ def main() -> int:
         f"{summary['id_kinds']} typed ids, "
         f"{summary['json_types']} JSON types, "
         f"{summary['event_types']} events, "
-        f"{summary['native_domains']} runtime domains"
+        f"{summary['native_domains']} runtime domains, "
+        f"{summary['export_roots']} unique export roots "
+        f"({summary['api_v5_roots']} API v5, "
+        f"{summary['platform_v1_roots']} Platform v1, "
+        f"{summary['shared_roots']} shared), and "
+        f"{summary['member_dispositions']} member dispositions"
     )
     return 0
 

--- a/tools/lua_api/check_luals_declarations.py
+++ b/tools/lua_api/check_luals_declarations.py
@@ -120,6 +120,15 @@ DECLARED_CLASS = re.compile(
     r"^---@class\s+([A-Za-z_][A-Za-z0-9_]*)",
     re.MULTILINE,
 )
+DECLARED_ALIAS = re.compile(
+    r"^---@alias\s+([A-Za-z_][A-Za-z0-9_]*)",
+    re.MULTILINE,
+)
+DECLARED_GENERIC = re.compile(
+    r"^---@generic\s+([A-Za-z_][A-Za-z0-9_]*)",
+    re.MULTILINE,
+)
+CUSTOM_TYPE_REFERENCE = re.compile(r"\b[A-Z][A-Za-z0-9_]*\b")
 NEW_USERTYPE = re.compile(
     r"new_usertype\s*<[^>]+>\s*\(\s*\"([^\"]+)\"",
     re.DOTALL,
@@ -155,6 +164,15 @@ LUA_RESERVED_WORDS = {
     "until",
     "while",
 }
+PLATFORM_PRIVATE_USERTYPE_ALIASES = {
+    "_ModDefinitionNative": "ModDefinition",
+}
+
+
+def platform_public_usertype_name(name: str) -> str | None:
+    if name in PLATFORM_PRIVATE_USERTYPE_ALIASES:
+        return PLATFORM_PRIVATE_USERTYPE_ALIASES[name]
+    return None if name.startswith("_") else name
 
 
 def catalua_sources() -> list[Path]:
@@ -194,7 +212,9 @@ def platform_source_usertypes() -> set[str]:
     result: set[str] = set()
     for path in platform_sources():
         contents = path.read_text(encoding="utf-8", errors="replace")
-        result.update(NEW_USERTYPE.findall(contents))
+        for native_name in NEW_USERTYPE.findall(contents):
+            if public_name := platform_public_usertype_name(native_name):
+                result.add(public_name)
     return result
 
 
@@ -203,7 +223,9 @@ def platform_usertype_members() -> dict[str, set[str]]:
     for path in platform_sources():
         contents = path.read_text(encoding="utf-8", errors="replace")
         for match in NEW_USERTYPE.finditer(contents):
-            usertype = match.group(1)
+            usertype = platform_public_usertype_name(match.group(1))
+            if usertype is None:
+                continue
             opening = contents.find("(", match.start())
             depth = 0
             quoted = False
@@ -244,16 +266,34 @@ def platform_source_properties() -> set[str]:
 
 
 PLATFORM_TABLE_CLASSES = {
+    "achievements": "CcbPlatformAchievementsApi",
+    "activities": "CcbPlatformActivitiesApi",
+    "bionics": "CcbPlatformBionicsApi",
     "content": "CcbPlatformContent",
+    "environment": "CcbPlatformEnvironmentQueries",
+    "inventory": "CcbPlatformInventoryApi",
+    "martial_arts": "CcbPlatformMartialArtsApi",
+    "morale": "CcbPlatformMoraleApi",
+    "mods": "CcbPlatformModQueries",
+    "random": "CcbPlatformRandomApi",
+    "recipes": "CcbPlatformRecipesApi",
     "runtime_api": "CcbPlatformRuntime",
     "scope": "CcbPlatformStateScope",
+    "strings": "CcbPlatformStringPredicates",
     "tasks": "CcbPlatformTasks",
     "presentation": "CcbPlatformPresentation",
     "services": "CcbPlatformServices",
+    "wounds": "CcbPlatformWoundsApi",
+}
+
+PLATFORM_INTENTIONALLY_UNDECLARED_TABLES = {
+    "ccb",
+    "lua",
 }
 
 PLATFORM_SERVICE_FIELDS = {
     "achievements",
+    "activities",
     "addictions",
     "bionics",
     "camps",
@@ -266,6 +306,7 @@ PLATFORM_SERVICE_FIELDS = {
     "enums",
     "factions",
     "followers",
+    "gameplay",
     "handles",
     "hordes",
     "inventory",
@@ -273,6 +314,7 @@ PLATFORM_SERVICE_FIELDS = {
     "martial_arts",
     "messages",
     "missions",
+    "morale",
     "mutations",
     "needs",
     "npcs",
@@ -296,6 +338,7 @@ PLATFORM_SERVICE_FIELDS = {
     "vehicles",
     "vitamins",
     "weather",
+    "wounds",
     "world",
     "zones",
 }
@@ -306,8 +349,24 @@ def platform_source_methods() -> dict[str, set[str]]:
     for path in platform_sources():
         contents = path.read_text(encoding="utf-8", errors="replace")
         for table, method in SET_FUNCTION.findall(contents):
-            if table in PLATFORM_TABLE_CLASSES:
-                result[table].add(method)
+            result[table].add(method)
+    unknown = sorted(
+        set(result) - set(PLATFORM_TABLE_CLASSES) -
+        PLATFORM_INTENTIONALLY_UNDECLARED_TABLES
+    )
+    if unknown:
+        raise RuntimeError(
+            "Platform LuaLS checker omits registered API table mappings: "
+            f"{unknown}"
+        )
+    result = defaultdict(
+        set,
+        {
+            table: methods
+            for table, methods in result.items()
+            if table in PLATFORM_TABLE_CLASSES
+        },
+    )
     # Platform installs this native snapshot layer directly into
     # `ccb.services`.  The implementation is shared with v5, while the table
     # membership is an independent Platform contract checked here.
@@ -378,6 +437,156 @@ def class_methods(contents: str, class_name: str) -> list[str]:
         for declared_class, method in DECLARED_METHOD.findall(contents)
         if declared_class == class_name
     ]
+
+
+def declared_type_names(contents: str) -> set[str]:
+    return (
+        set(DECLARED_CLASS.findall(contents)) |
+        set(DECLARED_ALIAS.findall(contents)) |
+        set(DECLARED_GENERIC.findall(contents))
+    )
+
+
+def leading_type_expression(value: str) -> str:
+    """Return the leading LuaLS type, without its prose description."""
+    value = value.strip()
+    depths = {"(": 0, "<": 0, "[": 0, "{": 0}
+    closers = {")": "(", ">": "<", "]": "[", "}": "{"}
+    quote: str | None = None
+    escaped = False
+    for index, character in enumerate(value):
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = None
+            continue
+        if character in {"'", '"'}:
+            quote = character
+            continue
+        if character in depths:
+            depths[character] += 1
+            continue
+        if character in closers:
+            opener = closers[character]
+            depths[opener] = max(0, depths[opener] - 1)
+            continue
+        if not character.isspace() or any(depths.values()):
+            continue
+        previous = value[:index].rstrip()[-1:]
+        following = value[index:].lstrip()[:1]
+        if previous in {":", "|", "&", ","}:
+            continue
+        if following in {"|", "&", "<", "["}:
+            continue
+        return value[:index]
+    return value
+
+
+def split_return_declarations(value: str) -> list[str]:
+    """Split a LuaLS return list without splitting generic arguments."""
+    result: list[str] = []
+    start = 0
+    depths = {"(": 0, "<": 0, "[": 0, "{": 0}
+    closers = {")": "(", ">": "<", "]": "[", "}": "{"}
+    quote: str | None = None
+    escaped = False
+    for index, character in enumerate(value):
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = None
+            continue
+        if character in {"'", '"'}:
+            quote = character
+            continue
+        if character in depths:
+            depths[character] += 1
+            continue
+        if character in closers:
+            opener = closers[character]
+            depths[opener] = max(0, depths[opener] - 1)
+            continue
+        if character == "," and not any(depths.values()):
+            result.append(value[start:index].strip())
+            start = index + 1
+    result.append(value[start:].strip())
+    return [entry for entry in result if entry]
+
+
+def referenced_type_names(contents: str) -> dict[str, set[int]]:
+    """Return custom LuaLS type references and their source lines."""
+    result: dict[str, set[int]] = defaultdict(set)
+    patterns = {
+        "field": re.compile(
+            r"^---@field\s+[A-Za-z_][A-Za-z0-9_]*\??\s+(.+)$"
+        ),
+        "param": re.compile(
+            r"^---@param\s+[A-Za-z_][A-Za-z0-9_]*\??\s+(.+)$"
+        ),
+        "return": re.compile(r"^---@return\s+(.+)$"),
+        "type": re.compile(r"^---@type\s+(.+)$"),
+        "overload": re.compile(r"^---@overload\s+(.+)$"),
+        "alias": re.compile(
+            r"^---@alias\s+[A-Za-z_][A-Za-z0-9_]*(?:\s+(.+))?$"
+        ),
+        "class": re.compile(
+            r"^---@class\s+[A-Za-z_][A-Za-z0-9_]*\s*:\s*(.+)$"
+        ),
+        "generic": re.compile(
+            r"^---@generic\s+[A-Za-z_][A-Za-z0-9_]*\s*:\s*(.+)$"
+        ),
+    }
+    for line_number, line in enumerate(contents.splitlines(), start=1):
+        for kind, pattern in patterns.items():
+            match = pattern.match(line)
+            if match is None or match.group(1) is None:
+                continue
+            raw = match.group(1)
+            if kind == "return":
+                expressions = [
+                    leading_type_expression(entry)
+                    for entry in split_return_declarations(raw)
+                ]
+            elif kind in {"field", "param", "type"}:
+                expressions = [leading_type_expression(raw)]
+            else:
+                expressions = [raw]
+            for expression in expressions:
+                without_literals = re.sub(
+                    r"'(?:\\.|[^'\\])*'|\"(?:\\.|[^\"\\])*\"",
+                    "",
+                    expression,
+                )
+                for name in CUSTOM_TYPE_REFERENCE.findall(without_literals):
+                    result[name].add(line_number)
+            break
+    return result
+
+
+def validate_type_references(
+    contents: str,
+    additional_types: set[str] | None = None,
+) -> None:
+    """Reject LuaLS annotations that refer to undeclared custom types."""
+    known = declared_type_names(contents)
+    if additional_types is not None:
+        known.update(additional_types)
+    references = referenced_type_names(contents)
+    missing = sorted(set(references) - known)
+    if missing:
+        details = ", ".join(
+            f"{name} (lines {sorted(references[name])})"
+            for name in missing
+        )
+        raise RuntimeError(
+            f"LuaLS declarations reference undefined types: {details}"
+        )
 
 
 def validate_table_mappings(
@@ -522,6 +731,7 @@ def check(path: Path) -> dict[str, int]:
         raise RuntimeError(
             f"LuaLS declarations omit usertypes: {missing_types}"
         )
+    validate_type_references(contents)
     coordinate_fields = set(
         re.findall(
             r"^---@field\s+((?:point|tripoint)_[a-z]+_[a-z]+)\s+fun",
@@ -600,15 +810,20 @@ def check_platform(path: Path = PLATFORM_DECLARATIONS) -> dict[str, int]:
         if module_fields.get(field) != expected_type:
             raise RuntimeError(
                 f"Platform LuaLS module field {field} is "
-                f"{module_fields.get(field) or 'missing'}, expected {expected_type}"
+                f"{module_fields.get(field) or 'missing'}, expected "
+                f"{expected_type}"
             )
     constructor = module_fields.get("ModDefinition", "")
     if not constructor.startswith("fun("):
-        raise RuntimeError("Platform LuaLS ModDefinition constructor is missing")
-    declared_service_fields = set(class_fields(contents, "CcbPlatformServices"))
+        raise RuntimeError(
+            "Platform LuaLS ModDefinition constructor is missing"
+        )
+    declared_service_fields = set(
+        class_fields(contents, "CcbPlatformServices")
+    )
     if declared_service_fields != PLATFORM_SERVICE_FIELDS:
         raise RuntimeError(
-            "Platform LuaLS service fields differ from the explicitly installed "
+            "Platform LuaLS service fields differ from the installed "
             f"domain set: declared={sorted(declared_service_fields)}, "
             f"expected={sorted(PLATFORM_SERVICE_FIELDS)}"
         )
@@ -616,20 +831,33 @@ def check_platform(path: Path = PLATFORM_DECLARATIONS) -> dict[str, int]:
     if set(methods) != set(PLATFORM_TABLE_CLASSES):
         raise RuntimeError(
             "Platform native method tables differ from checker mappings: "
-            f"native={sorted(methods)}, mapped={sorted(PLATFORM_TABLE_CLASSES)}"
+            f"native={sorted(methods)}, "
+            f"mapped={sorted(PLATFORM_TABLE_CLASSES)}"
         )
     for table, native_methods in methods.items():
-        declared = set(class_methods(contents, PLATFORM_TABLE_CLASSES[table]))
+        declared = set(
+            class_methods(contents, PLATFORM_TABLE_CLASSES[table])
+        )
         if native_methods != declared:
             raise RuntimeError(
-                f"Platform LuaLS methods differ for {PLATFORM_TABLE_CLASSES[table]}: "
+                "Platform LuaLS methods differ for "
+                f"{PLATFORM_TABLE_CLASSES[table]}: "
                 f"declared={sorted(declared)}, native={sorted(native_methods)}"
             )
+    shared_contents = (
+        REPOSITORY_ROOT / DEFAULT_DECLARATIONS
+    ).read_text(encoding="utf-8")
+    validate_type_references(
+        contents,
+        declared_type_names(shared_contents),
+    )
     return {
         "usertypes": len(usertypes),
         "properties": len(properties),
         "methods": sum(len(value) for value in methods.values()),
-        "usertype_members": sum(len(value) for value in native_members.values()),
+        "usertype_members": sum(
+            len(value) for value in native_members.values()
+        ),
     }
 
 

--- a/tools/lua_api/generate_ccb_inventory.py
+++ b/tools/lua_api/generate_ccb_inventory.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import argparse
 import json
 import re
+from collections import defaultdict, deque
+from functools import lru_cache
 from pathlib import Path
 
 
@@ -25,6 +27,214 @@ EVENT_ENUM_PATTERN = re.compile(
     r"enum class event_type\s*:\s*int\s*\{(?P<body>.*?)"
     r"num_event_types\b[^\n]*\n\s*\};",
     re.DOTALL,
+)
+
+USERTYPE_START_PATTERN = re.compile(r"\bnew_usertype\s*<")
+PUBLIC_USERTYPE_ALIASES = {
+    "_ModDefinitionNative": "ModDefinition",
+}
+META_FUNCTION_NAMES = {
+    "addition": "__add",
+    "division": "__div",
+    "equal_to": "__eq",
+    "less_than": "__lt",
+    "less_than_or_equal_to": "__le",
+    "multiplication": "__mul",
+    "subtraction": "__sub",
+    "to_string": "__tostring",
+    "unary_minus": "__unm",
+}
+
+# Each installer is located independently so the inventory can prove which
+# registrations are reachable from each public Lua surface.  Shared installers
+# deliberately have one node even though both surfaces call them.
+INSTALLER_SPECS = (
+    {
+        "id": "api_v5.initialize_state",
+        "function": "initialize_state",
+        "path": "src/catalua_ui.cpp",
+        "signature": "void initialize_state( runtime_state &state )",
+        "namespace": "global",
+    },
+    {
+        "id": "platform_v1.initialize_state",
+        "function": "initialize_state",
+        "path": "src/catalua_platform.cpp",
+        "signature": (
+            "void initialize_state( sol::state &lua, "
+            "const fs::path &requested_root,"
+        ),
+        "namespace": "ccb",
+    },
+    {
+        "id": "platform_v1.install_mod_definition",
+        "function": "install_mod_definition",
+        "path": "src/catalua_platform.cpp",
+        "signature": "void install_mod_definition( sol::table &ccb )",
+        "namespace": "ccb",
+    },
+    {
+        "id": "platform_v1.install_runtime_api",
+        "function": "install_runtime_api",
+        "path": "src/catalua_platform_runtime.cpp",
+        "signature": (
+            "void install_runtime_api( "
+            "const std::shared_ptr<runtime> &value,"
+        ),
+        "namespace": "ccb",
+    },
+    {
+        "id": "platform_v1.content_transaction.install_lua_api",
+        "function": "content_transaction::install_lua_api",
+        "path": "src/catalua_platform_runtime.cpp",
+        "signature": (
+            "void content_transaction::install_lua_api( "
+            "sol::state &lua, sol::table &ccb,"
+        ),
+        "namespace": "ccb",
+    },
+    {
+        "id": "shared.install_value_type_api",
+        "function": "install_value_type_api",
+        "path": "src/catalua_bindings_values.cpp",
+        "signature": "void install_value_type_api(",
+        "namespace": "global",
+    },
+    {
+        "id": "shared.install_enum_value_api",
+        "function": "install_enum_value_api",
+        "path": "src/catalua_bindings_enums.cpp",
+        "signature": "void install_enum_value_api(",
+        "namespace": "global",
+    },
+    {
+        "id": "shared.install_coordinate_value_api",
+        "function": "install_coordinate_value_api",
+        "path": "src/catalua_bindings_coords.cpp",
+        "signature": "void install_coordinate_value_api(",
+        "namespace": "global",
+    },
+    {
+        "id": "shared.install_game_handle_api",
+        "function": "install_game_handle_api",
+        "path": "src/catalua_game_handle.cpp",
+        "signature": "void install_game_handle_api(",
+        "namespace": "global",
+    },
+    {
+        "id": "shared.install_mission_api",
+        "function": "install_mission_api",
+        "path": "src/catalua_ui_missions.cpp",
+        "signature": "void install_mission_api(",
+        "namespace": "global",
+    },
+    {
+        "id": "shared.install_horde_api",
+        "function": "install_horde_api",
+        "path": "src/catalua_ui_hordes.cpp",
+        "signature": "void install_horde_api(",
+        "namespace": "global",
+    },
+    {
+        "id": "shared.install_zone_api",
+        "function": "install_zone_api",
+        "path": "src/catalua_ui_zones.cpp",
+        "signature": "void install_zone_api(",
+        "namespace": "global",
+    },
+)
+
+INSTALLER_EDGE_SPECS = (
+    (
+        "api_v5.initialize_state",
+        "shared.install_value_type_api",
+        "install_value_type_api(",
+    ),
+    (
+        "api_v5.initialize_state",
+        "shared.install_game_handle_api",
+        "install_game_handle_api(",
+    ),
+    (
+        "api_v5.initialize_state",
+        "shared.install_zone_api",
+        "install_zone_api(",
+    ),
+    (
+        "api_v5.initialize_state",
+        "shared.install_mission_api",
+        "install_mission_api(",
+    ),
+    (
+        "api_v5.initialize_state",
+        "shared.install_horde_api",
+        "install_horde_api(",
+    ),
+    (
+        "platform_v1.initialize_state",
+        "platform_v1.install_mod_definition",
+        "install_mod_definition(",
+    ),
+    (
+        "platform_v1.initialize_state",
+        "platform_v1.install_runtime_api",
+        "install_runtime_api(",
+    ),
+    (
+        "platform_v1.install_runtime_api",
+        "platform_v1.content_transaction.install_lua_api",
+        "content.install_lua_api(",
+    ),
+    (
+        "platform_v1.install_runtime_api",
+        "shared.install_value_type_api",
+        "install_value_type_api(",
+    ),
+    (
+        "platform_v1.install_runtime_api",
+        "shared.install_game_handle_api",
+        "install_game_handle_api(",
+    ),
+    (
+        "platform_v1.install_runtime_api",
+        "shared.install_mission_api",
+        "install_mission_api(",
+    ),
+    (
+        "platform_v1.install_runtime_api",
+        "shared.install_horde_api",
+        "install_horde_api(",
+    ),
+    (
+        "platform_v1.install_runtime_api",
+        "shared.install_zone_api",
+        "install_zone_api(",
+    ),
+    (
+        "shared.install_value_type_api",
+        "shared.install_enum_value_api",
+        "install_enum_value_api(",
+    ),
+    (
+        "shared.install_value_type_api",
+        "shared.install_coordinate_value_api",
+        "install_coordinate_value_api(",
+    ),
+)
+
+EXPORT_SURFACES = (
+    {
+        "id": "api_v5",
+        "api_version": 5,
+        "declarations": "data/lua/types/ccb_api_v5.d.lua",
+        "entrypoint": "api_v5.initialize_state",
+    },
+    {
+        "id": "platform_v1",
+        "api_version": 1,
+        "declarations": "data/lua/types/ccb_platform_v1.d.lua",
+        "entrypoint": "platform_v1.initialize_state",
+    },
 )
 
 NATIVE_DOMAINS = (
@@ -70,8 +280,334 @@ NATIVE_DOMAINS = (
 )
 
 
+@lru_cache(maxsize=None)
 def source_text(relative_path: str) -> str:
     return (REPOSITORY_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def line_number(contents: str, offset: int) -> int:
+    return contents.count("\n", 0, offset) + 1
+
+
+def source_location(
+    path: str, contents: str, offset: int
+) -> dict[str, object]:
+    return {
+        "path": path,
+        "line": line_number(contents, offset),
+    }
+
+
+@lru_cache(maxsize=32)
+def code_mask(contents: str) -> str:
+    """Preserve code offsets while blanking comments and quoted strings."""
+    result = list(contents)
+    quote: str | None = None
+    escaped = False
+    line_comment = False
+    block_comment = False
+    index = 0
+    while index < len(contents):
+        char = contents[index]
+        following = contents[index + 1] if index + 1 < len(contents) else ""
+        if line_comment:
+            if char == "\n":
+                line_comment = False
+            else:
+                result[index] = " "
+            index += 1
+            continue
+        if block_comment:
+            if char == "*" and following == "/":
+                result[index] = " "
+                result[index + 1] = " "
+                block_comment = False
+                index += 2
+            else:
+                if char != "\n":
+                    result[index] = " "
+                index += 1
+            continue
+        if quote is not None:
+            if char != "\n":
+                result[index] = " "
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            index += 1
+            continue
+        if char == "/" and following == "/":
+            result[index] = " "
+            result[index + 1] = " "
+            line_comment = True
+            index += 2
+            continue
+        if char == "/" and following == "*":
+            result[index] = " "
+            result[index + 1] = " "
+            block_comment = True
+            index += 2
+            continue
+        if char in {'"', "'"}:
+            result[index] = " "
+            quote = char
+        index += 1
+    return "".join(result)
+
+
+def extract_balanced(
+    contents: str, opening: int, opener: str = "(", closer: str = ")"
+) -> tuple[str, int]:
+    """Return a balanced C++ region, ignoring comments and strings."""
+    if opening >= len(contents) or contents[opening] != opener:
+        raise RuntimeError(f"expected {opener!r} at offset {opening}")
+    depth = 0
+    quote: str | None = None
+    escaped = False
+    line_comment = False
+    block_comment = False
+    index = opening
+    while index < len(contents):
+        char = contents[index]
+        following = contents[index + 1] if index + 1 < len(contents) else ""
+        if line_comment:
+            if char == "\n":
+                line_comment = False
+            index += 1
+            continue
+        if block_comment:
+            if char == "*" and following == "/":
+                block_comment = False
+                index += 2
+            else:
+                index += 1
+            continue
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            index += 1
+            continue
+        if char == "/" and following == "/":
+            line_comment = True
+            index += 2
+            continue
+        if char == "/" and following == "*":
+            block_comment = True
+            index += 2
+            continue
+        if char in {'"', "'"}:
+            quote = char
+            index += 1
+            continue
+        if char == opener:
+            depth += 1
+        elif char == closer:
+            depth -= 1
+            if depth == 0:
+                return contents[opening + 1:index], index + 1
+        index += 1
+    raise RuntimeError(f"unterminated {opener}{closer} region")
+
+
+def split_top_level(contents: str) -> list[str]:
+    """Split a C++ argument list without splitting nested expressions."""
+    parts: list[str] = []
+    start = 0
+    depths = {"(": 0, "[": 0, "{": 0}
+    matching = {")": "(", "]": "[", "}": "{"}
+    quote: str | None = None
+    escaped = False
+    line_comment = False
+    block_comment = False
+    index = 0
+    while index < len(contents):
+        char = contents[index]
+        following = contents[index + 1] if index + 1 < len(contents) else ""
+        if line_comment:
+            if char == "\n":
+                line_comment = False
+            index += 1
+            continue
+        if block_comment:
+            if char == "*" and following == "/":
+                block_comment = False
+                index += 2
+            else:
+                index += 1
+            continue
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            index += 1
+            continue
+        if char == "/" and following == "/":
+            line_comment = True
+            index += 2
+            continue
+        if char == "/" and following == "*":
+            block_comment = True
+            index += 2
+            continue
+        if char in {'"', "'"}:
+            quote = char
+        elif char in depths:
+            depths[char] += 1
+        elif char in matching:
+            depths[matching[char]] -= 1
+        elif char == "," and not any(depths.values()):
+            parts.append(contents[start:index].strip())
+            start = index + 1
+        index += 1
+    tail = contents[start:].strip()
+    if tail:
+        parts.append(tail)
+    return parts
+
+
+def function_region(
+    contents: str, signature: str
+) -> tuple[int, int, int]:
+    signature_offset = contents.find(signature)
+    if signature_offset < 0:
+        raise RuntimeError(f"installer signature was not found: {signature}")
+    opening = contents.find("{", signature_offset + len(signature))
+    if opening < 0:
+        raise RuntimeError(f"installer body was not found: {signature}")
+    _, after = extract_balanced(contents, opening, "{", "}")
+    return signature_offset, opening + 1, after - 1
+
+
+def member_public_name(key_expression: str) -> tuple[str, str]:
+    string_key = re.fullmatch(r'"([^"\\]*(?:\\.[^"\\]*)*)"', key_expression)
+    if string_key is not None:
+        return json.loads(f'"{string_key.group(1)}"'), "member"
+    meta_key = re.fullmatch(
+        r"sol::meta_function::([A-Za-z_][A-Za-z0-9_]*)",
+        key_expression,
+    )
+    if meta_key is None or meta_key.group(1) not in META_FUNCTION_NAMES:
+        raise RuntimeError(
+            f"unsupported usertype member key {key_expression!r}"
+        )
+    return META_FUNCTION_NAMES[meta_key.group(1)], "operator"
+
+
+def referenced_cpp_members(expression: str) -> list[str]:
+    address_members = re.findall(
+        r"&(?:[A-Za-z_][A-Za-z0-9_]*::)+"
+        r"([A-Za-z_][A-Za-z0-9_]*)",
+        expression,
+    )
+    adapted_members = re.findall(
+        r"\bself\.([A-Za-z_][A-Za-z0-9_]*)",
+        expression,
+    )
+    return sorted(set(address_members + adapted_members))
+
+
+def parse_usertype_registrations(
+    contents: str,
+    path: str,
+    start: int = 0,
+    end: int | None = None,
+) -> list[dict[str, object]]:
+    """Parse registrations and only their top-level public member keys."""
+    boundary = len(contents) if end is None else end
+    masked = code_mask(contents)
+    registrations: list[dict[str, object]] = []
+    for match in USERTYPE_START_PATTERN.finditer(masked, start, boundary):
+        angle_opening = masked.find("<", match.start(), boundary)
+        cpp_type, after_angle = extract_balanced(
+            contents, angle_opening, "<", ">"
+        )
+        opening = after_angle
+        while opening < boundary and contents[opening].isspace():
+            opening += 1
+        if opening >= boundary or contents[opening] != "(":
+            raise RuntimeError(
+                f"cannot parse usertype call at "
+                f"{path}:{line_number(contents, match.start())}"
+            )
+        body, after_call = extract_balanced(contents, opening)
+        if after_call > boundary:
+            raise RuntimeError(
+                f"usertype registration escapes installer at "
+                f"{path}:{line_number(contents, match.start())}"
+            )
+        arguments = split_top_level(body)
+        if len(arguments) < 2 or len(arguments[2:]) % 2 != 0:
+            raise RuntimeError(
+                f"cannot parse usertype arguments at "
+                f"{path}:{line_number(contents, match.start())}"
+            )
+        name_match = re.fullmatch(
+            r'"([^"\\]*(?:\\.[^"\\]*)*)"', arguments[0]
+        )
+        if name_match is None:
+            raise RuntimeError(
+                f"usertype name is not a string literal at "
+                f"{path}:{line_number(contents, match.start())}"
+            )
+        registration_name = json.loads(f'"{name_match.group(1)}"')
+        lua_name = PUBLIC_USERTYPE_ALIASES.get(
+            registration_name, registration_name
+        )
+        if lua_name.startswith("_"):
+            raise RuntimeError(
+                f"private usertype {registration_name} lacks a public alias"
+            )
+        members: list[dict[str, object]] = []
+        search_offset = 0
+        for key_expression, value_expression in zip(
+            arguments[2::2], arguments[3::2]
+        ):
+            lua_member, kind = member_public_name(key_expression)
+            relative_offset = body.find(key_expression, search_offset)
+            if relative_offset < 0:
+                raise RuntimeError(
+                    f"cannot locate {lua_name}.{lua_member} registration"
+                )
+            search_offset = relative_offset + len(key_expression)
+            if "sol::property" in value_expression:
+                kind = "property"
+            members.append(
+                {
+                    "id": lua_member,
+                    "cpp_members": referenced_cpp_members(value_expression),
+                    "cpp_kind": kind,
+                    "lua_access": [f"{lua_name}.{lua_member}"],
+                    "disposition": "bound",
+                    "evidence": [
+                        source_location(
+                            path,
+                            contents,
+                            opening + 1 + relative_offset,
+                        )
+                    ],
+                }
+            )
+        registrations.append(
+            {
+                "cpp_type": " ".join(cpp_type.split()),
+                "lua_name": lua_name,
+                "registration_name": registration_name,
+                "members": members,
+                "source": source_location(path, contents, match.start()),
+                "_offset": match.start(),
+            }
+        )
+    return registrations
 
 
 def parse_id_kinds(contents: str) -> list[dict[str, str]]:
@@ -132,14 +668,1066 @@ def parse_event_types(contents: str) -> list[dict[str, str]]:
     return [{"type": name} for name in names]
 
 
-def build_inventory() -> dict[str, object]:
+def registration_identity(entry: dict[str, object]) -> tuple[str, int]:
+    source = entry["source"]
+    if not isinstance(source, dict):
+        raise RuntimeError("usertype registration source must be an object")
+    return str(source["path"]), int(entry["_offset"])
+
+
+def build_installer_model() -> tuple[
+    list[dict[str, object]],
+    list[dict[str, object]],
+    dict[str, list[dict[str, object]]],
+]:
+    contents_by_path: dict[str, str] = {}
+    regions: dict[str, tuple[str, int, int]] = {}
+    registrations_by_installer: dict[str, list[dict[str, object]]] = {}
+    installers: list[dict[str, object]] = []
+
+    for spec in INSTALLER_SPECS:
+        installer_id = str(spec["id"])
+        path = str(spec["path"])
+        contents = contents_by_path.setdefault(path, source_text(path))
+        signature_offset, body_start, body_end = function_region(
+            contents, str(spec["signature"])
+        )
+        regions[installer_id] = (path, body_start, body_end)
+        registrations = parse_usertype_registrations(
+            contents, path, body_start, body_end
+        )
+        for registration in registrations:
+            registration["_installer"] = installer_id
+            registration["_namespace"] = str(spec["namespace"])
+        registrations_by_installer[installer_id] = registrations
+        installers.append(
+            {
+                "id": installer_id,
+                "function": spec["function"],
+                "namespace": spec["namespace"],
+                "source": source_location(
+                    path, contents, signature_offset
+                ),
+                "direct_roots": sorted(
+                    str(entry["lua_name"]) for entry in registrations
+                ),
+            }
+        )
+
+    assigned = {
+        registration_identity(registration)
+        for registrations in registrations_by_installer.values()
+        for registration in registrations
+    }
+    discovered: dict[tuple[str, int], dict[str, object]] = {}
+    source_directory = REPOSITORY_ROOT / "src"
+    for path_object in sorted(source_directory.glob("catalua*.cpp")):
+        relative_path = path_object.relative_to(REPOSITORY_ROOT).as_posix()
+        contents = contents_by_path.setdefault(
+            relative_path,
+            path_object.read_text(encoding="utf-8", errors="replace"),
+        )
+        for registration in parse_usertype_registrations(
+            contents, relative_path
+        ):
+            discovered[registration_identity(registration)] = registration
+    unassigned = sorted(set(discovered) - assigned)
+    if unassigned:
+        details = [
+            f"{path}:{line_number(contents_by_path[path], offset)}"
+            for path, offset in unassigned
+        ]
+        raise RuntimeError(
+            f"registered export roots lack installer nodes: {details}"
+        )
+    missing = sorted(assigned - set(discovered))
+    if missing:
+        raise RuntimeError(
+            f"installer nodes contain undiscovered registrations: {missing}"
+        )
+
+    edges: list[dict[str, object]] = []
+    for caller, callee, call_token in INSTALLER_EDGE_SPECS:
+        path, body_start, body_end = regions[caller]
+        contents = contents_by_path[path]
+        call_offset = code_mask(contents).find(
+            call_token, body_start, body_end
+        )
+        if call_offset < 0:
+            raise RuntimeError(
+                f"installer edge {caller} -> {callee} lacks source evidence"
+            )
+        edges.append(
+            {
+                "caller": caller,
+                "callee": callee,
+                "source": source_location(path, contents, call_offset),
+            }
+        )
+    return installers, edges, registrations_by_installer
+
+
+def reachable_installer_paths(
+    entrypoint: str, edges: list[dict[str, object]]
+) -> dict[str, list[str]]:
+    children: dict[str, list[str]] = defaultdict(list)
+    for edge in edges:
+        children[str(edge["caller"])].append(str(edge["callee"]))
+    for values in children.values():
+        values.sort()
+    paths = {entrypoint: [entrypoint]}
+    pending = deque([entrypoint])
+    while pending:
+        caller = pending.popleft()
+        for callee in children[caller]:
+            if callee in paths:
+                continue
+            paths[callee] = [*paths[caller], callee]
+            pending.append(callee)
+    return paths
+
+
+def evidence_for(
+    path: str, needle: str, start_needle: str | None = None
+) -> dict[str, object]:
+    contents = source_text(path)
+    start = 0
+    if start_needle is not None:
+        start = contents.find(start_needle)
+        if start < 0:
+            raise RuntimeError(
+                f"disposition evidence start {start_needle!r} was not found "
+                f"in {path}"
+            )
+    offset = contents.find(needle, start)
+    if offset < 0:
+        raise RuntimeError(
+            f"disposition evidence {needle!r} was not found in {path}"
+        )
+    return source_location(path, contents, offset)
+
+
+def reviewed_member(
+    identity: str,
+    cpp_members: list[str],
+    cpp_kind: str,
+    disposition: str,
+    evidence: dict[str, object],
+    *,
+    lua_access: list[str] | None = None,
+    reason_code: str,
+    reason: str,
+) -> dict[str, object]:
     return {
-        "schema_version": 1,
+        "id": identity,
+        "cpp_members": cpp_members,
+        "cpp_kind": cpp_kind,
+        "lua_access": [] if lua_access is None else lua_access,
+        "disposition": disposition,
+        "reason_code": reason_code,
+        "reason": reason,
+        "evidence": [evidence],
+    }
+
+
+def append_reviewed_member(
+    roots: dict[str, dict[str, object]],
+    root_name: str,
+    member: dict[str, object],
+) -> None:
+    root = roots[root_name]
+    disposition = root["member_disposition"]
+    if not isinstance(disposition, dict):
+        raise RuntimeError(f"{root_name} member disposition is malformed")
+    members = disposition["members"]
+    if not isinstance(members, list):
+        raise RuntimeError(f"{root_name} member list is malformed")
+    members.append(member)
+
+
+def add_reviewed_dispositions(
+    roots: dict[str, dict[str, object]]
+) -> None:
+    values_header = "src/catalua_bindings_values.h"
+    for method in (
+        "canonical_integer",
+        "canonical_number",
+        "canonical_wide",
+    ):
+        append_reviewed_member(
+            roots,
+            "UnitValue",
+            reviewed_member(
+                f"native.{method}",
+                [method],
+                "method",
+                "unbound",
+                evidence_for(values_header, f" {method}() const"),
+                reason_code="internal-canonical-storage",
+                reason=(
+                    "Canonical storage access stays native; Lua uses the "
+                    "unit-aware value conversion method."
+                ),
+            ),
+        )
+
+    coords_header = "src/catalua_bindings_coords.h"
+    for root_name, cpp_type in (
+        ("PointCoord", "script_point_coord"),
+        ("TripointCoord", "script_tripoint_coord"),
+    ):
+        append_reviewed_member(
+            roots,
+            root_name,
+            reviewed_member(
+                "native.line_to",
+                ["line_to"],
+                "method",
+                "adapted",
+                evidence_for(
+                    coords_header,
+                    " line_to(",
+                    f"class {cpp_type}",
+                ),
+                lua_access=[
+                    "game.coords.line",
+                    "ccb.services.coords.line",
+                ],
+                reason_code="bounded-service-adapter",
+                reason=(
+                    "Lua reaches line generation through the bounded "
+                    "coordinate service so maximum output is enforced."
+                ),
+            ),
+        )
+        for method in ("to_native", "native_origin", "native_scale"):
+            append_reviewed_member(
+                roots,
+                root_name,
+                reviewed_member(
+                    f"native.{method}",
+                    [method],
+                    "method",
+                    "unbound",
+                    evidence_for(
+                        coords_header,
+                        f" {method}() const",
+                        f"class {cpp_type}",
+                    ),
+                    reason_code="native-coordinate-bridge",
+                    reason=(
+                        "Native coordinate representations are engine-only; "
+                        "Lua uses checked coordinate values and services."
+                    ),
+                ),
+            )
+
+    handle_header = "src/catalua_game_handle.h"
+    for method in ("resolve_creature", "resolve_item", "resolve_vehicle"):
+        append_reviewed_member(
+            roots,
+            "GameHandle",
+            reviewed_member(
+                f"native.{method}",
+                [method],
+                "method",
+                "unbound",
+                evidence_for(
+                    handle_header, f" {method}(", "class game_handle"
+                ),
+                reason_code="native-pointer-escape",
+                reason=(
+                    "The native resolver returns a raw engine pointer; Lua "
+                    "must use audited handle-backed services instead."
+                ),
+            ),
+        )
+    append_reviewed_member(
+        roots,
+        "GameHandle",
+        reviewed_member(
+            "native.validation_error",
+            ["validation_error"],
+            "method",
+            "adapted",
+            evidence_for(
+                handle_header, " validation_error(", "class game_handle"
+            ),
+            lua_access=["GameHandle.is_valid", "GameHandle.status"],
+            reason_code="result-envelope-adapter",
+            reason=(
+                "Validation is exposed as a boolean and a detached result "
+                "envelope instead of a native optional error object."
+            ),
+        ),
+    )
+    for method in ("runtime_generation", "world_generation"):
+        append_reviewed_member(
+            roots,
+            "GameHandle",
+            reviewed_member(
+                f"native.{method}",
+                [method],
+                "method",
+                "unbound",
+                evidence_for(handle_header, f" {method}() const"),
+                reason_code="lifetime-generation-internal",
+                reason=(
+                    "Generation counters are internal lifetime guards and "
+                    "cannot be authored or inspected by Lua."
+                ),
+            ),
+        )
+    append_reviewed_member(
+        roots,
+        "GameHandle",
+        reviewed_member(
+            "native.runtime_owner",
+            ["runtime_owner_"],
+            "field",
+            "unbound",
+            evidence_for(handle_header, " runtime_owner_;"),
+            reason_code="native-owner-state",
+            reason=(
+                "The weak runtime-owner identity is an internal stale-handle "
+                "guard and cannot be observed or replaced by Lua."
+            ),
+        ),
+    )
+
+    platform_runtime = "src/catalua_platform_runtime.cpp"
+    for root in roots.values():
+        cpp_type = str(root["cpp_type"])
+        if not cpp_type.endswith("_definition_handle"):
+            continue
+        struct_marker = f"struct {cpp_type}"
+        for field, reason_code, reason in (
+            (
+                "definition",
+                "native-definition-storage",
+                "The transaction-owned definition payload is only reachable "
+                "through audited builder methods.",
+            ),
+            (
+                "token",
+                "native-owner-state",
+                "The owner token enforces transaction lifetime and is never "
+                "public Lua state.",
+            ),
+        ):
+            append_reviewed_member(
+                roots,
+                str(root["lua_name"]),
+                reviewed_member(
+                    f"native.{field}",
+                    [field],
+                    "field",
+                    "unbound",
+                    evidence_for(
+                        platform_runtime, f" {field};", struct_marker
+                    ),
+                    reason_code=reason_code,
+                    reason=reason,
+                ),
+            )
+
+    for field in (
+        "character",
+        "used_item",
+        "handle_runtime",
+        "world_generation",
+        "active",
+        "require_active",
+    ):
+        needle = (
+            " require_active()"
+            if field == "require_active"
+            else f" {field}"
+        )
+        append_reviewed_member(
+            roots,
+            "ItemUseContext",
+            reviewed_member(
+                f"native.{field}",
+                [field],
+                "method" if field == "require_active" else "field",
+                "unbound",
+                evidence_for(
+                    platform_runtime,
+                    needle,
+                    "struct use_context_data",
+                ),
+                reason_code=(
+                    "native-pointer-escape"
+                    if field in {"character", "used_item"}
+                    else "callback-lifetime-internal"
+                ),
+                reason=(
+                    "Raw callback pointers cannot escape into Lua."
+                    if field in {"character", "used_item"}
+                    else "Callback lifetime guards are enforced internally."
+                ),
+            ),
+        )
+    for identity, cpp_member, cpp_kind, needle in (
+        (
+            "native.copy_constructor",
+            "use_context_data(const&)",
+            "constructor",
+            "use_context_data( const use_context_data & ) = delete;",
+        ),
+        (
+            "native.copy_assignment",
+            "operator=(const&)",
+            "operator",
+            "operator=( const use_context_data & ) = delete;",
+        ),
+        (
+            "native.move_constructor",
+            "use_context_data(&&)",
+            "constructor",
+            "use_context_data( use_context_data && ) = delete;",
+        ),
+        (
+            "native.move_assignment",
+            "operator=(&&)",
+            "operator",
+            "operator=( use_context_data && ) = delete;",
+        ),
+    ):
+        append_reviewed_member(
+            roots,
+            "ItemUseContext",
+            reviewed_member(
+                identity,
+                [cpp_member],
+                cpp_kind,
+                "unbound",
+                evidence_for(
+                    platform_runtime,
+                    needle,
+                    "struct use_context_data",
+                ),
+                reason_code="callback-lifetime-internal",
+                reason=(
+                    "Callback userdata is pinned to one native scope lease "
+                    "and cannot be copied or moved."
+                ),
+            ),
+        )
+
+    platform_header = "src/catalua_platform.h"
+    for field in (
+        "id_set",
+        "name_set",
+        "version_set",
+        "entry_set",
+        "dependencies_set",
+        "core_set",
+    ):
+        append_reviewed_member(
+            roots,
+            "ModDefinition",
+            reviewed_member(
+                f"native.{field}",
+                [field],
+                "field",
+                "unbound",
+                evidence_for(platform_header, f" {field} ="),
+                reason_code="parser-presence-state",
+                reason=(
+                    "Field-presence tracking belongs to native metadata "
+                    "validation and is not Mod-authored state."
+                ),
+            ),
+        )
+
+    zones_source = "src/catalua_ui_zones.cpp"
+    for field in (
+        "runtime",
+        "world_generation",
+        "personal_start",
+        "personal_end",
+        "lifetime_identity",
+    ):
+        append_reviewed_member(
+            roots,
+            "ZoneToken",
+            reviewed_member(
+                f"native.{field}",
+                [field],
+                "field",
+                "unbound",
+                evidence_for(
+                    zones_source,
+                    f" {field}",
+                    "struct script_zone_token",
+                ),
+                reason_code="identity-or-lifetime-internal",
+                reason=(
+                    "Zone identity and lifetime internals are validated by "
+                    "native token resolution rather than exposed to Lua."
+                ),
+            ),
+        )
+
+    transient_tokens = (
+        (
+            "MissionToken",
+            "src/catalua_ui_missions.h",
+            "class mission_token",
+            " runtime_;",
+        ),
+        (
+            "HordeEntityToken",
+            "src/catalua_ui_hordes.cpp",
+            "class horde_entity_token",
+            " runtime_;",
+        ),
+        (
+            "LegacyHordeToken",
+            "src/catalua_ui_hordes.cpp",
+            "class legacy_horde_token",
+            " runtime_;",
+        ),
+    )
+    for root_name, path, marker, runtime_needle in transient_tokens:
+        append_reviewed_member(
+            roots,
+            root_name,
+            reviewed_member(
+                "native.runtime_context",
+                ["runtime_"],
+                "field",
+                "unbound",
+                evidence_for(path, runtime_needle, marker),
+                reason_code="native-owner-state",
+                reason=(
+                    "The complete runtime owner and generation context is an "
+                    "internal stale-token guard."
+                ),
+            ),
+        )
+        append_reviewed_member(
+            roots,
+            root_name,
+            reviewed_member(
+                "native.belongs_to",
+                ["belongs_to"],
+                "method",
+                "adapted",
+                evidence_for(path, " belongs_to(", marker),
+                lua_access=[f"{root_name}.is_valid"],
+                reason_code="runtime-identity-adapter",
+                reason=(
+                    "Lua receives a validity predicate that combines runtime "
+                    "owner identity with the token's other native guards."
+                ),
+            ),
+        )
+
+
+def lifetime_contract(root_name: str, cpp_type: str) -> dict[str, object]:
+    if cpp_type.endswith("_definition_handle"):
+        return {
+            "policy": "transaction-owned",
+            "guards": ["owner-token", "transaction-phase"],
+        }
+    if root_name == "ItemUseContext":
+        return {
+            "policy": "callback-borrowed",
+            "guards": [
+                "scope-lease",
+                "active-flag",
+                "noncopyable-nonmovable",
+                "runtime-owner-identity",
+                "runtime-generation",
+                "world-generation",
+            ],
+        }
+    if root_name == "GameHandle":
+        return {
+            "policy": "generation-checked-safe-reference",
+            "guards": [
+                "safe-reference",
+                "runtime-owner-identity",
+                "runtime-generation",
+                "world-generation",
+                "active-runtime-match",
+            ],
+        }
+    if root_name == "ZoneToken":
+        return {
+            "policy": "generation-and-identity-checked-token",
+            "guards": [
+                "runtime-owner-identity",
+                "runtime-generation",
+                "world-generation",
+                "native-lifetime-identity",
+                "active-runtime-match",
+            ],
+        }
+    if root_name == "MissionToken":
+        return {
+            "policy": "runtime-owner-and-generation-checked-token",
+            "guards": [
+                "runtime-owner-identity",
+                "runtime-generation",
+                "world-generation",
+                "active-runtime-match",
+                "native-token-resolution",
+            ],
+        }
+    if root_name in {"HordeEntityToken", "LegacyHordeToken"}:
+        return {
+            "policy": "runtime-owner-and-identity-checked-token",
+            "guards": [
+                "runtime-owner-identity",
+                "runtime-generation",
+                "world-generation",
+                "active-runtime-match",
+                "native-entity-identity",
+            ],
+        }
+    if root_name.endswith("Token"):
+        return {
+            "policy": "native-validated-token",
+            "guards": ["native-token-resolution"],
+        }
+    return {"policy": "lua-owned-value", "guards": []}
+
+
+def build_export_inventory() -> tuple[
+    list[dict[str, object]],
+    dict[str, object],
+    list[dict[str, object]],
+]:
+    installers, edges, registrations_by_installer = build_installer_model()
+    node_by_id = {str(node["id"]): node for node in installers}
+    surface_paths: dict[str, dict[str, list[str]]] = {}
+    export_surfaces: list[dict[str, object]] = []
+    for surface_spec in EXPORT_SURFACES:
+        surface_id = str(surface_spec["id"])
+        paths = reachable_installer_paths(
+            str(surface_spec["entrypoint"]), edges
+        )
+        surface_paths[surface_id] = paths
+        roots = sorted(
+            str(root)
+            for installer_id in paths
+            for root in node_by_id[installer_id]["direct_roots"]
+        )
+        export_surfaces.append({**surface_spec, "roots": roots})
+
+    for edge in edges:
+        edge["surfaces"] = sorted(
+            surface_id
+            for surface_id, paths in surface_paths.items()
+            if all(
+                (
+                    str(edge["caller"]) in paths,
+                    str(edge["callee"]) in paths,
+                )
+            )
+        )
+
+    roots: dict[str, dict[str, object]] = {}
+    for installer_id, registrations in registrations_by_installer.items():
+        installer = node_by_id[installer_id]
+        for registration in registrations:
+            root_name = str(registration["lua_name"])
+            if root_name in roots:
+                raise RuntimeError(
+                    f"duplicate public usertype registration {root_name}"
+                )
+            installations: list[dict[str, object]] = []
+            for surface_id, paths in surface_paths.items():
+                if installer_id not in paths:
+                    continue
+                installations.append(
+                    {
+                        "surface": surface_id,
+                        "namespace": installer["namespace"],
+                        "installer_chain": paths[installer_id],
+                    }
+                )
+            if not installations:
+                raise RuntimeError(
+                    f"registered export root {root_name} is unreachable"
+                )
+            source = registration["source"]
+            if not isinstance(source, dict):
+                raise RuntimeError(
+                    f"registered export root {root_name} lacks source"
+                )
+            members = registration["members"]
+            if not isinstance(members, list):
+                raise RuntimeError(
+                    f"registered export root {root_name} lacks members"
+                )
+            cpp_type = str(registration["cpp_type"])
+            roots[root_name] = {
+                "id": root_name,
+                "cpp_type": cpp_type,
+                "lua_name": root_name,
+                "registration_name": registration["registration_name"],
+                "registration": {
+                    **source,
+                    "installer": installer_id,
+                    "namespace": installer["namespace"],
+                },
+                "surfaces": sorted(
+                    str(entry["surface"]) for entry in installations
+                ),
+                "installations": installations,
+                "lifetime": lifetime_contract(root_name, cpp_type),
+                "member_disposition": {
+                    "scope": (
+                        "registered Lua members plus explicitly reviewed "
+                        "native adaptations and exclusions"
+                    ),
+                    "members": members,
+                },
+            }
+    add_reviewed_dispositions(roots)
+    for root in roots.values():
+        disposition = root["member_disposition"]
+        assert isinstance(disposition, dict)
+        members = disposition["members"]
+        assert isinstance(members, list)
+        members.sort(key=lambda entry: str(entry["id"]))
+
+    graph = {
+        "installers": installers,
+        "edges": edges,
+    }
+    return export_surfaces, graph, [roots[name] for name in sorted(roots)]
+
+
+def validate_export_contract(inventory: dict[str, object]) -> None:
+    """Validate installation reachability and every member disposition."""
+    graph = inventory.get("export_installation_graph")
+    surfaces = inventory.get("export_surfaces")
+    roots = inventory.get("export_roots")
+    if not isinstance(graph, dict):
+        raise RuntimeError("export installation graph must be an object")
+    if not isinstance(surfaces, list) or not isinstance(roots, list):
+        raise RuntimeError("export surfaces and roots must be arrays")
+    installers = graph.get("installers")
+    edges = graph.get("edges")
+    if not isinstance(installers, list) or not isinstance(edges, list):
+        raise RuntimeError("export installation graph arrays are missing")
+
+    node_by_id: dict[str, dict[str, object]] = {}
+    registration_owner: dict[str, str] = {}
+    for node in installers:
+        if not isinstance(node, dict) or not isinstance(node.get("id"), str):
+            raise RuntimeError("export installer node is malformed")
+        node_id = str(node["id"])
+        if node_id in node_by_id:
+            raise RuntimeError(f"duplicate export installer {node_id}")
+        direct_roots = node.get("direct_roots")
+        if not isinstance(direct_roots, list) or not all(
+            isinstance(root, str) for root in direct_roots
+        ):
+            raise RuntimeError(
+                f"installer {node_id} direct roots are malformed"
+            )
+        for root_name in direct_roots:
+            if root_name in registration_owner:
+                raise RuntimeError(
+                    f"export root {root_name} has multiple registrations"
+                )
+            registration_owner[root_name] = node_id
+        node_by_id[node_id] = node
+
+    edge_pairs: set[tuple[str, str]] = set()
+    for edge in edges:
+        if not isinstance(edge, dict):
+            raise RuntimeError("export installer edge is malformed")
+        caller = edge.get("caller")
+        callee = edge.get("callee")
+        if caller not in node_by_id or callee not in node_by_id:
+            raise RuntimeError(
+                "export installer edge has unknown endpoint: "
+                f"{caller} -> {callee}"
+            )
+        pair = str(caller), str(callee)
+        if pair in edge_pairs:
+            raise RuntimeError(f"duplicate export installer edge {pair}")
+        edge_pairs.add(pair)
+
+    expected_surface_roots: dict[str, set[str]] = {}
+    surface_entrypoints: dict[str, str] = {}
+    for surface in surfaces:
+        if not isinstance(surface, dict):
+            raise RuntimeError("export surface is malformed")
+        surface_id = surface.get("id")
+        entrypoint = surface.get("entrypoint")
+        listed_roots = surface.get("roots")
+        if not isinstance(surface_id, str) or entrypoint not in node_by_id:
+            raise RuntimeError(
+                "export surface identity or entrypoint is malformed"
+            )
+        if not isinstance(listed_roots, list) or not all(
+            isinstance(root, str) for root in listed_roots
+        ):
+            raise RuntimeError(f"surface {surface_id} roots are malformed")
+        if surface_id in expected_surface_roots:
+            raise RuntimeError(f"duplicate export surface {surface_id}")
+        paths = reachable_installer_paths(str(entrypoint), edges)
+        reachable_roots = {
+            str(root)
+            for node_id in paths
+            for root in node_by_id[node_id]["direct_roots"]
+        }
+        if set(listed_roots) != reachable_roots:
+            missing = sorted(reachable_roots - set(listed_roots))
+            extra = sorted(set(listed_roots) - reachable_roots)
+            raise RuntimeError(
+                f"{surface_id} installation root parity failed: "
+                f"missing={missing}, extra={extra}"
+            )
+        expected_surface_roots[surface_id] = reachable_roots
+        surface_entrypoints[surface_id] = str(entrypoint)
+
+    root_by_name: dict[str, dict[str, object]] = {}
+    for root in roots:
+        if not isinstance(root, dict):
+            raise RuntimeError("export root is malformed")
+        root_name = root.get("lua_name")
+        if not isinstance(root_name, str) or not root_name:
+            raise RuntimeError("export root lacks a Lua name")
+        if root_name in root_by_name:
+            raise RuntimeError(f"duplicate export root {root_name}")
+        if root.get("id") != root_name:
+            raise RuntimeError(f"export root {root_name} has a stale id")
+        if not isinstance(root.get("cpp_type"), str):
+            raise RuntimeError(f"export root {root_name} lacks a C++ type")
+        registration_name = root.get("registration_name")
+        if not isinstance(registration_name, str) or not registration_name:
+            raise RuntimeError(
+                f"export root {root_name} lacks a registration name"
+            )
+        registration = root.get("registration")
+        if not isinstance(registration, dict):
+            raise RuntimeError(f"export root {root_name} lacks registration")
+        registration_evidence_valid = all(
+            (
+                isinstance(registration.get("path"), str),
+                isinstance(registration.get("line"), int),
+                isinstance(registration.get("namespace"), str),
+            )
+        )
+        if not registration_evidence_valid:
+            raise RuntimeError(
+                f"export root {root_name} registration evidence is malformed"
+            )
+        owner = registration_owner.get(root_name)
+        if owner is None:
+            raise RuntimeError(
+                f"inventory export root is not registered: {root_name}"
+            )
+        if registration.get("installer") != owner:
+            raise RuntimeError(
+                f"export root {root_name} registration installer is stale"
+            )
+        lifetime = root.get("lifetime")
+        lifetime_valid = isinstance(lifetime, dict)
+        if lifetime_valid:
+            lifetime_valid = all(
+                (
+                    isinstance(lifetime.get("policy"), str),
+                    isinstance(lifetime.get("guards"), list),
+                )
+            )
+        if lifetime_valid:
+            lifetime_valid = all(
+                isinstance(guard, str) and guard
+                for guard in lifetime.get("guards", [])
+            )
+        if not lifetime_valid:
+            raise RuntimeError(
+                f"export root {root_name} lifetime contract is malformed"
+            )
+        disposition = root.get("member_disposition")
+        if not isinstance(disposition, dict):
+            raise RuntimeError(
+                f"export root {root_name} lacks member disposition structure"
+            )
+        if not isinstance(disposition.get("scope"), str):
+            raise RuntimeError(
+                f"export root {root_name} lacks member disposition scope"
+            )
+        members = disposition.get("members")
+        if not isinstance(members, list):
+            raise RuntimeError(
+                f"export root {root_name} lacks member dispositions"
+            )
+        member_ids: set[str] = set()
+        for member in members:
+            if not isinstance(member, dict) or not isinstance(
+                member.get("id"), str
+            ):
+                raise RuntimeError(f"{root_name} member is malformed")
+            member_id = str(member["id"])
+            if member_id in member_ids:
+                raise RuntimeError(
+                    f"duplicate member disposition {root_name}.{member_id}"
+                )
+            member_ids.add(member_id)
+            status = member.get("disposition")
+            if status not in {"bound", "adapted", "unbound"}:
+                raise RuntimeError(
+                    f"{root_name}.{member_id} lacks a valid disposition"
+                )
+            cpp_members = member.get("cpp_members")
+            if not isinstance(cpp_members, list) or not all(
+                isinstance(name, str) and name for name in cpp_members
+            ):
+                raise RuntimeError(
+                    f"{root_name}.{member_id} has malformed C++ members"
+                )
+            if not isinstance(member.get("cpp_kind"), str):
+                raise RuntimeError(
+                    f"{root_name}.{member_id} lacks a C++ member kind"
+                )
+            lua_access = member.get("lua_access")
+            if not isinstance(lua_access, list) or not all(
+                isinstance(path, str) and path for path in lua_access
+            ):
+                raise RuntimeError(
+                    f"{root_name}.{member_id} has malformed Lua access"
+                )
+            evidence = member.get("evidence")
+            if not isinstance(evidence, list) or not evidence:
+                raise RuntimeError(
+                    f"{root_name}.{member_id} lacks disposition evidence"
+                )
+            malformed_evidence = any(
+                not isinstance(location, dict) for location in evidence
+            )
+            if not malformed_evidence:
+                malformed_evidence = any(
+                    not all(
+                        (
+                            isinstance(location.get("path"), str),
+                            isinstance(location.get("line"), int),
+                        )
+                    )
+                    for location in evidence
+                )
+            if malformed_evidence:
+                raise RuntimeError(
+                    f"{root_name}.{member_id} has malformed evidence"
+                )
+            if status in {"bound", "adapted"} and not lua_access:
+                raise RuntimeError(
+                    f"{root_name}.{member_id} {status} disposition "
+                    "lacks Lua access"
+                )
+            if status == "unbound" and lua_access:
+                raise RuntimeError(
+                    f"{root_name}.{member_id} unbound disposition "
+                    "exposes Lua access"
+                )
+            if status in {"adapted", "unbound"}:
+                reason_code = member.get("reason_code")
+                reason = member.get("reason")
+                if not isinstance(reason_code, str) or not reason_code.strip():
+                    raise RuntimeError(
+                        f"{root_name}.{member_id} {status} disposition "
+                        "lacks a reason code"
+                    )
+                if not isinstance(reason, str) or not reason.strip():
+                    raise RuntimeError(
+                        f"{root_name}.{member_id} {status} disposition "
+                        "lacks a reason"
+                    )
+
+        installations = root.get("installations")
+        if not isinstance(installations, list) or not installations:
+            raise RuntimeError(f"export root {root_name} lacks installations")
+        installed_surfaces: set[str] = set()
+        for installation in installations:
+            if not isinstance(installation, dict):
+                raise RuntimeError(
+                    f"export root {root_name} installation is malformed"
+                )
+            surface_id = installation.get("surface")
+            chain = installation.get("installer_chain")
+            if surface_id not in expected_surface_roots:
+                raise RuntimeError(
+                    f"export root {root_name} has unknown surface {surface_id}"
+                )
+            if installation.get("namespace") != registration.get("namespace"):
+                raise RuntimeError(
+                    f"export root {root_name} installation namespace is stale"
+                )
+            if not isinstance(chain, list) or not chain:
+                raise RuntimeError(
+                    f"export root {root_name} has an empty installer chain"
+                )
+            endpoints_match = all(
+                (
+                    chain[0] == surface_entrypoints[str(surface_id)],
+                    chain[-1] == owner,
+                )
+            )
+            if not endpoints_match:
+                raise RuntimeError(
+                    f"export root {root_name} installer chain endpoints "
+                    "are stale"
+                )
+            if any(
+                (str(caller), str(callee)) not in edge_pairs
+                for caller, callee in zip(chain, chain[1:])
+            ):
+                raise RuntimeError(
+                    f"export root {root_name} installer chain has a "
+                    "missing edge"
+                )
+            installed_surfaces.add(str(surface_id))
+        listed_surfaces = root.get("surfaces")
+        surfaces_match = isinstance(listed_surfaces, list)
+        if surfaces_match:
+            surfaces_match = set(listed_surfaces) == installed_surfaces
+        if not surfaces_match:
+            raise RuntimeError(
+                f"export root {root_name} surface disposition is stale"
+            )
+        expected = {
+            surface_id
+            for surface_id, surface_roots in expected_surface_roots.items()
+            if root_name in surface_roots
+        }
+        if installed_surfaces != expected:
+            raise RuntimeError(
+                f"export root {root_name} installation surfaces are stale: "
+                f"expected={sorted(expected)}, "
+                f"actual={sorted(installed_surfaces)}"
+            )
+        root_by_name[root_name] = root
+
+    missing_roots = sorted(set(registration_owner) - set(root_by_name))
+    if missing_roots:
+        raise RuntimeError(
+            f"registered export roots missing from inventory: {missing_roots}"
+        )
+
+
+def build_inventory() -> dict[str, object]:
+    export_surfaces, installation_graph, export_roots = (
+        build_export_inventory()
+    )
+    inventory = {
+        "schema_version": 2,
         "source": {
             "project": "Cataclysm-Cleanwater-Bomb",
             "id_registry": "src/catalua_bindings_values.cpp",
             "json_registry": "src/init.cpp",
             "event_registry": "src/event.h",
+            "export_registry": "src/catalua*.cpp",
         },
         "id_kinds": parse_id_kinds(
             source_text("src/catalua_bindings_values.cpp")
@@ -150,7 +1738,12 @@ def build_inventory() -> dict[str, object]:
             {"id": domain, "requirement": requirement}
             for domain, requirement in NATIVE_DOMAINS
         ],
+        "export_surfaces": export_surfaces,
+        "export_installation_graph": installation_graph,
+        "export_roots": export_roots,
     }
+    validate_export_contract(inventory)
+    return inventory
 
 
 def inline_object(entry: dict[str, object]) -> str:
@@ -162,12 +1755,21 @@ def inline_object(entry: dict[str, object]) -> str:
     return "{ " + ", ".join(fields) + " }"
 
 
+def append_named_json(
+    lines: list[str], name: str, value: object, comma: bool
+) -> None:
+    encoded = json.dumps(value, ensure_ascii=False, indent=2).splitlines()
+    lines.append(f'  {json.dumps(name)}: {encoded[0]}')
+    lines.extend(f"  {line}" for line in encoded[1:])
+    if comma:
+        lines[-1] += ","
+
+
 def serialize_inventory(inventory: dict[str, object]) -> str:
     """Serialize the inventory in the repository's canonical JSON style."""
     source = inventory["source"]
     if not isinstance(source, dict):
         raise RuntimeError("inventory source must be an object")
-
     lines = [
         "{",
         f'  "schema_version": {inventory["schema_version"]},',
@@ -182,13 +1784,13 @@ def serialize_inventory(inventory: dict[str, object]) -> str:
         )
     lines.append("  },")
 
-    array_names = (
+    compact_arrays = (
         "id_kinds",
         "json_types",
         "event_types",
         "native_domains",
     )
-    for array_index, name in enumerate(array_names):
+    for name in compact_arrays:
         entries = inventory[name]
         if not isinstance(entries, list):
             raise RuntimeError(f"inventory {name} must be an array")
@@ -200,8 +1802,20 @@ def serialize_inventory(inventory: dict[str, object]) -> str:
                 )
             comma = "," if entry_index + 1 < len(entries) else ""
             lines.append(f"    {inline_object(entry)}{comma}")
-        comma = "," if array_index + 1 < len(array_names) else ""
-        lines.append(f"  ]{comma}")
+        lines.append("  ],")
+
+    nested_names = (
+        "export_surfaces",
+        "export_installation_graph",
+        "export_roots",
+    )
+    for index, name in enumerate(nested_names):
+        append_named_json(
+            lines,
+            name,
+            inventory[name],
+            comma=index + 1 < len(nested_names),
+        )
     lines.append("}")
     return "\n".join(lines) + "\n"
 

--- a/tools/lua_api/test_check_ccb_inventory.py
+++ b/tools/lua_api/test_check_ccb_inventory.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import copy
 import json
 import tempfile
 import unittest
@@ -26,20 +27,137 @@ class CcbInventoryCheckTest(unittest.TestCase):
                 "json_types": 190,
                 "event_types": 113,
                 "native_domains": 39,
+                "export_roots": 101,
+                "api_v5_roots": 16,
+                "platform_v1_roots": 97,
+                "shared_roots": 12,
+                "member_dispositions": 761,
             },
         )
+
+    def write_inventory(self, directory: str, value: object) -> Path:
+        path = Path(directory) / "inventory.json"
+        path.write_text(
+            json.dumps(value, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        return path
+
+    def test_missing_platform_shared_root_is_rejected(self) -> None:
+        stale = copy.deepcopy(build_inventory())
+        graph = stale["export_installation_graph"]
+        graph["edges"] = [
+            edge
+            for edge in graph["edges"]
+            if not all(
+                (
+                    edge["caller"] == "platform_v1.install_runtime_api",
+                    edge["callee"] == "shared.install_game_handle_api",
+                )
+            )
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(
+                RuntimeError,
+                r"platform_v1 installation root parity.*GameHandle",
+            ):
+                check(self.write_inventory(directory, stale))
+
+    def test_root_without_member_disposition_is_rejected(self) -> None:
+        stale = copy.deepcopy(build_inventory())
+        root = next(
+            entry
+            for entry in stale["export_roots"]
+            if entry["lua_name"] == "GameHandle"
+        )
+        root.pop("member_disposition")
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(
+                RuntimeError,
+                r"GameHandle lacks member disposition structure",
+            ):
+                check(self.write_inventory(directory, stale))
+
+    def test_member_without_disposition_is_rejected(self) -> None:
+        stale = copy.deepcopy(build_inventory())
+        root = next(
+            entry
+            for entry in stale["export_roots"]
+            if entry["lua_name"] == "GameHandle"
+        )
+        member = next(
+            entry
+            for entry in root["member_disposition"]["members"]
+            if entry["id"] == "status"
+        )
+        member.pop("disposition")
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(
+                RuntimeError,
+                r"GameHandle.status lacks a valid disposition",
+            ):
+                check(self.write_inventory(directory, stale))
+
+    def test_unbound_member_without_reason_is_rejected(self) -> None:
+        stale = copy.deepcopy(build_inventory())
+        root = next(
+            entry
+            for entry in stale["export_roots"]
+            if entry["lua_name"] == "UnitValue"
+        )
+        member = next(
+            entry
+            for entry in root["member_disposition"]["members"]
+            if entry["id"] == "native.canonical_wide"
+        )
+        member["reason"] = ""
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(
+                RuntimeError,
+                r"UnitValue.native.canonical_wide unbound.*reason",
+            ):
+                check(self.write_inventory(directory, stale))
+
+    def test_registered_root_missing_from_inventory_is_rejected(self) -> None:
+        stale = copy.deepcopy(build_inventory())
+        stale["export_roots"] = [
+            entry
+            for entry in stale["export_roots"]
+            if entry["lua_name"] != "GameHandle"
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(
+                RuntimeError,
+                r"registered export roots missing from inventory.*GameHandle",
+            ):
+                check(self.write_inventory(directory, stale))
+
+    def test_adapted_member_without_lua_access_is_rejected(self) -> None:
+        stale = copy.deepcopy(build_inventory())
+        root = next(
+            entry
+            for entry in stale["export_roots"]
+            if entry["lua_name"] == "PointCoord"
+        )
+        member = next(
+            entry
+            for entry in root["member_disposition"]["members"]
+            if entry["id"] == "native.line_to"
+        )
+        member["lua_access"] = []
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(
+                RuntimeError,
+                r"PointCoord.native.line_to adapted.*Lua access",
+            ):
+                check(self.write_inventory(directory, stale))
 
     def test_source_drift_is_rejected(self) -> None:
         stale = build_inventory()
         stale["id_kinds"] = stale["id_kinds"][:-1]
         with tempfile.TemporaryDirectory() as directory:
-            path = Path(directory) / "inventory.json"
-            path.write_text(
-                json.dumps(stale, ensure_ascii=False, indent=2) + "\n",
-                encoding="utf-8",
-            )
             with self.assertRaisesRegex(RuntimeError, "stale"):
-                check(path)
+                check(self.write_inventory(directory, stale))
 
     def test_non_object_inventory_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tools/lua_api/test_check_luals_declarations.py
+++ b/tools/lua_api/test_check_luals_declarations.py
@@ -10,13 +10,17 @@ try:
     from .check_luals_declarations import (
         check,
         check_platform,
+        platform_source_usertypes,
         validate_table_mappings,
+        validate_type_references,
     )
 except ImportError:
     from check_luals_declarations import (
         check,
         check_platform,
+        platform_source_usertypes,
         validate_table_mappings,
+        validate_type_references,
     )
 
 
@@ -55,11 +59,15 @@ class LuaLsDeclarationTest(unittest.TestCase):
     def test_platform_declarations_cover_the_separate_native_surface(
         self,
     ) -> None:
+        self.assertNotIn(
+            "_ModDefinitionNative", platform_source_usertypes()
+        )
+        self.assertIn("ModDefinition", platform_source_usertypes())
         result = check_platform(PLATFORM_DECLARATIONS)
-        self.assertEqual(result["usertypes"], 72)
-        self.assertEqual(result["properties"], 17)
-        self.assertEqual(result["methods"], 212)
-        self.assertEqual(result["usertype_members"], 223)
+        self.assertEqual(result["usertypes"], 85)
+        self.assertEqual(result["properties"], 6)
+        self.assertEqual(result["methods"], 229)
+        self.assertEqual(result["usertype_members"], 303)
 
         contents = PLATFORM_DECLARATIONS.read_text(encoding="utf-8")
         with tempfile.TemporaryDirectory() as directory:
@@ -88,8 +96,8 @@ class LuaLsDeclarationTest(unittest.TestCase):
             path = Path(directory) / PLATFORM_DECLARATIONS.name
             path.write_text(
                 contents.replace(
-                    "---@field achievements CcbAchievementsApi\n",
-                    "---@field achievements CcbAchievementsApi\n"
+                    "---@field achievements CcbPlatformAchievementsApi\n",
+                    "---@field achievements CcbPlatformAchievementsApi\n"
                     "---@field eocs CcbEocApi\n",
                     1,
                 ),
@@ -98,9 +106,52 @@ class LuaLsDeclarationTest(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "service fields differ"):
                 check_platform(path)
 
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / PLATFORM_DECLARATIONS.name
+            path.write_text(
+                contents.replace(
+                    "function CcbPlatformBionicsApi.grant("
+                    "character, id) end\n",
+                    "",
+                    1,
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(RuntimeError, "methods differ"):
+                check_platform(path)
+
     def test_unmapped_registered_table_is_rejected(self) -> None:
         with self.assertRaisesRegex(RuntimeError, "table mappings"):
             validate_table_mappings({"future_native_api": {"read"}})
+
+    def test_undefined_luals_type_reference_is_rejected(self) -> None:
+        contents = """\
+---@class DefinedType
+---@field child MissingType
+local DefinedType = {}
+"""
+        with self.assertRaisesRegex(RuntimeError, "MissingType"):
+            validate_type_references(contents)
+
+    def test_platform_undefined_type_reference_is_rejected(self) -> None:
+        contents = PLATFORM_DECLARATIONS.read_text(encoding="utf-8")
+        old = "---@field environment CcbPlatformEnvironmentQueries\n"
+        self.assertIn(old, contents)
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / PLATFORM_DECLARATIONS.name
+            path.write_text(
+                contents.replace(
+                    old,
+                    "---@field environment MissingPlatformType\n",
+                    1,
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "MissingPlatformType",
+            ):
+                check_platform(path)
 
     def test_missing_registered_method_is_rejected(self) -> None:
         self.check_modified(

--- a/tools/lua_api/test_generate_ccb_inventory.py
+++ b/tools/lua_api/test_generate_ccb_inventory.py
@@ -14,6 +14,7 @@ try:
         parse_event_types,
         parse_id_kinds,
         parse_json_types,
+        parse_usertype_registrations,
         serialize_inventory,
     )
 except ImportError:
@@ -24,6 +25,7 @@ except ImportError:
         parse_event_types,
         parse_id_kinds,
         parse_json_types,
+        parse_usertype_registrations,
         serialize_inventory,
     )
 
@@ -84,8 +86,38 @@ class CcbInventoryGeneratorTest(unittest.TestCase):
             [{"type": "first_event"}, {"type": "second_event"}],
         )
 
+    def test_usertype_parser_handles_nested_cpp_and_top_level_keys(
+        self,
+    ) -> None:
+        registrations = parse_usertype_registrations(
+            r'''
+            // lua.new_usertype<ignored>("Ignored", sol::no_constructor);
+            lua.new_usertype<std::pair<int, std::vector<long>>>(
+                "FutureRoot", sol::no_constructor,
+                "value", []( const auto &self ) {
+                    return std::string( "not,a,member" ) + self.value;
+                },
+                sol::meta_function::to_string, &future_root::to_string );
+            ''',
+            "fixture.cpp",
+        )
+        self.assertEqual(len(registrations), 1)
+        self.assertEqual(
+            registrations[0]["cpp_type"],
+            "std::pair<int, std::vector<long>>",
+        )
+        self.assertEqual(registrations[0]["lua_name"], "FutureRoot")
+        self.assertEqual(
+            [entry["id"] for entry in registrations[0]["members"]],
+            ["value", "__tostring"],
+        )
+        self.assertEqual(
+            registrations[0]["members"][0]["cpp_members"], ["value"]
+        )
+
     def test_repository_inventory_has_expected_native_baselines(self) -> None:
         inventory = build_inventory()
+        self.assertEqual(inventory["schema_version"], 2)
         self.assertEqual(len(inventory["id_kinds"]), 132)
         self.assertEqual(len(inventory["json_types"]), 190)
         self.assertEqual(len(inventory["event_types"]), 113)
@@ -97,6 +129,116 @@ class CcbInventoryGeneratorTest(unittest.TestCase):
             sorted(domain for domain, _ in NATIVE_DOMAINS),
             [domain for domain, _ in NATIVE_DOMAINS],
         )
+        surfaces = {
+            entry["id"]: set(entry["roots"])
+            for entry in inventory["export_surfaces"]
+        }
+        self.assertEqual(len(inventory["export_roots"]), 101)
+        self.assertEqual(len(surfaces["api_v5"]), 16)
+        self.assertEqual(len(surfaces["platform_v1"]), 97)
+        self.assertEqual(
+            len(surfaces["api_v5"] & surfaces["platform_v1"]), 12
+        )
+
+    def test_repository_inventory_records_alias_and_dispositions(self) -> None:
+        inventory = build_inventory()
+        roots = {
+            entry["lua_name"]: entry
+            for entry in inventory["export_roots"]
+        }
+        self.assertEqual(
+            roots["ModDefinition"]["registration_name"],
+            "_ModDefinitionNative",
+        )
+        unit_members = {
+            entry["id"]: entry
+            for entry in roots["UnitValue"]["member_disposition"]["members"]
+        }
+        self.assertEqual(
+            unit_members["native.canonical_wide"]["disposition"],
+            "unbound",
+        )
+        point_members = {
+            entry["id"]: entry
+            for entry in roots["PointCoord"]["member_disposition"]["members"]
+        }
+        self.assertEqual(
+            point_members["native.line_to"]["lua_access"],
+            ["game.coords.line", "ccb.services.coords.line"],
+        )
+        handle_members = {
+            entry["id"]: entry
+            for entry in roots["GameHandle"]["member_disposition"]["members"]
+        }
+        self.assertEqual(
+            handle_members["native.resolve_item"]["reason_code"],
+            "native-pointer-escape",
+        )
+        self.assertEqual(
+            handle_members["native.runtime_owner"]["disposition"],
+            "unbound",
+        )
+        self.assertIn(
+            "runtime-owner-identity",
+            roots["GameHandle"]["lifetime"]["guards"],
+        )
+        zone_members = {
+            entry["id"]: entry
+            for entry in roots["ZoneToken"]["member_disposition"]["members"]
+        }
+        self.assertNotIn("native.ordinal", zone_members)
+        self.assertNotIn("native.runtime_generation", zone_members)
+        self.assertEqual(
+            zone_members["native.runtime"]["disposition"],
+            "unbound",
+        )
+        self.assertEqual(
+            zone_members["native.lifetime_identity"]["disposition"],
+            "unbound",
+        )
+        item_use_members = {
+            entry["id"]: entry
+            for entry in roots["ItemUseContext"]["member_disposition"][
+                "members"
+            ]
+        }
+        self.assertIn("native.handle_runtime", item_use_members)
+        for identity in (
+            "native.copy_constructor",
+            "native.copy_assignment",
+            "native.move_constructor",
+            "native.move_assignment",
+        ):
+            self.assertEqual(
+                item_use_members[identity]["disposition"], "unbound"
+            )
+        self.assertIn(
+            "scope-lease",
+            roots["ItemUseContext"]["lifetime"]["guards"],
+        )
+        self.assertIn(
+            "noncopyable-nonmovable",
+            roots["ItemUseContext"]["lifetime"]["guards"],
+        )
+        for token_name in (
+            "MissionToken",
+            "HordeEntityToken",
+            "LegacyHordeToken",
+        ):
+            token_members = {
+                entry["id"]: entry
+                for entry in roots[token_name]["member_disposition"][
+                    "members"
+                ]
+            }
+            self.assertEqual(
+                token_members["native.runtime_context"]["disposition"],
+                "unbound",
+            )
+            self.assertEqual(
+                token_members["native.belongs_to"]["lua_access"],
+                [f"{token_name}.is_valid"],
+            )
 
     def test_repository_inventory_uses_generator_format(self) -> None:
         serialized = serialize_inventory(build_inventory())

--- a/tools/migrate_lua_first.py
+++ b/tools/migrate_lua_first.py
@@ -10,11 +10,13 @@ TODO.
 from __future__ import annotations
 
 import argparse
+import functools
 import json
 import math
 import os
 import re
 import shutil
+import struct
 import sys
 import tempfile
 import unicodedata
@@ -84,24 +86,102 @@ NATIVE_INT_MIN = -(1 << 31)
 NATIVE_INT_MAX = (1 << 31) - 1
 NATIVE_INT64_MAX = (1 << 63) - 1
 NATIVE_MASS_GRAMS_MAX = NATIVE_INT64_MAX // 1000
+NATIVE_FLOAT_MAX = float.fromhex("0x1.fffffep+127")
+PLATFORM_ID_MAX_BYTES = 256
+WOUND_NAME_MAX_BYTES = 1024
+WOUND_DESCRIPTION_MAX_BYTES = 32768
+MAX_EFFECT_DURATION_TURNS = 365 * 24 * 60 * 60
 NATIVE_MAX_SKILL = 10
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_GAME_START_SENDER_SITES = (("src/game.cpp", "send"),)
+# These native item-event contracts always name the legacy alpha/u Character
+# as `actors.character`.  An item talker is optional because ordinary event
+# sends do not carry the positional talker used by send_with_talker().  Keep
+# this allowlist closed so unrelated events and dialogue contexts never gain
+# an inferred legacy actor.
+PROVEN_ITEM_ACTOR_EVENTS = frozenset({
+    "character_wields_item",
+    "character_wears_item",
+    "character_takeoff_item",
+    "character_armor_destroyed",
+})
+
+
+@functools.lru_cache(maxsize=1)
+def game_start_sender_sites() -> tuple[tuple[str, str], ...]:
+    """Find canonical game-start construction sites without entering caches."""
+    sites: list[tuple[str, str]] = []
+    source_root = REPOSITORY_ROOT / "src"
+    for suffix in ("*.cpp", "*.h"):
+        for path in sorted(source_root.glob(suffix)):
+            text = path.read_text(encoding="utf-8")
+            for kind in ("send", "make"):
+                pattern = rf"\b{kind}\s*<\s*event_type::game_start\s*>"
+                sites.extend(
+                    (path.relative_to(REPOSITORY_ROOT).as_posix(), kind)
+                    for _ in re.finditer(pattern, text)
+                )
+    return tuple(sorted(sites))
+
+
+def game_start_avatar_actor_is_proven() -> bool:
+    """Fail closed if the reviewed canonical sender set ever changes."""
+    return game_start_sender_sites() == EXPECTED_GAME_START_SENDER_SITES
 
 
 def lua_quote(value: str) -> str:
-    escaped = (
-        value.replace("\\", "\\\\")
-        .replace("\n", "\\n")
-        .replace("\r", "\\r")
-        .replace("\t", "\\t")
-        .replace('"', '\\"')
-    )
-    return f'"{escaped}"'
+    escapes = {
+        "\\": "\\\\",
+        '"': '\\"',
+        "\a": "\\a",
+        "\b": "\\b",
+        "\f": "\\f",
+        "\n": "\\n",
+        "\r": "\\r",
+        "\t": "\\t",
+        "\v": "\\v",
+    }
+    escaped: list[str] = []
+    for character in value:
+        if character in escapes:
+            escaped.append(escapes[character])
+        elif ord(character) < 32 or ord(character) == 127:
+            escaped.append(f"\\{ord(character):03d}")
+        else:
+            escaped.append(character)
+    return '"' + "".join(escaped) + '"'
 
 
 def lua_number(value: int | float) -> str:
     if isinstance(value, int):
         return str(value)
     return format(value, ".17g")
+
+
+def finite_number_literal(value: Any) -> int | float | None:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return None
+    try:
+        if math.isfinite(float(value)):
+            return value
+    except (OverflowError, ValueError):
+        pass
+    return None
+
+
+def positive_native_float_literal(value: Any) -> int | float | None:
+    """Return a literal that remains positive after the native float cast."""
+    literal = finite_number_literal(value)
+    if literal is None:
+        return None
+    converted = float(literal)
+    if converted <= 0.0 or converted > NATIVE_FLOAT_MAX:
+        return None
+    try:
+        native = struct.unpack("=f", struct.pack("=f", converted))[0]
+    except (OverflowError, struct.error):
+        return None
+    return literal if math.isfinite(native) and native > 0.0 else None
 
 
 def display_text(value: Any, fallback: str = "") -> str:
@@ -197,10 +277,33 @@ def stable_id(value: dict[str, Any], fallback: str) -> str:
 
 def safe_platform_id(value: Any) -> bool:
     return (
-        isinstance(value, str)
-        and bool(value)
-        and "#" not in value
-        and "\0" not in value
+        isinstance(value, str) and
+        bool(value) and
+        "#" not in value and
+        "\0" not in value
+    )
+
+
+def bounded_utf8_string(
+    value: Any, maximum: int, *, allow_empty: bool = False
+) -> bool:
+    if (
+        not isinstance(value, str) or
+        (not allow_empty and not value) or
+        "\0" in value
+    ):
+        return False
+    try:
+        length = len(value.encode("utf-8"))
+    except UnicodeEncodeError:
+        return False
+    return (allow_empty or length > 0) and length <= maximum
+
+
+def bounded_platform_id(value: Any) -> bool:
+    return (
+        safe_platform_id(value) and
+        bounded_utf8_string(value, PLATFORM_ID_MAX_BYTES)
     )
 
 
@@ -221,6 +324,112 @@ class MigrationResult:
     converted: list[str] = field(default_factory=list)
     partial: list[str] = field(default_factory=list)
     todos: list[str] = field(default_factory=list)
+
+
+def render_mod_definition(
+    source: SourceObject, result: MigrationResult, mod_id: str
+) -> str:
+    value = source.value
+    complete = True
+    raw_id = value.get("id")
+    if (
+        not safe_platform_id(raw_id) or
+        len(raw_id.encode("utf-8")) > 256 or
+        raw_id != mod_id
+    ):
+        complete = False
+        result.todos.append(
+            f"{source.location}: MOD_INFO id {raw_id!r} does not match the resolved Platform id {mod_id!r}"
+        )
+
+    lines = [
+        'local ccb = require("ccb")',
+        "",
+        "return ccb.ModDefinition {",
+        f"    id = {lua_quote(mod_id)},",
+    ]
+
+    if "name" in value:
+        name = value["name"]
+        if (
+            isinstance(name, str) and
+            0 < len(name.encode("utf-8")) <= 512 and
+            "\0" not in name
+        ):
+            lines.append(f"    name = {lua_quote(name)},")
+        else:
+            complete = False
+            result.todos.append(
+                f"{source.location}: MOD_INFO name needs a bounded plain-string conversion"
+            )
+    else:
+        complete = False
+        result.todos.append(
+            f"{source.location}: MOD_INFO without a plain name has different legacy fallback presentation"
+        )
+
+    if "version" in value:
+        version = value["version"]
+        if (
+            isinstance(version, str) and
+            0 < len(version.encode("utf-8")) <= 128 and
+            "\0" not in version
+        ):
+            lines.append(f"    version = {lua_quote(version)},")
+        else:
+            complete = False
+            result.todos.append(
+                f"{source.location}: MOD_INFO version needs a bounded string conversion"
+            )
+
+    if "dependencies" in value:
+        dependencies = value["dependencies"]
+        valid_dependencies = (
+            isinstance(dependencies, list) and
+            len(dependencies) <= 256 and
+            all(
+                safe_platform_id(dependency) and
+                len(dependency.encode("utf-8")) <= 256
+                for dependency in dependencies
+            ) and
+            len(set(dependencies)) == len(dependencies) and
+            mod_id not in dependencies
+        )
+        if valid_dependencies:
+            rendered = ", ".join(lua_quote(value) for value in dependencies)
+            lines.append(f"    dependencies = {{ {rendered} }},")
+        else:
+            complete = False
+            result.todos.append(
+                f"{source.location}: MOD_INFO dependencies need a unique bounded string-array conversion"
+            )
+
+    if "core" in value:
+        core = value["core"]
+        if isinstance(core, bool):
+            lines.append(f"    core = {'true' if core else 'false'},")
+        else:
+            complete = False
+            result.todos.append(
+                f"{source.location}: MOD_INFO core must be a boolean"
+            )
+
+    unresolved = sorted(
+        set(value) - {"type", "id", "name", "version", "dependencies", "core"}
+    )
+    if unresolved:
+        complete = False
+        result.todos.append(
+            f"{source.location}: MOD_INFO unresolved fields: {', '.join(unresolved)}"
+        )
+
+    label = f"{source.location}: MOD_INFO {raw_id or '<invalid id>'}"
+    if complete:
+        result.converted.append(label)
+    else:
+        result.partial.append(label)
+    lines.extend(("}", ""))
+    return "\n".join(lines)
 
 
 def iter_json_files(inputs: Iterable[Path]) -> list[Path]:
@@ -271,14 +480,14 @@ def render_materials(lines: list[str], raw: Any, todos: list[str], location: str
         if isinstance(entry, str) and entry:
             lines.append(f"definition:material({lua_quote(entry)}, 1)")
         elif (
-            isinstance(entry, list)
-            and len(entry) == 2
-            and isinstance(entry[0], str)
-            and bool(entry[0])
-            and isinstance(entry[1], int)
-            and not isinstance(entry[1], bool)
-            and entry[1] > 0
-            and entry[1] <= NATIVE_INT_MAX
+            isinstance(entry, list) and
+            len(entry) == 2 and
+            isinstance(entry[0], str) and
+            bool(entry[0]) and
+            isinstance(entry[1], int) and
+            not isinstance(entry[1], bool) and
+            entry[1] > 0 and
+            entry[1] <= NATIVE_INT_MAX
         ):
             lines.append(f"definition:material({lua_quote(entry[0])}, {entry[1]})")
         else:
@@ -293,13 +502,13 @@ def render_pairs(
         return
     for entry in raw:
         if (
-            isinstance(entry, list)
-            and len(entry) >= 2
-            and isinstance(entry[0], str)
-            and bool(entry[0])
-            and isinstance(entry[1], int)
-            and not isinstance(entry[1], bool)
-            and 0 < entry[1] <= NATIVE_INT_MAX
+            isinstance(entry, list) and
+            len(entry) >= 2 and
+            isinstance(entry[0], str) and
+            bool(entry[0]) and
+            isinstance(entry[1], int) and
+            not isinstance(entry[1], bool) and
+            0 < entry[1] <= NATIVE_INT_MAX
         ):
             lines.append(f"definition:{method}({lua_quote(entry[0])}, {entry[1]})")
         else:
@@ -392,9 +601,9 @@ def render_item(source: SourceObject, result: MigrationResult) -> str | None:
             lines.append(f"definition:volume_ml({volume})")
     price = value.get("price")
     if (
-        isinstance(price, int)
-        and not isinstance(price, bool)
-        and 0 <= price <= NATIVE_INT_MAX
+        isinstance(price, int) and
+        not isinstance(price, bool) and
+        0 <= price <= NATIVE_INT_MAX
     ):
         lines.append(f"definition:price_cents({price})")
     elif "price" in value:
@@ -430,15 +639,15 @@ def requirement_choices(raw: Any, *, tools: bool = False) -> list[tuple[str, int
     result: list[tuple[str, int]] = []
     for entry in raw:
         if (
-            not isinstance(entry, list)
-            or len(entry) < 2
-            or not isinstance(entry[0], str)
-            or not entry[0]
-            or not isinstance(entry[1], int)
-            or isinstance(entry[1], bool)
-            or entry[1] == 0
-            or abs(entry[1]) > NATIVE_INT_MAX
-            or (entry[1] < 0 and not tools)
+            not isinstance(entry, list) or
+            len(entry) < 2 or
+            not isinstance(entry[0], str) or
+            not entry[0] or
+            not isinstance(entry[1], int) or
+            isinstance(entry[1], bool) or
+            entry[1] == 0 or
+            abs(entry[1]) > NATIVE_INT_MAX or
+            (entry[1] < 0 and not tools)
         ):
             return None
         result.append((entry[0], entry[1]))
@@ -506,10 +715,10 @@ def render_recipe(source: SourceObject, result: MigrationResult) -> str | None:
     category = value.get("category", "CC_MISC")
     subcategory = value.get("subcategory", "CSC_MISC")
     if (
-        not isinstance(category, str)
-        or not category
-        or not isinstance(subcategory, str)
-        or not subcategory
+        not isinstance(category, str) or
+        not category or
+        not isinstance(subcategory, str) or
+        not subcategory
     ):
         result.todos.append(
             f"{source.location}: recipe {recipe_id} category ids need review"
@@ -532,9 +741,9 @@ def render_recipe(source: SourceObject, result: MigrationResult) -> str | None:
         )
     difficulty = value.get("difficulty", 0)
     if (
-        isinstance(difficulty, int)
-        and not isinstance(difficulty, bool)
-        and 0 <= difficulty <= NATIVE_MAX_SKILL
+        isinstance(difficulty, int) and
+        not isinstance(difficulty, bool) and
+        0 <= difficulty <= NATIVE_MAX_SKILL
     ):
         lines.append(f"    difficulty = {difficulty},")
     else:
@@ -570,13 +779,13 @@ def render_recipe(source: SourceObject, result: MigrationResult) -> str | None:
     if isinstance(skills, list):
         for entry in skills:
             if (
-                isinstance(entry, list)
-                and len(entry) >= 2
-                and isinstance(entry[0], str)
-                and bool(entry[0])
-                and isinstance(entry[1], int)
-                and not isinstance(entry[1], bool)
-                and 0 <= entry[1] <= NATIVE_MAX_SKILL
+                isinstance(entry, list) and
+                len(entry) >= 2 and
+                isinstance(entry[0], str) and
+                bool(entry[0]) and
+                isinstance(entry[1], int) and
+                not isinstance(entry[1], bool) and
+                0 <= entry[1] <= NATIVE_MAX_SKILL
             ):
                 lines.append(f"definition:requires_skill({lua_quote(entry[0])}, {entry[1]})")
             else:
@@ -589,12 +798,12 @@ def render_recipe(source: SourceObject, result: MigrationResult) -> str | None:
     if isinstance(external, list):
         for entry in external:
             if (
-                isinstance(entry, list)
-                and len(entry) == 2
-                and safe_platform_id(entry[0])
-                and isinstance(entry[1], int)
-                and not isinstance(entry[1], bool)
-                and 0 < entry[1] <= NATIVE_INT_MAX
+                isinstance(entry, list) and
+                len(entry) == 2 and
+                safe_platform_id(entry[0]) and
+                isinstance(entry[1], int) and
+                not isinstance(entry[1], bool) and
+                0 < entry[1] <= NATIVE_INT_MAX
             ):
                 lines.append(
                     f"definition:requirement({lua_quote(entry[0])}, {entry[1]})"
@@ -638,8 +847,8 @@ def finish_catalog(
     unresolved = unresolved_fields(source.value, supported)
     if unresolved:
         result.todos.append(
-            f"{source.location}: {label} {object_id} unresolved fields: "
-            + ", ".join(unresolved)
+            f"{source.location}: {label} {object_id} unresolved fields: " +
+            ", ".join(unresolved)
         )
     status = result.partial if unresolved or len(result.todos) != todo_count else result.converted
     status.append(f"{source.location}: {label} {object_id}")
@@ -694,16 +903,16 @@ def render_requirement(source: SourceObject, result: MigrationResult) -> str | N
             converted: list[tuple[str, int, int]] = []
             for entry in group:
                 if (
-                    isinstance(entry, list)
-                    and 2 <= len(entry) <= 3
-                    and safe_platform_id(entry[0])
-                    and isinstance(entry[1], int)
-                    and not isinstance(entry[1], bool)
-                    and 0 < entry[1] <= NATIVE_INT_MAX
-                    and (len(entry) == 2 or (
-                        isinstance(entry[2], int)
-                        and not isinstance(entry[2], bool)
-                        and 0 < entry[2] <= NATIVE_INT_MAX
+                    isinstance(entry, list) and
+                    2 <= len(entry) <= 3 and
+                    safe_platform_id(entry[0]) and
+                    isinstance(entry[1], int) and
+                    not isinstance(entry[1], bool) and
+                    0 < entry[1] <= NATIVE_INT_MAX and
+                    (len(entry) == 2 or (
+                        isinstance(entry[2], int) and
+                        not isinstance(entry[2], bool) and
+                        0 < entry[2] <= NATIVE_INT_MAX
                     ))
                 ):
                     converted.append((entry[0], entry[1], entry[2] if len(entry) == 3 else 1))
@@ -892,12 +1101,12 @@ def render_speed_description(source: SourceObject, result: MigrationResult) -> s
             )
             descriptions = [display_text(text) for text in description_values]
             if (
-                not isinstance(threshold, (int, float))
-                or isinstance(threshold, bool)
-                or not math.isfinite(threshold)
-                or threshold < 0
-                or not descriptions
-                or any(not text for text in descriptions)
+                not isinstance(threshold, (int, float)) or
+                isinstance(threshold, bool) or
+                not math.isfinite(threshold) or
+                threshold < 0 or
+                not descriptions or
+                any(not text for text in descriptions)
             ):
                 result.todos.append(
                     f"{source.location}: speed description {description_id} value needs review"
@@ -1013,19 +1222,19 @@ def render_harvest(source: SourceObject, result: MigrationResult) -> str | None:
 
     def finite_number(raw: Any) -> bool:
         return (
-            isinstance(raw, (int, float))
-            and not isinstance(raw, bool)
-            and math.isfinite(raw)
-            and abs(raw) <= 3.402823466e38
+            isinstance(raw, (int, float)) and
+            not isinstance(raw, bool) and
+            math.isfinite(raw) and
+            abs(raw) <= 3.402823466e38
         )
 
     def number_pair(raw: Any, default: tuple[float, float], field_name: str) -> tuple[Any, Any]:
         if (
-            isinstance(raw, list)
-            and len(raw) == 2
-            and finite_number(raw[0])
-            and finite_number(raw[1])
-            and raw[0] <= raw[1]
+            isinstance(raw, list) and
+            len(raw) == 2 and
+            finite_number(raw[0]) and
+            finite_number(raw[1]) and
+            raw[0] <= raw[1]
         ):
             return raw[0], raw[1]
         result.todos.append(
@@ -1059,13 +1268,13 @@ def render_harvest(source: SourceObject, result: MigrationResult) -> str | None:
                 "mass_ratio",
                 "flags",
                 "faults",
-            }
-            and not key.startswith("//")
+            } and
+            not key.startswith("//")
         )
         if unresolved_entry:
             result.todos.append(
-                f"{source.location}: harvest {harvest_id} drop {index} unresolved fields: "
-                + ", ".join(unresolved_entry)
+                f"{source.location}: harvest {harvest_id} drop {index} unresolved fields: " +
+                ", ".join(unresolved_entry)
             )
         output = raw_entry.get("drop")
         if not safe_platform_id(output) or output in outputs:
@@ -1082,9 +1291,9 @@ def render_harvest(source: SourceObject, result: MigrationResult) -> str | None:
         )
         maximum = raw_entry.get("max", 1000)
         if (
-            not isinstance(maximum, int)
-            or isinstance(maximum, bool)
-            or not 0 < maximum <= NATIVE_INT_MAX
+            not isinstance(maximum, int) or
+            isinstance(maximum, bool) or
+            not 0 < maximum <= NATIVE_INT_MAX
         ):
             result.todos.append(
                 f"{source.location}: harvest {harvest_id} drop {output} max needs review"
@@ -1165,10 +1374,10 @@ def render_behavior(source: SourceObject, result: MigrationResult) -> str | None
     children: list[str] = []
     if raw_children is not None:
         if (
-            isinstance(raw_children, list)
-            and bool(raw_children)
-            and all(safe_platform_id(child) for child in raw_children)
-            and len(set(raw_children)) == len(raw_children)
+            isinstance(raw_children, list) and
+            bool(raw_children) and
+            all(safe_platform_id(child) for child in raw_children) and
+            len(set(raw_children)) == len(raw_children)
         ):
             children = raw_children
         else:
@@ -1235,17 +1444,17 @@ def render_behavior(source: SourceObject, result: MigrationResult) -> str | None
         )
         if unknown:
             result.todos.append(
-                f"{source.location}: behavior {behavior_id} condition {index} unresolved fields: "
-                + ", ".join(unknown)
+                f"{source.location}: behavior {behavior_id} condition {index} unresolved fields: " +
+                ", ".join(unknown)
             )
         predicate = raw_condition.get("predicate")
         argument = raw_condition.get("argument", "")
         inverted = raw_condition.get("invert_result", False)
         if (
-            not safe_platform_id(predicate)
-            or not isinstance(argument, str)
-            or "\0" in argument
-            or not isinstance(inverted, bool)
+            not safe_platform_id(predicate) or
+            not isinstance(argument, str) or
+            "\0" in argument or
+            not isinstance(inverted, bool)
         ):
             result.todos.append(
                 f"{source.location}: behavior {behavior_id} condition {index} needs review"
@@ -1316,22 +1525,23 @@ def lua_string_table(values: list[str]) -> str:
 
 def finite_number(value: Any, minimum: float | None = None,
                   maximum: float | None = None) -> int | float | None:
-    if not isinstance(value, (int, float)) or isinstance(value, bool) or not math.isfinite(value):
+    literal = finite_number_literal(value)
+    if literal is None:
         return None
-    if minimum is not None and value < minimum:
+    if minimum is not None and literal < minimum:
         return None
-    if maximum is not None and value > maximum:
+    if maximum is not None and literal > maximum:
         return None
-    return value
+    return literal
 
 
 def native_integer(value: Any, minimum: int = NATIVE_INT_MIN,
                    maximum: int = NATIVE_INT_MAX) -> int | None:
     if (
-        not isinstance(value, int)
-        or isinstance(value, bool)
-        or value < minimum
-        or value > maximum
+        not isinstance(value, int) or
+        isinstance(value, bool) or
+        value < minimum or
+        value > maximum
     ):
         return None
     return value
@@ -1385,7 +1595,7 @@ def render_monster_attack(source: SourceObject, result: MigrationResult) -> str 
         "    -- TODO: rewrite the legacy attack actor with native Lua services.",
         "    return false",
         "end, 1)",
-        f"local definition = content.MonsterAttack {{",
+        "local definition = content.MonsterAttack {",
         f"    id = {lua_quote(attack_id)},",
         f"    cooldown = {lua_number(cooldown)},",
         "}",
@@ -1658,8 +1868,8 @@ def render_weakpoint_set(source: SourceObject, result: MigrationResult) -> str |
             )
             if unknown_effect:
                 result.todos.append(
-                    f"{source.location}: weakpoint set {set_id} point {point_id} effect unresolved fields: "
-                    + ", ".join(unknown_effect)
+                    f"{source.location}: weakpoint set {set_id} point {point_id} effect unresolved fields: " +
+                    ", ".join(unknown_effect)
                 )
             lines.extend((
                 f"definition:effect({lua_quote(point_id)}, {{",
@@ -1675,8 +1885,8 @@ def render_weakpoint_set(source: SourceObject, result: MigrationResult) -> str |
         )
         if unknown_point:
             result.todos.append(
-                f"{source.location}: weakpoint set {set_id} point {point_id} unresolved fields: "
-                + ", ".join(unknown_point)
+                f"{source.location}: weakpoint set {set_id} point {point_id} unresolved fields: " +
+                ", ".join(unknown_point)
             )
     if rendered_points == 0:
         lines.extend((
@@ -1923,15 +2133,15 @@ def render_field_type(source: SourceObject, result: MigrationResult) -> str | No
             )
             if unknown_effect:
                 result.todos.append(
-                    f"{source.location}: field type {field_id} intensity {index} effect unresolved fields: "
-                    + ", ".join(unknown_effect)
+                    f"{source.location}: field type {field_id} intensity {index} effect unresolved fields: " +
+                    ", ".join(unknown_effect)
                 )
             lines.extend((f"definition:effect({native_index}, {{", *effect_options, "})"))
         unknown_level = unresolved_fields(level, intensity_supported)
         if unknown_level:
             result.todos.append(
-                f"{source.location}: field type {field_id} intensity {index} unresolved fields: "
-                + ", ".join(unknown_level)
+                f"{source.location}: field type {field_id} intensity {index} unresolved fields: " +
+                ", ".join(unknown_level)
             )
     if rendered_intensities == 0:
         lines.extend((
@@ -2023,17 +2233,17 @@ def render_item_group(source: SourceObject, result: MigrationResult) -> str | No
             unknown.extend(unresolved_fields(raw, allowed))
         probability_int = native_integer(probability, 1, 100 if kind == "collection" else NATIVE_INT_MAX)
         if (
-            not safe_platform_id(entry_id)
-            or probability_int is None
-            or not isinstance(variant, str)
-            or (group and variant)
+            not safe_platform_id(entry_id) or
+            probability_int is None or
+            not isinstance(variant, str) or
+            (group and variant)
         ):
             result.todos.append(f"{source.location}: item group {group_id} entry needs review")
             return
         if unknown:
             result.todos.append(
-                f"{source.location}: item group {group_id} entry unresolved fields: "
-                + ", ".join(unknown)
+                f"{source.location}: item group {group_id} entry unresolved fields: " +
+                ", ".join(unknown)
             )
         if group:
             lines.append(f"definition:group({lua_quote(entry_id)}, {probability_int})")
@@ -2083,10 +2293,10 @@ def damage_entries(value: Any) -> list[tuple[str, int | float, int | float]] | N
         amount = finite_number(raw.get("amount"), 0.0)
         armor_penetration = finite_number(raw.get("armor_penetration", 0), 0.0)
         if (
-            not safe_platform_id(damage_id)
-            or amount is None
-            or armor_penetration is None
-            or unresolved_fields(raw, {"damage_type", "amount", "armor_penetration"})
+            not safe_platform_id(damage_id) or
+            amount is None or
+            armor_penetration is None or
+            unresolved_fields(raw, {"damage_type", "amount", "armor_penetration"})
         ):
             return None
         entries.append((damage_id, amount, armor_penetration))
@@ -2111,11 +2321,11 @@ def render_sub_body_part(source: SourceObject, result: MigrationResult) -> str |
     coverage = native_integer(value.get("max_coverage", 100), 1, 100)
     secondary = value.get("secondary", False)
     if (
-        not plural
-        or not safe_platform_id(opposite)
-        or side not in {"left", "right", "both"}
-        or coverage is None
-        or not isinstance(secondary, bool)
+        not plural or
+        not safe_platform_id(opposite) or
+        side not in {"left", "right", "both"} or
+        coverage is None or
+        not isinstance(secondary, bool)
     ):
         plural, opposite, side, coverage, secondary = name, part_id, "both", 100, False
         result.todos.append(
@@ -2176,6 +2386,423 @@ def render_sub_body_part(source: SourceObject, result: MigrationResult) -> str |
             "type", "id", "name", "name_multiple", "parent", "opposite",
             "side", "secondary", "max_coverage", "locations_under",
             "similar_bodypart", "unarmed_damage",
+        },
+        todo_count,
+    )
+
+
+WOUND_BODY_PART_TYPES = {
+    "head", "torso", "sensor", "mouth", "arm", "hand", "leg", "foot",
+    "wing", "tail", "other",
+}
+
+
+def render_wound(source: SourceObject, result: MigrationResult) -> str | None:
+    value = source.value
+    wound_id = value.get("id")
+    name = display_text(value.get("name"))
+    description = display_text(value.get("description"))
+    damage_types = string_ids(value.get("damage_types"))
+    damage_required = value.get("damage_required")
+    if (
+        not bounded_platform_id(wound_id) or
+        not bounded_utf8_string(name, WOUND_NAME_MAX_BYTES) or
+        not bounded_utf8_string(description, WOUND_DESCRIPTION_MAX_BYTES) or
+        not damage_types or
+        not all(bounded_platform_id(entry) for entry in damage_types) or
+        len(set(damage_types)) != len(damage_types) or
+        not isinstance(damage_required, list) or
+        len(damage_required) != 2
+    ):
+        wound_label = wound_id if bounded_platform_id(wound_id) else "<invalid id>"
+        result.partial.append(
+            f"{source.location}: wound {wound_label}"
+        )
+        result.todos.append(
+            f"{source.location}: wound needs a stable id, text, distinct damage types, and a two-value damage range within Platform byte bounds"
+        )
+        return None
+    damage_min = native_integer(damage_required[0], 0)
+    damage_max = native_integer(damage_required[1], 0)
+    if damage_min is None or damage_max is None or damage_max < damage_min:
+        result.partial.append(f"{source.location}: wound {wound_id}")
+        result.todos.append(
+            f"{source.location}: wound {wound_id} damage range needs review"
+        )
+        return None
+
+    todo_count = len(result.todos)
+    raw_name = value.get("name")
+    plural_name = name
+    if isinstance(raw_name, dict):
+        raw_plural = raw_name.get("str_pl", name)
+        if bounded_utf8_string(raw_plural, WOUND_NAME_MAX_BYTES):
+            plural_name = raw_plural
+        elif "str_pl" in raw_name:
+            result.todos.append(
+                f"{source.location}: wound {wound_id} plural name needs a bounded text conversion"
+            )
+        if (
+            not isinstance(raw_name.get("str"), str) or
+            not raw_name.get("str") or
+            unresolved_fields(raw_name, {"str", "str_pl"})
+        ):
+            result.todos.append(
+                f"{source.location}: wound {wound_id} name translation metadata needs review"
+            )
+    elif not isinstance(raw_name, str):
+        result.todos.append(
+            f"{source.location}: wound {wound_id} name needs review"
+        )
+    raw_description = value.get("description")
+    if isinstance(raw_description, dict):
+        if (
+            not isinstance(raw_description.get("str"), str) or
+            unresolved_fields(raw_description, {"str"})
+        ):
+            result.todos.append(
+                f"{source.location}: wound {wound_id} description translation metadata needs review"
+            )
+
+    pain = value.get("pain", [0, 0])
+    pain_min: int | None = None
+    pain_max: int | None = None
+    if isinstance(pain, list) and len(pain) == 2:
+        pain_min = native_integer(pain[0], 0)
+        pain_max = native_integer(pain[1], 0)
+    if pain_min is None or pain_max is None or pain_max < pain_min:
+        pain_min, pain_max = 0, 0
+        result.todos.append(
+            f"{source.location}: wound {wound_id} pain range needs review"
+        )
+
+    healing = value.get("healing_time")
+    healing_min: int | None = None
+    healing_max: int | None = None
+    if isinstance(healing, list) and len(healing) == 2:
+        healing_min = parse_turns(healing[0])
+        healing_max = parse_turns(healing[1])
+    if (
+        healing_min is None or healing_max is None or
+        healing_min <= 0 or healing_max < healing_min or
+        healing_max > NATIVE_INT_MAX
+    ):
+        healing_min, healing_max = 1, 1
+        result.todos.append(
+            f"{source.location}: wound {wound_id} healing range needs an explicit finite duration review"
+        )
+
+    weight = native_integer(value.get("weight", 1), 1)
+    limit = native_integer(value.get("limit", 0), 0)
+    if weight is None:
+        weight = 1
+        result.todos.append(
+            f"{source.location}: wound {wound_id} weight needs review"
+        )
+    if limit is None:
+        limit = 0
+        result.todos.append(
+            f"{source.location}: wound {wound_id} per-part limit needs review"
+        )
+
+    lines = [
+        "local definition = content.Wound {",
+        f"    id = {lua_quote(wound_id)},",
+        f"    name = {lua_quote(name)},",
+        f"    plural_name = {lua_quote(plural_name)},",
+        f"    description = {lua_quote(description)},",
+        f"    pain_min = {pain_min},",
+        f"    pain_max = {pain_max},",
+        f"    healing_min_turns = {healing_min},",
+        f"    healing_max_turns = {healing_max},",
+        f"    damage_min = {damage_min},",
+        f"    damage_max = {damage_max},",
+        f"    weight = {weight},",
+        f"    per_part_limit = {limit},",
+    ]
+    body_part_flags: dict[str, str] = {}
+    for source_name, target_name in (
+        ("whitelist_bp_with_flag", "required_body_part_flag"),
+        ("blacklist_bp_with_flag", "forbidden_body_part_flag"),
+    ):
+        if source_name not in value:
+            continue
+        flag = value[source_name]
+        if bounded_platform_id(flag):
+            body_part_flags[target_name] = flag
+        else:
+            result.todos.append(
+                f"{source.location}: wound {wound_id} {source_name} needs review"
+            )
+    if (
+        body_part_flags.get("required_body_part_flag") ==
+        body_part_flags.get("forbidden_body_part_flag") and
+        "required_body_part_flag" in body_part_flags
+    ):
+        body_part_flags.clear()
+        result.todos.append(
+            f"{source.location}: wound {wound_id} cannot require and forbid the same body-part flag"
+        )
+    for target_name in ("required_body_part_flag", "forbidden_body_part_flag"):
+        if target_name in body_part_flags:
+            lines.append(
+                f"    {target_name} = {lua_quote(body_part_flags[target_name])},"
+            )
+    lines.append("}")
+    lines.extend(
+        f"definition:damage_type({lua_quote(damage_type)})"
+        for damage_type in damage_types
+    )
+
+    limb_scores = value.get("limb_scores", [])
+    if not isinstance(limb_scores, list):
+        limb_scores = []
+        result.todos.append(
+            f"{source.location}: wound {wound_id} limb scores need review"
+        )
+    seen_scores: set[str] = set()
+    for entry in limb_scores:
+        score = entry.get("score") if isinstance(entry, dict) else None
+        penalty = finite_number(entry.get("value", 0), 0, 1) if isinstance(entry, dict) else None
+        if (
+            not bounded_platform_id(score) or score in seen_scores or
+            penalty is None or
+            unresolved_fields(entry, {"score", "value"})
+        ):
+            result.todos.append(
+                f"{source.location}: wound {wound_id} limb-score entry needs review"
+            )
+            continue
+        seen_scores.add(score)
+        lines.append(
+            f"definition:limb_score({lua_quote(score)}, {lua_number(penalty)})"
+        )
+
+    progressions = value.get("wound_progression", [])
+    if not isinstance(progressions, list):
+        progressions = []
+        result.todos.append(
+            f"{source.location}: wound {wound_id} progression list needs review"
+        )
+    seen_progressions: set[str] = set()
+    for entry in progressions:
+        target = entry.get("id") if isinstance(entry, dict) else None
+        chance = native_integer(entry.get("chance", 0), 0, 100) if isinstance(entry, dict) else None
+        if (
+            not bounded_platform_id(target) or target == wound_id or
+            target in seen_progressions or chance is None or
+            unresolved_fields(entry, {"id", "chance"})
+        ):
+            result.todos.append(
+                f"{source.location}: wound {wound_id} progression entry needs review"
+            )
+            continue
+        seen_progressions.add(target)
+        lines.append(
+            f"definition:progression({lua_quote(target)}, {chance})"
+        )
+
+    required_types = string_ids(value.get("whitelist_body_part_types", []))
+    forbidden_types = string_ids(value.get("blacklist_body_part_types", []))
+    if (
+        required_types is None or forbidden_types is None or
+        len(set(required_types)) != len(required_types) or
+        len(set(forbidden_types)) != len(forbidden_types) or
+        not set(required_types).issubset(WOUND_BODY_PART_TYPES) or
+        not set(forbidden_types).issubset(WOUND_BODY_PART_TYPES) or
+        set(required_types) & set(forbidden_types)
+    ):
+        required_types, forbidden_types = [], []
+        result.todos.append(
+            f"{source.location}: wound {wound_id} body-part type filters need review"
+        )
+    lines.extend(
+        f"definition:require_body_part_type({lua_quote(kind)})"
+        for kind in required_types
+    )
+    lines.extend(
+        f"definition:forbid_body_part_type({lua_quote(kind)})"
+        for kind in forbidden_types
+    )
+    return finish_catalog(
+        source,
+        result,
+        "wound",
+        wound_id,
+        lines,
+        {
+            "type", "id", "name", "description", "pain", "healing_time",
+            "damage_types", "damage_required", "weight", "limb_scores",
+            "limit", "wound_progression", "whitelist_bp_with_flag",
+            "whitelist_body_part_types", "blacklist_bp_with_flag",
+            "blacklist_body_part_types",
+        },
+        todo_count,
+    )
+
+
+def render_wound_fix(source: SourceObject, result: MigrationResult) -> str | None:
+    value = source.value
+    fix_id = value.get("id")
+    name = display_text(value.get("name"))
+    description = display_text(value.get("description"))
+    removed = string_ids(value.get("wounds_removed"))
+    if (
+        not bounded_platform_id(fix_id) or
+        not bounded_utf8_string(name, WOUND_NAME_MAX_BYTES) or
+        not bounded_utf8_string(description, WOUND_DESCRIPTION_MAX_BYTES) or
+        not removed or
+        not all(bounded_platform_id(entry) for entry in removed) or
+        len(set(removed)) != len(removed)
+    ):
+        fix_label = fix_id if bounded_platform_id(fix_id) else "<invalid id>"
+        result.partial.append(
+            f"{source.location}: wound fix {fix_label}"
+        )
+        result.todos.append(
+            f"{source.location}: wound fix needs a stable id, text, and distinct removed wounds within Platform byte bounds"
+        )
+        return None
+    todo_count = len(result.todos)
+    added = string_ids(value.get("wounds_added", []))
+    if (
+        added is None or
+        not all(bounded_platform_id(entry) for entry in added) or
+        len(set(added)) != len(added) or
+        set(removed) & set(added)
+    ):
+        added = []
+        result.todos.append(
+            f"{source.location}: wound fix {fix_id} added wounds need review"
+        )
+
+    duration = parse_turns(value.get("time", 0))
+    if duration is None or duration < 0 or duration > NATIVE_INT_MAX // 100:
+        duration = 0
+        result.todos.append(
+            f"{source.location}: wound fix {fix_id} duration needs review"
+        )
+    health_delta = native_integer(value.get("mod_hp", 0))
+    if health_delta is None:
+        health_delta = 0
+        result.todos.append(
+            f"{source.location}: wound fix {fix_id} health delta needs review"
+        )
+    success_message = display_text(value.get("success_msg"), "")
+    if not bounded_utf8_string(
+        success_message, WOUND_DESCRIPTION_MAX_BYTES, allow_empty=True
+    ):
+        success_message = ""
+        result.todos.append(
+            f"{source.location}: wound fix {fix_id} success message needs a bounded text conversion"
+        )
+    for field_name in ("name", "description", "success_msg"):
+        raw = value.get(field_name)
+        if isinstance(raw, dict) and (
+            not isinstance(raw.get("str"), str) or
+            unresolved_fields(raw, {"str"})
+        ):
+            result.todos.append(
+                f"{source.location}: wound fix {fix_id} {field_name} translation metadata needs review"
+            )
+
+    lines = [
+        "local definition = content.WoundFix {",
+        f"    id = {lua_quote(fix_id)},",
+        f"    name = {lua_quote(name)},",
+        f"    description = {lua_quote(description)},",
+        f"    success_message = {lua_quote(success_message)},",
+        f"    duration_turns = {duration},",
+        f"    health_delta = {health_delta},",
+        "}",
+    ]
+
+    skills = value.get("skills", {})
+    if not isinstance(skills, dict):
+        skills = {}
+        result.todos.append(
+            f"{source.location}: wound fix {fix_id} skills need review"
+        )
+    for skill, raw_level in sorted(skills.items(), key=lambda entry: str(entry[0])):
+        level = native_integer(raw_level, 0, NATIVE_MAX_SKILL)
+        if not bounded_platform_id(skill) or level is None:
+            result.todos.append(
+                f"{source.location}: wound fix {fix_id} skill entry needs review"
+            )
+            continue
+        lines.append(f"definition:skill({lua_quote(skill)}, {level})")
+
+    proficiencies = value.get("proficiencies", [])
+    if not isinstance(proficiencies, list):
+        proficiencies = []
+        result.todos.append(
+            f"{source.location}: wound fix {fix_id} proficiencies need review"
+        )
+    seen_proficiencies: set[str] = set()
+    for entry in proficiencies:
+        proficiency = entry.get("proficiency") if isinstance(entry, dict) else None
+        multiplier = positive_native_float_literal(
+            entry.get("time_save", 1)
+        ) if isinstance(entry, dict) else None
+        mandatory = entry.get("is_mandatory", False) if isinstance(entry, dict) else None
+        if (
+            not bounded_platform_id(proficiency) or
+            proficiency in seen_proficiencies or multiplier is None or
+            not isinstance(mandatory, bool) or
+            unresolved_fields(
+                entry, {"proficiency", "time_save", "is_mandatory"}
+            )
+        ):
+            result.todos.append(
+                f"{source.location}: wound fix {fix_id} proficiency entry needs review"
+            )
+            continue
+        seen_proficiencies.add(proficiency)
+        lines.append(
+            "definition:proficiency("
+            f"{lua_quote(proficiency)}, {lua_number(multiplier)}, "
+            f"{'true' if mandatory else 'false'})"
+        )
+
+    lines.extend(f"definition:removes({lua_quote(wound)})" for wound in removed)
+    lines.extend(f"definition:adds({lua_quote(wound)})" for wound in added)
+    requirements = value.get("requirements", [])
+    if not isinstance(requirements, list):
+        requirements = []
+        result.todos.append(
+            f"{source.location}: wound fix {fix_id} requirements need review"
+        )
+    seen_requirements: set[str] = set()
+    for entry in requirements:
+        if (
+            not isinstance(entry, list) or len(entry) != 2 or
+            not bounded_platform_id(entry[0]) or
+            entry[0] in seen_requirements
+        ):
+            result.todos.append(
+                f"{source.location}: wound fix {fix_id} inline, duplicate, or malformed requirement needs a standalone Requirement"
+            )
+            continue
+        count = native_integer(entry[1], 1)
+        if count is None:
+            result.todos.append(
+                f"{source.location}: wound fix {fix_id} requirement multiplier needs review"
+            )
+            continue
+        seen_requirements.add(entry[0])
+        lines.append(
+            f"definition:requires({lua_quote(entry[0])}, {count})"
+        )
+    return finish_catalog(
+        source,
+        result,
+        "wound fix",
+        fix_id,
+        lines,
+        {
+            "type", "id", "name", "description", "success_msg", "mod_hp",
+            "time", "skills", "wounds_removed", "wounds_added",
+            "proficiencies", "requirements",
         },
         todo_count,
     )
@@ -2355,8 +2982,8 @@ def render_body_part(source: SourceObject, result: MigrationResult) -> str | Non
             unknown = unresolved_fields(raw, {"quality", "level", "disable_percent"})
             if unknown:
                 result.todos.append(
-                    f"{source.location}: body part {part_id} quality unresolved fields: "
-                    + ", ".join(unknown)
+                    f"{source.location}: body part {part_id} quality unresolved fields: " +
+                    ", ".join(unknown)
                 )
             lines.append(
                 f"definition:quality({lua_quote(quality_id)}, {level}, {lua_number(disable)})"
@@ -2431,9 +3058,9 @@ def render_body_graph(source: SourceObject, result: MigrationResult) -> str | No
         rows = []
         result.todos.append(f"{source.location}: body graph {graph_id} rows need review")
     if fill_rows is not None and (
-        not isinstance(fill_rows, list)
-        or len(fill_rows) != len(rows)
-        or not all(isinstance(row, str) and row for row in fill_rows)
+        not isinstance(fill_rows, list) or
+        len(fill_rows) != len(rows) or
+        not all(isinstance(row, str) and row for row in fill_rows)
     ):
         fill_rows = None
         result.todos.append(f"{source.location}: body graph {graph_id} fill rows need review")
@@ -2497,8 +3124,8 @@ def render_body_graph(source: SourceObject, result: MigrationResult) -> str | No
         )
         if unknown:
             result.todos.append(
-                f"{source.location}: body graph {graph_id} part {symbol} unresolved fields: "
-                + ", ".join(unknown)
+                f"{source.location}: body graph {graph_id} part {symbol} unresolved fields: " +
+                ", ".join(unknown)
             )
         if not has_target:
             result.todos.append(
@@ -2877,26 +3504,26 @@ def render_disease_type(source: SourceObject, result: MigrationResult) -> str | 
             f"{source.location}: disease type {disease_id} minimum duration needs review"
         )
     if (
-        maximum_duration is None
-        or not minimum_duration <= maximum_duration <= NATIVE_INT_MAX
+        maximum_duration is None or
+        not minimum_duration <= maximum_duration <= NATIVE_INT_MAX
     ):
         maximum_duration = minimum_duration
         result.todos.append(
             f"{source.location}: disease type {disease_id} maximum duration needs review"
         )
     if (
-        not isinstance(minimum_intensity, int)
-        or isinstance(minimum_intensity, bool)
-        or not 0 < minimum_intensity <= NATIVE_INT_MAX
+        not isinstance(minimum_intensity, int) or
+        isinstance(minimum_intensity, bool) or
+        not 0 < minimum_intensity <= NATIVE_INT_MAX
     ):
         minimum_intensity = 1
         result.todos.append(
             f"{source.location}: disease type {disease_id} minimum intensity needs review"
         )
     if (
-        not isinstance(maximum_intensity, int)
-        or isinstance(maximum_intensity, bool)
-        or not minimum_intensity <= maximum_intensity <= NATIVE_INT_MAX
+        not isinstance(maximum_intensity, int) or
+        isinstance(maximum_intensity, bool) or
+        not minimum_intensity <= maximum_intensity <= NATIVE_INT_MAX
     ):
         maximum_intensity = minimum_intensity
         result.todos.append(
@@ -2918,9 +3545,9 @@ def render_disease_type(source: SourceObject, result: MigrationResult) -> str | 
     ]
     threshold = value.get("health_threshold")
     if (
-        isinstance(threshold, int)
-        and not isinstance(threshold, bool)
-        and -NATIVE_INT_MAX - 1 <= threshold <= NATIVE_INT_MAX
+        isinstance(threshold, int) and
+        not isinstance(threshold, bool) and
+        -NATIVE_INT_MAX - 1 <= threshold <= NATIVE_INT_MAX
     ):
         lines.append(f"    health_threshold = {threshold},")
     elif threshold is not None:
@@ -3072,9 +3699,9 @@ def render_emission(source: SourceObject, result: MigrationResult) -> str | None
             continue
         number = value[source_name]
         if (
-            isinstance(number, int)
-            and not isinstance(number, bool)
-            and 1 <= number <= maximum
+            isinstance(number, int) and
+            not isinstance(number, bool) and
+            1 <= number <= maximum
         ):
             lines.append(f"    {target_name} = {number},")
         else:
@@ -3190,10 +3817,10 @@ def render_mutation_category(
             continue
         number = value[source_name]
         valid = (
-            isinstance(number, int)
-            and not isinstance(number, bool)
-            and 0 <= number <= NATIVE_INT_MAX
-            and (source_name != "base_removal_chance" or number <= 100)
+            isinstance(number, int) and
+            not isinstance(number, bool) and
+            0 <= number <= NATIVE_INT_MAX and
+            (source_name != "base_removal_chance" or number <= 100)
         )
         if valid:
             lines.append(f"    {target_name} = {number},")
@@ -3204,10 +3831,10 @@ def render_mutation_category(
     multiplier = value.get("base_removal_cost_mul")
     if multiplier is not None:
         if (
-            isinstance(multiplier, (int, float))
-            and not isinstance(multiplier, bool)
-            and math.isfinite(multiplier)
-            and multiplier >= 0
+            isinstance(multiplier, (int, float)) and
+            not isinstance(multiplier, bool) and
+            math.isfinite(multiplier) and
+            multiplier >= 0
         ):
             lines.append(
                 f"    base_removal_cost_multiplier = {lua_number(multiplier)},"
@@ -3306,9 +3933,9 @@ def render_vehicle_part_location(
         ("list_order", list_order, 5),
     ):
         if (
-            not isinstance(raw, int)
-            or isinstance(raw, bool)
-            or not -NATIVE_INT_MAX - 1 <= raw <= NATIVE_INT_MAX
+            not isinstance(raw, int) or
+            isinstance(raw, bool) or
+            not -NATIVE_INT_MAX - 1 <= raw <= NATIVE_INT_MAX
         ):
             result.todos.append(
                 f"{source.location}: vehicle part location {location_id} {field_name} needs review"
@@ -3359,12 +3986,12 @@ def render_mood_face(source: SourceObject, result: MigrationResult) -> str | Non
             score = entry.get("value") if isinstance(entry, dict) else None
             face = entry.get("face") if isinstance(entry, dict) else None
             if (
-                not isinstance(score, int)
-                or isinstance(score, bool)
-                or not -NATIVE_INT_MAX - 1 <= score <= NATIVE_INT_MAX
-                or score in seen_scores
-                or not isinstance(face, str)
-                or not face
+                not isinstance(score, int) or
+                isinstance(score, bool) or
+                not -NATIVE_INT_MAX - 1 <= score <= NATIVE_INT_MAX or
+                score in seen_scores or
+                not isinstance(face, str) or
+                not face
             ):
                 result.todos.append(
                     f"{source.location}: mood face {face_id} value needs review"
@@ -3434,10 +4061,10 @@ def render_damage_info_order(
         elif raw is None:
             continue
         if (
-            not isinstance(order, int)
-            or isinstance(order, bool)
-            or not -NATIVE_INT_MAX - 1 <= order <= NATIVE_INT_MAX
-            or not isinstance(show_type, bool)
+            not isinstance(order, int) or
+            isinstance(order, bool) or
+            not -NATIVE_INT_MAX - 1 <= order <= NATIVE_INT_MAX or
+            not isinstance(show_type, bool)
         ):
             result.todos.append(
                 f"{source.location}: damage info order {order_id} {source_name} needs review"
@@ -3483,9 +4110,9 @@ def render_vehicle_part_category(
             f"{source.location}: vehicle part category {category_id} labels need review"
         )
     if (
-        not isinstance(priority, int)
-        or isinstance(priority, bool)
-        or not -NATIVE_INT_MAX - 1 <= priority <= NATIVE_INT_MAX
+        not isinstance(priority, int) or
+        isinstance(priority, bool) or
+        not -NATIVE_INT_MAX - 1 <= priority <= NATIVE_INT_MAX
     ):
         priority = 0
         result.todos.append(
@@ -3512,9 +4139,9 @@ def render_vehicle_part_category(
 
 def parse_named_color(value: Any) -> tuple[int, int, int, int] | None:
     if isinstance(value, list) and len(value) in {3, 4} and all(
-        isinstance(channel, int)
-        and not isinstance(channel, bool)
-        and 0 <= channel <= 255
+        isinstance(channel, int) and
+        not isinstance(channel, bool) and
+        0 <= channel <= 255
         for channel in value
     ):
         channels = [*value]
@@ -3572,10 +4199,10 @@ def render_rotatable_symbol(
     value = source.value
     symbols = value.get("tuple")
     if (
-        not isinstance(symbols, list)
-        or len(symbols) not in {2, 4}
-        or not all(isinstance(symbol, str) and len(symbol) == 1 for symbol in symbols)
-        or len(set(symbols)) != len(symbols)
+        not isinstance(symbols, list) or
+        len(symbols) not in {2, 4} or
+        not all(isinstance(symbol, str) and len(symbol) == 1 for symbol in symbols) or
+        len(set(symbols)) != len(symbols)
     ):
         result.partial.append(f"{source.location}: rotatable symbol <invalid tuple>")
         result.todos.append(
@@ -3690,12 +4317,12 @@ def render_hit_range(source: SourceObject, result: MigrationResult) -> str | Non
     todo_count = len(result.todos)
     raw_values = value.get("even_good")
     valid = (
-        isinstance(raw_values, list)
-        and bool(raw_values)
-        and all(
-            isinstance(entry, int)
-            and not isinstance(entry, bool)
-            and 0 <= entry <= NATIVE_INT_MAX
+        isinstance(raw_values, list) and
+        bool(raw_values) and
+        all(
+            isinstance(entry, int) and
+            not isinstance(entry, bool) and
+            0 <= entry <= NATIVE_INT_MAX
             for entry in raw_values
         )
     )
@@ -3745,12 +4372,12 @@ def render_bash_damage_profile(
     else:
         for damage_id, factor in sorted(profile.items(), key=lambda entry: str(entry[0])):
             if (
-                not isinstance(damage_id, str)
-                or not damage_id
-                or not isinstance(factor, (int, float))
-                or isinstance(factor, bool)
-                or not math.isfinite(factor)
-                or factor < 0
+                not isinstance(damage_id, str) or
+                not damage_id or
+                not isinstance(factor, (int, float)) or
+                isinstance(factor, bool) or
+                not math.isfinite(factor) or
+                factor < 0
             ):
                 result.todos.append(
                     f"{source.location}: bash damage profile {profile_id} factor needs review"
@@ -3826,17 +4453,17 @@ def render_clothing_mod(source: SourceObject, result: MigrationResult) -> str | 
             scaling = modifier.get("proportion", [])
             round_up = modifier.get("round_up", False)
             valid = (
-                isinstance(stat, str)
-                and stat in valid_stats
-                and isinstance(amount, (int, float))
-                and not isinstance(amount, bool)
-                and math.isfinite(amount)
-                and isinstance(scaling, list)
-                and len(scaling) <= 2
-                and all(isinstance(entry, str) for entry in scaling)
-                and all(entry in {"thickness", "coverage"} for entry in scaling)
-                and len(set(scaling)) == len(scaling)
-                and isinstance(round_up, bool)
+                isinstance(stat, str) and
+                stat in valid_stats and
+                isinstance(amount, (int, float)) and
+                not isinstance(amount, bool) and
+                math.isfinite(amount) and
+                isinstance(scaling, list) and
+                len(scaling) <= 2 and
+                all(isinstance(entry, str) for entry in scaling) and
+                all(entry in {"thickness", "coverage"} for entry in scaling) and
+                len(set(scaling)) == len(scaling) and
+                isinstance(round_up, bool)
             )
             if not valid:
                 result.todos.append(
@@ -3892,22 +4519,22 @@ def render_overmap_land_use_code(
     name = display_text(value.get("name"), code_id)
     description = display_text(value.get("detailed_definition"), "")
     if (
-        not isinstance(numeric_code, int)
-        or isinstance(numeric_code, bool)
-        or not NATIVE_INT_MIN <= numeric_code <= NATIVE_INT_MAX
-        or not isinstance(symbol, str)
-        or len(symbol) != 1
-        or not isinstance(color, str)
-        or not color
+        not isinstance(numeric_code, int) or
+        isinstance(numeric_code, bool) or
+        not NATIVE_INT_MIN <= numeric_code <= NATIVE_INT_MAX or
+        not isinstance(symbol, str) or
+        len(symbol) != 1 or
+        not isinstance(color, str) or
+        not color
     ):
         result.todos.append(
             f"{source.location}: overmap land-use code {code_id} display values need review"
         )
     safe_code = (
         numeric_code
-        if isinstance(numeric_code, int)
-        and not isinstance(numeric_code, bool)
-        and NATIVE_INT_MIN <= numeric_code <= NATIVE_INT_MAX
+        if isinstance(numeric_code, int) and
+        not isinstance(numeric_code, bool) and
+        NATIVE_INT_MIN <= numeric_code <= NATIVE_INT_MAX
         else 0
     )
     safe_symbol = symbol if isinstance(symbol, str) and len(symbol) == 1 else "?"
@@ -3973,13 +4600,13 @@ def render_overmap_vision(source: SourceObject, result: MigrationResult) -> str 
         color = raw_level.get("color", "black")
         looks_like = raw_level.get("looks_like")
         if (
-            not isinstance(name, str)
-            or not name
-            or not isinstance(symbol, str)
-            or len(symbol) != 1
-            or not isinstance(color, str)
-            or not color
-            or (looks_like is not None and (
+            not isinstance(name, str) or
+            not name or
+            not isinstance(symbol, str) or
+            len(symbol) != 1 or
+            not isinstance(color, str) or
+            not color or
+            (looks_like is not None and (
                 not isinstance(looks_like, str) or not looks_like
             ))
         ):
@@ -4071,10 +4698,10 @@ def render_profession_group(source: SourceObject, result: MigrationResult) -> st
         return None
     professions = value.get("professions")
     if (
-        not isinstance(professions, list)
-        or not professions
-        or any(not isinstance(entry, str) or not entry for entry in professions)
-        or len(set(professions)) != len(professions)
+        not isinstance(professions, list) or
+        not professions or
+        any(not isinstance(entry, str) or not entry for entry in professions) or
+        len(set(professions)) != len(professions)
     ):
         result.partial.append(f"{source.location}: profession group {group_id}")
         result.todos.append(
@@ -4124,9 +4751,9 @@ def render_weighted_catalog(
     if chance:
         raw_chance = value.get("chance", 0)
         if (
-            not isinstance(raw_chance, int)
-            or isinstance(raw_chance, bool)
-            or not 0 <= raw_chance <= 4_294_967_295
+            not isinstance(raw_chance, int) or
+            isinstance(raw_chance, bool) or
+            not 0 <= raw_chance <= 4_294_967_295
         ):
             result.partial.append(f"{source.location}: {label} {group_id}")
             result.todos.append(f"{source.location}: {label} {group_id} chance needs review")
@@ -4152,18 +4779,18 @@ def render_weighted_catalog(
                     f"{source.location}: {label} {group_id} entry has unsupported fields"
                 )
         elif (
-            not object_style
-            and isinstance(raw_entry, list)
-            and len(raw_entry) == 2
+            not object_style and
+            isinstance(raw_entry, list) and
+            len(raw_entry) == 2
         ):
             entry_id, weight = raw_entry
         if (
-            not isinstance(entry_id, str)
-            or not entry_id
-            or entry_id in seen
-            or not isinstance(weight, int)
-            or isinstance(weight, bool)
-            or not 1 <= weight <= NATIVE_INT_MAX
+            not isinstance(entry_id, str) or
+            not entry_id or
+            entry_id in seen or
+            not isinstance(weight, int) or
+            isinstance(weight, bool) or
+            not 1 <= weight <= NATIVE_INT_MAX
         ):
             result.todos.append(
                 f"{source.location}: {label} {group_id} weighted entry needs review"
@@ -4192,10 +4819,10 @@ def render_explosion_light(source: SourceObject, result: MigrationResult) -> str
     def finite(name: str, default: float, *, positive: bool = False) -> float:
         raw = value.get(name, default)
         if (
-            isinstance(raw, (int, float))
-            and not isinstance(raw, bool)
-            and math.isfinite(raw)
-            and (raw > 0 if positive else raw >= 0)
+            isinstance(raw, (int, float)) and
+            not isinstance(raw, bool) and
+            math.isfinite(raw) and
+            (raw > 0 if positive else raw >= 0)
         ):
             return float(raw)
         result.todos.append(
@@ -4205,17 +4832,17 @@ def render_explosion_light(source: SourceObject, result: MigrationResult) -> str
 
     def rgba_stop(raw_color: Any, raw_alpha: Any) -> tuple[int, int, int, int] | None:
         if (
-            isinstance(raw_color, list)
-            and len(raw_color) == 3
-            and all(
-                isinstance(component, int)
-                and not isinstance(component, bool)
-                and 0 <= component <= 255
+            isinstance(raw_color, list) and
+            len(raw_color) == 3 and
+            all(
+                isinstance(component, int) and
+                not isinstance(component, bool) and
+                0 <= component <= 255
                 for component in raw_color
-            )
-            and isinstance(raw_alpha, int)
-            and not isinstance(raw_alpha, bool)
-            and 0 <= raw_alpha <= 255
+            ) and
+            isinstance(raw_alpha, int) and
+            not isinstance(raw_alpha, bool) and
+            0 <= raw_alpha <= 255
         ):
             return raw_color[0], raw_color[1], raw_color[2], raw_alpha
         return None
@@ -4349,9 +4976,9 @@ def render_ammo_effect(source: SourceObject, result: MigrationResult) -> str | N
 
     def native_integer(raw: Any, *, minimum: int = 0, maximum: int = NATIVE_INT_MAX) -> int | None:
         if (
-            isinstance(raw, int)
-            and not isinstance(raw, bool)
-            and minimum <= raw <= maximum
+            isinstance(raw, int) and
+            not isinstance(raw, bool) and
+            minimum <= raw <= maximum
         ):
             return raw
         return None
@@ -4394,15 +5021,15 @@ def render_ammo_effect(source: SourceObject, result: MigrationResult) -> str | N
                 "field_type", "intensity_min", "intensity_max", "chance"
             } | ({"radius", "radius_z", "size", "check_passable"} if burst else set())
             if (
-                minimum is None
-                or maximum is None
-                or maximum < minimum
-                or chance is None
-                or radius is None
-                or height is None
-                or footprint is None
-                or not isinstance(passable, bool)
-                or set(entry) - allowed
+                minimum is None or
+                maximum is None or
+                maximum < minimum or
+                chance is None or
+                radius is None or
+                height is None or
+                footprint is None or
+                not isinstance(passable, bool) or
+                set(entry) - allowed
             ):
                 result.todos.append(
                     f"{source.location}: ammo effect {effect_id} {method} entry needs review"
@@ -4431,12 +5058,12 @@ def render_ammo_effect(source: SourceObject, result: MigrationResult) -> str | N
                 duration = entry.get("duration") if isinstance(entry, dict) else None
                 intensity = native_integer(entry.get("intensity", 1), minimum=1) if isinstance(entry, dict) else None
                 if (
-                    not isinstance(entry, dict)
-                    or not safe_platform_id(entry.get("effect"))
-                    or native_integer(duration, minimum=1) is None
-                    or intensity is None
-                    or not isinstance(entry.get("need_touch_skin", False), bool)
-                    or set(entry) - {"effect", "duration", "intensity", "need_touch_skin"}
+                    not isinstance(entry, dict) or
+                    not safe_platform_id(entry.get("effect")) or
+                    native_integer(duration, minimum=1) is None or
+                    intensity is None or
+                    not isinstance(entry.get("need_touch_skin", False), bool) or
+                    set(entry) - {"effect", "duration", "intensity", "need_touch_skin"}
                 ):
                     result.todos.append(
                         f"{source.location}: ammo effect {effect_id} on-hit entry needs a turn-based duration review"
@@ -4471,22 +5098,22 @@ def render_ammo_effect(source: SourceObject, result: MigrationResult) -> str | N
                 radius = native_integer(entry.get("radius", 1))
                 hits = entry.get("hits_amount", [1, 1])
                 hits_ok = (
-                    isinstance(hits, list)
-                    and len(hits) == 2
-                    and native_integer(hits[0], minimum=1) is not None
-                    and native_integer(hits[1], minimum=hits[0]) is not None
+                    isinstance(hits, list) and
+                    len(hits) == 2 and
+                    native_integer(hits[0], minimum=1) is not None and
+                    native_integer(hits[1], minimum=hits[0]) is not None
                 )
                 if (
-                    not safe_platform_id(entry.get("effect"))
-                    or duration is None
-                    or minimum is None
-                    or maximum is None
-                    or maximum < minimum
-                    or chance is None
-                    or radius is None
-                    or not hits_ok
-                    or not isinstance(entry.get("all_bp", False), bool)
-                    or set(entry) - {"effect", "duration", "intensity_min", "intensity_max", "chance", "radius", "hits_amount", "all_bp"}
+                    not safe_platform_id(entry.get("effect")) or
+                    duration is None or
+                    minimum is None or
+                    maximum is None or
+                    maximum < minimum or
+                    chance is None or
+                    radius is None or
+                    not hits_ok or
+                    not isinstance(entry.get("all_bp", False), bool) or
+                    set(entry) - {"effect", "duration", "intensity_min", "intensity_max", "chance", "radius", "hits_amount", "all_bp"}
                 ):
                     result.todos.append(
                         f"{source.location}: ammo effect {effect_id} area-effect entry needs a turn-based duration review"
@@ -4518,12 +5145,18 @@ def render_ammo_effect(source: SourceObject, result: MigrationResult) -> str | N
             noise = native_integer(raw_explosion.get("max_noise", 90_000_000))
             fire = raw_explosion.get("fire", False)
             light = raw_explosion.get("light_effect", "")
-            numeric = lambda raw: isinstance(raw, (int, float)) and not isinstance(raw, bool) and math.isfinite(raw)
+
+            def numeric(raw: Any) -> bool:
+                return (
+                    isinstance(raw, (int, float)) and
+                    not isinstance(raw, bool) and
+                    math.isfinite(raw)
+                )
             if (
-                not numeric(power) or power < 0
-                or not numeric(factor) or not 0 <= factor <= 1
-                or noise is None or not isinstance(fire, bool)
-                or not isinstance(light, str)
+                not numeric(power) or power < 0 or
+                not numeric(factor) or not 0 <= factor <= 1 or
+                noise is None or not isinstance(fire, bool) or
+                not isinstance(light, str)
             ):
                 result.todos.append(
                     f"{source.location}: ammo effect {effect_id} explosion values need review"
@@ -4545,9 +5178,9 @@ def render_ammo_effect(source: SourceObject, result: MigrationResult) -> str | N
                     recovery = native_integer(shrapnel.get("recovery", 0), maximum=100)
                     drop = shrapnel.get("drop", "null")
                     if (
-                        casing is not None and numeric(fragment) and fragment > 0
-                        and recovery is not None and isinstance(drop, str)
-                        and not set(shrapnel) - {"casing_mass", "fragment_mass", "recovery", "drop"}
+                        casing is not None and numeric(fragment) and fragment > 0 and
+                        recovery is not None and isinstance(drop, str) and
+                        not set(shrapnel) - {"casing_mass", "fragment_mass", "recovery", "drop"}
                     ):
                         lines.extend((
                             "definition:shrapnel {",
@@ -4594,11 +5227,11 @@ def render_ammo_effect(source: SourceObject, result: MigrationResult) -> str | N
                 level = native_integer(entry.get("level", 0)) if isinstance(entry, dict) else None
                 self_target = entry.get("self", False) if isinstance(entry, dict) else None
                 if (
-                    not isinstance(entry, dict)
-                    or not safe_platform_id(entry.get("id"))
-                    or level is None
-                    or not isinstance(self_target, bool)
-                    or set(entry) - {"id", "level", "self"}
+                    not isinstance(entry, dict) or
+                    not safe_platform_id(entry.get("id")) or
+                    level is None or
+                    not isinstance(self_target, bool) or
+                    set(entry) - {"id", "level", "self"}
                 ):
                     result.todos.append(
                         f"{source.location}: ammo effect {effect_id} spell entry needs review"
@@ -4763,8 +5396,8 @@ def render_start_location(source: SourceObject, result: MigrationResult) -> str 
                 match = match_map.get(raw_match) if isinstance(raw_match, str) else None
                 raw_parameters = raw.get("parameters", {})
                 if (
-                    not isinstance(raw_parameters, dict)
-                    or not all(isinstance(key, str) and isinstance(item, str) for key, item in raw_parameters.items())
+                    not isinstance(raw_parameters, dict) or
+                    not all(isinstance(key, str) and isinstance(item, str) for key, item in raw_parameters.items())
                 ):
                     parameters = {}
                     match = None
@@ -4806,9 +5439,9 @@ def render_start_location(source: SourceObject, result: MigrationResult) -> str 
         if raw is None:
             return
         if (
-            isinstance(raw, list) and len(raw) == 2
-            and all(isinstance(item, int) and not isinstance(item, bool) and NATIVE_INT_MIN <= item <= NATIVE_INT_MAX for item in raw)
-            and raw[0] <= raw[1]
+            isinstance(raw, list) and len(raw) == 2 and
+            all(isinstance(item, int) and not isinstance(item, bool) and NATIVE_INT_MIN <= item <= NATIVE_INT_MAX for item in raw) and
+            raw[0] <= raw[1]
         ):
             lines.append(f"definition:{method}({raw[0]}, {raw[1]})")
         else:
@@ -4854,9 +5487,9 @@ def render_climbing_aid(source: SourceObject, result: MigrationResult) -> str | 
     uses = condition.get("uses", 0)
     range_value = condition.get("range", 1)
     if (
-        not isinstance(uses, int) or isinstance(uses, bool) or not 0 <= uses <= NATIVE_INT_MAX
-        or not isinstance(range_value, int) or isinstance(range_value, bool) or not 0 <= range_value <= NATIVE_INT_MAX
-        or set(condition) - {"type", "flag", "uses", "range"}
+        not isinstance(uses, int) or isinstance(uses, bool) or not 0 <= uses <= NATIVE_INT_MAX or
+        not isinstance(range_value, int) or isinstance(range_value, bool) or not 0 <= range_value <= NATIVE_INT_MAX or
+        set(condition) - {"type", "flag", "uses", "range"}
     ):
         result.partial.append(f"{source.location}: climbing aid {aid_id}")
         result.todos.append(f"{source.location}: climbing aid {aid_id} availability limits need review")
@@ -4968,9 +5601,9 @@ def render_weather_type(source: SourceObject, result: MigrationResult) -> str | 
     def integer_option(name: str, default: int) -> int:
         raw = value.get(name, default)
         if (
-            isinstance(raw, int)
-            and not isinstance(raw, bool)
-            and NATIVE_INT_MIN <= raw <= NATIVE_INT_MAX
+            isinstance(raw, int) and
+            not isinstance(raw, bool) and
+            NATIVE_INT_MIN <= raw <= NATIVE_INT_MAX
         ):
             return raw
         result.todos.append(
@@ -4981,10 +5614,10 @@ def render_weather_type(source: SourceObject, result: MigrationResult) -> str | 
     def number_option(name: str, default: float, *, non_negative: bool = False) -> float:
         raw = value.get(name, default)
         if (
-            isinstance(raw, (int, float))
-            and not isinstance(raw, bool)
-            and math.isfinite(raw)
-            and (not non_negative or raw >= 0)
+            isinstance(raw, (int, float)) and
+            not isinstance(raw, bool) and
+            math.isfinite(raw) and
+            (not non_negative or raw >= 0)
         ):
             return float(raw)
         result.todos.append(
@@ -5082,8 +5715,8 @@ def render_weather_type(source: SourceObject, result: MigrationResult) -> str | 
         )
         minimum_duration = 300
     if (
-        maximum_duration is None
-        or not minimum_duration <= maximum_duration <= NATIVE_INT_MAX
+        maximum_duration is None or
+        not minimum_duration <= maximum_duration <= NATIVE_INT_MAX
     ):
         result.todos.append(
             f"{source.location}: weather type {weather_id} maximum duration needs review"
@@ -5094,15 +5727,15 @@ def render_weather_type(source: SourceObject, result: MigrationResult) -> str | 
     animation = value.get("weather_animation")
     if animation is not None:
         if (
-            isinstance(animation, dict)
-            and isinstance(animation.get("factor"), (int, float))
-            and not isinstance(animation.get("factor"), bool)
-            and math.isfinite(animation["factor"])
-            and animation["factor"] >= 0
-            and isinstance(animation.get("color"), str)
-            and bool(animation["color"])
-            and isinstance(animation.get("sym"), str)
-            and len(animation["sym"]) == 1
+            isinstance(animation, dict) and
+            isinstance(animation.get("factor"), (int, float)) and
+            not isinstance(animation.get("factor"), bool) and
+            math.isfinite(animation["factor"]) and
+            animation["factor"] >= 0 and
+            isinstance(animation.get("color"), str) and
+            bool(animation["color"]) and
+            isinstance(animation.get("sym"), str) and
+            len(animation["sym"]) == 1
         ):
             lines.extend((
                 "definition:animation {",
@@ -5156,19 +5789,19 @@ def render_weather_type(source: SourceObject, result: MigrationResult) -> str | 
                 )
             }
             valid = (
-                minimum is not None
-                and maximum is not None
-                and 0 < minimum <= maximum <= NATIVE_INT_MAX
-                and isinstance(intensity, int)
-                and not isinstance(intensity, bool)
-                and 0 < intensity <= NATIVE_INT_MAX
-                and isinstance(body_part, str)
-                and isinstance(environmental, bool)
-                and all(isinstance(item, bool) for item in boolean_fields.values())
-                and all(
-                    isinstance(item, int)
-                    and not isinstance(item, bool)
-                    and 0 <= item <= 100
+                minimum is not None and
+                maximum is not None and
+                0 < minimum <= maximum <= NATIVE_INT_MAX and
+                isinstance(intensity, int) and
+                not isinstance(intensity, bool) and
+                0 < intensity <= NATIVE_INT_MAX and
+                isinstance(body_part, str) and
+                isinstance(environmental, bool) and
+                all(isinstance(item, bool) for item in boolean_fields.values()) and
+                all(
+                    isinstance(item, int) and
+                    not isinstance(item, bool) and
+                    0 <= item <= 100
                     for item in chance_fields.values()
                 )
             )
@@ -5217,10 +5850,10 @@ def render_weather_type(source: SourceObject, result: MigrationResult) -> str | 
     result.todos.append(
         f"{source.location}: weather type {weather_id} legacy condition tree/jmath must be rewritten as named Lua handler {handler_id}"
     )
-    for field in ("debug_cause_eoc", "debug_leave_eoc"):
-        if value.get(field):
+    for field_name in ("debug_cause_eoc", "debug_leave_eoc"):
+        if value.get(field_name):
             result.todos.append(
-                f"{source.location}: weather type {weather_id} {field} must be rewritten as explicit Lua debug behaviour"
+                f"{source.location}: weather type {weather_id} {field_name} must be rewritten as explicit Lua debug behaviour"
             )
     supported = {
         "type", "id", "name", "color", "map_color", "sym", "sun_sym",
@@ -5287,9 +5920,9 @@ def render_end_screen(source: SourceObject, result: MigrationResult) -> str | No
         )
         return None
     if (
-        not isinstance(priority, int)
-        or isinstance(priority, bool)
-        or not NATIVE_INT_MIN <= priority <= NATIVE_INT_MAX
+        not isinstance(priority, int) or
+        isinstance(priority, bool) or
+        not NATIVE_INT_MIN <= priority <= NATIVE_INT_MAX
     ):
         result.partial.append(f"{source.location}: end screen {screen_id}")
         result.todos.append(
@@ -5316,17 +5949,17 @@ def render_end_screen(source: SourceObject, result: MigrationResult) -> str | No
     if isinstance(information, list):
         for index, entry in enumerate(information):
             valid = (
-                isinstance(entry, list)
-                and len(entry) == 2
-                and isinstance(entry[0], list)
-                and len(entry[0]) == 2
-                and all(
-                    isinstance(number, int)
-                    and not isinstance(number, bool)
-                    and NATIVE_INT_MIN <= number <= NATIVE_INT_MAX
+                isinstance(entry, list) and
+                len(entry) == 2 and
+                isinstance(entry[0], list) and
+                len(entry[0]) == 2 and
+                all(
+                    isinstance(number, int) and
+                    not isinstance(number, bool) and
+                    NATIVE_INT_MIN <= number <= NATIVE_INT_MAX
                     for number in entry[0]
-                )
-                and bool(display_text(entry[1]))
+                ) and
+                bool(display_text(entry[1]))
             )
             if not valid:
                 result.todos.append(
@@ -5392,10 +6025,10 @@ def render_activity_type(source: SourceObject, result: MigrationResult) -> str |
     if isinstance(activity_level, str):
         activity_level = levels.get(activity_level)
     if (
-        not isinstance(activity_level, (int, float))
-        or isinstance(activity_level, bool)
-        or not math.isfinite(activity_level)
-        or activity_level <= 0
+        not isinstance(activity_level, (int, float)) or
+        isinstance(activity_level, bool) or
+        not math.isfinite(activity_level) or
+        activity_level <= 0
     ):
         result.partial.append(f"{source.location}: activity type {activity_id}")
         result.todos.append(
@@ -5491,11 +6124,11 @@ def render_help_topic(
     order = value.get("order")
     messages = value.get("messages")
     if (
-        not title
-        or not isinstance(order, int)
-        or isinstance(order, bool)
-        or not isinstance(messages, list)
-        or not messages
+        not title or
+        not isinstance(order, int) or
+        isinstance(order, bool) or
+        not isinstance(messages, list) or
+        not messages
     ):
         result.partial.append(f"{source.location}: help topic <invalid>")
         result.todos.append(
@@ -5581,11 +6214,11 @@ def collect_snippet_category(
         name = display_text(raw.get("name")) if "name" in raw else ""
         weight = raw.get("weight", 1)
         if (
-            not text
-            or not isinstance(weight, int)
-            or isinstance(weight, bool)
-            or weight <= 0
-            or (snippet_id is not None and not safe_platform_id(snippet_id))
+            not text or
+            not isinstance(weight, int) or
+            isinstance(weight, bool) or
+            weight <= 0 or
+            (snippet_id is not None and not safe_platform_id(snippet_id))
         ):
             result.todos.append(
                 f"{source.location}: snippet category {category_id} entry #{index} needs text, id, or weight review"
@@ -5607,8 +6240,8 @@ def collect_snippet_category(
         )
         if unresolved:
             result.todos.append(
-                f"{source.location}: snippet entry unresolved fields: "
-                + ", ".join(unresolved)
+                f"{source.location}: snippet entry unresolved fields: " +
+                ", ".join(unresolved)
             )
         kind = "entry" if isinstance(snippet_id, str) else "text"
         category["entries"].append(
@@ -5619,8 +6252,8 @@ def collect_snippet_category(
     unresolved = unresolved_fields(value, {"type", "category", "text", "override"})
     if unresolved:
         result.todos.append(
-            f"{source.location}: snippet category {category_id} unresolved fields: "
-            + ", ".join(unresolved)
+            f"{source.location}: snippet category {category_id} unresolved fields: " +
+            ", ".join(unresolved)
         )
     target = result.converted if valid_count == len(entries) and len(result.todos) == todo_count else result.partial
     target.append(f"{source.location}: snippet category {category_id}")
@@ -5693,12 +6326,12 @@ def render_playlists(source: SourceObject, result: MigrationResult) -> str | Non
         valid = True
         for track_index, track in enumerate(files):
             if (
-                not isinstance(track, dict)
-                or not isinstance(track.get("file"), str)
-                or not track["file"]
-                or not isinstance(track.get("volume"), int)
-                or isinstance(track.get("volume"), bool)
-                or not 0 <= track["volume"] <= 128
+                not isinstance(track, dict) or
+                not isinstance(track.get("file"), str) or
+                not track["file"] or
+                not isinstance(track.get("volume"), int) or
+                isinstance(track.get("volume"), bool) or
+                not 0 <= track["volume"] <= 128
             ):
                 result.todos.append(
                     f"{source.location}: playlist {playlist_id} track #{track_index} needs review"
@@ -5711,8 +6344,8 @@ def render_playlists(source: SourceObject, result: MigrationResult) -> str | Non
         unresolved = unresolved_fields(raw, {"id", "shuffle", "files"})
         if unresolved:
             result.todos.append(
-                f"{source.location}: playlist {playlist_id} unresolved fields: "
-                + ", ".join(unresolved)
+                f"{source.location}: playlist {playlist_id} unresolved fields: " +
+                ", ".join(unresolved)
             )
             valid = False
         if valid:
@@ -5721,8 +6354,8 @@ def render_playlists(source: SourceObject, result: MigrationResult) -> str | Non
     unresolved = unresolved_fields(value, {"type", "playlists"})
     if unresolved:
         result.todos.append(
-            f"{source.location}: playlist collection unresolved fields: "
-            + ", ".join(unresolved)
+            f"{source.location}: playlist collection unresolved fields: " +
+            ", ".join(unresolved)
         )
     target = result.converted if chunks and len(result.todos) == todo_count else result.partial
     target.append(f"{source.location}: playlist collection")
@@ -5745,12 +6378,12 @@ def render_nested_recipe_category(
         )
         return None
     if (
-        not name
-        or not safe_platform_id(category)
-        or not safe_platform_id(subcategory)
-        or not isinstance(members, list)
-        or not members
-        or not all(safe_platform_id(member) for member in members)
+        not name or
+        not safe_platform_id(category) or
+        not safe_platform_id(subcategory) or
+        not isinstance(members, list) or
+        not members or
+        not all(safe_platform_id(member) for member in members)
     ):
         result.partial.append(
             f"{source.location}: nested recipe category {category_id}"
@@ -5773,10 +6406,10 @@ def render_nested_recipe_category(
     if isinstance(activity, str):
         activity = activity_levels.get(activity)
     if (
-        not isinstance(activity, (int, float))
-        or isinstance(activity, bool)
-        or not math.isfinite(activity)
-        or activity <= 0
+        not isinstance(activity, (int, float)) or
+        isinstance(activity, bool) or
+        not math.isfinite(activity) or
+        activity <= 0
     ):
         result.todos.append(
             f"{source.location}: nested recipe category {category_id} activity level needs review"
@@ -5832,13 +6465,13 @@ def render_overlay_order(source: SourceObject, result: MigrationResult) -> str |
         raw_ids = entry.get("id")
         ids = [raw_ids] if isinstance(raw_ids, str) else raw_ids
         if (
-            not isinstance(order, int)
-            or isinstance(order, bool)
-            or not NATIVE_INT_MIN <= order <= NATIVE_INT_MAX
-            or not isinstance(ids, list)
-            or not ids
-            or not all(safe_platform_id(item) for item in ids)
-            or set(entry) - {"id", "order"}
+            not isinstance(order, int) or
+            isinstance(order, bool) or
+            not NATIVE_INT_MIN <= order <= NATIVE_INT_MAX or
+            not isinstance(ids, list) or
+            not ids or
+            not all(safe_platform_id(item) for item in ids) or
+            set(entry) - {"id", "order"}
         ):
             result.todos.append(
                 f"{source.location}: overlay order entry #{index} needs review"
@@ -5939,9 +6572,9 @@ def render_attack_vector(source: SourceObject, result: MigrationResult) -> str |
     def bounded_integer(name: str, default: int, minimum: int, maximum: int) -> int:
         raw = value.get(name, default)
         if (
-            isinstance(raw, int)
-            and not isinstance(raw, bool)
-            and minimum <= raw <= maximum
+            isinstance(raw, int) and
+            not isinstance(raw, bool) and
+            minimum <= raw <= maximum
         ):
             return raw
         result.todos.append(
@@ -5990,13 +6623,13 @@ def render_attack_vector(source: SourceObject, result: MigrationResult) -> str |
     else:
         for requirement in limb_requirements:
             valid = (
-                isinstance(requirement, list)
-                and len(requirement) == 2
-                and isinstance(requirement[0], str)
-                and requirement[0]
-                and isinstance(requirement[1], int)
-                and not isinstance(requirement[1], bool)
-                and 0 < requirement[1] <= NATIVE_INT_MAX
+                isinstance(requirement, list) and
+                len(requirement) == 2 and
+                isinstance(requirement[0], str) and
+                requirement[0] and
+                isinstance(requirement[1], int) and
+                not isinstance(requirement[1], bool) and
+                0 < requirement[1] <= NATIVE_INT_MAX
             )
             if not valid:
                 result.todos.append(
@@ -6084,10 +6717,10 @@ def render_magic_type(source: SourceObject, result: MigrationResult) -> str | No
     def nonnegative_number(name: str, default: float) -> float:
         raw = value.get(name, default)
         if (
-            isinstance(raw, (int, float))
-            and not isinstance(raw, bool)
-            and math.isfinite(raw)
-            and raw >= 0
+            isinstance(raw, (int, float)) and
+            not isinstance(raw, bool) and
+            math.isfinite(raw) and
+            raw >= 0
         ):
             return float(raw)
         result.todos.append(
@@ -6117,9 +6750,9 @@ def render_magic_type(source: SourceObject, result: MigrationResult) -> str | No
     raw_maximum = value.get("max_book_level")
     if raw_maximum is not None:
         if (
-            isinstance(raw_maximum, int)
-            and not isinstance(raw_maximum, bool)
-            and 0 <= raw_maximum <= NATIVE_INT_MAX
+            isinstance(raw_maximum, int) and
+            not isinstance(raw_maximum, bool) and
+            0 <= raw_maximum <= NATIVE_INT_MAX
         ):
             lines.append(f"    max_book_level = {raw_maximum},")
         else:
@@ -6147,12 +6780,12 @@ def render_magic_type(source: SourceObject, result: MigrationResult) -> str | No
         "casting_xp_formula_id": "definition:casting_experience handler",
         "failure_chance_formula_id": "definition:failure_chance handler",
     }
-    for field, replacement in formula_migrations.items():
-        if field in value:
+    for field_name, replacement in formula_migrations.items():
+        if field_name in value:
             result.todos.append(
-                f"{source.location}: magic type {magic_id} {field} must be rewritten as {replacement}"
+                f"{source.location}: magic type {magic_id} {field_name} must be rewritten as {replacement}"
             )
-            lines.append(f"-- TODO: rewrite {field} as {replacement}.")
+            lines.append(f"-- TODO: rewrite {field_name} as {replacement}.")
     if "failure_eocs" in value:
         result.todos.append(
             f"{source.location}: magic type {magic_id} failure_eocs must be rewritten as a named Lua on_failure handler"
@@ -6208,10 +6841,10 @@ def render_movement_mode(source: SourceObject, result: MigrationResult) -> str |
         if isinstance(raw, str) and raw in activity_levels:
             raw = activity_levels[raw]
         if (
-            isinstance(raw, (int, float))
-            and not isinstance(raw, bool)
-            and math.isfinite(raw)
-            and (raw > 0 if positive else raw >= 0)
+            isinstance(raw, (int, float)) and
+            not isinstance(raw, bool) and
+            math.isfinite(raw) and
+            (raw > 0 if positive else raw >= 0)
         ):
             return float(raw)
         result.todos.append(
@@ -6222,9 +6855,9 @@ def render_movement_mode(source: SourceObject, result: MigrationResult) -> str |
     def native_integer(name: str, default: int, minimum: int) -> int:
         raw = value.get(name, default)
         if (
-            isinstance(raw, int)
-            and not isinstance(raw, bool)
-            and minimum <= raw <= NATIVE_INT_MAX
+            isinstance(raw, int) and
+            not isinstance(raw, bool) and
+            minimum <= raw <= NATIVE_INT_MAX
         ):
             return raw
         result.todos.append(
@@ -6239,17 +6872,17 @@ def render_movement_mode(source: SourceObject, result: MigrationResult) -> str |
     panel_color = value.get("panel_color", "white")
     symbol_color = value.get("symbol_color", "white")
     if (
-        not isinstance(name, str)
-        or not name
-        or kind not in {"prone", "crouching", "walking", "running"}
-        or not isinstance(character, str)
-        or len(character) != 1
-        or not isinstance(panel_symbol, str)
-        or len(panel_symbol) != 1
-        or not isinstance(panel_color, str)
-        or not panel_color
-        or not isinstance(symbol_color, str)
-        or not symbol_color
+        not isinstance(name, str) or
+        not name or
+        kind not in {"prone", "crouching", "walking", "running"} or
+        not isinstance(character, str) or
+        len(character) != 1 or
+        not isinstance(panel_symbol, str) or
+        len(panel_symbol) != 1 or
+        not isinstance(panel_color, str) or
+        not panel_color or
+        not isinstance(symbol_color, str) or
+        not symbol_color
     ):
         result.partial.append(f"{source.location}: movement mode {mode_id}")
         result.todos.append(
@@ -6346,13 +6979,13 @@ def render_tool_quality(source: SourceObject, result: MigrationResult) -> str | 
     if isinstance(usages, list):
         for usage in usages:
             if (
-                isinstance(usage, list)
-                and len(usage) == 2
-                and isinstance(usage[0], int)
-                and not isinstance(usage[0], bool)
-                and 0 <= usage[0] <= NATIVE_INT_MAX
-                and isinstance(usage[1], list)
-                and all(isinstance(text, str) and text for text in usage[1])
+                isinstance(usage, list) and
+                len(usage) == 2 and
+                isinstance(usage[0], int) and
+                not isinstance(usage[0], bool) and
+                0 <= usage[0] <= NATIVE_INT_MAX and
+                isinstance(usage[1], list) and
+                all(isinstance(text, str) and text for text in usage[1])
             ):
                 lines.extend(
                     f"definition:usage({usage[0]}, {lua_quote(text)})"
@@ -6449,11 +7082,11 @@ def render_skill(source: SourceObject, result: MigrationResult) -> str | None:
     if isinstance(companion, list):
         for entry in companion:
             if (
-                isinstance(entry, dict)
-                and safe_platform_id(entry.get("skill"))
-                and isinstance(entry.get("weight"), int)
-                and not isinstance(entry["weight"], bool)
-                and -NATIVE_INT_MAX <= entry["weight"] <= NATIVE_INT_MAX
+                isinstance(entry, dict) and
+                safe_platform_id(entry.get("skill")) and
+                isinstance(entry.get("weight"), int) and
+                not isinstance(entry["weight"], bool) and
+                -NATIVE_INT_MAX <= entry["weight"] <= NATIVE_INT_MAX
             ):
                 lines.append(
                     f"definition:companion_practice({lua_quote(entry['skill'])}, {entry['weight']})"
@@ -6475,11 +7108,11 @@ def render_skill(source: SourceObject, result: MigrationResult) -> str | None:
             continue
         for entry in entries:
             if (
-                isinstance(entry, dict)
-                and isinstance(entry.get("level"), int)
-                and not isinstance(entry["level"], bool)
-                and 0 <= entry["level"] <= NATIVE_MAX_SKILL
-                and display_text(entry.get("description"))
+                isinstance(entry, dict) and
+                isinstance(entry.get("level"), int) and
+                not isinstance(entry["level"], bool) and
+                0 <= entry["level"] <= NATIVE_MAX_SKILL and
+                display_text(entry.get("description"))
             ):
                 description_text = display_text(entry["description"])
                 level_descriptions.setdefault(entry["level"], {})[variant] = description_text
@@ -6597,9 +7230,9 @@ def render_vitamin(source: SourceObject, result: MigrationResult) -> str | None:
         if isinstance(entries, list):
             for entry in entries:
                 if (
-                    isinstance(entry, list)
-                    and len(entry) == 2
-                    and all(isinstance(number, int) and not isinstance(number, bool) and -NATIVE_INT_MAX <= number <= NATIVE_INT_MAX for number in entry)
+                    isinstance(entry, list) and
+                    len(entry) == 2 and
+                    all(isinstance(number, int) and not isinstance(number, bool) and -NATIVE_INT_MAX <= number <= NATIVE_INT_MAX for number in entry)
                 ):
                     lines.append(f"definition:{method}({entry[0]}, {entry[1]})")
                 else:
@@ -6614,12 +7247,12 @@ def render_vitamin(source: SourceObject, result: MigrationResult) -> str | None:
     if isinstance(decays, list):
         for entry in decays:
             if (
-                isinstance(entry, list)
-                and len(entry) == 2
-                and safe_platform_id(entry[0])
-                and isinstance(entry[1], int)
-                and not isinstance(entry[1], bool)
-                and 0 < entry[1] <= NATIVE_INT_MAX
+                isinstance(entry, list) and
+                len(entry) == 2 and
+                safe_platform_id(entry[0]) and
+                isinstance(entry[1], int) and
+                not isinstance(entry[1], bool) and
+                0 < entry[1] <= NATIVE_INT_MAX
             ):
                 lines.append(f"definition:decays_into({lua_quote(entry[0])}, {entry[1]})")
             else:
@@ -7196,28 +7829,580 @@ def render_weapon_category(source: SourceObject, result: MigrationResult) -> str
     )
 
 
+def lua_scalar_literal(value: Any) -> str | None:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, str):
+        return lua_quote(value)
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float) and math.isfinite(value):
+        return lua_number(value)
+    return None
+
+
+def render_eoc_value_expression(value: Any, missing_default: str) -> str | None:
+    literal = lua_scalar_literal(value)
+    if literal is not None:
+        return literal
+    if not isinstance(value, dict) or len(value) != 1:
+        return None
+    key, name = next(iter(value.items()))
+    if (
+        key not in {"context_val", "u_val"} or
+        not isinstance(name, str) or
+        not name or len(name) > 1024 or "\0" in name
+    ):
+        return None
+    quoted = lua_quote(name)
+    if key == "context_val":
+        return f"context.data[{quoted}]"
+    return f"ccb.state.character.get({quoted}, {missing_default})"
+
+
+def render_eoc_string_expression(value: Any) -> str | None:
+    if isinstance(value, str):
+        return lua_quote(value)
+    if isinstance(value, bool) or not isinstance(value, dict):
+        return None
+    rendered = render_eoc_value_expression(value, lua_quote(""))
+    return None if rendered is None else f"tostring(({rendered}) or {lua_quote('')})"
+
+
+def render_eoc_numeric_expression(value: Any, missing_default: str) -> str | None:
+    if isinstance(value, bool) or isinstance(value, str):
+        return None
+    if isinstance(value, (int, float)):
+        return lua_scalar_literal(value)
+    rendered = render_eoc_value_expression(value, missing_default)
+    return None if rendered is None else f"tonumber(({rendered}) or {missing_default})"
+
+
+def render_eoc_condition_expression(
+    condition: Any, avatar_actor_proven: bool = False,
+    weapon_actor_proven: bool = False,
+) -> str | None:
+    """Translate bounded legacy predicates into ordinary Lua composition."""
+    if condition is None:
+        return "true"
+    if isinstance(condition, bool):
+        return "true" if condition else "false"
+    if isinstance(condition, str):
+        if avatar_actor_proven and condition == "u_has_activity":
+            return "service_value(services.activities.snapshot(actor)).active"
+        if weapon_actor_proven and condition == "u_has_weapon":
+            return "character_has_weapon(actor)"
+        if weapon_actor_proven and condition == "u_can_drop_weapon":
+            return "character_can_drop_weapon(actor)"
+        return None
+    if not isinstance(condition, dict):
+        return None
+
+    if (
+        avatar_actor_proven and
+        set(condition) == {"u_has_activity"} and
+        isinstance(condition.get("u_has_activity"), str)
+    ):
+        return "service_value(services.activities.snapshot(actor)).active"
+
+    if set(condition) in ({"and"}, {"or"}):
+        operator = "and" if "and" in condition else "or"
+        entries = condition[operator]
+        if not isinstance(entries, list) or not entries:
+            return None
+        rendered = [
+            render_eoc_condition_expression(
+                entry, avatar_actor_proven, weapon_actor_proven
+            )
+            for entry in entries
+        ]
+        if any(entry is None for entry in rendered):
+            return None
+        return f" {operator} ".join(f"({entry})" for entry in rendered)
+    if set(condition) == {"not"}:
+        rendered = render_eoc_condition_expression(
+            condition["not"], avatar_actor_proven, weapon_actor_proven
+        )
+        return None if rendered is None else f"not ({rendered})"
+
+    for key, function_name, minimum in (
+        ("compare_string", "any_equal", 2),
+        ("compare_string_match_all", "all_equal", 1),
+    ):
+        if set(condition) == {key}:
+            values = condition[key]
+            if not isinstance(values, list) or len(values) < minimum:
+                return None
+            rendered = [
+                render_eoc_string_expression(value)
+                for value in values
+            ]
+            if any(value is None for value in rendered):
+                return None
+            rendered_values = ", ".join(rendered)
+            return (
+                f"services.gameplay.strings.{function_name}"
+                f"({{{rendered_values}}})"
+            )
+
+    if set(condition) == {"one_in_chance"}:
+        value = finite_number_literal(condition["one_in_chance"])
+        if value is None or value < -1000000000 or value > 1000000000:
+            return None
+        return f"services.random.one_in({lua_number(value)})"
+
+    if set(condition) == {"x_in_y_chance"}:
+        chance = condition["x_in_y_chance"]
+        if not isinstance(chance, dict) or set(chance) != {"x", "y"}:
+            return None
+        numerator = finite_number_literal(chance["x"])
+        denominator = finite_number_literal(chance["y"])
+        if (
+            numerator is None or denominator is None or
+            denominator <= 0 or numerator < 0 or numerator > denominator
+        ):
+            return None
+        return (
+            "services.random.probability("
+            f"{lua_number(numerator)}, {lua_number(denominator)})"
+        )
+
+    if set(condition) <= {"roll_contested", "difficulty", "die_size"} and {
+        "roll_contested", "difficulty"
+    } <= set(condition):
+        check = finite_number_literal(condition["roll_contested"])
+        difficulty = finite_number_literal(condition["difficulty"])
+        raw_die_size = condition.get("die_size", 10)
+        die_size = (
+            raw_die_size
+            if isinstance(raw_die_size, int) and
+            not isinstance(raw_die_size, bool)
+            else None
+        )
+        if (
+            check is None or difficulty is None or die_size is None or
+            die_size <= 0 or die_size > 1000000000
+        ):
+            return None
+        return (
+            "services.random.contested("
+            f"{lua_number(check)}, {lua_number(difficulty)}, {die_size})"
+        )
+
+    if set(condition) == {"mod_is_loaded"} and isinstance(
+        condition["mod_is_loaded"], str
+    ):
+        return (
+            "services.gameplay.mods.is_loaded("
+            f"{lua_quote(condition['mod_is_loaded'])})"
+        )
+    if set(condition) == {"current_dimension"} and isinstance(
+        condition["current_dimension"], str
+    ):
+        return (
+            "services.gameplay.environment.dimension() == "
+            f"{lua_quote(condition['current_dimension'])}"
+        )
+    if (
+        avatar_actor_proven and
+        set(condition) == {"u_has_trait"} and
+        safe_platform_id(condition.get("u_has_trait"))
+    ):
+        return (
+            "service_value(services.mutations.has("
+            "actor, "
+            "services.types.id(\"mutation\", "
+            f"{lua_quote(condition['u_has_trait'])})))"
+        )
+    if avatar_actor_proven and set(condition) == {"u_has_any_trait"}:
+        traits = condition.get("u_has_any_trait")
+        if (
+            not isinstance(traits, list) or
+            not traits or
+            not all(safe_platform_id(trait) for trait in traits)
+        ):
+            return None
+        queries = [
+            "service_value(services.mutations.has("
+            "actor, "
+            "services.types.id(\"mutation\", "
+            f"{lua_quote(trait)})))"
+            for trait in traits
+        ]
+        return " or ".join(f"({query})" for query in queries)
+    if (
+        avatar_actor_proven and
+        set(condition) == {"u_has_martial_art"} and
+        safe_platform_id(condition.get("u_has_martial_art"))
+    ):
+        return (
+            "service_value(services.martial_arts.get("
+            "actor, "
+            "services.types.id(\"martial_art\", "
+            f"{lua_quote(condition['u_has_martial_art'])}))).known"
+        )
+    if (
+        avatar_actor_proven and
+        set(condition) == {"u_using_martial_art"} and
+        safe_platform_id(condition.get("u_using_martial_art"))
+    ):
+        return (
+            "service_value(services.martial_arts.get("
+            "actor, "
+            "services.types.id(\"martial_art\", "
+            f"{lua_quote(condition['u_using_martial_art'])}))).selected"
+        )
+    if (
+        avatar_actor_proven and
+        set(condition) == {"u_has_proficiency"} and
+        safe_platform_id(condition.get("u_has_proficiency"))
+    ):
+        return (
+            "service_value(services.proficiencies.get("
+            "actor, "
+            "services.types.id(\"proficiency\", "
+            f"{lua_quote(condition['u_has_proficiency'])}))).known"
+        )
+    if (
+        avatar_actor_proven and
+        set(condition) == {"u_know_recipe"} and
+        safe_platform_id(condition.get("u_know_recipe"))
+    ):
+        return (
+            "service_value(services.recipes.knows("
+            "actor, "
+            "services.types.id(\"recipe\", "
+            f"{lua_quote(condition['u_know_recipe'])})))"
+        )
+    if (
+        avatar_actor_proven and
+        set(condition) == {"u_has_bionics"} and
+        safe_platform_id(condition.get("u_has_bionics"))
+    ):
+        if condition["u_has_bionics"] == "ANY":
+            return "character_has_any_bionic_or_capacity(actor)"
+        return (
+            "service_value(services.bionics.has("
+            "actor, "
+            "services.types.id(\"bionic\", "
+            f"{lua_quote(condition['u_has_bionics'])})))"
+        )
+    if (
+        avatar_actor_proven and
+        set(condition) == {"u_has_item"} and
+        safe_platform_id(condition.get("u_has_item"))
+    ):
+        return (
+            "character_has_item(actor, "
+            f"{lua_quote(condition['u_has_item'])})"
+        )
+    if (
+        avatar_actor_proven and
+        set(condition) == {"u_has_move_mode"} and
+        safe_platform_id(condition.get("u_has_move_mode"))
+    ):
+        return (
+            "service_value(services.characters.snapshot(actor))"
+            ".movement.id == "
+            f"{lua_quote(condition['u_has_move_mode'])}"
+        )
+    if (
+        weapon_actor_proven and
+        set(condition) == {"u_has_wielded_with_flag"} and
+        safe_platform_id(condition.get("u_has_wielded_with_flag")) and
+        len(condition["u_has_wielded_with_flag"].encode("utf-8")) <= 256
+    ):
+        return (
+            "character_wields_with_flag(actor, "
+            "services.types.id(\"json_flag\", "
+            f"{lua_quote(condition['u_has_wielded_with_flag'])}))"
+        )
+    return None
+
+
 def render_eoc(source: SourceObject, result: MigrationResult) -> str:
     value = source.value
     eoc_id = stable_id(value, f"anonymous_{source.index}")
     stable_handler = isinstance(value.get("id"), str) and bool(value["id"])
     handler_id = f"migrated.{eoc_id}"
+    required_event = value.get("required_event")
+    avatar_actor_proven = (
+        required_event == "game_start" and
+        game_start_avatar_actor_is_proven()
+    )
+    item_event_character_actor_proven = (
+        isinstance(required_event, str) and
+        required_event in PROVEN_ITEM_ACTOR_EVENTS
+    )
+    character_actor_proven = (
+        avatar_actor_proven or item_event_character_actor_proven
+    )
+    weapon_actor_proven = character_actor_proven
     lines = [
         f"-- Extracted from {source.location}; review every TODO before enabling.",
         f"runtime.handler({lua_quote(handler_id)}, function(context)",
     ]
+    if avatar_actor_proven:
+        lines.append("    local actor = services.characters.avatar()")
+    elif item_event_character_actor_proven:
+        lines.append("    local actor = context.actors.character")
+    raw_condition = value.get("condition", True)
+    condition_expression = render_eoc_condition_expression(
+        raw_condition, avatar_actor_proven, weapon_actor_proven
+    )
+    condition_converted = condition_expression is not None
+    if condition_expression is None:
+        lines.append("    -- TODO: translate the legacy condition into a Lua predicate.")
+        result.todos.append(
+            f"{source.location}: EOC {eoc_id} condition needs a native Lua predicate"
+        )
+    elif condition_expression != "true":
+        lines.append(f"    if not ({condition_expression}) then")
+        lines.append("        return")
+        lines.append("    end")
     effects = value.get("effect", [])
-    if isinstance(effects, dict):
+    if isinstance(effects, (dict, str)):
         effects = [effects]
     converted_effect = False
     all_effects_converted = True
     if isinstance(effects, list):
         for effect_index, effect in enumerate(effects):
-            if (
-                isinstance(effect, dict)
-                and set(effect) == {"message"}
-                and isinstance(effect.get("message"), str)
+            if avatar_actor_proven and effect == "u_cancel_activity":
+                lines.append("    services.activities.cancel(actor)")
+                converted_effect = True
+            elif (
+                isinstance(effect, dict) and
+                set(effect) == {"message"} and
+                isinstance(effect.get("message"), str)
             ):
                 lines.append(f"    services.message({lua_quote(effect['message'])})")
+                converted_effect = True
+            elif (
+                isinstance(effect, dict) and
+                set(effect) == {"give_achievement"} and
+                safe_platform_id(effect.get("give_achievement"))
+            ):
+                lines.append("    services.achievements.complete(")
+                lines.append(
+                    "        services.types.id(\"achievement\", "
+                    f"{lua_quote(effect['give_achievement'])}))"
+                )
+                converted_effect = True
+            elif (
+                avatar_actor_proven and
+                isinstance(effect, dict) and
+                set(effect) == {"u_add_bionic"} and
+                safe_platform_id(effect.get("u_add_bionic"))
+            ):
+                lines.append("    services.bionics.grant(")
+                lines.append("        actor,")
+                lines.append(
+                    "        services.types.id(\"bionic\", "
+                    f"{lua_quote(effect['u_add_bionic'])}))"
+                )
+                converted_effect = True
+            elif (
+                avatar_actor_proven and
+                isinstance(effect, dict) and
+                set(effect) == {"u_lose_bionic"} and
+                safe_platform_id(effect.get("u_lose_bionic"))
+            ):
+                lines.append("    services.bionics.remove_type(")
+                lines.append("        actor,")
+                lines.append(
+                    "        services.types.id(\"bionic\", "
+                    f"{lua_quote(effect['u_lose_bionic'])}))"
+                )
+                converted_effect = True
+            elif (
+                avatar_actor_proven and
+                isinstance(effect, dict) and
+                set(effect) == {"u_learn_recipe"} and
+                safe_platform_id(effect.get("u_learn_recipe"))
+            ):
+                lines.append("    services.recipes.learn(")
+                lines.append("        actor,")
+                lines.append(
+                    "        services.types.id(\"recipe\", "
+                    f"{lua_quote(effect['u_learn_recipe'])}))"
+                )
+                converted_effect = True
+            elif (
+                avatar_actor_proven and
+                isinstance(effect, dict) and
+                set(effect) in (
+                    {"u_forget_recipe", "category"},
+                    {"u_forget_recipe", "subcategory"},
+                    {"u_forget_recipe", "category", "subcategory"},
+                ) and
+                safe_platform_id(effect.get("u_forget_recipe")) and
+                (
+                    effect.get("category") is True or
+                    "subcategory" in effect
+                ) and
+                (
+                    "subcategory" not in effect or
+                    safe_platform_id(effect.get("subcategory"))
+                )
+            ):
+                lines.append("    services.recipes.forget_category(")
+                lines.append("        actor,")
+                category_suffix = "," if "subcategory" in effect else ")"
+                lines.append(
+                    "        services.types.id(\"crafting_category\", "
+                    f"{lua_quote(effect['u_forget_recipe'])}){category_suffix}"
+                )
+                if "subcategory" in effect:
+                    lines.append(
+                        f"        {lua_quote(effect['subcategory'])})"
+                    )
+                converted_effect = True
+            elif (
+                avatar_actor_proven and
+                isinstance(effect, dict) and
+                set(effect) == {"u_forget_recipe"} and
+                safe_platform_id(effect.get("u_forget_recipe"))
+            ):
+                lines.append("    services.recipes.forget(")
+                lines.append("        actor,")
+                lines.append(
+                    "        services.types.id(\"recipe\", "
+                    f"{lua_quote(effect['u_forget_recipe'])}))"
+                )
+                converted_effect = True
+            elif (
+                avatar_actor_proven and
+                isinstance(effect, dict) and
+                set(effect) == {"u_learn_martial_art"} and
+                safe_platform_id(effect.get("u_learn_martial_art"))
+            ):
+                lines.append("    services.martial_arts.learn(")
+                lines.append("        actor,")
+                lines.append(
+                    "        services.types.id(\"martial_art\", "
+                    f"{lua_quote(effect['u_learn_martial_art'])}))"
+                )
+                converted_effect = True
+            elif (
+                avatar_actor_proven and
+                isinstance(effect, dict) and
+                set(effect) == {"u_forget_martial_art"} and
+                safe_platform_id(effect.get("u_forget_martial_art"))
+            ):
+                lines.append("    services.martial_arts.forget(")
+                lines.append("        actor,")
+                lines.append(
+                    "        services.types.id(\"martial_art\", "
+                    f"{lua_quote(effect['u_forget_martial_art'])}))"
+                )
+                converted_effect = True
+            elif (
+                avatar_actor_proven and
+                isinstance(effect, dict) and
+                set(effect) == {"u_add_effect", "duration"} and
+                safe_platform_id(effect.get("u_add_effect")) and
+                (
+                    effect.get("duration") == "PERMANENT" or
+                    (
+                        isinstance(effect.get("duration"), int) and
+                        not isinstance(effect.get("duration"), bool) and
+                        1 <= effect["duration"] <= MAX_EFFECT_DURATION_TURNS
+                    )
+                )
+            ):
+                permanent = effect["duration"] == "PERMANENT"
+                duration = 1 if permanent else effect["duration"]
+                lines.append("    services.effects.add(")
+                lines.append("        actor,")
+                lines.append(
+                    "        services.types.id(\"effect\", "
+                    f"{lua_quote(effect['u_add_effect'])}),"
+                )
+                suffix = ", { permanent = true })" if permanent else ")"
+                lines.append(
+                    "        services.time.duration("
+                    f"{duration}, \"turn\"){suffix}"
+                )
+                converted_effect = True
+            elif (
+                avatar_actor_proven and
+                isinstance(effect, dict) and
+                set(effect) == {"u_lose_effect"} and
+                safe_platform_id(effect.get("u_lose_effect"))
+            ):
+                lines.append("    services.effects.remove(")
+                lines.append("        actor,")
+                lines.append(
+                    "        services.types.id(\"effect\", "
+                    f"{lua_quote(effect['u_lose_effect'])}))"
+                )
+                converted_effect = True
+            elif (
+                avatar_actor_proven and
+                isinstance(effect, dict) and
+                set(effect) == {"u_add_morale", "bonus", "max_bonus"} and
+                safe_platform_id(effect.get("u_add_morale")) and
+                isinstance(effect.get("bonus"), int) and
+                not isinstance(effect.get("bonus"), bool) and
+                NATIVE_INT_MIN <= effect["bonus"] <= NATIVE_INT_MAX and
+                isinstance(effect.get("max_bonus"), int) and
+                not isinstance(effect.get("max_bonus"), bool) and
+                NATIVE_INT_MIN <= effect["max_bonus"] <= NATIVE_INT_MAX
+            ):
+                lines.append("    services.morale.add(")
+                lines.append("        actor,")
+                lines.append(
+                    "        services.types.id(\"morale\", "
+                    f"{lua_quote(effect['u_add_morale'])}),"
+                )
+                lines.append(
+                    f"        {effect['bonus']}, {effect['max_bonus']})"
+                )
+                converted_effect = True
+            elif (
+                avatar_actor_proven and
+                isinstance(effect, dict) and
+                set(effect) == {"u_lose_morale"} and
+                safe_platform_id(effect.get("u_lose_morale"))
+            ):
+                lines.append("    services.morale.remove(")
+                lines.append("        actor,")
+                lines.append(
+                    "        services.types.id(\"morale\", "
+                    f"{lua_quote(effect['u_lose_morale'])}))"
+                )
+                converted_effect = True
+            elif (
+                item_event_character_actor_proven and
+                isinstance(effect, dict) and
+                set(effect) == {"npc_set_flag"} and
+                safe_platform_id(effect.get("npc_set_flag")) and
+                len(effect["npc_set_flag"].encode("utf-8")) <= 256
+            ):
+                lines.append("    if context.actors.item ~= nil then")
+                lines.append("        services.items.set_flag(")
+                lines.append("            context.actors.item,")
+                lines.append(
+                    "            services.types.id(\"json_flag\", "
+                    f"{lua_quote(effect['npc_set_flag'])}), true)"
+                )
+                lines.append("    end")
+                converted_effect = True
+            elif (
+                item_event_character_actor_proven and
+                isinstance(effect, dict) and
+                set(effect) == {"npc_unset_flag"} and
+                safe_platform_id(effect.get("npc_unset_flag")) and
+                len(effect["npc_unset_flag"].encode("utf-8")) <= 256
+            ):
+                lines.append("    if context.actors.item ~= nil then")
+                lines.append("        services.items.set_flag(")
+                lines.append("            context.actors.item,")
+                lines.append(
+                    "            services.types.id(\"json_flag\", "
+                    f"{lua_quote(effect['npc_unset_flag'])}), false)"
+                )
+                lines.append("    end")
                 converted_effect = True
             else:
                 lines.append("    -- TODO: translate one legacy effect into domain-service calls.")
@@ -7232,7 +8417,6 @@ def render_eoc(source: SourceObject, result: MigrationResult) -> str:
         )
         all_effects_converted = False
     lines.extend(("end)", ""))
-    required_event = value.get("required_event")
     has_trigger = isinstance(required_event, str) and bool(required_event)
     if has_trigger:
         lines.append(f"runtime.on({lua_quote('game:' + required_event)}, {lua_quote(handler_id)})")
@@ -7244,10 +8428,6 @@ def render_eoc(source: SourceObject, result: MigrationResult) -> str:
     unresolved = sorted(
         set(value) - {"type", "id", "eoc_type", "required_event", "effect", "condition"}
     )
-    if value.get("condition") not in (None, True):
-        result.todos.append(
-            f"{source.location}: EOC {eoc_id} condition needs a native Lua predicate"
-        )
     if not stable_handler:
         result.todos.append(
             f"{source.location}: EOC {eoc_id} needs a stable handler id"
@@ -7257,12 +8437,12 @@ def render_eoc(source: SourceObject, result: MigrationResult) -> str:
             f"{source.location}: EOC {eoc_id} unresolved fields: {', '.join(unresolved)}"
         )
     if (
-        stable_handler
-        and converted_effect
-        and all_effects_converted
-        and has_trigger
-        and value.get("condition") in (None, True)
-        and not unresolved
+        stable_handler and
+        converted_effect and
+        all_effects_converted and
+        has_trigger and
+        condition_converted and
+        not unresolved
     ):
         result.converted.append(f"{source.location}: EOC {eoc_id}")
     else:
@@ -7326,7 +8506,9 @@ def migrate(objects: list[SourceObject], mod_id: str) -> MigrationResult:
         "effect_type": [],
         "item_group": [],
         "sub_body_part": [],
+        "wound": [],
         "body_part": [],
+        "wound_fix": [],
         "anatomy": [],
         "body_graph": [],
         "field_type": [],
@@ -7387,11 +8569,19 @@ def migrate(objects: list[SourceObject], mod_id: str) -> MigrationResult:
     behaviour_chunks: list[str] = []
     speech_pools: dict[str, list[tuple[str, int]]] = {}
     snippet_categories: dict[str, dict[str, Any]] = {}
-    metadata: dict[str, Any] | None = None
+    metadata: SourceObject | None = None
     for source in objects:
         kind = source.value.get("type")
         if kind == "MOD_INFO" and metadata is None:
-            metadata = source.value
+            metadata = source
+        elif kind == "MOD_INFO":
+            metadata_id = stable_id(source.value, "<invalid id>")
+            result.partial.append(
+                f"{source.location}: MOD_INFO {metadata_id}"
+            )
+            result.todos.append(
+                f"{source.location}: additional MOD_INFO cannot be represented by one Platform ModDefinition"
+            )
         elif kind in ITEM_TYPES:
             rendered = render_item(source, result)
             if rendered:
@@ -7498,8 +8688,16 @@ def migrate(objects: list[SourceObject], mod_id: str) -> MigrationResult:
             rendered = render_sub_body_part(source, result)
             if rendered:
                 catalog_chunks[kind].append(rendered)
+        elif kind == "wound":
+            rendered = render_wound(source, result)
+            if rendered:
+                catalog_chunks[kind].append(rendered)
         elif kind == "body_part":
             rendered = render_body_part(source, result)
+            if rendered:
+                catalog_chunks[kind].append(rendered)
+        elif kind == "wound_fix":
+            rendered = render_wound_fix(source, result)
             if rendered:
                 catalog_chunks[kind].append(rendered)
         elif kind == "anatomy":
@@ -7712,13 +8910,13 @@ def migrate(objects: list[SourceObject], mod_id: str) -> MigrationResult:
             sound = display_text(value.get("sound"))
             volume = value.get("volume")
             valid = (
-                isinstance(speakers, list)
-                and bool(speakers)
-                and all(safe_platform_id(speaker) for speaker in speakers)
-                and bool(sound)
-                and isinstance(volume, int)
-                and not isinstance(volume, bool)
-                and NATIVE_INT_MIN <= volume <= NATIVE_INT_MAX
+                isinstance(speakers, list) and
+                bool(speakers) and
+                all(safe_platform_id(speaker) for speaker in speakers) and
+                bool(sound) and
+                isinstance(volume, int) and
+                not isinstance(volume, bool) and
+                NATIVE_INT_MIN <= volume <= NATIVE_INT_MAX
             )
             unresolved = unresolved_fields(
                 value, {"type", "speaker", "sound", "volume"}
@@ -7728,8 +8926,8 @@ def migrate(objects: list[SourceObject], mod_id: str) -> MigrationResult:
                     speech_pools.setdefault(speaker, []).append((sound, volume))
             if unresolved:
                 result.todos.append(
-                    f"{source.location}: speech unresolved fields: "
-                    + ", ".join(unresolved)
+                    f"{source.location}: speech unresolved fields: " +
+                    ", ".join(unresolved)
                 )
             if valid and not unresolved:
                 result.converted.append(f"{source.location}: speech line")
@@ -7809,7 +9007,7 @@ def migrate(objects: list[SourceObject], mod_id: str) -> MigrationResult:
         catalog_chunks["speech"].append("\n".join(lines))
 
     for category_id, category in snippet_categories.items():
-        rendered = render_collected_snippet_category( category_id, category )
+        rendered = render_collected_snippet_category(category_id, category)
         if rendered:
             catalog_chunks["snippet"].append(rendered)
 
@@ -7820,6 +9018,109 @@ def migrate(objects: list[SourceObject], mod_id: str) -> MigrationResult:
         "local runtime = ccb.runtime",
         "local services = ccb.services",
     ]
+    needs_character_has_item = any(
+        "character_has_item(" in chunk for chunk in behaviour_chunks
+    )
+    needs_character_has_weapon = any(
+        "character_has_weapon(" in chunk for chunk in behaviour_chunks
+    )
+    needs_character_has_any_bionic_or_capacity = any(
+        "character_has_any_bionic_or_capacity(" in chunk
+        for chunk in behaviour_chunks
+    )
+    needs_character_can_drop_weapon = any(
+        "character_can_drop_weapon(" in chunk for chunk in behaviour_chunks
+    )
+    needs_character_wields_with_flag = any(
+        "character_wields_with_flag(" in chunk for chunk in behaviour_chunks
+    )
+    needs_character_weapon_helpers = (
+        needs_character_has_weapon or
+        needs_character_can_drop_weapon or
+        needs_character_wields_with_flag
+    )
+    if (
+        needs_character_has_item or
+        needs_character_has_any_bionic_or_capacity or
+        needs_character_weapon_helpers or
+        any("service_value(" in chunk for chunk in behaviour_chunks)
+    ):
+        main.extend(
+            (
+                "",
+                "local function service_value(result)",
+                "    if not result.ok then",
+                "        error(result.error.message)",
+                "    end",
+                "    return result.value",
+                "end",
+            )
+        )
+    if needs_character_has_any_bionic_or_capacity:
+        main.extend(
+            (
+                "",
+                "local function character_has_any_bionic_or_capacity(character)",
+                "    local summary = service_value(services.bionics.summary(character))",
+                "    return summary.installed_count > 0 or summary.has_capacity",
+                "end",
+            )
+        )
+    if needs_character_has_weapon:
+        main.extend(
+            (
+                "",
+                "local function character_has_weapon(character)",
+                "    local wielded = service_value(services.inventory.wielded(character))",
+                "    if wielded == nil then",
+                "        return false",
+                "    end",
+                "    local style = service_value(services.martial_arts.current(character))",
+                "    return not style.force_unarmed",
+                "end",
+            )
+        )
+    if needs_character_can_drop_weapon:
+        main.extend(
+            (
+                "",
+                "local function character_can_drop_weapon(character)",
+                "    local wielded = service_value(services.inventory.wielded(character))",
+                "    if wielded == nil then",
+                "        return false",
+                "    end",
+                "    local style = service_value(services.martial_arts.current(character))",
+                "    if style.force_unarmed then",
+                "        return false",
+                "    end",
+                "    local no_unwield = service_value(services.items.has_flag(",
+                "        wielded, services.types.id(\"json_flag\", \"NO_UNWIELD\")))",
+                "    return not no_unwield",
+                "end",
+            )
+        )
+    if needs_character_wields_with_flag:
+        main.extend(
+            (
+                "",
+                "local function character_wields_with_flag(character, flag)",
+                "    local wielded = service_value(services.inventory.wielded(character))",
+                "    return wielded ~= nil and service_value(",
+                "        services.items.has_flag(wielded, flag))",
+                "end",
+            )
+        )
+    if needs_character_has_item:
+        main.extend(
+            (
+                "",
+                "local function character_has_item(character, item_id)",
+                "    local resources = service_value(services.inventory.resources(",
+                "        character, services.types.id(\"item\", item_id), 1))",
+                "    return resources.has_charges or resources.has_amount",
+                "end",
+            )
+        )
     catalog_labels = {
         "ascii_art": "Native ASCII-art definitions",
         "json_flag": "Native JSON-flag definitions",
@@ -7845,7 +9146,9 @@ def migrate(objects: list[SourceObject], mod_id: str) -> MigrationResult:
         "effect_type": "Native effect types",
         "item_group": "Native composable item groups",
         "sub_body_part": "Native sub-body-part definitions",
+        "wound": "Native wound definitions",
         "body_part": "Native body-part definitions",
+        "wound_fix": "Native wound-fix definitions",
         "anatomy": "Native anatomy definitions",
         "body_graph": "Native body-graph definitions",
         "field_type": "Native field types",
@@ -7914,26 +9217,8 @@ def migrate(objects: list[SourceObject], mod_id: str) -> MigrationResult:
     result.files[Path("main.lua")] = "\n".join(main)
 
     if metadata is not None:
-        dependencies = metadata.get("dependencies", [])
-        if not isinstance(dependencies, list):
-            dependencies = []
-        dependency_values = ", ".join(
-            lua_quote(value) for value in dependencies if isinstance(value, str)
-        )
-        name = display_text(metadata.get("name"), mod_id)
-        version = str(metadata.get("version", "0.1.0-migrating"))
-        result.files[Path("mod.lua")] = "\n".join(
-            (
-                'local ccb = require("ccb")',
-                "",
-                "return ccb.ModDefinition {",
-                f"    id = {lua_quote(mod_id)},",
-                f"    name = {lua_quote(name)},",
-                f"    version = {lua_quote(version)},",
-                f"    dependencies = {{ {dependency_values} }},",
-                "}",
-                "",
-            )
+        result.files[Path("mod.lua")] = render_mod_definition(
+            metadata, result, mod_id
         )
     result.files[Path("MIGRATION_REPORT.md")] = render_report(result, mod_id)
     return result

--- a/tools/test_create_lua_mod.py
+++ b/tools/test_create_lua_mod.py
@@ -46,7 +46,9 @@ class CreateLuaModTest(unittest.TestCase):
             sentinel.write_text("author owned\n", encoding="utf-8")
             with self.assertRaises(FileExistsError):
                 create_mod(target, "complete")
-            self.assertEqual(sentinel.read_text(encoding="utf-8"), "author owned\n")
+            self.assertEqual(
+                sentinel.read_text(encoding="utf-8"), "author owned\n"
+            )
 
     def test_file_target_is_never_replaced(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -54,7 +56,9 @@ class CreateLuaModTest(unittest.TestCase):
             target.write_text("author owned\n", encoding="utf-8")
             with self.assertRaises(FileExistsError):
                 create_mod(target, "minimal")
-            self.assertEqual(target.read_text(encoding="utf-8"), "author owned\n")
+            self.assertEqual(
+                target.read_text(encoding="utf-8"), "author owned\n"
+            )
 
     def test_symlink_target_is_never_replaced(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/tools/test_migrate_lua_first.py
+++ b/tools/test_migrate_lua_first.py
@@ -10,6 +10,23 @@ import migrate_lua_first
 
 
 class LuaFirstMigrationTest(unittest.TestCase):
+    def test_game_start_avatar_proof_tracks_the_canonical_sender_set(self) -> None:
+        self.assertEqual(
+            migrate_lua_first.game_start_sender_sites(),
+            migrate_lua_first.EXPECTED_GAME_START_SENDER_SITES,
+        )
+        self.assertTrue(migrate_lua_first.game_start_avatar_actor_is_proven())
+
+        with tempfile.TemporaryDirectory() as temporary:
+            with patch.object(
+                migrate_lua_first, "REPOSITORY_ROOT", Path(temporary)
+            ):
+                migrate_lua_first.game_start_sender_sites.cache_clear()
+                self.assertFalse(
+                    migrate_lua_first.game_start_avatar_actor_is_proven()
+                )
+        migrate_lua_first.game_start_sender_sites.cache_clear()
+
     def test_directory_discovery_prunes_build_caches(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -38,6 +55,71 @@ class LuaFirstMigrationTest(unittest.TestCase):
             )
             objects = migrate_lua_first.load_objects([source])
             self.assertEqual([entry.value["id"] for entry in objects], ["kept"])
+
+    def test_mod_info_and_literal_item_shapes_are_audited_as_bounded(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "source.json"
+            source.write_text(
+                json.dumps(
+                    [
+                        {
+                            "type": "MOD_INFO",
+                            "id": "bounded_mod",
+                            "name": "Bounded Mod",
+                            "version": "1.2.3",
+                            "dependencies": ["dda"],
+                            "core": False,
+                        },
+                        {
+                            "type": "ITEM",
+                            "id": "bounded_item",
+                            "name": "bounded item",
+                        },
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            result = migrate_lua_first.migrate(
+                migrate_lua_first.load_objects([source]), "bounded_mod"
+            )
+            metadata = result.files[Path("mod.lua")]
+            main = result.files[Path("main.lua")]
+
+            self.assertEqual(len(result.converted), 2)
+            self.assertEqual(result.partial, [])
+            self.assertIn('id = "bounded_mod"', metadata)
+            self.assertIn('name = "Bounded Mod"', metadata)
+            self.assertIn('version = "1.2.3"', metadata)
+            self.assertIn('dependencies = { "dda" }', metadata)
+            self.assertIn("core = false", metadata)
+            self.assertIn("content.Item", main)
+            self.assertIn('id = "bounded_item"', main)
+
+    def test_mod_info_reports_every_field_outside_the_bounded_shape(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "source.json"
+            source.write_text(
+                json.dumps(
+                    {
+                        "type": "MOD_INFO",
+                        "id": "bounded_mod",
+                        "name": "Bounded Mod",
+                        "authors": ["Legacy Author"],
+                        "description": "Not silently discarded",
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = migrate_lua_first.migrate(
+                migrate_lua_first.load_objects([source]), "bounded_mod"
+            )
+            report = result.files[Path("MIGRATION_REPORT.md")]
+
+            self.assertEqual(result.converted, [])
+            self.assertEqual(len(result.partial), 1)
+            self.assertIn("MOD_INFO unresolved fields: authors, description", report)
 
     def test_emits_native_lua_and_explicit_todos_without_legacy_calls(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -118,6 +200,1207 @@ class LuaFirstMigrationTest(unittest.TestCase):
             self.assertEqual(len(result.partial), 2)
             self.assertIn("ARMOR subtype", report)
             self.assertIn("inheritance must become", report)
+
+    def test_translates_bounded_eoc_predicates_into_lua_composition(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "source.json"
+            predicates = [
+                {"compare_string": ["a", "b", "a"]},
+                {"compare_string_match_all": ["same", "same"]},
+                {"one_in_chance": 3},
+                {"x_in_y_chance": {"x": 1.5, "y": 4.0}},
+                {"roll_contested": 2, "difficulty": 5, "die_size": 8},
+                {"mod_is_loaded": "dda"},
+                {"current_dimension": "default"},
+                {"u_has_trait": "SAMPLE_TRAIT"},
+                {"u_has_any_trait": ["SAMPLE_TRAIT", "TOUGH"]},
+                {"u_has_martial_art": "style_karate"},
+                {"u_using_martial_art": "style_karate"},
+                {"u_has_proficiency": "prof_knapping"},
+                {"u_has_bionics": "bio_earplugs"},
+                {"u_has_item": "water_clean"},
+                {"u_has_move_mode": "walk"},
+                "u_has_activity",
+                {"u_has_activity": "ignored"},
+                {
+                    "compare_string": [
+                        "expected",
+                        {"context_val": "event_value"},
+                        {"u_val": "remembered_value"},
+                    ]
+                },
+                {
+                    "and": [
+                        {"one_in_chance": 2},
+                        {"not": {"mod_is_loaded": "missing_mod"}},
+                    ]
+                },
+            ]
+            source.write_text(
+                json.dumps(
+                    [
+                        {
+                            "type": "effect_on_condition",
+                            "id": f"predicate_{index}",
+                            "required_event": "game_start",
+                            "condition": predicate,
+                            "effect": {"message": f"predicate {index}"},
+                        }
+                        for index, predicate in enumerate(predicates)
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            result = migrate_lua_first.migrate(
+                migrate_lua_first.load_objects([source]), "predicate_mod"
+            )
+            main = result.files[Path("main.lua")]
+            report = result.files[Path("MIGRATION_REPORT.md")]
+
+            self.assertEqual(len(result.converted), len(predicates))
+            self.assertEqual(result.partial, [])
+            self.assertIn("services.gameplay.strings.any_equal", main)
+            self.assertIn("services.gameplay.strings.all_equal", main)
+            self.assertIn("services.random.one_in(3)", main)
+            self.assertIn("services.random.probability(1.5, 4)", main)
+            self.assertIn("services.random.contested(2, 5, 8)", main)
+            self.assertIn('services.gameplay.mods.is_loaded("dda")', main)
+            self.assertIn(
+                'services.gameplay.environment.dimension() == "default"',
+                main,
+            )
+            self.assertEqual(main.count("local function service_value"), 1)
+            self.assertIn(
+                'services.types.id("mutation", "SAMPLE_TRAIT")',
+                main,
+            )
+            self.assertIn('services.types.id("mutation", "TOUGH")', main)
+            self.assertIn(
+                'services.types.id("martial_art", "style_karate")',
+                main,
+            )
+            self.assertIn(
+                'services.types.id("proficiency", "prof_knapping")',
+                main,
+            )
+            self.assertIn(
+                'services.types.id("bionic", "bio_earplugs")',
+                main,
+            )
+            self.assertIn("services.mutations.has", main)
+            self.assertIn("services.martial_arts.get", main)
+            self.assertIn("services.proficiencies.get", main)
+            self.assertIn("services.bionics.has", main)
+            self.assertEqual(main.count("local function character_has_item"), 1)
+            self.assertIn("services.inventory.resources", main)
+            self.assertIn('services.types.id("item", item_id)', main)
+            self.assertIn('character_has_item(actor, "water_clean")', main)
+            self.assertIn("services.characters.snapshot(actor)", main)
+            self.assertIn('.movement.id == "walk"', main)
+            self.assertIn("services.activities.snapshot(actor)", main)
+            self.assertIn('tostring((context.data["event_value"]) or "")', main)
+            self.assertIn(
+                'tostring((ccb.state.character.get("remembered_value", "")) or "")',
+                main,
+            )
+            self.assertIn("not (services.gameplay.mods.is_loaded", main)
+            self.assertNotIn("condition needs a native Lua predicate", report)
+
+    def test_translates_bounded_weapon_predicates_for_proven_u_actors(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "source.json"
+            cases = [
+                ("game_start", "u_has_weapon"),
+                ("game_start", "u_can_drop_weapon"),
+                (
+                    "game_start",
+                    {"u_has_wielded_with_flag": "SPEAR"},
+                ),
+                ("character_wields_item", "u_has_weapon"),
+                ("character_wears_item", "u_can_drop_weapon"),
+                (
+                    "character_takeoff_item",
+                    {"u_has_wielded_with_flag": "DURABLE_MELEE"},
+                ),
+                (
+                    "character_armor_destroyed",
+                    {"not": "u_has_weapon"},
+                ),
+            ]
+            source.write_text(
+                json.dumps(
+                    [
+                        {
+                            "type": "effect_on_condition",
+                            "id": f"weapon_{index}",
+                            "required_event": event,
+                            "condition": condition,
+                            "effect": {"message": "bounded weapon predicate"},
+                        }
+                        for index, (event, condition) in enumerate(cases)
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            result = migrate_lua_first.migrate(
+                migrate_lua_first.load_objects([source]), "weapon_mod"
+            )
+            main = result.files[Path("main.lua")]
+
+            self.assertEqual(len(result.converted), len(cases))
+            self.assertEqual(result.partial, [])
+            self.assertEqual(main.count("local function character_has_weapon"), 1)
+            self.assertEqual(
+                main.count("local function character_can_drop_weapon"), 1
+            )
+            self.assertEqual(
+                main.count("local function character_wields_with_flag"), 1
+            )
+            self.assertIn("services.inventory.wielded(character)", main)
+            self.assertIn("services.martial_arts.current(character)", main)
+            self.assertIn("return not style.force_unarmed", main)
+            self.assertIn('services.types.id("json_flag", "NO_UNWIELD")', main)
+            self.assertIn("services.items.has_flag(wielded, flag)", main)
+            self.assertIn('services.types.id("json_flag", "SPEAR")', main)
+            self.assertIn(
+                'services.types.id("json_flag", "DURABLE_MELEE")', main
+            )
+            self.assertEqual(
+                main.count("local actor = context.actors.character"), 4
+            )
+            self.assertIn("local actor = services.characters.avatar()", main)
+            self.assertNotIn("context.alpha", main)
+            self.assertNotIn("context.beta", main)
+
+    def test_weapon_predicates_without_exact_shape_or_actor_proof_stay_partial(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "source.json"
+            cases = [
+                ("character_kills_monster", "u_has_weapon"),
+                ("game_start", "npc_has_weapon"),
+                ("character_wields_item", "npc_can_drop_weapon"),
+                ([], "u_has_weapon"),
+                ("game_start", {"u_has_weapon": True}),
+                (
+                    "game_start",
+                    {
+                        "u_has_wielded_with_flag": {
+                            "context_val": "dynamic_flag"
+                        }
+                    },
+                ),
+                (
+                    "game_start",
+                    {"npc_has_wielded_with_flag": "SPEAR"},
+                ),
+                (
+                    "game_start",
+                    {"u_has_wielded_with_flag": "X" * 257},
+                ),
+            ]
+            source.write_text(
+                json.dumps(
+                    [
+                        {
+                            "type": "effect_on_condition",
+                            "id": f"unsafe_weapon_{index}",
+                            "required_event": event,
+                            "condition": condition,
+                            "effect": {"message": "must remain partial"},
+                        }
+                        for index, (event, condition) in enumerate(cases)
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            result = migrate_lua_first.migrate(
+                migrate_lua_first.load_objects([source]), "weapon_mod"
+            )
+            main = result.files[Path("main.lua")]
+            report = result.files[Path("MIGRATION_REPORT.md")]
+
+            self.assertEqual(result.converted, [])
+            self.assertEqual(len(result.partial), len(cases))
+            self.assertNotIn("local function character_has_weapon", main)
+            self.assertNotIn("local function character_can_drop_weapon", main)
+            self.assertNotIn("local function character_wields_with_flag", main)
+            self.assertNotIn("services.inventory.wielded", main)
+            self.assertEqual(
+                report.count("condition needs a native Lua predicate"),
+                len(cases),
+            )
+
+    def test_item_event_npc_flag_effects_use_optional_item_actor_guard(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "source.json"
+            cases = [
+                ("character_wields_item", {"npc_set_flag": "FILTHY"}),
+                ("character_wears_item", {"npc_unset_flag": "WET"}),
+                ("character_takeoff_item", {"npc_set_flag": "FIT"}),
+                (
+                    "character_armor_destroyed",
+                    {"npc_unset_flag": "NO_UNWIELD"},
+                ),
+            ]
+            source.write_text(
+                json.dumps(
+                    [
+                        {
+                            "type": "effect_on_condition",
+                            "id": f"item_flag_{index}",
+                            "required_event": event,
+                            "effect": effect,
+                        }
+                        for index, (event, effect) in enumerate(cases)
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            result = migrate_lua_first.migrate(
+                migrate_lua_first.load_objects([source]), "item_flag_mod"
+            )
+            main = result.files[Path("main.lua")]
+
+            self.assertEqual(len(result.converted), len(cases))
+            self.assertEqual(result.partial, [])
+            self.assertEqual(
+                main.count("if context.actors.item ~= nil then"), len(cases)
+            )
+            self.assertEqual(
+                main.count("services.items.set_flag("), len(cases)
+            )
+            self.assertIn('services.types.id("json_flag", "FILTHY"), true)', main)
+            self.assertIn('services.types.id("json_flag", "WET"), false)', main)
+            self.assertNotIn("context.alpha", main)
+            self.assertNotIn("context.beta", main)
+
+    def test_unsafe_or_wrong_talker_flag_effects_never_emit_item_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "source.json"
+            cases = [
+                ("game_start", {"npc_set_flag": "FILTHY"}),
+                ("character_kills_monster", {"npc_unset_flag": "WET"}),
+                ("character_wields_item", {"u_set_flag": "FILTHY"}),
+                ("character_wears_item", {"u_unset_flag": "WET"}),
+                (
+                    "character_takeoff_item",
+                    {"npc_set_flag": {"context_val": "dynamic_flag"}},
+                ),
+                (
+                    "character_armor_destroyed",
+                    {"npc_unset_flag": "X" * 257},
+                ),
+            ]
+            source.write_text(
+                json.dumps(
+                    [
+                        {
+                            "type": "effect_on_condition",
+                            "id": f"unsafe_item_flag_{index}",
+                            "required_event": event,
+                            "effect": effect,
+                        }
+                        for index, (event, effect) in enumerate(cases)
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            result = migrate_lua_first.migrate(
+                migrate_lua_first.load_objects([source]), "item_flag_mod"
+            )
+            main = result.files[Path("main.lua")]
+            report = result.files[Path("MIGRATION_REPORT.md")]
+
+            self.assertEqual(result.converted, [])
+            self.assertEqual(len(result.partial), len(cases))
+            self.assertNotIn("services.items.set_flag", main)
+            self.assertEqual(
+                report.count("effect #0 needs domain-service conversion"),
+                len(cases),
+            )
+
+    def test_literal_character_wound_changes_remain_partial(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "source.json"
+            source.write_text(
+                json.dumps(
+                    [
+                        {
+                            "type": "effect_on_condition",
+                            "id": "add_avatar_wound",
+                            "required_event": "game_start",
+                            "effect": {
+                                "u_add_wound": "arm_l",
+                                "wound_id": "scratch",
+                            },
+                        },
+                        {
+                            "type": "effect_on_condition",
+                            "id": "remove_avatar_wounds",
+                            "required_event": "game_start",
+                            "effect": {
+                                "u_remove_wound": "arm_l",
+                                "wound_id": ["scratch", "deep_scratch"],
+                            },
+                        },
+                        {
+                            "type": "effect_on_condition",
+                            "id": "add_named_character_wound",
+                            "required_event": "character_wields_item",
+                            "effect": {
+                                "u_add_wound": "hand_r",
+                                "wound_id": "cut",
+                            },
+                        },
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            result = migrate_lua_first.migrate(
+                migrate_lua_first.load_objects([source]), "wound_mod"
+            )
+            main = result.files[Path("main.lua")]
+            report = result.files[Path("MIGRATION_REPORT.md")]
+
+            self.assertEqual(result.converted, [])
+            self.assertEqual(len(result.partial), 3)
+            self.assertNotIn("services.wounds.add", main)
+            self.assertNotIn("services.wounds.remove", main)
+            self.assertIn("local actor = services.characters.avatar()", main)
+            self.assertIn("local actor = context.actors.character", main)
+            self.assertEqual(
+                report.count("effect #0 needs domain-service conversion"),
+                3,
+            )
+            self.assertNotIn("context.alpha", main)
+            self.assertNotIn("context.beta", main)
+            self.assertNotIn("run_eoc", main)
+
+    def test_unproven_or_nonliteral_wound_shapes_remain_partial(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "source.json"
+            cases = [
+                (
+                    "game_start",
+                    {"npc_add_wound": "arm_l", "wound_id": "scratch"},
+                ),
+                (
+                    "game_start",
+                    {
+                        "npc_remove_wound": "arm_l",
+                        "wound_id": ["scratch"],
+                    },
+                ),
+                (
+                    "character_kills_monster",
+                    {"u_add_wound": "arm_l", "wound_id": "scratch"},
+                ),
+                (
+                    "game_start",
+                    {
+                        "u_add_wound": {"context_val": "body_part"},
+                        "wound_id": "scratch",
+                    },
+                ),
+                (
+                    "game_start",
+                    {
+                        "u_add_wound": "arm_l",
+                        "wound_id": {"context_val": "wound"},
+                    },
+                ),
+                (
+                    "game_start",
+                    {"u_remove_wound": "arm_l", "wound_id": "scratch"},
+                ),
+                (
+                    "game_start",
+                    {"u_remove_wound": "arm_l", "wound_id": []},
+                ),
+                (
+                    "game_start",
+                    {
+                        "u_remove_wound": "arm_l",
+                        "wound_id": ["scratch", {"context_val": "wound"}],
+                    },
+                ),
+                (
+                    "game_start",
+                    {
+                        "u_add_wound": "arm_l",
+                        "wound_id": "scratch",
+                        "unexpected": True,
+                    },
+                ),
+                (
+                    [],
+                    {"u_add_wound": "arm_l", "wound_id": "scratch"},
+                ),
+            ]
+            source.write_text(
+                json.dumps(
+                    [
+                        {
+                            "type": "effect_on_condition",
+                            "id": f"unsafe_wound_{index}",
+                            "required_event": event,
+                            "effect": effect,
+                        }
+                        for index, (event, effect) in enumerate(cases)
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            result = migrate_lua_first.migrate(
+                migrate_lua_first.load_objects([source]), "wound_mod"
+            )
+            main = result.files[Path("main.lua")]
+            report = result.files[Path("MIGRATION_REPORT.md")]
+
+            self.assertEqual(result.converted, [])
+            self.assertEqual(len(result.partial), len(cases))
+            self.assertNotIn("services.wounds.add", main)
+            self.assertNotIn("services.wounds.remove", main)
+            self.assertEqual(
+                report.count("effect #0 needs domain-service conversion"),
+                len(cases),
+            )
+
+    def test_dynamic_or_out_of_contract_random_conditions_stay_partial(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "source.json"
+            predicates = [
+                {"one_in_chance": {"context_val": "denominator"}},
+                {
+                    "x_in_y_chance": {
+                        "x": {"context_val": "chance"},
+                        "y": 10,
+                    }
+                },
+                {"x_in_y_chance": {"x": 2, "y": 1}},
+                {
+                    "roll_contested": 2,
+                    "difficulty": 5,
+                    "die_size": {"context_val": "die_size"},
+                },
+                {"roll_contested": 2, "difficulty": 5, "die_size": 0},
+            ]
+            source.write_text(
+                json.dumps(
+                    [
+                        {
+                            "type": "effect_on_condition",
+                            "id": f"unsafe_random_{index}",
+                            "required_event": "game_start",
+                            "condition": predicate,
+                            "effect": {"message": "bounded only"},
+                        }
+                        for index, predicate in enumerate(predicates)
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            result = migrate_lua_first.migrate(
+                migrate_lua_first.load_objects([source]), "predicate_mod"
+            )
+            main = result.files[Path("main.lua")]
+            report = result.files[Path("MIGRATION_REPORT.md")]
+
+            self.assertEqual(result.converted, [])
+            self.assertEqual(len(result.partial), len(predicates))
+            self.assertNotIn("services.random.one_in", main)
+            self.assertNotIn("services.random.probability", main)
+            self.assertNotIn("services.random.contested", main)
+            self.assertEqual(
+                report.count("condition needs a native Lua predicate"),
+                len(predicates),
+            )
+
+    def test_translates_bionic_any_and_literal_recipe_knowledge(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "source.json"
+            source.write_text(
+                json.dumps(
+                    [
+                        {
+                            "type": "effect_on_condition",
+                            "id": "has_any_bionic_or_power",
+                            "required_event": "game_start",
+                            "condition": {"u_has_bionics": "ANY"},
+                            "effect": {"message": "powered"},
+                        },
+                        {
+                            "type": "effect_on_condition",
+                            "id": "knows_recipe",
+                            "required_event": "game_start",
+                            "condition": {
+                                "u_know_recipe": "cudgel_test_no_tools"
+                            },
+                            "effect": {"message": "known"},
+                        },
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            result = migrate_lua_first.migrate(
+                migrate_lua_first.load_objects([source]), "predicate_mod"
+            )
+            main = result.files[Path("main.lua")]
+
+            self.assertEqual(len(result.converted), 2)
+            self.assertEqual(result.partial, [])
+            self.assertEqual(
+                main.count("local function character_has_any_bionic_or_capacity"),
+                1,
+            )
+            self.assertIn("services.bionics.summary(character)", main)
+            self.assertIn(
+                "summary.installed_count > 0 or summary.has_capacity",
+                main,
+            )
+            self.assertIn("services.recipes.knows", main)
+            self.assertIn(
+                'services.types.id("recipe", "cudgel_test_no_tools")',
+                main,
+            )
+            self.assertNotIn("run_eoc", main)
+
+    def test_dynamic_or_unproven_bionic_and_recipe_conditions_stay_partial(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "source.json"
+            source.write_text(
+                json.dumps(
+                    [
+                        {
+                            "type": "effect_on_condition",
+                            "id": "unproven_any_bionic",
+                            "required_event": "character_kills_monster",
+                            "condition": {"u_has_bionics": "ANY"},
+                            "effect": {"message": "bounded only"},
+                        },
+                        {
+                            "type": "effect_on_condition",
+                            "id": "dynamic_bionic",
+                            "required_event": "game_start",
+                            "condition": {
+                                "u_has_bionics": {"context_val": "bionic_id"}
+                            },
+                            "effect": {"message": "bounded only"},
+                        },
+                        {
+                            "type": "effect_on_condition",
+                            "id": "dynamic_recipe",
+                            "required_event": "game_start",
+                            "condition": {
+                                "u_know_recipe": {"context_val": "recipe_id"}
+                            },
+                            "effect": {"message": "bounded only"},
+                        },
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            result = migrate_lua_first.migrate(
+                migrate_lua_first.load_objects([source]), "predicate_mod"
+            )
+            main = result.files[Path("main.lua")]
+            report = result.files[Path("MIGRATION_REPORT.md")]
+
+            self.assertEqual(result.converted, [])
+            self.assertEqual(len(result.partial), 3)
+            self.assertNotIn("services.bionics.summary", main)
+            self.assertNotIn("services.recipes.knows", main)
+            self.assertEqual(
+                report.count("condition needs a native Lua predicate"),
+                3,
+            )
+
+    def test_translates_proven_avatar_activity_cancellation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "source.json"
+            source.write_text(
+                json.dumps(
+                    {
+                        "type": "effect_on_condition",
+                        "id": "cancel_activity",
+                        "required_event": "game_start",
+                        "effect": "u_cancel_activity",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            result = migrate_lua_first.migrate(
+                migrate_lua_first.load_objects([source]), "activity_mod"
+            )
+            main = result.files[Path("main.lua")]
+
+            self.assertEqual(len(result.converted), 1)
+            self.assertEqual(result.partial, [])
+            self.assertIn("local actor = services.characters.avatar()", main)
+            self.assertIn("services.activities.cancel(actor)", main)
+            self.assertNotIn("run_eoc", main)
+
+    def test_item_presence_emits_its_result_helper_when_used_alone(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "source.json"
+            source.write_text(
+                json.dumps(
+                    {
+                        "type": "effect_on_condition",
+                        "id": "has_water",
+                        "required_event": "game_start",
+                        "condition": {"u_has_item": "water_clean"},
+                        "effect": {"message": "water found"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            result = migrate_lua_first.migrate(
+                migrate_lua_first.load_objects([source]), "inventory_mod"
+            )
+            main = result.files[Path("main.lua")]
+
+            self.assertEqual(len(result.converted), 1)
+            self.assertEqual(result.partial, [])
+            self.assertEqual(main.count("local function service_value"), 1)
+            self.assertEqual(main.count("local function character_has_item"), 1)
+            self.assertIn("resources.has_charges or resources.has_amount", main)
+
+    def test_translates_achievement_awards_without_an_eoc_runner(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "source.json"
+            source.write_text(
+                json.dumps(
+                    {
+                        "type": "effect_on_condition",
+                        "id": "award",
+                        "required_event": "game_start",
+                        "effect": {
+                            "give_achievement": "achievement_reach_string_dimension"
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            result = migrate_lua_first.migrate(
+                migrate_lua_first.load_objects([source]), "achievement_mod"
+            )
+            main = result.files[Path("main.lua")]
+
+            self.assertEqual(len(result.converted), 1)
+            self.assertEqual(result.partial, [])
+            self.assertIn("services.achievements.complete", main)
+            self.assertIn(
+                'services.types.id("achievement", '
+                '"achievement_reach_string_dimension")',
+                main,
+            )
+            self.assertNotIn("run_eoc", main)
+
+    def test_translates_avatar_bionic_install_without_a_dialogue_actor(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "source.json"
+            source.write_text(
+                json.dumps(
+                    {
+                        "type": "effect_on_condition",
+                        "id": "install_bionic",
+                        "required_event": "game_start",
+                        "effect": {"u_add_bionic": "bio_earplugs"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            result = migrate_lua_first.migrate(
+                migrate_lua_first.load_objects([source]), "bionic_mod"
+            )
+            main = result.files[Path("main.lua")]
+
+            self.assertEqual(len(result.converted), 1)
+            self.assertEqual(result.partial, [])
+            self.assertIn("services.bionics.grant", main)
+            self.assertIn("local actor = services.characters.avatar()", main)
+            self.assertNotIn("context.alpha", main)
+            self.assertIn(
+                'services.types.id("bionic", "bio_earplugs")',
+                main,
+            )
+            self.assertNotIn("run_eoc", main)
+
+    def test_translates_avatar_bionic_removal_by_type(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "source.json"
+            source.write_text(
+                json.dumps(
+                    {
+                        "type": "effect_on_condition",
+                        "id": "remove_bionic",
+                        "required_event": "game_start",
+                        "effect": {"u_lose_bionic": "bio_earplugs"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            result = migrate_lua_first.migrate(
+                migrate_lua_first.load_objects([source]), "bionic_mod"
+            )
+            main = result.files[Path("main.lua")]
+
+            self.assertEqual(len(result.converted), 1)
+            self.assertEqual(result.partial, [])
+            self.assertIn("services.bionics.remove_type", main)
+            self.assertIn("local actor = services.characters.avatar()", main)
+            self.assertNotIn("context.alpha", main)
+            self.assertIn(
+                'services.types.id("bionic", "bio_earplugs")',
+                main,
+            )
+            self.assertNotIn("run_eoc", main)
+
+    def test_translates_avatar_recipe_learning_without_a_dialogue_actor(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "source.json"
+            source.write_text(
+                json.dumps(
+                    {
+                        "type": "effect_on_condition",
+                        "id": "learn_recipe",
+                        "required_event": "game_start",
+                        "effect": {"u_learn_recipe": "cudgel_test_no_tools"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            result = migrate_lua_first.migrate(
+                migrate_lua_first.load_objects([source]), "recipe_mod"
+            )
+            main = result.files[Path("main.lua")]
+
+            self.assertEqual(len(result.converted), 1)
+            self.assertEqual(result.partial, [])
+            self.assertIn("services.recipes.learn", main)
+            self.assertIn("local actor = services.characters.avatar()", main)
+            self.assertNotIn("context.alpha", main)
+            self.assertIn(
+                'services.types.id("recipe", "cudgel_test_no_tools")',
+                main,
+            )
+            self.assertNotIn("run_eoc", main)
+
+    def test_translates_avatar_recipe_and_literal_category_forgetting(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "source.json"
+            source.write_text(
+                json.dumps(
+                    [
+                        {
+                            "type": "effect_on_condition",
+                            "id": "forget_recipe",
+                            "required_event": "game_start",
+                            "effect": {"u_forget_recipe": "cudgel_test_no_tools"},
+                        },
+                        {
+                            "type": "effect_on_condition",
+                            "id": "forget_category",
+                            "required_event": "game_start",
+                            "effect": {
+                                "u_forget_recipe": "CC_FOOD",
+                                "category": True,
+                            },
+                        },
+                        {
+                            "type": "effect_on_condition",
+                            "id": "forget_subcategory",
+                            "required_event": "game_start",
+                            "effect": {
+                                "u_forget_recipe": "CC_FOOD",
+                                "subcategory": "CSC_FOOD_DRINKS",
+                            },
+                        },
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            result = migrate_lua_first.migrate(
+                migrate_lua_first.load_objects([source]), "recipe_mod"
+            )
+            main = result.files[Path("main.lua")]
+
+            self.assertEqual(len(result.converted), 3)
+            self.assertEqual(result.partial, [])
+            self.assertIn("services.recipes.forget", main)
+            self.assertIn(
+                'services.types.id("recipe", "cudgel_test_no_tools")',
+                main,
+            )
+            self.assertEqual(main.count("services.recipes.forget_category"), 2)
+            self.assertEqual(
+                main.count(
+                    'services.types.id("crafting_category", "CC_FOOD")'
+                ),
+                2,
+            )
+            self.assertIn(
+                '"CSC_FOOD_DRINKS")',
+                main,
+            )
+            self.assertNotIn("run_eoc", main)
+
+    def test_dynamic_recipe_category_forgetting_stays_partial(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "source.json"
+            source.write_text(
+                json.dumps(
+                    [
+                        {
+                            "type": "effect_on_condition",
+                            "id": "dynamic_category",
+                            "required_event": "game_start",
+                            "effect": {
+                                "u_forget_recipe": {
+                                    "context_val": "category_id"
+                                },
+                                "category": True,
+                            },
+                        },
+                        {
+                            "type": "effect_on_condition",
+                            "id": "dynamic_subcategory",
+                            "required_event": "game_start",
+                            "effect": {
+                                "u_forget_recipe": "CC_FOOD",
+                                "subcategory": {
+                                    "context_val": "subcategory_id"
+                                },
+                            },
+                        },
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            result = migrate_lua_first.migrate(
+                migrate_lua_first.load_objects([source]), "recipe_mod"
+            )
+            main = result.files[Path("main.lua")]
+            report = result.files[Path("MIGRATION_REPORT.md")]
+
+            self.assertEqual(result.converted, [])
+            self.assertEqual(len(result.partial), 2)
+            self.assertNotIn("services.recipes.forget_category", main)
+            self.assertEqual(
+                report.count("effect #0 needs domain-service conversion"),
+                2,
+            )
+
+    def test_translates_avatar_martial_art_learning_and_forgetting(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "source.json"
+            source.write_text(
+                json.dumps(
+                    [
+                        {
+                            "type": "effect_on_condition",
+                            "id": "learn_style",
+                            "required_event": "game_start",
+                            "effect": {"u_learn_martial_art": "style_karate"},
+                        },
+                        {
+                            "type": "effect_on_condition",
+                            "id": "forget_style",
+                            "required_event": "game_start",
+                            "effect": {"u_forget_martial_art": "style_karate"},
+                        },
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            result = migrate_lua_first.migrate(
+                migrate_lua_first.load_objects([source]), "martial_art_mod"
+            )
+            main = result.files[Path("main.lua")]
+
+            self.assertEqual(len(result.converted), 2)
+            self.assertEqual(result.partial, [])
+            self.assertIn("services.martial_arts.learn", main)
+            self.assertIn("services.martial_arts.forget", main)
+            self.assertIn("local actor = services.characters.avatar()", main)
+            self.assertNotIn("context.alpha", main)
+            self.assertIn(
+                'services.types.id("martial_art", "style_karate")',
+                main,
+            )
+            self.assertNotIn("run_eoc", main)
+
+    def test_translates_bounded_avatar_morale_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "source.json"
+            source.write_text(
+                json.dumps(
+                    [
+                        {
+                            "type": "effect_on_condition",
+                            "id": "add_morale",
+                            "required_event": "game_start",
+                            "effect": {
+                                "u_add_morale": "morale_feeling_good",
+                                "bonus": 10,
+                                "max_bonus": 50,
+                            },
+                        },
+                        {
+                            "type": "effect_on_condition",
+                            "id": "remove_morale",
+                            "required_event": "game_start",
+                            "effect": {"u_lose_morale": "morale_feeling_good"},
+                        },
+                        {
+                            "type": "effect_on_condition",
+                            "id": "timed_morale",
+                            "required_event": "game_start",
+                            "effect": {
+                                "u_add_morale": "morale_feeling_good",
+                                "bonus": 10,
+                                "max_bonus": 50,
+                                "duration": "2 hours",
+                            },
+                        },
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            result = migrate_lua_first.migrate(
+                migrate_lua_first.load_objects([source]), "morale_mod"
+            )
+            main = result.files[Path("main.lua")]
+            report = result.files[Path("MIGRATION_REPORT.md")]
+
+            self.assertEqual(len(result.converted), 2)
+            self.assertEqual(len(result.partial), 1)
+            self.assertIn("services.morale.add", main)
+            self.assertIn("services.morale.remove", main)
+            self.assertIn(
+                'services.types.id("morale", "morale_feeling_good")',
+                main,
+            )
+            self.assertIn("10, 50)", main)
+            self.assertIn(
+                "EOC timed_morale effect #0 needs domain-service conversion",
+                report,
+            )
+            self.assertNotIn("run_eoc", main)
+
+    def test_unsupported_timed_morale_never_emits_a_service_call(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "source.json"
+            source.write_text(
+                json.dumps(
+                    {
+                        "type": "effect_on_condition",
+                        "id": "timed_morale_only",
+                        "required_event": "game_start",
+                        "effect": {
+                            "u_add_morale": "morale_feeling_good",
+                            "bonus": 10,
+                            "max_bonus": 50,
+                            "duration": "2 hours",
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            result = migrate_lua_first.migrate(
+                migrate_lua_first.load_objects([source]), "morale_mod"
+            )
+            main = result.files[Path("main.lua")]
+
+            self.assertEqual(result.converted, [])
+            self.assertEqual(len(result.partial), 1)
+            self.assertNotIn("services.morale.add", main)
+            self.assertNotIn("services.morale.remove", main)
+            self.assertNotIn("run_eoc", main)
+
+    def test_translates_only_bounded_literal_avatar_effect_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "source.json"
+            source.write_text(
+                json.dumps(
+                    [
+                        {
+                            "type": "effect_on_condition",
+                            "id": "add_timed_effect",
+                            "required_event": "game_start",
+                            "effect": {
+                                "u_add_effect": "downed",
+                                "duration": 60,
+                            },
+                        },
+                        {
+                            "type": "effect_on_condition",
+                            "id": "add_permanent_effect",
+                            "required_event": "game_start",
+                            "effect": {
+                                "u_add_effect": "incorporeal",
+                                "duration": "PERMANENT",
+                            },
+                        },
+                        {
+                            "type": "effect_on_condition",
+                            "id": "remove_effect",
+                            "required_event": "game_start",
+                            "effect": {"u_lose_effect": "downed"},
+                        },
+                        {
+                            "type": "effect_on_condition",
+                            "id": "zero_duration",
+                            "required_event": "game_start",
+                            "effect": {"u_add_effect": "blind", "duration": 0},
+                        },
+                        {
+                            "type": "effect_on_condition",
+                            "id": "effect_options",
+                            "required_event": "game_start",
+                            "effect": {
+                                "u_add_effect": "bleed",
+                                "duration": 60,
+                                "intensity": 2,
+                            },
+                        },
+                        {
+                            "type": "effect_on_condition",
+                            "id": "variable_remove_bug_compatibility",
+                            "required_event": "game_start",
+                            "effect": {
+                                "u_lose_effect": {"context_val": "effect_id"}
+                            },
+                        },
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            result = migrate_lua_first.migrate(
+                migrate_lua_first.load_objects([source]), "effect_mod"
+            )
+            main = result.files[Path("main.lua")]
+            report = result.files[Path("MIGRATION_REPORT.md")]
+
+            self.assertEqual(len(result.converted), 3)
+            self.assertEqual(len(result.partial), 3)
+            self.assertIn("services.effects.add", main)
+            self.assertIn("services.effects.remove", main)
+            self.assertIn(
+                'services.types.id("effect", "downed")',
+                main,
+            )
+            self.assertIn('services.time.duration(60, "turn")', main)
+            self.assertIn(
+                'services.time.duration(1, "turn"), { permanent = true }',
+                main,
+            )
+            self.assertIn(
+                "EOC zero_duration effect #0 needs domain-service conversion",
+                report,
+            )
+            self.assertIn(
+                "EOC effect_options effect #0 needs domain-service conversion",
+                report,
+            )
+            self.assertIn(
+                "EOC variable_remove_bug_compatibility effect #0 needs "
+                "domain-service conversion",
+                report,
+            )
+            self.assertNotIn("run_eoc", main)
+
+    def test_unsupported_effect_shapes_never_emit_effect_service_calls(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "source.json"
+            source.write_text(
+                json.dumps(
+                    [
+                        {
+                            "type": "effect_on_condition",
+                            "id": "zero_duration",
+                            "required_event": "game_start",
+                            "effect": {"u_add_effect": "blind", "duration": 0},
+                        },
+                        {
+                            "type": "effect_on_condition",
+                            "id": "effect_options",
+                            "required_event": "game_start",
+                            "effect": {
+                                "u_add_effect": "bleed",
+                                "duration": 60,
+                                "intensity": 2,
+                            },
+                        },
+                        {
+                            "type": "effect_on_condition",
+                            "id": "variable_remove",
+                            "required_event": "game_start",
+                            "effect": {
+                                "u_lose_effect": {"context_val": "effect_id"}
+                            },
+                        },
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            result = migrate_lua_first.migrate(
+                migrate_lua_first.load_objects([source]), "effect_mod"
+            )
+            main = result.files[Path("main.lua")]
+
+            self.assertEqual(result.converted, [])
+            self.assertEqual(len(result.partial), 3)
+            self.assertNotIn("services.effects.add", main)
+            self.assertNotIn("services.effects.remove", main)
+            self.assertNotIn("run_eoc", main)
+
+    def test_keeps_actor_dependent_u_shapes_partial_without_avatar_proof(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "source.json"
+            source.write_text(
+                json.dumps(
+                    {
+                        "type": "effect_on_condition",
+                        "id": "ambiguous_alpha",
+                        "required_event": "character_kills_monster",
+                        "condition": {"u_has_trait": "TOUGH"},
+                        "effect": {
+                            "u_add_effect": "downed",
+                            "duration": 1,
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            result = migrate_lua_first.migrate(
+                migrate_lua_first.load_objects([source]), "actor_mod"
+            )
+            main = result.files[Path("main.lua")]
+            report = result.files[Path("MIGRATION_REPORT.md")]
+
+            self.assertEqual(result.converted, [])
+            self.assertEqual(len(result.partial), 1)
+            self.assertNotIn("services.mutations.has", main)
+            self.assertNotIn("services.effects.add", main)
+            self.assertIn(
+                "EOC ambiguous_alpha condition needs a native Lua predicate",
+                report,
+            )
+            self.assertIn(
+                "EOC ambiguous_alpha effect #0 needs domain-service conversion",
+                report,
+            )
+            self.assertNotIn("run_eoc", main)
 
     def test_recipe_abstracts_uncraft_and_missing_results_are_partial(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -1006,7 +2289,7 @@ class LuaFirstMigrationTest(unittest.TestCase):
                                 "id": "sample_recipe",
                                 "description": "Craft sample",
                                 "om_terrains": ["ANY"],
-                                }],
+                            }],
                         },
                         {
                             "type": "nested_category",
@@ -1299,8 +2582,8 @@ class LuaFirstMigrationTest(unittest.TestCase):
             )
             self.assertTrue(
                 any(
-                    "monster attack sample_lua_attack" in todo
-                    and "named Lua handler" in todo
+                    "monster attack sample_lua_attack" in todo and
+                    "named Lua handler" in todo
                     for todo in result.todos
                 )
             )
@@ -1401,6 +2684,339 @@ class LuaFirstMigrationTest(unittest.TestCase):
             self.assertEqual(len(result.partial), 1)
             self.assertNotIn("run_eoc", main)
             self.assertNotIn("load_json", main)
+
+    def test_converts_bounded_wound_and_wound_fix_definitions(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "source.json"
+            source.write_text(
+                json.dumps(
+                    [
+                        {
+                            "type": "wound",
+                            "id": "lua_laceration",
+                            "name": {
+                                "str": "laceration",
+                                "str_pl": "lacerations",
+                            },
+                            "description": "A deep open cut.",
+                            "pain": [1, 3],
+                            "healing_time": ["1 hour", "2 hours"],
+                            "damage_types": ["cut", "stab"],
+                            "damage_required": [5, 30],
+                            "weight": 2,
+                            "limb_scores": [
+                                {"score": "manip", "value": 0.25}
+                            ],
+                            "limit": 2,
+                            "wound_progression": [
+                                {"id": "lua_deep_laceration", "chance": 20}
+                            ],
+                            "whitelist_bp_with_flag": "LIMB",
+                            "whitelist_body_part_types": ["arm", "hand"],
+                            "blacklist_bp_with_flag": "BIONIC_LIMB",
+                            "blacklist_body_part_types": ["head"],
+                        },
+                        {
+                            "type": "wound_fix",
+                            "id": "lua_suture",
+                            "name": "suture wound",
+                            "description": "Close a laceration.",
+                            "success_msg": "You close the wound.",
+                            "mod_hp": 3,
+                            "time": "5 minutes",
+                            "skills": {"firstaid": 2},
+                            "wounds_removed": ["lua_laceration"],
+                            "wounds_added": ["lua_sutured"],
+                            "proficiencies": [
+                                {
+                                    "proficiency": "prof_wound_care",
+                                    "time_save": 0.75,
+                                    "is_mandatory": True,
+                                }
+                            ],
+                            "requirements": [["wound_care", 2]],
+                        },
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            result = migrate_lua_first.migrate(
+                migrate_lua_first.load_objects([source]), "wound_mod"
+            )
+            main = result.files[Path("main.lua")]
+
+            self.assertEqual(len(result.converted), 2)
+            self.assertEqual(result.partial, [])
+            self.assertEqual(result.todos, [])
+            self.assertIn("content.Wound {", main)
+            self.assertIn('plural_name = "lacerations"', main)
+            self.assertIn("healing_min_turns = 3600", main)
+            self.assertIn('definition:damage_type("cut")', main)
+            self.assertIn('definition:limb_score("manip", 0.25)', main)
+            self.assertIn(
+                'definition:progression("lua_deep_laceration", 20)', main
+            )
+            self.assertIn('definition:require_body_part_type("arm")', main)
+            self.assertIn("content.WoundFix {", main)
+            self.assertIn("duration_turns = 300", main)
+            self.assertIn('definition:skill("firstaid", 2)', main)
+            self.assertIn(
+                'definition:proficiency("prof_wound_care", 0.75, true)',
+                main,
+            )
+            self.assertIn('definition:removes("lua_laceration")', main)
+            self.assertIn('definition:requires("wound_care", 2)', main)
+            self.assertNotIn("load_json", main)
+            self.assertNotIn("run_eoc", main)
+
+    def test_wound_and_fix_accept_exact_platform_utf8_byte_caps(self) -> None:
+        bounded_id = "界" * 85 + "a"
+        bounded_name = "界" * 341 + "a"
+        bounded_description = "界" * 10922 + "ab"
+        self.assertEqual(len(bounded_id.encode("utf-8")), 256)
+        self.assertEqual(len(bounded_name.encode("utf-8")), 1024)
+        self.assertEqual(len(bounded_description.encode("utf-8")), 32768)
+
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "source.json"
+            source.write_text(
+                json.dumps(
+                    [
+                        {
+                            "type": "wound",
+                            "id": bounded_id,
+                            "name": bounded_name,
+                            "description": bounded_description,
+                            "healing_time": [1, 1],
+                            "damage_types": ["d" * 256],
+                            "damage_required": [0, 1],
+                            "limb_scores": [
+                                {"score": "l" * 256, "value": 0.5}
+                            ],
+                            "wound_progression": [
+                                {"id": "p" * 256, "chance": 1}
+                            ],
+                            "whitelist_bp_with_flag": "r" * 256,
+                            "blacklist_bp_with_flag": "f" * 256,
+                        },
+                        {
+                            "type": "wound_fix",
+                            "id": "x" * 256,
+                            "name": bounded_name,
+                            "description": bounded_description,
+                            "success_msg": bounded_description,
+                            "skills": {"s" * 256: 1},
+                            "wounds_removed": [bounded_id],
+                            "wounds_added": ["a" * 256],
+                            "proficiencies": [
+                                {
+                                    "proficiency": "q" * 256,
+                                    "time_save": 2 ** -149,
+                                }
+                            ],
+                            "requirements": [["e" * 256, 1]],
+                        },
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            result = migrate_lua_first.migrate(
+                migrate_lua_first.load_objects([source]), "wound_mod"
+            )
+            main = result.files[Path("main.lua")]
+
+            self.assertEqual(len(result.converted), 2)
+            self.assertEqual(result.partial, [])
+            self.assertEqual(result.todos, [])
+            self.assertIn(
+                f'definition:damage_type("{"d" * 256}")', main
+            )
+            self.assertIn(
+                f'definition:proficiency("{"q" * 256}", '
+                f'{migrate_lua_first.lua_number(2 ** -149)}, false)',
+                main,
+            )
+
+    def test_wound_and_fix_reject_overlong_required_fields(self) -> None:
+        valid_wound = {
+            "type": "wound",
+            "id": "valid_wound",
+            "name": "wound",
+            "description": "description",
+            "damage_types": ["bash"],
+            "damage_required": [0, 1],
+        }
+        wound_cases = {
+            "id": {"id": "i" * 257},
+            "multibyte id": {"id": "界" * 86},
+            "name": {"name": "n" * 1025},
+            "description": {"description": "d" * 32769},
+            "damage type": {"damage_types": ["t" * 257]},
+            "unencodable id": {"id": "\ud800"},
+        }
+        for label, replacement in wound_cases.items():
+            with self.subTest(kind="wound", field=label):
+                result = migrate_lua_first.MigrationResult()
+                rendered = migrate_lua_first.render_wound(
+                    migrate_lua_first.SourceObject(
+                        Path("source.json"), 0, valid_wound | replacement
+                    ),
+                    result,
+                )
+                self.assertIsNone(rendered)
+                self.assertEqual(len(result.partial), 1)
+                self.assertEqual(len(result.todos), 1)
+
+        valid_fix = {
+            "type": "wound_fix",
+            "id": "valid_fix",
+            "name": "fix",
+            "description": "description",
+            "wounds_removed": ["valid_wound"],
+        }
+        fix_cases = {
+            "id": {"id": "i" * 257},
+            "name": {"name": "n" * 1025},
+            "description": {"description": "d" * 32769},
+            "removed wound": {"wounds_removed": ["w" * 257]},
+            "unencodable text": {"name": "\ud800"},
+        }
+        for label, replacement in fix_cases.items():
+            with self.subTest(kind="wound fix", field=label):
+                result = migrate_lua_first.MigrationResult()
+                rendered = migrate_lua_first.render_wound_fix(
+                    migrate_lua_first.SourceObject(
+                        Path("source.json"), 0, valid_fix | replacement
+                    ),
+                    result,
+                )
+                self.assertIsNone(rendered)
+                self.assertEqual(len(result.partial), 1)
+                self.assertEqual(len(result.todos), 1)
+
+    def test_wound_optional_values_fail_closed_to_valid_lua(self) -> None:
+        overlong_id = "z" * 257
+        wound_result = migrate_lua_first.MigrationResult()
+        wound = migrate_lua_first.render_wound(
+            migrate_lua_first.SourceObject(
+                Path("source.json"),
+                0,
+                {
+                    "type": "wound",
+                    "id": "bounded_wound",
+                    "name": {"str": "wound", "str_pl": "n" * 1025},
+                    "description": "description",
+                    "damage_types": ["bash"],
+                    "damage_required": [0, 1],
+                    "limb_scores": [
+                        {"score": overlong_id, "value": 0.5},
+                        {"score": "huge_penalty", "value": 10 ** 10000},
+                    ],
+                    "wound_progression": [
+                        {"id": overlong_id, "chance": 1}
+                    ],
+                    "whitelist_bp_with_flag": "SAME_FLAG",
+                    "blacklist_bp_with_flag": "SAME_FLAG",
+                },
+            ),
+            wound_result,
+        )
+        self.assertIsNotNone(wound)
+        assert wound is not None
+        self.assertIn('plural_name = "wound"', wound)
+        self.assertNotIn("required_body_part_flag", wound)
+        self.assertNotIn("forbidden_body_part_flag", wound)
+        self.assertNotIn(overlong_id, wound)
+        self.assertEqual(wound_result.converted, [])
+        self.assertEqual(len(wound_result.partial), 1)
+        self.assertTrue(
+            any("cannot require and forbid" in todo for todo in wound_result.todos)
+        )
+
+        fix_result = migrate_lua_first.MigrationResult()
+        wound_fix = migrate_lua_first.render_wound_fix(
+            migrate_lua_first.SourceObject(
+                Path("source.json"),
+                1,
+                {
+                    "type": "wound_fix",
+                    "id": "bounded_fix",
+                    "name": "fix",
+                    "description": "description",
+                    "success_msg": "m" * 32769,
+                    "skills": {overlong_id: 1},
+                    "wounds_removed": ["bounded_wound"],
+                    "wounds_added": [overlong_id],
+                    "proficiencies": [
+                        {"proficiency": overlong_id, "time_save": 1},
+                        {"proficiency": "underflow", "time_save": 2 ** -150},
+                        {
+                            "proficiency": "overflow",
+                            "time_save": migrate_lua_first.NATIVE_FLOAT_MAX * 2,
+                        },
+                        {"proficiency": "huge", "time_save": 10 ** 10000},
+                        {"proficiency": "small_ok", "time_save": 2 ** -149},
+                    ],
+                    "requirements": [[overlong_id, 1]],
+                },
+            ),
+            fix_result,
+        )
+        self.assertIsNotNone(wound_fix)
+        assert wound_fix is not None
+        self.assertIn('success_message = ""', wound_fix)
+        self.assertNotIn(overlong_id, wound_fix)
+        self.assertNotIn('definition:proficiency("underflow"', wound_fix)
+        self.assertNotIn('definition:proficiency("overflow"', wound_fix)
+        self.assertNotIn('definition:proficiency("huge"', wound_fix)
+        self.assertIn('definition:proficiency("small_ok"', wound_fix)
+        self.assertEqual(fix_result.converted, [])
+        self.assertEqual(len(fix_result.partial), 1)
+
+        self.assertEqual(
+            migrate_lua_first.lua_quote("a\x01\b\f\v\x7f"),
+            '"a\\001\\b\\f\\v\\127"',
+        )
+
+    def test_wound_inheritance_and_inline_requirements_stay_explicit(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "source.json"
+            source.write_text(
+                json.dumps(
+                    [
+                        {
+                            "type": "wound",
+                            "id": "inherited_wound",
+                            "copy-from": "base_wound",
+                        },
+                        {
+                            "type": "wound_fix",
+                            "id": "inline_fix",
+                            "name": "patch wound",
+                            "description": "Patch a wound.",
+                            "wounds_removed": ["lua_laceration"],
+                            "requirements": [
+                                {"components": [["rag", 1]]}
+                            ],
+                        },
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            result = migrate_lua_first.migrate(
+                migrate_lua_first.load_objects([source]), "wound_mod"
+            )
+            main = result.files[Path("main.lua")]
+            report = result.files[Path("MIGRATION_REPORT.md")]
+
+            self.assertEqual(result.converted, [])
+            self.assertEqual(len(result.partial), 2)
+            self.assertIn("wound needs a stable id, text", report)
+            self.assertIn("needs a standalone Requirement", report)
+            self.assertIn("content.WoundFix {", main)
+            self.assertNotIn("content.Wound {", main)
+            self.assertNotIn("load_json", main)
+            self.assertNotIn("run_eoc", main)
 
     def test_check_mode_is_non_mutating_and_detects_stale_output(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
#### Summary

Feature "Expand and validate the Lua-first Platform"

#### Responsible human

@LYHGLYTX

#### Purpose of change

CCB needs a long-term pure-Lua authoring path for core content and Mods without requiring public JSON loaders, EOC runners, a mandatory `lua/` directory, or author-maintained `manifest.json` files. This layer moves the accepted architecture beyond documentation into bounded native content, runtime services, migration tooling, checked developer contracts, and a playable zero-JSON/EOC vertical slice.

#### Describe the solution

- Expand transactional `ccb.content` native builders and finalize/rollback handling across the documented static-content slice.
- Add composable Lua-native gameplay services, predicates, events, hooks, callbacks, persistent state/tasks, and typed domain handles instead of EOC-key-shaped wrappers.
- Harden GameHandle, Mission, Horde, Zone, and item-use lifetimes with explicit runtime-owner and generation validation.
- Add deterministic migration extraction, exact replacement-ledger dispositions, public/native inventories, LuaLS declarations, templates, and a zero-JSON example Mod.
- Give the bundled example native `mod.lua` metadata and dependency declaration, with no JSON, EOC, manifest, or required `lua/` directory.
- Prove a playable save/reload loop through real Mod discovery and selection, item/recipe use, three `game::save()` calls, runtime shutdown, full data reload, restored character/world state, and exactly-once delayed-task execution.
- Keep the example visible with an actionable diagnostic in builds compiled without Lua.
- Keep the bilingual Platform architecture, roadmap, Agent routing, generated references, and dedicated test-matrix merge gates synchronized with source and tests.

#### Describe alternatives you've considered

A public JSON loader or EOC compatibility API would preserve the legacy authoring model and prevent Lua from becoming the native composition language. This change keeps any transitional legacy adapters private and promotes only explicitly bounded, source-backed shapes. Full field-level parity and legacy removal remain later milestones rather than being claimed by this PR.

#### Testing

Passed locally on Linux with Lua enabled:

- `make -j8 BUILD_PREFIX=ccb-verify- ODIR=ccb-verify-obj CATA_ENABLE_LUA_UI=1 ASTYLE=0 LINTJSON=0 LOCALIZE=0 DEBUGSYMS= tests`
  - compiled and linked the Lua-enabled C++ test program successfully
- `./tests/ccb-verify-cata_test "[lua]"`
  - 191 matching test cases, 2738 assertions
- `[playable_mvp]` installed-Mod vertical slice
  - 1 case, 32 assertions
  - discovery, dependency-aware `mod_ui::try_add`, native item/recipe loading, real item-use actor, three saves, runtime shutdown, full core/Mod reload, state restoration, continued gameplay, and one-time overdue task execution
- Sequential isolation regression coverage
  - 3 cases, 47 assertions
- Fresh build compiled with `CATA_ENABLE_LUA_UI=0`
  - compiled and linked successfully
  - focused Mod-manager fallback: 1 case, 13 assertions
- Lua API unit tests: 61/61
- Agent metadata/unit tests: 71/71
- Migration extractor: 46/46
- Mod scaffolder: 9/9
- Built-in Mod generator: 6/6
- JSON/EOC contract tests: 15/15
- Agent context benchmark: 9/9
- LuaLS coverage: 2398/2398 (100%)
- Native/public contracts: 101 export roots, 761 member dispositions, 0 undocumented public symbols
- Replacement ledger: 775 selectors, 119 bounded-unverified dispositions
- `make -j8 json-check`: passed
- `make python-check`: passed with the isolated flake8 environment
- Required AStyle 3.1 dry-run: both C++ test files changed by this update passed
- `git diff --check`: passed

Android arm64-v8a Stable Release also passed:

- SDL3, arm64-v8a only, Stable Release, with `CATA_ENABLE_LUA_UI=1`
- Native C++ compiled and linked to `libmain.so`; Gradle `:app:assembleStableRelease` completed 52 tasks successfully
- Output: `android/app/build/outputs/apk/stable/release/cataclysmdda-2026-08-12-09b8c386750-dirty-stable-arm64-v8a-release-unsigned.apk`
- The unsigned APK contains `lib/arm64-v8a/libmain.so`; `apksigner verify` correctly reports that it is unsigned

The repository-wide AStyle 3.1 target still reports three unchanged baseline files: `src/activity_item_handling.cpp`, `src/catalua_ui.h`, and `src/vehicle.cpp`. They were not reformatted in this scoped layer.

Manual desktop/Android Mod-selector and complex presentation interaction checks remain follow-up work. This playable MVP does not claim full JSON/EOC parity across all 775 replacement-ledger entries, and the full unfiltered C++ suite was not rerun for this final documentation-only adjustment.

#### Documentation impact

Updates the repository-authoritative bilingual Lua-first Platform architecture, implementation roadmap, Agent guidance, developer templates, example Mod, playable-MVP merge gate, and validation status.

#### Related CCB-Docs PR

https://github.com/CrimsonCrossBunker/CCB-Docs/pull/35

#### Affected documentation IDs

architecture.lua-first-platform, architecture.lua-first-roadmap, architecture.lua-first-glossary

#### Generated reference impact

Regenerates the native/public Lua inventories and coverage reference, exact JSON/EOC replacement-ledger inputs and output, Agent benchmark baseline, and related checked metadata. Generated files were refreshed only through their named generators. This final playable-MVP update changes no generated file by hand.

#### Additional context

Stack layer 14/14. Base: `agent/lua-first-stack-13-replacement-ledger` (PR #631). Previous: https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/pull/631. This PR remains draft while its base PR is draft and until the remaining manual platform interaction checks are accepted. Do not merge the stack out of order.