### PR TITLE
fix(ui): prevent character creator list clipping

### DIFF
--- a/src/uilist.cpp
+++ b/src/uilist.cpp
@@ -74,6 +74,12 @@ void uilist_impl::draw_controls()
         }
     }
 
+    ImVec2 menu_size = parent.calculated_menu_size;
+    if( parent.force_desired_bounds && parent.desired_bounds.has_value() ) {
+        menu_size = uilist_menu_size_for_available_region( ImGui::GetContentRegionAvail(),
+            parent.extra_space_left, parent.extra_space_right );
+    }
+
     // An invisible table with three columns. Used to create a sidebar effect.
     // Ideally we would use a layout engine for this, but ImGui does not natively support any.
     // TODO: Investigate using Stack Layout (https://github.com/thedmd/imgui/tree/feature/layout-external)
@@ -84,7 +90,7 @@ void uilist_impl::draw_controls()
                            ImGuiTableFlags_SizingFixedFit | ImGuiTableFlags_NoPadInnerX | ImGuiTableFlags_NoPadOuterX |
                            ImGuiTableFlags_Hideable ) ) {
         ImGui::TableSetupColumn( "left", ImGuiTableColumnFlags_WidthFixed, parent.extra_space_left );
-        ImGui::TableSetupColumn( "menu", ImGuiTableColumnFlags_WidthFixed, parent.calculated_menu_size.x );
+        ImGui::TableSetupColumn( "menu", ImGuiTableColumnFlags_WidthFixed, menu_size.x );
         ImGui::TableSetupColumn( "right", ImGuiTableColumnFlags_WidthFixed, parent.extra_space_right );
 
         ImGui::TableSetColumnEnabled( 0, parent.extra_space_left < 1.0f ? false : true );
@@ -93,9 +99,16 @@ void uilist_impl::draw_controls()
         ImGui::TableNextRow();
         ImGui::TableSetColumnIndex( 1 );
 
+        if( parent.force_desired_bounds && parent.desired_bounds.has_value() ) {
+            // Query this after entering the table cell: it is the exact vertical space left after
+            // window padding, category tabs, and the cell's top padding have been consumed.
+            menu_size.y = uilist_menu_size_for_available_region(
+                              ImGui::GetContentRegionAvail(), 0.0F, 0.0F ).y;
+        }
+
         float entry_height = ImGui::GetTextLineHeightWithSpacing();
         ImGuiStyle &style = ImGui::GetStyle();
-        if( ImGui::BeginChild( "scroll", parent.calculated_menu_size, ImGuiChildFlags_None,
+        if( ImGui::BeginChild( "scroll", menu_size, ImGuiChildFlags_None,
                                ImGuiWindowFlags_NoNavInputs ) ) {
             if( ImGui::BeginTable( "menu items", 3, ImGuiTableFlags_SizingFixedFit ) ) {
                 ImGui::TableSetupColumn( "hotkey", ImGuiTableColumnFlags_WidthFixed,
@@ -763,10 +776,6 @@ void uilist::calc_data()
         calculated_menu_size.x = longest_line_width;
         calculated_label_width = calculated_menu_size.x - calculated_hotkey_width - padding -
                                  calculated_secondary_width - padding - padding;
-    }
-    if( force_desired_bounds && desired_bounds.has_value() ) {
-        calculated_menu_size.x = desired_bounds->w;
-        calculated_menu_size.y = desired_bounds->h;
     }
 }
 

--- a/src/uilist.h
+++ b/src/uilist.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_UI_H
 #define CATA_SRC_UI_H
 
+#include <algorithm>
 #include <functional>
 #include <initializer_list>
 #include <map>
@@ -45,6 +46,16 @@ class string_input_popup_imgui;
 class uilist_impl;
 
 catacurses::window new_centered_win( int nlines, int ncols );
+
+// Fit a menu into the content region that remains after any preceding controls were drawn.
+// Horizontal side columns consume part of that region; vertical controls have already been
+// accounted for by ImGui in available_size.y.
+inline ImVec2 uilist_menu_size_for_available_region( const ImVec2 &available_size,
+        const float extra_space_left, const float extra_space_right )
+{
+    return ImVec2( std::max( 1.0F, available_size.x - extra_space_left - extra_space_right ),
+                   std::max( 1.0F, available_size.y ) );
+}
 
 /**
  * mvwzstr: line of text with horizontal offset and color
@@ -497,7 +508,7 @@ class uilist // NOLINT(cata-xy)
         bool hilight_disabled = false;
         // if true, calculates size to include all categories
         bool size_to_all_categories = false;
-        // if true, forces `calculated_menu_size` to equal `desired_bounds`
+        // if true, fills the actual content region inside `desired_bounds`
         bool force_desired_bounds = false;
 
     private:

--- a/tests/uilist_test.cpp
+++ b/tests/uilist_test.cpp
@@ -1,0 +1,22 @@
+#include "catch/catch.hpp"
+
+#include "uilist.h"
+
+TEST_CASE( "forced_uilist_menu_uses_the_remaining_content_region", "[ui][uilist]" )
+{
+    const ImVec2 available_after_tabs( 926.0F, 789.0F );
+    const ImVec2 menu_size = uilist_menu_size_for_available_region(
+                                 available_after_tabs, 4.0F, 4.0F );
+
+    CHECK( menu_size.x == 918.0F );
+    CHECK( menu_size.y == available_after_tabs.y );
+}
+
+TEST_CASE( "forced_uilist_menu_size_stays_positive_in_tiny_regions", "[ui][uilist]" )
+{
+    const ImVec2 menu_size = uilist_menu_size_for_available_region(
+                                 ImVec2( 5.0F, -2.0F ), 4.0F, 4.0F );
+
+    CHECK( menu_size.x == 1.0F );
+    CHECK( menu_size.y == 1.0F );
+}


### PR DESCRIPTION
#### Summary

Bugfixes "修复角色创建列表末项被裁剪的问题"

#### Responsible human

@LYHGLYTX

#### Purpose of change

角色创建的场景、职业、背景等列表最后一项只能显示一部分，特性列表还会有一到两项被分类栏遮挡。继续向下导航时，隐藏的末项之后会按列表原有的循环行为跳回第一项，导致用户看起来无法访问这些词条。

根因是强制尺寸的 `uilist` 将外层窗口的完整宽高直接用于内部滚动区域，没有扣除窗口边距、表格单元格和特性分类标签已经占用的空间。

复现步骤：

1. 进入自定义角色创建。
2. 打开场景、职业、背景或特性页面。
3. 滚动到列表底部。
4. 观察末项被底部边界裁剪；特性页可能完全隐藏末尾一到两项。

#### Describe the solution

强制尺寸的 `uilist` 现在会在绘制时读取 ImGui 当前实际剩余的内容区域：

- 横向扣除左右辅助列占用的空间。
- 纵向在进入列表表格单元格后计算，因此窗口内边距、分类标签和单元格顶部边距都会自动计入。
- 极小区域下将宽高限制为至少 1 像素。
- 新增聚焦回归测试，覆盖剩余区域尺寸和极小区域行为。

这保留了角色创建左栏的外层尺寸，同时防止内部滚动区越过窗口底部。

#### Describe alternatives you've considered

考虑过只在 `newcharacter.cpp` 中手动减去固定高度，但不同页面拥有不同的分类栏和布局边距，固定值容易再次失配。修正 `uilist` 的强制尺寸语义可以直接使用 ImGui 的实际布局结果。

也考虑过取消列表的循环导航，但循环本身不是根因；末项可见后，现有导航行为不再阻止访问词条。

#### Testing

- 独立 Catch2 回归测试：2 个测试用例、4 个断言通过。
- 终端构建路径：`make CATA_ENABLE_LUA_UI=0 BUILD_PREFIX=playtest- playtest-obj/uilist.o`。
- Tiles/SDL3 构建路径：`make TILES=1 SOUND=1 CATA_ENABLE_LUA_UI=0 BUILD_PREFIX=waterfix- waterfix-obj/tiles/uilist.o`。
- `git diff --check` 通过。
- `make astyle-check` 已执行，但仓库当前存在大量与本 PR 无关的既有格式基线失败；新增测试文件由当前 AStyle 版本检查为 unchanged。

建议审阅者在 Tiles 角色创建页分别滚动场景、职业、背景和特性列表到底部，确认最后一项完整可见。

#### Documentation impact

None

#### Related CCB-Docs PR

None

#### Affected documentation IDs

None

#### Generated reference impact

None

#### Additional context

该修复针对桌面/Tiles 使用的传统角色创建 `uilist` 布局，不修改词条数据或列表的循环导航规则。
