### PR TITLE
Fix atomic lights remaining lit when turned off

### DIFF
--- a/data/mods/FuturismCataclysmLegacy/items/tool/lighting.json
+++ b/data/mods/FuturismCataclysmLegacy/items/tool/lighting.json
@@ -31,6 +31,7 @@
     "name": { "str": "atomic lamp (covered)", "str_pl": "atomic lamps (covered)" },
     "description": "Powered by the magic of nuclear decay and low-energy LEDs, this very expensive lamp will emit a small amount of light for at least a decade.  Before the Cataclysm, it was mostly an expensive way to show off your preparedness.  Now, it's actually really useful.  The cover is closed.  Use it to open the cover and show the light.",
     "use_action": { "target": "fcl_atomic_lamp", "msg": "You open the lamp's cover.", "menu_text": "Open cover", "type": "transform" },
+    "light": 0,
     "flags": [ "LEAK_DAM", "RADIOACTIVE", "ALLOWS_REMOTE_USE", "DURABLE_MELEE" ]
   },
   {
@@ -64,6 +65,7 @@
     "name": { "str": "atomic reading light (covered)", "str_pl": "atomic reading lights (covered)" },
     "description": "Powered by the magic of nuclear decay and low-energy LEDs, this extremely expensive little light will provide just enough light to read by for at least a decade.  It is also available with a cute cartoon bear cover to turn it into a nightlight for a very wealthy child with a fear of the dark.  The cover is closed.  Use it to open the cover and show the light.",
     "use_action": { "target": "fcl_atomic_light", "msg": "You open the lamp's cover.", "menu_text": "Open cover", "type": "transform" },
+    "light": 0,
     "flags": [ "LEAK_DAM", "RADIOACTIVE", "DURABLE_MELEE", "ALLOWS_REMOTE_USE" ]
   }
 ]

--- a/data/mods/FuturismCataclysmLegacy/items/tool_armor.json
+++ b/data/mods/FuturismCataclysmLegacy/items/tool_armor.json
@@ -51,6 +51,7 @@
     "name": { "str": "atomic headlamp (covered)", "str_pl": "atomic headlamps (covered)" },
     "description": "A custom-made, reinforced headlamp powered by the magic of nuclear decay, focused for more usable brightness.  The adjustable strap allows it to be comfortably worn on your head or attached to your helmet.  Use it to open the cover and show the light.",
     "flags": [ "LEAK_DAM", "RADIOACTIVE", "STURDY", "OVERSIZE", "BELTED", "PADDED", "ALLOWS_NATURAL_ATTACKS" ],
+    "light": 0,
     "use_action": {
       "type": "transform",
       "msg": "You open the headlamp's cover.",

--- a/data/mods/aftershock_exoplanet/items/tools.json
+++ b/data/mods/aftershock_exoplanet/items/tools.json
@@ -1050,6 +1050,7 @@
     "name": { "str": "atomic lamp (covered)", "str_pl": "atomic lamps (covered)" },
     "description": "A fairly hefty and frankly ugly lamp with a thick base and an odd spheroidal \"shade\".  While this is a commercial product, early versions were made from scavenged landing or spacecraft lights.  While the appeal of them there was to lower the maintence burden, as a lamp it's nothing more than a gimmick of infinite, albeit dim light.  This one has been closed.",
     "use_action": { "target": "afs_atomic_lamp", "msg": "You open the lamp's cover.", "menu_text": "Open cover", "type": "transform" },
+    "light": 0,
     "flags": [ "LEAK_DAM", "RADIOACTIVE", "ALLOWS_REMOTE_USE" ]
   },
   {
@@ -1083,6 +1084,7 @@
     "name": { "str": "atomic reading light (covered)", "str_pl": "atomic reading lights (covered)" },
     "description": "A commercially produced reading light, with the gimmick of never having to replace batteries thanks to its nuclear decay powered power source.  Instead of having an on/off switch, there is instead a cover you close over it.",
     "use_action": { "target": "afs_atomic_light", "msg": "You open the lamp's cover.", "menu_text": "Open cover", "type": "transform" },
+    "light": 0,
     "flags": [ "LEAK_DAM", "RADIOACTIVE", "ALLOWS_REMOTE_USE" ]
   },
   {
@@ -1137,6 +1139,7 @@
     "name": { "str": "atomic headlamp (covered)", "str_pl": "atomic headlamps (covered)" },
     "description": "A custom-made headlamp, salvaged from an atomic lamp.  While the weight on your head is light, you had to awkwardly find a way to carry the base of the lamp, which provided the actual power.  The base now proudly sits strapped to your back.  It is now covered, concealing the light.",
     "flags": [ "LEAK_DAM", "RADIOACTIVE", "OVERSIZE", "PADDED", "ALLOWS_NATURAL_ATTACKS" ],
+    "light": 0,
     "use_action": {
       "type": "transform",
       "msg": "You open the headlamp's cover.",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
All atomic lighting devices in the Aftershock: Exoplanet mod have a configuration bug. Their off state uses the `copy-from` JSON inheritance mechanism, but does not override and redefine the `light` field to 0, causing all atomic lights to remain permanently unable to turn off. The similar mod Futurism Cataclysm: Legacy, having assumed that the original mod did not contain this kind of error, directly copied this configuration pattern, causing the bug to appear in multiple mods.

#### Describe the solution
`"light": 0`