### PR TITLE
feat: 物品栏按w/W直接手持/穿戴、制作液体可食用、自动旅行同步队伍

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -275,7 +275,9 @@ void game_menus::inv::common()
 
     inv_s.set_title( _( "Inventory" ) );
     inv_s.set_hint( string_format(
-                        _( "Item hotkeys assigned: <color_light_gray>%d</color>/<color_light_gray>%d</color>" ),
+                        _( "<color_yellow>%s</color> Wield  <color_yellow>%s</color> Wear  Item hotkeys assigned: <color_light_gray>%d</color>/<color_light_gray>%d</color>" ),
+                        inv_s.key_desc( "WIELD" ),
+                        inv_s.key_desc( "WEAR" ),
                         you.allocated_invlets().count(), inv_chars.size() ) );
 
     int res = 0;

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -3416,6 +3416,40 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                     }
                 }
 
+                // QQ#183: while auto-moving (auto travel mode or destination
+                // travel), pace to the slowest following NPC so the party stays
+                // together.  If a follower slower than the avatar has fallen
+                // behind, spend the rest of the turn waiting for it to catch up
+                // instead of stepping away again.
+                if( player_character.is_auto_moving() && !player_character.in_vehicle ) {
+                    npc *slowest_follower = nullptr;
+                    int worst_lag = 0;
+                    const int player_speed = player_character.get_speed();
+                    for( npc *guy : g->get_npcs_if( []( const npc & n ) {
+                    return n.is_walking_with() && n.can_follow_player_now();
+                    } ) ) {
+                        if( guy->get_speed() >= player_speed ) {
+                            continue;
+                        }
+                        const int lag = square_dist( guy->pos_bub(), player_character.pos_bub() );
+                        if( lag > worst_lag ) {
+                            worst_lag = lag;
+                            slowest_follower = guy;
+                        }
+                    }
+                    if( slowest_follower != nullptr ) {
+                        const int threshold =
+                            std::max( slowest_follower->desired_follow_radius() + 1, 4 );
+                        // Only pace while the follower is still on the way; a far-away
+                        // or stuck follower must not stop travel forever.
+                        if( worst_lag > threshold && worst_lag < 20 ) {
+                            player_character.set_moves( 0 );
+                            add_msg( m_info, _( "You slow down to let %s catch up." ),
+                                     slowest_follower->get_name() );
+                        }
+                    }
+                }
+
                 // if we changed move modes this action, refund half the cost of changing move mode
                 // if their move action was an easy movement to represent combining the two actions
                 if( desired_move_mode_cost > 0 ) {

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -3431,7 +3431,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                         if( guy->get_speed() >= player_speed ) {
                             continue;
                         }
-                        const int lag = square_dist( guy->pos_bub(), player_character.pos_bub() );
+                        const int lag = rl_dist( guy->pos_bub(), player_character.pos_bub() );
                         if( lag > worst_lag ) {
                             worst_lag = lag;
                             slowest_follower = guy;

--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -314,7 +314,9 @@ static bool get_liquid_target( item &liquid, const item *const source, const int
         menu.text = string_format( pgettext( "liquid", "What to do with the %s?" ), liquid_name );
     }
     std::vector<std::function<void()>> actions;
-    if( player_character.can_consume_as_is( liquid ) && !source_mon && ( source_veh || source_pos ) ) {
+    // Allow consuming freshly crafted liquids (no vehicle/map source), matching CBN;
+    // still exclude liquids obtained from monsters.
+    if( player_character.can_consume_as_is( liquid ) && !source_mon ) {
         menu.addentry( -1, true, 'e', _( "Consume it" ) );
         actions.emplace_back( [&]() {
             target.dest_opt = LD_CONSUME;

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -3893,6 +3893,14 @@ std::string inventory_selector::action_bound_to_key( char key ) const
     return ctxt.input_to_action( input_event( key, input_event_t::keyboard_char ) );
 }
 
+std::string inventory_selector::key_desc( const std::string &action ) const
+{
+    return ctxt.get_desc( action );
+}
+
+static item_location get_item_to_highlight_after_use( inventory_column &column,
+        item_location const &loc );
+
 item_location inventory_pick_selector::execute()
 {
     shared_ptr_fast<ui_adaptor> ui = create_or_get_ui_adaptor();
@@ -3903,7 +3911,13 @@ item_location inventory_pick_selector::execute()
         ui_manager::redraw();
         const inventory_input input = get_input();
 
-        if( input.entry != nullptr ) {
+        if( input.action == "WIELD" ) {
+            wield_highlighted();
+            continue;
+        } else if( input.action == "WEAR" ) {
+            wear_highlighted();
+            continue;
+        } else if( input.entry != nullptr ) {
             if( drag_enabled && input.action == "CLICK_AND_DRAG" ) {
                 if( input.entry->is_item() ) {
                     dragActive = true;
@@ -3953,6 +3967,83 @@ item_location inventory_pick_selector::execute()
     }
 }
 
+void inventory_pick_selector::refresh_after_use( const item_location &it )
+{
+    // Reload the list so the just-used item moves to its new slot, and keep
+    // the selection on the next item after the one that was used.
+    const item_location next_item = get_item_to_highlight_after_use( get_active_column(), it );
+    clear_items();
+    add_character_items( u );
+    if( next_item ) {
+        highlight_one_of( { next_item } );
+    }
+}
+
+bool inventory_pick_selector::wield_highlighted()
+{
+    inventory_entry &selected = get_active_column().get_highlighted();
+    if( !selected.is_item() ) {
+        return false;
+    }
+
+    item_location it = selected.any_item();
+    // Snapshot the name first: wear/wield may replace the item object on
+    // failure (rollback creates a copy), invalidating the location.
+    const std::string item_name = it->display_name();
+    // Pre-check first: the common "can't wield" case is caught without ever
+    // touching the item, so the list stays valid and the reason is specific.
+    const ret_val<void> check = u.can_wield( *it );
+    if( !check.success() ) {
+        popup_getkey( check.c_str() );
+        return false;
+    }
+    // Wield immediately (like the game's w key) so the item state changes
+    // while the menu stays open; an activity would only run after closing it.
+    if( u.wield( it ) ) {
+        refresh_after_use( it );
+        return true;
+    }
+    // Failed wield after a successful pre-check (e.g. state changed): rebuild
+    // the list so the menu never dereferences dangling locations.
+    refresh_after_use( item_location() );
+    popup_getkey( _( "You can't wield the %s." ), item_name );
+
+    return false;
+}
+
+bool inventory_pick_selector::wear_highlighted()
+{
+    inventory_entry &selected = get_active_column().get_highlighted();
+    if( !selected.is_item() ) {
+        return false;
+    }
+
+    item_location it = selected.any_item();
+    // Snapshot the name first: wear/wield may replace the item object on
+    // failure (rollback creates a copy), invalidating the location.
+    const std::string item_name = it->display_name();
+    // Pre-check first: the common "can't wear" case is caught without ever
+    // touching the item, so the list stays valid and the reason is specific.
+    const ret_val<void> check = u.can_wear( *it );
+    if( !check.success() ) {
+        popup_getkey( check.c_str() );
+        return false;
+    }
+    // Wear immediately (like the game's W key), keeping the menu open.
+    if( u.wear( it ) ) {
+        refresh_after_use( it );
+        return true;
+    }
+    // Failed wear after a successful pre-check (e.g. the interactive prompt
+    // was cancelled): the rollback replaced the item with a copy, which
+    // invalidates every entry location — rebuild the list before the next
+    // redraw so the menu never dereferences dangling locations.
+    refresh_after_use( item_location() );
+    popup_getkey( _( "You can't wear the %s." ), item_name );
+
+    return false;
+}
+
 inventory_selector::header_stats container_inventory_selector::get_raw_stats() const
 {
     pocket_constraint container_constraints = loc.get_pocket_constraints_recursive();
@@ -3998,14 +4089,17 @@ std::vector<reload_target> get_possible_reload_targets( const item_location &tar
 {
     std::vector<reload_target> opts;
 
+    // MSVC 14.33 workaround: hoist the filter lambda out of the outer lambda,
+    // which triggers C2280 in older MSVC versions.
+    static const auto pocket_filter = []( const item_pocket & ) {
+        return true;
+    };
     auto append_owner = [&opts]( const item_location & owner ) {
         // pocket_index is the position in contents (stable across empty
         // wells), not the position in magazines_current().
         const bool multimag = owner->uses_firing_requirements();
         int idx = 0;
-        for( const item_pocket *p : owner->get_pockets( []( const item_pocket & ) {
-        return true;
-    } ) ) {
+        for( const item_pocket *p : owner->get_pockets( pocket_filter ) ) {
             if( p->is_type( pocket_type::MAGAZINE_WELL ) ) {
                 reload_target well;
                 well.target = owner;
@@ -5288,6 +5382,7 @@ std::pair<item_location, bool> unload_selector::execute()
     while( true ) {
         ui_manager::redraw();
         const inventory_input input = get_input();
+
         if( input.entry != nullptr ) {
             if( drag_enabled && input.action == "CLICK_AND_DRAG" ) {
                 if( input.entry->is_item() ) {

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -14,6 +14,7 @@
 #include "catacharset.h"
 #include "character.h"
 #include "character_attire.h"
+#include "contents_change_handler.h"
 #include "cuboid_rectangle.h"
 #include "debug.h"
 #include "enum_conversions.h"
@@ -3999,7 +4000,14 @@ bool inventory_pick_selector::wield_highlighted()
     }
     // Wield immediately (like the game's w key) so the item state changes
     // while the menu stays open; an activity would only run after closing it.
-    if( u.wield( it ) ) {
+    // The contents change handler matches the item action menu path: sealed
+    // pockets holding the item are unsealed and spill/on-contents handling
+    // runs after the item is taken.
+    contents_change_handler handler;
+    handler.unseal_pocket_containing( it );
+    const bool wielded = u.wield( it );
+    handler.handle_by( u );
+    if( wielded ) {
         refresh_after_use( it );
         return true;
     }
@@ -4030,7 +4038,14 @@ bool inventory_pick_selector::wear_highlighted()
         return false;
     }
     // Wear immediately (like the game's W key), keeping the menu open.
-    if( u.wear( it ) ) {
+    // The contents change handler matches the item action menu path: sealed
+    // pockets holding the item are unsealed and spill/on-contents handling
+    // runs after the item is taken.
+    contents_change_handler handler;
+    handler.unseal_pocket_containing( it );
+    const auto wear_result = u.wear( it );
+    handler.handle_by( u );
+    if( wear_result ) {
         refresh_after_use( it );
         return true;
     }
@@ -4089,11 +4104,6 @@ std::vector<reload_target> get_possible_reload_targets( const item_location &tar
 {
     std::vector<reload_target> opts;
 
-    // MSVC 14.33 workaround: hoist the filter lambda out of the outer lambda,
-    // which triggers C2280 in older MSVC versions.
-    static const auto pocket_filter = []( const item_pocket & ) {
-        return true;
-    };
     auto append_owner = [&opts]( const item_location & owner ) {
         // pocket_index is the position in contents (stable across empty
         // wells), not the position in magazines_current().

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -691,6 +691,9 @@ class inventory_selector
         /** Get the last filter string set by set_filter or entered by the player. */
         std::string get_filter() const;
 
+        /** Key description for an action registered in this selector's input context. */
+        std::string key_desc( const std::string &action ) const;
+
         enum selector_invlet_type {
             SELECTOR_INVLET_DEFAULT,
             SELECTOR_INVLET_NUMERIC,
@@ -1025,9 +1028,18 @@ class inventory_pick_selector : public inventory_selector
                                           const inventory_selector_preset &preset = default_preset ) :
             inventory_selector( p, preset ) {
             drag_enabled = false;
+            // Same direct-action keys as the pickup (g) interface: wield/wear the
+            // highlighted item without leaving the menu.
+            ctxt.register_action( "WEAR" );
+            ctxt.register_action( "WIELD" );
         }
         bool drag_enabled;
         item_location execute();
+
+    private:
+        bool wield_highlighted();
+        bool wear_highlighted();
+        void refresh_after_use( const item_location &it );
 };
 
 class container_inventory_selector : public inventory_pick_selector


### PR DESCRIPTION
#### Summary
Interface "物品栏 w/W 直按手持/穿戴；制作液体可直接食用；自动旅行同步队伍最慢 NPC"

#### Responsible human
@QSln

#### Purpose of change
三项玩家社区提议（QQ 意见表玩家建议 101/183/193）落地：
1. QQ玩家提议表101 制作液体加「食用」选项：制作产出液体时，液体处理菜单新增「Consume it (e)」选项（原仅车辆/地图来源液体显示此选项），可直接饮用制作出的液体，对齐 CBN 行为；怪物来源液体仍排除。
2. QQ玩家提议表193 i 物品栏集成 g 界面按键：i 物品栏中高亮物品可直接按 w 手持、W 穿戴（与游戏内 w/W 键同路径即时执行），无需进入物品动作菜单；菜单保持打开并刷新列表、高亮移至下一项；不可行时显示具体原因。
3. QQ玩家提议表183 自动旅行速度同步队伍最慢 NPC：自动移动（自动旅行模式或目的地旅行）时，若存在速度低于玩家的跟随 NPC 且掉队超过其跟随半径，玩家本回合剩余行动点清零等待（提示 You slow down to let X catch up.），队伍保持同步；跟得上的 NPC 不触发。

#### Describe the solution
1. src/handle_liquid.cpp：放宽液体「食用」选项条件（can_consume_as_is && !source_mon，去掉车辆/地图来源限制）。
2. src/inventory_ui.h/.cpp、src/game_inventory.cpp：inventory_pick_selector 注册并处理 WIELD/WEAR 输入动作（复用 g 拾取界面的键位）；即时装备（u.wield/u.wear）保证菜单打开时物品状态即时可见；防崩溃设计：can_wield/can_wear 预检拦截常见失败（物品不被触碰、提示具体原因），预检通过后 wear 仍可能失败（交互弹窗取消等，回滚会以拷贝重建物品使列表 item_location 失效），失败路径重建列表避免悬垂重绘崩溃；i 界面标题行提示 w/W 键。
3. src/handle_action.cpp：自动移动步进后检查跟随 NPC（is_walking_with && can_follow_player_now，仅速度低于玩家的），掉队超过 max(desired_follow_radius()+1, 4) 格（且 <20 格防卡死）时 set_moves(0) 等待。

#### Describe alternatives you've considered
- w/W 曾用 activity actor 方案（装备在关闭菜单后才执行），不满足「菜单保持打开且状态即时可见」，改为即时装备。
- 自动旅行同步曾限定 auto_travel_mode 开关，目的地旅行（TRAVEL_TO）不生效，改为 is_auto_moving() 判定覆盖两种自动移动。

#### Testing
- 构建：Release x64（MSVC + vcpkg，/target:Cataclysm-vcpkg-static）成功产出 cataclysm-tiles.exe；
- 进游戏手动实测（2026-08-11 用户实测通过）：
  - 101：制作可饮用液体（水净化/热汤）→ 液体菜单出现 e 食用，可直接饮用；怪物来源液体无此选项；
  - 193：i 菜单高亮物品按 w 手持/W 穿戴，菜单保持打开、物品即时移动、高亮移至下一项；穿戴不可穿戴物品弹具体原因提示不崩溃；
  - 183：带慢速跟随 NPC 开自动旅行/目的地旅行 → 玩家在 NPC 掉队时等待（提示 You slow down to let X catch up.），队伍不掉队；无跟随 NPC 或 NPC 跟得上时行为不变。
- 单元测试：未运行——本机旧 MSVC 14.33 无法编译 tests 目标（C2280），由 CI 执行。

#### Documentation impact
None（无）

#### Related CCB-Docs PR
None（无）

#### Affected documentation IDs
None（无）

#### Generated reference impact
None（无）

#### Additional context
- 提议来源为 QQ 意见表（玩家建议收集表）。