### PR TITLE
Build: keep Lua runtime C++17-compatible

### DIFF
--- a/src/catalua_platform_runtime.cpp
+++ b/src/catalua_platform_runtime.cpp
@@ -5488,8 +5488,9 @@ sol::table persistent_table( sol::state &lua, const persistent_state &values )
 {
     sol::table result = lua.create_table();
     for( const auto &[key, value] : values ) {
-        std::visit( [&result, &key]( const auto & entry ) {
-            result[key] = entry;
+        const std::string persistent_key = key;
+        std::visit( [&result, &persistent_key]( const auto & entry ) {
+            result[persistent_key] = entry;
         }, value );
     }
     return result;


### PR DESCRIPTION
#### Summary

Build "Keep the Lua-first runtime compatible with the repository's C++17 build"

#### Responsible human

@LYHGLYTX

#### Purpose of change

The post-merge Clang Build Analyzer run for `c663ceb2c1bd1f5b23ffc533c2e7944fd859b4bd` fails in `persistent_table` because a lambda captures the `key` structured binding. Capturing a structured binding is a C++20 extension, while CCB builds as C++17 with warnings promoted to errors.

Failing run: https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/actions/runs/31530538203

#### Describe the solution

Copy the structured-binding key into an ordinary `std::string` local and capture that local in the visitor lambda. Runtime behavior is unchanged; the code now remains valid under the supported C++17 language mode.

#### Describe alternatives you've considered

An init-capture could also avoid directly capturing the structured binding, but the explicit ordinary local is clearer and makes the C++17 boundary unambiguous.

#### Testing

- `git diff --check`
- Reproduced the CI toolchain boundary with Clang 18, `-std=c++17`, and `-Werror`
- `clang++ -fsyntax-only ... src/catalua_platform_runtime.cpp` passed with the same warning policy and relevant feature defines used by the failing job
- A full object build was attempted in an isolated worktree but the temporary tmpfs rejected PCH output with `Disk quota exceeded`; no pass is claimed for that attempt
- `make astyle-check` was run and reports the existing repository-wide formatting baseline, including hundreds of files unrelated to this one-line compatibility fix; no pass is claimed

#### Documentation impact

None

#### Related CCB-Docs PR

None

#### Affected documentation IDs

None

#### Generated reference impact

None

#### Additional context

This focused follow-up restores the post-merge analyzer before the final experimental release is accepted.