### PR TITLE
Tests: remove redundant Lua token capture

### DIFF
--- a/tests/catalua_ui_test.cpp
+++ b/tests/catalua_ui_test.cpp
@@ -8150,7 +8150,7 @@ TEST_CASE( "lua_native_tokens_bind_owner_identity_and_keep_expired_equality_stab
         game,
     [&active_runtime]() {
         return active_runtime;
-    }, [world_generation]() {
+    }, []() {
         return world_generation;
     }, []() {}, []() {} );
     lua["origin_token"] = token;


### PR DESCRIPTION
#### Summary

None

#### Responsible human

@LYHGLYTX

#### Purpose of change

The final master Clang Build Analyzer run failed while compiling `tests/catalua_ui_test.cpp` with Clang 18, C++17, and `-Werror`. The local `world_generation` value is `constexpr`, so explicitly capturing it produces `-Wunused-lambda-capture`.

#### Describe the solution

Remove the redundant `world_generation` capture from the callback lambda. The callback still returns the same constexpr value, so test behavior is unchanged.

#### Describe alternatives you've considered

Disabling the warning or weakening `-Werror` would hide the test defect across the build. Changing the value away from `constexpr` would alter the test unnecessarily.

#### Testing

- `clang++ -std=c++17 -Werror -Wall -Wextra -Wunused-lambda-capture ... -fsyntax-only tests/catalua_ui_test.cpp` (Clang 22.1.8)
- `git diff --check`

No build cache or `obj-lua/` output was created or touched.

#### Documentation impact

None

#### Related CCB-Docs PR

None

#### Affected documentation IDs

None

#### Generated reference impact

None

#### Additional context

Fixes the sole compiler error from Clang Build Analyzer run https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/actions/runs/31536661296. This test-only path does not trigger the Experimental Release workflow.
