### PR TITLE
Tests: split oversized Lua catalog script

### DIFF
--- a/tests/catalua_ui_test.cpp
+++ b/tests/catalua_ui_test.cpp
@@ -1255,7 +1255,7 @@ TEST_CASE( "lua_first_foundational_catalogs_are_native_and_transactional",
     const std::size_t previous_movement_mode_count = move_modes_by_speed().size();
     REQUIRE( base_mutation_overlay_ordering.count(
                  "ccb_platform_test_overlay" ) == 0 );
-    test_mod.write( "main.lua", R"lua(
+    std::string catalog_source = R"lua(
 local ccb = require("ccb")
 
 ccb.runtime.handler("ccb_platform_test_damage_hit", function(payload)
@@ -1600,7 +1600,8 @@ local art = ccb.content.AsciiArt {
 art:line("native Lua")
 art:line("content art")
 ccb.content.add(art)
-
+)lua";
+    catalog_source += R"lua(
 local end_screen = ccb.content.EndScreen {
     id = "ccb_platform_test_end_screen",
     picture = "ccb_platform_test_art",
@@ -1999,7 +2000,8 @@ local recipe_group = ccb.content.RecipeGroup {
 recipe_group:recipe("ccb_platform_catalog_recipe", "Craft Platform catalog item")
 recipe_group:terrain("ccb_platform_catalog_recipe", "ANY", "TYPE")
 ccb.content.add(recipe_group)
-)lua" );
+)lua";
+    test_mod.write( "main.lua", catalog_source );
 
     std::string error;
     REQUIRE( cata::lua_platform::prepare_mods(


### PR DESCRIPTION
#### Summary

None

#### Responsible human

@LYHGLYTX

#### Purpose of change

The final master Windows CI fails with MSVC `C2026: string too big, trailing characters truncated` in `tests/catalua_ui_test.cpp`. The foundational catalog test embeds a 21,143-byte Lua script in one raw string literal, exceeding MSVC's per-literal limit.

#### Describe the solution

Build the same Lua source from two runtime `std::string` fragments split at a complete Lua statement boundary, then pass the combined source to the existing test Mod writer. The reconstructed script is byte-for-byte identical to the original.

#### Describe alternatives you've considered

Disabling the Windows test target or suppressing the compiler error would leave the source truncated. Moving the script to a new fixture file would broaden this narrowly scoped build fix and add fixture lifecycle concerns.

#### Testing

- Compared the original literal with the reconstructed two-part script using `cmp`: byte-for-byte identical (21,143 bytes)
- Parsed the reconstructed script with `luac -p`
- Verified the largest remaining Lua raw literal is 11,035 bytes, below the 16,380-byte MSVC boundary
- Clang 22 C++17 `-Werror -fsyntax-only tests/catalua_ui_test.cpp`
- `git diff --check`

No build cache or `obj-lua/` output was created or touched.

#### Documentation impact

None

#### Related CCB-Docs PR

None

#### Affected documentation IDs

None

#### Generated reference impact

None

#### Additional context

Fixes the sole compiler error from Windows run https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/actions/runs/31544084600. This test-only path does not trigger Experimental Release.
