### PR TITLE
Make Synthetic Lungs' minimum cardiofit guarantee flag-controlled and only active when enabled

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1337,7 +1337,8 @@
     "canceled_mutations": [ "GOODCARDIO", "BADCARDIO", "GOODCARDIO2", "PERSISTENCE_HUNTER", "PERSISTENCE_HUNTER2", "ASTHMA" ],
     "enchantments": [
       { "condition": "ALWAYS", "values": [ { "value": "MOD_HEALTH", "add": -1 }, { "value": "MOD_HEALTH_CAP", "add": -10 } ] }
-    ]
+    ],
+    "active_flags": [ "CARDIO_MIN_GUARANTE" ]
   },
   {
     "id": "bio_targeting",

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -1488,6 +1488,10 @@
     "type": "json_flag"
   },
   {
+    "id": "CARDIO_MIN_GUARANTE",
+    "type": "json_flag"
+  },
+  {
     "id": "CARNIVORE_OK",
     "type": "json_flag"
   },

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -378,6 +378,7 @@ Character flags can be `trait_id`, `json_flag_id` or `flag_id`.  Some of these a
 - ```BLIND``` Makes you blind.
 - ```BLOCK_HUGE_ATTACKS``` Size limitations on blocking are ignored
 - ```BLOCK_SUPERNATURAL_HEALING``` Blocks supernatural healing effects, like magical healing spells, from taking effect.  This flag does not block EoC-based healing like using the u_hp() effect.
+- ```CARDIO_MIN_GUARANTE``` If this flag is set, the character's cardiofit will be at least three times the base value (i.e., 3000).
 - ```BULLET_IMMUNE``` You are immune to bullet damage.
 - ```CANNIBAL``` Butcher humans, eat foods with the `CANNIBALISM` and `STRICT_HUMANITARIANISM` flags without a morale penalty.
 - ```CANNOT_ATTACK``` A creature with this flag cannot attack (includes spellcasting).

--- a/src/character_health.cpp
+++ b/src/character_health.cpp
@@ -169,6 +169,7 @@ static const json_character_flag json_flag_BIONIC_FAULTY( "BIONIC_FAULTY" );
 static const json_character_flag json_flag_BIONIC_LIMB( "BIONIC_LIMB" );
 static const json_character_flag json_flag_BIONIC_SHOCKPROOF( "BIONIC_SHOCKPROOF" );
 static const json_character_flag json_flag_BLIND( "BLIND" );
+static const json_character_flag json_flag_CARDIO_MIN_GUARANTE( "CARDIO_MIN_GUARANTE" );
 static const json_character_flag json_flag_CANNIBAL( "CANNIBAL" );
 static const json_character_flag json_flag_CANNOT_GAIN_WEARINESS( "CANNOT_GAIN_WEARINESS" );
 static const json_character_flag json_flag_CANNOT_TAKE_DAMAGE( "CANNOT_TAKE_DAMAGE" );
@@ -2464,7 +2465,7 @@ int Character::get_cardiofit() const
     // Modify cardio accumulator by our cardio mods.
     const int cardio_fitness = static_cast<int>( cardio_base * cardio_modifier );
 
-    if( has_bionic( bio_synlungs ) ) {
+    if( has_flag( json_flag_CARDIO_MIN_GUARANTE ) ) {
         // If you have synthetic lung bionics, your cardioaccuracy will have a minimum guaranteed value.
         if( cardio_fitness < 3 * get_cardio_acc_base() ) {
             return 3 * get_cardio_acc_base();


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Synthetic Lungs originally had a feature where, "If you have synthetic lung bionics, your cardio_fitness will be calculated using a minimum guaranteed value 3000." It is always enabled and hardcoded to be available only to this CBM. On the one hand, I think other mods may also have a need for this functionality. On the other hand, Synthetic Lungs requires power to function, so if the bionic power is depleted and it can no longer guarantee that it is providing normal breathing capability, losing this fallback value is also reasonable.

#### Describe the solution
Add the `CARDIO_MIN_GUARANTE` flag and add it to the `active_flags` of `bio_synlungs`.

Change the if branch in `character_health.cpp`'s `get_cardiofit()` function that clamps `cardio_fitness` to 3000 or above to use the flag for the check.