### PR TITLE
Allow `REBREATHER_INTERNAL` to be used for cases such as CBMs

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2019,6 +2019,10 @@
     "type": "json_flag"
   },
   {
+    "id": "REBREATHER_INTERNAL",
+    "type": "json_flag"
+  },
+  {
     "id": "RECHARGE",
     "type": "json_flag"
   },

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -371,6 +371,7 @@ Character flags can be `trait_id`, `json_flag_id` or `flag_id`.  Some of these a
 - ```ATTUNEMENT``` Turns a mutation with this flag green on the list.  Currently used in mods for mutations that grant spellcasting or other supernatural powers.
 - ```BARKY``` Makes you considered to be made of bark for the purposes of making blistering harder.
 - ```BASH_IMMUNE``` You are immune to bashing damage.
+- ```REBREATHER_INTERNAL``` Just like `REBREATHER`, but it work as character flag.
 - ```BG_OTHER_SURVIVORS_STORY``` Given to NPC when it has other survival story.
 - ```BG_SURVIVAL_STORY``` Given to NPC when it has a survival story.
 - ```BIO_IMMUNE``` You are immune to biological damage.

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -126,6 +126,7 @@ static const itype_id itype_oxygen_tank( "oxygen_tank" );
 static const itype_id itype_smoxygen_tank( "smoxygen_tank" );
 
 static const json_character_flag json_flag_ALBINO( "ALBINO" );
+static const json_character_flag json_flag_REBREATHER_INTERNAL( "REBREATHER_INTERNAL" );
 static const json_character_flag json_flag_DAYFEAR( "DAYFEAR" );
 static const json_character_flag json_flag_ETHEREAL( "ETHEREAL" );
 static const json_character_flag json_flag_GILLS( "GILLS" );
@@ -341,7 +342,7 @@ void suffer::while_underwater( Character &you )
     if( !you.has_flag( json_flag_GILLS ) ) {
         you.oxygen--;
     }
-    if( you.oxygen < 12 && you.worn_with_flag( flag_REBREATHER ) ) {
+    if( you.oxygen < 12 && ( you.worn_with_flag( flag_REBREATHER ) || you.has_flag( json_flag_REBREATHER_INTERNAL ) ) ) {
         you.oxygen += 12;
     }
     if( you.oxygen <= 5 ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
`REBREATHER` was originally a flag specifically intended for rebreathers, with the effect of keeping the character's oxygen at 12 or above as long as the rebreather remains active, preventing suffocation. However, its check only considers worn items. I may add a CBM form of rebreather to Futurism Cataclysm: Legacy. Although I have not designed it yet, I think this simple functionality can be supported in advance.

#### Describe the solution
Add the `REBREATHER_INTERNAL` flag, with the same effect as `REBREATHER`, both of which work in `while_underwater` in `suffer.cpp`.

Expand the original `you.worn_with_flag( flag_REBREATHER )` check to `( you.worn_with_flag( flag_REBREATHER ) || you.has_flag( json_flag_REBREATHER_INTERNAL ) )`.