### PR TITLE
Allow vehicle parts to configure and apply spoil multipliers (affecting rot speed)

### DIFF
--- a/doc/JSON/JSON_INFO.md
+++ b/doc/JSON/JSON_INFO.md
@@ -2909,7 +2909,8 @@ Unless specified as optional, the following fields are mandatory for parts with 
 "cargo_weight_modifier": 33,  // (Optional, default = 100) Multiplies cargo weight by this percentage.
 "cargo_spoil_multiplier": 50, // (Optional, default = 100) Multiplies the spoilage rate of items
                               // stored in this part by this percentage.  0 preserves indefinitely.
-                              // Also applies to the contents of FLUIDTANK parts.
+                              // Also applies to the contents of FLUIDTANK parts, which only
+                              // accept values in the 0-100 range.
 ```
 
 #### The following optional fields are specific to ENGINEs.

--- a/doc/JSON/JSON_INFO.md
+++ b/doc/JSON/JSON_INFO.md
@@ -2907,6 +2907,9 @@ Unless specified as optional, the following fields are mandatory for parts with 
 ```jsonc
 "size": "400 L",              // for parts with "CARGO" flag the capacity in liters
 "cargo_weight_modifier": 33,  // (Optional, default = 100) Multiplies cargo weight by this percentage.
+"cargo_spoil_multiplier": 50, // (Optional, default = 100) Multiplies the spoilage rate of items
+                              // stored in this part by this percentage.  0 preserves indefinitely.
+                              // Also applies to the contents of FLUIDTANK parts.
 ```
 
 #### The following optional fields are specific to ENGINEs.

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -15199,7 +15199,7 @@ void zone_sort_activity_actor::deliver_picked_items( Character &you,
             // determines the fallback chain: vehicle-only zones skip
             // ground, everything else tries cargo then ground.
             const zone_type_id drop_zt = mgr.get_near_zone_type_for_item( **iter,
-                                         drop_dest, 0, fac_id );
+                                         drop_dest, 0, fac_id, iter->spoil_multiplier() );
             const bool vehicle_only = drop_zt != zone_type_id::NULL_ID() &&
                                       mgr.has_vehicle( drop_zt, drop_dest, fac_id ) &&
                                       !mgr.has_terrain( drop_zt, drop_dest, fac_id );

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -15616,13 +15616,22 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
             continue;
         }
 
+        float spoil_multiplier = 1.0f;
+        if( it->second ) {
+            if( const std::optional<vpart_reference> ovp =
+                    zone_sorting::cargo_part_from_index( src_bub, *it->second ) ) {
+                spoil_multiplier = ovp->info().cargo_spoil_multiplier / 100.0f;
+            }
+        }
+
         if( zone_sorting::sort_skip_item( you, it->first, other_activity_items,
-                                          mgr.has( zone_type_LOOT_IGNORE_FAVORITES, src, fac_id ), src ) ) {
+                                          mgr.has( zone_type_LOOT_IGNORE_FAVORITES, src, fac_id ),
+                                          src, spoil_multiplier ) ) {
             continue;
         }
 
         const zone_type_id zt_id = mgr.get_near_zone_type_for_item( thisitem, abspos,
-                                   MAX_VIEW_DISTANCE, fac_id );
+                                   MAX_VIEW_DISTANCE, fac_id, spoil_multiplier );
 
         std::unordered_set<tripoint_abs_ms> dest_set =
             mgr.get_near( zt_id, abspos, MAX_VIEW_DISTANCE, &thisitem, fac_id );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1180,8 +1180,16 @@ bool has_items_to_sort( Character &you, const tripoint_abs_ms &src,
         }
 
         item *it = it_pair.first;
+        float spoil_multiplier = 1.0f;
+        if( it_pair.second ) {
+            const std::optional<vpart_reference> ovp =
+                cargo_part_from_index( get_map().get_bub( src ), *it_pair.second );
+            if( ovp ) {
+                spoil_multiplier = ovp->info().cargo_spoil_multiplier / 100.0f;
+            }
+        }
         const zone_type_id dest_zone_type_id = mgr.get_near_zone_type_for_item( *it, abspos,
-                                               MAX_VIEW_DISTANCE, fac_id );
+                                               MAX_VIEW_DISTANCE, fac_id, spoil_multiplier );
 
         if( dest_zone_type_id == zone_type_id::NULL_ID() ) {
             continue;

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -919,6 +919,7 @@ bool route_to_destination( Character &you, player_activity &act,
 bool sort_skip_item( Character &you, const item *it,
                      const std::vector<item_location> &other_activity_items,
                      bool ignore_favorite, const tripoint_abs_ms &src,
+                     const float base_spoil_multiplier,
                      bool *spillable_skipped )
 {
     const zone_manager &mgr = zone_manager::get_manager();
@@ -962,7 +963,7 @@ bool sort_skip_item( Character &you, const item *it,
 
     const faction_id fac_id = _fac_id( you );
     const zone_type_id zt_id = mgr.get_near_zone_type_for_item( *it, you.pos_abs(),
-                               MAX_VIEW_DISTANCE, fac_id );
+                               MAX_VIEW_DISTANCE, fac_id, base_spoil_multiplier );
     // Skip items already at their destination regardless of whether the zone
     // is bound to terrain or vehicle cargo. Delivery tries cargo first, so
     // items often land in vehicle storage even at terrain-bound zones (e.g.,

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -4353,8 +4353,7 @@ static int get_comestible_order( Character &you, const item_location &loc,
         }
     } else if( time == 0_turns ) {
         return 4;
-    } else if( loc.has_parent() &&
-               loc.parent_pocket()->spoil_multiplier() == 0.0f ) {
+    } else if( loc.spoil_multiplier() == 0.0f ) {
         return 3;
     } else {
         return 2;

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1213,7 +1213,8 @@ bool has_items_to_sort( Character &you, const tripoint_abs_ms &src,
         }
 
         if( sort_skip_item( you, it, other_activity_items,
-                            zone_unload_options.ignore_favorite, src, spillable_skipped ) ) {
+                            zone_unload_options.ignore_favorite, src, spoil_multiplier,
+                            spillable_skipped ) ) {
             continue;
         }
 

--- a/src/activity_item_handling.h
+++ b/src/activity_item_handling.h
@@ -80,6 +80,7 @@ bool route_to_destination( Character &you, player_activity &act,
 bool sort_skip_item( Character &you, const item *it,
                      const std::vector<item_location> &other_activity_items,
                      bool ignore_favorite, const tripoint_abs_ms &src,
+                     float base_spoil_multiplier = 1.0f,
                      bool *spillable_skipped = nullptr );
 
 /**

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -651,11 +651,14 @@ struct advanced_inv_sorter {
                 }
             }
             break;
-            case SORTBY_SPOILAGE:
-                if( d1.items.front()->spoilage_sort_order() != d2.items.front()->spoilage_sort_order() ) {
-                    return d1.items.front()->spoilage_sort_order() < d2.items.front()->spoilage_sort_order();
+            case SORTBY_SPOILAGE: {
+                const int order1 = d1.items.front()->spoilage_sort_order( d1.items.front().spoil_multiplier() );
+                const int order2 = d2.items.front()->spoilage_sort_order( d2.items.front().spoil_multiplier() );
+                if( order1 != order2 ) {
+                    return order1 < order2;
                 }
-                break;
+            }
+            break;
             case SORTBY_PRICE:
                 if( d1.items.front()->price( true ) != d2.items.front()->price( true ) ) {
                     return d1.items.front()->price( true ) > d2.items.front()->price( true );

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -652,8 +652,10 @@ struct advanced_inv_sorter {
             }
             break;
             case SORTBY_SPOILAGE: {
-                const int order1 = d1.items.front()->spoilage_sort_order( d1.items.front().spoil_multiplier() );
-                const int order2 = d2.items.front()->spoilage_sort_order( d2.items.front().spoil_multiplier() );
+                const float mult1 = d1.items.front().spoil_multiplier();
+                const float mult2 = d2.items.front().spoil_multiplier();
+                const int order1 = d1.items.front()->spoilage_sort_order( mult1 );
+                const int order2 = d2.items.front()->spoilage_sort_order( mult2 );
                 if( order1 != order2 ) {
                     return order1 < order2;
                 }

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -1404,7 +1404,8 @@ std::optional<tripoint_abs_ms> zone_manager::get_nearest( const zone_type_id &ty
 }
 
 zone_type_id zone_manager::get_near_zone_type_for_item( const item &it,
-        const tripoint_abs_ms &where, int range, const faction_id &fac ) const
+        const tripoint_abs_ms &where, int range, const faction_id &fac,
+        const float base_spoil_multiplier ) const
 {
     const item_category &cat = it.get_category_of_contents();
 
@@ -1450,16 +1451,18 @@ zone_type_id zone_manager::get_near_zone_type_for_item( const item &it,
         bool perishable = false;
         // Look for food, and whether any contents which will spoil if left out.
         // Food crafts and food without comestible, like MREs, will fall down to LOOT_FOOD.
-        it.visit_items( [&it_food, &perishable]( const item * node, const item * parent ) {
+        it.visit_items( [&it_food, &perishable, base_spoil_multiplier](
+                            const item * node, const item * parent ) {
             if( node && node->is_food() ) {
                 it_food = node;
 
                 if( node->goes_bad() ) {
-                    float spoil_multiplier = 1.0f;
+                    float spoil_multiplier = base_spoil_multiplier;
                     if( parent ) {
                         const item_pocket *parent_pocket = parent->contained_where( *node );
                         if( parent_pocket ) {
-                            spoil_multiplier = parent_pocket->spoil_multiplier();
+                            spoil_multiplier = std::min( spoil_multiplier,
+                                                         parent_pocket->spoil_multiplier() );
                         }
                     }
                     if( spoil_multiplier > 0.0f ) {

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -1452,7 +1452,7 @@ zone_type_id zone_manager::get_near_zone_type_for_item( const item &it,
         // Look for food, and whether any contents which will spoil if left out.
         // Food crafts and food without comestible, like MREs, will fall down to LOOT_FOOD.
         it.visit_items( [&it_food, &perishable, base_spoil_multiplier](
-                            const item * node, const item * parent ) {
+                        const item * node, const item * parent ) {
             if( node && node->is_food() ) {
                 it_food = node;
 

--- a/src/clzones.h
+++ b/src/clzones.h
@@ -713,7 +713,8 @@ class zone_manager
             const zone_type_id &type, const tripoint_abs_ms &where, int range = MAX_DISTANCE,
             const faction_id &fac = your_fac ) const;
         zone_type_id get_near_zone_type_for_item( const item &it, const tripoint_abs_ms &where,
-                int range = MAX_DISTANCE, const faction_id &fac = your_fac ) const;
+                int range = MAX_DISTANCE, const faction_id &fac = your_fac,
+                float base_spoil_multiplier = 1.0f ) const;
         std::vector<zone_data> get_zones( const zone_type_id &type, const tripoint_abs_ms &where,
                                           const faction_id &fac = your_fac ) const;
         const zone_data *get_zone_at( const tripoint_abs_ms &where, bool loot_only = false,

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -5629,15 +5629,16 @@ item basecamp::make_fake_food( const nutrients &to_use ) const
     return food_item;
 }
 
-static time_point rot_time( const item &it, item *const container )
+static time_point rot_time( const item &it, item *const container,
+                            const float base_spoil_multiplier )
 {
     if( !it.goes_bad() ) {
         return calendar::turn_zero;
     }
-    float spoil_mod = 1.0f;
+    float spoil_mod = base_spoil_multiplier;
     if( container ) {
         if( item_pocket *const pocket = container->contained_where( it ) ) {
-            spoil_mod = pocket->spoil_multiplier();
+            spoil_mod = std::min( spoil_mod, pocket->spoil_multiplier() );
         }
     }
     // Container seals and prevents any spoilage.
@@ -5699,7 +5700,7 @@ static void add_consumed_nutrients( std::map<time_point, nutrients> &into, time_
 // Checks the contents of the item for nutrients, and removes ones with nutrients
 // nutrients gained from this item and it's contents are the value of the ret_val
 static ret_val<std::map<time_point, nutrients>> nutrients_from( item &it, item *const container,
-        bool distribute_vitamins )
+        bool distribute_vitamins, const float base_spoil_multiplier = 1.0f )
 {
     // nutrients consumed and when they will rot
     std::map<time_point, nutrients> consumed;
@@ -5710,7 +5711,8 @@ static ret_val<std::map<time_point, nutrients>> nutrients_from( item &it, item *
             if( from_item.has_value() ) {
                 // we perform a magic act here and remove the item that's preserving it while keeping it preserved
                 to_remove.push_back( content );
-                add_consumed_nutrients( consumed, rot_time( *content, container ), *from_item );
+                const time_point rot = rot_time( *content, container, base_spoil_multiplier );
+                add_consumed_nutrients( consumed, rot, *from_item );
                 return VisitResponse::SKIP;
             }
             return VisitResponse::NEXT;
@@ -5729,7 +5731,7 @@ static ret_val<std::map<time_point, nutrients>> nutrients_from( item &it, item *
     if( !from_this.has_value() ) {
         return ret_val<std::map<time_point, nutrients>>::make_failure( consumed );
     }
-    add_consumed_nutrients( consumed, rot_time( it, container ), *from_this );
+    add_consumed_nutrients( consumed, rot_time( it, container, base_spoil_multiplier ), *from_this );
     return ret_val<std::map<time_point, nutrients>>::make_success( consumed );
 }
 

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -5638,7 +5638,7 @@ static time_point rot_time( const item &it, item *const container,
     float spoil_mod = base_spoil_multiplier;
     if( container ) {
         if( item_pocket *const pocket = container->contained_where( it ) ) {
-            spoil_mod = std::min( spoil_mod, pocket->spoil_multiplier() );
+            spoil_mod *= pocket->spoil_multiplier();
         }
     }
     // Container seals and prevents any spoilage.

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -5784,9 +5784,10 @@ bool basecamp::distribute_food( bool player_command )
         }
         if( const std::optional<vpart_reference> ovp = here.veh_at( p_food_stock ).cargo() ) {
             vehicle_stack items = ovp->items();
+            const float cargo_spoil = ovp->info().cargo_spoil_multiplier / 100.0f;
             for( auto iter = items.begin(); iter != items.end(); ) {
                 ret_val<std::map<time_point, nutrients>> ret = nutrients_from( *iter, nullptr,
-                                                      distribute_vitamins );
+                                                      distribute_vitamins, cargo_spoil );
                 if( ret.success() ) {
                     iter = items.erase( iter );
                 } else {

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -882,8 +882,7 @@ class comestible_inventory_preset : public inventory_selector_preset
                 }
             } else if( time == 0_turns ) {
                 return 4;
-            } else if( loc.has_parent() &&
-                       loc.parent_pocket()->spoil_multiplier() == 0.0f ) {
+            } else if( loc.spoil_multiplier() == 0.0f ) {
                 return 3;
             } else {
                 return 2;

--- a/src/item.h
+++ b/src/item.h
@@ -1242,7 +1242,8 @@ class item : public visitable
          * Get minimum time for this item or any of its contents to rot, ignoring
          * fridge. If this item is a container, its spoil multiplier is taken into
          * account, but the spoil multiplier of the parent container of this item,
-         * if any, is not.
+         * if any, is not.  \p base_spoil_multiplier is additionally combined,
+         * e.g. the spoil multiplier of the vehicle part storing this item.
          *
          * If this item does not rot and none of its contents rot either, the function
          * returns INT_MAX - N,
@@ -1253,7 +1254,7 @@ class item : public visitable
          * 1 for other comestibles,
          * 0 otherwise.
          */
-        int spoilage_sort_order() const;
+        int spoilage_sort_order( float base_spoil_multiplier = 1.0f ) const;
 
         /** an item is fresh if it is capable of rotting but still has a long shelf life remaining */
         bool is_fresh() const {

--- a/src/item_degrade.cpp
+++ b/src/item_degrade.cpp
@@ -521,7 +521,8 @@ int item::spoilage_sort_order( const float base_spoil_multiplier ) const
             if( parent ) {
                 const item_pocket *const parent_pocket = parent->contained_where( *node );
                 if( parent_pocket ) {
-                    spoil_multiplier = std::min( spoil_multiplier, parent_pocket->spoil_multiplier() );
+                    spoil_multiplier = std::min( spoil_multiplier,
+                                                 parent_pocket->spoil_multiplier() );
                 }
             }
             if( spoil_multiplier > 0.0f ) {

--- a/src/item_degrade.cpp
+++ b/src/item_degrade.cpp
@@ -521,8 +521,7 @@ int item::spoilage_sort_order( const float base_spoil_multiplier ) const
             if( parent ) {
                 const item_pocket *const parent_pocket = parent->contained_where( *node );
                 if( parent_pocket ) {
-                    spoil_multiplier = std::min( spoil_multiplier,
-                                                 parent_pocket->spoil_multiplier() );
+                    spoil_multiplier *= parent_pocket->spoil_multiplier();
                 }
             }
             if( spoil_multiplier > 0.0f ) {

--- a/src/item_degrade.cpp
+++ b/src/item_degrade.cpp
@@ -509,7 +509,7 @@ void item::randomize_rot()
     }
 }
 
-int item::spoilage_sort_order() const
+int item::spoilage_sort_order( const float base_spoil_multiplier ) const
 {
     int bottom = std::numeric_limits<int>::max();
 
@@ -517,11 +517,11 @@ int item::spoilage_sort_order() const
     time_duration min_spoil_time = calendar::INDEFINITELY_LONG_DURATION;
     visit_items( [&]( item * const node, item * const parent ) {
         if( node && node->goes_bad() ) {
-            float spoil_multiplier = 1.0f;
+            float spoil_multiplier = base_spoil_multiplier;
             if( parent ) {
                 const item_pocket *const parent_pocket = parent->contained_where( *node );
                 if( parent_pocket ) {
-                    spoil_multiplier = parent_pocket->spoil_multiplier();
+                    spoil_multiplier = std::min( spoil_multiplier, parent_pocket->spoil_multiplier() );
                 }
             }
             if( spoil_multiplier > 0.0f ) {

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -1409,6 +1409,23 @@ const vehicle_cursor *item_location::veh_cursor() const
     return ptr->veh_cursor();
 }
 
+float item_location::spoil_multiplier() const
+{
+    float multiplier = 1.0f;
+    item_location parent = *this;
+    while( parent.has_parent() ) {
+        if( item_pocket *const pocket = parent.parent_pocket() ) {
+            multiplier = std::min( multiplier, pocket->spoil_multiplier() );
+        }
+        parent = parent.parent_item();
+    }
+    if( const vehicle_cursor *const cur = parent.veh_cursor() ) {
+        multiplier = std::min( multiplier,
+                               cur->veh.part( cur->part ).info().cargo_spoil_multiplier / 100.0f );
+    }
+    return multiplier;
+}
+
 bool item_location::held_by( Character const &who ) const
 {
     return carrier() == &who;

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -1415,13 +1415,12 @@ float item_location::spoil_multiplier() const
     item_location parent = *this;
     while( parent.has_parent() ) {
         if( item_pocket *const pocket = parent.parent_pocket() ) {
-            multiplier = std::min( multiplier, pocket->spoil_multiplier() );
+            multiplier *= pocket->spoil_multiplier();
         }
         parent = parent.parent_item();
     }
     if( const vehicle_cursor *const cur = parent.veh_cursor() ) {
-        multiplier = std::min( multiplier,
-                               cur->veh.part( cur->part ).info().cargo_spoil_multiplier / 100.0f );
+        multiplier *= cur->veh.part( cur->part ).info().cargo_spoil_multiplier / 100.0f;
     }
     return multiplier;
 }

--- a/src/item_location.h
+++ b/src/item_location.h
@@ -121,6 +121,10 @@ class item_location
         /** returns the vehicle whose inventory contains this item, nullptr if none **/
         const vehicle_cursor *veh_cursor() const;
 
+        /** effective spoilage multiplier of the storage this item sits in, combining all
+         *  parent pockets and the vehicle part it may be stored in */
+        float spoil_multiplier() const;
+
         /** returns true if the item is in the inventory of the given character **/
         bool held_by( Character const &who ) const;
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7534,7 +7534,8 @@ void map::process_items_in_vehicle( vehicle &cur_veh, submap &current_submap )
         bool in_tank = pt.info().has_flag( VPFLAG_FLUIDTANK );
         if( !process_map_items( *this, items, active_item_ref.item_ref, active_item_ref.parent,
                                 item_loc, it_insulation, flag,
-                                active_item_ref.spoil_multiplier(), in_tank || active_item_ref.has_watertight_container() ) ) {
+                                active_item_ref.spoil_multiplier() * pt.info().cargo_spoil_multiplier / 100.0f,
+                                in_tank || active_item_ref.has_watertight_container() ) ) {
             // If the item was NOT destroyed, we can skip the remainder,
             // which handles fallout from the vehicle being damaged.
             continue;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7534,7 +7534,8 @@ void map::process_items_in_vehicle( vehicle &cur_veh, submap &current_submap )
         bool in_tank = pt.info().has_flag( VPFLAG_FLUIDTANK );
         if( !process_map_items( *this, items, active_item_ref.item_ref, active_item_ref.parent,
                                 item_loc, it_insulation, flag,
-                                active_item_ref.spoil_multiplier() * pt.info().cargo_spoil_multiplier / 100.0f,
+                                active_item_ref.spoil_multiplier() *
+                                pt.info().cargo_spoil_multiplier / 100.0f,
                                 in_tank || active_item_ref.has_watertight_container() ) ) {
             // If the item was NOT destroyed, we can skip the remainder,
             // which handles fallout from the vehicle being damaged.

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -837,6 +837,11 @@ void vpart_info::check() const
         debugmsg( "vehicle part '%s' uses reserved character %c", id.str(), vehicles::variant_separator );
     }
 
+    if( has_flag( VPFLAG_FLUIDTANK ) && cargo_spoil_multiplier > 100 ) {
+        debugmsg( "vehicle part '%s' is a FLUIDTANK, cargo_spoil_multiplier above 100 has no effect",
+                  id.str() );
+    }
+
     for( const auto&[vid, vv] : variants ) {
         for( size_t i = 0; i < vv.symbols.size(); i++ ) {
             if( ( mk_wcwidth( vv.symbols[i] ) != 1 ) ||

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -1070,6 +1070,14 @@ int vpart_info::format_description( std::string &msg, const nc_color &format_col
             append_desc( json_flag::get( flagid ).info() );
         }
     }
+    if( cargo_spoil_multiplier != 100 ) {
+        if( cargo_spoil_multiplier != 0 ) {
+            append_desc( string_format( _( "Stored items spoil at %d%% their original rate." ),
+                                        cargo_spoil_multiplier ) );
+        } else {
+            append_desc( _( "Stored items won't spoil." ) );
+        }
+    }
     if( has_flag( "TURRET" ) ) {
         class::item base( base_item );
         if( base.ammo_required() && !base.ammo_remaining( ) ) {

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -277,6 +277,7 @@ void vpart_info::load( const JsonObject &jo, const std::string_view src )
         light_color.b = jarr.get_int( 2 ) / 255.0f;
     }
     optional( jo, was_loaded, "cargo_weight_modifier", cargo_weight_modifier, 100 );
+    optional( jo, was_loaded, "cargo_spoil_multiplier", cargo_spoil_multiplier, 100 );
     optional( jo, was_loaded, "categories", categories, string_reader{} );
     optional( jo, was_loaded, "flags", flags, string_reader{} );
     optional( jo, was_loaded, "description", description );

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -1070,12 +1070,22 @@ int vpart_info::format_description( std::string &msg, const nc_color &format_col
             append_desc( json_flag::get( flagid ).info() );
         }
     }
-    if( cargo_spoil_multiplier != 100 ) {
-        if( cargo_spoil_multiplier != 0 ) {
-            append_desc( string_format( _( "Stored items spoil at %d%% their original rate." ),
-                                        cargo_spoil_multiplier ) );
-        } else {
-            append_desc( _( "Stored items won't spoil." ) );
+    if( has_flag( VPFLAG_FLUIDTANK ) || cargo_spoil_multiplier != 100 ) {
+        float spoil_multiplier = cargo_spoil_multiplier / 100.0f;
+        if( has_flag( VPFLAG_FLUIDTANK ) ) {
+            class::item base( base_item );
+            for( item_pocket *const pocket : base.get_container_pockets() ) {
+                spoil_multiplier = std::min( spoil_multiplier, pocket->spoil_multiplier() );
+            }
+        }
+        if( spoil_multiplier != 1.0f ) {
+            if( spoil_multiplier != 0.0f ) {
+                const int percent = static_cast<int>( std::lround( spoil_multiplier * 100 ) );
+                append_desc( string_format( _( "Stored items spoil at %d%% their original rate." ),
+                                            percent ) );
+            } else {
+                append_desc( _( "Stored items won't spoil." ) );
+            }
         }
     }
     if( has_flag( "TURRET" ) ) {

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -532,6 +532,9 @@ class vpart_info
         /** cargo weight modifier (percentage) */
         int cargo_weight_modifier = 100;
 
+        /** spoilage rate modifier for items stored in this part (percentage) */
+        int cargo_spoil_multiplier = 100;
+
         /*Comfort data for sleeping in vehicles*/
         int comfort = 0;
         units::temperature_delta floor_bedding_warmth = 0_C_delta;

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -547,7 +547,7 @@ void vehicle_part::process_contents( map &here, const tripoint_bub_ms &pos, cons
     } else if( enabled && info().has_flag( VPFLAG_HEATED_TANK ) ) {
         flag = temperature_flag::HEATER;
     }
-    base.process( here, nullptr, pos, 1, flag );
+    base.process( here, nullptr, pos, 1, flag, info().cargo_spoil_multiplier / 100.0f );
 }
 
 bool vehicle_part::fill_with( item &liquid, int qty )

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -547,7 +547,8 @@ void vehicle_part::process_contents( map &here, const tripoint_bub_ms &pos, cons
     } else if( enabled && info().has_flag( VPFLAG_HEATED_TANK ) ) {
         flag = temperature_flag::HEATER;
     }
-    base.process( here, nullptr, pos, 1, flag, info().cargo_spoil_multiplier / 100.0f );
+    base.process( here, nullptr, pos, 1, flag,
+                  std::min( 1.0f, info().cargo_spoil_multiplier / 100.0f ) );
 }
 
 bool vehicle_part::fill_with( item &liquid, int qty )


### PR DESCRIPTION
#### Summary
Features "Allow vehicle parts to configure and apply spoil multipliers"

#### Purpose of change
When I was making mods for 0.i DDA, before CCB was established and before I had joined it, I already noticed that the "containers" of vehicle parts seemed unable to support spoilage rate properties. Furniture and terrain have flags that stop spoilage, but vehicle parts cannot recognize or use them; item pockets have a `spoil_multiplier` field, and although the capacity of vehicle liquid tanks directly inherits from item pockets, it also seemed unable to correctly pass this pocket parameter through (looking at the code now, it is supported, but for a third-party modder who does not inspect the source code at all, it is indeed difficult to perceive).

In short, container pockets have `spoil_multiplier` to reduce the spoilage rate of their contents, but vehicle cargo and liquid tank parts lack an equivalent mechanism. Preservation can only rely on FRIDGE/FREEZER temperatures or the pockets of the underlying container itself. But since I could already discover this when I was not yet a game developer and was only a mod developer, it was naturally because I had tried to use or write content related to this and ran into obstacles. Therefore, I think other modders may also find this useful. This is also an effort to improve mod support and expose more interfaces, as described in issue #44.

#### Describe the solution
- Add the vpart_info field `cargo_spoil_multiplier` (integer percentage, default 100, 0 means never spoils, following the same logic as `cargo_weight_modifier`).
- Cargo compartments (those with the `CARGO` flag): `process_items_in_vehicle` multiplies the vehicle part multiplier into the item spoilage modifier.
- Tanks (those with the `FLUIDTANK` flag): `process_contents` passes the multiplier as `spoil_multiplier_parent` into the base container processing chain, taking the min with the container's own pocket multiplier (following the existing processing semantics).
- UI: `format_description` for vehicle parts displays a spoilage preservation effect line. For `FLUIDTANK`, the default display uses the `spoil_multiplier` configured for the underlying item's pocket.
- Add the `item_location::spoil_multiplier()` helper function, allowing food sorting, advanced inventory sorting, perishable item categorization, and camp food distribution to uniformly recognize vehicle part multipliers; all of these are minimal incremental changes with additional default parameters.

#### Documentation impact
Update doc/JSON/JSON_INFO.md: add documentation for the vehicle_part field `cargo_spoil_multiplier`.