### PR TITLE
微调部分选项

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2069,7 +2069,7 @@ void options_manager::add_options_general()
                                         to_translation( "Options regarding safe mode." ) ),
     [&]( const std::string & page_id ) {
         add( "SAFEMODEDEFAULTSTATE", page_id, to_translation( "Safe mode default state" ),
-             to_translation( "The default state of save mode when starting game." ),
+             to_translation( "The default state of safe mode when starting game." ),
              true
            );
 
@@ -2959,6 +2959,15 @@ void options_manager::add_options_graphics()
     add_option_group( "graphics", Group( "term_opts", to_translation( "Terminal display options" ),
                                          to_translation( "Options regarding terminal display." ) ),
     [&]( const std::string & page_id ) {
+#if defined(__ANDROID__)
+        add( "ANDROID_TERMINAL_SIZE", page_id, to_translation( "Terminal size" ),
+             to_translation( "Automatically match the terminal layout to the usable Android screen area.  Manual uses Terminal width and Terminal height instead." ),
+        {
+            { "auto", to_translation( "Automatic" ) },
+            { "manual", to_translation( "Manual" ) }
+        }, "auto"
+           );
+#endif
         add( "TERMINAL_X", page_id, to_translation( "Terminal width" ),
              to_translation( "Set the size of the terminal along the X axis." ),
              80, 960, 80, COPT_POSIX_CURSES_HIDE
@@ -2968,6 +2977,10 @@ void options_manager::add_options_graphics()
              to_translation( "Set the size of the terminal along the Y axis." ),
              24, 270, 24, COPT_POSIX_CURSES_HIDE
            );
+#if defined(__ANDROID__)
+        get_option( "TERMINAL_X" ).setPrerequisite( "ANDROID_TERMINAL_SIZE", "manual" );
+        get_option( "TERMINAL_Y" ).setPrerequisite( "ANDROID_TERMINAL_SIZE", "manual" );
+#endif
     } );
 
     add_empty_line();
@@ -3523,19 +3536,6 @@ void options_manager::add_options_world_default()
 
     add_empty_line();
 
-    // string_input (free text) rather than string_select: total-conversion
-    // mods set this via EXTERNAL_OPTION (e.g. Aftershock -> "default_aftershock"),
-    // and a string_select silently rejects any value not in its candidate list.
-    // The candidate list cannot be pre-populated here because region data loads
-    // after options, so a free-text field is the only form that accepts arbitrary
-    // (mod-provided or player-typed) region ids while staying visible in worldgen.
-    add( "DEFAULT_REGION", "world_default", to_translation( "Default region type" ),
-         to_translation( "(WIP feature) Determines terrain, shops, plants, and more.  Set by total-conversion mods; leave as \"default\" unless you know the id of an installed region." ),
-         "default", 60
-       );
-
-    add_empty_line();
-
     add_option_group( "world_default", Group( "spawn_time_opts", to_translation( "World time options" ),
                       to_translation( "Options regarding the passage of time in the world." ) ),
     [&]( const std::string & page_id ) {
@@ -3565,13 +3565,43 @@ void options_manager::add_options_world_default()
 
     add_empty_line();
 
+    add_option_group( "world_default", Group( "crop_opts", to_translation( "Crop options" ),
+                      to_translation( "Options regarding crop growth, harvest yield and water consumption." ) ),
+    [&]( const std::string & page_id ) {
+        add( "CROP_GROWTH_SPEED", page_id, to_translation( "Crop growth speed" ),
+             to_translation( "Multiplier for crop growth speed.  Higher values make crops grow faster." ),
+             0.1f, 10.0f, 1.0f, 0.1f, COPT_NO_HIDE, "%.1f"
+           );
+
+        add( "CROP_HARVEST_MULTIPLIER", page_id, to_translation( "Crop harvest yield" ),
+             to_translation( "Multiplier for the number of crops harvested from a plant." ),
+             0.1f, 10.0f, 1.0f, 0.1f, COPT_NO_HIDE, "%.1f"
+           );
+
+        add( "CROP_WATER_CONSUMPTION", page_id, to_translation( "Crop water consumption" ),
+             to_translation( "Multiplier for daily water consumption of irrigated crops.  "
+                             "Higher values make crops thirstier." ),
+             0.1f, 10.0f, 1.0f, 0.1f, COPT_NO_HIDE, "%.1f"
+           );
+
+        add( "CROP_OVERGROWN_ENABLED", page_id,
+             to_translation( "Crops can wither from overgrowth" ),
+             to_translation( "If true, mature crops will eventually become overgrown and "
+                             "wither if not harvested." ),
+             true
+           );
+    } );
+
+    add_empty_line();
+
     add_option_group( "world_default", Group( "misc_worlddef_opts", to_translation( "Misc options" ),
                       to_translation( "Miscellaneous options." ) ),
     [&]( const std::string & page_id ) {
-        add( "WANDER_SPAWNS", page_id, to_translation( "Wandering hordes" ),
-             to_translation( "If true, emulates zombie hordes.  Zombies can group together into hordes, which can wander around cities and will sometimes move towards noise.  Note: the current implementation does not properly respect obstacles, so hordes can appear to walk through walls under some circumstances.  Must reset world directory after changing for it to take effect." ),
-             false
-           );
+        // TODO: find the code keypoint and implement this option.
+        // add( "WANDER_SPAWNS", page_id, to_translation( "Wandering hordes" ),
+        //      to_translation( "If true, emulates zombie hordes.  Zombies can group together into hordes, which can wander around cities and will sometimes move towards noise.  Note: the current implementation does not properly respect obstacles, so hordes can appear to walk through walls under some circumstances.  Must reset world directory after changing for it to take effect." ),
+        //      false
+        //    );
 
         add( "FACTION_TERRITORY_CHECKS", page_id,
              to_translation( "Faction territory permission checks" ),
@@ -3599,7 +3629,7 @@ void options_manager::add_options_world_default()
     add( "CHARACTER_POINT_POOLS", "world_default", to_translation( "Character point pools" ),
          to_translation( "Allowed point pools for character generation." ),
     { { "any", to_translation( "Any" ) }, { "multi_pool", to_translation( "Legacy Multipool" ) }, { "story_teller", to_translation( "Survivor" ) } },
-    "story_teller"
+    "any"
        );
 
     add_empty_line();
@@ -3617,32 +3647,16 @@ void options_manager::add_options_world_default()
 
     add_empty_line();
 
-    add_option_group( "world_default", Group( "crop_opts", to_translation( "Crop options" ),
-                      to_translation( "Options regarding crop growth, harvest yield and water consumption." ) ),
-    [&]( const std::string & page_id ) {
-        add( "CROP_GROWTH_SPEED", page_id, to_translation( "Crop growth speed" ),
-             to_translation( "Multiplier for crop growth speed.  Higher values make crops grow faster." ),
-             0.1f, 10.0f, 1.0f, 0.1f, COPT_NO_HIDE, "%.1f"
-           );
-
-        add( "CROP_HARVEST_MULTIPLIER", page_id, to_translation( "Crop harvest yield" ),
-             to_translation( "Multiplier for the number of crops harvested from a plant." ),
-             0.1f, 10.0f, 1.0f, 0.1f, COPT_NO_HIDE, "%.1f"
-           );
-
-        add( "CROP_WATER_CONSUMPTION", page_id, to_translation( "Crop water consumption" ),
-             to_translation( "Multiplier for daily water consumption of irrigated crops.  "
-                             "Higher values make crops thirstier." ),
-             0.1f, 10.0f, 1.0f, 0.1f, COPT_NO_HIDE, "%.1f"
-           );
-
-        add( "CROP_OVERGROWN_ENABLED", page_id,
-             to_translation( "Crops can wither from overgrowth" ),
-             to_translation( "If true, mature crops will eventually become overgrown and "
-                             "wither if not harvested." ),
-             true
-           );
-    } );
+    // string_input (free text) rather than string_select: total-conversion
+    // mods set this via EXTERNAL_OPTION (e.g. Aftershock -> "default_aftershock"),
+    // and a string_select silently rejects any value not in its candidate list.
+    // The candidate list cannot be pre-populated here because region data loads
+    // after options, so a free-text field is the only form that accepts arbitrary
+    // (mod-provided or player-typed) region ids while staying visible in worldgen.
+    add( "DEFAULT_REGION", "world_default", to_translation( "Default region type" ),
+         to_translation( "(WIP feature) Determines terrain, shops, plants, and more.  Set by total-conversion mods; leave as \"default\" unless you know the id of an installed region." ),
+         "default", 60
+       );
 }
 
 void options_manager::add_options_debug()
@@ -3749,14 +3763,6 @@ void options_manager::add_options_android()
         add( "ANDROID_RENDER_SAFE_AREA", page_id, to_translation( "Confine display to safe area" ),
              to_translation( "If true, keep the game within the screen's safe area so it does not draw under the camera cutout or other unsafe edges.  If false, the game fills the entire screen.  This does not show or hide Android system bars." ),
              true
-           );
-
-        add( "ANDROID_TERMINAL_SIZE", page_id, to_translation( "Terminal size" ),
-             to_translation( "Automatically match the terminal layout to the usable Android screen area.  Manual uses Terminal width and Terminal height instead." ),
-        {
-            { "auto", to_translation( "Automatic" ) },
-            { "manual", to_translation( "Manual" ) }
-        }, "auto"
            );
     } );
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2165,34 +2165,6 @@ void options_manager::add_options_general()
 
     add_empty_line();
 
-    add_option_group( "general", Group( "misc_general_opts", to_translation( "Misc Options" ),
-                                        to_translation( "Miscellaneous options." ) ),
-    [&]( const std::string & page_id ) {
-        add( "CIRCLEDIST", page_id, to_translation( "Circular distances" ),
-             to_translation( "If true, the game will calculate range in a realistic way: light sources will be circles, diagonal movement will cover more ground and take longer.  If false, everything is square: moving to the northwest corner of a building takes as long as moving to the north wall." ),
-             true
-           );
-
-        add( "DROP_EMPTY", page_id, to_translation( "Drop empty containers" ),
-             to_translation( "Set to drop empty containers after use.  No: Don't drop any.  - Watertight: All except watertight containers.  - All: Drop all containers." ),
-        { { "no", to_translation( "No" ) }, { "watertight", to_translation( "Watertight" ) }, { "all", to_translation( "All" ) } },
-        "no"
-           );
-
-        add( "DEATHCAM", page_id, to_translation( "DeathCam" ),
-             to_translation( "Always: Always start deathcam.  Ask: Query upon death.  Never: Never show deathcam." ),
-        { { "always", to_translation( "Always" ) }, { "ask", to_translation( "Ask" ) }, { "never", to_translation( "Never" ) } },
-        "ask"
-           );
-
-        add( "EVENT_SPAWNS", page_id, to_translation( "Special event spawns" ),
-             to_translation( "If not disabled, unique items and/or monsters can spawn during special events (Christmas, Halloween, etc.)" ),
-        { { "off", to_translation( "Disabled" ) }, { "items", to_translation( "Items" ) }, { "monsters", to_translation( "Monsters" ) }, { "both", to_translation( "Both" ) } },
-        "off" );
-    } );
-
-    add_empty_line();
-
     add_option_group( "general", Group( "soundpacks_opts", to_translation( "Soundpack options" ),
                                         to_translation( "Options regarding soundpack." ) ),
     [&]( const std::string & page_id ) {
@@ -2234,6 +2206,34 @@ void options_manager::add_options_general()
            );
 
         get_option( "AMBIENT_SOUND_VOLUME" ).setPrerequisite( "SOUND_ENABLED" );
+    } );
+
+    add_empty_line();
+
+    add_option_group( "general", Group( "misc_general_opts", to_translation( "Misc Options" ),
+                                        to_translation( "Miscellaneous options." ) ),
+    [&]( const std::string & page_id ) {
+        add( "CIRCLEDIST", page_id, to_translation( "Circular distances" ),
+             to_translation( "If true, the game will calculate range in a realistic way: light sources will be circles, diagonal movement will cover more ground and take longer.  If false, everything is square: moving to the northwest corner of a building takes as long as moving to the north wall." ),
+             true
+           );
+
+        add( "DROP_EMPTY", page_id, to_translation( "Drop empty containers" ),
+             to_translation( "Set to drop empty containers after use.  No: Don't drop any.  - Watertight: All except watertight containers.  - All: Drop all containers." ),
+        { { "no", to_translation( "No" ) }, { "watertight", to_translation( "Watertight" ) }, { "all", to_translation( "All" ) } },
+        "no"
+           );
+
+        add( "DEATHCAM", page_id, to_translation( "DeathCam" ),
+             to_translation( "Always: Always start deathcam.  Ask: Query upon death.  Never: Never show deathcam." ),
+        { { "always", to_translation( "Always" ) }, { "ask", to_translation( "Ask" ) }, { "never", to_translation( "Never" ) } },
+        "ask"
+           );
+
+        add( "EVENT_SPAWNS", page_id, to_translation( "Special event spawns" ),
+             to_translation( "If not disabled, unique items and/or monsters can spawn during special events (Christmas, Halloween, etc.)" ),
+        { { "off", to_translation( "Disabled" ) }, { "items", to_translation( "Items" ) }, { "monsters", to_translation( "Monsters" ) }, { "both", to_translation( "Both" ) } },
+        "off" );
     } );
 
     add_empty_line();
@@ -2934,6 +2934,12 @@ void options_manager::add_options_graphics()
     add_option_group( "graphics", Group( "ascii_opts", to_translation( "ASCII graphic options" ),
                                          to_translation( "Options regarding ASCII graphic." ) ),
     [&]( const std::string & page_id ) {
+        add( "ENABLE_ASCII_ART", page_id,
+             to_translation( "Enable ASCII art in item/monster descriptions" ),
+             to_translation( "If true, item and monster description will show a picture of the object in ASCII art when available." ),
+             true
+           );
+
         add( "ENABLE_ASCII_TITLE", page_id,
              to_translation( "Enable ASCII art on the title screen" ),
              to_translation( "If true, shows an ASCII graphic on the title screen.  If false, shows a text-only title screen." ),
@@ -3051,14 +3057,6 @@ void options_manager::add_options_graphics()
            );
     } );
 #endif // TILES
-
-    add_empty_line();
-
-    add( "ENABLE_ASCII_ART", "graphics",
-         to_translation( "Enable ASCII art in item and monster descriptions" ),
-         to_translation( "If true, item and monster description will show a picture of the object in ASCII art when available." ),
-         true, COPT_NO_HIDE
-       );
 
     add_empty_line();
 


### PR DESCRIPTION
#### Summary
<!-- #### 概述 -->
None


#### Responsible human
<!-- #### 责任人 -->

@Minecrafthyr

<!-- 每个 PR 必须指定一名真实的人类责任人。AI 工具或模型无需披露，但责任人
必须理解修改、审查最终 diff、确认测试与许可证/外部来源，并回答审阅问题。 -->

#### Purpose of change

与解决方案写在一起。

#### Describe the solution

- 修复我上次将 safe mode 被错误拼写为 save mode 的问题。
- 对调“常规”中的“音效包”和“其他选项”（其他选项应该在音效包下面？）。
- 安卓的终端大小：自动/手动选项和终端宽高选项距离太远，且（据说）会使手动设置失效。将ANDROID_TERMINAL_SIZE移动至图形→终端显示里，并使终端宽高选项在手动模式下才能修改。
- 将ENABLE_ASCII_ART移动至ASCII字符画折叠区域内。
- 在“默认世界选项”中，下移少用的默认地区类型，上移作物选项。
- 注释掉游荡尸潮选项，因其不能发挥作用，如果有人实现了其功能再加回来。
- 起始玩家点数池改为任意，这样有需要的玩家就不用再过来开选项了。

#### Describe alternatives you've considered
<!-- #### 你考虑过的替代方案 -->
None
<!-- 说明你为解决同一问题考虑过的其他方案、不同思路或可能性。 -->

#### Testing
<!-- #### 测试 -->
- 我这里无法测试安卓的实际情况。
<!-- 描述你采取了哪些步骤来测试这个 PR 是否修复了 bug 或添加了特性，以及你做了哪些测试以确保没有引入回归问题。也请为审阅者和维护者提供测试建议。参见 TESTING_YOUR_CHANGES.md -->

#### Documentation impact
<!-- None，或说明需要新增、更新、迁移、归档或标记 stale 的开发文档。
实际执行级别以 ai/docs-impact.yml 为准。required 映射不能填写 None/N/A/TBD。 -->

None

#### Related CCB-Docs PR
<!-- None，或填写 CrimsonCrossBunker/CCB-Docs 的 PR 链接。required 映射必须链接实际 PR。 -->

None

#### Affected documentation IDs
<!-- None，或填写 docs-catalog.yml 中稳定的文档 ID，多个 ID 用逗号分隔。
required 映射至少填写一个 ai/docs-impact.yml 列出的对应 ID。 -->

None

#### Generated reference impact
<!-- None，或说明 Schema、LuaLS、注册信息或生成清单是否需要刷新。 -->

None

#### Additional context
<!-- #### 补充说明 -->
None
<!-- 在此添加关于这个特性或 bug 修复的其他背景信息（例如原型图、概念验证或截图）。 -->


<!--README: Cataclysm: Cleanwater Bomb (CCB) 以 Creative Commons Attribution ShareAlike 3.0 许可证发布。
游戏的代码与内容可自由用于任何目的的使用、修改和再分发。
通过为本项目做贡献，你即同意该许可证的条款，并同意你所做的任何贡献也将受同一许可证覆盖。
详见 http://creativecommons.org/licenses/by-sa/3.0/ 。 -->
