### PR TITLE
Add non-hostile melee distraction setting

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -22,12 +22,14 @@
 #include "creature.h"
 #include "creature_tracker.h"
 #include "debug.h"
+#include "distraction_manager.h"
 #include "enums.h"
 #include "flag.h"
 #include "game.h"
 #include "game_constants.h"
 #include "game_inventory.h"
 #include "gun_mode.h"
+#include "input.h"
 #include "input_context.h"
 #include "inventory.h"
 #include "item.h"
@@ -60,6 +62,7 @@
 #include "type_id.h"
 #include "ui_manager.h"
 #include "uilist.h"
+#include "uistate.h"
 #include "veh_type.h"
 #include "vehicle.h"
 #include "vpart_position.h"
@@ -180,6 +183,49 @@ static bool check_water_affect_items( avatar &you )
     menu.query();
     if( menu.ret != 1 ) {
         you.add_msg_if_player( _( "You back away from the water." ) );
+        return false;
+    }
+
+    return true;
+}
+
+static bool confirm_non_hostile_melee_attack( avatar &you, const monster &critter )
+{
+    if( !uistate.distraction_non_hostile_melee ||
+        critter.attitude_to( you ) == Creature::Attitude::HOSTILE ) {
+        return true;
+    }
+
+    const bool force_uc = get_option<bool>( "FORCE_CAPITAL_YN" );
+    const auto &allow_key = force_uc ? input_context::disallow_lower_case_or_non_modified_letters
+                            : input_context::allow_all_keys;
+
+    while( uistate.distraction_non_hostile_melee ) {
+        const std::string action = query_popup()
+                                   .preferred_keyboard_mode( keyboard_mode::keycode )
+                                   .context( "CANCEL_ACTIVITY_OR_IGNORE_QUERY" )
+                                   .message( force_uc && !is_keycode_mode_supported() ?
+                                             pgettext( "non_hostile_melee_query",
+                                                     "<color_light_red>Really attack the non-hostile %s? (Case Sensitive)</color>" ) :
+                                             pgettext( "non_hostile_melee_query",
+                                                     "<color_light_red>Really attack the non-hostile %s?</color>" ),
+                                             critter.name() )
+                                   .option( "YES", allow_key )
+                                   .option( "NO", allow_key )
+                                   .option( "MANAGER", allow_key )
+                                   .cursor( 1 )
+                                   .query()
+                                   .action;
+
+        if( action == "YES" ) {
+            return true;
+        }
+        if( action == "MANAGER" ) {
+            get_distraction_manager().show();
+            ui_manager::redraw();
+            refresh_display();
+            continue;
+        }
         return false;
     }
 
@@ -397,8 +443,7 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
                                           _( "You're too pacified to strike anything…" ) ) ) {
                 return false;
             }
-            if( critter.attitude_to( you ) != Creature::Attitude::HOSTILE &&
-                !you.query_yn( _( "Really attack the non-hostile %s?" ), critter.name() ) ) {
+            if( !confirm_non_hostile_melee_attack( you, critter ) ) {
                 return false;
             }
             const int hp_before = critter.get_hp();

--- a/src/distraction_manager.cpp
+++ b/src/distraction_manager.cpp
@@ -46,6 +46,7 @@ static const std::vector<configurable_distraction> &get_configurable_distraction
         {&uistate.distraction_oxygen,          translate_marker( "Asphyxiation" ),                 translate_marker( "This distraction will interrupt your activity when you can't breathe." )},
         {&uistate.distraction_withdrawal,      translate_marker( "Withdrawal" ),                  translate_marker( "This distraction will interrupt your activity when you have withdrawals." )},
         {&uistate.distraction_craft_step_complete, translate_marker( "Craft step complete" ),      translate_marker( "This distraction will interrupt your activity when an unattended crafting step completes." )},
+        {&uistate.distraction_non_hostile_melee, translate_marker( "Non-hostile melee confirmation" ), translate_marker( "This prompt asks for confirmation when moving into a non-hostile monster would attack it." )},
         {&uistate.distraction_all,             translate_marker( "Toggle all" ),                   translate_marker( "Toggle all distractions" ), true }
     };
     return configurable_distractions;
@@ -162,6 +163,7 @@ void distraction_manager_gui::show()
                 uistate.distraction_oxygen = toggle_state;
                 uistate.distraction_withdrawal = toggle_state;
                 uistate.distraction_craft_step_complete = toggle_state;
+                uistate.distraction_non_hostile_melee = toggle_state;
             }
         }
     }

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -430,6 +430,7 @@ void uistatedata::serialize( JsonOut &json ) const
     json.member( "distraction_oxygen", distraction_oxygen );
     json.member( "distraction_withdrawal", distraction_withdrawal );
     json.member( "distraction_craft_step_complete", distraction_craft_step_complete );
+    json.member( "distraction_non_hostile_melee", distraction_non_hostile_melee );
     json.member( "numpad_navigation", numpad_navigation );
 
     json.member( "overmap_sidebar_uistate" );
@@ -530,6 +531,7 @@ void uistatedata::deserialize( const JsonObject &jo )
     jo.read( "distraction_oxygen", distraction_oxygen );
     jo.read( "distraction_withdrawal", distraction_withdrawal );
     jo.read( "distraction_craft_step_complete", distraction_craft_step_complete );
+    jo.read( "distraction_non_hostile_melee", distraction_non_hostile_melee );
     jo.read( "numpad_navigation", numpad_navigation );
     jo.read( "vmenu_tab", vmenu_tab );
     jo.read( "vmenu_item_sort", vmenu_item_sort );

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -231,6 +231,7 @@ class uistatedata
         bool distraction_oxygen = true;
         bool distraction_withdrawal = true;
         bool distraction_craft_step_complete = true;
+        bool distraction_non_hostile_melee = true;
         bool distraction_all = true; // NOLINT(cata-serialize)
         bool numpad_navigation = false;
 


### PR DESCRIPTION

<!-- 使用说明：在下面每个「#### 标题」下填写与你的 PR 相关的信息。
请保留这些标题。像这样的注释可以安全删除。

如果你是在 GitHub 网页界面发起这个 PR，可以用「preview（预览）」按钮查看 PR 对他人显示的样子。

PR 提交准则：
- 让你的改动只聚焦于一个具体的问题或变更，外加为实现它所必需的最小相关改动。
- 一个经验法则：大多数 PR 的改动应少于 500 行。
- 你可以另开 PR 来拆分一次较大的预期改动；如果不确定怎么拆，尽管问。我们很乐意与你协作，并建议合并你 PR 的最佳方式。
-->

#### Summary
<!-- #### 概述 -->
- Add a persisted non-hostile melee confirmation distraction setting, enabled by default and included in Toggle all.
- Replace the plain yes/no prompt with the distraction-style popup, including an Open manager action.
- Skip the confirmation when the setting is disabled.

<!-- 这一节应当只有一行，请编辑上面那一行。
1. 把「分类」替换为下列具体分类之一：Features、Content、Interface、Mods、Balance、Bugfixes、Performance、Infrastructure、Build、I18N。
2. 把引号内的文字替换为对你改动的简要描述。
如果你不希望生成更新日志条目，把整行替换为单独一个词「None」（不带引号）。
示例：
1. None
2. Bugfixes "修复长矛无法锁定不同楼层敌人的问题"
3. Interface "在制作界面显示制作失败几率"
分类含义详见：
https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/blob/master/doc/CHANGELOG_GUIDELINES.md
合并后，你的概述会被加入项目更新日志：
https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/blob/master/data/changelog.txt -->

#### Responsible human
<!-- #### 责任人 -->

@username

<!-- 每个 PR 必须指定一名真实的人类责任人。AI 工具或模型无需披露，但责任人
必须理解修改、审查最终 diff、确认测试与许可证/外部来源，并回答审阅问题。 -->

#### Purpose of change
<!-- #### 变更目的 -->
Prevent accidental movement-triggered attacks against non-hostile monsters while letting players disable the safeguard from distraction settings.
<!-- 用几句话描述你做这次改动的原因。
如果它与某个已有 issue 相关，可以用「#」加 GitHub issue 编号来关联，例如 #1234。

【重要】当你的 PR 能完全解决某个 issue 时，必须使用 [GitHub 的英文关闭关键字](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
才能在 PR 合并后自动关闭该 issue，例如：Fixes #1234。
只能用以下英文关键词（后面紧跟「#编号」）：
  close / closes / closed
  fix / fixes / fixed
  resolve / resolves / resolved
注意：中文「修复 #1234」不会触发自动关闭，GitHub 只识别上述英文关键词。

如果没有相关 issue，请在这里说明你要解决的问题、特性或其他关注点。如果这是一个 bug 修复，请附上复现原始 bug 的步骤，以便你的修复可以被验证。 -->


#### Describe the solution
<!-- #### 解决方案描述 -->
Use the existing query_popup CANCEL_ACTIVITY_OR_IGNORE_QUERY context for the confirmation controls and manager button, while keeping the movement melee attack decision local to avatar movement.
<!-- 这个特性是如何工作的，或者这个 bug 是怎么被修复的？方案越易于理解，就越快能被合并。 -->

#### Describe alternatives you've considered
<!-- #### 你考虑过的替代方案 -->

<!-- 说明你为解决同一问题考虑过的其他方案、不同思路或可能性。 -->

#### Testing
<!-- #### 测试 -->

<!-- 描述你采取了哪些步骤来测试这个 PR 是否修复了 bug 或添加了特性，以及你做了哪些测试以确保没有引入回归问题。也请为审阅者和维护者提供测试建议。参见 TESTING_YOUR_CHANGES.md -->

#### Documentation impact
<!-- None，或说明需要新增、更新、迁移、归档或标记 stale 的开发文档。
实际执行级别以 ai/docs-impact.yml 为准。required 映射不能填写 None/N/A/TBD。 -->

None

#### Related CCB-Docs PR
<!-- None，或填写 CrimsonCrossBunker/CCB-Docs 的 PR 链接。required 映射必须链接实际 PR。 -->

None

#### Affected documentation IDs
<!-- None，或填写 docs-catalog.yml 中稳定的文档 ID，多个 ID 用逗号分隔。
required 映射至少填写一个 ai/docs-impact.yml 列出的对应 ID。 -->

None

#### Generated reference impact
<!-- None，或说明 Schema、LuaLS、注册信息或生成清单是否需要刷新。 -->

None

#### Additional context
<!-- #### 补充说明 -->

<!-- 在此添加关于这个特性或 bug 修复的其他背景信息（例如原型图、概念验证或截图）。 -->


<!--README: Cataclysm: Cleanwater Bomb (CCB) 以 Creative Commons Attribution ShareAlike 3.0 许可证发布。
游戏的代码与内容可自由用于任何目的的使用、修改和再分发。
通过为本项目做贡献，你即同意该许可证的条款，并同意你所做的任何贡献也将受同一许可证覆盖。
详见 http://creativecommons.org/licenses/by-sa/3.0/ 。 -->
