### PR TITLE
Feat(lua): support AutoRetailer Lua migration

### DIFF
--- a/data/lua/LUA_FIRST_PLATFORM.md
+++ b/data/lua/LUA_FIRST_PLATFORM.md
@@ -1059,6 +1059,16 @@ Lua API v5 dispatcher keeps its own compatibility payload unchanged and runs
 before Platform, so its candidate result is visible through
 `payload.results` without becoming Platform's authoring vocabulary.
 
+Lua-owned dialogue topics use `ccb.runtime.dialogue_topic(topic_id, handler_id)`
+to render inside the native NPC dialogue window.  The named
+handler receives generation-bound `avatar` and `interlocutor` handles plus the
+current `topic`.  It is called with `phase = "line"` to return one non-empty
+string and with `phase = "responses"` to return a bounded dense array of
+`{ text = string, topic = string? }` descriptors.  Topic transitions and
+selection-side effects remain explicit native dialogue hooks; this API does
+not expose borrowed `dialogue` pointers, JSON talk-topic objects, or EOC
+execution.
+
 `ccb.runtime.hook` 将命名 handler 接到受检的同步 Hook 目录；payload 中的活对象只以
 代次绑定 handle 或快照跨界。只有 Hook 契约声明过的否决、文本、替换值或菜单结果才会
 生效，Platform handler 按 Mod 依赖顺序与原生 dispatcher 合成。字符串结果与菜单项必须
@@ -1076,6 +1086,13 @@ before Platform, so its candidate result is visible through
 `alpha`/`beta` 别名。现有 Lua API v5 dispatcher 为兼容仍保留自己的旧 payload，并先于
 Platform 运行；它产生的候选结果只通过 `payload.results` 进入 Platform，不会成为新的
 作者词汇。
+
+Lua 自有对话主题通过 `ccb.runtime.dialogue_topic(topic_id, handler_id)` 在原生 NPC
+对话窗口中渲染。命名 handler 得到受代次约束的 `avatar`、`interlocutor` handle 与当前
+`topic`；`phase = "line"` 时返回一个非空字符串，`phase = "responses"` 时返回有界、
+从 1 开始且无空洞的 `{ text = string, topic = string? }` 数组。主题跳转和选项副作用仍
+由显式原生对话 Hook 处理；该 API 不暴露借用的 `dialogue` 指针、JSON talk-topic 对象，
+也不提供 EOC 执行入口。
 
 Dialogue predicate queries are ordinary bounded snapshots over the same
 domain services instead of per-key condition functions.  A character

--- a/data/lua/types/ccb_api_v5.d.lua
+++ b/data/lua/types/ccb_api_v5.d.lua
@@ -1778,6 +1778,95 @@ function ScriptMapgenContext:set_furniture(x, y, id) end
 ---@return boolean
 function ScriptMapgenContext:set_trap(x, y, id) end
 
+---@param x integer
+---@param y integer
+---@param id string Existing terrain id.
+---@return boolean changed
+function ScriptMapgenContext:set_terrain_id(x, y, id) end
+
+---@param x integer
+---@param y integer
+---@param id string Existing furniture id; `f_null` clears furniture.
+---@return boolean changed
+function ScriptMapgenContext:set_furniture_id(x, y, id) end
+
+---@param x integer
+---@param y integer
+---@param id string Existing trap id; `tr_null` clears the trap.
+---@return boolean changed
+function ScriptMapgenContext:set_trap_id(x, y, id) end
+
+---@param terrain_id string Existing terrain id used for all 24x24 squares.
+function ScriptMapgenContext:reset(terrain_id) end
+
+---@param x integer
+---@param y integer
+---@param item_id string Existing item id.
+---@param quantity integer Positive item quantity.
+---@param charges integer Non-negative charge override.
+---@param faction_id string Faction owner id, or empty for none.
+function ScriptMapgenContext:place_item(x, y, item_id, quantity, charges, faction_id) end
+
+---@param x1 integer
+---@param y1 integer
+---@param x2 integer
+---@param y2 integer
+---@param group_id string Existing item-group id.
+---@param chance integer Chance from one through 100.
+---@param faction_id string Faction owner id, or empty for none.
+function ScriptMapgenContext:place_item_group(x1, y1, x2, y2, group_id, chance, faction_id) end
+
+---@param x integer
+---@param y integer
+---@param item_id string Existing liquid item id.
+---@param charges integer Positive charges.
+function ScriptMapgenContext:place_liquid(x, y, item_id, charges) end
+
+---@param x integer
+---@param y integer
+---@param charges integer Non-negative water charges.
+function ScriptMapgenContext:place_toilet(x, y, charges) end
+
+---@param x integer
+---@param y integer
+---@param text string Sign text.
+---@param furniture_id string Existing sign furniture id.
+function ScriptMapgenContext:place_sign(x, y, text, furniture_id) end
+
+---@param x1 integer
+---@param y1 integer
+---@param x2 integer
+---@param y2 integer
+---@param zone_type string Existing zone-type id.
+---@param faction_id string Faction id, or empty for none.
+---@param name string Zone name.
+---@param filter string Zone item filter.
+function ScriptMapgenContext:place_zone(x1, y1, x2, y2, zone_type, faction_id, name, filter) end
+
+---@param x integer
+---@param y integer
+---@param template_id string Existing NPC-template id.
+---@param unique_id string Optional stable unique id, or empty.
+---@return integer character_id
+function ScriptMapgenContext:place_npc(x, y, template_id, unique_id) end
+
+---@param x integer
+---@param y integer
+---@param prototype_or_group_id string Existing vehicle prototype or group id.
+---@param rotation_degrees integer
+---@param fuel_percent integer From -1 through 100.
+---@param status integer From -1 through 2.
+---@param faction_id string Faction owner id, or empty for none.
+---@return boolean placed
+function ScriptMapgenContext:place_vehicle(x, y, prototype_or_group_id, rotation_degrees, fuel_percent, status, faction_id) end
+
+---@param x1 integer
+---@param y1 integer
+---@param x2 integer
+---@param y2 integer
+---@param faction_id string Existing faction id.
+function ScriptMapgenContext:apply_faction_ownership(x1, y1, x2, y2, faction_id) end
+
 function ScriptMapgenContext:fill_groundcover() end
 
 ---@param id string
@@ -4033,6 +4122,75 @@ function CcbVehiclesApi.set_tracking(handle, enabled) end
 ---@return CcbResult
 function CcbVehiclesApi.set_part_enabled(handle, part_index, enabled) end
 
+---@param prototype GameId GameId<vehicle_prototype>.
+---@param post_cataclysm? boolean Defaults to true.
+---@return integer cents Prototype part value in cents.
+function CcbVehiclesApi.prototype_value(prototype, post_cataclysm) end
+
+---@class CcbVehicleValueOptions
+---@field post_cataclysm? boolean Defaults to true.
+---@field include_liquid_engine_fuel? boolean Defaults to true.
+
+---@class CcbVehicleValue
+---@field parts_cents integer
+---@field liquid_engine_fuel_cents integer
+---@field total_cents integer
+---@field post_cataclysm boolean
+
+---@param handle GameHandle
+---@param options? CcbVehicleValueOptions
+---@return CcbResult result `value` is CcbVehicleValue.
+function CcbVehiclesApi.value(handle, options) end
+
+---@param handle GameHandle
+---@return CcbResult result `value` is true only while the avatar controls this vehicle.
+function CcbVehiclesApi.is_player_controlling(handle) end
+
+---@class CcbVehicleSpawnOptions
+---@field rotation_degrees? integer Rotation from -360 through 360.
+---@field fuel_percent? integer Fuel fill from -1 through 100.
+---@field status? integer Native spawn status from -1 through 2.
+---@field merge_wrecks? boolean Whether placement may merge wrecks.
+---@field owner? GameId Valid GameId<faction> assigned as owner.
+
+---@class CcbVehicleSpawnResult
+---@field handle GameHandle Live vehicle handle.
+---@field vehicle CcbVehicleSnapshot Snapshot after spawning.
+
+---@param prototype GameId GameId<vehicle_prototype>.
+---@param position TripointCoord Loaded absolute map-square position.
+---@param options? CcbVehicleSpawnOptions
+---@return CcbResult result `value` is CcbVehicleSpawnResult.
+function CcbVehiclesApi.spawn(prototype, position, options) end
+
+---@param handle GameHandle
+---@return CcbResult result `value.destroyed` is true after removal; occupied vehicles return `blocked`.
+function CcbVehiclesApi.destroy(handle) end
+
+---@param handle GameHandle
+---@param owner GameId Valid GameId<faction>.
+---@return CcbResult
+function CcbVehiclesApi.set_owner(handle, owner) end
+
+---@param vehicle GameHandle
+---@param mechanic GameHandle NPC mechanic handle.
+---@param repair_multiplier? number Positive price multiplier; defaults to one.
+---@return CcbResult result `value` contains native full-repair quote fields.
+function CcbVehiclesApi.quote_full_repair(vehicle, mechanic, repair_multiplier) end
+
+---@param vehicle GameHandle
+---@param mechanic GameHandle NPC mechanic handle.
+---@param repair_multiplier? number Positive price multiplier; defaults to one.
+---@return CcbResult result `value.status` reports quote, cancellation, or activity state.
+function CcbVehiclesApi.start_full_repair(vehicle, mechanic, repair_multiplier) end
+
+---@param vehicle GameHandle
+---@param mechanic GameHandle NPC mechanic handle.
+---@param repair_multiplier? number Positive repair price multiplier; defaults to one.
+---@param install_multiplier? number Positive install price multiplier; defaults to one.
+---@return CcbResult result `value.status` reports the native part-service result.
+function CcbVehiclesApi.open_part_service(vehicle, mechanic, repair_multiplier, install_multiplier) end
+
 ---@class CcbNpcClassDefinition
 ---@field id GameId
 ---@field name string
@@ -4079,6 +4237,7 @@ function CcbVehiclesApi.set_part_enabled(handle, part_index, enabled) end
 ---@field guarding boolean
 ---@field patrolling boolean
 ---@field shopkeeper boolean
+---@field restock_turn integer Absolute game turn when native shop stock next refreshes.
 ---@field faction_representative boolean
 ---@field opinion CcbNpcOpinion
 ---@field personality table
@@ -4130,6 +4289,20 @@ function CcbNpcsApi.modify_opinion(handle, deltas) end
 ---`cbm_recharge`, and `cbm_reserve` string ids, a dense one-based `allies`
 ---string list of enabled ally rules, and a `pickup_whitelist` boolean.
 function CcbNpcsApi.ai_rules(handle) end
+
+---@class CcbTradeApi
+local CcbTradeApi = {}
+
+---@param npc GameHandle NPC trader handle.
+---@param cost? integer Non-negative additional cost in cents.
+---@param deal? string Player-facing deal label.
+---@return CcbResult result `value` is true when the trade completes.
+function CcbTradeApi.open(npc, cost, deal) end
+
+---@param npc GameHandle NPC payee handle.
+---@param cost integer Positive cost in cents.
+---@return CcbResult result `value` is true when payment completes.
+function CcbTradeApi.pay(npc, cost) end
 
 ---@class CcbFactionReputation
 ---@field likes integer
@@ -4653,6 +4826,7 @@ function CcbWeatherApi.refresh() end
 ---@field random CcbRandomApi
 ---@field sound CcbSoundApi
 ---@field targeting CcbTargetingApi
+---@field trade CcbTradeApi
 ---@field spawns CcbSpawnsApi
 ---@field followers CcbFollowersApi
 ---@field relocation CcbRelocationApi

--- a/data/lua/types/ccb_platform_v1.d.lua
+++ b/data/lua/types/ccb_platform_v1.d.lua
@@ -9,6 +9,9 @@
 ---@field version? string 1-128-byte author-defined Mod version.
 ---@field entry? string Root-relative entry path of at most 4096 bytes; defaults to main.lua.
 ---@field dependencies? string[] Dense one-based array of at most 256 unique stable Mod ids loaded before this Mod.
+---@field authors? string[] Dense one-based array of unique author names.
+---@field description? string Player-facing Mod description of at most 4096 bytes.
+---@field category? string Existing Mod-list category id.
 ---@field core? boolean Whether this is a core Mod.
 
 ---@class ModDefinition
@@ -17,6 +20,9 @@
 ---@field version string
 ---@field entry string
 ---@field dependencies string[]
+---@field authors string[]
+---@field description string
+---@field category string
 ---@field core boolean
 local ModDefinition = {}
 
@@ -34,9 +40,18 @@ local ModDefinition = {}
 
 ---@class ItemDefinitionOptions
 ---@field id string Stable item type id.
+---@field copy_from? string Existing item id used as the patch base.
 ---@field name? string Display name; defaults to id.
 ---@field description? string Player-facing description.
 ---@field symbol? string Map symbol; defaults to `?`.
+---@field color? string Native color id.
+---@field category? string Native item-category id.
+---@field looks_like? string Existing item id used for presentation.
+---@field mass_grams? integer Non-negative mass in grams.
+---@field volume_ml? integer Non-negative volume in milliliters.
+---@field price_cents? integer Non-negative pre-Cataclysm price in cents.
+---@field price_postapoc_cents? integer Non-negative post-Cataclysm price in cents.
+---@field magazine_capacity? integer Positive legacy magazine capacity, independent of per-ammo pocket restrictions.
 
 ---@class ItemDefinition
 ---@field id string
@@ -53,6 +68,24 @@ function ItemDefinition:volume_ml(milliliters) end
 ---@param cents integer
 ---@return ItemDefinition self
 function ItemDefinition:price_cents(cents) end
+
+---@param cents integer
+---@return ItemDefinition self
+function ItemDefinition:price_postapoc_cents(cents) end
+
+---@param damage_type string
+---@param amount number
+---@return ItemDefinition self
+function ItemDefinition:melee_damage(damage_type, amount) end
+
+---@param ammo_type string
+---@param capacity integer
+---@return ItemDefinition self
+function ItemDefinition:magazine_ammo(ammo_type, capacity) end
+
+---@param capacity integer Positive legacy magazine capacity, independent of per-ammo pocket restrictions.
+---@return ItemDefinition self
+function ItemDefinition:magazine_capacity(capacity) end
 
 ---@param id string
 ---@param portions integer
@@ -87,10 +120,12 @@ function ItemDefinition:on_use(handler_id, label) end
 ---progression data stays author-owned Lua behaviour.
 ---@field uncraft? boolean Whether this is a disassembly recipe staged into the
 ---native uncraft dictionary.
+---@field activity_level? number Positive native exertion multiplier.
 
 ---@class RecipeComponentAlternative
 ---@field id string Item type id.
 ---@field count? integer Positive count; defaults to one.
+---@field requirement? boolean Treat `id` as a native Requirement id (`LIST` semantics).
 
 ---@class RecipeDefinition
 ---@field id string
@@ -102,8 +137,9 @@ function RecipeDefinition:duration_moves(moves) end
 
 ---@param id string
 ---@param count integer
+---@param requirement? boolean Treat `id` as a native Requirement id.
 ---@return RecipeDefinition self
-function RecipeDefinition:component(id, count) end
+function RecipeDefinition:component(id, count, requirement) end
 
 ---@param choices RecipeComponentAlternative[] Dense one-based array with at most 128 entries.
 ---@return RecipeDefinition self
@@ -111,18 +147,21 @@ function RecipeDefinition:component_any(choices) end
 
 ---@param id string
 ---@param count integer Positive number of tool instances; tools are not consumed.
+---@param requirement? boolean Treat `id` as a native Requirement id.
 ---@return RecipeDefinition self
-function RecipeDefinition:tool(id, count) end
+function RecipeDefinition:tool(id, count, requirement) end
 
 ---@param id string
 ---@param charges integer Positive charges consumed by crafting.
+---@param requirement? boolean Treat `id` as a native Requirement id.
 ---@return RecipeDefinition self
-function RecipeDefinition:tool_charges(id, charges) end
+function RecipeDefinition:tool_charges(id, charges, requirement) end
 
 ---@class RecipeToolAlternative
 ---@field id string Item type id.
 ---@field count? integer Positive non-consuming instance count; defaults to one.
 ---@field charges? integer Positive charge count consumed instead of `count`.
+---@field requirement? boolean Treat `id` as a native Requirement id (`LIST` semantics).
 
 ---@param choices RecipeToolAlternative[] Dense one-based array with at most 128 entries.
 ---@return RecipeDefinition self
@@ -137,6 +176,21 @@ function RecipeDefinition:requires_skill(id, level) end
 ---@param multiplier integer Positive multiplier.
 ---@return RecipeDefinition self
 function RecipeDefinition:requirement(requirement_id, multiplier) end
+
+---@class RecipeProficiencyOptions
+---@field required? boolean Whether crafting is forbidden without this proficiency.
+---@field time_multiplier? number Native time multiplier when missing.
+---@field skill_penalty? number Native skill penalty when missing.
+
+---@param proficiency_id string Existing proficiency id.
+---@param options? RecipeProficiencyOptions
+---@return RecipeDefinition self
+function RecipeDefinition:proficiency(proficiency_id, options) end
+
+---@param item_id string Existing book item id.
+---@param skill_level integer Required primary skill level.
+---@return RecipeDefinition self
+function RecipeDefinition:book(item_id, skill_level) end
 
 ---@class NestedRecipeCategoryDefinitionOptions
 ---@field id string Stable nested-category recipe id.
@@ -161,6 +215,7 @@ function NestedRecipeCategoryDefinition:recipe(recipe_id) end
 ---@class RequirementAlternative
 ---@field id string Item type id.
 ---@field count? integer Positive count; defaults to one.
+---@field requirement? boolean Treat `id` as another native Requirement id (`LIST` semantics).
 
 ---@class RequirementQualityAlternative
 ---@field id string ToolQuality id.
@@ -173,8 +228,9 @@ local RequirementDefinition = {}
 
 ---@param item_id string
 ---@param count integer
+---@param requirement? boolean Treat `item_id` as another native Requirement id.
 ---@return RequirementDefinition self
-function RequirementDefinition:component(item_id, count) end
+function RequirementDefinition:component(item_id, count, requirement) end
 
 ---@param choices RequirementAlternative[] Dense one-based array with at most 128 entries.
 ---@return RequirementDefinition self
@@ -182,13 +238,15 @@ function RequirementDefinition:component_any(choices) end
 
 ---@param item_id string
 ---@param count integer Positive non-consuming instance count.
+---@param requirement? boolean Treat `item_id` as another native Requirement id.
 ---@return RequirementDefinition self
-function RequirementDefinition:tool(item_id, count) end
+function RequirementDefinition:tool(item_id, count, requirement) end
 
 ---@param item_id string
 ---@param charges integer Positive charge count consumed.
+---@param requirement? boolean Treat `item_id` as another native Requirement id.
 ---@return RequirementDefinition self
-function RequirementDefinition:tool_charges(item_id, charges) end
+function RequirementDefinition:tool_charges(item_id, charges, requirement) end
 
 ---@param choices RecipeToolAlternative[] Dense one-based array with at most 128 entries.
 ---@return RequirementDefinition self
@@ -273,6 +331,7 @@ local ItemActionDefinition = {}
 ---@field reveal_locale? boolean Whether the start locale is revealed; defaults to true.
 ---@field hard_requirement? boolean Whether the unlock requirement applies with metaprogression disabled.
 ---@field distance_initial_visibility? integer Initial overmap visibility distance.
+---@field map_extra? string Native map-extra id applied at game start; omission means none.
 
 ---@class ScenarioDefinition
 ---@field id string
@@ -680,6 +739,17 @@ function ItemGroupDefinition:item(item_id, probability, variant) end
 ---@param probability? integer Positive distribution weight or collection percentage.
 ---@return ItemGroupDefinition self
 function ItemGroupDefinition:group(group_id, probability) end
+
+---@class ItemGroupEntryOptions
+---@field item? string Exactly one of item or group is required.
+---@field group? string Exactly one of item or group is required.
+---@field probability? integer Positive distribution weight or collection percentage.
+---@field count? integer[] Two-element inclusive count interval.
+---@field variant? string Native item variant id.
+
+---@param options ItemGroupEntryOptions
+---@return ItemGroupDefinition self
+function ItemGroupDefinition:entry(options) end
 
 ---@class SubBodyPartDefinitionOptions
 ---@field id string Stable native sub-body-part id.
@@ -2332,8 +2402,14 @@ local MonsterAdjustmentDefinition = {}
 
 ---@param trait_id string Native trait id weighted by this group.
 ---@param weight integer Positive weight.
+---@param variant? string Native mutation variant id.
 ---@return TraitGroupDefinition self
-function TraitGroupDefinition:trait(trait_id, weight) end
+function TraitGroupDefinition:trait(trait_id, weight, variant) end
+
+---@param group_id string Existing trait-group id.
+---@param weight integer Positive weight.
+---@return TraitGroupDefinition self
+function TraitGroupDefinition:group(group_id, weight) end
 
 ---@class ShopkeeperEntryOptions
 ---@field item? string Item id matched by this entry.
@@ -2786,12 +2862,270 @@ local ItemUseContext = {}
 ---@param text string
 function ItemUseContext:message(text) end
 
+---@class FactionDefinitionOptions
+---@field id string Stable faction id.
+---@field name? string Player-facing name; defaults to id.
+---@field description? string Player-facing description.
+---@field likes? integer Initial player like score.
+---@field respects? integer Initial player respect score.
+---@field trusts? integer Initial player trust score.
+---@field known? boolean Whether the player initially knows the faction.
+---@field size? integer Initial member count.
+---@field power? integer Initial power score.
+---@field wealth? integer Initial wealth score.
+---@field food_calories? integer Initial food energy in kilocalories.
+---@field food_vitamins? table<string, integer> Initial native vitamin units keyed by vitamin id.
+---@field consumes_food? boolean Whether faction members consume the shared supply.
+---@field lone_wolf? boolean Whether the faction is a lone-wolf faction.
+---@field limited_area? boolean Whether area claims are limited.
+---@field currency? string Existing item id used as faction currency.
+---@field monster_faction? string Existing monster-faction id; defaults to human.
+---@field relations? table<string, string[]> Relation flags keyed by target faction id.
+
+---@class FactionDefinition
+---@field id string
+local FactionDefinition = {}
+
+---@class NpcDistribution
+---@field constant? integer Constant value.
+---@field rng? integer[] Two-element inclusive random interval.
+---@field dice? integer[] Two-element dice count and sides.
+---@field add? integer Constant added to the selected distribution.
+
+---@class NpcShopGroupOptions
+---@field id string Existing item-group id.
+---@field trust? integer Minimum trust.
+---@field strict? boolean Native strict matching flag.
+---@field rigid? boolean Native rigid restock flag.
+
+---@class NpcPriceRuleOptions
+---@field item? string Item id matched by this rule.
+---@field group? string Item-group id matched by this rule.
+---@field category? string Item-category id matched by this rule.
+---@field markup? number Sale markup; defaults to one.
+---@field premium? number Purchase premium; defaults to one.
+---@field fixed_adjustment? number Optional fixed adjustment.
+---@field price? integer Optional fixed price in cents.
+
+---@class NpcClassDefinitionOptions
+---@field id string Stable NPC-class id.
+---@field name? string Player-facing class name; defaults to id.
+---@field job_description? string Player-facing job description.
+---@field common? boolean Whether random NPC generation may select the class.
+---@field sells_belongings? boolean Whether the NPC sells personal belongings.
+---@field worn? string Existing starting worn item-group id.
+---@field carry? string Existing starting carried item-group id.
+---@field weapon? string Existing starting weapon item-group id.
+---@field traits? string Existing or same-transaction trait-group id.
+---@field consumption_rates? string Existing shopkeeper-consumption-rates id.
+---@field strength? NpcDistribution
+---@field dexterity? NpcDistribution
+---@field intelligence? NpcDistribution
+---@field perception? NpcDistribution
+---@field skills? table<string, NpcDistribution> Base skill distributions keyed by skill id.
+---@field bonus_skills? table<string, NpcDistribution> Bonus skill distributions keyed by skill id.
+---@field shop_groups? NpcShopGroupOptions[]
+---@field price_rules? NpcPriceRuleOptions[]
+
+---@class NpcClassDefinition
+---@field id string
+local NpcClassDefinition = {}
+
+---@class NpcDefinitionOptions
+---@field id string Stable NPC-template id.
+---@field unique_name? string Fixed personal name.
+---@field suffix? string Display-name suffix.
+---@field temporary_suffix? string Temporary display-name suffix.
+---@field gender? 'male'|'female'|'random'
+---@field class string Existing or same-transaction NPC-class id.
+---@field faction? string Existing or same-transaction faction id.
+---@field attitude? integer Native NPC-attitude value.
+---@field mission? string Native NPC-mission enum name.
+---@field chat? string Initial dialogue topic id.
+---@field stole_item_chat? string Stolen-item dialogue topic id.
+---@field age? integer Fixed generated age.
+---@field height? integer Fixed generated height in centimeters.
+
+---@class NpcDefinition
+---@field id string
+local NpcDefinition = {}
+
+---@class OvermapTerrainDefinitionOptions
+---@field id string Stable overmap-terrain type id.
+---@field name? string Player-facing name; defaults to id.
+---@field symbol? string Single display symbol.
+---@field color? string Native color id.
+---@field see_cost? string Native overmap see-cost enum name.
+---@field default_map_data? string Native map-data-summary id; defaults to `full_omt`.
+---@field vision_levels? string Native overmap-vision id; defaults to `default`.
+---@field monster_density? integer Native monster density.
+---@field flags? string[] Native overmap-terrain flags.
+
+---@class OvermapTerrainDefinition
+---@field id string
+local OvermapTerrainDefinition = {}
+
+---@class OvermapSpecialTerrainOptions
+---@field point integer[] Three-element relative overmap-terrain coordinate.
+---@field terrain? string Concrete overmap-terrain id; empty marks a location-only footprint tile.
+---@field locations? string[] Allowed overmap-location ids for this tile.
+---@field flags? string[] Native special-terrain flags.
+
+---@class OvermapSpecialConnectionOptions
+---@field point integer[] Three-element relative overmap-terrain coordinate.
+---@field from? integer[] Optional three-element source coordinate.
+---@field terrain? string Overmap-terrain type connected at this point.
+---@field connection? string Existing overmap-connection id.
+---@field existing? boolean Whether the connection must already exist.
+
+---@class OvermapSpecialDefinitionOptions
+---@field id string Stable overmap-special id.
+---@field terrains? OvermapSpecialTerrainOptions[]
+---@field connections? OvermapSpecialConnectionOptions[]
+---@field locations? string[] Default overmap-location ids.
+---@field flags? string[] Native overmap-special flags.
+---@field city_size? integer[] Two-element inclusive city-size interval.
+---@field city_distance? integer[] Two-element inclusive city-distance interval.
+---@field occurrences? integer[] Two-element inclusive occurrence interval.
+---@field priority? integer Placement priority.
+---@field rotate? boolean Whether the special may rotate.
+
+---@class OvermapSpecialDefinition
+---@field id string
+local OvermapSpecialDefinition = {}
+
+---@class VehiclePartVariantOptions
+---@field id? string Native variant id; empty is the default variant.
+---@field label? string Player-facing variant label.
+---@field symbols? string Native eight-direction symbol sequence.
+---@field broken_symbols? string Native eight-direction broken symbol sequence.
+
+---@class VehiclePartRequirementReference
+---@field id string Existing Requirement id.
+---@field multiplier? integer Positive multiplier; defaults to one.
+
+---@class VehiclePartRequirementOptions
+---@field id? string Single existing Requirement id.
+---@field multiplier? integer Positive multiplier for id.
+---@field using? VehiclePartRequirementReference[] Ordered existing Requirement references.
+---@field time_minutes? integer Native work time in minutes.
+---@field skills? table<string, integer> Required levels keyed by skill id.
+
+---@class VehiclePartControlOptions
+---@field air_proficiencies? string[] Existing air-control proficiency ids.
+---@field land_proficiencies? string[] Existing land-control proficiency ids.
+
+---@class VehiclePartDefinitionOptions
+---@field id string Stable vehicle-part id.
+---@field copy_from? string Existing vehicle-part id used as the patch base.
+---@field name? string Player-facing name.
+---@field description? string Player-facing description.
+---@field item? string Existing or same-transaction base item id.
+---@field location? string Existing vehicle-part-location id.
+---@field looks_like? string Existing vehicle-part id used for presentation.
+---@field color? string Native color id.
+---@field broken_color? string Native broken color id.
+---@field fuel_type? string Existing fuel item id.
+---@field durability? integer Positive durability.
+---@field size_ml? integer Cargo size in milliliters.
+---@field damage_modifier? integer Native damage modifier.
+---@field power_watts? integer Mechanical power in watts.
+---@field epower_watts? integer Electrical power in watts.
+---@field energy_consumption_watts? integer Fuel-energy consumption in watts.
+---@field balloon_height? number Per-part balloon lift in kilograms.
+---@field backfire_threshold? number Engine backfire threshold.
+---@field backfire_frequency? integer Engine backfire frequency.
+---@field damaged_power_factor? number Damaged engine power factor.
+---@field noise_factor? integer Engine noise factor.
+---@field m2c? integer Engine mechanical-to-combustion factor.
+---@field categories? string[] Vehicle-part category ids replacing inherited categories.
+---@field flags? string[] Vehicle-part flags replacing inherited flags.
+---@field variants? VehiclePartVariantOptions[] Variants replacing inherited variants.
+---@field fuel_options? string[] Engine fuel item ids replacing inherited options.
+---@field damage_reduction? table<string, number> Damage reduction keyed by damage-type id.
+---@field breaks_into? string Existing or same-transaction item-group id.
+---@field install? VehiclePartRequirementOptions
+---@field removal? VehiclePartRequirementOptions
+---@field repair? VehiclePartRequirementOptions
+---@field control? VehiclePartControlOptions
+
+---@class VehiclePartDefinition
+---@field id string
+local VehiclePartDefinition = {}
+
+---@class VehiclePartPlacementOptions
+---@field x integer Mount x coordinate.
+---@field y integer Mount y coordinate.
+---@field part string Existing or same-transaction vehicle-part id.
+---@field variant? string Vehicle-part variant id.
+---@field with_ammo? integer Ammo fill percentage.
+---@field ammo_types? string[] Allowed ammo item ids.
+---@field ammo_quantity? integer[] Two-element ammo quantity interval.
+---@field fuel? string Initial fuel item id.
+---@field tools? string[] Initial tool item ids.
+
+---@class VehicleItemPlacementOptions
+---@field x integer Mount x coordinate.
+---@field y integer Mount y coordinate.
+---@field chance? integer Spawn chance from zero through 100.
+---@field with_ammo? integer Ammo fill percentage.
+---@field with_magazine? integer Magazine chance percentage.
+---@field items? string[] Concrete item ids.
+---@field groups? string[] Item-group ids.
+
+---@class VehicleZonePlacementOptions
+---@field x integer Mount x coordinate.
+---@field y integer Mount y coordinate.
+---@field type string Existing zone-type id.
+---@field name? string Zone name.
+---@field filter? string Zone item filter.
+
+---@class VehicleDefinitionOptions
+---@field id string Stable vehicle prototype id.
+---@field name string Player-facing vehicle name.
+---@field color_palette? string Existing vehicle-color-palette id.
+---@field parts VehiclePartPlacementOptions[]
+---@field items? VehicleItemPlacementOptions[]
+---@field zones? VehicleZonePlacementOptions[]
+
+---@class VehicleDefinition
+---@field id string
+local VehicleDefinition = {}
+
 ---@class CcbPlatformContent
 local CcbPlatformContent = {}
 
 ---@param options ItemDefinitionOptions
 ---@return ItemDefinition
 function CcbPlatformContent.Item(options) end
+
+---@param options FactionDefinitionOptions
+---@return FactionDefinition
+function CcbPlatformContent.Faction(options) end
+
+---@param options NpcClassDefinitionOptions
+---@return NpcClassDefinition
+function CcbPlatformContent.NpcClass(options) end
+
+---@param options NpcDefinitionOptions
+---@return NpcDefinition
+function CcbPlatformContent.Npc(options) end
+
+---@param options OvermapTerrainDefinitionOptions
+---@return OvermapTerrainDefinition
+function CcbPlatformContent.OvermapTerrain(options) end
+
+---@param options OvermapSpecialDefinitionOptions
+---@return OvermapSpecialDefinition
+function CcbPlatformContent.OvermapSpecial(options) end
+
+---@param options VehiclePartDefinitionOptions
+---@return VehiclePartDefinition
+function CcbPlatformContent.VehiclePart(options) end
+
+---@param options VehicleDefinitionOptions
+---@return VehicleDefinition
+function CcbPlatformContent.Vehicle(options) end
 
 ---@param options RecipeDefinitionOptions
 ---@return RecipeDefinition
@@ -3236,7 +3570,7 @@ function CcbPlatformContent.MagicType(options) end
 ---@return MovementModeDefinition
 function CcbPlatformContent.MovementMode(options) end
 
----@alias PlatformContentDefinition ItemDefinition|RecipeDefinition|NestedRecipeCategoryDefinition|ToolQualityDefinition|SkillDisplayDefinition|SkillDefinition|VitaminDefinition|JsonFlagDefinition|DamageTypeDefinition|MaterialDefinition|AmmunitionTypeDefinition|ItemCategoryDefinition|RecipeCategoryDefinition|ProficiencyCategoryDefinition|ProficiencyDefinition|WeaponCategoryDefinition|RequirementDefinition|RecipeGroupDefinition|ScentTypeDefinition|SpeedDescriptionDefinition|HarvestDropTypeDefinition|HarvestDefinition|BehaviorDefinition|MonsterAttackDefinition|EffectTypeDefinition|WeakpointSetDefinition|FieldTypeDefinition|ItemGroupDefinition|SubBodyPartDefinition|WoundDefinition|BodyPartDefinition|WoundFixDefinition|AnatomyDefinition|BodyGraphDefinition|MonsterDefinition|MoraleTypeDefinition|DiseaseTypeDefinition|MonsterFlagDefinition|SpeciesDefinition|EmissionDefinition|MonsterFactionDefinition|MutationTypeDefinition|ConnectGroupDefinition|MutationCategoryDefinition|ConstructionCategoryDefinition|ConstructionGroupDefinition|VehiclePartLocationDefinition|MoodFaceDefinition|DamageInfoOrderDefinition|VehiclePartCategoryDefinition|NamedColorDefinition|RotatableSymbolDefinition|AsciiArtDefinition|LimbScoreDefinition|HitRangeDefinition|BashDamageProfileDefinition|ClothingModDefinition|OvermapLandUseCodeDefinition|OvermapVisionDefinition|OvermapLocationDefinition|ProfessionGroupDefinition|MapExtraCollectionDefinition|VehicleGroupDefinition|FaultGroupDefinition|ExplosionLightDefinition|AmmoEffectDefinition|AddictionTypeDefinition|CharacterModifierDefinition|StartLocationDefinition|ClimbingAidDefinition|WeatherTypeDefinition|ScoreDefinition|OverlayOrderDefinition|ZoneTypeDefinition|SpeechPoolDefinition|EndScreenDefinition|ActivityTypeDefinition|HelpTopicDefinition|SnippetCategoryDefinition|PlaylistDefinition|AttackVectorDefinition|MagicTypeDefinition|MovementModeDefinition
+---@alias PlatformContentDefinition FactionDefinition|NpcClassDefinition|NpcDefinition|OvermapTerrainDefinition|OvermapSpecialDefinition|VehiclePartDefinition|VehicleDefinition|ItemDefinition|RecipeDefinition|NestedRecipeCategoryDefinition|ToolQualityDefinition|SkillDisplayDefinition|SkillDefinition|VitaminDefinition|JsonFlagDefinition|DamageTypeDefinition|MaterialDefinition|AmmunitionTypeDefinition|ItemCategoryDefinition|RecipeCategoryDefinition|ProficiencyCategoryDefinition|ProficiencyDefinition|WeaponCategoryDefinition|RequirementDefinition|RecipeGroupDefinition|ScentTypeDefinition|SpeedDescriptionDefinition|HarvestDropTypeDefinition|HarvestDefinition|BehaviorDefinition|MonsterAttackDefinition|EffectTypeDefinition|WeakpointSetDefinition|FieldTypeDefinition|ItemGroupDefinition|SubBodyPartDefinition|WoundDefinition|BodyPartDefinition|WoundFixDefinition|AnatomyDefinition|BodyGraphDefinition|MonsterDefinition|MoraleTypeDefinition|DiseaseTypeDefinition|MonsterFlagDefinition|SpeciesDefinition|EmissionDefinition|MonsterFactionDefinition|MutationTypeDefinition|ConnectGroupDefinition|MutationCategoryDefinition|ConstructionCategoryDefinition|ConstructionGroupDefinition|VehiclePartLocationDefinition|MoodFaceDefinition|DamageInfoOrderDefinition|VehiclePartCategoryDefinition|NamedColorDefinition|RotatableSymbolDefinition|AsciiArtDefinition|LimbScoreDefinition|HitRangeDefinition|BashDamageProfileDefinition|ClothingModDefinition|OvermapLandUseCodeDefinition|OvermapVisionDefinition|OvermapLocationDefinition|ProfessionGroupDefinition|MapExtraCollectionDefinition|VehicleGroupDefinition|FaultGroupDefinition|ExplosionLightDefinition|AmmoEffectDefinition|AddictionTypeDefinition|CharacterModifierDefinition|StartLocationDefinition|ClimbingAidDefinition|WeatherTypeDefinition|ScoreDefinition|OverlayOrderDefinition|ZoneTypeDefinition|SpeechPoolDefinition|EndScreenDefinition|ActivityTypeDefinition|HelpTopicDefinition|SnippetCategoryDefinition|PlaylistDefinition|AttackVectorDefinition|MagicTypeDefinition|MovementModeDefinition
 
 ---@param definition PlatformContentDefinition
 function CcbPlatformContent.add(definition) end
@@ -3622,6 +3956,22 @@ function CcbPlatformRuntime.on(event_name, handler_id) end
 ---@param handler_id string Named Platform handler.
 function CcbPlatformRuntime.hook(hook_name, handler_id) end
 
+---Render a Lua-owned topic inside the native NPC dialogue window. The named
+---handler receives CcbPlatformDialogueRenderHook for both phases.
+---@param topic_id string Native dialogue topic id.
+---@param handler_id string Named Platform handler returning a line or response array.
+function CcbPlatformRuntime.dialogue_topic(topic_id, handler_id) end
+
+---@class CcbPlatformDialogueResponse
+---@field text string Player response displayed by the native dialogue window.
+---@field topic? string Next native or Lua-owned topic; defaults to `TALK_NONE`.
+
+---@class CcbPlatformDialogueRenderHook
+---@field avatar GameHandle The avatar participating in the dialogue.
+---@field interlocutor GameHandle|table The creature/entity handle or detached talker snapshot.
+---@field topic string Topic currently being rendered.
+---@field phase 'line'|'responses' Return a string for `line`, or CcbPlatformDialogueResponse[] for `responses`.
+
 ---@class PlatformTaskMigration
 ---@field task_id integer
 ---@field handler_id string
@@ -3707,6 +4057,24 @@ function CcbPlatformPresentation.choose(prompt, entries) end
 ---@return string|nil text
 function CcbPlatformPresentation.input_text(prompt, options) end
 
+---@class CcbPlatformMapgenRegistrationOptions
+---@field terrain_ids? string[] Concrete directional overmap-terrain ids to match.
+---@field z_min? integer Minimum generated z level.
+---@field z_max? integer Maximum generated z level.
+
+---@class CcbPlatformMapgenApi
+local CcbPlatformMapgenApi = {}
+
+---Register a primary OMT generator invoked before native missing-mapgen fallback.
+---@param handler_id string Registered Platform handler receiving `{ context = ScriptMapgenContext }`.
+---@param options? CcbPlatformMapgenRegistrationOptions
+function CcbPlatformMapgenApi.on_generate(handler_id, options) end
+
+---Register a generator invoked after the primary native or Platform mapgen finishes.
+---@param handler_id string Registered Platform handler receiving `{ context = ScriptMapgenContext }`.
+---@param options? CcbPlatformMapgenRegistrationOptions
+function CcbPlatformMapgenApi.on_postprocess(handler_id, options) end
+
 ---@class CcbPlatformServices
 ---@field achievements CcbPlatformAchievementsApi
 ---@field activities CcbPlatformActivitiesApi
@@ -3730,6 +4098,7 @@ function CcbPlatformPresentation.input_text(prompt, options) end
 ---@field messages CcbMessagesApi
 ---@field missions CcbMissionsApi
 ---@field morale CcbPlatformMoraleApi
+---@field mapgen CcbPlatformMapgenApi
 ---@field mutations CcbMutationsApi
 ---@field needs CcbNeedsApi
 ---@field npcs CcbNpcsApi
@@ -3747,6 +4116,7 @@ function CcbPlatformPresentation.input_text(prompt, options) end
 ---@field statistics CcbStatisticsApi
 ---@field targeting CcbTargetingApi
 ---@field time CcbTimeApi
+---@field trade CcbTradeApi
 ---@field types CcbTypesApi
 ---@field units CcbUnitsApi
 ---@field variables CcbVariablesApi

--- a/src/catalua_platform.cpp
+++ b/src/catalua_platform.cpp
@@ -135,30 +135,32 @@ void set_optional_field( const sol::table &values, const char *key, T &field, bo
     was_set = true;
 }
 
-std::vector<std::string> dependency_array( const sol::table &values )
+std::vector<std::string> bounded_string_array( const sol::table &values,
+        const std::string_view field )
 {
-    constexpr std::size_t maximum_dependencies = 256;
+    constexpr std::size_t maximum_entries = 256;
     const std::size_t count = values.size();
-    if( count > maximum_dependencies ) {
-        throw std::runtime_error( "ModDefinition dependencies exceed 256 entries" );
+    if( count > maximum_entries ) {
+        throw std::runtime_error( "ModDefinition " + std::string( field ) +
+                                  " exceed 256 entries" );
     }
     std::size_t observed = 0;
     for( const auto &entry : values ) {
         const sol::object key = entry.first;
         if( !key.is<lua_Integer>() ) {
             throw std::runtime_error(
-                "ModDefinition dependencies must be a dense array" );
+                "ModDefinition " + std::string( field ) + " must be a dense array" );
         }
         const lua_Integer index = key.as<lua_Integer>();
         if( index < 1 || static_cast<std::uint64_t>( index ) > count ) {
             throw std::runtime_error(
-                "ModDefinition dependencies must be a dense array" );
+                "ModDefinition " + std::string( field ) + " must be a dense array" );
         }
         ++observed;
     }
     if( observed != count ) {
         throw std::runtime_error(
-            "ModDefinition dependencies must be a dense array" );
+            "ModDefinition " + std::string( field ) + " must be a dense array" );
     }
     std::vector<std::string> result;
     result.reserve( count );
@@ -166,7 +168,7 @@ std::vector<std::string> dependency_array( const sol::table &values )
         const sol::object entry = values.raw_get<sol::object>( index );
         if( entry.get_type() != sol::type::string ) {
             throw std::runtime_error(
-                "ModDefinition dependencies may only contain strings" );
+                "ModDefinition " + std::string( field ) + " may only contain strings" );
         }
         result.push_back( entry.as<std::string>() );
     }
@@ -180,6 +182,9 @@ mod_definition make_mod_definition( const sol::table &values )
     set_optional_field( values, "name", result.name, result.name_set );
     set_optional_field( values, "version", result.version, result.version_set );
     set_optional_field( values, "entry", result.entry, result.entry_set );
+    set_optional_field( values, "description", result.description,
+                        result.description_set );
+    set_optional_field( values, "category", result.category, result.category_set );
     set_optional_field( values, "core", result.core, result.core_set );
     const sol::object dependencies = values.raw_get<sol::object>( "dependencies" );
     if( dependencies.valid() && dependencies.get_type() != sol::type::nil ) {
@@ -187,8 +192,19 @@ mod_definition make_mod_definition( const sol::table &values )
             throw std::runtime_error(
                 "ModDefinition dependencies must be a dense array" );
         }
-        result.dependencies = dependency_array( dependencies.as<sol::table>() );
+        result.dependencies = bounded_string_array(
+                                  dependencies.as<sol::table>(), "dependencies" );
         result.dependencies_set = true;
+    }
+    const sol::object authors = values.raw_get<sol::object>( "authors" );
+    if( authors.valid() && authors.get_type() != sol::type::nil ) {
+        if( authors.get_type() != sol::type::table ) {
+            throw std::runtime_error(
+                "ModDefinition authors must be a dense array" );
+        }
+        result.authors = bounded_string_array(
+                             authors.as<sol::table>(), "authors" );
+        result.authors_set = true;
     }
     return result;
 }
@@ -234,8 +250,32 @@ void install_mod_definition( sol::table &ccb )
         return definition.dependencies;
     },
     []( mod_definition & definition, const sol::table & value ) {
-        definition.dependencies = dependency_array( value );
+        definition.dependencies = bounded_string_array( value, "dependencies" );
         definition.dependencies_set = true;
+    } ),
+    "authors", sol::property(
+    []( const mod_definition & definition ) {
+        return definition.authors;
+    },
+    []( mod_definition & definition, const sol::table & value ) {
+        definition.authors = bounded_string_array( value, "authors" );
+        definition.authors_set = true;
+    } ),
+    "description", sol::property(
+    []( const mod_definition & definition ) {
+        return definition.description;
+    },
+    []( mod_definition & definition, std::string value ) {
+        definition.description = std::move( value );
+        definition.description_set = true;
+    } ),
+    "category", sol::property(
+    []( const mod_definition & definition ) {
+        return definition.category;
+    },
+    []( mod_definition & definition, std::string value ) {
+        definition.category = std::move( value );
+        definition.category_set = true;
     } ),
     "core", sol::property(
     []( const mod_definition & definition ) {
@@ -557,6 +597,16 @@ std::vector<std::string> loaded_mod_ids()
     return result;
 }
 
+bool has_primary_mapgen_for( const std::string_view terrain_id )
+{
+    const std::vector<runtime_state> &states = candidate_is_prepared ?
+            prepared_states : active_states;
+    return std::any_of( states.begin(), states.end(),
+    [terrain_id]( const runtime_state & state ) {
+        return runtime_has_primary_mapgen_for( state.platform, terrain_id );
+    } );
+}
+
 std::string prepared_content_fingerprint()
 {
     std::ostringstream joined;
@@ -696,6 +746,11 @@ void shutdown()
 std::vector<std::string> loaded_mod_ids()
 {
     return {};
+}
+
+bool has_primary_mapgen_for( std::string_view )
+{
+    return false;
 }
 
 std::string prepared_content_fingerprint()

--- a/src/catalua_platform.h
+++ b/src/catalua_platform.h
@@ -4,6 +4,7 @@
 
 #include <filesystem>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace cata::lua_platform
@@ -27,6 +28,9 @@ struct mod_definition {
     std::string version;
     std::string entry = "main.lua";
     std::vector<std::string> dependencies;
+    std::vector<std::string> authors;
+    std::string description;
+    std::string category;
     bool core = false;
 
     bool id_set = false;
@@ -34,6 +38,9 @@ struct mod_definition {
     bool version_set = false;
     bool entry_set = false;
     bool dependencies_set = false;
+    bool authors_set = false;
+    bool description_set = false;
+    bool category_set = false;
     bool core_set = false;
 };
 
@@ -74,6 +81,9 @@ void shutdown();
 
 /** IDs whose entry states are currently active, in dependency/load order. */
 std::vector<std::string> loaded_mod_ids();
+
+/** Whether the prepared candidate, or otherwise the active runtime, handles this concrete OMT. */
+bool has_primary_mapgen_for( std::string_view terrain_id );
 
 /** Deterministic fingerprint of the currently prepared static definitions. */
 std::string prepared_content_fingerprint();

--- a/src/catalua_platform_content.h
+++ b/src/catalua_platform_content.h
@@ -94,6 +94,13 @@ struct sub_body_part_type;
 struct weakpoints;
 class wound_fix;
 class wound_type;
+class faction_template;
+class npc_class;
+struct oter_t;
+struct oter_type_t;
+class overmap_special;
+class vpart_info;
+struct vehicle_prototype;
 
 namespace behavior
 {
@@ -181,9 +188,15 @@ std::size_t platform_item_blacklist_count();
 void insert_platform_scenario_blacklist( const platform_blacklist_data &value );
 void insert_platform_profession_blacklist( const platform_blacklist_data &value );
 void erase_platform_profession_blacklist( const platform_blacklist_data &value );
+struct platform_trait_group_entry {
+    std::string id;
+    std::int64_t weight = 100;
+    bool group = false;
+    std::string variant;
+};
 void insert_platform_trait_group(
     const std::string &id,
-    const std::vector<std::pair<std::string, std::int64_t>> &entries );
+    const std::vector<platform_trait_group_entry> &entries );
 void erase_platform_trait_group( const std::string &id );
 void append_platform_monster_adjustment( const std::string &species,
                                          const std::string &stat,
@@ -251,6 +264,13 @@ generic_factory<anatomy> &anatomy_registry();
 generic_factory<bodygraph> &bodygraph_registry();
 generic_factory<morale_type_data> &morale_type_registry();
 generic_factory<move_mode> &movement_mode_registry();
+std::vector<faction_template> &faction_template_registry();
+generic_factory<npc_class> &npc_class_registry();
+generic_factory<oter_type_t> &overmap_terrain_type_registry();
+generic_factory<oter_t> &overmap_terrain_registry();
+generic_factory<overmap_special> &overmap_special_registry();
+generic_factory<vpart_info> &vehicle_part_registry();
+generic_factory<vehicle_prototype> &vehicle_prototype_registry();
 void refresh_movement_mode_registry();
 generic_factory<zone_type> &zone_type_registry();
 generic_factory<disease_type> &disease_type_registry();

--- a/src/catalua_platform_runtime.cpp
+++ b/src/catalua_platform_runtime.cpp
@@ -48,6 +48,7 @@
 #include "cata_utility.h"
 #include "cata_variant.h"
 #include "catalua_platform_content.h"
+#include "catalua_platform_world_content.h"
 #include "catalua_ui_state.h"
 #include "catalua_bindings_coords.h"
 #include "catalua_bindings_values.h"
@@ -67,6 +68,7 @@
 #include "catalua_ui_interaction.h"
 #include "catalua_ui_items.h"
 #include "catalua_ui_magic.h"
+#include "catalua_ui_mapgen.h"
 #include "catalua_ui_martial_arts.h"
 #include "catalua_ui_missions.h"
 #include "catalua_ui_mutations.h"
@@ -97,6 +99,7 @@
 #include "construction_group.h"
 #include "crafting_gui.h"
 #include "debug.h"
+#include "dialogue.h"
 #include "disease.h"
 #include "emit.h"
 #include "effect.h"
@@ -132,6 +135,7 @@
 #include "json_loader.h"
 #include "map.h"
 #include "map_accessories.h"
+#include "mapgendata.h"
 #include "mapdata.h"
 #include "map_extras.h"
 #include "map_scale_constants.h"
@@ -268,15 +272,34 @@ struct quality_level {
 
 struct item_definition_data {
     std::string id;
+    std::string copy_from;
     std::string name;
     std::string description;
     std::string symbol = "?";
     std::int64_t mass_grams = 0;
     std::int64_t volume_ml = 0;
     std::int64_t price_cents = 0;
+    std::int64_t price_postapoc_cents = 0;
+    std::string color = "white";
+    std::string category;
+    std::string looks_like;
+    bool has_name = false;
+    bool has_description = false;
+    bool has_symbol = false;
+    bool has_mass = false;
+    bool has_volume = false;
+    bool has_price = false;
+    bool has_price_postapoc = false;
+    bool has_color = false;
+    bool has_category = false;
+    bool has_looks_like = false;
     std::vector<material_part> materials;
     std::vector<quality_level> qualities;
     std::set<std::string> flags;
+    std::map<std::string, double> melee_damage;
+    std::map<std::string, std::int64_t> magazine_ammo;
+    std::int64_t magazine_capacity = 0;
+    bool has_magazine_capacity = false;
     std::string use_handler;
     std::string use_label;
     bool registered = false;
@@ -285,6 +308,7 @@ struct item_definition_data {
 struct component_requirement {
     std::string id;
     std::int64_t count = 1;
+    bool requirement = false;
 };
 
 struct recipe_definition_data {
@@ -308,6 +332,15 @@ struct recipe_definition_data {
     std::vector<std::vector<component_requirement>> tools;
     std::map<std::string, std::int64_t> required_skills;
     std::map<std::string, std::int64_t> external_requirements;
+    struct proficiency_data {
+        std::string id;
+        bool required = false;
+        double time_multiplier = 0.0;
+        double skill_penalty = 0.0;
+        bool skill_penalty_assigned = false;
+    };
+    std::vector<proficiency_data> proficiencies;
+    std::map<std::string, std::int64_t> books;
     bool registered = false;
 };
 
@@ -387,6 +420,7 @@ struct scenario_definition_data {
     std::vector<std::string> forced_traits;
     std::vector<std::string> forbidden_traits;
     std::vector<std::string> flags;
+    std::string map_extra;
     std::string requirement;
     bool registered = false;
 };
@@ -643,6 +677,8 @@ struct item_group_entry_definition_data {
     bool group = false;
     std::int64_t probability = 100;
     std::string variant;
+    std::int64_t count_min = 1;
+    std::int64_t count_max = 1;
 };
 
 struct item_group_definition_data {
@@ -1962,6 +1998,7 @@ struct item_definition_handle {
             throw std::runtime_error( "item mass is outside the native range" );
         }
         definition->mass_grams = grams;
+        definition->has_mass = true;
         return *this;
     }
 
@@ -1972,6 +2009,7 @@ struct item_definition_handle {
             throw std::runtime_error( "item volume is outside the native range" );
         }
         definition->volume_ml = milliliters;
+        definition->has_volume = true;
         return *this;
     }
 
@@ -1981,6 +2019,48 @@ struct item_definition_handle {
             throw std::runtime_error( "item price is outside the native range" );
         }
         definition->price_cents = cents;
+        definition->has_price = true;
+        return *this;
+    }
+
+    item_definition_handle &price_postapoc( std::int64_t cents ) {
+        require_building_handle( token, *definition, "item" );
+        if( cents < 0 || cents > std::numeric_limits<units::money::value_type>::max() ) {
+            throw std::runtime_error( "item post-Cataclysm price is outside the native range" );
+        }
+        definition->price_postapoc_cents = cents;
+        definition->has_price_postapoc = true;
+        return *this;
+    }
+
+    item_definition_handle &melee( const std::string &damage_type, double amount ) {
+        require_building_handle( token, *definition, "item" );
+        if( damage_type.empty() || !std::isfinite( amount ) ) {
+            throw std::runtime_error( "item melee damage requires a type and finite amount" );
+        }
+        definition->melee_damage[damage_type] = amount;
+        return *this;
+    }
+
+    item_definition_handle &magazine_ammo( const std::string &ammo_type,
+                                            std::int64_t capacity ) {
+        require_building_handle( token, *definition, "item" );
+        if( ammo_type.empty() || capacity <= 0 ||
+            capacity > std::numeric_limits<int>::max() ) {
+            throw std::runtime_error(
+                "item magazine ammo requires a type and positive native capacity" );
+        }
+        definition->magazine_ammo[ammo_type] = capacity;
+        return *this;
+    }
+
+    item_definition_handle &magazine_capacity( std::int64_t capacity ) {
+        require_building_handle( token, *definition, "item" );
+        if( capacity <= 0 || capacity > std::numeric_limits<int>::max() ) {
+            throw std::runtime_error( "item magazine capacity is outside the native range" );
+        }
+        definition->magazine_capacity = capacity;
+        definition->has_magazine_capacity = true;
         return *this;
     }
 
@@ -2041,12 +2121,13 @@ struct recipe_definition_handle {
         return *this;
     }
 
-    recipe_definition_handle &component( const std::string &id, std::int64_t count ) {
+    recipe_definition_handle &component( const std::string &id, std::int64_t count,
+                                         const sol::optional<bool> &requirement ) {
         require_building_handle( token, *definition, "recipe" );
         if( id.empty() || count <= 0 || count > std::numeric_limits<int>::max() ) {
             throw std::runtime_error( "recipe component requires a non-empty id and positive count" );
         }
-        definition->components.push_back( { { id, count } } );
+        definition->components.push_back( { { id, count, requirement.value_or( false ) } } );
         return *this;
     }
 
@@ -2067,29 +2148,31 @@ struct recipe_definition_handle {
             if( id.empty() || count <= 0 || count > std::numeric_limits<int>::max() ) {
                 throw std::runtime_error( "recipe component alternative requires an id and positive count" );
             }
-            group.push_back( { id, count } );
+            group.push_back( { id, count, choice.get_or( "requirement", false ) } );
         }
         definition->components.push_back( std::move( group ) );
         return *this;
     }
 
-    recipe_definition_handle &tool( const std::string &id, std::int64_t count ) {
+    recipe_definition_handle &tool( const std::string &id, std::int64_t count,
+                                    const sol::optional<bool> &requirement ) {
         require_building_handle( token, *definition, "recipe" );
         if( id.empty() || count <= 0 || count > std::numeric_limits<int>::max() ) {
             throw std::runtime_error(
                 "recipe tool requires a non-empty id and positive instance count" );
         }
-        definition->tools.push_back( { { id, -count } } );
+        definition->tools.push_back( { { id, -count, requirement.value_or( false ) } } );
         return *this;
     }
 
-    recipe_definition_handle &tool_charges( const std::string &id, std::int64_t charges ) {
+    recipe_definition_handle &tool_charges( const std::string &id, std::int64_t charges,
+                                            const sol::optional<bool> &requirement ) {
         require_building_handle( token, *definition, "recipe" );
         if( id.empty() || charges <= 0 || charges > std::numeric_limits<int>::max() ) {
             throw std::runtime_error(
                 "recipe tool charges require a non-empty id and positive charge count" );
         }
-        definition->tools.push_back( { { id, charges } } );
+        definition->tools.push_back( { { id, charges, requirement.value_or( false ) } } );
         return *this;
     }
 
@@ -2122,7 +2205,8 @@ struct recipe_definition_handle {
                 throw std::runtime_error(
                     "recipe tool alternative requires an id and positive amount" );
             }
-            group.push_back( { id, consumes_charges ? amount : -amount } );
+            group.push_back( { id, consumes_charges ? amount : -amount,
+                               choice.get_or( "requirement", false ) } );
         }
         definition->tools.push_back( std::move( group ) );
         return *this;
@@ -2145,6 +2229,36 @@ struct recipe_definition_handle {
                 "recipe external requirement needs a non-empty id and positive multiplier" );
         }
         definition->external_requirements[id] = multiplier;
+        return *this;
+    }
+
+    recipe_definition_handle &proficiency( const std::string &id,
+                                            const sol::optional<sol::table> &options ) {
+        require_building_handle( token, *definition, "recipe" );
+        if( id.empty() ) {
+            throw std::runtime_error( "recipe proficiency id cannot be empty" );
+        }
+        recipe_definition_data::proficiency_data value;
+        value.id = id;
+        if( options ) {
+            value.required = options->get_or( "required", false );
+            value.time_multiplier = options->get_or( "time_multiplier", 0.0 );
+            if( const sol::optional<double> penalty =
+                    options->get<sol::optional<double>>( "skill_penalty" ) ) {
+                value.skill_penalty = *penalty;
+                value.skill_penalty_assigned = true;
+            }
+        }
+        definition->proficiencies.push_back( std::move( value ) );
+        return *this;
+    }
+
+    recipe_definition_handle &book( const std::string &id, std::int64_t skill_level ) {
+        require_building_handle( token, *definition, "recipe" );
+        if( id.empty() || skill_level < 0 || skill_level > MAX_SKILL ) {
+            throw std::runtime_error( "recipe book needs an id and valid skill level" );
+        }
+        definition->books[id] = skill_level;
         return *this;
     }
 
@@ -2177,12 +2291,13 @@ struct requirement_definition_handle {
     std::shared_ptr<requirement_definition_data> definition;
     std::shared_ptr<owner_token> token;
 
-    requirement_definition_handle &component( const std::string &id, std::int64_t count ) {
+    requirement_definition_handle &component( const std::string &id, std::int64_t count,
+            const sol::optional<bool> &requirement ) {
         require_building_handle( token, *definition, "requirement" );
         if( id.empty() || count <= 0 || count > std::numeric_limits<int>::max() ) {
             throw std::runtime_error( "requirement component needs an id and positive count" );
         }
-        definition->components.push_back( { { id, count } } );
+        definition->components.push_back( { { id, count, requirement.value_or( false ) } } );
         return *this;
     }
 
@@ -2200,28 +2315,29 @@ struct requirement_definition_handle {
                 throw std::runtime_error(
                     "requirement component alternative needs an id and positive count" );
             }
-            group.push_back( { id, amount } );
+            group.push_back( { id, amount, choice.get_or( "requirement", false ) } );
         }
         definition->components.push_back( std::move( group ) );
         return *this;
     }
 
-    requirement_definition_handle &tool( const std::string &id, std::int64_t count ) {
+    requirement_definition_handle &tool( const std::string &id, std::int64_t count,
+                                         const sol::optional<bool> &requirement ) {
         require_building_handle( token, *definition, "requirement" );
         if( id.empty() || count <= 0 || count > std::numeric_limits<int>::max() ) {
             throw std::runtime_error( "requirement tool needs an id and positive count" );
         }
-        definition->tools.push_back( { { id, -count } } );
+        definition->tools.push_back( { { id, -count, requirement.value_or( false ) } } );
         return *this;
     }
 
     requirement_definition_handle &tool_charges( const std::string &id,
-            std::int64_t charges ) {
+            std::int64_t charges, const sol::optional<bool> &requirement ) {
         require_building_handle( token, *definition, "requirement" );
         if( id.empty() || charges <= 0 || charges > std::numeric_limits<int>::max() ) {
             throw std::runtime_error( "requirement tool charges need an id and positive amount" );
         }
-        definition->tools.push_back( { { id, charges } } );
+        definition->tools.push_back( { { id, charges, requirement.value_or( false ) } } );
         return *this;
     }
 
@@ -2249,7 +2365,8 @@ struct requirement_definition_handle {
                 throw std::runtime_error(
                     "requirement tool alternative needs an id and positive amount" );
             }
-            group.push_back( { id, charges ? amount : -amount } );
+            group.push_back( { id, charges ? amount : -amount,
+                               choice.get_or( "requirement", false ) } );
         }
         definition->tools.push_back( std::move( group ) );
         return *this;
@@ -4042,6 +4159,34 @@ struct item_group_definition_handle {
             return add_entry( id, true, probability.value_or( 100 ), std::string() );
         }
 
+        item_group_definition_handle &entry( const sol::table &options ) {
+            const std::string item = options.get_or( "item", std::string() );
+            const std::string group_id = options.get_or( "group", std::string() );
+            if( item.empty() == group_id.empty() ) {
+                throw std::runtime_error(
+                    "item-group entry requires exactly one of item or group" );
+            }
+            item_group_entry_definition_data value;
+            value.id = item.empty() ? group_id : item;
+            value.group = item.empty();
+            value.probability = options.get_or<std::int64_t>( "probability", 100 );
+            value.variant = options.get_or( "variant", std::string() );
+            if( const sol::optional<sol::table> count =
+                    options.get<sol::optional<sol::table>>( "count" ) ) {
+                require_dense_array( *count, "item-group count", 2, 2 );
+                value.count_min = count->raw_get<std::int64_t>( 1 );
+                value.count_max = count->raw_get<std::int64_t>( 2 );
+            }
+            if( value.probability <= 0 || value.count_min < 0 ||
+                value.count_max < value.count_min ||
+                value.count_max > std::numeric_limits<int>::max() ) {
+                throw std::runtime_error( "item-group entry has invalid probability or count" );
+            }
+            require_building_handle( token, *definition, "item group" );
+            definition->entries.push_back( std::move( value ) );
+            return *this;
+        }
+
         std::string id() const {
             require_readable_handle( token, *definition, "item group" );
             return definition->id;
@@ -5683,7 +5828,7 @@ struct monster_adjustment_definition_data {
 
 struct trait_group_definition_data {
     std::string id;
-    std::vector<std::pair<std::string, std::int64_t>> entries;
+    std::vector<detail::platform_trait_group_entry> entries;
     bool registered = false;
 };
 
@@ -5771,12 +5916,25 @@ struct trait_group_definition_handle {
     std::shared_ptr<owner_token> token;
 
     trait_group_definition_handle &trait( const std::string &trait,
-                                          const std::int64_t weight ) {
+                                          const std::int64_t weight,
+                                          const sol::optional<std::string> &variant ) {
         require_building_handle( token, *definition, "trait group" );
         if( trait.empty() || weight <= 0 ) {
             throw std::runtime_error( "trait-group entry must be positive" );
         }
-        definition->entries.emplace_back( trait, weight );
+        definition->entries.push_back( {
+            trait, weight, false, variant.value_or( std::string() )
+        } );
+        return *this;
+    }
+
+    trait_group_definition_handle &group( const std::string &group,
+                                          const std::int64_t weight ) {
+        require_building_handle( token, *definition, "trait group" );
+        if( group.empty() || weight <= 0 ) {
+            throw std::runtime_error( "trait-group subgroup must be positive" );
+        }
+        definition->entries.push_back( { group, weight, true, std::string() } );
         return *this;
     }
 
@@ -6820,6 +6978,15 @@ class runtime : public std::enable_shared_from_this<runtime>
                 task_migrations;
         std::unordered_map<std::string, std::vector<std::string>> subscriptions;
         std::unordered_map<std::string, std::vector<std::string>> hooks;
+        std::map<std::string, std::string> dialogue_topics;
+        struct mapgen_registration {
+            std::string handler_id;
+            std::vector<std::string> terrain_ids;
+            int z_min = std::numeric_limits<int>::min();
+            int z_max = std::numeric_limits<int>::max();
+            bool primary = false;
+        };
+        std::vector<mapgen_registration> mapgen_handlers;
         persistent_state character_state;
         persistent_state world_state;
         std::vector<persistent_task> tasks;
@@ -6838,11 +7005,13 @@ struct content_transaction::impl {
     impl( std::string owner_id, std::size_t owner_generation ) :
         owner( std::move( owner_id ) ), generation( owner_generation ),
         token( std::make_shared<owner_token>( owner_token{ owner, generation,
-                                              handle_lifecycle::building } ) ) {}
+                                              handle_lifecycle::building } ) ),
+        world( owner, generation ) {}
 
     std::string owner;
     std::size_t generation = 0;
     std::shared_ptr<owner_token> token;
+    world_content_transaction world;
     std::vector<tool_quality_registration> tool_qualities;
     std::vector<skill_display_registration> skill_displays;
     std::vector<skill_registration> skills;
@@ -8091,6 +8260,10 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         "mass_grams", &item_definition_handle::mass,
         "volume_ml", &item_definition_handle::volume,
         "price_cents", &item_definition_handle::price,
+        "price_postapoc_cents", &item_definition_handle::price_postapoc,
+        "melee_damage", &item_definition_handle::melee,
+        "magazine_ammo", &item_definition_handle::magazine_ammo,
+        "magazine_capacity", &item_definition_handle::magazine_capacity,
         "material", &item_definition_handle::material,
         "quality", &item_definition_handle::quality,
         "flag", &item_definition_handle::flag,
@@ -8105,7 +8278,9 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         "tool_charges", &recipe_definition_handle::tool_charges,
         "tool_any", &recipe_definition_handle::tool_any,
         "requires_skill", &recipe_definition_handle::requires_skill,
-        "requirement", &recipe_definition_handle::requirement );
+        "requirement", &recipe_definition_handle::requirement,
+        "proficiency", &recipe_definition_handle::proficiency,
+        "book", &recipe_definition_handle::book );
     ccb.new_usertype<nested_recipe_category_definition_handle>(
         "NestedRecipeCategoryDefinition", sol::no_constructor,
         "id", sol::property( &nested_recipe_category_definition_handle::id ),
@@ -8219,7 +8394,8 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         "ItemGroupDefinition", sol::no_constructor,
         "id", sol::property( &item_group_definition_handle::id ),
         "item", &item_group_definition_handle::item,
-        "group", &item_group_definition_handle::group );
+        "group", &item_group_definition_handle::group,
+        "entry", &item_group_definition_handle::entry );
     ccb.new_usertype<sub_body_part_definition_handle>(
         "SubBodyPartDefinition", sol::no_constructor,
         "id", sol::property( &sub_body_part_definition_handle::id ),
@@ -8571,7 +8747,8 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
     ccb.new_usertype<trait_group_definition_handle>(
         "TraitGroupDefinition", sol::no_constructor,
         "id", sol::property( &trait_group_definition_handle::id ),
-        "trait", &trait_group_definition_handle::trait );
+        "trait", &trait_group_definition_handle::trait,
+        "group", &trait_group_definition_handle::group );
     ccb.new_usertype<monster_adjustment_definition_handle>(
         "MonsterAdjustmentDefinition", sol::no_constructor );
     ccb.new_usertype<magic_type_definition_handle>(
@@ -8786,9 +8963,54 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         }
         auto definition = std::make_shared<item_definition_data>();
         definition->id = options.get_or( "id", std::string() );
-        definition->name = options.get_or( "name", definition->id );
-        definition->description = options.get_or( "description", std::string() );
-        definition->symbol = options.get_or( "symbol", std::string( "?" ) );
+        definition->copy_from = options.get_or( "copy_from", std::string() );
+        const auto read_string = [&options]( const char *key, std::string &target,
+        bool &present ) {
+            if( const sol::optional<std::string> value =
+                    options.get<sol::optional<std::string>>( key ) ) {
+                target = *value;
+                present = true;
+            }
+        };
+        read_string( "name", definition->name, definition->has_name );
+        read_string( "description", definition->description, definition->has_description );
+        read_string( "symbol", definition->symbol, definition->has_symbol );
+        read_string( "color", definition->color, definition->has_color );
+        read_string( "category", definition->category, definition->has_category );
+        read_string( "looks_like", definition->looks_like, definition->has_looks_like );
+        if( !definition->has_name && definition->copy_from.empty() ) {
+            definition->name = definition->id;
+            definition->has_name = true;
+        }
+        if( const sol::optional<std::int64_t> mass =
+                options.get<sol::optional<std::int64_t>>( "mass_grams" ) ) {
+            definition->mass_grams = *mass;
+            definition->has_mass = true;
+        }
+        if( const sol::optional<std::int64_t> volume =
+                options.get<sol::optional<std::int64_t>>( "volume_ml" ) ) {
+            definition->volume_ml = *volume;
+            definition->has_volume = true;
+        }
+        if( const sol::optional<std::int64_t> price =
+                options.get<sol::optional<std::int64_t>>( "price_cents" ) ) {
+            definition->price_cents = *price;
+            definition->has_price = true;
+        }
+        if( const sol::optional<std::int64_t> price_postapoc =
+                options.get<sol::optional<std::int64_t>>( "price_postapoc_cents" ) ) {
+            definition->price_postapoc_cents = *price_postapoc;
+            definition->has_price_postapoc = true;
+        }
+        if( const sol::optional<std::int64_t> magazine_capacity =
+                options.get<sol::optional<std::int64_t>>( "magazine_capacity" ) ) {
+            if( *magazine_capacity <= 0 ||
+                *magazine_capacity > std::numeric_limits<int>::max() ) {
+                throw std::runtime_error( "item magazine capacity is outside the native range" );
+            }
+            definition->magazine_capacity = *magazine_capacity;
+            definition->has_magazine_capacity = true;
+        }
         return item_definition_handle{ std::move( definition ), transaction->token };
     } );
     content.set_function( "Recipe", [transaction]( const sol::table & options ) {
@@ -8808,6 +9030,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->reversible = options.get_or( "reversible", false );
         definition->practice = options.get_or( "practice", false );
         definition->uncraft = options.get_or( "uncraft", false );
+        definition->activity_level = options.get_or( "activity_level", 1.0 );
         return recipe_definition_handle{ std::move( definition ), transaction->token };
     } );
     content.set_function( "NestedRecipeCategory", [transaction]( const sol::table & options ) {
@@ -8888,6 +9111,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
         definition->hard_requirement = options.get_or( "hard_requirement", false );
         definition->distance_initial_visibility = options.get_or<std::int64_t>(
                     "distance_initial_visibility", 15 );
+        definition->map_extra = options.get_or( "map_extra", std::string() );
         return scenario_definition_handle{ std::move( definition ), transaction->token };
     } );
     content.set_function( "VehicleColorPalette",
@@ -11087,6 +11311,10 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             transaction->recipes.push_back( { operation, handle.definition } );
             return;
         }
+        if( transaction->world.register_definition(
+                value, static_cast<int>( operation ) ) ) {
+            return;
+        }
         throw std::runtime_error(
             "content registration requires a native Platform definition" );
     };
@@ -11686,6 +11914,7 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             std::move( definition ), transaction->token
         };
     } );
+    transaction->world.install_lua_api( lua, ccb, content );
     ccb["content"] = std::move( content );
 
     static_cast<void>( owner_runtime );
@@ -12371,6 +12600,7 @@ bool content_transaction::validate( const runtime &owner_runtime,
                     ( check_engine_state && *match == ot_match_type::exact &&
                       !oter_str_id( target.terrain ).is_valid() ) ||
                     ( check_engine_state && *match == ot_match_type::type &&
+                      !pimpl_->world.defines_overmap_terrain_type( target.terrain ) &&
                       !oter_type_str_id( target.terrain ).is_valid() ) ) {
                     throw std::runtime_error( "start location '" + definition.id +
                                               "' has an invalid or duplicate terrain selector" );
@@ -14022,7 +14252,8 @@ bool content_transaction::validate( const runtime &owner_runtime,
                                           "' requires a name and one registration per transaction" );
             }
             for( const std::string &location : definition.locations ) {
-                if( !start_location_id( location ).is_valid() ) {
+                if( start_location_ids.count( location ) == 0 &&
+                    !start_location_id( location ).is_valid() ) {
                     throw std::runtime_error( "scenario '" + definition.id +
                                               "' references unknown start location '" + location + "'" );
                 }
@@ -14050,6 +14281,13 @@ bool content_transaction::validate( const runtime &owner_runtime,
                     throw std::runtime_error( "scenario '" + definition.id +
                                               "' references unknown trait '" + trait + "'" );
                 }
+            }
+            if( !definition.map_extra.empty() &&
+                map_extra_ids.count( definition.map_extra ) == 0 &&
+                !map_extra_id( definition.map_extra ).is_valid() ) {
+                throw std::runtime_error( "scenario '" + definition.id +
+                                          "' references unknown map extra '" +
+                                          definition.map_extra + "'" );
             }
             if( !definition.requirement.empty() &&
                 !achievement_id( definition.requirement ).is_valid() ) {
@@ -15281,7 +15519,10 @@ bool content_transaction::validate( const runtime &owner_runtime,
                                           "' must contain native requirements and be registered once per transaction" );
             }
             staged_requirements.emplace( definition.id, &definition );
-            const auto validate_item_groups = [&declared_item_ids, &definition](
+        }
+        for( const requirement_registration &entry : pimpl_->requirements ) {
+            const requirement_definition_data &definition = *entry.definition;
+            const auto validate_item_groups = [&declared_item_ids, &requirement_ids, &definition](
             const std::vector<std::vector<component_requirement>> &groups, const char *kind ) {
                 for( const std::vector<component_requirement> &group : groups ) {
                     if( group.empty() ) {
@@ -15289,10 +15530,17 @@ bool content_transaction::validate( const runtime &owner_runtime,
                                                   "' has an empty alternative group" );
                     }
                     for( const component_requirement &component : group ) {
-                        if( declared_item_ids.count( component.id ) == 0 &&
-                            !item::type_is_defined( itype_id( component.id ) ) ) {
+                        const bool valid = component.requirement ?
+                                           requirement_ids.count( component.id ) != 0 ||
+                                           requirement_data::registry().count(
+                                               requirement_id( component.id ) ) != 0 :
+                                           declared_item_ids.count( component.id ) != 0 ||
+                                           item::type_is_defined( itype_id( component.id ) );
+                        if( !valid ) {
                             throw std::runtime_error( "requirement '" + definition.id +
-                                                      "' references unknown " + kind + " '" +
+                                                      "' references unknown " +
+                                                      ( component.requirement ?
+                                                        std::string( "requirement" ) : kind ) + " '" +
                                                       component.id + "'" );
                         }
                     }
@@ -15461,15 +15709,15 @@ bool content_transaction::validate( const runtime &owner_runtime,
                             staged->second->components, scaled_component_groups,
                         []( const component_requirement & component ) {
                             return component.id;
-                        }, []( const component_requirement & ) {
-                            return false;
+                        }, []( const component_requirement & component ) {
+                            return component.requirement;
                         } );
                         append_scaled_groups(
                             staged->second->tools, scaled_tool_groups,
                         []( const component_requirement & component ) {
                             return component.id;
-                        }, []( const component_requirement & ) {
-                            return false;
+                        }, []( const component_requirement & component ) {
+                            return component.requirement;
                         } );
                     }
                 } else {
@@ -15703,8 +15951,21 @@ bool content_transaction::validate( const runtime &owner_runtime,
             if( definition.id.empty() || definition.id.find( '#' ) != std::string::npos ) {
                 throw std::runtime_error( "invalid item id '" + definition.id + "'" );
             }
-            if( definition.name.empty() || definition.symbol.empty() ) {
+            if( definition.copy_from.empty() &&
+                ( definition.name.empty() || definition.symbol.empty() ) ) {
                 throw std::runtime_error( "item '" + definition.id + "' requires a name and symbol" );
+            }
+            if( !definition.copy_from.empty() && check_engine_state &&
+                declared_item_ids.count( definition.copy_from ) == 0 &&
+                !item::type_is_defined( itype_id( definition.copy_from ) ) &&
+                item_controller->get_generic_factory().find_abstract(
+                    definition.copy_from ) == nullptr ) {
+                throw std::runtime_error( "item '" + definition.id +
+                                          "' copies unknown item '" + definition.copy_from + "'" );
+            }
+            if( definition.has_color &&
+                color_from_string( definition.color, report_color_error::no ) == c_unset ) {
+                throw std::runtime_error( "item '" + definition.id + "' has an invalid color" );
             }
             if( !item_ids.insert( definition.id ).second ) {
                 throw std::runtime_error( "item '" + definition.id +
@@ -15840,6 +16101,47 @@ bool content_transaction::validate( const runtime &owner_runtime,
                     throw std::runtime_error( "recipe '" + definition.id +
                                               "' references unknown requirement '" +
                                               requirement_key + "'" );
+                }
+            }
+            const auto validate_recipe_groups = [&definition, &declared_item_ids,
+                                                &requirement_ids](
+            const std::vector<std::vector<component_requirement>> &groups,
+            const char *kind ) {
+                for( const std::vector<component_requirement> &group : groups ) {
+                    for( const component_requirement &component : group ) {
+                        const bool valid = component.requirement ?
+                                           requirement_ids.count( component.id ) != 0 ||
+                                           requirement_data::registry().count(
+                                               requirement_id( component.id ) ) != 0 :
+                                           declared_item_ids.count( component.id ) != 0 ||
+                                           item::type_is_defined( itype_id( component.id ) );
+                        if( !valid ) {
+                            throw std::runtime_error( "recipe '" + definition.id +
+                                                      "' references unknown " +
+                                                      ( component.requirement ?
+                                                        std::string( "requirement" ) : kind ) + " '" +
+                                                      component.id + "'" );
+                        }
+                    }
+                }
+            };
+            validate_recipe_groups( definition.components, "component" );
+            validate_recipe_groups( definition.tools, "tool" );
+            for( const recipe_definition_data::proficiency_data &proficiency :
+                 definition.proficiencies ) {
+                if( proficiency.id.empty() ||
+                    ( check_engine_state && !proficiency_id( proficiency.id ).is_valid() ) ||
+                    !std::isfinite( proficiency.time_multiplier ) ||
+                    !std::isfinite( proficiency.skill_penalty ) ) {
+                    throw std::runtime_error( "recipe '" + definition.id +
+                                              "' has an invalid proficiency" );
+                }
+            }
+            for( const auto &[book, level] : definition.books ) {
+                if( level < 0 || ( check_engine_state &&
+                                   !item::type_is_defined( itype_id( book ) ) ) ) {
+                    throw std::runtime_error( "recipe '" + definition.id +
+                                              "' has an invalid book" );
                 }
             }
         }
@@ -16037,6 +16339,9 @@ bool content_transaction::validate( const runtime &owner_runtime,
             validate_triggers( definition.anger_triggers );
             validate_triggers( definition.fear_triggers );
             validate_triggers( definition.placate_triggers );
+        }
+        if( !pimpl_->world.validate( check_engine_state, error ) ) {
+            return false;
         }
         error.clear();
         return true;
@@ -18282,6 +18587,8 @@ bool content_transaction::apply( std::string &error )
             native.hard_requirement = source.hard_requirement;
             native.distance_initial_visibility =
                 static_cast<int>( source.distance_initial_visibility );
+            native._map_extra = source.map_extra.empty() ?
+                                map_extra_id::NULL_ID() : map_extra_id( source.map_extra );
             for( const std::string &location : source.locations ) {
                 native._allowed_locs.push_back( start_location_id( location ) );
             }
@@ -18463,14 +18770,22 @@ bool content_transaction::apply( std::string &error )
                               static_cast<int>( source.with_magazine ),
                               "Lua-first item group " + source.id );
             for( const item_group_entry_definition_data &source_entry : source.entries ) {
-                if( source_entry.group ) {
-                    native->add_group_entry( item_group_id( source_entry.id ),
-                                             static_cast<int>( source_entry.probability ) );
-                } else {
-                    native->add_item_entry( itype_id( source_entry.id ),
-                                            static_cast<int>( source_entry.probability ),
-                                            source_entry.variant );
+                const Single_item_creator::Type entry_type = source_entry.group ?
+                        Single_item_creator::S_ITEM_GROUP : Single_item_creator::S_ITEM;
+                auto native_entry = std::make_unique<Single_item_creator>(
+                                        source_entry.id, entry_type,
+                                        static_cast<int>( source_entry.probability ),
+                                        "Lua-first item-group entry " + source.id );
+                if( source_entry.count_min != 1 || source_entry.count_max != 1 ||
+                    !source_entry.variant.empty() ) {
+                    native_entry->modifier.emplace();
+                    native_entry->modifier->count = {
+                        static_cast<int>( source_entry.count_min ),
+                        static_cast<int>( source_entry.count_max )
+                    };
+                    native_entry->modifier->variant = source_entry.variant;
                 }
+                native->add_entry( std::move( native_entry ) );
             }
             item_controller->m_template_groups[id] = std::move( native );
         }
@@ -19131,8 +19446,10 @@ bool content_transaction::apply( std::string &error )
             for( const std::vector<component_requirement> &source_group : source.components ) {
                 std::vector<item_comp> group;
                 for( const component_requirement &component : source_group ) {
-                    group.emplace_back( itype_id( component.id ),
-                                        static_cast<int>( component.count ) );
+                    item_comp native_component( itype_id( component.id ),
+                                                static_cast<int>( component.count ) );
+                    native_component.requirement = component.requirement;
+                    group.push_back( std::move( native_component ) );
                 }
                 components.push_back( std::move( group ) );
             }
@@ -19140,7 +19457,9 @@ bool content_transaction::apply( std::string &error )
             for( const std::vector<component_requirement> &source_group : source.tools ) {
                 std::vector<tool_comp> group;
                 for( const component_requirement &tool : source_group ) {
-                    group.emplace_back( itype_id( tool.id ), static_cast<int>( tool.count ) );
+                    tool_comp native_tool( itype_id( tool.id ), static_cast<int>( tool.count ) );
+                    native_tool.requirement = tool.requirement;
+                    group.push_back( std::move( native_tool ) );
                 }
                 tools.push_back( std::move( group ) );
             }
@@ -19228,17 +19547,72 @@ bool content_transaction::apply( std::string &error )
                 id, previous == item_controller->m_runtimes.end() ?
                 std::optional<itype>() : std::optional<itype>( *previous->second ) );
 
-            auto native = std::make_unique<itype>();
+            const item_definition_data &definition = *entry.definition;
+            std::unique_ptr<itype> native;
+            if( definition.copy_from.empty() ) {
+                native = std::make_unique<itype>();
+            } else {
+                const itype_id source_id( definition.copy_from );
+                const itype *source = nullptr;
+                const auto runtime_source = item_controller->m_runtimes.find( source_id );
+                if( runtime_source != item_controller->m_runtimes.end() ) {
+                    source = runtime_source->second.get();
+                } else {
+                    generic_factory<itype> &factory = item_controller->get_generic_factory();
+                    if( factory.is_valid( source_id ) ) {
+                        source = &factory.obj( source_id );
+                    } else {
+                        source = factory.find_abstract( definition.copy_from );
+                    }
+                }
+                if( source == nullptr ) {
+                    throw std::runtime_error( "item '" + definition.id +
+                                              "' lost its copy-from source '" +
+                                              definition.copy_from + "' while being applied" );
+                }
+                native = std::make_unique<itype>( *source );
+            }
             native->id = id;
-            native->name = no_translation( entry.definition->name );
-            native->description = no_translation( entry.definition->description );
-            native->sym = entry.definition->symbol;
-            native->weight = units::from_gram<std::int64_t>( entry.definition->mass_grams );
-            native->volume = units::from_milliliter<std::int64_t>( entry.definition->volume_ml );
-            native->price = units::from_cent<std::int64_t>( entry.definition->price_cents );
+            if( entry.definition->has_name ) {
+                native->name = no_translation( entry.definition->name );
+            }
+            if( entry.definition->has_description ) {
+                native->description = no_translation( entry.definition->description );
+            }
+            if( entry.definition->has_symbol ) {
+                native->sym = entry.definition->symbol;
+            }
+            if( entry.definition->has_mass ) {
+                native->weight = units::from_gram<std::int64_t>( entry.definition->mass_grams );
+            }
+            if( entry.definition->has_volume ) {
+                native->volume = units::from_milliliter<std::int64_t>( entry.definition->volume_ml );
+            }
+            if( entry.definition->has_price ) {
+                native->price = units::from_cent<std::int64_t>( entry.definition->price_cents );
+            }
+            if( entry.definition->has_price_postapoc ) {
+                native->price_post = units::from_cent<std::int64_t>(
+                                         entry.definition->price_postapoc_cents );
+            }
+            if( entry.definition->has_color ) {
+                native->color = color_from_string( entry.definition->color,
+                                                   report_color_error::no );
+            }
+            if( entry.definition->has_category ) {
+                native->category_force = item_category_id( entry.definition->category );
+            }
+            if( entry.definition->has_looks_like ) {
+                native->looks_like = itype_id( entry.definition->looks_like );
+            }
             native->was_loaded = true;
+            native->src.clear();
             native->src.emplace_back( id, mod_id( pimpl_->owner ) );
             bool first_material = true;
+            if( !entry.definition->materials.empty() ) {
+                native->materials.clear();
+                native->mat_portion_total = 0;
+            }
             for( const material_part &material : entry.definition->materials ) {
                 const material_id material_key( material.id );
                 native->materials[material_key] += static_cast<int>( material.portions );
@@ -19258,6 +19632,35 @@ bool content_transaction::apply( std::string &error )
             }
             for( const std::string &flag : entry.definition->flags ) {
                 native->item_tags.insert( flag_id( flag ) );
+            }
+            for( const auto &[damage, amount] : entry.definition->melee_damage ) {
+                native->melee.damage_map[damage_type_id( damage )] = static_cast<float>( amount );
+            }
+            if( !entry.definition->magazine_ammo.empty() ) {
+                if( !native->magazine ) {
+                    native->magazine = cata::make_value<islot_magazine>();
+                }
+                native->magazine->was_loaded = true;
+                native->magazine->type.clear();
+                native->magazine->capacity = 0;
+                pocket_data pocket( pocket_type::MAGAZINE );
+                for( const auto &[ammo, capacity] : entry.definition->magazine_ammo ) {
+                    native->magazine->type.emplace( ammo );
+                    native->magazine->capacity = std::max(
+                                                    native->magazine->capacity,
+                                                    static_cast<int>( capacity ) );
+                    pocket.ammo_restriction.emplace(
+                        ammotype( ammo ), static_cast<int>( capacity ) );
+                }
+                if( entry.definition->has_magazine_capacity ) {
+                    native->magazine->capacity = static_cast<int>(
+                                                     entry.definition->magazine_capacity );
+                }
+                native->pockets.erase( std::remove_if( native->pockets.begin(),
+                native->pockets.end(), []( const pocket_data & value ) {
+                    return value.type == pocket_type::MAGAZINE;
+                } ), native->pockets.end() );
+                native->pockets.push_back( std::move( pocket ) );
             }
             if( !entry.definition->use_handler.empty() ) {
                 const std::string action_id = "lua_platform:" + pimpl_->owner + ":" +
@@ -19341,17 +19744,33 @@ bool content_transaction::apply( std::string &error )
                                 skill_id::NULL_ID() : skill_id( entry.definition->skill );
             native.autolearn = entry.definition->autolearn;
             native.reversible = entry.definition->reversible;
+            native.exertion = static_cast<float>( entry.definition->activity_level );
             native.was_loaded = true;
             native.src.emplace_back( id, mod_id( pimpl_->owner ) );
             for( const auto &[skill, level] : entry.definition->required_skills ) {
                 native.required_skills[skill_id( skill )] = static_cast<int>( level );
             }
+            for( const recipe_definition_data::proficiency_data &source :
+                 entry.definition->proficiencies ) {
+                recipe_proficiency native_proficiency;
+                native_proficiency.id = proficiency_id( source.id );
+                native_proficiency.required = source.required;
+                native_proficiency.time_multiplier = static_cast<float>( source.time_multiplier );
+                native_proficiency.skill_penalty = static_cast<float>( source.skill_penalty );
+                native_proficiency._skill_penalty_assigned = source.skill_penalty_assigned;
+                native.proficiencies.push_back( std::move( native_proficiency ) );
+            }
+            for( const auto &[book, level] : entry.definition->books ) {
+                native.booksets[itype_id( book )].skill_req = static_cast<int>( level );
+            }
             requirement_data::alter_item_comp_vector components;
             for( const std::vector<component_requirement> &group : entry.definition->components ) {
                 std::vector<item_comp> alternatives;
                 for( const component_requirement &component : group ) {
-                    alternatives.emplace_back( itype_id( component.id ),
-                                               static_cast<int>( component.count ) );
+                    item_comp native_component( itype_id( component.id ),
+                                                static_cast<int>( component.count ) );
+                    native_component.requirement = component.requirement;
+                    alternatives.push_back( std::move( native_component ) );
                 }
                 components.push_back( std::move( alternatives ) );
             }
@@ -19359,8 +19778,9 @@ bool content_transaction::apply( std::string &error )
             for( const std::vector<component_requirement> &group : entry.definition->tools ) {
                 std::vector<tool_comp> alternatives;
                 for( const component_requirement &tool : group ) {
-                    alternatives.emplace_back( itype_id( tool.id ),
-                                               static_cast<int>( tool.count ) );
+                    tool_comp native_tool( itype_id( tool.id ), static_cast<int>( tool.count ) );
+                    native_tool.requirement = tool.requirement;
+                    alternatives.push_back( std::move( native_tool ) );
                 }
                 tools.push_back( std::move( alternatives ) );
             }
@@ -19560,6 +19980,9 @@ bool content_transaction::apply( std::string &error )
             !pimpl_->body_parts.empty() ) {
             detail::refresh_wound_fix_links();
             detail::refresh_body_part_wound_cache();
+        }
+        if( !pimpl_->world.apply( error ) ) {
+            throw std::runtime_error( error );
         }
         pimpl_->applied = true;
         error.clear();
@@ -20330,12 +20753,16 @@ bool content_transaction::validate_finalized( std::string &error ) const
             return false;
         }
     }
+    if( !pimpl_->world.validate_finalized( error ) ) {
+        return false;
+    }
     error.clear();
     return true;
 }
 
 void content_transaction::rollback()
 {
+    pimpl_->world.rollback();
     const bool rebuild_wound_fixes = !pimpl_->requirement_undo.empty() ||
                                      !pimpl_->wound_fix_undo.empty();
     const bool refresh_wound_derived = !pimpl_->wound_type_undo.empty() ||
@@ -21560,6 +21987,7 @@ void content_transaction::rollback()
 
 void content_transaction::commit()
 {
+    pimpl_->world.commit();
     if( !pimpl_->applied ) {
         return;
     }
@@ -21676,6 +22104,7 @@ void content_transaction::commit()
 
 void content_transaction::seal()
 {
+    pimpl_->world.seal();
     if( pimpl_->token->lifecycle == handle_lifecycle::building ) {
         pimpl_->token->lifecycle = handle_lifecycle::committed;
     }
@@ -21684,6 +22113,7 @@ void content_transaction::seal()
 void content_transaction::discard()
 {
     rollback();
+    pimpl_->world.discard();
     pimpl_->token->lifecycle = handle_lifecycle::discarded;
 }
 
@@ -21691,6 +22121,7 @@ std::string content_transaction::fingerprint() const
 {
     std::uint64_t state = 1469598103934665603ULL;
     hash_part( state, pimpl_->owner );
+    pimpl_->world.append_fingerprint( state );
     for( const json_flag_registration &entry : pimpl_->json_flags ) {
         hash_part( state, "json_flag" );
         hash_part( state, operation_name( entry.operation ) );
@@ -22654,6 +23085,8 @@ std::string content_transaction::fingerprint() const
             hash_part( state, group_entry.id );
             hash_part( state, std::to_string( group_entry.probability ) );
             hash_part( state, group_entry.variant );
+            hash_part( state, std::to_string( group_entry.count_min ) );
+            hash_part( state, std::to_string( group_entry.count_max ) );
         }
     }
     for( const harvest_drop_type_registration &entry : pimpl_->harvest_drop_types ) {
@@ -23174,6 +23607,7 @@ std::string content_transaction::fingerprint() const
             for( const component_requirement &component : group ) {
                 hash_part( state, component.id );
                 hash_part( state, std::to_string( component.count ) );
+                hash_part( state, component.requirement ? "requirement" : "item" );
             }
         }
         for( const auto &group : value.tools ) {
@@ -23181,6 +23615,7 @@ std::string content_transaction::fingerprint() const
             for( const component_requirement &tool : group ) {
                 hash_part( state, tool.id );
                 hash_part( state, std::to_string( tool.count ) );
+                hash_part( state, tool.requirement ? "requirement" : "item" );
             }
         }
         for( const auto &group : value.qualities ) {
@@ -23253,12 +23688,18 @@ std::string content_transaction::fingerprint() const
         hash_part( state, operation_name( entry.operation ) );
         const item_definition_data &value = *entry.definition;
         hash_part( state, value.id );
+        hash_part( state, value.copy_from );
         hash_part( state, value.name );
         hash_part( state, value.description );
         hash_part( state, value.symbol );
         hash_part( state, std::to_string( value.mass_grams ) );
         hash_part( state, std::to_string( value.volume_ml ) );
         hash_part( state, std::to_string( value.price_cents ) );
+        hash_part( state, std::to_string( value.price_postapoc_cents ) );
+        hash_part( state, value.color );
+        hash_part( state, value.category );
+        hash_part( state, value.looks_like );
+        hash_part( state, std::to_string( value.magazine_capacity ) );
         hash_part( state, value.use_handler );
         hash_part( state, value.use_label );
         for( const material_part &material : value.materials ) {
@@ -23271,6 +23712,14 @@ std::string content_transaction::fingerprint() const
         }
         for( const std::string &flag : value.flags ) {
             hash_part( state, flag );
+        }
+        for( const auto &[damage, amount] : value.melee_damage ) {
+            hash_part( state, damage );
+            hash_part( state, std::to_string( amount ) );
+        }
+        for( const auto &[ammo, capacity] : value.magazine_ammo ) {
+            hash_part( state, ammo );
+            hash_part( state, std::to_string( capacity ) );
         }
     }
     for( const clothing_mod_registration &entry : pimpl_->clothing_mods ) {
@@ -23316,6 +23765,7 @@ std::string content_transaction::fingerprint() const
             for( const component_requirement &component : group ) {
                 hash_part( state, component.id );
                 hash_part( state, std::to_string( component.count ) );
+                hash_part( state, component.requirement ? "requirement" : "item" );
             }
         }
         for( const auto &group : value.tools ) {
@@ -23323,6 +23773,7 @@ std::string content_transaction::fingerprint() const
             for( const component_requirement &tool : group ) {
                 hash_part( state, tool.id );
                 hash_part( state, std::to_string( tool.count ) );
+                hash_part( state, tool.requirement ? "requirement" : "item" );
             }
         }
         for( const auto &[skill, level] : value.required_skills ) {
@@ -23332,6 +23783,17 @@ std::string content_transaction::fingerprint() const
         for( const auto &[requirement_key, multiplier] : value.external_requirements ) {
             hash_part( state, requirement_key );
             hash_part( state, std::to_string( multiplier ) );
+        }
+        for( const recipe_definition_data::proficiency_data &proficiency :
+             value.proficiencies ) {
+            hash_part( state, proficiency.id );
+            hash_part( state, proficiency.required ? "required" : "optional" );
+            hash_part( state, std::to_string( proficiency.time_multiplier ) );
+            hash_part( state, std::to_string( proficiency.skill_penalty ) );
+        }
+        for( const auto &[book, level] : value.books ) {
+            hash_part( state, book );
+            hash_part( state, std::to_string( level ) );
         }
     }
     std::ostringstream result;
@@ -23540,6 +24002,7 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
                           sol::state &lua, sol::table &ccb )
 {
     value->content.install_lua_api( lua, ccb, value );
+    cata::lua_ui::install_script_mapgen_context_api( lua );
 
     ccb.new_usertype<use_context_data>(
         "ItemUseContext", sol::no_constructor,
@@ -23652,6 +24115,26 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
                                       "' for handler '" + handler_id + "'" );
         }
         handlers.push_back( handler_id );
+    } );
+    runtime_api.set_function( "dialogue_topic", [weak]( const std::string & topic_id,
+    const std::string & handler_id ) {
+        const std::shared_ptr<runtime> owner = weak.lock();
+        if( !owner ) {
+            throw std::runtime_error( "stale Platform runtime" );
+        }
+        if( topic_id.empty() || topic_id.size() > 256 ||
+            topic_id.find( '\0' ) != std::string::npos ) {
+            throw std::runtime_error( "dialogue topic id must contain 1 to 256 non-NUL bytes" );
+        }
+        if( handler_id.empty() ) {
+            throw std::runtime_error( "dialogue topic handler id cannot be empty" );
+        }
+        if( owner->dialogue_topics.size() >= 256 ) {
+            throw std::runtime_error( "dialogue topic registration limit reached" );
+        }
+        if( !owner->dialogue_topics.emplace( topic_id, handler_id ).second ) {
+            throw std::runtime_error( "duplicate dialogue topic '" + topic_id + "'" );
+        }
     } );
     ccb["runtime"] = std::move( runtime_api );
 
@@ -23843,6 +24326,77 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
         }
         return to_turn<std::int64_t>( calendar::turn );
     } );
+    sol::table mapgen = lua.create_table();
+    const auto register_mapgen = [weak](
+                                           const std::string &handler_id,
+                                           const sol::optional<sol::table> &options,
+                                           const bool primary,
+                                           const std::string_view api_name ) {
+        const std::shared_ptr<runtime> owner = weak.lock();
+        if( !owner ) {
+            throw std::runtime_error( "stale Platform runtime" );
+        }
+        if( handler_id.empty() ) {
+            throw std::invalid_argument(
+                std::string( api_name ) + " requires a handler id" );
+        }
+        runtime::mapgen_registration registration;
+        registration.handler_id = handler_id;
+        registration.primary = primary;
+        if( options ) {
+            if( const sol::optional<int> z_min =
+                    options->get<sol::optional<int>>( "z_min" ) ) {
+                registration.z_min = *z_min;
+            }
+            if( const sol::optional<int> z_max =
+                    options->get<sol::optional<int>>( "z_max" ) ) {
+                registration.z_max = *z_max;
+            }
+            const sol::object terrain_ids = options->raw_get<sol::object>(
+                                                "terrain_ids" );
+            if( terrain_ids.valid() && terrain_ids.get_type() != sol::type::nil ) {
+                if( terrain_ids.get_type() != sol::type::table ) {
+                    throw std::invalid_argument(
+                        "mapgen terrain_ids must be a dense string array" );
+                }
+                const sol::table values = terrain_ids.as<sol::table>();
+                const std::size_t count = require_dense_array(
+                                              values, "mapgen terrain_ids", 1, 256 );
+                registration.terrain_ids.reserve( count );
+                for( std::size_t index = 1; index <= count; ++index ) {
+                    const sol::object entry = values.raw_get<sol::object>( index );
+                    if( entry.get_type() != sol::type::string ) {
+                        throw std::invalid_argument(
+                            "mapgen terrain_ids must contain only strings" );
+                    }
+                    registration.terrain_ids.push_back( entry.as<std::string>() );
+                }
+                std::sort( registration.terrain_ids.begin(),
+                           registration.terrain_ids.end() );
+                if( std::adjacent_find( registration.terrain_ids.begin(),
+                                        registration.terrain_ids.end() ) !=
+                    registration.terrain_ids.end() ) {
+                    throw std::invalid_argument(
+                        "mapgen terrain_ids cannot contain duplicates" );
+                }
+            }
+        }
+        if( registration.z_min > registration.z_max ) {
+            throw std::invalid_argument( "mapgen z_min cannot exceed z_max" );
+        }
+        owner->mapgen_handlers.push_back( std::move( registration ) );
+    };
+    mapgen.set_function( "on_generate", [register_mapgen](
+    const std::string &handler_id, const sol::optional<sol::table> &options ) {
+        register_mapgen( handler_id, options, true,
+                         "services.mapgen.on_generate" );
+    } );
+    mapgen.set_function( "on_postprocess", [register_mapgen](
+    const std::string &handler_id, const sol::optional<sol::table> &options ) {
+        register_mapgen( handler_id, options, false,
+                         "services.mapgen.on_postprocess" );
+    } );
+    services["mapgen"] = std::move( mapgen );
 
     // Platform and the capability-scoped v5 runtime share these native domain
     // implementations, but not an authoring contract or Lua state.  Platform
@@ -25170,7 +25724,282 @@ bool validate_runtime( const std::shared_ptr<runtime> &value,
             }
         }
     }
+    for( const runtime::mapgen_registration &registration :
+         value->mapgen_handlers ) {
+        if( value->handlers.count( registration.handler_id ) == 0 ) {
+            error = "Lua-first Mod '" + value->mod_id +
+                    "' mapgen registration references missing handler '" +
+                    registration.handler_id + "'";
+            return false;
+        }
+    }
+    for( const auto &[topic_id, handler_id] : value->dialogue_topics ) {
+        if( value->handlers.count( handler_id ) == 0 ) {
+            error = "Lua-first Mod '" + value->mod_id +
+                    "' dialogue topic '" + topic_id +
+                    "' references missing handler '" + handler_id + "'";
+            return false;
+        }
+    }
     return value->content.validate( *value, check_engine_state, error );
+}
+
+namespace
+{
+
+bool dispatch_platform_mapgen_phase( mapgendata &data, const bool primary )
+{
+    if( platform_event_dispatch_depth >= 4 ) {
+        DebugLog( D_ERROR, D_MAP_GEN ) <<
+                "Lua-first Platform mapgen recursion limit reached";
+        return false;
+    }
+    platform_event_dispatch_scope dispatch_scope;
+    bool matched = false;
+    const std::vector<std::shared_ptr<runtime>> runtimes = active_runtimes;
+    for( const std::shared_ptr<runtime> &owner : runtimes ) {
+        if( !owner || owner->lua == nullptr ) {
+            continue;
+        }
+        for( const runtime::mapgen_registration &registration :
+             owner->mapgen_handlers ) {
+            if( registration.primary != primary ||
+                data.zlevel() < registration.z_min ||
+                data.zlevel() > registration.z_max ) {
+                continue;
+            }
+            const std::string terrain_id = data.terrain_type().id().str();
+            if( !registration.terrain_ids.empty() &&
+                !std::binary_search( registration.terrain_ids.begin(),
+                                     registration.terrain_ids.end(), terrain_id ) ) {
+                continue;
+            }
+            matched = true;
+            const auto handler = owner->handlers.find( registration.handler_id );
+            if( handler == owner->handlers.end() || owner->callback_depth >= 16 ) {
+                continue;
+            }
+            std::uint64_t seed = fnv1a( owner->mod_id );
+            seed = fnv1a( terrain_id, seed );
+            seed = fnv1a( std::to_string( data.pos().x() ), seed );
+            seed = fnv1a( std::to_string( data.pos().y() ), seed );
+            seed = fnv1a( std::to_string( data.pos().z() ), seed );
+            if( g != nullptr ) {
+                seed ^= static_cast<std::uint64_t>( g->get_seed() );
+            }
+            const std::shared_ptr<cata::lua_ui::script_mapgen_context> context =
+                std::make_shared<cata::lua_ui::script_mapgen_context>(
+                    data, true, seed );
+            sol::table payload = owner->lua->create_table();
+            payload["context"] = context;
+            sol::protected_function callback = handler->second.callback;
+            callback_scope scope( *owner );
+            const sol::protected_function_result result = callback( payload );
+            context->invalidate();
+            if( !result.valid() ) {
+                report_callback_error( *owner, registration.handler_id, result );
+            }
+        }
+    }
+    return matched;
+}
+
+} // namespace
+
+bool runtime_has_primary_mapgen_for( const std::shared_ptr<runtime> &value,
+                                     const std::string_view terrain_id )
+{
+    if( !value ) {
+        return false;
+    }
+    return std::any_of( value->mapgen_handlers.begin(), value->mapgen_handlers.end(),
+    [terrain_id]( const runtime::mapgen_registration & registration ) {
+        return registration.primary &&
+               ( registration.terrain_ids.empty() ||
+                 std::binary_search( registration.terrain_ids.begin(),
+                                     registration.terrain_ids.end(), std::string( terrain_id ) ) );
+    } );
+}
+
+namespace
+{
+
+struct platform_dialogue_handler {
+    std::shared_ptr<runtime> owner;
+    std::string handler_id;
+};
+
+std::optional<platform_dialogue_handler> find_platform_dialogue_handler(
+    const std::string_view topic_id )
+{
+    for( const std::shared_ptr<runtime> &owner : active_runtimes ) {
+        if( !owner || !owner->world_is_ready || owner->lua == nullptr ) {
+            continue;
+        }
+        const auto registration = owner->dialogue_topics.find(
+                                      std::string( topic_id ) );
+        if( registration == owner->dialogue_topics.end() ) {
+            continue;
+        }
+        return platform_dialogue_handler{ owner, registration->second };
+    }
+    return std::nullopt;
+}
+
+sol::protected_function_result invoke_platform_dialogue_handler(
+    const platform_dialogue_handler &registration, dialogue &d,
+    const talk_topic &topic, const std::string_view phase )
+{
+    runtime &owner = *registration.owner;
+    const auto handler = owner.handlers.find( registration.handler_id );
+    if( handler == owner.handlers.end() ) {
+        throw std::runtime_error( "missing dialogue handler '" +
+                                  registration.handler_id + "'" );
+    }
+    if( owner.callback_depth >= 16 ) {
+        throw std::runtime_error( "dialogue callback recursion limit reached" );
+    }
+    sol::table payload = platform_callback_payload( owner, {
+        { "avatar", d.const_actor( false ) },
+        { "interlocutor", d.const_actor( true ) },
+        { "topic", topic.id },
+        { "phase", std::string( phase ) }
+    } );
+    sol::protected_function callback = handler->second.callback;
+    callback_scope scope( owner );
+    return callback( payload );
+}
+
+void report_platform_dialogue_error( const platform_dialogue_handler &registration,
+                                     const std::string_view topic_id,
+                                     const std::string &error )
+{
+    DebugLog( D_ERROR, D_MAIN ) << "Lua-first Mod '" << registration.owner->mod_id
+                                << "' dialogue topic '" << topic_id << "': " << error;
+}
+
+void add_platform_dialogue_response( dialogue &d, const std::string &text,
+                                     const std::string &next_topic )
+{
+    talk_response response;
+    response.truetext = no_translation( text );
+    response.truefalse_condition = []( const_dialogue const & ) {
+        return true;
+    };
+    response.success.next_topic = talk_topic( next_topic );
+    d.add_gen_response( response, false );
+}
+
+} // namespace
+
+std::optional<std::string> platform_dialogue_dynamic_line( dialogue &d,
+        const talk_topic &topic )
+{
+    const std::optional<platform_dialogue_handler> registration =
+        find_platform_dialogue_handler( topic.id );
+    if( !registration ) {
+        return std::nullopt;
+    }
+    try {
+        const sol::protected_function_result result =
+            invoke_platform_dialogue_handler( *registration, d, topic, "line" );
+        if( !result.valid() ) {
+            const sol::error error = result;
+            throw std::runtime_error( error.what() );
+        }
+        if( result.get_type() != sol::type::string ) {
+            throw std::runtime_error( "line phase must return a string" );
+        }
+        std::string line = result.get<std::string>();
+        if( line.empty() || line.size() > 16384 ||
+            line.find( '\0' ) != std::string::npos ) {
+            throw std::runtime_error( "line must contain 1 to 16384 non-NUL bytes" );
+        }
+        return line;
+    } catch( const std::exception &exception ) {
+        report_platform_dialogue_error( *registration, topic.id, exception.what() );
+        return "&This dialogue is unavailable because its Lua handler failed.";
+    }
+}
+
+bool gen_platform_dialogue_responses( dialogue &d, const talk_topic &topic )
+{
+    const std::optional<platform_dialogue_handler> registration =
+        find_platform_dialogue_handler( topic.id );
+    if( !registration ) {
+        return false;
+    }
+    try {
+        const sol::protected_function_result result =
+            invoke_platform_dialogue_handler( *registration, d, topic, "responses" );
+        if( !result.valid() ) {
+            const sol::error error = result;
+            throw std::runtime_error( error.what() );
+        }
+        if( result.get_type() != sol::type::table ) {
+            throw std::runtime_error( "responses phase must return an array table" );
+        }
+        const sol::table responses = result.get<sol::table>();
+        const std::size_t count = require_dense_array(
+                                      responses, "dialogue responses", 1, 256 );
+        for( std::size_t index = 1; index <= count; ++index ) {
+            const sol::object entry = responses.raw_get<sol::object>( index );
+            if( entry.get_type() != sol::type::table ) {
+                throw std::runtime_error( "dialogue responses must contain tables" );
+            }
+            const sol::table descriptor = entry.as<sol::table>();
+            for( const auto &field : descriptor ) {
+                if( field.first.get_type() != sol::type::string ) {
+                    throw std::runtime_error(
+                        "dialogue response descriptor keys must be strings" );
+                }
+                const std::string key = field.first.as<std::string>();
+                if( key != "text" && key != "topic" ) {
+                    throw std::runtime_error(
+                        "dialogue response descriptor has unknown field '" + key + "'" );
+                }
+            }
+            const sol::object text_value = descriptor.raw_get<sol::object>( "text" );
+            if( text_value.get_type() != sol::type::string ) {
+                throw std::runtime_error(
+                    "dialogue response descriptor requires string field 'text'" );
+            }
+            const std::string text = text_value.as<std::string>();
+            const sol::object topic_value = descriptor.raw_get<sol::object>( "topic" );
+            if( topic_value.valid() && topic_value.get_type() != sol::type::nil &&
+                topic_value.get_type() != sol::type::string ) {
+                throw std::runtime_error(
+                    "dialogue response descriptor field 'topic' must be a string" );
+            }
+            const std::string next_topic = topic_value.valid() &&
+                                           topic_value.get_type() == sol::type::string ?
+                                           topic_value.as<std::string>() : "TALK_NONE";
+            if( text.empty() || text.size() > 16384 ||
+                text.find( '\0' ) != std::string::npos ) {
+                throw std::runtime_error( "dialogue response text is invalid" );
+            }
+            if( next_topic.empty() || next_topic.size() > 256 ||
+                next_topic.find( '\0' ) != std::string::npos ) {
+                throw std::runtime_error( "dialogue response topic is invalid" );
+            }
+            add_platform_dialogue_response( d, text, next_topic );
+        }
+        return true;
+    } catch( const std::exception &exception ) {
+        report_platform_dialogue_error( *registration, topic.id, exception.what() );
+        add_platform_dialogue_response( d, "End the conversation.", "TALK_DONE" );
+        return true;
+    }
+}
+
+bool dispatch_platform_mapgen_generate( mapgendata &data )
+{
+    return dispatch_platform_mapgen_phase( data, true );
+}
+
+void dispatch_platform_mapgen_postprocess( mapgendata &data )
+{
+    static_cast<void>( dispatch_platform_mapgen_phase( data, false ) );
 }
 
 bool apply_runtime_content( const std::shared_ptr<runtime> &value, std::string &error )

--- a/src/catalua_platform_runtime.h
+++ b/src/catalua_platform_runtime.h
@@ -16,9 +16,12 @@ class Character;
 class Creature;
 class item;
 class map;
+class mapgendata;
 class player_activity;
 class recipe;
+struct dialogue;
 struct itype;
+struct talk_topic;
 struct w_point;
 
 #if defined(CATA_ENABLE_LUA_UI) && CATA_ENABLE_LUA_UI
@@ -141,6 +144,12 @@ void hot_swap_active_runtimes(
     const std::vector<std::shared_ptr<runtime>> &values );
 void clear_active_runtimes();
 
+bool runtime_has_primary_mapgen_for( const std::shared_ptr<runtime> &value,
+                                     std::string_view terrain_id );
+std::optional<std::string> platform_dialogue_dynamic_line( dialogue &d,
+        const talk_topic &topic );
+bool gen_platform_dialogue_responses( dialogue &d, const talk_topic &topic );
+
 std::optional<int> invoke_use_handler( std::string_view mod_id,
                                        std::string_view handler_id,
                                        Character *character, item &used_item,
@@ -152,6 +161,8 @@ void runtime_before_save();
 bool runtime_save( std::string &error );
 void runtime_after_save( bool success, std::string_view error );
 void runtime_process_tasks();
+bool dispatch_platform_mapgen_generate( mapgendata &data );
+void dispatch_platform_mapgen_postprocess( mapgendata &data );
 
 bool has_runtime_hook( std::string_view name );
 cata::lua_ui::native_hook_result dispatch_runtime_hook(

--- a/src/catalua_platform_world_content.cpp
+++ b/src/catalua_platform_world_content.cpp
@@ -1,0 +1,1978 @@
+#include "catalua_platform_world_content.h"
+
+#if defined(CATA_ENABLE_LUA_UI) && CATA_ENABLE_LUA_UI
+
+#include <algorithm>
+#include <array>
+#include <bitset>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <map>
+#include <optional>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "calendar.h"
+#include "catacharset.h"
+#include "catalua_platform_content.h"
+#include "color.h"
+#include "coordinates.h"
+#include "enum_conversions.h"
+#include "faction.h"
+#include "generic_factory.h"
+#include "item_group.h"
+#include "memory_fast.h"
+#include "mod_manager.h"
+#include "npc.h"
+#include "npc_class.h"
+#include "omdata.h"
+#include "requirements.h"
+#include "shop_cons_rate.h"
+#include "translations.h"
+#include "type_id.h"
+#include "units.h"
+#include "veh_type.h"
+
+namespace cata::lua_platform
+{
+
+namespace
+{
+
+enum class lifecycle : int {
+    building,
+    committed,
+    discarded
+};
+
+enum class operation : int {
+    add,
+    replace,
+    edit
+};
+
+struct token {
+    lifecycle state = lifecycle::building;
+};
+
+struct definition_base {
+    std::string id;
+    bool registered = false;
+};
+
+struct interval_data {
+    int minimum = 0;
+    int maximum = 0;
+};
+
+struct distribution_data {
+    enum class kind : int {
+        constant,
+        random,
+        dice
+    };
+    kind type = kind::constant;
+    int first = 0;
+    int second = 0;
+    int add = 0;
+};
+
+struct faction_data : definition_base {
+    std::string name;
+    std::string description;
+    int likes = 0;
+    int respects = 0;
+    int trusts = 0;
+    bool known = true;
+    int size = 0;
+    int power = 0;
+    int wealth = 0;
+    int food_calories = 0;
+    std::map<std::string, int> food_vitamins;
+    bool consumes_food = false;
+    bool lone_wolf = false;
+    bool limited_area = false;
+    std::string currency;
+    std::string monster_faction = "human";
+    std::map<std::string, std::set<std::string>> relations;
+};
+
+struct price_rule_data {
+    std::string item;
+    std::string group;
+    std::string category;
+    double markup = 1.0;
+    double premium = 1.0;
+    std::optional<double> fixed_adjustment;
+    std::optional<int> price;
+};
+
+struct shop_group_data {
+    std::string id;
+    int trust = 0;
+    bool strict = false;
+    bool rigid = false;
+};
+
+struct npc_class_data : definition_base {
+    std::string name;
+    std::string job_description;
+    bool common = false;
+    bool sells_belongings = true;
+    std::string worn;
+    std::string carry;
+    std::string weapon;
+    std::string traits = "EMPTY_GROUP";
+    std::string consumption_rates;
+    distribution_data strength;
+    distribution_data dexterity;
+    distribution_data intelligence;
+    distribution_data perception;
+    std::map<std::string, distribution_data> skills;
+    std::map<std::string, distribution_data> bonus_skills;
+    std::vector<shop_group_data> shop_groups;
+    std::vector<price_rule_data> price_rules;
+};
+
+struct npc_data : definition_base {
+    std::string unique_name;
+    std::string suffix;
+    std::string temporary_suffix;
+    std::string gender = "random";
+    std::string npc_class;
+    std::string faction;
+    int attitude = 0;
+    std::string mission = "NULL";
+    std::string chat = "TALK_NONE";
+    std::string stole_item_chat;
+    std::optional<int> age;
+    std::optional<int> height;
+};
+
+struct overmap_terrain_data : definition_base {
+    std::string name;
+    std::string symbol = "?";
+    std::string color = "white";
+    std::string see_cost = "none";
+    std::string default_map_data = "full_omt";
+    std::string vision_levels = "default";
+    int monster_density = 0;
+    std::set<std::string> flags;
+};
+
+struct special_terrain_data {
+    int x = 0;
+    int y = 0;
+    int z = 0;
+    std::string terrain;
+    std::set<std::string> locations;
+    std::set<std::string> flags;
+};
+
+struct special_connection_data {
+    int x = 0;
+    int y = 0;
+    int z = 0;
+    std::optional<std::array<int, 3>> from;
+    std::string terrain;
+    std::string connection;
+    bool existing = false;
+};
+
+struct overmap_special_data : definition_base {
+    std::vector<special_terrain_data> terrains;
+    std::vector<special_connection_data> connections;
+    std::set<std::string> default_locations;
+    std::set<std::string> flags;
+    interval_data city_size{ 0, std::numeric_limits<int>::max() };
+    interval_data city_distance{ 0, std::numeric_limits<int>::max() };
+    interval_data occurrences{ 0, 0 };
+    int priority = 0;
+    bool rotate = true;
+};
+
+struct vpart_variant_data {
+    std::string id;
+    std::string label;
+    std::string symbols = "?";
+    std::string broken_symbols = "?";
+};
+
+struct vpart_requirement_data {
+    std::string id;
+    int multiplier = 1;
+    std::vector<std::pair<std::string, int>> using_requirements;
+    int time_minutes = -1;
+    std::map<std::string, int> skills;
+};
+
+struct vehicle_part_data : definition_base {
+    std::string copy_from;
+    std::optional<std::string> name;
+    std::optional<std::string> description;
+    std::optional<std::string> item;
+    std::optional<std::string> location;
+    std::optional<std::string> looks_like;
+    std::optional<std::string> color;
+    std::optional<std::string> broken_color;
+    std::optional<std::string> fuel_type;
+    std::optional<int> durability;
+    std::optional<int> size_ml;
+    std::optional<int> damage_modifier;
+    std::optional<int> power_watts;
+    std::optional<int> epower_watts;
+    std::optional<int> energy_consumption_watts;
+    std::optional<float> balloon_height;
+    std::optional<float> backfire_threshold;
+    std::optional<int> backfire_frequency;
+    std::optional<float> damaged_power_factor;
+    std::optional<int> noise_factor;
+    std::optional<int> m2c;
+    std::optional<std::set<std::string>> categories;
+    std::optional<std::set<std::string>> flags;
+    std::optional<std::vector<vpart_variant_data>> variants;
+    std::vector<std::string> fuel_options;
+    std::map<std::string, float> damage_reduction;
+    std::string breaks_into;
+    vpart_requirement_data install;
+    vpart_requirement_data removal;
+    vpart_requirement_data repair;
+    std::optional<std::set<std::string>> air_proficiencies;
+    std::optional<std::set<std::string>> land_proficiencies;
+};
+
+struct vehicle_part_placement_data {
+    int x = 0;
+    int y = 0;
+    std::string part;
+    std::string variant;
+    int with_ammo = 0;
+    std::set<std::string> ammo_types;
+    std::pair<int, int> ammo_quantity = { -1, -1 };
+    std::string fuel;
+    std::vector<std::string> tools;
+};
+
+struct vehicle_item_data {
+    int x = 0;
+    int y = 0;
+    int chance = 0;
+    int with_ammo = 0;
+    int with_magazine = 0;
+    std::vector<std::string> items;
+    std::vector<std::string> groups;
+};
+
+struct vehicle_zone_data {
+    int x = 0;
+    int y = 0;
+    std::string type;
+    std::string name;
+    std::string filter;
+};
+
+struct vehicle_data : definition_base {
+    std::string name;
+    std::string color_palette;
+    std::vector<vehicle_part_placement_data> parts;
+    std::vector<vehicle_item_data> items;
+    std::vector<vehicle_zone_data> zones;
+};
+
+template<typename Definition>
+struct definition_handle {
+    std::shared_ptr<Definition> definition;
+    std::shared_ptr<token> owner;
+
+    std::string id() const {
+        if( !owner || owner->state == lifecycle::discarded ) {
+            throw std::runtime_error( "Platform content handle is no longer readable" );
+        }
+        return definition->id;
+    }
+};
+
+template<typename Definition>
+struct registration {
+    operation op = operation::add;
+    std::shared_ptr<Definition> definition;
+};
+
+template<typename T>
+std::vector<T> read_dense_array( const sol::table &source, const char *description )
+{
+    if( source.size() > 8192 ) {
+        throw std::invalid_argument( std::string( description ) + " is too large" );
+    }
+    std::vector<T> result;
+    result.reserve( source.size() );
+    for( std::size_t index = 1; index <= source.size(); ++index ) {
+        const sol::object value = source.raw_get<sol::object>( index );
+        if( !value.valid() || value.get_type() == sol::type::nil ) {
+            throw std::invalid_argument( std::string( description ) + " must be a dense array" );
+        }
+        result.push_back( value.as<T>() );
+    }
+    return result;
+}
+
+template<typename T>
+std::optional<T> read_optional( const sol::table &source, const char *key )
+{
+    const sol::optional<T> value = source.get<sol::optional<T>>( key );
+    return value ? std::optional<T>( *value ) : std::nullopt;
+}
+
+std::set<std::string> read_string_set( const sol::optional<sol::table> &source,
+                                       const char *description )
+{
+    if( !source ) {
+        return {};
+    }
+    const std::vector<std::string> values = read_dense_array<std::string>( *source, description );
+    return std::set<std::string>( values.begin(), values.end() );
+}
+
+std::vector<std::string> read_string_vector( const sol::optional<sol::table> &source,
+        const char *description )
+{
+    return source ? read_dense_array<std::string>( *source, description ) :
+           std::vector<std::string>();
+}
+
+std::array<int, 3> read_point( const sol::table &source, const char *description )
+{
+    const std::vector<int> values = read_dense_array<int>( source, description );
+    if( values.size() != 3 ) {
+        throw std::invalid_argument( std::string( description ) + " must have three integers" );
+    }
+    return { values[0], values[1], values[2] };
+}
+
+interval_data read_interval( const sol::optional<sol::table> &source,
+                             interval_data fallback, const char *description )
+{
+    if( !source ) {
+        return fallback;
+    }
+    const std::vector<int> values = read_dense_array<int>( *source, description );
+    if( values.size() != 2 ) {
+        throw std::invalid_argument( std::string( description ) + " must have two integers" );
+    }
+    int maximum = values[1];
+    if( maximum < values[0] ) {
+        if( maximum >= 0 ) {
+            throw std::invalid_argument(
+                std::string( description ) + " must be an ordered interval" );
+        }
+        maximum = std::numeric_limits<int>::max();
+    }
+    return { values[0], maximum };
+}
+
+distribution_data read_distribution( const sol::optional<sol::table> &source )
+{
+    distribution_data result;
+    if( !source ) {
+        return result;
+    }
+    result.add = source->get_or( "add", 0 );
+    if( const sol::optional<sol::table> random = source->get<sol::optional<sol::table>>( "rng" ) ) {
+        const std::vector<int> values = read_dense_array<int>( *random, "distribution rng" );
+        if( values.size() != 2 ) {
+            throw std::invalid_argument( "distribution rng must have two integers" );
+        }
+        result.type = distribution_data::kind::random;
+        result.first = values[0];
+        result.second = values[1];
+    } else if( const sol::optional<sol::table> dice =
+                   source->get<sol::optional<sol::table>>( "dice" ) ) {
+        const std::vector<int> values = read_dense_array<int>( *dice, "distribution dice" );
+        if( values.size() != 2 ) {
+            throw std::invalid_argument( "distribution dice must have two integers" );
+        }
+        result.type = distribution_data::kind::dice;
+        result.first = values[0];
+        result.second = values[1];
+    } else {
+        result.first = source->get_or( "constant", 0 );
+    }
+    return result;
+}
+
+distribution make_distribution( const distribution_data &source )
+{
+    distribution result;
+    switch( source.type ) {
+        case distribution_data::kind::constant:
+            result = distribution::constant( source.first );
+            break;
+        case distribution_data::kind::random:
+            result = distribution::rng_roll( source.first, source.second );
+            break;
+        case distribution_data::kind::dice:
+            result = distribution::dice_roll( source.first, source.second );
+            break;
+    }
+    return source.add == 0 ? result : result + distribution::constant( source.add );
+}
+
+template<typename Definition>
+void require_definition_id( const Definition &definition, const char *kind )
+{
+    if( definition.id.empty() || definition.id.size() > 256 ||
+        definition.id.find( '#' ) != std::string::npos ) {
+        throw std::runtime_error( std::string( "invalid " ) + kind + " id '" +
+                                  definition.id + "'" );
+    }
+}
+
+template<typename Definition, typename Exists>
+void validate_registrations( const std::vector<registration<Definition>> &entries,
+                             const char *kind, bool check_engine_state, Exists exists )
+{
+    std::set<std::string> ids;
+    for( const registration<Definition> &entry : entries ) {
+        require_definition_id( *entry.definition, kind );
+        if( !ids.insert( entry.definition->id ).second ) {
+            throw std::runtime_error( std::string( kind ) + " '" + entry.definition->id +
+                                      "' is registered more than once" );
+        }
+        if( !check_engine_state ) {
+            continue;
+        }
+        const bool present = exists( entry.definition->id );
+        if( entry.op == operation::add && present ) {
+            throw std::runtime_error( std::string( "add would overwrite existing " ) + kind +
+                                      " '" + entry.definition->id + "'" );
+        }
+        if( entry.op == operation::replace && !present ) {
+            throw std::runtime_error( std::string( "replace requires existing " ) + kind +
+                                      " '" + entry.definition->id + "'" );
+        }
+    }
+}
+
+void hash_part( std::uint64_t &state, const std::string_view value )
+{
+    for( const unsigned char byte : value ) {
+        state ^= byte;
+        state *= 1099511628211ULL;
+    }
+    state ^= 0xff;
+    state *= 1099511628211ULL;
+}
+
+template<typename Value>
+void hash_number( std::uint64_t &state, const Value value )
+{
+    hash_part( state, std::to_string( value ) );
+}
+
+void hash_bool( std::uint64_t &state, const bool value )
+{
+    hash_part( state, value ? "true" : "false" );
+}
+
+template<typename Value>
+void hash_optional_number( std::uint64_t &state, const std::optional<Value> &value )
+{
+    hash_part( state, value ? "present" : "absent" );
+    if( value ) {
+        hash_number( state, *value );
+    }
+}
+
+void hash_optional_string( std::uint64_t &state, const std::optional<std::string> &value )
+{
+    hash_part( state, value ? "present" : "absent" );
+    if( value ) {
+        hash_part( state, *value );
+    }
+}
+
+template<typename Collection>
+void hash_strings( std::uint64_t &state, const Collection &values )
+{
+    hash_number( state, values.size() );
+    for( const std::string &value : values ) {
+        hash_part( state, value );
+    }
+}
+
+void hash_distribution( std::uint64_t &state, const distribution_data &value )
+{
+    hash_number( state, static_cast<int>( value.type ) );
+    hash_number( state, value.first );
+    hash_number( state, value.second );
+    hash_number( state, value.add );
+}
+
+void hash_interval( std::uint64_t &state, const interval_data &value )
+{
+    hash_number( state, value.minimum );
+    hash_number( state, value.maximum );
+}
+
+void hash_definition( std::uint64_t &state, const faction_data &value )
+{
+    hash_part( state, value.id );
+    hash_part( state, value.name );
+    hash_part( state, value.description );
+    hash_number( state, value.likes );
+    hash_number( state, value.respects );
+    hash_number( state, value.trusts );
+    hash_bool( state, value.known );
+    hash_number( state, value.size );
+    hash_number( state, value.power );
+    hash_number( state, value.wealth );
+    hash_number( state, value.food_calories );
+    for( const auto &[vitamin, amount] : value.food_vitamins ) {
+        hash_part( state, vitamin );
+        hash_number( state, amount );
+    }
+    hash_bool( state, value.consumes_food );
+    hash_bool( state, value.lone_wolf );
+    hash_bool( state, value.limited_area );
+    hash_part( state, value.currency );
+    hash_part( state, value.monster_faction );
+    for( const auto &[faction, flags] : value.relations ) {
+        hash_part( state, faction );
+        hash_strings( state, flags );
+    }
+}
+
+void hash_definition( std::uint64_t &state, const npc_class_data &value )
+{
+    hash_part( state, value.id );
+    hash_part( state, value.name );
+    hash_part( state, value.job_description );
+    hash_bool( state, value.common );
+    hash_bool( state, value.sells_belongings );
+    hash_part( state, value.worn );
+    hash_part( state, value.carry );
+    hash_part( state, value.weapon );
+    hash_part( state, value.traits );
+    hash_part( state, value.consumption_rates );
+    hash_distribution( state, value.strength );
+    hash_distribution( state, value.dexterity );
+    hash_distribution( state, value.intelligence );
+    hash_distribution( state, value.perception );
+    for( const auto &[skill, distribution] : value.skills ) {
+        hash_part( state, skill );
+        hash_distribution( state, distribution );
+    }
+    for( const auto &[skill, distribution] : value.bonus_skills ) {
+        hash_part( state, skill );
+        hash_distribution( state, distribution );
+    }
+    for( const shop_group_data &group : value.shop_groups ) {
+        hash_part( state, group.id );
+        hash_number( state, group.trust );
+        hash_bool( state, group.strict );
+        hash_bool( state, group.rigid );
+    }
+    for( const price_rule_data &rule : value.price_rules ) {
+        hash_part( state, rule.item );
+        hash_part( state, rule.group );
+        hash_part( state, rule.category );
+        hash_number( state, rule.markup );
+        hash_number( state, rule.premium );
+        hash_optional_number( state, rule.fixed_adjustment );
+        hash_optional_number( state, rule.price );
+    }
+}
+
+void hash_definition( std::uint64_t &state, const npc_data &value )
+{
+    hash_part( state, value.id );
+    hash_part( state, value.unique_name );
+    hash_part( state, value.suffix );
+    hash_part( state, value.temporary_suffix );
+    hash_part( state, value.gender );
+    hash_part( state, value.npc_class );
+    hash_part( state, value.faction );
+    hash_number( state, value.attitude );
+    hash_part( state, value.mission );
+    hash_part( state, value.chat );
+    hash_part( state, value.stole_item_chat );
+    hash_optional_number( state, value.age );
+    hash_optional_number( state, value.height );
+}
+
+void hash_definition( std::uint64_t &state, const overmap_terrain_data &value )
+{
+    hash_part( state, value.id );
+    hash_part( state, value.name );
+    hash_part( state, value.symbol );
+    hash_part( state, value.color );
+    hash_part( state, value.see_cost );
+    hash_part( state, value.default_map_data );
+    hash_part( state, value.vision_levels );
+    hash_number( state, value.monster_density );
+    hash_strings( state, value.flags );
+}
+
+void hash_definition( std::uint64_t &state, const overmap_special_data &value )
+{
+    hash_part( state, value.id );
+    for( const special_terrain_data &terrain : value.terrains ) {
+        hash_number( state, terrain.x );
+        hash_number( state, terrain.y );
+        hash_number( state, terrain.z );
+        hash_part( state, terrain.terrain );
+        hash_strings( state, terrain.locations );
+        hash_strings( state, terrain.flags );
+    }
+    for( const special_connection_data &connection : value.connections ) {
+        hash_number( state, connection.x );
+        hash_number( state, connection.y );
+        hash_number( state, connection.z );
+        hash_part( state, connection.from ? "present" : "absent" );
+        if( connection.from ) {
+            for( const int coordinate : *connection.from ) {
+                hash_number( state, coordinate );
+            }
+        }
+        hash_part( state, connection.terrain );
+        hash_part( state, connection.connection );
+        hash_bool( state, connection.existing );
+    }
+    hash_strings( state, value.default_locations );
+    hash_strings( state, value.flags );
+    hash_interval( state, value.city_size );
+    hash_interval( state, value.city_distance );
+    hash_interval( state, value.occurrences );
+    hash_number( state, value.priority );
+    hash_bool( state, value.rotate );
+}
+
+void hash_vpart_requirement( std::uint64_t &state, const vpart_requirement_data &value )
+{
+    hash_part( state, value.id );
+    hash_number( state, value.multiplier );
+    for( const auto &[requirement, multiplier] : value.using_requirements ) {
+        hash_part( state, requirement );
+        hash_number( state, multiplier );
+    }
+    hash_number( state, value.time_minutes );
+    for( const auto &[skill, level] : value.skills ) {
+        hash_part( state, skill );
+        hash_number( state, level );
+    }
+}
+
+void hash_optional_strings( std::uint64_t &state,
+                            const std::optional<std::set<std::string>> &value )
+{
+    hash_part( state, value ? "present" : "absent" );
+    if( value ) {
+        hash_strings( state, *value );
+    }
+}
+
+void hash_definition( std::uint64_t &state, const vehicle_part_data &value )
+{
+    hash_part( state, value.id );
+    hash_part( state, value.copy_from );
+    hash_optional_string( state, value.name );
+    hash_optional_string( state, value.description );
+    hash_optional_string( state, value.item );
+    hash_optional_string( state, value.location );
+    hash_optional_string( state, value.looks_like );
+    hash_optional_string( state, value.color );
+    hash_optional_string( state, value.broken_color );
+    hash_optional_string( state, value.fuel_type );
+    hash_optional_number( state, value.durability );
+    hash_optional_number( state, value.size_ml );
+    hash_optional_number( state, value.damage_modifier );
+    hash_optional_number( state, value.power_watts );
+    hash_optional_number( state, value.epower_watts );
+    hash_optional_number( state, value.energy_consumption_watts );
+    hash_optional_number( state, value.balloon_height );
+    hash_optional_number( state, value.backfire_threshold );
+    hash_optional_number( state, value.backfire_frequency );
+    hash_optional_number( state, value.damaged_power_factor );
+    hash_optional_number( state, value.noise_factor );
+    hash_optional_number( state, value.m2c );
+    hash_optional_strings( state, value.categories );
+    hash_optional_strings( state, value.flags );
+    hash_part( state, value.variants ? "present" : "absent" );
+    if( value.variants ) {
+        for( const vpart_variant_data &variant : *value.variants ) {
+            hash_part( state, variant.id );
+            hash_part( state, variant.label );
+            hash_part( state, variant.symbols );
+            hash_part( state, variant.broken_symbols );
+        }
+    }
+    hash_strings( state, value.fuel_options );
+    for( const auto &[damage, amount] : value.damage_reduction ) {
+        hash_part( state, damage );
+        hash_number( state, amount );
+    }
+    hash_part( state, value.breaks_into );
+    hash_vpart_requirement( state, value.install );
+    hash_vpart_requirement( state, value.removal );
+    hash_vpart_requirement( state, value.repair );
+    hash_optional_strings( state, value.air_proficiencies );
+    hash_optional_strings( state, value.land_proficiencies );
+}
+
+void hash_definition( std::uint64_t &state, const vehicle_data &value )
+{
+    hash_part( state, value.id );
+    hash_part( state, value.name );
+    hash_part( state, value.color_palette );
+    for( const vehicle_part_placement_data &part : value.parts ) {
+        hash_number( state, part.x );
+        hash_number( state, part.y );
+        hash_part( state, part.part );
+        hash_part( state, part.variant );
+        hash_number( state, part.with_ammo );
+        hash_strings( state, part.ammo_types );
+        hash_number( state, part.ammo_quantity.first );
+        hash_number( state, part.ammo_quantity.second );
+        hash_part( state, part.fuel );
+        hash_strings( state, part.tools );
+    }
+    for( const vehicle_item_data &item : value.items ) {
+        hash_number( state, item.x );
+        hash_number( state, item.y );
+        hash_number( state, item.chance );
+        hash_number( state, item.with_ammo );
+        hash_number( state, item.with_magazine );
+        hash_strings( state, item.items );
+        hash_strings( state, item.groups );
+    }
+    for( const vehicle_zone_data &zone : value.zones ) {
+        hash_number( state, zone.x );
+        hash_number( state, zone.y );
+        hash_part( state, zone.type );
+        hash_part( state, zone.name );
+        hash_part( state, zone.filter );
+    }
+}
+
+template<typename Definition>
+void hash_registrations( std::uint64_t &state, const char *kind,
+                         const std::vector<registration<Definition>> &entries )
+{
+    for( const registration<Definition> &entry : entries ) {
+        hash_part( state, kind );
+        hash_part( state, std::to_string( static_cast<int>( entry.op ) ) );
+        hash_definition( state, *entry.definition );
+    }
+}
+
+std::array<char32_t, 8> read_variant_symbols( const std::string &source,
+        const std::string &part_id )
+{
+    const std::vector<std::string> symbols = utf8_display_split( source );
+    std::array<char32_t, 8> result;
+    if( symbols.size() == 1 ) {
+        result.fill( UTF8_getch( symbols.front() ) );
+        return result;
+    }
+    if( symbols.size() != result.size() ) {
+        throw std::runtime_error( "vehicle part '" + part_id +
+                                  "' variant symbols need one or eight characters" );
+    }
+    for( std::size_t index = 0; index < result.size(); ++index ) {
+        result[index] = UTF8_getch( symbols[index] );
+    }
+    return result;
+}
+
+} // namespace
+
+struct world_content_transaction::impl {
+    impl( std::string owner_id, std::size_t owner_generation ) :
+        owner( std::move( owner_id ) ), generation( owner_generation ),
+        handle_token( std::make_shared<token>() ) {}
+
+    std::string owner;
+    std::size_t generation = 0;
+    std::shared_ptr<token> handle_token;
+    bool applied = false;
+
+    std::vector<registration<faction_data>> factions;
+    std::vector<registration<npc_class_data>> npc_classes;
+    std::vector<registration<npc_data>> npcs;
+    std::vector<registration<overmap_terrain_data>> overmap_terrains;
+    std::vector<registration<overmap_special_data>> overmap_specials;
+    std::vector<registration<vehicle_part_data>> vehicle_parts;
+    std::vector<registration<vehicle_data>> vehicles;
+
+    std::vector<std::pair<faction_id, std::optional<faction_template>>> faction_undo;
+    std::vector<std::pair<npc_class_id, std::optional<npc_class>>> npc_class_undo;
+    std::vector<std::pair<npc_template_id,
+        std::map<npc_template_id, npc_template>::node_type>> npc_undo;
+    struct overmap_terrain_undo_data {
+        oter_type_str_id id;
+        std::optional<oter_type_t> previous;
+        std::vector<oter_id> generated;
+    };
+    std::vector<overmap_terrain_undo_data> overmap_terrain_undo;
+    std::vector<std::pair<overmap_special_id, std::optional<overmap_special>>>
+    overmap_special_undo;
+    std::vector<std::pair<vpart_id, std::optional<vpart_info>>> vehicle_part_undo;
+    std::vector<std::pair<vproto_id, std::optional<vehicle_prototype>>> vehicle_undo;
+};
+
+world_content_transaction::world_content_transaction( std::string owner,
+        const std::size_t generation ) :
+    pimpl_( std::make_unique<impl>( std::move( owner ), generation ) )
+{
+}
+
+world_content_transaction::~world_content_transaction() = default;
+
+void world_content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
+        sol::table &content )
+{
+    using faction_handle = definition_handle<faction_data>;
+    using npc_class_handle = definition_handle<npc_class_data>;
+    using npc_handle = definition_handle<npc_data>;
+    using omt_handle = definition_handle<overmap_terrain_data>;
+    using special_handle = definition_handle<overmap_special_data>;
+    using vpart_handle = definition_handle<vehicle_part_data>;
+    using vehicle_handle = definition_handle<vehicle_data>;
+
+    ccb.new_usertype<faction_handle>( "FactionDefinition", sol::no_constructor,
+                                     "id", sol::property( &faction_handle::id ) );
+    ccb.new_usertype<npc_class_handle>( "NpcClassDefinition", sol::no_constructor,
+                                       "id", sol::property( &npc_class_handle::id ) );
+    ccb.new_usertype<npc_handle>( "NpcDefinition", sol::no_constructor,
+                                 "id", sol::property( &npc_handle::id ) );
+    ccb.new_usertype<omt_handle>( "OvermapTerrainDefinition", sol::no_constructor,
+                                 "id", sol::property( &omt_handle::id ) );
+    ccb.new_usertype<special_handle>( "OvermapSpecialDefinition", sol::no_constructor,
+                                     "id", sol::property( &special_handle::id ) );
+    ccb.new_usertype<vpart_handle>( "VehiclePartDefinition", sol::no_constructor,
+                                   "id", sol::property( &vpart_handle::id ) );
+    ccb.new_usertype<vehicle_handle>( "VehicleDefinition", sol::no_constructor,
+                                     "id", sol::property( &vehicle_handle::id ) );
+
+    const std::shared_ptr<token> owner = pimpl_->handle_token;
+    content.set_function( "Faction", [owner]( const sol::table &options ) {
+        if( owner->state != lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto value = std::make_shared<faction_data>();
+        value->id = options.get_or( "id", std::string() );
+        value->name = options.get_or( "name", value->id );
+        value->description = options.get_or( "description", std::string() );
+        value->likes = options.get_or( "likes", 0 );
+        value->respects = options.get_or( "respects", 0 );
+        value->trusts = options.get_or( "trusts", 0 );
+        value->known = options.get_or( "known", true );
+        value->size = options.get_or( "size", 0 );
+        value->power = options.get_or( "power", 0 );
+        value->wealth = options.get_or( "wealth", 0 );
+        value->food_calories = options.get_or( "food_calories", 0 );
+        if( const sol::optional<sol::table> vitamins =
+                options.get<sol::optional<sol::table>>( "food_vitamins" ) ) {
+            for( const auto &entry : *vitamins ) {
+                value->food_vitamins[entry.first.as<std::string>()] = entry.second.as<int>();
+            }
+        }
+        value->consumes_food = options.get_or( "consumes_food", false );
+        value->lone_wolf = options.get_or( "lone_wolf", false );
+        value->limited_area = options.get_or( "limited_area", false );
+        value->currency = options.get_or( "currency", std::string() );
+        value->monster_faction = options.get_or( "monster_faction", std::string( "human" ) );
+        if( const sol::optional<sol::table> relations =
+                options.get<sol::optional<sol::table>>( "relations" ) ) {
+            for( const auto &entry : *relations ) {
+                const std::string target = entry.first.as<std::string>();
+                value->relations[target] = read_string_set(
+                                               entry.second.as<sol::table>(), "faction relations" );
+            }
+        }
+        return faction_handle{ std::move( value ), owner };
+    } );
+    content.set_function( "NpcClass", [owner]( const sol::table &options ) {
+        if( owner->state != lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto value = std::make_shared<npc_class_data>();
+        value->id = options.get_or( "id", std::string() );
+        value->name = options.get_or( "name", value->id );
+        value->job_description = options.get_or( "job_description", std::string() );
+        value->common = options.get_or( "common", false );
+        value->sells_belongings = options.get_or( "sells_belongings", true );
+        value->worn = options.get_or( "worn", std::string() );
+        value->carry = options.get_or( "carry", std::string() );
+        value->weapon = options.get_or( "weapon", std::string() );
+        value->traits = options.get_or( "traits", std::string( "EMPTY_GROUP" ) );
+        value->consumption_rates = options.get_or( "consumption_rates", std::string() );
+        value->strength = read_distribution(
+                              options.get<sol::optional<sol::table>>( "strength" ) );
+        value->dexterity = read_distribution(
+                               options.get<sol::optional<sol::table>>( "dexterity" ) );
+        value->intelligence = read_distribution(
+                                  options.get<sol::optional<sol::table>>( "intelligence" ) );
+        value->perception = read_distribution(
+                                options.get<sol::optional<sol::table>>( "perception" ) );
+        const auto read_skills = []( const sol::optional<sol::table> &source,
+        std::map<std::string, distribution_data> &target ) {
+            if( !source ) {
+                return;
+            }
+            for( const auto &entry : *source ) {
+                target[entry.first.as<std::string>()] = read_distribution(
+                        entry.second.as<sol::table>() );
+            }
+        };
+        read_skills( options.get<sol::optional<sol::table>>( "skills" ), value->skills );
+        read_skills( options.get<sol::optional<sol::table>>( "bonus_skills" ),
+                     value->bonus_skills );
+        if( const sol::optional<sol::table> groups =
+                options.get<sol::optional<sol::table>>( "shop_groups" ) ) {
+            for( const sol::table &group : read_dense_array<sol::table>( *groups,
+                    "NPC class shop groups" ) ) {
+                value->shop_groups.push_back( {
+                    group.get_or( "id", std::string() ), group.get_or( "trust", 0 ),
+                    group.get_or( "strict", false ), group.get_or( "rigid", false )
+                } );
+            }
+        }
+        if( const sol::optional<sol::table> rules =
+                options.get<sol::optional<sol::table>>( "price_rules" ) ) {
+            for( const sol::table &rule : read_dense_array<sol::table>( *rules,
+                    "NPC class price rules" ) ) {
+                price_rule_data parsed;
+                parsed.item = rule.get_or( "item", std::string() );
+                parsed.group = rule.get_or( "group", std::string() );
+                parsed.category = rule.get_or( "category", std::string() );
+                parsed.markup = rule.get_or( "markup", 1.0 );
+                parsed.premium = rule.get_or( "premium", 1.0 );
+                parsed.fixed_adjustment = read_optional<double>( rule, "fixed_adjustment" );
+                parsed.price = read_optional<int>( rule, "price" );
+                value->price_rules.push_back( std::move( parsed ) );
+            }
+        }
+        return npc_class_handle{ std::move( value ), owner };
+    } );
+    content.set_function( "Npc", [owner]( const sol::table &options ) {
+        if( owner->state != lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto value = std::make_shared<npc_data>();
+        value->id = options.get_or( "id", std::string() );
+        value->unique_name = options.get_or( "unique_name", std::string() );
+        value->suffix = options.get_or( "suffix", std::string() );
+        value->temporary_suffix = options.get_or( "temporary_suffix", std::string() );
+        value->gender = options.get_or( "gender", std::string( "random" ) );
+        value->npc_class = options.get_or( "class", std::string() );
+        value->faction = options.get_or( "faction", std::string() );
+        value->attitude = options.get_or( "attitude", 0 );
+        value->mission = options.get_or( "mission", std::string( "NULL" ) );
+        value->chat = options.get_or( "chat", std::string( "TALK_NONE" ) );
+        value->stole_item_chat = options.get_or( "stole_item_chat", std::string() );
+        value->age = read_optional<int>( options, "age" );
+        value->height = read_optional<int>( options, "height" );
+        return npc_handle{ std::move( value ), owner };
+    } );
+    content.set_function( "OvermapTerrain", [owner]( const sol::table &options ) {
+        if( owner->state != lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto value = std::make_shared<overmap_terrain_data>();
+        value->id = options.get_or( "id", std::string() );
+        value->name = options.get_or( "name", value->id );
+        value->symbol = options.get_or( "symbol", std::string( "?" ) );
+        value->color = options.get_or( "color", std::string( "white" ) );
+        value->see_cost = options.get_or( "see_cost", std::string( "none" ) );
+        value->default_map_data = options.get_or( "default_map_data", std::string( "full_omt" ) );
+        value->vision_levels = options.get_or( "vision_levels", std::string( "default" ) );
+        value->monster_density = options.get_or( "monster_density", 0 );
+        value->flags = read_string_set(
+                           options.get<sol::optional<sol::table>>( "flags" ), "overmap terrain flags" );
+        return omt_handle{ std::move( value ), owner };
+    } );
+    content.set_function( "OvermapSpecial", [owner]( const sol::table &options ) {
+        if( owner->state != lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto value = std::make_shared<overmap_special_data>();
+        value->id = options.get_or( "id", std::string() );
+        value->default_locations = read_string_set(
+                                       options.get<sol::optional<sol::table>>( "locations" ),
+                                       "overmap special locations" );
+        value->flags = read_string_set(
+                           options.get<sol::optional<sol::table>>( "flags" ), "overmap special flags" );
+        value->city_size = read_interval(
+                               options.get<sol::optional<sol::table>>( "city_size" ), value->city_size,
+                               "overmap special city size" );
+        value->city_distance = read_interval(
+                                   options.get<sol::optional<sol::table>>( "city_distance" ),
+                                   value->city_distance, "overmap special city distance" );
+        value->occurrences = read_interval(
+                                 options.get<sol::optional<sol::table>>( "occurrences" ), value->occurrences,
+                                 "overmap special occurrences" );
+        value->priority = options.get_or( "priority", 0 );
+        value->rotate = options.get_or( "rotate", true );
+        if( const sol::optional<sol::table> terrains =
+                options.get<sol::optional<sol::table>>( "terrains" ) ) {
+            for( const sol::table &terrain : read_dense_array<sol::table>( *terrains,
+                    "overmap special terrains" ) ) {
+                const std::array<int, 3> point = read_point(
+                        terrain.get<sol::table>( "point" ), "overmap special point" );
+                value->terrains.push_back( {
+                    point[0], point[1], point[2],
+                    terrain.get_or( "terrain", std::string() ),
+                    read_string_set( terrain.get<sol::optional<sol::table>>( "locations" ),
+                                     "overmap special terrain locations" ),
+                    read_string_set( terrain.get<sol::optional<sol::table>>( "flags" ),
+                                     "overmap special terrain flags" )
+                } );
+            }
+        }
+        if( const sol::optional<sol::table> connections =
+                options.get<sol::optional<sol::table>>( "connections" ) ) {
+            for( const sol::table &connection : read_dense_array<sol::table>( *connections,
+                    "overmap special connections" ) ) {
+                const std::array<int, 3> point = read_point(
+                        connection.get<sol::table>( "point" ), "overmap connection point" );
+                special_connection_data parsed;
+                parsed.x = point[0];
+                parsed.y = point[1];
+                parsed.z = point[2];
+                if( const sol::optional<sol::table> from =
+                        connection.get<sol::optional<sol::table>>( "from" ) ) {
+                    parsed.from = read_point( *from, "overmap connection from" );
+                }
+                parsed.terrain = connection.get_or( "terrain", std::string() );
+                parsed.connection = connection.get_or( "connection", std::string() );
+                parsed.existing = connection.get_or( "existing", false );
+                value->connections.push_back( std::move( parsed ) );
+            }
+        }
+        return special_handle{ std::move( value ), owner };
+    } );
+    content.set_function( "VehiclePart", [owner]( const sol::table &options ) {
+        if( owner->state != lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto value = std::make_shared<vehicle_part_data>();
+        value->id = options.get_or( "id", std::string() );
+        value->copy_from = options.get_or( "copy_from", std::string() );
+        value->name = read_optional<std::string>( options, "name" );
+        value->description = read_optional<std::string>( options, "description" );
+        value->item = read_optional<std::string>( options, "item" );
+        value->location = read_optional<std::string>( options, "location" );
+        value->looks_like = read_optional<std::string>( options, "looks_like" );
+        value->color = read_optional<std::string>( options, "color" );
+        value->broken_color = read_optional<std::string>( options, "broken_color" );
+        value->fuel_type = read_optional<std::string>( options, "fuel_type" );
+        value->durability = read_optional<int>( options, "durability" );
+        value->size_ml = read_optional<int>( options, "size_ml" );
+        value->damage_modifier = read_optional<int>( options, "damage_modifier" );
+        value->power_watts = read_optional<int>( options, "power_watts" );
+        value->epower_watts = read_optional<int>( options, "epower_watts" );
+        value->energy_consumption_watts =
+            read_optional<int>( options, "energy_consumption_watts" );
+        value->balloon_height = read_optional<float>( options, "balloon_height" );
+        value->backfire_threshold = read_optional<float>( options, "backfire_threshold" );
+        value->backfire_frequency = read_optional<int>( options, "backfire_frequency" );
+        value->damaged_power_factor = read_optional<float>( options, "damaged_power_factor" );
+        value->noise_factor = read_optional<int>( options, "noise_factor" );
+        value->m2c = read_optional<int>( options, "m2c" );
+        if( const sol::optional<sol::table> categories =
+                options.get<sol::optional<sol::table>>( "categories" ) ) {
+            value->categories = read_string_set( categories, "vehicle part categories" );
+        }
+        if( const sol::optional<sol::table> flags =
+                options.get<sol::optional<sol::table>>( "flags" ) ) {
+            value->flags = read_string_set( flags, "vehicle part flags" );
+        }
+        value->fuel_options = read_string_vector(
+                                  options.get<sol::optional<sol::table>>( "fuel_options" ),
+                                  "vehicle part fuel options" );
+        value->breaks_into = options.get_or( "breaks_into", std::string() );
+        if( const sol::optional<sol::table> reductions =
+                options.get<sol::optional<sol::table>>( "damage_reduction" ) ) {
+            for( const auto &entry : *reductions ) {
+                value->damage_reduction[entry.first.as<std::string>()] = entry.second.as<float>();
+            }
+        }
+        if( const sol::optional<sol::table> variants =
+                options.get<sol::optional<sol::table>>( "variants" ) ) {
+            value->variants.emplace();
+            for( const sol::table &variant : read_dense_array<sol::table>( *variants,
+                    "vehicle part variants" ) ) {
+                value->variants->push_back( {
+                    variant.get_or( "id", std::string() ),
+                    variant.get_or( "label", std::string() ),
+                    variant.get_or( "symbols", std::string( "?" ) ),
+                    variant.get_or( "broken_symbols", std::string( "?" ) )
+                } );
+            }
+        }
+        const auto read_requirement = []( const sol::optional<sol::table> &source,
+        vpart_requirement_data &target ) {
+            if( !source ) {
+                return;
+            }
+            target.id = source->get_or( "id", std::string() );
+            target.multiplier = source->get_or( "multiplier", 1 );
+            if( const sol::optional<sol::table> requirements =
+                    source->get<sol::optional<sol::table>>( "using" ) ) {
+                for( const sol::table &requirement : read_dense_array<sol::table>(
+                            *requirements, "vehicle part requirements" ) ) {
+                    target.using_requirements.emplace_back(
+                        requirement.get_or( "id", std::string() ),
+                        requirement.get_or( "multiplier", 1 ) );
+                }
+            }
+            target.time_minutes = source->get_or( "time_minutes", -1 );
+            if( const sol::optional<sol::table> skills =
+                    source->get<sol::optional<sol::table>>( "skills" ) ) {
+                for( const auto &entry : *skills ) {
+                    target.skills[entry.first.as<std::string>()] = entry.second.as<int>();
+                }
+            }
+        };
+        read_requirement( options.get<sol::optional<sol::table>>( "install" ), value->install );
+        read_requirement( options.get<sol::optional<sol::table>>( "removal" ), value->removal );
+        read_requirement( options.get<sol::optional<sol::table>>( "repair" ), value->repair );
+        if( const sol::optional<sol::table> control =
+                options.get<sol::optional<sol::table>>( "control" ) ) {
+            if( const sol::optional<sol::table> proficiencies =
+                    control->get<sol::optional<sol::table>>( "air_proficiencies" ) ) {
+                value->air_proficiencies = read_string_set(
+                                               proficiencies, "air control proficiencies" );
+            }
+            if( const sol::optional<sol::table> proficiencies =
+                    control->get<sol::optional<sol::table>>( "land_proficiencies" ) ) {
+                value->land_proficiencies = read_string_set(
+                                                proficiencies, "land control proficiencies" );
+            }
+        }
+        return vpart_handle{ std::move( value ), owner };
+    } );
+    content.set_function( "Vehicle", [owner]( const sol::table &options ) {
+        if( owner->state != lifecycle::building ) {
+            throw std::runtime_error( "content transaction is no longer building" );
+        }
+        auto value = std::make_shared<vehicle_data>();
+        value->id = options.get_or( "id", std::string() );
+        value->name = options.get_or( "name", value->id );
+        value->color_palette = options.get_or( "color_palette", std::string() );
+        if( const sol::optional<sol::table> parts =
+                options.get<sol::optional<sol::table>>( "parts" ) ) {
+            for( const sol::table &part : read_dense_array<sol::table>( *parts,
+                    "vehicle parts" ) ) {
+                vehicle_part_placement_data parsed;
+                parsed.x = part.get_or( "x", 0 );
+                parsed.y = part.get_or( "y", 0 );
+                parsed.part = part.get_or( "part", std::string() );
+                parsed.variant = part.get_or( "variant", std::string() );
+                parsed.with_ammo = part.get_or( "with_ammo", 0 );
+                parsed.ammo_types = read_string_set(
+                                        part.get<sol::optional<sol::table>>( "ammo_types" ),
+                                        "vehicle part ammo types" );
+                if( const sol::optional<sol::table> quantity =
+                        part.get<sol::optional<sol::table>>( "ammo_quantity" ) ) {
+                    const std::vector<int> range = read_dense_array<int>( *quantity,
+                                                   "vehicle part ammo quantity" );
+                    if( range.size() != 2 ) {
+                        throw std::invalid_argument( "vehicle part ammo quantity needs two integers" );
+                    }
+                    parsed.ammo_quantity = { range[0], range[1] };
+                }
+                parsed.fuel = part.get_or( "fuel", std::string() );
+                parsed.tools = read_string_vector(
+                                   part.get<sol::optional<sol::table>>( "tools" ), "vehicle part tools" );
+                value->parts.push_back( std::move( parsed ) );
+            }
+        }
+        if( const sol::optional<sol::table> items =
+                options.get<sol::optional<sol::table>>( "items" ) ) {
+            for( const sol::table &item : read_dense_array<sol::table>( *items,
+                    "vehicle item spawns" ) ) {
+                vehicle_item_data parsed;
+                parsed.x = item.get_or( "x", 0 );
+                parsed.y = item.get_or( "y", 0 );
+                parsed.chance = item.get_or( "chance", 0 );
+                parsed.with_ammo = item.get_or( "with_ammo", 0 );
+                parsed.with_magazine = item.get_or( "with_magazine", 0 );
+                parsed.items = read_string_vector(
+                                   item.get<sol::optional<sol::table>>( "items" ), "vehicle spawn items" );
+                parsed.groups = read_string_vector(
+                                    item.get<sol::optional<sol::table>>( "groups" ), "vehicle spawn groups" );
+                value->items.push_back( std::move( parsed ) );
+            }
+        }
+        if( const sol::optional<sol::table> zones =
+                options.get<sol::optional<sol::table>>( "zones" ) ) {
+            for( const sol::table &zone : read_dense_array<sol::table>( *zones,
+                    "vehicle zones" ) ) {
+                value->zones.push_back( {
+                    zone.get_or( "x", 0 ), zone.get_or( "y", 0 ),
+                    zone.get_or( "type", std::string() ),
+                    zone.get_or( "name", std::string() ),
+                    zone.get_or( "filter", std::string() )
+                } );
+            }
+        }
+        return vehicle_handle{ std::move( value ), owner };
+    } );
+
+    static_cast<void>( lua );
+}
+
+bool world_content_transaction::register_definition( const sol::object &value,
+        const int raw_operation )
+{
+    if( raw_operation < 0 || raw_operation > 2 ) {
+        throw std::runtime_error( "invalid Platform content operation" );
+    }
+    const operation op = static_cast<operation>( raw_operation );
+    const auto register_value = [this, op]( auto handle, auto &entries, const char *kind ) {
+        if( handle.owner != pimpl_->handle_token ) {
+            throw std::runtime_error( std::string( "cannot register a " ) + kind +
+                                      " definition owned by another Mod" );
+        }
+        if( handle.owner->state != lifecycle::building || handle.definition->registered ) {
+            throw std::runtime_error( std::string( kind ) + " definition is not building" );
+        }
+        handle.definition->registered = true;
+        if( op == operation::edit ) {
+            const auto target = std::find_if( entries.rbegin(), entries.rend(),
+            [&handle]( const auto &entry ) {
+                return entry.definition->id == handle.definition->id;
+            } );
+            if( target == entries.rend() ) {
+                handle.definition->registered = false;
+                throw std::runtime_error( std::string( "edit requires a " ) + kind +
+                                          " staged earlier by this Mod" );
+            }
+            target->definition = handle.definition;
+            return;
+        }
+        entries.push_back( { op, handle.definition } );
+    };
+
+#define CATA_REGISTER_WORLD_DEFINITION( Data, Entries, Label ) \
+    if( value.is<definition_handle<Data>>() ) { \
+        register_value( value.as<definition_handle<Data>>(), pimpl_->Entries, Label ); \
+        return true; \
+    }
+    CATA_REGISTER_WORLD_DEFINITION( faction_data, factions, "faction" )
+    CATA_REGISTER_WORLD_DEFINITION( npc_class_data, npc_classes, "NPC class" )
+    CATA_REGISTER_WORLD_DEFINITION( npc_data, npcs, "NPC" )
+    CATA_REGISTER_WORLD_DEFINITION( overmap_terrain_data, overmap_terrains, "overmap terrain" )
+    CATA_REGISTER_WORLD_DEFINITION( overmap_special_data, overmap_specials, "overmap special" )
+    CATA_REGISTER_WORLD_DEFINITION( vehicle_part_data, vehicle_parts, "vehicle part" )
+    CATA_REGISTER_WORLD_DEFINITION( vehicle_data, vehicles, "vehicle" )
+#undef CATA_REGISTER_WORLD_DEFINITION
+    return false;
+}
+
+bool world_content_transaction::validate( const bool check_engine_state,
+        std::string &error ) const
+{
+    try {
+        const auto faction_exists = []( const std::string &id ) {
+            const auto &values = detail::faction_template_registry();
+            return std::any_of( values.begin(), values.end(), [&id]( const faction_template &value ) {
+                return value.id == faction_id( id );
+            } );
+        };
+        validate_registrations( pimpl_->factions, "faction", check_engine_state, faction_exists );
+        validate_registrations( pimpl_->npc_classes, "NPC class", check_engine_state,
+        []( const std::string &id ) { return npc_class_id( id ).is_valid(); } );
+        validate_registrations( pimpl_->npcs, "NPC", check_engine_state,
+        []( const std::string &id ) { return npc_template_id( id ).is_valid(); } );
+        validate_registrations( pimpl_->overmap_terrains, "overmap terrain", check_engine_state,
+        []( const std::string &id ) { return oter_type_str_id( id ).is_valid(); } );
+        validate_registrations( pimpl_->overmap_specials, "overmap special", check_engine_state,
+        []( const std::string &id ) { return overmap_special_id( id ).is_valid(); } );
+        validate_registrations( pimpl_->vehicle_parts, "vehicle part", check_engine_state,
+        []( const std::string &id ) { return vpart_id( id ).is_valid(); } );
+        validate_registrations( pimpl_->vehicles, "vehicle", check_engine_state,
+        []( const std::string &id ) { return vproto_id( id ).is_valid(); } );
+        for( const registration<overmap_terrain_data> &entry : pimpl_->overmap_terrains ) {
+            if( UTF8_getch( entry.definition->symbol ) == UNKNOWN_UNICODE ||
+                color_from_string( entry.definition->color, report_color_error::no ) == c_unset ) {
+                throw std::runtime_error( "overmap terrain '" + entry.definition->id +
+                                          "' has an invalid symbol or color" );
+            }
+        }
+        for( const registration<vehicle_part_data> &entry : pimpl_->vehicle_parts ) {
+            if( !entry.definition->copy_from.empty() &&
+                !vpart_id( entry.definition->copy_from ).is_valid() ) {
+                throw std::runtime_error( "vehicle part '" + entry.definition->id +
+                                          "' has unknown copy_from '" + entry.definition->copy_from + "'" );
+            }
+        }
+        error.clear();
+        return true;
+    } catch( const std::exception &exception ) {
+        error = "Lua-first Mod '" + pimpl_->owner + "': " + exception.what();
+        return false;
+    }
+}
+
+bool world_content_transaction::defines_overmap_terrain_type( const std::string &id ) const
+{
+    return std::any_of( pimpl_->overmap_terrains.begin(), pimpl_->overmap_terrains.end(),
+    [&id]( const registration<overmap_terrain_data> &entry ) {
+        return entry.definition->id == id;
+    } );
+}
+
+bool world_content_transaction::apply( std::string &error )
+{
+    if( pimpl_->applied ) {
+        error = "world content transaction was already applied";
+        return false;
+    }
+    try {
+        for( const registration<faction_data> &entry : pimpl_->factions ) {
+            const faction_data &source = *entry.definition;
+            const faction_id id( source.id );
+            std::vector<faction_template> &registry = detail::faction_template_registry();
+            const auto previous = std::find_if( registry.begin(), registry.end(),
+            [&id]( const faction_template &value ) { return value.id == id; } );
+            pimpl_->faction_undo.emplace_back(
+                id, previous == registry.end() ? std::nullopt :
+                std::optional<faction_template>( *previous ) );
+            if( previous != registry.end() ) {
+                registry.erase( previous );
+            }
+            faction_template native;
+            native.id = id;
+            native.set_name( source.name );
+            native.desc = no_translation( source.description );
+            native.likes_u = source.likes;
+            native.respects_u = source.respects;
+            native.trusts_u = source.trusts;
+            native.known_by_u = source.known;
+            native.size = source.size;
+            native.power = source.power;
+            native.wealth = source.wealth;
+            native.consumes_food = source.consumes_food;
+            native.lone_wolf_faction = source.lone_wolf;
+            native.limited_area_claim = source.limited_area;
+            if( !source.currency.empty() ) {
+                native.currency = itype_id( source.currency );
+            }
+            native.mon_faction = mfaction_str_id( source.monster_faction );
+            if( source.food_calories > 0 || !source.food_vitamins.empty() ) {
+                nutrients supply;
+                supply.calories = static_cast<std::int64_t>( source.food_calories ) * 1000;
+                for( const auto &[vitamin, amount] : source.food_vitamins ) {
+                    supply.set_vitamin( vitamin_id( vitamin ), amount );
+                }
+                native.add_to_food_supply( { { calendar::turn_zero, std::move( supply ) } } );
+            }
+            for( const auto &[target, flags] : source.relations ) {
+                std::bitset<static_cast<std::size_t>( npc_factions::relationship::rel_types )> bits;
+                for( const std::string &flag : flags ) {
+                    const auto relation = npc_factions::relation_strs.find( flag );
+                    if( relation == npc_factions::relation_strs.end() ) {
+                        throw std::runtime_error( "faction '" + source.id +
+                                                  "' has unknown relation flag '" + flag + "'" );
+                    }
+                    bits.set( static_cast<std::size_t>( relation->second ) );
+                }
+                native.relations[target] = bits;
+            }
+            registry.push_back( std::move( native ) );
+        }
+
+        for( const registration<npc_class_data> &entry : pimpl_->npc_classes ) {
+            const npc_class_data &source = *entry.definition;
+            const npc_class_id id( source.id );
+            pimpl_->npc_class_undo.emplace_back(
+                id, id.is_valid() ? std::optional<npc_class>( id.obj() ) : std::nullopt );
+            npc_class native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            native.name = no_translation( source.name );
+            native.job_description = no_translation( source.job_description );
+            native.common = source.common;
+            native.sells_belongings = source.sells_belongings;
+            native.worn_override = item_group_id( source.worn );
+            native.carry_override = item_group_id( source.carry );
+            native.weapon_override = item_group_id( source.weapon );
+            native.traits = trait_group::Trait_group_tag( source.traits );
+            native.shop_cons_rates_id = shopkeeper_cons_rates_id( source.consumption_rates );
+            native.bonus_str = make_distribution( source.strength );
+            native.bonus_dex = make_distribution( source.dexterity );
+            native.bonus_int = make_distribution( source.intelligence );
+            native.bonus_per = make_distribution( source.perception );
+            for( const auto &[skill, value] : source.skills ) {
+                native.skills[skill_id( skill )] = make_distribution( value );
+            }
+            for( const auto &[skill, value] : source.bonus_skills ) {
+                native.bonus_skills[skill_id( skill )] = make_distribution( value );
+            }
+            for( const shop_group_data &group : source.shop_groups ) {
+                native.shop_item_groups.emplace_back( group.id, group.trust,
+                                                      group.strict, group.rigid );
+            }
+            for( const price_rule_data &rule : source.price_rules ) {
+                icg_entry base{ itype_id( rule.item ), item_category_id( rule.category ),
+                                item_group_id( rule.group ), translation(), {} };
+                faction_price_rule native_rule( base );
+                native_rule.markup = rule.markup;
+                native_rule.premium = rule.premium;
+                native_rule.fixed_adj = rule.fixed_adjustment;
+                native_rule.price = rule.price;
+                native.shop_price_rules.push_back( std::move( native_rule ) );
+            }
+            detail::npc_class_registry().insert( native );
+        }
+        for( const registration<npc_data> &entry : pimpl_->npcs ) {
+            const npc_data &source = *entry.definition;
+            const npc_template_id id( source.id );
+            std::map<npc_template_id, npc_template> &registry = npc_template::get_npc_templates();
+            pimpl_->npc_undo.emplace_back( id, registry.extract( id ) );
+            npc_template native;
+            native.guy.idz = id;
+            native.guy.myclass = npc_class_id( source.npc_class );
+            if( !source.faction.empty() ) {
+                native.guy.set_fac_id( source.faction );
+            }
+            native.guy.set_attitude( static_cast<npc_attitude>( source.attitude ) );
+            native.guy.mission = io::string_to_enum<npc_mission>( source.mission );
+            native.guy.chatbin.first_topic = source.chat;
+            if( !source.stole_item_chat.empty() ) {
+                native.guy.chatbin.talk_stole_item = source.stole_item_chat;
+            }
+            native.name_unique = no_translation( source.unique_name );
+            native.name_suffix = no_translation( source.suffix );
+            native.temp_suffix = no_translation( source.temporary_suffix );
+            native.gender_override = source.gender == "male" ? npc_template::gender::male :
+                                     source.gender == "female" ? npc_template::gender::female :
+                                     npc_template::gender::random;
+            native.age = source.age;
+            native.height = source.height;
+            registry.emplace( id, std::move( native ) );
+        }
+
+        for( const registration<overmap_terrain_data> &entry : pimpl_->overmap_terrains ) {
+            const overmap_terrain_data &source = *entry.definition;
+            const oter_type_str_id id( source.id );
+            pimpl_->overmap_terrain_undo.push_back( {
+                id, id.is_valid() ? std::optional<oter_type_t>( id.obj() ) : std::nullopt, {}
+            } );
+            if( pimpl_->overmap_terrain_undo.back().previous ) {
+                for( const oter_id &terrain :
+                     pimpl_->overmap_terrain_undo.back().previous->directional_peers ) {
+                    detail::overmap_terrain_registry().erase( terrain.id() );
+                }
+            }
+            oter_type_t native;
+            native.id = id;
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            native.name = no_translation( source.name );
+            native.symbol = UTF8_getch( source.symbol );
+            native.color = color_from_string( source.color, report_color_error::no );
+            native.see_cost = io::string_to_enum<oter_type_t::see_costs>( source.see_cost );
+            native.default_map_data = string_id<map_data_summary>( source.default_map_data );
+            native.vision_levels = oter_vision_id( source.vision_levels );
+            native.mondensity = source.monster_density;
+            for( const std::string &flag : source.flags ) {
+                native.set_flag( io::string_to_enum<oter_flags>( flag ) );
+            }
+            detail::overmap_terrain_type_registry().insert( native );
+        }
+
+        for( const registration<overmap_special_data> &entry : pimpl_->overmap_specials ) {
+            const overmap_special_data &source = *entry.definition;
+            const overmap_special_id id( source.id );
+            pimpl_->overmap_special_undo.emplace_back(
+                id, id.is_valid() ? std::optional<overmap_special>( id.obj() ) : std::nullopt );
+            overmap_special native;
+            native.id = id;
+            native.was_loaded = true;
+            native.subtype_ = overmap_special_subtype::fixed;
+            native.constraints_.city_size = { source.city_size.minimum, source.city_size.maximum };
+            native.constraints_.city_distance = {
+                source.city_distance.minimum, source.city_distance.maximum
+            };
+            native.constraints_.occurrences = {
+                source.occurrences.minimum, source.occurrences.maximum
+            };
+            native.rotatable_ = source.rotate;
+            native.priority_ = source.priority;
+            native.flags_.insert( source.flags.begin(), source.flags.end() );
+            for( const std::string &location : source.default_locations ) {
+                native.default_locations_.insert( overmap_location_id( location ) );
+            }
+            auto fixed = make_shared_fast<fixed_overmap_special_data>();
+            for( const special_terrain_data &terrain : source.terrains ) {
+                cata::flat_set<overmap_location_id> locations;
+                for( const std::string &location : terrain.locations ) {
+                    locations.insert( overmap_location_id( location ) );
+                }
+                fixed->terrains.emplace_back(
+                    tripoint_rel_omt( terrain.x, terrain.y, terrain.z ),
+                    oter_str_id( terrain.terrain ), locations, terrain.flags );
+            }
+            for( const special_connection_data &connection : source.connections ) {
+                overmap_special_connection native_connection;
+                native_connection.p = tripoint_rel_omt( connection.x, connection.y, connection.z );
+                if( connection.from ) {
+                    native_connection.from = tripoint_rel_omt(
+                                                 ( *connection.from )[0], ( *connection.from )[1],
+                                                 ( *connection.from )[2] );
+                }
+                native_connection.terrain = oter_type_str_id( connection.terrain );
+                native_connection.connection = overmap_connection_id( connection.connection );
+                native_connection.existing = connection.existing;
+                fixed->connections.push_back( std::move( native_connection ) );
+            }
+            native.data_ = std::move( fixed );
+            detail::overmap_special_registry().insert( native );
+        }
+
+        for( const registration<vehicle_part_data> &entry : pimpl_->vehicle_parts ) {
+            const vehicle_part_data &source = *entry.definition;
+            const vpart_id id( source.id );
+            pimpl_->vehicle_part_undo.emplace_back(
+                id, id.is_valid() ? std::optional<vpart_info>( id.obj() ) : std::nullopt );
+            vpart_info native = source.copy_from.empty() ? vpart_info() :
+                                vpart_id( source.copy_from ).obj();
+            native.id = id;
+            native.src.clear();
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            if( source.name ) {
+                native.name_ = no_translation( *source.name );
+            }
+            if( source.description ) {
+                native.description = no_translation( *source.description );
+            }
+            if( source.item ) {
+                native.base_item = itype_id( *source.item );
+            }
+            if( source.location ) {
+                native.location = vpart_location_id( *source.location );
+            }
+            if( source.looks_like ) {
+                native.looks_like = *source.looks_like;
+            }
+            if( source.color ) {
+                native.color = color_from_string( *source.color, report_color_error::no );
+            }
+            if( source.broken_color ) {
+                native.color_broken = color_from_string( *source.broken_color,
+                                      report_color_error::no );
+            }
+            if( source.fuel_type ) {
+                native.fuel_type = itype_id( *source.fuel_type );
+            }
+            if( source.durability ) {
+                native.durability = *source.durability;
+            }
+            if( source.size_ml ) {
+                native.size = units::from_milliliter( *source.size_ml );
+            }
+            if( source.damage_modifier ) {
+                native.dmg_mod = *source.damage_modifier;
+            }
+            if( source.power_watts ) {
+                native.power = units::from_watt( *source.power_watts );
+            }
+            if( source.epower_watts ) {
+                native.epower = units::from_watt( *source.epower_watts );
+            }
+            if( source.energy_consumption_watts ) {
+                native.energy_consumption = units::from_watt( *source.energy_consumption_watts );
+            }
+            if( source.balloon_height ) {
+                native.balloon_info = vpslot_balloon{ true, *source.balloon_height };
+            }
+            if( source.categories ) {
+                native.categories = *source.categories;
+            }
+            if( source.flags ) {
+                native.flags.clear();
+                native.bitflags.reset();
+                for( const std::string &flag : *source.flags ) {
+                    native.set_flag( flag );
+                }
+            }
+            if( source.variants ) {
+                native.variants.clear();
+                native.variant_default.clear();
+                for( const vpart_variant_data &variant : *source.variants ) {
+                    vpart_variant native_variant;
+                    native_variant.id = variant.id;
+                    native_variant.label_ = variant.label;
+                    native_variant.symbols = read_variant_symbols( variant.symbols, source.id );
+                    native_variant.symbols_broken = read_variant_symbols(
+                                                        variant.broken_symbols, source.id );
+                    if( native.variants.empty() ) {
+                        native.variant_default = native_variant.id;
+                    }
+                    native.variants[native_variant.id] = std::move( native_variant );
+                }
+            }
+            if( !source.fuel_options.empty() || source.backfire_threshold ||
+                source.backfire_frequency || source.damaged_power_factor ||
+                source.noise_factor || source.m2c ) {
+                if( !native.engine_info ) {
+                    native.engine_info.emplace();
+                }
+                native.engine_info->was_loaded = true;
+                if( source.backfire_threshold ) {
+                    native.engine_info->backfire_threshold = *source.backfire_threshold;
+                }
+                if( source.backfire_frequency ) {
+                    native.engine_info->backfire_freq = *source.backfire_frequency;
+                }
+                if( source.damaged_power_factor ) {
+                    native.engine_info->damaged_power_factor = *source.damaged_power_factor;
+                }
+                if( source.noise_factor ) {
+                    native.engine_info->noise_factor = *source.noise_factor;
+                }
+                if( source.m2c ) {
+                    native.engine_info->m2c = *source.m2c;
+                }
+                if( !source.fuel_options.empty() ) {
+                    native.engine_info->fuel_opts.clear();
+                    for( const std::string &fuel : source.fuel_options ) {
+                        native.engine_info->fuel_opts.emplace_back( fuel );
+                    }
+                }
+            }
+            if( !source.breaks_into.empty() ) {
+                native.breaks_into_group = item_group_id( source.breaks_into );
+            }
+            for( const auto &[damage, amount] : source.damage_reduction ) {
+                native.damage_reduction[damage_type_id( damage )] = amount;
+            }
+            const auto apply_requirement = []( const vpart_requirement_data &value,
+            std::vector<std::pair<requirement_id, int>> &requirements,
+            std::map<skill_id, int> &skills, time_duration &time ) {
+                if( !value.id.empty() ) {
+                    requirements = { { requirement_id( value.id ), value.multiplier } };
+                }
+                if( !value.using_requirements.empty() ) {
+                    requirements.clear();
+                    for( const auto &[id, multiplier] : value.using_requirements ) {
+                        requirements.emplace_back( requirement_id( id ), multiplier );
+                    }
+                }
+                for( const auto &[skill, level] : value.skills ) {
+                    skills[skill_id( skill )] = level;
+                }
+                if( value.time_minutes >= 0 ) {
+                    time = time_duration::from_minutes( value.time_minutes );
+                }
+            };
+            apply_requirement( source.install, native.install_reqs,
+                               native.install_skills, native.install_moves );
+            apply_requirement( source.removal, native.removal_reqs,
+                               native.removal_skills, native.removal_moves );
+            apply_requirement( source.repair, native.repair_reqs,
+                               native.repair_skills, native.repair_moves );
+            if( source.air_proficiencies ) {
+                native.control_air.proficiencies.clear();
+                for( const std::string &proficiency : *source.air_proficiencies ) {
+                    native.control_air.proficiencies.emplace( proficiency );
+                }
+            }
+            if( source.land_proficiencies ) {
+                native.control_land.proficiencies.clear();
+                for( const std::string &proficiency : *source.land_proficiencies ) {
+                    native.control_land.proficiencies.emplace( proficiency );
+                }
+            }
+            detail::vehicle_part_registry().insert( native );
+        }
+
+        for( const registration<vehicle_data> &entry : pimpl_->vehicles ) {
+            const vehicle_data &source = *entry.definition;
+            const vproto_id id( source.id );
+            pimpl_->vehicle_undo.emplace_back(
+                id, id.is_valid() ? std::optional<vehicle_prototype>( id.obj() ) : std::nullopt );
+            vehicle_prototype native;
+            native.id = id;
+            native.name = no_translation( source.name );
+            native.src.emplace_back( id, mod_id( pimpl_->owner ) );
+            native.was_loaded = true;
+            native.color_palette = vpalette_id( source.color_palette );
+            for( const vehicle_part_placement_data &part : source.parts ) {
+                vehicle_prototype::part_def native_part;
+                native_part.pos = point_rel_ms( part.x, part.y );
+                native_part.part = vpart_id( part.part );
+                native_part.variant = part.variant;
+                native_part.with_ammo = part.with_ammo;
+                for( const std::string &ammo : part.ammo_types ) {
+                    native_part.ammo_types.emplace( ammo );
+                }
+                native_part.ammo_qty = part.ammo_quantity;
+                if( !part.fuel.empty() ) {
+                    native_part.fuel = itype_id( part.fuel );
+                }
+                for( const std::string &tool : part.tools ) {
+                    native_part.tools.emplace_back( tool );
+                }
+                native.parts.push_back( std::move( native_part ) );
+            }
+            for( const vehicle_item_data &spawn : source.items ) {
+                vehicle_item_spawn native_spawn;
+                native_spawn.pos = point_rel_ms( spawn.x, spawn.y );
+                native_spawn.chance = spawn.chance;
+                native_spawn.with_ammo = spawn.with_ammo;
+                native_spawn.with_magazine = spawn.with_magazine;
+                for( const std::string &item : spawn.items ) {
+                    native_spawn.item_ids.emplace_back( itype_id( item ), std::string() );
+                }
+                for( const std::string &group : spawn.groups ) {
+                    native_spawn.item_groups.emplace_back( group );
+                }
+                native.item_spawns.push_back( std::move( native_spawn ) );
+            }
+            for( const vehicle_zone_data &zone : source.zones ) {
+                native.zone_defs.push_back( {
+                    zone_type_id( zone.type ), zone.name, zone.filter,
+                    point_rel_ms( zone.x, zone.y )
+                } );
+            }
+            detail::vehicle_prototype_registry().insert( native );
+        }
+        pimpl_->applied = true;
+        error.clear();
+        return true;
+    } catch( const std::exception &exception ) {
+        rollback();
+        error = "Lua-first Mod '" + pimpl_->owner + "': " + exception.what();
+        return false;
+    }
+}
+
+bool world_content_transaction::validate_finalized( std::string &error ) const
+{
+    if( !pimpl_->applied ) {
+        error = "world content transaction is not applied";
+        return false;
+    }
+    const auto validate = [&error]( const auto &entries, auto make_id, const char *kind ) {
+        for( const auto &entry : entries ) {
+            if( !make_id( entry.definition->id ).is_valid() ) {
+                error = std::string( "Lua-first " ) + kind + " '" + entry.definition->id +
+                        "' did not survive global finalization";
+                return false;
+            }
+        }
+        return true;
+    };
+    const std::vector<faction_template> &factions = detail::faction_template_registry();
+    for( const registration<faction_data> &entry : pimpl_->factions ) {
+        if( std::none_of( factions.begin(), factions.end(), [&entry]( const faction_template &value ) {
+        return value.id == faction_id( entry.definition->id );
+    } ) ) {
+            error = "Lua-first faction '" + entry.definition->id +
+                    "' did not survive global finalization";
+            return false;
+        }
+    }
+    if( !validate( pimpl_->npc_classes, []( const std::string &id ) {
+    return npc_class_id( id );
+}, "NPC class" ) ||
+    !validate( pimpl_->npcs, []( const std::string &id ) {
+    return npc_template_id( id );
+}, "NPC" ) ||
+    !validate( pimpl_->overmap_terrains, []( const std::string &id ) {
+    return oter_type_str_id( id );
+}, "overmap terrain" ) ||
+    !validate( pimpl_->overmap_specials, []( const std::string &id ) {
+    return overmap_special_id( id );
+}, "overmap special" ) ||
+    !validate( pimpl_->vehicle_parts, []( const std::string &id ) {
+    return vpart_id( id );
+}, "vehicle part" ) ||
+    !validate( pimpl_->vehicles, []( const std::string &id ) {
+    return vproto_id( id );
+}, "vehicle" ) ) {
+        return false;
+    }
+    error.clear();
+    return true;
+}
+
+void world_content_transaction::rollback()
+{
+    const bool rebuild_vehicles = !pimpl_->vehicle_undo.empty() ||
+                                  !pimpl_->vehicle_part_undo.empty();
+    for( auto it = pimpl_->vehicle_undo.rbegin(); it != pimpl_->vehicle_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::vehicle_prototype_registry().restore( *it->second );
+        } else {
+            detail::vehicle_prototype_registry().erase( it->first );
+        }
+    }
+    pimpl_->vehicle_undo.clear();
+    for( auto it = pimpl_->vehicle_part_undo.rbegin();
+         it != pimpl_->vehicle_part_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::vehicle_part_registry().restore( *it->second );
+        } else {
+            detail::vehicle_part_registry().erase( it->first );
+        }
+    }
+    pimpl_->vehicle_part_undo.clear();
+    if( rebuild_vehicles ) {
+        vehicles::finalize_prototypes();
+    }
+    for( auto it = pimpl_->overmap_special_undo.rbegin();
+         it != pimpl_->overmap_special_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::overmap_special_registry().restore( *it->second );
+        } else {
+            detail::overmap_special_registry().erase( it->first );
+        }
+    }
+    pimpl_->overmap_special_undo.clear();
+    for( auto it = pimpl_->overmap_terrain_undo.rbegin();
+         it != pimpl_->overmap_terrain_undo.rend(); ++it ) {
+        std::vector<oter_id> generated = it->generated;
+        if( generated.empty() && it->id.is_valid() ) {
+            generated = it->id.obj().directional_peers;
+        }
+        for( const oter_id &terrain : generated ) {
+            detail::overmap_terrain_registry().erase( terrain.id() );
+        }
+        detail::overmap_terrain_type_registry().erase( it->id );
+        if( it->previous ) {
+            oter_type_t &restored = detail::overmap_terrain_type_registry().restore(
+                                        *it->previous );
+            restored.finalize();
+        }
+    }
+    pimpl_->overmap_terrain_undo.clear();
+    std::map<npc_template_id, npc_template> &npc_registry = npc_template::get_npc_templates();
+    for( auto it = pimpl_->npc_undo.rbegin(); it != pimpl_->npc_undo.rend(); ++it ) {
+        npc_registry.erase( it->first );
+        if( !it->second.empty() ) {
+            npc_registry.insert( std::move( it->second ) );
+        }
+    }
+    pimpl_->npc_undo.clear();
+    for( auto it = pimpl_->npc_class_undo.rbegin();
+         it != pimpl_->npc_class_undo.rend(); ++it ) {
+        if( it->second ) {
+            detail::npc_class_registry().restore( *it->second );
+        } else {
+            detail::npc_class_registry().erase( it->first );
+        }
+    }
+    pimpl_->npc_class_undo.clear();
+    std::vector<faction_template> &factions = detail::faction_template_registry();
+    for( auto it = pimpl_->faction_undo.rbegin(); it != pimpl_->faction_undo.rend(); ++it ) {
+        const auto current = std::find_if( factions.begin(), factions.end(),
+        [&it]( const faction_template &value ) { return value.id == it->first; } );
+        if( current != factions.end() ) {
+            factions.erase( current );
+        }
+        if( it->second ) {
+            factions.push_back( *it->second );
+        }
+    }
+    pimpl_->faction_undo.clear();
+    pimpl_->applied = false;
+}
+
+void world_content_transaction::commit()
+{
+    pimpl_->faction_undo.clear();
+    pimpl_->npc_class_undo.clear();
+    pimpl_->npc_undo.clear();
+    pimpl_->overmap_terrain_undo.clear();
+    pimpl_->overmap_special_undo.clear();
+    pimpl_->vehicle_part_undo.clear();
+    pimpl_->vehicle_undo.clear();
+    pimpl_->handle_token->state = lifecycle::committed;
+}
+
+void world_content_transaction::seal()
+{
+    if( pimpl_->handle_token->state == lifecycle::building ) {
+        pimpl_->handle_token->state = lifecycle::committed;
+    }
+}
+
+void world_content_transaction::discard()
+{
+    rollback();
+    pimpl_->handle_token->state = lifecycle::discarded;
+}
+
+void world_content_transaction::append_fingerprint( std::uint64_t &state ) const
+{
+    hash_registrations( state, "faction", pimpl_->factions );
+    hash_registrations( state, "npc_class", pimpl_->npc_classes );
+    hash_registrations( state, "npc", pimpl_->npcs );
+    hash_registrations( state, "overmap_terrain", pimpl_->overmap_terrains );
+    hash_registrations( state, "overmap_special", pimpl_->overmap_specials );
+    hash_registrations( state, "vehicle_part", pimpl_->vehicle_parts );
+    hash_registrations( state, "vehicle", pimpl_->vehicles );
+}
+
+} // namespace cata::lua_platform
+
+#else
+
+namespace cata::lua_platform
+{
+
+struct world_content_transaction::impl {};
+
+world_content_transaction::world_content_transaction( std::string, std::size_t ) :
+    pimpl_( std::make_unique<impl>() )
+{
+}
+
+world_content_transaction::~world_content_transaction() = default;
+
+bool world_content_transaction::validate( bool, std::string &error ) const
+{
+    error.clear();
+    return true;
+}
+
+bool world_content_transaction::defines_overmap_terrain_type( const std::string & ) const
+{
+    return false;
+}
+
+bool world_content_transaction::apply( std::string &error )
+{
+    error.clear();
+    return true;
+}
+
+bool world_content_transaction::validate_finalized( std::string &error ) const
+{
+    error.clear();
+    return true;
+}
+
+void world_content_transaction::rollback() {}
+void world_content_transaction::commit() {}
+void world_content_transaction::seal() {}
+void world_content_transaction::discard() {}
+void world_content_transaction::append_fingerprint( std::uint64_t & ) const {}
+
+} // namespace cata::lua_platform
+
+#endif

--- a/src/catalua_platform_world_content.h
+++ b/src/catalua_platform_world_content.h
@@ -1,0 +1,52 @@
+#pragma once
+#ifndef CATA_SRC_CATALUA_PLATFORM_WORLD_CONTENT_H
+#define CATA_SRC_CATALUA_PLATFORM_WORLD_CONTENT_H
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#if defined(CATA_ENABLE_LUA_UI) && CATA_ENABLE_LUA_UI
+#include "catalua_sol.h"
+#endif
+
+namespace cata::lua_platform
+{
+
+/**
+ * Transactional Platform-Lua definitions for world-facing content whose
+ * native registries live outside Item_factory and DynamicDataLoader.
+ */
+class world_content_transaction
+{
+    public:
+        world_content_transaction( std::string owner, std::size_t generation );
+        ~world_content_transaction();
+
+        world_content_transaction( const world_content_transaction & ) = delete;
+        world_content_transaction &operator=( const world_content_transaction & ) = delete;
+
+#if defined(CATA_ENABLE_LUA_UI) && CATA_ENABLE_LUA_UI
+        void install_lua_api( sol::state &lua, sol::table &ccb, sol::table &content );
+        bool register_definition( const sol::object &value, int operation );
+#endif
+
+        bool validate( bool check_engine_state, std::string &error ) const;
+        bool defines_overmap_terrain_type( const std::string &id ) const;
+        bool apply( std::string &error );
+        bool validate_finalized( std::string &error ) const;
+        void rollback();
+        void commit();
+        void seal();
+        void discard();
+        void append_fingerprint( std::uint64_t &state ) const;
+
+    private:
+        struct impl;
+        std::unique_ptr<impl> pimpl_;
+};
+
+} // namespace cata::lua_platform
+
+#endif // CATA_SRC_CATALUA_PLATFORM_WORLD_CONTENT_H

--- a/src/catalua_ui.cpp
+++ b/src/catalua_ui.cpp
@@ -3935,40 +3935,7 @@ void initialize_state( runtime_state &state )
                    source_id + ":" + name, copied );
     } );
 
-    state.lua.new_usertype<script_mapgen_context>(
-        "ScriptMapgenContext", sol::no_constructor,
-        "valid", &script_mapgen_context::valid,
-        "operations_used", &script_mapgen_context::operations_used,
-        "operations_remaining",
-        &script_mapgen_context::operations_remaining,
-        "id", &script_mapgen_context::id,
-        "north", &script_mapgen_context::north,
-        "east", &script_mapgen_context::east,
-        "south", &script_mapgen_context::south,
-        "west", &script_mapgen_context::west,
-        "neast", &script_mapgen_context::neast,
-        "seast", &script_mapgen_context::seast,
-        "swest", &script_mapgen_context::swest,
-        "nwest", &script_mapgen_context::nwest,
-        "above", &script_mapgen_context::above,
-        "below", &script_mapgen_context::below,
-        "get_nesw", &script_mapgen_context::get_nesw,
-        "zlevel", &script_mapgen_context::zlevel,
-        "get_direction", &script_mapgen_context::get_direction,
-        "set_dir", &script_mapgen_context::set_dir,
-        "get_rotation", &script_mapgen_context::get_rotation,
-        "get_rot_suffix", &script_mapgen_context::get_rot_suffix,
-        "random_int", &script_mapgen_context::random_int,
-        "random_chance", &script_mapgen_context::random_chance,
-        "terrain_at", &script_mapgen_context::terrain_at,
-        "furniture_at", &script_mapgen_context::furniture_at,
-        "trap_at", &script_mapgen_context::trap_at,
-        "set_terrain", &script_mapgen_context::set_terrain,
-        "set_furniture", &script_mapgen_context::set_furniture,
-        "set_trap", &script_mapgen_context::set_trap,
-        "fill_groundcover", &script_mapgen_context::fill_groundcover,
-        "nest", &script_mapgen_context::nest,
-        "generate", &script_mapgen_context::generate );
+    install_script_mapgen_context_api( state.lua );
 
     state.lua.new_usertype<script_dialogue_context>(
         "ScriptDialogueContext", sol::no_constructor,
@@ -6885,6 +6852,10 @@ void clear_dialogue_response_callbacks()
 std::optional<std::string> dialogue_dynamic_line(
     dialogue &d, const talk_topic &topic )
 {
+    if( std::optional<std::string> line =
+            cata::lua_platform::platform_dialogue_dynamic_line( d, topic ) ) {
+        return line;
+    }
     if( !active_state ) {
         return std::nullopt;
     }
@@ -6948,6 +6919,9 @@ std::optional<std::string> dialogue_dynamic_line(
 bool gen_lua_dialogue_responses(
     dialogue &d, const talk_topic &topic )
 {
+    if( cata::lua_platform::gen_platform_dialogue_responses( d, topic ) ) {
+        return true;
+    }
     if( !active_state ) {
         return false;
     }
@@ -7370,6 +7344,7 @@ void dispatch_mapgen_postprocess( mapgendata &data )
         return;
     }
     bootstrap_mapgen_runtime_if_needed();
+    cata::lua_platform::dispatch_platform_mapgen_postprocess( data );
     if( !active_state ) {
         return;
     }
@@ -7488,6 +7463,15 @@ void dispatch_mapgen_postprocess( mapgendata &data )
             remove_mapgen_handler( state, handler.id );
         }
     }
+}
+
+bool dispatch_mapgen_generate( mapgendata &data )
+{
+    if( is_pool_worker_thread() ) {
+        return false;
+    }
+    bootstrap_mapgen_runtime_if_needed();
+    return cata::lua_platform::dispatch_platform_mapgen_generate( data );
 }
 
 void on_world_ready( const world_ready_kind kind )

--- a/src/catalua_ui.h
+++ b/src/catalua_ui.h
@@ -235,6 +235,7 @@ void on_turn();
 // Invoke final, bounded Lua mapgen handlers for one newly generated OMT.
 // Worker threads never enter Lua, and builds without Lua provide a no-op.
 void dispatch_mapgen_postprocess( mapgendata &data );
+bool dispatch_mapgen_generate( mapgendata &data );
 
 // Load scripts after a new game or save has finished initializing.  Errors are
 // logged and reported through status(), without aborting game startup.

--- a/src/catalua_ui_disabled.cpp
+++ b/src/catalua_ui_disabled.cpp
@@ -201,6 +201,11 @@ void dispatch_mapgen_postprocess( mapgendata & )
 {
 }
 
+bool dispatch_mapgen_generate( mapgendata & )
+{
+    return false;
+}
+
 void on_world_ready( world_ready_kind )
 {
 }

--- a/src/catalua_ui_mapgen.cpp
+++ b/src/catalua_ui_mapgen.cpp
@@ -8,15 +8,25 @@
 #include <stdexcept>
 #include <string_view>
 
+#include "calendar.h"
+#include "clzones.h"
 #include "game_constants.h"
+#include "game.h"
+#include "item.h"
+#include "item_group.h"
 #include "map.h"
 #include "mapgen.h"
 #include "mapgen_functions.h"
 #include "mapgendata.h"
+#include "npc.h"
 #include "omdata.h"
 #include "point.h"
 #include "trap.h"
 #include "type_id.h"
+#include "units.h"
+#include "vehicle.h"
+#include "vehicle_group.h"
+#include "veh_type.h"
 
 namespace cata::lua_ui
 {
@@ -51,6 +61,18 @@ void require_mapgen_id( const std::string &id, const std::string_view api_name )
         throw std::invalid_argument(
             std::string( api_name ) +
             " id must contain 1 to 256 non-NUL bytes" );
+    }
+}
+
+void require_rectangle( const int x1, const int y1, const int x2, const int y2,
+                        const std::string_view api_name )
+{
+    if( x1 < 0 || y1 < 0 || x2 < x1 || y2 < y1 ||
+        x2 >= script_mapgen_context::map_width ||
+        y2 >= script_mapgen_context::map_height ) {
+        throw std::out_of_range(
+            std::string( api_name ) +
+            " rectangle must stay within the current 24x24 OMT" );
     }
 }
 
@@ -432,6 +454,274 @@ bool script_mapgen_context::set_trap(
     return state.data->m.tr_at( position ).id.id() == target;
 }
 
+bool script_mapgen_context::set_terrain_id(
+    const int x, const int y, const std::string &id )
+{
+    require_mapgen_id( id, "Lua mapgen set_terrain_id" );
+    const ter_str_id target( id );
+    if( !target.is_valid() ) {
+        throw std::invalid_argument(
+            "Lua mapgen set_terrain_id received unknown terrain '" + id + "'" );
+    }
+    context_state &state = require_write_state();
+    const tripoint_bub_ms position = bounded_position( state, x, y );
+    consume( 1 );
+    return state.data->m.ter_set( position, target.id() );
+}
+
+bool script_mapgen_context::set_furniture_id(
+    const int x, const int y, const std::string &id )
+{
+    furn_id target = furn_str_id::NULL_ID().id();
+    if( !id.empty() ) {
+        require_mapgen_id( id, "Lua mapgen set_furniture_id" );
+        const furn_str_id source( id );
+        if( !source.is_valid() ) {
+            throw std::invalid_argument(
+                "Lua mapgen set_furniture_id received unknown furniture '" + id + "'" );
+        }
+        target = source.id();
+    }
+    context_state &state = require_write_state();
+    const tripoint_bub_ms position = bounded_position( state, x, y );
+    consume( 1 );
+    return state.data->m.furn_set( position, target );
+}
+
+bool script_mapgen_context::set_trap_id(
+    const int x, const int y, const std::string &id )
+{
+    trap_id target = tr_null;
+    if( !id.empty() ) {
+        require_mapgen_id( id, "Lua mapgen set_trap_id" );
+        const trap_str_id source( id );
+        if( !source.is_valid() ) {
+            throw std::invalid_argument(
+                "Lua mapgen set_trap_id received unknown trap '" + id + "'" );
+        }
+        target = source.id();
+    }
+    context_state &state = require_write_state();
+    const tripoint_bub_ms position = bounded_position( state, x, y );
+    consume( 1 );
+    state.data->m.trap_set( position, target );
+    return state.data->m.tr_at( position ).id.id() == target;
+}
+
+void script_mapgen_context::reset( const std::string &terrain_id )
+{
+    require_mapgen_id( terrain_id, "Lua mapgen reset" );
+    const ter_str_id target( terrain_id );
+    if( !target.is_valid() ) {
+        throw std::invalid_argument(
+            "Lua mapgen reset received unknown terrain '" + terrain_id + "'" );
+    }
+    context_state &state = require_write_state();
+    consume( static_cast<std::size_t>( map_width ) * map_height );
+    for( int y = 0; y < map_height; ++y ) {
+        for( int x = 0; x < map_width; ++x ) {
+            const tripoint_bub_ms position = bounded_position( state, x, y );
+            state.data->m.i_clear( position );
+            state.data->m.clear_fields( position );
+            state.data->m.trap_set( position, tr_null );
+            state.data->m.furn_set( position, furn_str_id::NULL_ID().id() );
+            state.data->m.ter_set( position, target.id() );
+        }
+    }
+}
+
+void script_mapgen_context::place_item(
+    const int x, const int y, const std::string &item_id,
+    const int quantity, const int charges, const std::string &faction_id )
+{
+    require_mapgen_id( item_id, "Lua mapgen place_item" );
+    const itype_id type( item_id );
+    if( !item::type_is_defined( type ) ) {
+        throw std::invalid_argument(
+            "Lua mapgen place_item received unknown item '" + item_id + "'" );
+    }
+    if( quantity <= 0 || quantity > 10000 || charges < 0 ) {
+        throw std::invalid_argument(
+            "Lua mapgen place_item quantity or charges are outside native limits" );
+    }
+    context_state &state = require_write_state();
+    const tripoint_bub_ms position = bounded_position( state, x, y );
+    consume( static_cast<std::size_t>( quantity ) );
+    state.data->m.spawn_item(
+        position, type, static_cast<unsigned>( quantity ), charges,
+        calendar::start_of_cataclysm, 0, {}, "", faction_id );
+}
+
+void script_mapgen_context::place_item_group(
+    const int x1, const int y1, const int x2, const int y2,
+    const std::string &group_id, const int chance,
+    const std::string &faction_id )
+{
+    require_rectangle( x1, y1, x2, y2, "Lua mapgen place_item_group" );
+    require_mapgen_id( group_id, "Lua mapgen place_item_group" );
+    const item_group_id group( group_id );
+    if( !item_group::group_is_defined( group ) || chance <= 0 || chance > 100 ) {
+        throw std::invalid_argument(
+            "Lua mapgen place_item_group requires a known group and chance from 1 to 100" );
+    }
+    context_state &state = require_write_state();
+    const tripoint_bub_ms start = bounded_position( state, x1, y1 );
+    const tripoint_bub_ms end = bounded_position( state, x2, y2 );
+    consume( static_cast<std::size_t>( x2 - x1 + 1 ) *
+             static_cast<std::size_t>( y2 - y1 + 1 ) );
+    state.data->m.place_items( group, chance, start, end, true,
+                               calendar::start_of_cataclysm, 0, 0, faction_id );
+}
+
+void script_mapgen_context::place_liquid(
+    const int x, const int y, const std::string &item_id, const int charges )
+{
+    if( charges <= 0 ) {
+        throw std::invalid_argument( "Lua mapgen liquid charges must be positive" );
+    }
+    place_item( x, y, item_id, 1, charges, "" );
+}
+
+void script_mapgen_context::place_toilet(
+    const int x, const int y, const int charges )
+{
+    if( charges < 0 ) {
+        throw std::invalid_argument( "Lua mapgen toilet charges cannot be negative" );
+    }
+    context_state &state = require_write_state();
+    const tripoint_bub_ms position = bounded_position( state, x, y );
+    consume( 1 );
+    if( charges == 0 ) {
+        state.data->m.place_toilet( position );
+    } else {
+        state.data->m.place_toilet( position, charges );
+    }
+}
+
+void script_mapgen_context::place_sign(
+    const int x, const int y, const std::string &text,
+    const std::string &furniture_id )
+{
+    if( text.empty() || text.size() > 4096 || text.find( '\0' ) != std::string::npos ) {
+        throw std::invalid_argument( "Lua mapgen sign text is invalid" );
+    }
+    const std::string target_id = furniture_id.empty() ? "f_sign" : furniture_id;
+    const furn_str_id target( target_id );
+    if( !target.is_valid() ) {
+        throw std::invalid_argument(
+            "Lua mapgen place_sign received unknown furniture '" + target_id + "'" );
+    }
+    context_state &state = require_write_state();
+    const tripoint_bub_ms position = bounded_position( state, x, y );
+    consume( 1 );
+    state.data->m.furn_set( position, target.id() );
+    state.data->m.set_signage( position, text );
+}
+
+void script_mapgen_context::place_zone(
+    const int x1, const int y1, const int x2, const int y2,
+    const std::string &zone_type, const std::string &faction,
+    const std::string &name, const std::string &filter )
+{
+    require_rectangle( x1, y1, x2, y2, "Lua mapgen place_zone" );
+    const zone_type_id type( zone_type );
+    const faction_id owner( faction );
+    if( !type.is_valid() || !owner.is_valid() ) {
+        throw std::invalid_argument(
+            "Lua mapgen place_zone requires known zone and faction ids" );
+    }
+    context_state &state = require_write_state();
+    const tripoint_abs_ms start = state.data->m.get_abs(
+                                      bounded_position( state, x1, y1 ) );
+    const tripoint_abs_ms end = state.data->m.get_abs(
+                                    bounded_position( state, x2, y2 ) );
+    consume( static_cast<std::size_t>( x2 - x1 + 1 ) *
+             static_cast<std::size_t>( y2 - y1 + 1 ) );
+    mapgen_place_zone( start, end, type, owner, name, filter, &state.data->m );
+}
+
+std::int64_t script_mapgen_context::place_npc(
+    const int x, const int y, const std::string &template_id,
+    const std::string &unique_id )
+{
+    const string_id<npc_template> type( template_id );
+    if( !type.is_valid() ) {
+        throw std::invalid_argument(
+            "Lua mapgen place_npc received unknown template '" + template_id + "'" );
+    }
+    if( !unique_id.empty() && g != nullptr && g->unique_npc_exists( unique_id ) ) {
+        return 0;
+    }
+    context_state &state = require_write_state();
+    const tripoint_bub_ms position = bounded_position( state, x, y );
+    consume( 1 );
+    const character_id id = state.data->m.place_npc( position.xy(), type );
+    if( !unique_id.empty() && g != nullptr ) {
+        if( npc *placed = g->find_npc( id ) ) {
+            placed->set_unique_id( unique_id );
+        }
+    }
+    return id.get_value();
+}
+
+bool script_mapgen_context::place_vehicle(
+    const int x, const int y, const std::string &prototype_or_group_id,
+    const int rotation_degrees, const int fuel_percent, const int status,
+    const std::string &faction )
+{
+    vproto_id prototype( prototype_or_group_id );
+    if( !prototype.is_valid() ) {
+        const vgroup_id group( prototype_or_group_id );
+        if( !group.is_valid() ) {
+            throw std::invalid_argument(
+                "Lua mapgen place_vehicle received unknown prototype or group '" +
+                prototype_or_group_id + "'" );
+        }
+        prototype = group->pick();
+    }
+    if( fuel_percent < -1 || fuel_percent > 100 || status < -1 || status > 2 ) {
+        throw std::invalid_argument(
+            "Lua mapgen vehicle fuel or status is outside native limits" );
+    }
+    std::optional<faction_id> owner;
+    if( !faction.empty() ) {
+        owner.emplace( faction );
+        if( !owner->is_valid() ) {
+            throw std::invalid_argument(
+                "Lua mapgen place_vehicle received unknown faction '" + faction + "'" );
+        }
+    }
+    context_state &state = require_write_state();
+    const tripoint_bub_ms position = bounded_position( state, x, y );
+    consume( 1 );
+    vehicle *placed = state.data->m.add_vehicle(
+                          prototype, position, units::from_degrees( rotation_degrees ),
+                          fuel_percent, static_cast<veh_spawn_status>( status ) );
+    if( placed != nullptr && owner ) {
+        placed->set_owner( *owner );
+    }
+    return placed != nullptr;
+}
+
+void script_mapgen_context::apply_faction_ownership(
+    const int x1, const int y1, const int x2, const int y2,
+    const std::string &faction )
+{
+    require_rectangle( x1, y1, x2, y2,
+                       "Lua mapgen apply_faction_ownership" );
+    const faction_id owner( faction );
+    if( !owner.is_valid() ) {
+        throw std::invalid_argument(
+            "Lua mapgen apply_faction_ownership received unknown faction '" +
+            faction + "'" );
+    }
+    context_state &state = require_write_state();
+    consume( static_cast<std::size_t>( x2 - x1 + 1 ) *
+             static_cast<std::size_t>( y2 - y1 + 1 ) );
+    state.data->m.apply_faction_ownership(
+        point_bub_ms( x1, y1 ), point_bub_ms( x2, y2 ), owner );
+}
+
 void script_mapgen_context::fill_groundcover()
 {
     context_state &state = require_write_state();
@@ -514,6 +804,57 @@ void script_mapgen_context::generate( const std::string &id )
             "Lua mapgen full generator had no selectable implementation" );
     }
     resolve_regional_terrain_and_furniture( *state.data );
+}
+
+void install_script_mapgen_context_api( sol::state &lua )
+{
+    lua.new_usertype<script_mapgen_context>(
+        "ScriptMapgenContext", sol::no_constructor,
+        "valid", &script_mapgen_context::valid,
+        "operations_used", &script_mapgen_context::operations_used,
+        "operations_remaining", &script_mapgen_context::operations_remaining,
+        "id", &script_mapgen_context::id,
+        "north", &script_mapgen_context::north,
+        "east", &script_mapgen_context::east,
+        "south", &script_mapgen_context::south,
+        "west", &script_mapgen_context::west,
+        "neast", &script_mapgen_context::neast,
+        "seast", &script_mapgen_context::seast,
+        "swest", &script_mapgen_context::swest,
+        "nwest", &script_mapgen_context::nwest,
+        "above", &script_mapgen_context::above,
+        "below", &script_mapgen_context::below,
+        "get_nesw", &script_mapgen_context::get_nesw,
+        "zlevel", &script_mapgen_context::zlevel,
+        "get_direction", &script_mapgen_context::get_direction,
+        "set_dir", &script_mapgen_context::set_dir,
+        "get_rotation", &script_mapgen_context::get_rotation,
+        "get_rot_suffix", &script_mapgen_context::get_rot_suffix,
+        "random_int", &script_mapgen_context::random_int,
+        "random_chance", &script_mapgen_context::random_chance,
+        "terrain_at", &script_mapgen_context::terrain_at,
+        "furniture_at", &script_mapgen_context::furniture_at,
+        "trap_at", &script_mapgen_context::trap_at,
+        "set_terrain", &script_mapgen_context::set_terrain,
+        "set_furniture", &script_mapgen_context::set_furniture,
+        "set_trap", &script_mapgen_context::set_trap,
+        "set_terrain_id", &script_mapgen_context::set_terrain_id,
+        "set_furniture_id", &script_mapgen_context::set_furniture_id,
+        "set_trap_id", &script_mapgen_context::set_trap_id,
+        "reset", &script_mapgen_context::reset,
+        "place_item", &script_mapgen_context::place_item,
+        "place_item_group", &script_mapgen_context::place_item_group,
+        "place_liquid", &script_mapgen_context::place_liquid,
+        "place_toilet", &script_mapgen_context::place_toilet,
+        "place_sign", &script_mapgen_context::place_sign,
+        "place_zone", &script_mapgen_context::place_zone,
+        "place_npc", &script_mapgen_context::place_npc,
+        "place_vehicle", &script_mapgen_context::place_vehicle,
+        "apply_faction_ownership",
+        &script_mapgen_context::apply_faction_ownership,
+        "fill_groundcover", &script_mapgen_context::fill_groundcover,
+        "nest", &script_mapgen_context::nest,
+        "generate", &script_mapgen_context::generate );
 }
 
 } // namespace cata::lua_ui

--- a/src/catalua_ui_mapgen.h
+++ b/src/catalua_ui_mapgen.h
@@ -72,6 +72,36 @@ class script_mapgen_context
         bool set_trap( int x, int y,
                        const std::optional<script_game_id> &id );
 
+        bool set_terrain_id( int x, int y, const std::string &id );
+        bool set_furniture_id( int x, int y, const std::string &id );
+        bool set_trap_id( int x, int y, const std::string &id );
+        void reset( const std::string &terrain_id );
+        void place_item( int x, int y, const std::string &item_id,
+                         int quantity, int charges,
+                         const std::string &faction_id );
+        void place_item_group( int x1, int y1, int x2, int y2,
+                               const std::string &group_id, int chance,
+                               const std::string &faction_id );
+        void place_liquid( int x, int y, const std::string &item_id,
+                           int charges );
+        void place_toilet( int x, int y, int charges );
+        void place_sign( int x, int y, const std::string &text,
+                         const std::string &furniture_id );
+        void place_zone( int x1, int y1, int x2, int y2,
+                         const std::string &zone_type,
+                         const std::string &faction,
+                         const std::string &name,
+                         const std::string &filter );
+        std::int64_t place_npc( int x, int y,
+                                const std::string &template_id,
+                                const std::string &unique_id );
+        bool place_vehicle( int x, int y,
+                            const std::string &prototype_or_group_id,
+                            int rotation_degrees, int fuel_percent,
+                            int status, const std::string &faction );
+        void apply_faction_ownership( int x1, int y1, int x2, int y2,
+                                      const std::string &faction );
+
         void fill_groundcover();
         void nest( const std::string &id, int x, int y );
         void generate( const std::string &id );
@@ -85,6 +115,10 @@ class script_mapgen_context
         void consume( std::size_t amount ) const;
         std::uint64_t next_random();
 };
+
+#if defined(CATA_ENABLE_LUA_UI) && CATA_ENABLE_LUA_UI
+void install_script_mapgen_context_api( sol::state &lua );
+#endif
 
 } // namespace cata::lua_ui
 

--- a/src/catalua_ui_npcs.cpp
+++ b/src/catalua_ui_npcs.cpp
@@ -16,6 +16,7 @@
 
 #include "avatar.h"
 #include "auto_pickup.h"
+#include "calendar.h"
 #include "catalua_bindings_coords.h"
 #include "catalua_bindings_values.h"
 #include "catalua_game_handle.h"
@@ -24,6 +25,7 @@
 #include "game.h"
 #include "npc.h"
 #include "npc_class.h"
+#include "npctrade.h"
 
 namespace cata::lua_ui
 {
@@ -414,6 +416,8 @@ sol::table snapshot_npc(
     result["patrolling"] = entry.is_patrolling();
     result["shopkeeper"] =
         entry.is_shopkeeper();
+    result["restock_turn"] =
+        to_turn<std::int64_t>( entry.restock_time() );
     result["faction_representative"] =
         entry.faction_representative;
     result["opinion"] =
@@ -564,6 +568,51 @@ sol::table get_npc(
                        state, *entry,
                        runtime_generation,
                        world_generation ) ) );
+}
+
+sol::table open_trade(
+    sol::this_state lua, const game_handle &handle, const int cost,
+    const std::string &deal,
+    const game_handle_runtime &runtime_generation,
+    const std::size_t world_generation )
+{
+    if( cost < 0 ) {
+        throw std::invalid_argument( "game.trade.open cost cannot be negative" );
+    }
+    if( deal.empty() || deal.size() > 256 ) {
+        throw std::invalid_argument(
+            "game.trade.open deal must contain 1 to 256 bytes" );
+    }
+    sol::state_view state( lua );
+    std::optional<game_handle_error> error;
+    npc *entry = resolve_npc(
+                     handle, runtime_generation, world_generation, error );
+    if( entry == nullptr ) {
+        return make_game_error_result( state, *error );
+    }
+    return make_game_value_result(
+               state, sol::make_object(
+                   state, npc_trading::trade( *entry, cost, deal ) ) );
+}
+
+sol::table pay_npc(
+    sol::this_state lua, const game_handle &handle, const int cost,
+    const game_handle_runtime &runtime_generation,
+    const std::size_t world_generation )
+{
+    if( cost <= 0 ) {
+        throw std::invalid_argument( "game.trade.pay cost must be positive" );
+    }
+    sol::state_view state( lua );
+    std::optional<game_handle_error> error;
+    npc *entry = resolve_npc(
+                     handle, runtime_generation, world_generation, error );
+    if( entry == nullptr ) {
+        return make_game_error_result( state, *error );
+    }
+    return make_game_value_result(
+               state, sol::make_object(
+                   state, npc_trading::pay_npc( *entry, cost ) ) );
 }
 
 void validate_npc_name( const std::string &name )
@@ -922,6 +971,31 @@ void install_npc_api(
                        state, snapshot_ai_rules( state, *entry ) ) );
     } );
     game["npcs"] = std::move( npcs );
+
+    sol::table trade = lua.create_table();
+    trade.set_function(
+        "open",
+        [current_runtime_generation, current_world_generation, require_write](
+            sol::this_state lua_state, const game_handle &handle,
+            const sol::optional<int> &cost,
+    const sol::optional<std::string> &deal ) {
+        require_write();
+        return open_trade(
+                   lua_state, handle, cost.value_or( 0 ),
+                   deal.value_or( "Trade" ), current_runtime_generation(),
+                   current_world_generation() );
+    } );
+    trade.set_function(
+        "pay",
+        [current_runtime_generation, current_world_generation, require_write](
+            sol::this_state lua_state, const game_handle &handle,
+    const int cost ) {
+        require_write();
+        return pay_npc(
+                   lua_state, handle, cost, current_runtime_generation(),
+                   current_world_generation() );
+    } );
+    game["trade"] = std::move( trade );
 }
 
 } // namespace cata::lua_ui

--- a/src/catalua_ui_vehicles.cpp
+++ b/src/catalua_ui_vehicles.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cmath>
 #include <cstddef>
 #include <map>
 #include <optional>
@@ -14,14 +15,21 @@
 #include <utility>
 #include <vector>
 
+#include "avatar.h"
 #include "catalua_bindings_coords.h"
 #include "catalua_bindings_values.h"
 #include "catalua_game_handle.h"
 #include "coordinates.h"
+#include "game.h"
 #include "map.h"
+#include "math_parser_diag_value.h"
+#include "npc.h"
+#include "npctalk.h"
+#include "npctrade.h"
 #include "units.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_price.h"
 
 namespace cata::lua_ui
 {
@@ -40,6 +48,12 @@ constexpr int maximum_part_offset = 1000000;
 constexpr std::size_t maximum_fuel_entries = 128;
 constexpr std::size_t maximum_vehicle_name_bytes = 256;
 constexpr int maximum_requested_velocity = 1000000;
+constexpr int minimum_spawn_fuel = -1;
+constexpr int maximum_spawn_fuel = 100;
+
+const std::string vehicle_service_target = "vehicle_part_repair_target";
+const std::string vehicle_repair_multiplier = "vehicle_part_repair_price_multiplier";
+const std::string vehicle_install_multiplier = "vehicle_part_install_price_multiplier";
 
 struct definition_options {
     int offset = 0;
@@ -248,6 +262,60 @@ vehicle *resolve_vehicle(
         return nullptr;
     }
     return resolved.value;
+}
+
+npc *resolve_mechanic(
+    const game_handle &handle, const game_handle_runtime &runtime_generation,
+    const std::size_t world_generation,
+    std::optional<game_handle_error> &error )
+{
+    const native_handle_result<Creature> resolved =
+        handle.resolve_creature( runtime_generation, world_generation );
+    if( !resolved ) {
+        error = resolved.error;
+        return nullptr;
+    }
+    npc *result = resolved.value->as_npc();
+    if( result == nullptr ) {
+        error = game_handle_error{
+            "wrong_subtype", "The requested character is not an NPC"
+        };
+    }
+    return result;
+}
+
+game_handle make_vehicle_handle(
+    vehicle &entry, const game_handle_runtime &runtime_generation,
+    const std::size_t world_generation )
+{
+    const tripoint_abs_ms position = entry.pos_abs();
+    game_handle_locator locator;
+    locator.scope = "map_vehicle";
+    locator.x = position.x();
+    locator.y = position.y();
+    locator.z = position.z();
+    return game_handle::from_vehicle(
+               entry, std::move( locator ), runtime_generation,
+               world_generation );
+}
+
+tripoint_bub_ms require_loaded_position(
+    map &here, const script_tripoint_coord &position,
+    const std::string_view api_name )
+{
+    if( position.native_origin() != coords::origin::abs ||
+        position.native_scale() != coords::scale::map_square ) {
+        throw std::invalid_argument(
+            std::string( api_name ) +
+            " requires an absolute map-square Tripoint" );
+    }
+    const tripoint_abs_ms absolute( position.to_native() );
+    if( !here.inbounds( absolute ) ) {
+        throw std::invalid_argument(
+            std::string( api_name ) +
+            " position is outside the active map" );
+    }
+    return here.get_bub( absolute );
 }
 
 sol::table snapshot_motion(
@@ -948,6 +1016,357 @@ sol::table set_vehicle_part_enabled(
                    state, std::move( value ) ) );
 }
 
+int prototype_value( const script_game_id &id, const bool post_cataclysm )
+{
+    require_vehicle_prototype_id( id, "game.vehicles.prototype_value" );
+    const vehicle_prototype &prototype = vproto_id( id.value() ).obj();
+    return prototype.blueprint ?
+           vehicle_part_base_price( *prototype.blueprint, post_cataclysm ) : 0;
+}
+
+sol::table live_vehicle_value(
+    sol::this_state lua, const game_handle &handle,
+    const sol::optional<sol::table> &requested,
+    const game_handle_runtime &runtime_generation,
+    const std::size_t world_generation )
+{
+    bool post_cataclysm = true;
+    bool include_liquid_engine_fuel = true;
+    if( requested ) {
+        post_cataclysm = requested->get_or( "post_cataclysm", post_cataclysm );
+        include_liquid_engine_fuel = requested->get_or(
+                                         "include_liquid_engine_fuel",
+                                         include_liquid_engine_fuel );
+    }
+    sol::state_view state( lua );
+    std::optional<game_handle_error> error;
+    vehicle *entry = resolve_vehicle(
+                         handle, runtime_generation, world_generation, error );
+    if( entry == nullptr ) {
+        return make_game_error_result( state, *error );
+    }
+    const int parts = vehicle_part_base_price( *entry, post_cataclysm );
+    const int fuel = post_cataclysm && include_liquid_engine_fuel ?
+                     vehicle_tank_fuel_price_postapoc( *entry ) : 0;
+    sol::table value = state.create_table();
+    value["parts_cents"] = parts;
+    value["liquid_engine_fuel_cents"] = fuel;
+    value["total_cents"] = parts + fuel;
+    value["post_cataclysm"] = post_cataclysm;
+    return make_game_value_result(
+               state, sol::make_object( state, std::move( value ) ) );
+}
+
+sol::table is_player_controlling_vehicle(
+    sol::this_state lua, const game_handle &handle,
+    const game_handle_runtime &runtime_generation,
+    const std::size_t world_generation )
+{
+    sol::state_view state( lua );
+    std::optional<game_handle_error> error;
+    vehicle *entry = resolve_vehicle(
+                         handle, runtime_generation, world_generation, error );
+    if( entry == nullptr ) {
+        return make_game_error_result( state, *error );
+    }
+    return make_game_value_result(
+               state, sol::make_object(
+                   state, entry->player_in_control( get_map(), get_avatar() ) ) );
+}
+
+struct vehicle_spawn_options {
+    int rotation_degrees = 0;
+    int fuel_percent = -1;
+    int status = -1;
+    bool merge_wrecks = false;
+    std::optional<faction_id> owner;
+};
+
+vehicle_spawn_options read_vehicle_spawn_options(
+    const sol::optional<sol::table> &requested )
+{
+    vehicle_spawn_options result;
+    if( requested ) {
+        result.rotation_degrees = requested->get_or(
+                                      "rotation_degrees", result.rotation_degrees );
+        result.fuel_percent = requested->get_or(
+                                  "fuel_percent", result.fuel_percent );
+        result.status = requested->get_or( "status", result.status );
+        result.merge_wrecks = requested->get_or(
+                                  "merge_wrecks", result.merge_wrecks );
+        const sol::object owner = requested->raw_get<sol::object>( "owner" );
+        if( owner.valid() && owner.get_type() != sol::type::nil ) {
+            if( !owner.is<script_game_id>() ) {
+                throw std::invalid_argument(
+                    "game.vehicles.spawn owner must be a GameId<faction>" );
+            }
+            const script_game_id id = owner.as<script_game_id>();
+            if( id.kind() != "faction" || !id.is_valid() ) {
+                throw std::invalid_argument(
+                    "game.vehicles.spawn owner must be a valid GameId<faction>" );
+            }
+            result.owner = faction_id( id.value() );
+        }
+    }
+    if( result.rotation_degrees < -360 || result.rotation_degrees > 360 ) {
+        throw std::invalid_argument(
+            "game.vehicles.spawn rotation_degrees must be within -360..360" );
+    }
+    if( result.fuel_percent < minimum_spawn_fuel ||
+        result.fuel_percent > maximum_spawn_fuel ) {
+        throw std::invalid_argument(
+            "game.vehicles.spawn fuel_percent must be within -1..100" );
+    }
+    if( result.status < -1 || result.status > 2 ) {
+        throw std::invalid_argument(
+            "game.vehicles.spawn status must be within -1..2" );
+    }
+    return result;
+}
+
+sol::table spawn_vehicle(
+    sol::this_state lua, const script_game_id &prototype,
+    const script_tripoint_coord &position,
+    const sol::optional<sol::table> &requested,
+    const game_handle_runtime &runtime_generation,
+    const std::size_t world_generation )
+{
+    require_vehicle_prototype_id( prototype, "game.vehicles.spawn" );
+    const vehicle_spawn_options options = read_vehicle_spawn_options( requested );
+    map &here = get_map();
+    const tripoint_bub_ms local = require_loaded_position(
+                                      here, position, "game.vehicles.spawn" );
+    vehicle *created = here.add_vehicle(
+                           vproto_id( prototype.value() ), local,
+                           units::from_degrees( options.rotation_degrees ),
+                           options.fuel_percent,
+                           static_cast<veh_spawn_status>( options.status ),
+                           options.merge_wrecks, true );
+    sol::state_view state( lua );
+    if( created == nullptr ) {
+        return make_game_error_result(
+        state, { "blocked", "The vehicle could not be placed at the requested position" } );
+    }
+    if( options.owner ) {
+        created->set_owner( *options.owner );
+        created->remove_old_owner();
+    }
+    sol::table value = state.create_table();
+    value["handle"] = make_vehicle_handle(
+                           *created, runtime_generation, world_generation );
+    value["vehicle"] = snapshot_live_vehicle( state, here, *created );
+    return make_game_value_result(
+               state, sol::make_object( state, std::move( value ) ) );
+}
+
+sol::table destroy_live_vehicle(
+    sol::this_state lua, const game_handle &handle,
+    const game_handle_runtime &runtime_generation,
+    const std::size_t world_generation )
+{
+    sol::state_view state( lua );
+    std::optional<game_handle_error> error;
+    vehicle *entry = resolve_vehicle(
+                         handle, runtime_generation, world_generation, error );
+    if( entry == nullptr ) {
+        return make_game_error_result( state, *error );
+    }
+    if( !entry->boarded_parts().empty() ) {
+        return make_game_error_result(
+                   state, { "blocked", "The vehicle cannot be destroyed while occupied" } );
+    }
+    sol::table value = state.create_table();
+    value["name"] = entry->disp_name();
+    value["position"] = script_tripoint_coord::from_native(
+                              coords::origin::abs, coords::scale::map_square,
+                              entry->pos_abs().raw() );
+    get_map().destroy_vehicle( entry );
+    value["destroyed"] = true;
+    return make_game_value_result(
+               state, sol::make_object( state, std::move( value ) ) );
+}
+
+sol::table set_vehicle_owner(
+    sol::this_state lua, const game_handle &handle,
+    const script_game_id &owner,
+    const game_handle_runtime &runtime_generation,
+    const std::size_t world_generation )
+{
+    if( owner.kind() != "faction" || !owner.is_valid() ) {
+        throw std::invalid_argument(
+            "game.vehicles.set_owner requires a valid GameId<faction>" );
+    }
+    sol::state_view state( lua );
+    std::optional<game_handle_error> error;
+    vehicle *entry = resolve_vehicle(
+                         handle, runtime_generation, world_generation, error );
+    if( entry == nullptr ) {
+        return make_game_error_result( state, *error );
+    }
+    sol::table value = state.create_table();
+    value["before"] = entry->get_owner().is_null() ? sol::make_object( state, sol::nil ) :
+                      sol::make_object( state, script_game_id(
+                                           "faction", entry->get_owner().str() ) );
+    entry->set_owner( faction_id( owner.value() ) );
+    entry->remove_old_owner();
+    value["after"] = owner;
+    return make_game_value_result(
+               state, sol::make_object( state, std::move( value ) ) );
+}
+
+void mark_vehicle_for_service( vehicle &target, const double repair_multiplier,
+                               const double install_multiplier )
+{
+    for( wrapped_vehicle &wrapped : get_map().get_vehicles() ) {
+        if( wrapped.v != nullptr ) {
+            wrapped.v->remove_value( vehicle_service_target );
+        }
+    }
+    target.set_value( vehicle_service_target, "yes" );
+    static_cast<void>( repair_multiplier );
+    static_cast<void>( install_multiplier );
+}
+
+std::string npc_value_string( const npc &mechanic, const std::string &key )
+{
+    const diag_value *value = mechanic.maybe_get_value( key );
+    return value == nullptr ? std::string() : value->to_string();
+}
+
+int npc_value_integer( const npc &mechanic, const std::string &key )
+{
+    const diag_value *value = mechanic.maybe_get_value( key );
+    return value != nullptr && value->is_dbl() ? static_cast<int>( value->dbl() ) : 0;
+}
+
+sol::table full_repair_quote_value( sol::state_view state, const npc &mechanic )
+{
+    sol::table value = state.create_table();
+    value["status"] = npc_value_string( mechanic, "vehicle_full_repair_status" );
+    value["vehicle_name"] = npc_value_string(
+                                  mechanic, "vehicle_full_repair_vehicle_name" );
+    value["part_count"] = npc_value_integer(
+                                mechanic, "vehicle_full_repair_part_count" );
+    value["cost_cents"] = npc_value_integer(
+                                mechanic, "vehicle_full_repair_cost" );
+    value["cost_text"] = npc_value_string(
+                               mechanic, "vehicle_full_repair_cost_text" );
+    value["time_turns"] = npc_value_integer(
+                                mechanic, "vehicle_full_repair_time" );
+    value["time_text"] = npc_value_string(
+                               mechanic, "vehicle_full_repair_time_text" );
+    return value;
+}
+
+std::pair<vehicle *, npc *> resolve_vehicle_service(
+    const game_handle &vehicle_handle, const game_handle &mechanic_handle,
+    const game_handle_runtime &runtime_generation,
+    const std::size_t world_generation,
+    std::optional<game_handle_error> &error )
+{
+    vehicle *target = resolve_vehicle(
+                          vehicle_handle, runtime_generation, world_generation, error );
+    if( target == nullptr ) {
+        return { nullptr, nullptr };
+    }
+    npc *mechanic = resolve_mechanic(
+                        mechanic_handle, runtime_generation, world_generation, error );
+    return { target, mechanic };
+}
+
+sol::table quote_full_repair(
+    sol::this_state lua, const game_handle &vehicle_handle,
+    const game_handle &mechanic_handle, const double repair_multiplier,
+    const game_handle_runtime &runtime_generation,
+    const std::size_t world_generation )
+{
+    if( !std::isfinite( repair_multiplier ) || repair_multiplier <= 0.0 ||
+        repair_multiplier > 1000.0 ) {
+        throw std::invalid_argument(
+            "game.vehicles.quote_full_repair multiplier must be within (0, 1000]" );
+    }
+    sol::state_view state( lua );
+    std::optional<game_handle_error> error;
+    const auto [target, mechanic] = resolve_vehicle_service(
+                                        vehicle_handle, mechanic_handle,
+                                        runtime_generation, world_generation, error );
+    if( target == nullptr || mechanic == nullptr ) {
+        return make_game_error_result( state, *error );
+    }
+    mark_vehicle_for_service( *target, repair_multiplier, 1.0 );
+    mechanic->set_value( vehicle_repair_multiplier, repair_multiplier );
+    talk_function::quote_vehicle_full_repair( *mechanic );
+    return make_game_value_result(
+               state, sol::make_object(
+                   state, full_repair_quote_value( state, *mechanic ) ) );
+}
+
+sol::table start_full_repair(
+    sol::this_state lua, const game_handle &vehicle_handle,
+    const game_handle &mechanic_handle, const double repair_multiplier,
+    const game_handle_runtime &runtime_generation,
+    const std::size_t world_generation )
+{
+    sol::table quoted = quote_full_repair(
+                            lua, vehicle_handle, mechanic_handle, repair_multiplier,
+                            runtime_generation, world_generation );
+    if( !quoted.get_or( "ok", false ) ) {
+        return quoted;
+    }
+    sol::state_view state( lua );
+    std::optional<game_handle_error> error;
+    npc *mechanic = resolve_mechanic(
+                        mechanic_handle, runtime_generation, world_generation, error );
+    if( mechanic == nullptr ) {
+        return make_game_error_result( state, *error );
+    }
+    const int cost = npc_value_integer( *mechanic, "vehicle_full_repair_cost" );
+    if( npc_value_string( *mechanic, "vehicle_full_repair_status" ) != "quoted" || cost <= 0 ) {
+        return quoted;
+    }
+    if( !npc_trading::pay_npc( *mechanic, cost ) ) {
+        sol::table value = full_repair_quote_value( state, *mechanic );
+        value["status"] = "payment_cancelled";
+        return make_game_value_result(
+                   state, sol::make_object( state, std::move( value ) ) );
+    }
+    talk_function::start_vehicle_full_repair( *mechanic );
+    return make_game_value_result(
+               state, sol::make_object(
+                   state, full_repair_quote_value( state, *mechanic ) ) );
+}
+
+sol::table open_part_service(
+    sol::this_state lua, const game_handle &vehicle_handle,
+    const game_handle &mechanic_handle, const double repair_multiplier,
+    const double install_multiplier,
+    const game_handle_runtime &runtime_generation,
+    const std::size_t world_generation )
+{
+    if( !std::isfinite( repair_multiplier ) || repair_multiplier <= 0.0 ||
+        repair_multiplier > 1000.0 || !std::isfinite( install_multiplier ) ||
+        install_multiplier <= 0.0 || install_multiplier > 1000.0 ) {
+        throw std::invalid_argument(
+            "game.vehicles.open_part_service multipliers must be within (0, 1000]" );
+    }
+    sol::state_view state( lua );
+    std::optional<game_handle_error> error;
+    const auto [target, mechanic] = resolve_vehicle_service(
+                                        vehicle_handle, mechanic_handle,
+                                        runtime_generation, world_generation, error );
+    if( target == nullptr || mechanic == nullptr ) {
+        return make_game_error_result( state, *error );
+    }
+    mark_vehicle_for_service( *target, repair_multiplier, install_multiplier );
+    mechanic->set_value( vehicle_repair_multiplier, repair_multiplier );
+    mechanic->set_value( vehicle_install_multiplier, install_multiplier );
+    talk_function::select_vehicle_part_service( *mechanic );
+    sol::table value = state.create_table();
+    value["status"] = npc_value_string( *mechanic, "vehicle_part_service_status" );
+    return make_game_value_result(
+               state, sol::make_object( state, std::move( value ) ) );
+}
+
 } // namespace
 
 void install_vehicle_api(
@@ -1061,6 +1480,100 @@ void install_vehicle_api(
                    lua_state, handle, part_index, enabled,
                    current_runtime_generation(),
                    current_world_generation() );
+    } );
+    vehicles_api.set_function(
+        "prototype_value",
+        [require_read]( const script_game_id &id,
+    const sol::optional<bool> &post_cataclysm ) {
+        require_read();
+        return prototype_value( id, post_cataclysm.value_or( true ) );
+    } );
+    vehicles_api.set_function(
+        "value",
+        [current_runtime_generation, current_world_generation, require_read](
+            sol::this_state lua_state, const game_handle &handle,
+    const sol::optional<sol::table> &options ) {
+        require_read();
+        return live_vehicle_value(
+                   lua_state, handle, options, current_runtime_generation(),
+                   current_world_generation() );
+    } );
+    vehicles_api.set_function(
+        "is_player_controlling",
+        [current_runtime_generation, current_world_generation, require_read](
+    sol::this_state lua_state, const game_handle &handle ) {
+        require_read();
+        return is_player_controlling_vehicle(
+                   lua_state, handle, current_runtime_generation(),
+                   current_world_generation() );
+    } );
+    vehicles_api.set_function(
+        "spawn",
+        [current_runtime_generation, current_world_generation, require_write](
+            sol::this_state lua_state, const script_game_id &prototype,
+            const script_tripoint_coord &position,
+    const sol::optional<sol::table> &options ) {
+        require_write();
+        return spawn_vehicle(
+                   lua_state, prototype, position, options,
+                   current_runtime_generation(), current_world_generation() );
+    } );
+    vehicles_api.set_function(
+        "destroy",
+        [current_runtime_generation, current_world_generation, require_write](
+    sol::this_state lua_state, const game_handle &handle ) {
+        require_write();
+        return destroy_live_vehicle(
+                   lua_state, handle, current_runtime_generation(),
+                   current_world_generation() );
+    } );
+    vehicles_api.set_function(
+        "set_owner",
+        [current_runtime_generation, current_world_generation, require_write](
+            sol::this_state lua_state, const game_handle &handle,
+    const script_game_id &owner ) {
+        require_write();
+        return set_vehicle_owner(
+                   lua_state, handle, owner, current_runtime_generation(),
+                   current_world_generation() );
+    } );
+    vehicles_api.set_function(
+        "quote_full_repair",
+        [current_runtime_generation, current_world_generation, require_write](
+            sol::this_state lua_state, const game_handle &vehicle_handle,
+            const game_handle &mechanic_handle,
+    const sol::optional<double> &repair_multiplier ) {
+        require_write();
+        return quote_full_repair(
+                   lua_state, vehicle_handle, mechanic_handle,
+                   repair_multiplier.value_or( 1.0 ), current_runtime_generation(),
+                   current_world_generation() );
+    } );
+    vehicles_api.set_function(
+        "start_full_repair",
+        [current_runtime_generation, current_world_generation, require_write](
+            sol::this_state lua_state, const game_handle &vehicle_handle,
+            const game_handle &mechanic_handle,
+    const sol::optional<double> &repair_multiplier ) {
+        require_write();
+        return start_full_repair(
+                   lua_state, vehicle_handle, mechanic_handle,
+                   repair_multiplier.value_or( 1.0 ), current_runtime_generation(),
+                   current_world_generation() );
+    } );
+    vehicles_api.set_function(
+        "open_part_service",
+        [current_runtime_generation, current_world_generation, require_write](
+            sol::this_state lua_state, const game_handle &vehicle_handle,
+            const game_handle &mechanic_handle,
+            const sol::optional<double> &repair_multiplier,
+    const sol::optional<double> &install_multiplier ) {
+        require_write();
+        return open_part_service(
+                   lua_state, vehicle_handle, mechanic_handle,
+                   repair_multiplier.value_or( 1.0 ),
+                   install_multiplier.value_or( 1.0 ),
+                   current_runtime_generation(), current_world_generation() );
     } );
     game["vehicles"] = std::move( vehicles_api );
 }

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "calendar.h"
+#include "catalua_platform_content.h"
 #include "character.h"
 #include "debug.h"
 #include "flexbuffer_json.h"
@@ -25,6 +26,11 @@ namespace npc_factions
 {
 static std::vector<faction_template> all_templates;
 } // namespace npc_factions
+
+std::vector<faction_template> &cata::lua_platform::detail::faction_template_registry()
+{
+    return npc_factions::all_templates;
+}
 
 faction_template::faction_template()
 {

--- a/src/faction.h
+++ b/src/faction.h
@@ -33,6 +33,11 @@ std::string fac_wealth_text( int val, int size );
 std::string fac_combat_ability_text( int val );
 
 class JsonObject;
+
+namespace cata::lua_platform
+{
+class world_content_transaction;
+} // namespace cata::lua_platform
 class JsonOut;
 class JsonValue;
 class item;
@@ -111,6 +116,7 @@ struct faction_epilogue_data {
 
 class faction_template
 {
+    friend class cata::lua_platform::world_content_transaction;
     protected:
         faction_template();
         void load_relations( const JsonObject &jsobj );

--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -535,6 +535,12 @@ class generic_factory
         std::vector<T> &get_all_mod() {
             return list;
         }
+
+        /** Returns a JSON abstract while inheritance is still being resolved. */
+        const T *find_abstract( const std::string &id ) const {
+            const auto found = abstracts.find( id );
+            return found == abstracts.end() ? nullptr : &found->second;
+        }
         /**
          * @name `string_id/int_id` interface functions
          *

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -6557,7 +6557,8 @@ void map::draw_map( mapgendata &dat )
     const oter_id &terrain_type = dat.terrain_type();
     const std::string function_key = terrain_type->get_mapgen_id();
 
-    if( !run_mapgen_func( function_key, dat ) ) {
+    if( !run_mapgen_func( function_key, dat ) &&
+        !cata::lua_ui::dispatch_mapgen_generate( dat ) ) {
         debugmsg( "Error: tried to generate map for omtype %s, \"%s\" (id_mapgen %s)",
                   terrain_type.id().c_str(), terrain_type->get_name( om_vision_level::full ), function_key.c_str() );
         // Fallback to the default mapgen for this z-level or just a grass fill if something has gone horribly wrong

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -61,6 +61,7 @@
 #include "value_ptr.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_price.h"
 #include "vpart_position.h"
 #include "vpart_range.h"
 #include "weather.h"
@@ -95,57 +96,6 @@ bool is_beta( char scope )
         default:
             return false;
     }
-}
-
-int vehicle_part_base_price( const vehicle &veh, bool practical )
-{
-    int ret = 0;
-    for( const vpart_reference &vpr : veh.get_all_parts() ) {
-        const vehicle_part &vp = vpr.part();
-        if( vp.removed ) {
-            continue;
-        }
-        ret += vp.get_base().price_no_contents( practical );
-    }
-    return ret;
-}
-
-std::set<itype_id> vehicle_liquid_engine_fuels()
-{
-    std::set<itype_id> result;
-    for( const vpart_info &vpi : vehicles::parts::get_all() ) {
-        if( !vpi.engine_info ) {
-            continue;
-        }
-        for( const itype_id &fuel_id : vpi.engine_info->fuel_opts ) {
-            if( fuel_id.is_null() || !fuel_id.is_valid() ) {
-                continue;
-            }
-            const item fuel( fuel_id, calendar::turn_zero, 1 );
-            if( fuel.made_of( phase_id::LIQUID ) ) {
-                result.insert( fuel_id );
-            }
-        }
-    }
-    return result;
-}
-
-int vehicle_tank_fuel_price_postapoc( const vehicle &veh )
-{
-    const std::set<itype_id> liquid_engine_fuels = vehicle_liquid_engine_fuels();
-    int ret = 0;
-    for( const vpart_reference &vpr : veh.get_any_parts( vpart_bitflags::VPFLAG_FLUIDTANK ) ) {
-        const vehicle_part &vp = vpr.part();
-        if( vp.has_flag( vp_flag::carried_flag ) || vp.ammo_remaining() <= 0 ) {
-            continue;
-        }
-        const itype_id fuel_id = vp.ammo_current();
-        if( !liquid_engine_fuels.count( fuel_id ) ) {
-            continue;
-        }
-        ret += item( fuel_id, calendar::turn_zero, vp.ammo_remaining() ).price_no_contents( true );
-    }
-    return ret;
 }
 
 constexpr bool is_true( double dbl )

--- a/src/mod_manager.cpp
+++ b/src/mod_manager.cpp
@@ -436,6 +436,18 @@ void mod_manager::load_lua_platform_mod( const cata_path &root )
         record_rejection( "Mod version must contain between 1 and 128 bytes" );
         return;
     }
+    if( definition.description_set &&
+        ( definition.description.size() > 4096 ||
+          definition.description.find( '\0' ) != std::string::npos ) ) {
+        record_rejection( "Mod description cannot exceed 4096 bytes or contain NUL" );
+        return;
+    }
+    if( definition.category_set &&
+        ( definition.category.empty() || definition.category.size() > 128 ||
+          definition.category.find( '\0' ) != std::string::npos ) ) {
+        record_rejection( "Mod category must contain between 1 and 128 bytes" );
+        return;
+    }
     if( ident_string.find( '#' ) != std::string::npos ) {
         record_rejection( "Mod id '" + ident_string +
                           "' contains illegal '#' character" );
@@ -462,6 +474,36 @@ void mod_manager::load_lua_platform_mod( const cata_path &root )
             return;
         }
         dependencies.push_back( dependency );
+    }
+    std::set<std::string> authors;
+    for( const std::string &author : definition.authors ) {
+        if( author.empty() || author.size() > 256 ||
+            author.find( '\0' ) != std::string::npos ) {
+            record_rejection( "Mod authors must contain between 1 and 256 bytes" );
+            return;
+        }
+        if( !authors.insert( author ).second ) {
+            record_rejection( "duplicate Mod author '" + author + "'" );
+            return;
+        }
+    }
+
+    std::optional<std::pair<int, translation>> category;
+    if( definition.category_set ) {
+        const auto found = std::find_if(
+                               get_mod_list_categories().begin(),
+                               get_mod_list_categories().end(),
+        [&definition]( const auto & entry ) {
+            return entry.first == definition.category;
+        } );
+        if( found == get_mod_list_categories().end() ) {
+            record_rejection( "unknown Mod category '" + definition.category + "'" );
+            return;
+        }
+        category = std::make_pair(
+                       static_cast<int>( std::distance(
+                                             get_mod_list_categories().begin(), found ) ),
+                       found->second );
     }
 
     const std::string entry_string = definition.entry_set ? definition.entry : "main.lua";
@@ -511,6 +553,15 @@ void mod_manager::load_lua_platform_mod( const cata_path &root )
         if( definition.dependencies_set ) {
             hybrid.dependencies = std::move( dependencies );
         }
+        if( definition.authors_set ) {
+            hybrid.authors = std::move( authors );
+        }
+        if( definition.description_set ) {
+            hybrid.description = no_translation( definition.description );
+        }
+        if( category ) {
+            hybrid.category = *category;
+        }
         if( definition.core_set ) {
             hybrid.core = definition.core;
         }
@@ -530,11 +581,14 @@ void mod_manager::load_lua_platform_mod( const cata_path &root )
     mod.ident = ident;
     mod.name_ = no_translation( definition.name_set ? definition.name : ident_string );
     const size_t default_category = get_mod_list_categories().size() - 1;
-    mod.category = { static_cast<int>( default_category ),
-                     get_mod_list_categories()[default_category].second
-                   };
+    mod.category = category.value_or( std::make_pair(
+                                          static_cast<int>( default_category ),
+                                          get_mod_list_categories()[default_category].second ) );
     mod.version = definition.version_set ? definition.version : std::string();
     mod.dependencies = std::move( dependencies );
+    mod.authors = std::move( authors );
+    mod.description = definition.description_set ?
+                      no_translation( definition.description ) : translation();
     mod.core = definition.core_set && definition.core;
     mod.path = root;
     mod.mod_root_path = root;

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -1073,11 +1073,17 @@ void mutation_branch::load_trait_group( const JsonObject &jsobj )
 
 void cata::lua_platform::detail::insert_platform_trait_group(
     const std::string &id,
-    const std::vector<std::pair<std::string, std::int64_t>> &entries )
+    const std::vector<platform_trait_group_entry> &entries )
 {
     auto group = make_shared_fast<Trait_group_collection>( 100 );
-    for( const auto &[trait, weight] : entries ) {
-        group->add_trait_entry( trait_id( trait ), "", static_cast<int>( weight ) );
+    for( const platform_trait_group_entry &entry : entries ) {
+        if( entry.group ) {
+            group->add_group_entry( trait_group::Trait_group_tag( entry.id ),
+                                    static_cast<int>( entry.weight ) );
+        } else {
+            group->add_trait_entry( trait_id( entry.id ), entry.variant,
+                                    static_cast<int>( entry.weight ) );
+        }
     }
     trait_groups[trait_group::Trait_group_tag( id )] = std::move( group );
 }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -181,13 +181,6 @@ static void starting_clothes( npc &who, const npc_class_id &type, bool male );
 static void starting_inv( npc &who, const npc_class_id &type );
 static void starting_inv_ammo( npc &who, std::list<item> &res, int multiplier );
 
-template <typename T> struct enum_traits;
-
-template<>
-struct enum_traits<npc_mission> {
-    static constexpr npc_mission last = npc_mission::NPC_MISSION_LAST;
-};
-
 namespace io
 {
 template<>

--- a/src/npc.h
+++ b/src/npc.h
@@ -54,6 +54,14 @@ class mission;
 class monster;
 class talker;
 class vehicle;
+template<typename E>
+struct enum_traits;
+
+namespace io
+{
+template<typename E>
+std::string enum_to_string( E );
+} // namespace io
 
 namespace npc_factions
 {
@@ -178,6 +186,17 @@ enum npc_mission : int {
     NPC_MISSION_CAMP_RESIDENT, // Attached to camp, works jobs + has free time
     NPC_MISSION_LAST
 };
+
+template<>
+struct enum_traits<npc_mission> {
+    static constexpr npc_mission last = npc_mission::NPC_MISSION_LAST;
+};
+
+namespace io
+{
+template<>
+std::string enum_to_string<npc_mission>( npc_mission data );
+} // namespace io
 
 struct npc_companion_mission {
     mission_id miss_id;

--- a/src/npc_class.cpp
+++ b/src/npc_class.cpp
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "avatar.h"
+#include "catalua_platform_content.h"
 #include "condition.h"
 #include "creature.h"
 #include "debug.h"
@@ -28,6 +29,11 @@
 class item;
 
 static generic_factory<npc_class> npc_class_factory( "npc_class" );
+
+generic_factory<npc_class> &cata::lua_platform::detail::npc_class_registry()
+{
+    return npc_class_factory;
+}
 
 /** @relates string_id */
 template<>

--- a/src/npc_class.h
+++ b/src/npc_class.h
@@ -19,6 +19,11 @@ class JsonObject;
 class Trait_group;
 class item;
 class npc;
+
+namespace cata::lua_platform
+{
+class world_content_transaction;
+} // namespace cata::lua_platform
 struct const_dialogue;
 struct shopkeeper_blacklist;
 struct shopkeeper_whitelist;
@@ -76,6 +81,7 @@ struct shopkeeper_item_group {
 
 class npc_class
 {
+    friend class cata::lua_platform::world_content_transaction;
     private:
         translation name;
         translation job_description;

--- a/src/omdata.h
+++ b/src/omdata.h
@@ -52,6 +52,7 @@ template <typename T> class generic_factory;
 namespace cata::lua_platform
 {
 class content_transaction;
+class world_content_transaction;
 namespace detail
 {
 std::vector<std::pair<std::string, std::string>> overmap_special_migration_snapshot();
@@ -418,6 +419,7 @@ class oter_vision
 };
 
 struct oter_type_t {
+    friend class cata::lua_platform::world_content_transaction;
     public:
         static const oter_type_t null_type;
 
@@ -778,6 +780,7 @@ struct special_placement_result;
 
 class overmap_special
 {
+    friend class cata::lua_platform::world_content_transaction;
     public:
         overmap_special() = default;
         overmap_special( const overmap_special_id &, const overmap_special_terrain & );

--- a/src/overmap_special.cpp
+++ b/src/overmap_special.cpp
@@ -41,6 +41,11 @@ generic_factory<overmap_special_migration> migrations( "overmap special migratio
 
 } // namespace
 
+generic_factory<overmap_special> &cata::lua_platform::detail::overmap_special_registry()
+{
+    return specials;
+}
+
 generic_factory<overmap_special_migration> &
 cata::lua_platform::detail::overmap_special_migration_registry()
 {

--- a/src/overmap_terrain.cpp
+++ b/src/overmap_terrain.cpp
@@ -10,6 +10,7 @@
 #include "cata_assert.h"
 #include "cata_utility.h"
 #include "catacharset.h"
+#include "catalua_platform.h"
 #include "catalua_platform_content.h"
 #include "coordinates.h"
 #include "debug.h"
@@ -87,6 +88,16 @@ generic_factory<oter_type_t> terrain_types( "overmap terrain type" );
 generic_factory<oter_t> terrains( "overmap terrain" );
 
 } // namespace
+
+generic_factory<oter_type_t> &cata::lua_platform::detail::overmap_terrain_type_registry()
+{
+    return terrain_types;
+}
+
+generic_factory<oter_t> &cata::lua_platform::detail::overmap_terrain_registry()
+{
+    return terrains;
+}
 
 generic_factory<overmap_land_use_code> &
 cata::lua_platform::detail::overmap_land_use_code_registry()
@@ -924,7 +935,8 @@ void overmap_terrains::check_consistency()
                 }
             }
             check_mapgen_consistent_with( mid, elem );
-        } else if( !elem.has_uniform_terrain() ) {
+        } else if( !elem.has_uniform_terrain() &&
+                   !cata::lua_platform::has_primary_mapgen_for( elem.id.str() ) ) {
             debugmsg( "No mapgen terrain exists for \"%s\".", mid.c_str() );
         }
     }

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -60,6 +60,16 @@ generic_factory<vehicle_prototype> vehicle_prototype_factory( "vehicle", "id" );
 generic_factory<vpart_info> vpart_info_factory( "vehicle_part", "id" );
 } // namespace
 
+generic_factory<vpart_info> &cata::lua_platform::detail::vehicle_part_registry()
+{
+    return vpart_info_factory;
+}
+
+generic_factory<vehicle_prototype> &cata::lua_platform::detail::vehicle_prototype_registry()
+{
+    return vehicle_prototype_factory;
+}
+
 static const ammotype ammo_battery( "battery" );
 
 static const itype_id fuel_type_animal( "animal" );

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -33,6 +33,7 @@ class vpart_category;
 namespace cata::lua_platform
 {
 class content_transaction;
+class world_content_transaction;
 namespace detail
 {
 int vehicle_part_category_priority( const vpart_category & );
@@ -283,6 +284,7 @@ class vpart_category
 
 class vpart_variant
 {
+    friend class cata::lua_platform::world_content_transaction;
     public:
         std::string id;
         std::array<char32_t, 8> symbols;
@@ -313,6 +315,7 @@ class vpart_variant
 
 class vpart_info
 {
+    friend class cata::lua_platform::world_content_transaction;
     public:
         vpart_id id;
 
@@ -574,6 +577,7 @@ struct vehicle_item_spawn {
  * is a nullptr. Creating a new vehicle copies the blueprint vehicle.
  */
 struct vehicle_prototype {
+    friend class cata::lua_platform::world_content_transaction;
     public:
         struct part_def {
             point_rel_ms pos;

--- a/src/vehicle_price.cpp
+++ b/src/vehicle_price.cpp
@@ -1,0 +1,69 @@
+#include "vehicle_price.h"
+
+#include <set>
+
+#include "calendar.h"
+#include "item.h"
+#include "itype.h"
+#include "type_id.h"
+#include "veh_type.h"
+#include "vehicle.h"
+#include "vpart_position.h"
+#include "vpart_range.h"
+
+int vehicle_part_base_price( const vehicle &veh, const bool post_cataclysm )
+{
+    int result = 0;
+    for( const vpart_reference &reference : veh.get_all_parts() ) {
+        const vehicle_part &part = reference.part();
+        if( !part.removed ) {
+            result += part.get_base().price_no_contents( post_cataclysm );
+        }
+    }
+    return result;
+}
+
+namespace
+{
+
+std::set<itype_id> liquid_engine_fuels()
+{
+    std::set<itype_id> result;
+    for( const vpart_info &part : vehicles::parts::get_all() ) {
+        if( !part.engine_info ) {
+            continue;
+        }
+        for( const itype_id &fuel_id : part.engine_info->fuel_opts ) {
+            if( fuel_id.is_null() || !fuel_id.is_valid() ) {
+                continue;
+            }
+            const item fuel( fuel_id, calendar::turn_zero, 1 );
+            if( fuel.made_of( phase_id::LIQUID ) ) {
+                result.insert( fuel_id );
+            }
+        }
+    }
+    return result;
+}
+
+} // namespace
+
+int vehicle_tank_fuel_price_postapoc( const vehicle &veh )
+{
+    const std::set<itype_id> engine_fuels = liquid_engine_fuels();
+    int result = 0;
+    for( const vpart_reference &reference :
+         veh.get_any_parts( vpart_bitflags::VPFLAG_FLUIDTANK ) ) {
+        const vehicle_part &part = reference.part();
+        if( part.has_flag( vp_flag::carried_flag ) || part.ammo_remaining() <= 0 ) {
+            continue;
+        }
+        const itype_id fuel_id = part.ammo_current();
+        if( engine_fuels.count( fuel_id ) == 0 ) {
+            continue;
+        }
+        result += item( fuel_id, calendar::turn_zero,
+                        part.ammo_remaining() ).price_no_contents( true );
+    }
+    return result;
+}

--- a/src/vehicle_price.h
+++ b/src/vehicle_price.h
@@ -1,0 +1,13 @@
+#pragma once
+#ifndef CATA_SRC_VEHICLE_PRICE_H
+#define CATA_SRC_VEHICLE_PRICE_H
+
+class vehicle;
+
+/** Sum the base-item value of all installed, non-removed vehicle parts. */
+int vehicle_part_base_price( const vehicle &veh, bool post_cataclysm );
+
+/** Value liquid engine fuels carried in the vehicle's tanks after the Cataclysm. */
+int vehicle_tank_fuel_price_postapoc( const vehicle &veh );
+
+#endif // CATA_SRC_VEHICLE_PRICE_H

--- a/tools/lua_api/check_luals_declarations.py
+++ b/tools/lua_api/check_luals_declarations.py
@@ -72,6 +72,7 @@ TABLE_CLASSES = {
     "statistics": "CcbStatisticsApi",
     "targeting": "CcbTargetingApi",
     "time": "CcbTimeApi",
+    "trade": "CcbTradeApi",
     "types": "CcbTypesApi",
     "ui": "CcbUiApi",
     "units": "CcbUnitsApi",
@@ -188,6 +189,7 @@ def platform_sources() -> list[Path]:
     return [
         REPOSITORY_ROOT / "src/catalua_platform.cpp",
         REPOSITORY_ROOT / "src/catalua_platform_runtime.cpp",
+        REPOSITORY_ROOT / "src/catalua_platform_world_content.cpp",
     ]
 
 
@@ -272,6 +274,7 @@ PLATFORM_TABLE_CLASSES = {
     "content": "CcbPlatformContent",
     "environment": "CcbPlatformEnvironmentQueries",
     "inventory": "CcbPlatformInventoryApi",
+    "mapgen": "CcbPlatformMapgenApi",
     "martial_arts": "CcbPlatformMartialArtsApi",
     "morale": "CcbPlatformMoraleApi",
     "mods": "CcbPlatformModQueries",
@@ -311,6 +314,7 @@ PLATFORM_SERVICE_FIELDS = {
     "hordes",
     "inventory",
     "items",
+    "mapgen",
     "martial_arts",
     "messages",
     "missions",
@@ -332,6 +336,7 @@ PLATFORM_SERVICE_FIELDS = {
     "statistics",
     "targeting",
     "time",
+    "trade",
     "types",
     "units",
     "variables",


### PR DESCRIPTION
<!-- 使用说明：在下面每个「#### 标题」下填写与你的 PR 相关的信息。
请保留这些标题。像这样的注释可以安全删除。

如果你是在 GitHub 网页界面发起这个 PR，可以用「preview（预览）」按钮查看 PR 对他人显示的样子。

PR 提交准则：
- 让你的改动只聚焦于一个具体的问题或变更，外加为实现它所必需的最小相关改动。
- 一个经验法则：大多数 PR 的改动应少于 500 行。
- 你可以另开 PR 来拆分一次较大的预期改动；如果不确定怎么拆，尽管问。我们很乐意与你协作，并建议合并你 PR 的最佳方式。
-->

#### Summary
<!-- #### 概述 -->
1、Extended Lua-first content registration for world content, NPCs, factions, scenarios, start locations, overmap terrain, overmap specials, mapgen, items, mutations, and vehicles.
2、Added native dialogue topic and option-hook integration.
3、Added Lua APIs for vehicle discovery, ownership, pricing, spawning, selling, full repair, and individual part services.
4、Added mapgen and NPC helper APIs required by the migrated mod.
5、Introduced shared vehicle pricing utilities.
6、Updated LuaLS declarations, API validation scripts, and Lua-first platform documentation.
7、Added transactional validation, rollback, duplicate detection, and content fingerprinting.

<!-- 这一节应当只有一行，请编辑上面那一行。
1. 把「分类」替换为下列具体分类之一：Features、Content、Interface、Mods、Balance、Bugfixes、Performance、Infrastructure、Build、I18N。
2. 把引号内的文字替换为对你改动的简要描述。
如果你不希望生成更新日志条目，把整行替换为单独一个词「None」（不带引号）。
示例：
1. None
2. Bugfixes "修复长矛无法锁定不同楼层敌人的问题"
3. Interface "在制作界面显示制作失败几率"
分类含义详见：
https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/blob/master/doc/CHANGELOG_GUIDELINES.md
合并后，你的概述会被加入项目更新日志：
https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/blob/master/data/changelog.txt -->

#### Responsible human
<!-- #### 责任人 -->

@username

<!-- 每个 PR 必须指定一名真实的人类责任人。AI 工具或模型无需披露，但责任人
必须理解修改、审查最终 diff、确认测试与许可证/外部来源，并回答审阅问题。 -->

#### Purpose of change
<!-- #### 变更目的 -->
Enable the AutoRetailer mod to migrate completely to Lua while preserving its original content, native NPC dialogue UI, map generation, vehicle trading, repair, and installation workflows.

<!-- 用几句话描述你做这次改动的原因。
如果它与某个已有 issue 相关，可以用「#」加 GitHub issue 编号来关联，例如 #1234。

【重要】当你的 PR 能完全解决某个 issue 时，必须使用 [GitHub 的英文关闭关键字](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
才能在 PR 合并后自动关闭该 issue，例如：Fixes #1234。
只能用以下英文关键词（后面紧跟「#编号」）：
  close / closes / closed
  fix / fixes / fixed
  resolve / resolves / resolved
注意：中文「修复 #1234」不会触发自动关闭，GitHub 只识别上述英文关键词。

如果没有相关 issue，请在这里说明你要解决的问题、特性或其他关注点。如果这是一个 bug 修复，请附上复现原始 bug 的步骤，以便你的修复可以被验证。 -->


#### Describe the solution
<!-- #### 解决方案描述 -->
Implement a transactional Lua-first world-content layer that registers definitions in the correct engine loading phase and validates references before committing them. Expose existing native gameplay systems through structured Lua APIs instead of reimplementing their behavior in Lua. Native dialogue, vehicle service activities, payment handling, and map generation remain engine-managed, allowing Lua mods to preserve existing gameplay behavior and UI while defining all mod-specific content and logic in Lua.
<!-- 这个特性是如何工作的，或者这个 bug 是怎么被修复的？方案越易于理解，就越快能被合并。 -->

#### Describe alternatives you've considered
<!-- #### 你考虑过的替代方案 -->

<!-- 说明你为解决同一问题考虑过的其他方案、不同思路或可能性。 -->

#### Testing
<!-- #### 测试 -->

<!-- 描述你采取了哪些步骤来测试这个 PR 是否修复了 bug 或添加了特性，以及你做了哪些测试以确保没有引入回归问题。也请为审阅者和维护者提供测试建议。参见 TESTING_YOUR_CHANGES.md -->

#### Documentation impact
<!-- None，或说明需要新增、更新、迁移、归档或标记 stale 的开发文档。
实际执行级别以 ai/docs-impact.yml 为准。required 映射不能填写 None/N/A/TBD。 -->

None

#### Related CCB-Docs PR
<!-- None，或填写 CrimsonCrossBunker/CCB-Docs 的 PR 链接。required 映射必须链接实际 PR。 -->

None

#### Affected documentation IDs
<!-- None，或填写 docs-catalog.yml 中稳定的文档 ID，多个 ID 用逗号分隔。
required 映射至少填写一个 ai/docs-impact.yml 列出的对应 ID。 -->

None

#### Generated reference impact
<!-- None，或说明 Schema、LuaLS、注册信息或生成清单是否需要刷新。 -->

None

#### Additional context
<!-- #### 补充说明 -->

<!-- 在此添加关于这个特性或 bug 修复的其他背景信息（例如原型图、概念验证或截图）。 -->


<!--README: Cataclysm: Cleanwater Bomb (CCB) 以 Creative Commons Attribution ShareAlike 3.0 许可证发布。
游戏的代码与内容可自由用于任何目的的使用、修改和再分发。
通过为本项目做贡献，你即同意该许可证的条款，并同意你所做的任何贡献也将受同一许可证覆盖。
详见 http://creativecommons.org/licenses/by-sa/3.0/ 。 -->
