### PR TITLE
修复qq文档问题#140

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -10961,7 +10961,7 @@ void firstaid_activity_actor::finish( player_activity &act, Character &who )
     act.set_to_null();
     act.values.clear();
 
-    if( who.is_avatar() ) {
+    if( who.is_avatar() && patient->is_avatar() ) {
         uistate.open_menu = []() {
             avatar_action::eat_or_use( get_avatar(),
                                        game_menus::inv::consume( uistate.consume_uistate.consume_menu_comestype ) );


### PR DESCRIPTION
使用治疗道具的对象检测一遍是否是玩家，避免玩家对npc使用治疗道具的时候打开该菜单

看了一下issue没有对应问题