### PR TITLE
Add options for unlock limits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1463,7 +1463,7 @@ json-check: $(CHKJSON_BIN)
 clean: clean-tests clean-lang
 	rm -rf *$(TARGET_NAME) *$(TILES_TARGET_NAME)
 	rm -rf *$(TILES_TARGET_NAME).exe *$(TARGET_NAME).exe *$(TARGET_NAME).a
-	rm -rf *obj *objwin
+	rm -rf *obj *objwin *obj-lua
 	rm -rf *$(BINDIST_DIR) *cataclysmdda-*.tar.gz *cataclysmdda-*.zip
 	rm -f $(SRC_DIR)/version.h $(SRC_DIR)/prefix.h
 	rm -f $(CHKJSON_BIN)

--- a/doc/JSON/NPCs.md
+++ b/doc/JSON/NPCs.md
@@ -167,7 +167,7 @@ Specifies whitelist of items, shopkeeper will not accept anything else.  Format 
 ```
 
 #### Shop restocking
-NPCs with at least one `shopkeeper_item_group` will (re)stock their shop in nearby loot zones (within `PICKUP_RANGE` = 6 tiles) owned by their faction and will ignore all other items. If there isn't at least one `LOOT_UNSORTED` zone nearby, fallback zones will be automatically placed on all nearby, reachable, unsealed furniture with either the `CONTAINER` flag or a max volume higher than the floor. If there is no suitable furniture around, a 3x3 zone centered on the NPC will be created instead.
+NPCs with at least one `shopkeeper_item_group` will (re)stock their shop in nearby loot zones (within `pickup_range`, 6 tiles by default) owned by their faction and will ignore all other items. If there isn't at least one `LOOT_UNSORTED` zone nearby, fallback zones will be automatically placed on all nearby, reachable, unsealed furniture with either the `CONTAINER` flag or a max volume higher than the floor. If there is no suitable furniture around, a 3x3 zone centered on the NPC will be created instead.
 
 Before restocking, items owned by the NPC's faction within these zones will be consumed according to `shopkeeper_consumption_rates`.
 

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -643,9 +643,9 @@ bool can_butcher_at( map &here, const tripoint_bub_ms &p )
     }
     Character &player_character = get_player_character();
     // TODO: unify this with game::butcher
-    const int factor = player_character.max_quality( qual_BUTCHER, get_option<int>( "PICKUP_RANGE" ) );
+    const int factor = player_character.max_quality( qual_BUTCHER, pickup_range );
     const int factorD = player_character.max_quality( qual_CUT_FINE,
-                        get_option<int>( "PICKUP_RANGE" ) );
+                        pickup_range );
     bool has_item = false;
     bool has_corpse = false;
 

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -643,8 +643,9 @@ bool can_butcher_at( map &here, const tripoint_bub_ms &p )
     }
     Character &player_character = get_player_character();
     // TODO: unify this with game::butcher
-    const int factor = player_character.max_quality( qual_BUTCHER, PICKUP_RANGE );
-    const int factorD = player_character.max_quality( qual_CUT_FINE, PICKUP_RANGE );
+    const int factor = player_character.max_quality( qual_BUTCHER, get_option<int>( "PICKUP_RANGE" ) );
+    const int factorD = player_character.max_quality( qual_CUT_FINE,
+                        get_option<int>( "PICKUP_RANGE" ) );
     bool has_item = false;
     bool has_corpse = false;
 

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -644,8 +644,7 @@ bool can_butcher_at( map &here, const tripoint_bub_ms &p )
     Character &player_character = get_player_character();
     // TODO: unify this with game::butcher
     const int factor = player_character.max_quality( qual_BUTCHER, pickup_range );
-    const int factorD = player_character.max_quality( qual_CUT_FINE,
-                        pickup_range );
+    const int factorD = player_character.max_quality( qual_CUT_FINE, pickup_range );
     bool has_item = false;
     bool has_corpse = false;
 

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4315,7 +4315,7 @@ item_location efile_activity_actor::find_external_transfer_estorage( Character &
                it->remaining_ememory() >= largest_efile_size &&
                it->is_tool();
     };
-    std::vector<item_location> nearby_etds = p.nearby( func, get_option<int>( "PICKUP_RANGE" ) );
+    std::vector<item_location> nearby_etds = p.nearby( func, pickup_range );
     for( item_location &loc : nearby_etds ) {
         if( loc->type->tool->etransfer_rate > fastest_rate ) {
             fastest_edevice = loc;
@@ -5696,8 +5696,8 @@ requirement_check_result multi_zone_activity_actor::check_requirements( Characte
             combined_spots.emplace_back( elem );
         }
         for( const tripoint_bub_ms &elem : here.points_in_radius( src_loc,
-                get_option<int>( "PICKUP_RANGE" ),
-                get_option<int>( "PICKUP_RANGE" ) ) ) {
+                pickup_range,
+                pickup_range ) ) {
             combined_spots.push_back( elem );
         }
         multi_activity_actor::add_basecamp_storage_to_loot_zone_list( mgr, src_loc, you, loot_zone_spots,
@@ -5775,7 +5775,7 @@ requirement_check_result multi_zone_activity_actor::fetch_requirements( Characte
     }
     std::vector<tripoint_bub_ms> candidates;
     for( const tripoint_bub_ms &point_elem :
-         here.points_in_radius( src_loc, get_option<int>( "PICKUP_RANGE" ) - 1, 0 ) ) {
+         here.points_in_radius( src_loc, pickup_range - 1, 0 ) ) {
         // we don't want to place the components where they could interfere with our ( or someone else's ) construction spots
         if( ( std::find( local_src_set.begin(), local_src_set.end(),
                          point_elem ) != local_src_set.end() ) || !here.can_put_items_ter_furn( point_elem ) ) {
@@ -6650,7 +6650,7 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
                 break;
             }
             if( !crafter.verify_step_tools( craft, craft.get_current_step(),
-                                            crafter.pos_bub(), get_option<int>( "PICKUP_RANGE" ), /*pin_to_map=*/false ) ) {
+                                            crafter.pos_bub(), pickup_range, /*pin_to_map=*/false ) ) {
                 rewind_turn();
                 return;
             }
@@ -6663,7 +6663,7 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
         const int closing_step = rec.has_steps()
                                  ? static_cast<int>( rec.steps().size() ) - 1 : 0;
         if( !crafter.verify_step_tools( craft, closing_step,
-                                        crafter.pos_bub(), get_option<int>( "PICKUP_RANGE" ), /*pin_to_map=*/false ) ) {
+                                        crafter.pos_bub(), pickup_range, /*pin_to_map=*/false ) ) {
             rewind_turn();
             return;
         }
@@ -12724,14 +12724,14 @@ void heat_activity_actor::finish( player_activity &act, Character &p )
                 cold_item.remove_item();
             }
             if( copy.made_of( phase_id::LIQUID ) ) {
-                liquid_handler::handle_all_liquid( copy, get_option<int>( "PICKUP_RANGE" ) );
+                liquid_handler::handle_all_liquid( copy, pickup_range );
             } else {
                 p.i_add_or_drop( copy );
             }
         } else {
             cold_item->heat_up();
             if( cold_item.get_item()->made_of( phase_id::LIQUID ) ) {
-                liquid_handler::handle_all_liquid( *cold_item, get_option<int>( "PICKUP_RANGE" ) );
+                liquid_handler::handle_all_liquid( *cold_item, pickup_range );
             } else {
                 p.i_add_or_drop( *cold_item );
                 cold_item.remove_item();
@@ -12831,7 +12831,7 @@ void fire_start_activity_actor::do_turn( player_activity &act, Character &who )
                 return loc->has_flag( flag_TINDER );
             } );
             inventory_pick_selector inv_s( who, preset );
-            inv_s.add_nearby_items( get_option<int>( "PICKUP_RANGE" ) );
+            inv_s.add_nearby_items( pickup_range );
             inv_s.add_character_items( who );
 
             inv_s.set_title( _( "Select tinder to use for lighting a fire" ) );
@@ -14354,7 +14354,7 @@ void vehicle_part_install_service_activity_actor::settle_failed_order( Character
                 if( mechanic->is_shopkeeper() ) {
                     zone_manager &zones = zone_manager::get_manager();
                     const std::unordered_set<tripoint_bub_ms> shop_tiles =
-                        zones.get_point_set_loot( mechanic->pos_abs(), get_option<int>( "PICKUP_RANGE" ),
+                        zones.get_point_set_loot( mechanic->pos_abs(), pickup_range,
                                                   mechanic->get_fac_id() );
                     if( !shop_tiles.empty() ) {
                         get_map().add_item_or_charges( *shop_tiles.begin(), reserved_part );

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5695,9 +5695,7 @@ requirement_check_result multi_zone_activity_actor::check_requirements( Characte
             loot_zone_spots.emplace_back( elem );
             combined_spots.emplace_back( elem );
         }
-        for( const tripoint_bub_ms &elem : here.points_in_radius( src_loc,
-                pickup_range,
-                pickup_range ) ) {
+        for( const tripoint_bub_ms &elem : here.points_in_radius( src_loc, pickup_range, pickup_range ) ) {
             combined_spots.push_back( elem );
         }
         multi_activity_actor::add_basecamp_storage_to_loot_zone_list( mgr, src_loc, you, loot_zone_spots,

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4315,7 +4315,7 @@ item_location efile_activity_actor::find_external_transfer_estorage( Character &
                it->remaining_ememory() >= largest_efile_size &&
                it->is_tool();
     };
-    std::vector<item_location> nearby_etds = p.nearby( func, PICKUP_RANGE );
+    std::vector<item_location> nearby_etds = p.nearby( func, get_option<int>( "PICKUP_RANGE" ) );
     for( item_location &loc : nearby_etds ) {
         if( loc->type->tool->etransfer_rate > fastest_rate ) {
             fastest_edevice = loc;
@@ -5695,8 +5695,9 @@ requirement_check_result multi_zone_activity_actor::check_requirements( Characte
             loot_zone_spots.emplace_back( elem );
             combined_spots.emplace_back( elem );
         }
-        for( const tripoint_bub_ms &elem : here.points_in_radius( src_loc, PICKUP_RANGE,
-                PICKUP_RANGE ) ) {
+        for( const tripoint_bub_ms &elem : here.points_in_radius( src_loc,
+                get_option<int>( "PICKUP_RANGE" ),
+                get_option<int>( "PICKUP_RANGE" ) ) ) {
             combined_spots.push_back( elem );
         }
         multi_activity_actor::add_basecamp_storage_to_loot_zone_list( mgr, src_loc, you, loot_zone_spots,
@@ -5774,7 +5775,7 @@ requirement_check_result multi_zone_activity_actor::fetch_requirements( Characte
     }
     std::vector<tripoint_bub_ms> candidates;
     for( const tripoint_bub_ms &point_elem :
-         here.points_in_radius( src_loc, PICKUP_RANGE - 1, 0 ) ) {
+         here.points_in_radius( src_loc, get_option<int>( "PICKUP_RANGE" ) - 1, 0 ) ) {
         // we don't want to place the components where they could interfere with our ( or someone else's ) construction spots
         if( ( std::find( local_src_set.begin(), local_src_set.end(),
                          point_elem ) != local_src_set.end() ) || !here.can_put_items_ter_furn( point_elem ) ) {
@@ -6649,7 +6650,7 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
                 break;
             }
             if( !crafter.verify_step_tools( craft, craft.get_current_step(),
-                                            crafter.pos_bub(), PICKUP_RANGE, /*pin_to_map=*/false ) ) {
+                                            crafter.pos_bub(), get_option<int>( "PICKUP_RANGE" ), /*pin_to_map=*/false ) ) {
                 rewind_turn();
                 return;
             }
@@ -6662,7 +6663,7 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
         const int closing_step = rec.has_steps()
                                  ? static_cast<int>( rec.steps().size() ) - 1 : 0;
         if( !crafter.verify_step_tools( craft, closing_step,
-                                        crafter.pos_bub(), PICKUP_RANGE, /*pin_to_map=*/false ) ) {
+                                        crafter.pos_bub(), get_option<int>( "PICKUP_RANGE" ), /*pin_to_map=*/false ) ) {
             rewind_turn();
             return;
         }
@@ -12723,14 +12724,14 @@ void heat_activity_actor::finish( player_activity &act, Character &p )
                 cold_item.remove_item();
             }
             if( copy.made_of( phase_id::LIQUID ) ) {
-                liquid_handler::handle_all_liquid( copy, PICKUP_RANGE );
+                liquid_handler::handle_all_liquid( copy, get_option<int>( "PICKUP_RANGE" ) );
             } else {
                 p.i_add_or_drop( copy );
             }
         } else {
             cold_item->heat_up();
             if( cold_item.get_item()->made_of( phase_id::LIQUID ) ) {
-                liquid_handler::handle_all_liquid( *cold_item, PICKUP_RANGE );
+                liquid_handler::handle_all_liquid( *cold_item, get_option<int>( "PICKUP_RANGE" ) );
             } else {
                 p.i_add_or_drop( *cold_item );
                 cold_item.remove_item();
@@ -12830,7 +12831,7 @@ void fire_start_activity_actor::do_turn( player_activity &act, Character &who )
                 return loc->has_flag( flag_TINDER );
             } );
             inventory_pick_selector inv_s( who, preset );
-            inv_s.add_nearby_items( PICKUP_RANGE );
+            inv_s.add_nearby_items( get_option<int>( "PICKUP_RANGE" ) );
             inv_s.add_character_items( who );
 
             inv_s.set_title( _( "Select tinder to use for lighting a fire" ) );
@@ -14353,7 +14354,7 @@ void vehicle_part_install_service_activity_actor::settle_failed_order( Character
                 if( mechanic->is_shopkeeper() ) {
                     zone_manager &zones = zone_manager::get_manager();
                     const std::unordered_set<tripoint_bub_ms> shop_tiles =
-                        zones.get_point_set_loot( mechanic->pos_abs(), PICKUP_RANGE,
+                        zones.get_point_set_loot( mechanic->pos_abs(), get_option<int>( "PICKUP_RANGE" ),
                                                   mechanic->get_fac_id() );
                     if( !shop_tiles.empty() ) {
                         get_map().add_item_or_charges( *shop_tiles.begin(), reserved_part );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -22,6 +22,7 @@
 #include "activity_type.h"
 #include "avatar.h"
 #include "butchery.h"
+#include "cached_options.h"
 #include "calendar.h"
 #include "cata_utility.h"
 #include "character.h"
@@ -1121,7 +1122,7 @@ bool dest_has_capacity( const tripoint_abs_ms &dest, const zone_type_id &ztype,
             return false;
         }
     }
-    return static_cast<int>( here.i_at( dest_bub ).size() ) < get_option<int>( "MAX_ITEM_IN_SQUARE" ) &&
+    return static_cast<int>( here.i_at( dest_bub ).size() ) < max_item_in_square&&
            here.free_volume( dest_bub ) >= sample.volume();
 }
 
@@ -1462,7 +1463,7 @@ void move_item( Character &you, const std::optional<vpart_reference> &vpr_src,
 
         // skip tiles with inaccessible furniture, like filled charcoal kiln
         if( !here.can_put_items_ter_furn( dest_loc ) ||
-            static_cast<int>( here.i_at( dest_loc ).size() ) >= get_option<int>( "MAX_ITEM_IN_SQUARE" ) ) {
+            static_cast<int>( here.i_at( dest_loc ).size() ) >= max_item_in_square) {
             continue;
         }
 
@@ -1888,7 +1889,7 @@ static activity_reason_info find_base_construction(
     if( !cc ) {
         return activity_reason_info::build( do_activity_reason::BLOCKING_TILE, false, idx );
     }
-    const inventory &inv = you.crafting_inventory( inv_from_loc, get_option<int>( "PICKUP_RANGE" ) );
+    const inventory &inv = you.crafting_inventory( inv_from_loc, pickup_range );
     if( !player_can_build( you, inv, build, true ) ) {
         //can't build with current inventory, do not look for pre-req
         return activity_reason_info::build( do_activity_reason::NO_COMPONENTS, false, build.id );
@@ -1975,7 +1976,7 @@ bool are_requirements_nearby(
     }
     // use nearby welding rig without needing to drag it or position yourself on the right side of the vehicle.
     if( !found_welder ) {
-        int radius = get_option<int>( "PICKUP_RANGE" ) - 1;
+        int radius = pickup_range - 1;
         for( const tripoint_bub_ms &elem : here.points_in_radius( src_loc, radius, radius ) ) {
             const std::optional<vpart_reference> &vp = here.veh_at( elem ).part_with_tool( here, itype_welder );
 
@@ -2159,7 +2160,7 @@ activity_reason_info multi_vehicle_repair_activity_actor::multi_activity_can_do(
         }
         const requirement_data &reqs = vpinfo.repair_requirements();
         const inventory &inv =
-            you.crafting_inventory( src_loc, get_option<int>( "PICKUP_RANGE" ) - 1, false );
+            you.crafting_inventory( src_loc, pickup_range - 1, false );
         const bool can_make = reqs.can_make_with_inventory( inv, is_crafting_component );
         you.set_value( "veh_index_type", vpinfo.name() );
         // temporarily store the intended index, we do this so two NPCs don't try and work on the same part at same time.
@@ -2514,7 +2515,7 @@ activity_reason_info multi_craft_activity_actor::multi_activity_can_do( Characte
     if( p ) {
         item_location to_craft = p->get_item_to_craft();
         if( to_craft && to_craft->is_craft() ) {
-            const inventory &inv = you.crafting_inventory( src_loc, get_option<int>( "PICKUP_RANGE" ), false );
+            const inventory &inv = you.crafting_inventory( src_loc, pickup_range, false );
             const recipe &r = to_craft->get_making();
             std::vector<std::vector<item_comp>> item_comp_vector =
                                                  to_craft->get_continue_reqs().get_components();
@@ -2557,7 +2558,7 @@ activity_reason_info multi_disassemble_activity_actor::multi_activity_can_do( Ch
 
     map &here = get_map();
     // Is there anything to be disassembled?
-    const inventory &inv = you.crafting_inventory( src_loc, get_option<int>( "PICKUP_RANGE" ), false );
+    const inventory &inv = you.crafting_inventory( src_loc, pickup_range, false );
     requirement_data req;
     for( item &i : here.i_at( src_loc ) ) {
         // Skip items marked by other ppl.
@@ -2998,7 +2999,7 @@ std::vector<std::tuple<tripoint_bub_ms, itype_id, int>>
     map &here = get_map();
     const tripoint_bub_ms &src_loc = here.get_bub( fetch_for_activity_position );
     for( const tripoint_bub_ms &elem : here.points_in_radius( src_loc,
-            get_option<int>( "PICKUP_RANGE" ) - 1 ) ) {
+            pickup_range - 1 ) ) {
         already_there_spots.push_back( elem );
         combined_spots.push_back( elem );
     }
@@ -4259,7 +4260,7 @@ static std::optional<tripoint_bub_ms> find_best_fire( const std::vector<tripoint
     for( const tripoint_bub_ms &pt : from ) {
         field_entry *fire = here.get_field( pt, fd_fire );
         if( fire == nullptr || fire->get_field_intensity() > 1 ||
-            !here.clear_path( center, pt, get_option<int>( "PICKUP_RANGE" ), 1, 100 ) ) {
+            !here.clear_path( center, pt, pickup_range, 1, 100 ) ) {
             continue;
         }
         time_duration fire_age = fire->get_field_age();
@@ -4283,7 +4284,7 @@ static bool has_clear_path_to_pickup_items(
     map &here = get_map();
     return here.has_items( to ) &&
            here.accessible_items( to ) &&
-           here.clear_path( from, to, get_option<int>( "PICKUP_RANGE" ), 1, 100 );
+           here.clear_path( from, to, pickup_range, 1, 100 );
 }
 
 static std::optional<tripoint_bub_ms> find_refuel_spot_zone( const tripoint_bub_ms &center,
@@ -4294,7 +4295,7 @@ static std::optional<tripoint_bub_ms> find_refuel_spot_zone( const tripoint_bub_
     const tripoint_abs_ms center_abs = here.get_abs( center );
 
     const std::unordered_set<tripoint_abs_ms> tiles_abs_unordered =
-        mgr.get_near( zone_type_SOURCE_FIREWOOD, center_abs, get_option<int>( "PICKUP_RANGE" ), nullptr,
+        mgr.get_near( zone_type_SOURCE_FIREWOOD, center_abs, pickup_range, nullptr,
                       fac );
     const std::vector<tripoint_abs_ms> &tiles_abs =
         get_sorted_tiles_by_distance( center_abs, tiles_abs_unordered );
@@ -4531,7 +4532,7 @@ bool try_fuel_fire( Character &you, std::optional<tripoint_bub_ms> fire_target )
 {
     const tripoint_bub_ms pos = you.pos_bub();
     std::vector<tripoint_bub_ms> adjacent = closest_points_first( pos, 1,
-                                            get_option<int>( "PICKUP_RANGE" ) );
+                                            pickup_range );
 
     map &here = get_map();
     std::optional<tripoint_bub_ms> best_fire =

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1122,7 +1122,7 @@ bool dest_has_capacity( const tripoint_abs_ms &dest, const zone_type_id &ztype,
             return false;
         }
     }
-    return static_cast<int>( here.i_at( dest_bub ).size() ) < max_item_in_square&&
+    return static_cast<int>( here.i_at( dest_bub ).size() ) < max_item_in_square &&
            here.free_volume( dest_bub ) >= sample.volume();
 }
 
@@ -1463,7 +1463,7 @@ void move_item( Character &you, const std::optional<vpart_reference> &vpr_src,
 
         // skip tiles with inaccessible furniture, like filled charcoal kiln
         if( !here.can_put_items_ter_furn( dest_loc ) ||
-            static_cast<int>( here.i_at( dest_loc ).size() ) >= max_item_in_square) {
+            static_cast<int>( here.i_at( dest_loc ).size() ) >= max_item_in_square ) {
             continue;
         }
 

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -4295,8 +4295,7 @@ static std::optional<tripoint_bub_ms> find_refuel_spot_zone( const tripoint_bub_
     const tripoint_abs_ms center_abs = here.get_abs( center );
 
     const std::unordered_set<tripoint_abs_ms> tiles_abs_unordered =
-        mgr.get_near( zone_type_SOURCE_FIREWOOD, center_abs, pickup_range, nullptr,
-                      fac );
+        mgr.get_near( zone_type_SOURCE_FIREWOOD, center_abs, pickup_range, nullptr, fac );
     const std::vector<tripoint_abs_ms> &tiles_abs =
         get_sorted_tiles_by_distance( center_abs, tiles_abs_unordered );
 
@@ -4531,8 +4530,7 @@ int get_auto_consume_moves( Character &you, const bool food )
 bool try_fuel_fire( Character &you, std::optional<tripoint_bub_ms> fire_target )
 {
     const tripoint_bub_ms pos = you.pos_bub();
-    std::vector<tripoint_bub_ms> adjacent = closest_points_first( pos, 1,
-                                            pickup_range );
+    std::vector<tripoint_bub_ms> adjacent = closest_points_first( pos, 1, pickup_range );
 
     map &here = get_map();
     std::optional<tripoint_bub_ms> best_fire =

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1121,7 +1121,7 @@ bool dest_has_capacity( const tripoint_abs_ms &dest, const zone_type_id &ztype,
             return false;
         }
     }
-    return static_cast<int>( here.i_at( dest_bub ).size() ) < MAX_ITEM_IN_SQUARE &&
+    return static_cast<int>( here.i_at( dest_bub ).size() ) < get_option<int>( "MAX_ITEM_IN_SQUARE" ) &&
            here.free_volume( dest_bub ) >= sample.volume();
 }
 
@@ -1462,7 +1462,7 @@ void move_item( Character &you, const std::optional<vpart_reference> &vpr_src,
 
         // skip tiles with inaccessible furniture, like filled charcoal kiln
         if( !here.can_put_items_ter_furn( dest_loc ) ||
-            static_cast<int>( here.i_at( dest_loc ).size() ) >= MAX_ITEM_IN_SQUARE ) {
+            static_cast<int>( here.i_at( dest_loc ).size() ) >= get_option<int>( "MAX_ITEM_IN_SQUARE" ) ) {
             continue;
         }
 
@@ -1888,7 +1888,7 @@ static activity_reason_info find_base_construction(
     if( !cc ) {
         return activity_reason_info::build( do_activity_reason::BLOCKING_TILE, false, idx );
     }
-    const inventory &inv = you.crafting_inventory( inv_from_loc, PICKUP_RANGE );
+    const inventory &inv = you.crafting_inventory( inv_from_loc, get_option<int>( "PICKUP_RANGE" ) );
     if( !player_can_build( you, inv, build, true ) ) {
         //can't build with current inventory, do not look for pre-req
         return activity_reason_info::build( do_activity_reason::NO_COMPONENTS, false, build.id );
@@ -1975,8 +1975,8 @@ bool are_requirements_nearby(
     }
     // use nearby welding rig without needing to drag it or position yourself on the right side of the vehicle.
     if( !found_welder ) {
-        for( const tripoint_bub_ms &elem : here.points_in_radius( src_loc, PICKUP_RANGE - 1,
-                PICKUP_RANGE - 1 ) ) {
+        int radius = get_option<int>( "PICKUP_RANGE" ) - 1;
+        for( const tripoint_bub_ms &elem : here.points_in_radius( src_loc, radius, radius ) ) {
             const std::optional<vpart_reference> &vp = here.veh_at( elem ).part_with_tool( here, itype_welder );
 
             if( vp ) {
@@ -2159,7 +2159,7 @@ activity_reason_info multi_vehicle_repair_activity_actor::multi_activity_can_do(
         }
         const requirement_data &reqs = vpinfo.repair_requirements();
         const inventory &inv =
-            you.crafting_inventory( src_loc, PICKUP_RANGE - 1, false );
+            you.crafting_inventory( src_loc, get_option<int>( "PICKUP_RANGE" ) - 1, false );
         const bool can_make = reqs.can_make_with_inventory( inv, is_crafting_component );
         you.set_value( "veh_index_type", vpinfo.name() );
         // temporarily store the intended index, we do this so two NPCs don't try and work on the same part at same time.
@@ -2514,7 +2514,7 @@ activity_reason_info multi_craft_activity_actor::multi_activity_can_do( Characte
     if( p ) {
         item_location to_craft = p->get_item_to_craft();
         if( to_craft && to_craft->is_craft() ) {
-            const inventory &inv = you.crafting_inventory( src_loc, PICKUP_RANGE, false );
+            const inventory &inv = you.crafting_inventory( src_loc, get_option<int>( "PICKUP_RANGE" ), false );
             const recipe &r = to_craft->get_making();
             std::vector<std::vector<item_comp>> item_comp_vector =
                                                  to_craft->get_continue_reqs().get_components();
@@ -2557,7 +2557,7 @@ activity_reason_info multi_disassemble_activity_actor::multi_activity_can_do( Ch
 
     map &here = get_map();
     // Is there anything to be disassembled?
-    const inventory &inv = you.crafting_inventory( src_loc, PICKUP_RANGE, false );
+    const inventory &inv = you.crafting_inventory( src_loc, get_option<int>( "PICKUP_RANGE" ), false );
     requirement_data req;
     for( item &i : here.i_at( src_loc ) ) {
         // Skip items marked by other ppl.
@@ -2998,7 +2998,7 @@ std::vector<std::tuple<tripoint_bub_ms, itype_id, int>>
     map &here = get_map();
     const tripoint_bub_ms &src_loc = here.get_bub( fetch_for_activity_position );
     for( const tripoint_bub_ms &elem : here.points_in_radius( src_loc,
-            PICKUP_RANGE - 1 ) ) {
+            get_option<int>( "PICKUP_RANGE" ) - 1 ) ) {
         already_there_spots.push_back( elem );
         combined_spots.push_back( elem );
     }
@@ -4259,7 +4259,7 @@ static std::optional<tripoint_bub_ms> find_best_fire( const std::vector<tripoint
     for( const tripoint_bub_ms &pt : from ) {
         field_entry *fire = here.get_field( pt, fd_fire );
         if( fire == nullptr || fire->get_field_intensity() > 1 ||
-            !here.clear_path( center, pt, PICKUP_RANGE, 1, 100 ) ) {
+            !here.clear_path( center, pt, get_option<int>( "PICKUP_RANGE" ), 1, 100 ) ) {
             continue;
         }
         time_duration fire_age = fire->get_field_age();
@@ -4283,7 +4283,7 @@ static bool has_clear_path_to_pickup_items(
     map &here = get_map();
     return here.has_items( to ) &&
            here.accessible_items( to ) &&
-           here.clear_path( from, to, PICKUP_RANGE, 1, 100 );
+           here.clear_path( from, to, get_option<int>( "PICKUP_RANGE" ), 1, 100 );
 }
 
 static std::optional<tripoint_bub_ms> find_refuel_spot_zone( const tripoint_bub_ms &center,
@@ -4294,7 +4294,8 @@ static std::optional<tripoint_bub_ms> find_refuel_spot_zone( const tripoint_bub_
     const tripoint_abs_ms center_abs = here.get_abs( center );
 
     const std::unordered_set<tripoint_abs_ms> tiles_abs_unordered =
-        mgr.get_near( zone_type_SOURCE_FIREWOOD, center_abs, PICKUP_RANGE, nullptr, fac );
+        mgr.get_near( zone_type_SOURCE_FIREWOOD, center_abs, get_option<int>( "PICKUP_RANGE" ), nullptr,
+                      fac );
     const std::vector<tripoint_abs_ms> &tiles_abs =
         get_sorted_tiles_by_distance( center_abs, tiles_abs_unordered );
 
@@ -4529,7 +4530,8 @@ int get_auto_consume_moves( Character &you, const bool food )
 bool try_fuel_fire( Character &you, std::optional<tripoint_bub_ms> fire_target )
 {
     const tripoint_bub_ms pos = you.pos_bub();
-    std::vector<tripoint_bub_ms> adjacent = closest_points_first( pos, 1, PICKUP_RANGE );
+    std::vector<tripoint_bub_ms> adjacent = closest_points_first( pos, 1,
+                                            get_option<int>( "PICKUP_RANGE" ) );
 
     map &here = get_map();
     std::optional<tripoint_bub_ms> best_fire =

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -2209,8 +2209,8 @@ bool advanced_inventory::query_destination( aim_location &def )
         for( aim_location &ordered_loc : ordered_locs ) {
             advanced_inv_area &s = squares[ordered_loc];
             const int size = s.get_item_count();
-            std::string prefix = string_format( "%2d/%d", size, get_option<int>( "MAX_ITEM_IN_SQUARE" ) );
-            if( size >= get_option<int>( "MAX_ITEM_IN_SQUARE" ) ) {
+            std::string prefix = string_format( "%2d/%d", size, max_item_in_square);
+            if( size >= max_item_in_square) {
                 prefix += _( " (FULL)" );
             }
             if( s.veh != nullptr ) {

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -2209,8 +2209,8 @@ bool advanced_inventory::query_destination( aim_location &def )
         for( aim_location &ordered_loc : ordered_locs ) {
             advanced_inv_area &s = squares[ordered_loc];
             const int size = s.get_item_count();
-            std::string prefix = string_format( "%2d/%d", size, max_item_in_square);
-            if( size >= max_item_in_square) {
+            std::string prefix = string_format( "%2d/%d", size, max_item_in_square );
+            if( size >= max_item_in_square ) {
                 prefix += _( " (FULL)" );
             }
             if( s.veh != nullptr ) {

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -2209,8 +2209,8 @@ bool advanced_inventory::query_destination( aim_location &def )
         for( aim_location &ordered_loc : ordered_locs ) {
             advanced_inv_area &s = squares[ordered_loc];
             const int size = s.get_item_count();
-            std::string prefix = string_format( "%2d/%d", size, MAX_ITEM_IN_SQUARE );
-            if( size >= MAX_ITEM_IN_SQUARE ) {
+            std::string prefix = string_format( "%2d/%d", size, get_option<int>( "MAX_ITEM_IN_SQUARE" ) );
+            if( size >= get_option<int>( "MAX_ITEM_IN_SQUARE" ) ) {
                 prefix += _( " (FULL)" );
             }
             if( s.veh != nullptr ) {

--- a/src/advanced_inv_area.cpp
+++ b/src/advanced_inv_area.cpp
@@ -90,7 +90,7 @@ void advanced_inv_area::init()
                 vstor = vp->part_index();
                 desc[0] = veh->name;
                 canputitemsloc = true;
-                max_size = MAX_ITEM_IN_VEHICLE_STORAGE;
+                max_size = get_option<int>( "MAX_ITEM_IN_SQUARE" );
             } else {
                 canputitemsloc = false;
                 desc[0] = _( "No dragged vehicle!" );
@@ -125,7 +125,7 @@ void advanced_inv_area::init()
                 vstor = vp->part_index();
             }
             canputitemsloc = can_store_in_vehicle() || here.can_put_items_ter_furn( pos );
-            max_size = MAX_ITEM_IN_SQUARE;
+            max_size = get_option<int>( "MAX_ITEM_IN_SQUARE" );
             if( can_store_in_vehicle() ) {
                 std::string part_name = vp->info().name();
                 desc[1] = vp->get_label().value_or( part_name );

--- a/src/advanced_inv_area.cpp
+++ b/src/advanced_inv_area.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "avatar.h"
+#include "cached_options.h"
 #include "character.h"
 #include "character_attire.h"
 #include "debug.h"
@@ -90,7 +91,7 @@ void advanced_inv_area::init()
                 vstor = vp->part_index();
                 desc[0] = veh->name;
                 canputitemsloc = true;
-                max_size = get_option<int>( "MAX_ITEM_IN_SQUARE" );
+                max_size = max_item_in_square;
             } else {
                 canputitemsloc = false;
                 desc[0] = _( "No dragged vehicle!" );
@@ -125,7 +126,7 @@ void advanced_inv_area::init()
                 vstor = vp->part_index();
             }
             canputitemsloc = can_store_in_vehicle() || here.can_put_items_ter_furn( pos );
-            max_size = get_option<int>( "MAX_ITEM_IN_SQUARE" );
+            max_size = max_item_in_square;
             if( can_store_in_vehicle() ) {
                 std::string part_name = vp->info().name();
                 desc[1] = vp->get_label().value_or( part_name );

--- a/src/ammo.cpp
+++ b/src/ammo.cpp
@@ -57,7 +57,7 @@ const ammunition_type &string_id<ammunition_type>::obj() const
 }
 
 std::vector<std::pair<ammotype, ammunition_type>>
-cata::lua_platform::detail::ammunition_type_registry_snapshot()
+        cata::lua_platform::detail::ammunition_type_registry_snapshot()
 {
     std::vector<std::pair<ammotype, ammunition_type>> result;
     const ammunition_type::registry_type &registry = ammunition_type::registry();
@@ -66,7 +66,7 @@ cata::lua_platform::detail::ammunition_type_registry_snapshot()
         result.emplace_back( id, value );
     }
     std::sort( result.begin(), result.end(),
-    []( const auto &left, const auto &right ) {
+    []( const auto & left, const auto & right ) {
         return left.first.str() < right.first.str();
     } );
     return result;

--- a/src/ammo.h
+++ b/src/ammo.h
@@ -26,7 +26,7 @@ class ammunition_type
         friend class DynamicDataLoader;
         friend class cata::lua_platform::content_transaction;
         friend std::vector<std::pair<ammotype, ammunition_type>>
-        cata::lua_platform::detail::ammunition_type_registry_snapshot();
+                cata::lua_platform::detail::ammunition_type_registry_snapshot();
         template<typename T> friend class string_id;
     public:
         ammunition_type();

--- a/src/butchery.cpp
+++ b/src/butchery.cpp
@@ -282,8 +282,7 @@ bool set_up_butchery( player_activity &act, Character &you, butchery_data bd )
     const requirement_id butchery_requirement = bd.req;
 
     if( !butchery_requirement->can_make_with_inventory(
-            you.crafting_inventory( you.pos_bub(), pickup_range ),
-            is_crafting_component ) ) {
+            you.crafting_inventory( you.pos_bub(), pickup_range ), is_crafting_component ) ) {
         std::string popup_output = _( "You can't butcher this; you are missing some tools.\n" );
 
         for( const std::string &str : butchery_requirement->get_folded_components_list(
@@ -291,8 +290,8 @@ bool set_up_butchery( player_activity &act, Character &you, butchery_data bd )
                  is_crafting_component ) ) {
             popup_output += str + '\n';
         }
-        for( const std::string &str : butchery_requirement->get_folded_tools_list(
-                 45, c_light_gray, you.crafting_inventory( you.pos_bub(), pickup_range ) ) ) {
+        for( const std::string &str : butchery_requirement->get_folded_tools_list( 45, c_light_gray,
+                you.crafting_inventory( you.pos_bub(), pickup_range ) ) ) {
             popup_output += str + '\n';
         }
 
@@ -617,8 +616,7 @@ static std::vector<item> create_charge_items( const itype *drop, int count,
     std::vector<item> objs;
     while( count > 0 ) {
         item obj( drop, calendar::turn, 1 );
-        obj.charges = std::min( count,
-                                default_tile_volume / obj.volume() );
+        obj.charges = std::min( count, default_tile_volume / obj.volume() );
         count -= obj.charges;
 
         if( obj.has_temperature() ) {
@@ -1254,8 +1252,7 @@ std::optional<butcher_type> butcher_submenu( const std::vector<map_stack::iterat
                                   ? string_format( _( "Your best tool has <color_cyan>%d butchering</color>." ), factor )
                                   :  _( "You have no butchering tool." );
 
-    const int factorD = player_character.max_quality( qual_CUT_FINE,
-                        pickup_range );
+    const int factorD = player_character.max_quality( qual_CUT_FINE, pickup_range );
     const std::string msgFactorD = factorD > INT_MIN
                                    ? string_format( _( "Your best tool has <color_cyan>%d fine cutting</color>." ), factorD )
                                    :  _( "You have no fine cutting tool." );

--- a/src/butchery.cpp
+++ b/src/butchery.cpp
@@ -237,7 +237,7 @@ static bool check_anger_empathetic_npcs_with_cannibalism( const Character &you,
 bool set_up_butchery( player_activity &act, Character &you, butchery_data bd )
 {
     const int factor = you.max_quality( bd.b_type == butcher_type::DISSECT ? qual_CUT_FINE :
-                                        qual_BUTCHER, PICKUP_RANGE );
+                                        qual_BUTCHER, get_option<int>( "PICKUP_RANGE" ) );
 
     const butcher_type action = bd.b_type;
     const item &corpse_item = *bd.corpse;
@@ -281,15 +281,17 @@ bool set_up_butchery( player_activity &act, Character &you, butchery_data bd )
     const requirement_id butchery_requirement = bd.req;
 
     if( !butchery_requirement->can_make_with_inventory(
-            you.crafting_inventory( you.pos_bub(), PICKUP_RANGE ), is_crafting_component ) ) {
+            you.crafting_inventory( you.pos_bub(), get_option<int>( "PICKUP_RANGE" ) ),
+            is_crafting_component ) ) {
         std::string popup_output = _( "You can't butcher this; you are missing some tools.\n" );
 
         for( const std::string &str : butchery_requirement->get_folded_components_list(
-                 45, c_light_gray, you.crafting_inventory( you.pos_bub(), PICKUP_RANGE ), is_crafting_component ) ) {
+                 45, c_light_gray, you.crafting_inventory( you.pos_bub(), get_option<int>( "PICKUP_RANGE" ) ),
+                 is_crafting_component ) ) {
             popup_output += str + '\n';
         }
         for( const std::string &str : butchery_requirement->get_folded_tools_list(
-                 45, c_light_gray, you.crafting_inventory( you.pos_bub(), PICKUP_RANGE ) ) ) {
+                 45, c_light_gray, you.crafting_inventory( you.pos_bub(), get_option<int>( "PICKUP_RANGE" ) ) ) ) {
             popup_output += str + '\n';
         }
 
@@ -399,7 +401,7 @@ int butcher_time_to_cut( Character &you, const item &corpse_item, const butcher_
 {
     const mtype &corpse = *corpse_item.get_mtype();
     const int factor = you.max_quality( action == butcher_type::DISSECT ? qual_CUT_FINE : qual_BUTCHER,
-                                        PICKUP_RANGE );
+                                        get_option<int>( "PICKUP_RANGE" ) );
     // in moves
     int time_to_cut;
     switch( corpse.size ) {
@@ -614,7 +616,8 @@ static std::vector<item> create_charge_items( const itype *drop, int count,
     std::vector<item> objs;
     while( count > 0 ) {
         item obj( drop, calendar::turn, 1 );
-        obj.charges = std::min( count, DEFAULT_TILE_VOLUME / obj.volume() );
+        obj.charges = std::min( count,
+                                units::from_liter( get_option<int>( "DEFAULT_TILE_VOLUME" ) ) / obj.volume() );
         count -= obj.charges;
 
         if( obj.has_temperature() ) {
@@ -646,7 +649,7 @@ bool butchery_drops_harvest( butchery_data bt, Character &you )
     const time_duration moves_total = bt.time_to_butcher;
 
     const int tool_quality = you.max_quality( action == butcher_type::DISSECT ? qual_CUT_FINE :
-                             qual_BUTCHER, PICKUP_RANGE );
+                             qual_BUTCHER, get_option<int>( "PICKUP_RANGE" ) );
 
     //all BUTCHERY types - FATAL FAILURE
     if( action != butcher_type::DISSECT &&
@@ -1135,7 +1138,7 @@ void destroy_the_carcass( const butchery_data &bd, Character &you )
         case butcher_type::FIELD_DRESS: {
             bool success = roll_butchery_dissect( round( you.get_average_skill_level( skill_survival ) ),
                                                   you.get_dex(),
-                                                  you.max_quality( qual_BUTCHER, PICKUP_RANGE ) ) > 0;
+                                                  you.max_quality( qual_BUTCHER, get_option<int>( "PICKUP_RANGE" ) ) ) > 0;
             add_msg( success ? m_good : m_warning,
                      SNIPPET.random_from_category( success ? "harvest_drop_default_field_dress_success" :
                                                    "harvest_drop_default_field_dress_failed" ).value_or( translation() ).translated() );
@@ -1245,12 +1248,13 @@ std::optional<butcher_type> butcher_submenu( const std::vector<map_stack::iterat
     };
     const bool enough_light = player_character.fine_detail_vision_mod() <= 4;
 
-    const int factor = player_character.max_quality( qual_BUTCHER, PICKUP_RANGE );
+    const int factor = player_character.max_quality( qual_BUTCHER, get_option<int>( "PICKUP_RANGE" ) );
     const std::string msgFactor = factor > INT_MIN
                                   ? string_format( _( "Your best tool has <color_cyan>%d butchering</color>." ), factor )
                                   :  _( "You have no butchering tool." );
 
-    const int factorD = player_character.max_quality( qual_CUT_FINE, PICKUP_RANGE );
+    const int factorD = player_character.max_quality( qual_CUT_FINE,
+                        get_option<int>( "PICKUP_RANGE" ) );
     const std::string msgFactorD = factorD > INT_MIN
                                    ? string_format( _( "Your best tool has <color_cyan>%d fine cutting</color>." ), factorD )
                                    :  _( "You have no fine cutting tool." );

--- a/src/butchery.cpp
+++ b/src/butchery.cpp
@@ -12,6 +12,7 @@
 #include "activity_handlers.h"
 #include "avatar.h"
 #include "butchery_requirements.h"
+#include "cached_options.h"
 #include "calendar.h"
 #include "cata_utility.h"
 #include "character.h"
@@ -237,7 +238,7 @@ static bool check_anger_empathetic_npcs_with_cannibalism( const Character &you,
 bool set_up_butchery( player_activity &act, Character &you, butchery_data bd )
 {
     const int factor = you.max_quality( bd.b_type == butcher_type::DISSECT ? qual_CUT_FINE :
-                                        qual_BUTCHER, get_option<int>( "PICKUP_RANGE" ) );
+                                        qual_BUTCHER, pickup_range );
 
     const butcher_type action = bd.b_type;
     const item &corpse_item = *bd.corpse;
@@ -281,17 +282,17 @@ bool set_up_butchery( player_activity &act, Character &you, butchery_data bd )
     const requirement_id butchery_requirement = bd.req;
 
     if( !butchery_requirement->can_make_with_inventory(
-            you.crafting_inventory( you.pos_bub(), get_option<int>( "PICKUP_RANGE" ) ),
+            you.crafting_inventory( you.pos_bub(), pickup_range ),
             is_crafting_component ) ) {
         std::string popup_output = _( "You can't butcher this; you are missing some tools.\n" );
 
         for( const std::string &str : butchery_requirement->get_folded_components_list(
-                 45, c_light_gray, you.crafting_inventory( you.pos_bub(), get_option<int>( "PICKUP_RANGE" ) ),
+                 45, c_light_gray, you.crafting_inventory( you.pos_bub(), pickup_range ),
                  is_crafting_component ) ) {
             popup_output += str + '\n';
         }
         for( const std::string &str : butchery_requirement->get_folded_tools_list(
-                 45, c_light_gray, you.crafting_inventory( you.pos_bub(), get_option<int>( "PICKUP_RANGE" ) ) ) ) {
+                 45, c_light_gray, you.crafting_inventory( you.pos_bub(), pickup_range ) ) ) {
             popup_output += str + '\n';
         }
 
@@ -401,7 +402,7 @@ int butcher_time_to_cut( Character &you, const item &corpse_item, const butcher_
 {
     const mtype &corpse = *corpse_item.get_mtype();
     const int factor = you.max_quality( action == butcher_type::DISSECT ? qual_CUT_FINE : qual_BUTCHER,
-                                        get_option<int>( "PICKUP_RANGE" ) );
+                                        pickup_range );
     // in moves
     int time_to_cut;
     switch( corpse.size ) {
@@ -617,7 +618,7 @@ static std::vector<item> create_charge_items( const itype *drop, int count,
     while( count > 0 ) {
         item obj( drop, calendar::turn, 1 );
         obj.charges = std::min( count,
-                                units::from_liter( get_option<int>( "DEFAULT_TILE_VOLUME" ) ) / obj.volume() );
+                                default_tile_volume / obj.volume() );
         count -= obj.charges;
 
         if( obj.has_temperature() ) {
@@ -649,7 +650,7 @@ bool butchery_drops_harvest( butchery_data bt, Character &you )
     const time_duration moves_total = bt.time_to_butcher;
 
     const int tool_quality = you.max_quality( action == butcher_type::DISSECT ? qual_CUT_FINE :
-                             qual_BUTCHER, get_option<int>( "PICKUP_RANGE" ) );
+                             qual_BUTCHER, pickup_range );
 
     //all BUTCHERY types - FATAL FAILURE
     if( action != butcher_type::DISSECT &&
@@ -1138,7 +1139,7 @@ void destroy_the_carcass( const butchery_data &bd, Character &you )
         case butcher_type::FIELD_DRESS: {
             bool success = roll_butchery_dissect( round( you.get_average_skill_level( skill_survival ) ),
                                                   you.get_dex(),
-                                                  you.max_quality( qual_BUTCHER, get_option<int>( "PICKUP_RANGE" ) ) ) > 0;
+                                                  you.max_quality( qual_BUTCHER, pickup_range ) ) > 0;
             add_msg( success ? m_good : m_warning,
                      SNIPPET.random_from_category( success ? "harvest_drop_default_field_dress_success" :
                                                    "harvest_drop_default_field_dress_failed" ).value_or( translation() ).translated() );
@@ -1248,13 +1249,13 @@ std::optional<butcher_type> butcher_submenu( const std::vector<map_stack::iterat
     };
     const bool enough_light = player_character.fine_detail_vision_mod() <= 4;
 
-    const int factor = player_character.max_quality( qual_BUTCHER, get_option<int>( "PICKUP_RANGE" ) );
+    const int factor = player_character.max_quality( qual_BUTCHER, pickup_range );
     const std::string msgFactor = factor > INT_MIN
                                   ? string_format( _( "Your best tool has <color_cyan>%d butchering</color>." ), factor )
                                   :  _( "You have no butchering tool." );
 
     const int factorD = player_character.max_quality( qual_CUT_FINE,
-                        get_option<int>( "PICKUP_RANGE" ) );
+                        pickup_range );
     const std::string msgFactorD = factorD > INT_MIN
                                    ? string_format( _( "Your best tool has <color_cyan>%d fine cutting</color>." ), factorD )
                                    :  _( "You have no fine cutting tool." );

--- a/src/cached_options.cpp
+++ b/src/cached_options.cpp
@@ -1,4 +1,5 @@
 #include "cached_options.h"
+#include "units.h"
 
 bool keycode_mode;
 bool log_from_top;
@@ -24,6 +25,10 @@ int pixel_minimap_r;
 int pixel_minimap_g;
 int pixel_minimap_b;
 int pixel_minimap_a;
+
+int max_item_in_square;
+units::volume default_tile_volume;
+int pickup_range;
 
 namespace cata::options
 {

--- a/src/cached_options.h
+++ b/src/cached_options.h
@@ -4,6 +4,7 @@
 
 #include <string>
 #include <vector>
+#include "units.h"
 
 // A collection of options which are accessed frequently enough that we don't
 // want to pay the overhead of a string lookup each time one is tested.
@@ -29,6 +30,9 @@ extern int pixel_minimap_r;
 extern int pixel_minimap_g;
 extern int pixel_minimap_b;
 extern int pixel_minimap_a;
+extern int max_item_in_square;
+extern units::volume default_tile_volume;
+extern int pickup_range;
 
 namespace cata::options
 {

--- a/src/catalua_platform_content.h
+++ b/src/catalua_platform_content.h
@@ -186,10 +186,10 @@ void insert_platform_trait_group(
     const std::vector<std::pair<std::string, std::int64_t>> &entries );
 void erase_platform_trait_group( const std::string &id );
 void append_platform_monster_adjustment( const std::string &species,
-                                         const std::string &stat,
-                                         double stat_adjust,
-                                         const std::string &flag, bool flag_val,
-                                         const std::string &special );
+        const std::string &stat,
+        double stat_adjust,
+        const std::string &flag, bool flag_val,
+        const std::string &special );
 std::size_t platform_monster_adjustment_count();
 void truncate_platform_monster_adjustments( std::size_t count );
 void erase_platform_scenario_blacklist( const platform_blacklist_data &value );

--- a/src/catalua_platform_runtime.cpp
+++ b/src/catalua_platform_runtime.cpp
@@ -2870,9 +2870,9 @@ struct butchery_requirement_definition_handle {
                 "butchery requirement size, butcher, and requirement cannot be empty" );
         }
         definition->entries.push_back(
-            butchery_requirement_definition_data::requirement_entry{
-                speed, size, butcher, requirement_id
-            } );
+        butchery_requirement_definition_data::requirement_entry{
+            speed, size, butcher, requirement_id
+        } );
         return *this;
     }
 
@@ -10897,10 +10897,10 @@ void content_transaction::install_lua_api( sol::state &lua, sol::table &ccb,
             }
             if( handle.definition->files.empty() ) {
                 transaction->sound_effect_preloads.push_back(
-                    { operation, handle.definition } );
+                { operation, handle.definition } );
             } else {
                 transaction->sound_effects.push_back(
-                    { operation, handle.definition } );
+                { operation, handle.definition } );
             }
             return;
         }
@@ -13048,8 +13048,9 @@ bool content_transaction::validate( const runtime &owner_runtime,
                                           "' has invalid ranges or a duplicate registration" );
             }
             if( check_engine_state ) {
-                for( const std::string &target :
-                     { definition.open, definition.close, definition.lockpick_result } ) {
+                for( const std::string &target : {
+                         definition.open, definition.close, definition.lockpick_result
+                     } ) {
                     if( !target.empty() && !furn_str_id( target ).is_valid() ) {
                         throw std::runtime_error( "furniture '" + definition.id +
                                                   "' references an invalid furniture id '" +
@@ -13085,9 +13086,10 @@ bool content_transaction::validate( const runtime &owner_runtime,
                                           "' has invalid ranges or a duplicate registration" );
             }
             if( check_engine_state ) {
-                for( const std::string &target :
-                     { definition.open, definition.close, definition.transforms_into,
-                       definition.roof, definition.lockpick_result } ) {
+                for( const std::string &target : {
+                         definition.open, definition.close, definition.transforms_into,
+                         definition.roof, definition.lockpick_result
+                     } ) {
                     if( !target.empty() && !ter_str_id( target ).is_valid() ) {
                         throw std::runtime_error( "terrain '" + definition.id +
                                                   "' references an invalid terrain id '" +
@@ -15767,9 +15769,9 @@ bool content_transaction::validate( const runtime &owner_runtime,
                                           "' is registered more than once in one transaction" );
             }
             const bool exists = entry.definition->uncraft ?
-                               recipe_dict.uncraft.count(
-                                   recipe_id( entry.definition->result ) ) > 0 :
-                               recipe_dict.recipes.count( recipe_id( definition.id ) ) > 0;
+                                recipe_dict.uncraft.count(
+                                    recipe_id( entry.definition->result ) ) > 0 :
+                                recipe_dict.recipes.count( recipe_id( definition.id ) ) > 0;
             validate_operation( entry.operation, exists, definition.id,
                                 definition.nested_category ?
                                 "nested recipe category" : "recipe" );
@@ -17500,7 +17502,7 @@ bool content_transaction::apply( std::string &error )
             native.src.emplace_back( id, mod_id( pimpl_->owner ) );
             native.name = no_translation( source.name );
             native.description = source.description.empty() ? translation() :
-                                no_translation( source.description );
+                                 no_translation( source.description );
             if( !source.avatar_message.empty() ) {
                 native.avatar_message = no_translation( source.avatar_message );
             }
@@ -17560,7 +17562,7 @@ bool content_transaction::apply( std::string &error )
             native.src.emplace_back( id, mod_id( pimpl_->owner ) );
             native.name = no_translation( source.name );
             native.description = source.description.empty() ? translation() :
-                               no_translation( source.description );
+                                 no_translation( source.description );
             if( !source.initiate_avatar.empty() ) {
                 native.initiate.emplace_back( no_translation( source.initiate_avatar ) );
             }
@@ -20320,7 +20322,7 @@ bool content_transaction::validate_finalized( std::string &error ) const
     }
     for( const recipe_registration &entry : pimpl_->recipes ) {
         const auto &native_dict = entry.definition->uncraft ?
-                                 recipe_dict.uncraft : recipe_dict.recipes;
+                                  recipe_dict.uncraft : recipe_dict.recipes;
         const recipe_id id( entry.definition->uncraft ?
                             recipe_id( entry.definition->result ) :
                             recipe_id( entry.definition->id ) );
@@ -24563,8 +24565,8 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
                            world_generation() ) ) );
     } );
     inventory.set_function( "is_wearing", [require_read, runtime_generation,
-                                                    world_generation]( sol::this_state state,
-    const cata::lua_ui::game_handle & handle,
+                                                         world_generation]( sol::this_state state,
+                                                   const cata::lua_ui::game_handle & handle,
     const cata::lua_ui::script_game_id & id ) {
         require_read();
         if( id.kind() != "item" ) {
@@ -24999,7 +25001,7 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
                           with_fields.value_or( true ) );
     } );
     environment.set_function( "furniture_has_flag", [require_read](
-    const cata::lua_ui::script_tripoint_coord & position, const std::string &flag ) {
+    const cata::lua_ui::script_tripoint_coord & position, const std::string & flag ) {
         require_read();
         if( flag.empty() || flag.size() > 256 || flag.find( '\0' ) != std::string::npos ) {
             throw std::invalid_argument(
@@ -25042,7 +25044,7 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
         return here.furn( here.get_bub( absolute ) ).id().str();
     } );
     environment.set_function( "field_exists", [require_read](
-    const cata::lua_ui::script_tripoint_coord & position, const std::string &field_id ) {
+    const cata::lua_ui::script_tripoint_coord & position, const std::string & field_id ) {
         require_read();
         if( field_id.empty() || field_id.size() > 256 || field_id.find( '\0' ) != std::string::npos ) {
             throw std::invalid_argument(
@@ -25059,7 +25061,7 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
                    field_type_id( field_id ) );
     } );
     environment.set_function( "terrain_has_flag", [require_read](
-    const cata::lua_ui::script_tripoint_coord & position, const std::string &flag ) {
+    const cata::lua_ui::script_tripoint_coord & position, const std::string & flag ) {
         require_read();
         if( flag.empty() || flag.size() > 256 || flag.find( '\0' ) != std::string::npos ) {
             throw std::invalid_argument(
@@ -25091,7 +25093,7 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
         return !here.is_outside( bub );
     } );
     environment.set_function( "safe_mode_dangerous", [require_read](
-    const std::string &direction ) {
+    const std::string & direction ) {
         require_read();
         const std::optional<cardinal_direction> dir =
             io::string_to_enum_optional<cardinal_direction>( direction );
@@ -25100,7 +25102,7 @@ void install_runtime_api( const std::shared_ptr<runtime> &value,
                 "services.gameplay.environment.safe_mode_dangerous requires a valid cardinal direction" );
         }
         return get_avatar().get_mon_visible().dangerous[
-                   static_cast<int>( *dir )];
+            static_cast<int>( *dir )];
     } );
     gameplay["environment"] = std::move( environment );
     services["gameplay"] = std::move( gameplay );

--- a/src/catalua_ui_camps.cpp
+++ b/src/catalua_ui_camps.cpp
@@ -603,7 +603,7 @@ void install_camp_api(
     } );
     camps.set_function(
         "player_has_camp",
-        [require_read]( sol::this_state lua_state ) {
+    [require_read]( sol::this_state lua_state ) {
         require_read();
         return player_has_camp( lua_state );
     } );

--- a/src/catalua_ui_creatures.cpp
+++ b/src/catalua_ui_creatures.cpp
@@ -951,7 +951,7 @@ void install_creature_api(
     creatures.set_function(
         "can_see",
         [current_runtime_generation, current_world_generation, require_read](
-    sol::this_state lua_state, const game_handle & observer,
+            sol::this_state lua_state, const game_handle & observer,
     const game_handle & target ) {
         require_read();
         sol::state_view state( lua_state );
@@ -1057,7 +1057,7 @@ void install_creature_api(
     characters.set_function(
         "has_flag",
         [current_runtime_generation, current_world_generation, require_read](
-    sol::this_state lua_state, const game_handle & handle,
+            sol::this_state lua_state, const game_handle & handle,
     const script_game_id & flag ) {
         require_read();
         if( flag.kind() != "json_flag" ) {
@@ -1082,7 +1082,7 @@ void install_creature_api(
     characters.set_function(
         "has_profession",
         [current_runtime_generation, current_world_generation, require_read](
-    sol::this_state lua_state, const game_handle & handle,
+            sol::this_state lua_state, const game_handle & handle,
     const std::string & profession_id_string ) {
         require_read();
         sol::state_view state( lua_state );
@@ -1101,7 +1101,7 @@ void install_creature_api(
     characters.set_function(
         "add_wet",
         [current_runtime_generation, current_world_generation, require_write](
-    sol::this_state lua_state, const game_handle & handle,
+            sol::this_state lua_state, const game_handle & handle,
     const std::int64_t amount ) {
         require_write();
         if( amount < -1000000 || amount > 1000000 ) {

--- a/src/catalua_ui_overmap.cpp
+++ b/src/catalua_ui_overmap.cpp
@@ -1300,7 +1300,7 @@ void install_overmap_api(
     overmap.set_function(
         "is_safe",
         [require_read](
-            const script_tripoint_coord & position ) {
+    const script_tripoint_coord & position ) {
         require_read();
         return overmap_buffer.is_safe(
                    require_absolute_omt(
@@ -1309,7 +1309,7 @@ void install_overmap_api(
     overmap.set_function(
         "is_in_city",
         [require_read](
-            const script_tripoint_coord & position ) {
+    const script_tripoint_coord & position ) {
         require_read();
         if( position.native_origin() != coords::origin::abs ||
             position.native_scale() != coords::scale::map_square ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2871,7 +2871,7 @@ units::mass Character::best_nearby_lifting_assist( const tripoint_bub_ms &world_
         }
     }
     int lift_quality = std::max( { this->max_quality( qual_LIFT ), mech_lift,
-                                   map_selector( this->pos_bub(), PICKUP_RANGE ).max_quality( qual_LIFT ),
+                                   map_selector( this->pos_bub(), get_option<int>( "PICKUP_RANGE" ) ).max_quality( qual_LIFT ),
                                    vehicle_selector( here, world_pos, 4, true, true ).max_quality( qual_LIFT )
                                  } );
     return lifting_quality_to_mass( lift_quality );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2871,7 +2871,7 @@ units::mass Character::best_nearby_lifting_assist( const tripoint_bub_ms &world_
         }
     }
     int lift_quality = std::max( { this->max_quality( qual_LIFT ), mech_lift,
-                                   map_selector( this->pos_bub(), get_option<int>( "PICKUP_RANGE" ) ).max_quality( qual_LIFT ),
+                                   map_selector( this->pos_bub(), pickup_range ).max_quality( qual_LIFT ),
                                    vehicle_selector( here, world_pos, 4, true, true ).max_quality( qual_LIFT )
                                  } );
     return lifting_quality_to_mass( lift_quality );

--- a/src/character.h
+++ b/src/character.h
@@ -24,6 +24,7 @@
 #include "activity_tracker.h"
 #include "body_part_set.h"
 #include "bodypart.h"
+#include "cached_options.h"
 #include "calendar.h"
 #include "cata_utility.h"
 #include "character_attire.h"
@@ -3653,15 +3654,15 @@ class Character : public Creature, public visitable
         * @returns Craftable inventory items found.
         * */
         const inventory &crafting_inventory( const tripoint_bub_ms &src_pos = tripoint_bub_ms::zero,
-                                             int radius = get_option<int>( "PICKUP_RANGE" ), bool clear_path = true ) const;
+                                             int radius = pickup_range, bool clear_path = true ) const;
         const inventory &crafting_inventory( map *here,
                                              const tripoint_bub_ms &src_pos = tripoint_bub_ms::zero,
-                                             int radius = get_option<int>( "PICKUP_RANGE" ), bool clear_path = true ) const;
+                                             int radius = pickup_range, bool clear_path = true ) const;
         void invalidate_crafting_inventory();
         // Efficiently query book proficiency bonuses from nearby items
         // without rebuilding the full crafting inventory.
         // Walks map tiles and vehicle cargo in range, plus character inventory.
-        book_proficiency_bonuses book_bonuses_nearby( int radius = get_option<int>( "PICKUP_RANGE" ) )
+        book_proficiency_bonuses book_bonuses_nearby( int radius = pickup_range )
         const;
 
         /** Returns a value from 1.0 to 11.0 that acts as a multiplier

--- a/src/character.h
+++ b/src/character.h
@@ -44,6 +44,7 @@
 #include "item_pocket.h"
 #include "memory_fast.h"
 #include "monster.h"
+#include "options.h"
 #include "pimpl.h"
 #include "player_activity.h"
 #include "pocket_type.h"
@@ -3652,15 +3653,16 @@ class Character : public Creature, public visitable
         * @returns Craftable inventory items found.
         * */
         const inventory &crafting_inventory( const tripoint_bub_ms &src_pos = tripoint_bub_ms::zero,
-                                             int radius = PICKUP_RANGE, bool clear_path = true ) const;
+                                             int radius = get_option<int>( "PICKUP_RANGE" ), bool clear_path = true ) const;
         const inventory &crafting_inventory( map *here,
                                              const tripoint_bub_ms &src_pos = tripoint_bub_ms::zero,
-                                             int radius = PICKUP_RANGE, bool clear_path = true ) const;
+                                             int radius = get_option<int>( "PICKUP_RANGE" ), bool clear_path = true ) const;
         void invalidate_crafting_inventory();
         // Efficiently query book proficiency bonuses from nearby items
         // without rebuilding the full crafting inventory.
         // Walks map tiles and vehicle cargo in range, plus character inventory.
-        book_proficiency_bonuses book_bonuses_nearby( int radius = PICKUP_RANGE ) const;
+        book_proficiency_bonuses book_bonuses_nearby( int radius = get_option<int>( "PICKUP_RANGE" ) )
+        const;
 
         /** Returns a value from 1.0 to 11.0 that acts as a multiplier
          * for the time taken to perform tasks that require detail vision,
@@ -3904,7 +3906,7 @@ class Character : public Creature, public visitable
                                 const tripoint_bub_ms &origin, int radius, bool pin_to_map );
         void consume_tools( const comp_selection<tool_comp> &tool, int batch );
         void consume_tools( map &m, const comp_selection<tool_comp> &tool, int batch,
-                            const tripoint_bub_ms &origin = tripoint_bub_ms::zero, int radius = PICKUP_RANGE,
+                            const tripoint_bub_ms &origin, int radius,
                             basecamp *bcp = nullptr );
         void consume_tools( map &m, const comp_selection<tool_comp> &tool, int batch,
                             const std::vector<tripoint_bub_ms> &reachable_pts = {},   basecamp *bcp = nullptr );

--- a/src/character.h
+++ b/src/character.h
@@ -3907,7 +3907,7 @@ class Character : public Creature, public visitable
                                 const tripoint_bub_ms &origin, int radius, bool pin_to_map );
         void consume_tools( const comp_selection<tool_comp> &tool, int batch );
         void consume_tools( map &m, const comp_selection<tool_comp> &tool, int batch,
-                            const tripoint_bub_ms &origin, int radius,
+                            const tripoint_bub_ms &origin = tripoint_bub_ms::zero, int radius = pickup_range,
                             basecamp *bcp = nullptr );
         void consume_tools( map &m, const comp_selection<tool_comp> &tool, int batch,
                             const std::vector<tripoint_bub_ms> &reachable_pts = {},   basecamp *bcp = nullptr );

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -20,6 +20,7 @@
 #include "avatar.h"
 #include "basecamp.h"
 #include "bodypart.h"
+#include "cached_options.h"
 #include "calendar.h"
 #include "character.h"
 #include "character_id.h"
@@ -743,7 +744,7 @@ conditional_t::func f_has_items_sum( const JsonObject &jo, std::string_view memb
         double total_present;
         const Character *you = d.const_actor( is_npc )->get_const_character();
         inventory inventory_and_around = you->crafting_inventory( you->pos_bub(),
-                                         get_option<int>( "PICKUP_RANGE" ) );
+                                         pickup_range );
 
         for( const auto &pair : item_and_amount ) {
             item_to_find = itype_id( pair.first.evaluate( d ) );

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -743,8 +743,7 @@ conditional_t::func f_has_items_sum( const JsonObject &jo, std::string_view memb
         double charges_present;
         double total_present;
         const Character *you = d.const_actor( is_npc )->get_const_character();
-        inventory inventory_and_around = you->crafting_inventory( you->pos_bub(),
-                                         pickup_range );
+        inventory inventory_and_around = you->crafting_inventory( you->pos_bub(), pickup_range );
 
         for( const auto &pair : item_and_amount ) {
             item_to_find = itype_id( pair.first.evaluate( d ) );

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -742,7 +742,8 @@ conditional_t::func f_has_items_sum( const JsonObject &jo, std::string_view memb
         double charges_present;
         double total_present;
         const Character *you = d.const_actor( is_npc )->get_const_character();
-        inventory inventory_and_around = you->crafting_inventory( you->pos_bub(), PICKUP_RANGE );
+        inventory inventory_and_around = you->crafting_inventory( you->pos_bub(),
+                                         get_option<int>( "PICKUP_RANGE" ) );
 
         for( const auto &pair : item_and_amount ) {
             item_to_find = itype_id( pair.first.evaluate( d ) );

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "activity_actor_definitions.h"
+#include "cached_options.h"
 #include "calendar.h"
 #include "character.h"
 #include "crafting.h"
@@ -151,7 +152,7 @@ void craft_command::execute( bool only_cache_comps )
 
     bool need_selections = true;
     inventory map_inv;
-    map_inv.form_from_map( crafter->pos_bub(), get_option<int>( "PICKUP_RANGE" ), crafter );
+    map_inv.form_from_map( crafter->pos_bub(), pickup_range, crafter );
 
     if( has_cached_selections() ) {
         std::vector<comp_selection<item_comp>> missing_items = check_item_components_missing( map_inv );
@@ -346,7 +347,7 @@ bool craft_command::continue_prompt_liquids( const std::function<bool( const ite
         for( int i = 0; i < 2 && real_count > 0; i++ ) {
             if( it.use_from & usage_from::map ) {
                 const tripoint_bub_ms &loc = crafter->pos_bub();
-                for( int radius = 0; radius <= get_option<int>( "PICKUP_RANGE" ) && real_count > 0; radius++ ) {
+                for( int radius = 0; radius <= pickup_range && real_count > 0; radius++ ) {
                     for( const tripoint_bub_ms &p : m.points_in_radius( loc, radius ) ) {
                         if( rl_dist( loc, p ) >= radius ) {
                             // "Simulate" consuming items and put them back
@@ -423,7 +424,7 @@ static std::list<item> sane_consume_items( const comp_selection<item_comp> &it, 
     for( int i = 0; i < 2 && real_count > 0; i++ ) {
         if( it.use_from & usage_from::map ) {
             const tripoint_bub_ms &loc = crafter->pos_bub();
-            for( int radius = 0; radius <= get_option<int>( "PICKUP_RANGE" ) && real_count > 0; radius++ ) {
+            for( int radius = 0; radius <= pickup_range && real_count > 0; radius++ ) {
                 for( const tripoint_bub_ms &p : m.points_in_radius( loc, radius ) ) {
                     if( rl_dist( loc, p ) >= radius ) {
                         std::list<item> tmp = m.use_amount_square( p, it.comp.type, real_count,
@@ -613,7 +614,7 @@ item craft_command::create_in_progress_craft()
     }
 
     inventory map_inv;
-    map_inv.form_from_map( crafter->pos_bub(), get_option<int>( "PICKUP_RANGE" ), crafter );
+    map_inv.form_from_map( crafter->pos_bub(), pickup_range, crafter );
 
     if( !check_item_components_missing( map_inv ).empty() ) {
         debugmsg( "Aborting crafting: couldn't find cached components" );

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -151,7 +151,7 @@ void craft_command::execute( bool only_cache_comps )
 
     bool need_selections = true;
     inventory map_inv;
-    map_inv.form_from_map( crafter->pos_bub(), PICKUP_RANGE, crafter );
+    map_inv.form_from_map( crafter->pos_bub(), get_option<int>( "PICKUP_RANGE" ), crafter );
 
     if( has_cached_selections() ) {
         std::vector<comp_selection<item_comp>> missing_items = check_item_components_missing( map_inv );
@@ -346,7 +346,7 @@ bool craft_command::continue_prompt_liquids( const std::function<bool( const ite
         for( int i = 0; i < 2 && real_count > 0; i++ ) {
             if( it.use_from & usage_from::map ) {
                 const tripoint_bub_ms &loc = crafter->pos_bub();
-                for( int radius = 0; radius <= PICKUP_RANGE && real_count > 0; radius++ ) {
+                for( int radius = 0; radius <= get_option<int>( "PICKUP_RANGE" ) && real_count > 0; radius++ ) {
                     for( const tripoint_bub_ms &p : m.points_in_radius( loc, radius ) ) {
                         if( rl_dist( loc, p ) >= radius ) {
                             // "Simulate" consuming items and put them back
@@ -423,7 +423,7 @@ static std::list<item> sane_consume_items( const comp_selection<item_comp> &it, 
     for( int i = 0; i < 2 && real_count > 0; i++ ) {
         if( it.use_from & usage_from::map ) {
             const tripoint_bub_ms &loc = crafter->pos_bub();
-            for( int radius = 0; radius <= PICKUP_RANGE && real_count > 0; radius++ ) {
+            for( int radius = 0; radius <= get_option<int>( "PICKUP_RANGE" ) && real_count > 0; radius++ ) {
                 for( const tripoint_bub_ms &p : m.points_in_radius( loc, radius ) ) {
                     if( rl_dist( loc, p ) >= radius ) {
                         std::list<item> tmp = m.use_amount_square( p, it.comp.type, real_count,
@@ -613,7 +613,7 @@ item craft_command::create_in_progress_craft()
     }
 
     inventory map_inv;
-    map_inv.form_from_map( crafter->pos_bub(), PICKUP_RANGE, crafter );
+    map_inv.form_from_map( crafter->pos_bub(), get_option<int>( "PICKUP_RANGE" ), crafter );
 
     if( !check_item_components_missing( map_inv ).empty() ) {
         debugmsg( "Aborting crafting: couldn't find cached components" );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -326,7 +326,8 @@ float Character::workbench_crafting_speed_multiplier( const item &craft,
     }
 
     multiplier *= lerped_multiplier( craft_mass, allowed_mass, 1000_kilogram );
-    multiplier *= lerped_multiplier( craft_volume, allowed_volume, DEFAULT_TILE_VOLUME );
+    multiplier *= lerped_multiplier( craft_volume, allowed_volume,
+                                     units::from_liter( get_option<int>( "DEFAULT_TILE_VOLUME" ) ) );
 
     return multiplier;
 }
@@ -603,9 +604,11 @@ std::vector<const item *> Character::get_eligible_containers_for_crafting() cons
 
     map &here = get_map();
     // get all potential containers within PICKUP_RANGE tiles including vehicles
-    for( const tripoint_bub_ms &loc : closest_points_first( pos_bub(), PICKUP_RANGE ) ) {
+    for( const tripoint_bub_ms &loc : closest_points_first( pos_bub(),
+            get_option<int>( "PICKUP_RANGE" ) ) ) {
         // can not reach this -> can not access its contents
-        if( pos_bub() != loc && !here.clear_path( pos_bub(), loc, PICKUP_RANGE, 1, 100 ) ) {
+        if( pos_bub() != loc &&
+            !here.clear_path( pos_bub(), loc, get_option<int>( "PICKUP_RANGE" ), 1, 100 ) ) {
             continue;
         }
         if( here.accessible_items( loc ) ) {
@@ -660,7 +663,7 @@ bool Character::can_start_craft( const recipe *rec, recipe_filter_flags flags,
 
 const inventory &Character::crafting_inventory( bool clear_path ) const
 {
-    return crafting_inventory( tripoint_bub_ms::zero, PICKUP_RANGE, clear_path );
+    return crafting_inventory( tripoint_bub_ms::zero, get_option<int>( "PICKUP_RANGE" ), clear_path );
 }
 
 const inventory &Character::crafting_inventory( const tripoint_bub_ms &src_pos, int radius,
@@ -802,7 +805,7 @@ static item_location set_item_inventory( Character &p, item &newit )
 {
     item_location ret_val = item_location::nowhere;
     if( newit.made_of( phase_id::LIQUID ) ) {
-        liquid_handler::handle_all_or_npc_liquid( p, newit, PICKUP_RANGE );
+        liquid_handler::handle_all_or_npc_liquid( p, newit, get_option<int>( "PICKUP_RANGE" ) );
     } else {
         p.inv->assign_empty_invlet( newit, p );
         // We might not have space for the item
@@ -1229,7 +1232,7 @@ namespace
 // radius (map craft), else null when only the map at the craft is reachable.
 struct step_source_context {
     tripoint_bub_ms origin;
-    int radius = PICKUP_RANGE;
+    int radius;
     Character *present_char = nullptr;
 };
 } // namespace
@@ -1239,7 +1242,7 @@ static step_source_context resolve_step_source( const item &craft, const item_lo
     map &m = get_map();
     step_source_context src;
     src.origin = m.get_bub( loc.pos_abs() );
-    src.radius = PICKUP_RANGE;
+    src.radius = get_option<int>( "PICKUP_RANGE" );
     if( loc.where() == item_location::type::character ) {
         src.present_char = loc.carrier();
     } else {
@@ -2516,7 +2519,7 @@ static void spawn_items( Character &guy, std::vector<item> &results,
         prepare( newit );
 
         if( newit.made_of( phase_id::LIQUID ) ) {
-            liquid_handler::handle_all_or_npc_liquid( guy, newit, PICKUP_RANGE );
+            liquid_handler::handle_all_or_npc_liquid( guy, newit, get_option<int>( "PICKUP_RANGE" ) );
             ++i;
             continue;
         }
@@ -2761,7 +2764,7 @@ bool Character::can_continue_craft( item &craft, const requirement_data &continu
         }
 
         inventory map_inv;
-        map_inv.form_from_map( pos_bub(), PICKUP_RANGE, this );
+        map_inv.form_from_map( pos_bub(), get_option<int>( "PICKUP_RANGE" ), this );
 
         auto filter = [&]( const item & it ) {
             return std_filter( it ) &&
@@ -2841,7 +2844,7 @@ bool Character::can_continue_craft( item &craft, const requirement_data &continu
         }
 
         inventory map_inv;
-        map_inv.form_from_map( pos_bub(), PICKUP_RANGE, this );
+        map_inv.form_from_map( pos_bub(), get_option<int>( "PICKUP_RANGE" ), this );
 
         if( rec.has_steps() ) {
             const std::vector<std::vector<step_tool_alloc>> &prior = craft.get_step_tool_allocs();
@@ -3287,7 +3290,7 @@ std::vector<item_location> preview_source_locations( Character &crafter,
     map &here = get_map();
     if( selection.use_from & usage_from::map ) {
         const std::vector<tripoint_bub_ms> reachable = here.reachable_item_points(
-                    crafter.pos_bub(), PICKUP_RANGE, 1, 100 );
+                    crafter.pos_bub(), get_option<int>( "PICKUP_RANGE" ), 1, 100 );
         for( const tripoint_bub_ms &point : reachable ) {
             if( !here.accessible_items( point ) ) {
                 continue;
@@ -3312,7 +3315,7 @@ std::optional<item> preview_infinite_map_charge_source( Character &crafter, cons
 {
     map &here = get_map();
     const std::vector<tripoint_bub_ms> reachable = here.reachable_item_points(
-                crafter.pos_bub(), PICKUP_RANGE, 1, 100 );
+                crafter.pos_bub(), get_option<int>( "PICKUP_RANGE" ), 1, 100 );
     for( const tripoint_bub_ms &point : reachable ) {
         item source = here.liquid_from( point );
         if( source.typeId() == type && source.charges == item::INFINITE_CHARGES ) {
@@ -3418,7 +3421,7 @@ std::optional<item_components> Character::preview_crafting_components(
                             *this, map_selection, filter, preferred );
                 map &here = get_map();
                 const std::vector<tripoint_bub_ms> reachable = here.reachable_item_points(
-                            pos_bub(), PICKUP_RANGE, 1, 100 );
+                            pos_bub(), get_option<int>( "PICKUP_RANGE" ), 1, 100 );
                 const bool vehicle_first = !by_charges;
                 for( const tripoint_bub_ms &point : reachable ) {
                     for( item_location &location : map_candidates ) {
@@ -3476,7 +3479,7 @@ std::list<item> Character::consume_items( const comp_selection<item_comp> &is, i
     }
     // populate a grid of spots that can be reached
     const std::vector<tripoint_bub_ms> &reachable_pts = m.reachable_item_points( pos_bub(),
-            PICKUP_RANGE, 1, 100 );
+            get_option<int>( "PICKUP_RANGE" ), 1, 100 );
     return consume_items( m, is, batch, filter, reachable_pts, select_ind, disable_preference );
 }
 
@@ -3592,7 +3595,7 @@ std::list<item> Character::consume_items( const std::vector<item_comp> &componen
         const bool can_cancel, const bool disable_preference )
 {
     inventory map_inv;
-    map_inv.form_from_map( pos_bub(), PICKUP_RANGE, this );
+    map_inv.form_from_map( pos_bub(), get_option<int>( "PICKUP_RANGE" ), this );
     comp_selection<item_comp> sel = select_item_component( components, batch, map_inv, can_cancel,
                                     filter );
     return consume_items( sel, batch, filter, select_ind( sel.comp.type ), disable_preference );
@@ -3787,7 +3790,7 @@ bool Character::craft_consume_tools( item &craft, int multiplier, bool start_cra
     }
 
     inventory map_inv;
-    map_inv.form_from_map( pos_bub(), PICKUP_RANGE, this );
+    map_inv.form_from_map( pos_bub(), get_option<int>( "PICKUP_RANGE" ), this );
 
     for( const comp_selection<tool_comp> &tool_sel : cached_tool_selections ) {
         itype_id type = tool_sel.comp.type;
@@ -4094,7 +4097,7 @@ bool Character::craft_consume_step_tools( item &craft, const crafting_cost_conte
         }
     }
     return consume_step_tool_targets( craft, targets,
-                                      pos_bub(), PICKUP_RANGE, /*pin_to_map=*/false );
+                                      pos_bub(), get_option<int>( "PICKUP_RANGE" ), /*pin_to_map=*/false );
 }
 
 bool Character::craft_consume_passive_step_tools( item &craft, time_point now,
@@ -4143,7 +4146,7 @@ bool Character::craft_consume_passive_step_tools( item &craft, time_point now,
 
 void Character::consume_tools( const comp_selection<tool_comp> &tool, int batch )
 {
-    consume_tools( get_map(), tool, batch, pos_bub(), PICKUP_RANGE );
+    consume_tools( get_map(), tool, batch, pos_bub(), get_option<int>( "PICKUP_RANGE" ) );
 }
 
 /* we use this if we selected the tool earlier */
@@ -4200,7 +4203,7 @@ to consume_tools */
 void Character::consume_tools( const std::vector<tool_comp> &tools, int batch )
 {
     inventory map_inv;
-    map_inv.form_from_map( pos_bub(), PICKUP_RANGE, this );
+    map_inv.form_from_map( pos_bub(), get_option<int>( "PICKUP_RANGE" ), this );
     consume_tools( select_tool_component( tools, batch, map_inv ), batch );
 }
 
@@ -4675,7 +4678,7 @@ void Character::complete_disassemble( item_location &target, const recipe &dis )
             }
 
             if( act_item.made_of( phase_id::LIQUID ) ) {
-                liquid_handler::handle_all_or_npc_liquid( *this, act_item, PICKUP_RANGE );
+                liquid_handler::handle_all_or_npc_liquid( *this, act_item, get_option<int>( "PICKUP_RANGE" ) );
             } else {
                 drop_items.push_back( act_item );
             }
@@ -4744,7 +4747,7 @@ void drop_or_handle( const item &newit, Character &p )
 {
     item tmp( newit );
     if( newit.made_of( phase_id::LIQUID ) ) {
-        liquid_handler::handle_all_or_npc_liquid( p, tmp, PICKUP_RANGE );
+        liquid_handler::handle_all_or_npc_liquid( p, tmp, get_option<int>( "PICKUP_RANGE" ) );
     } else {
         p.i_add_or_drop( tmp );
     }
@@ -4792,15 +4795,15 @@ std::vector<Character *> Character::get_crafting_helpers() const
                && ( !is_mp_partner || cata_mp::is_partner_helping_us() )
                && !guy.in_sleep_state()
                && guy.is_obeying( *this )
-               && rl_dist( guy.pos_bub(), pos_bub() ) < PICKUP_RANGE
-               && get_map().clear_path( pos_bub(), guy.pos_bub(), PICKUP_RANGE, 1, 100 );
+               && rl_dist( guy.pos_bub(), pos_bub() ) < get_option<int>( "PICKUP_RANGE" )
+               && get_map().clear_path( pos_bub(), guy.pos_bub(), get_option<int>( "PICKUP_RANGE" ), 1, 100 );
 #else
         return getID() != guy.getID()
                && guy.is_npc()
                && !guy.in_sleep_state()
                && guy.is_obeying( *this )
-               && rl_dist( guy.pos_bub(), pos_bub() ) < PICKUP_RANGE
-               && get_map().clear_path( pos_bub(), guy.pos_bub(), PICKUP_RANGE, 1, 100 );
+               && rl_dist( guy.pos_bub(), pos_bub() ) < get_option<int>( "PICKUP_RANGE" )
+               && get_map().clear_path( pos_bub(), guy.pos_bub(), get_option<int>( "PICKUP_RANGE" ), 1, 100 );
 #endif
     } );
 }
@@ -4812,12 +4815,12 @@ std::vector<Character *> Character::get_crafting_group() const
         const bool is_mp_partner = cata_mp::is_partner_npc( guy.getID() );
         return guy.is_ally( *this )
                && ( !is_mp_partner || cata_mp::is_partner_helping_us() )
-               && rl_dist( guy.pos_bub(), pos_bub() ) < PICKUP_RANGE
-               && get_map().clear_path( pos_bub(), guy.pos_bub(), PICKUP_RANGE, 1, 100 );
+               && rl_dist( guy.pos_bub(), pos_bub() ) < get_option<int>( "PICKUP_RANGE" )
+               && get_map().clear_path( pos_bub(), guy.pos_bub(), get_option<int>( "PICKUP_RANGE" ), 1, 100 );
 #else
         return guy.is_ally( *this )
-               && rl_dist( guy.pos_bub(), pos_bub() ) < PICKUP_RANGE
-               && get_map().clear_path( pos_bub(), guy.pos_bub(), PICKUP_RANGE, 1, 100 );
+               && rl_dist( guy.pos_bub(), pos_bub() ) < get_option<int>( "PICKUP_RANGE" )
+               && get_map().clear_path( pos_bub(), guy.pos_bub(), get_option<int>( "PICKUP_RANGE" ), 1, 100 );
 #endif
     } );
 }

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -326,8 +326,7 @@ float Character::workbench_crafting_speed_multiplier( const item &craft,
     }
 
     multiplier *= lerped_multiplier( craft_mass, allowed_mass, 1000_kilogram );
-    multiplier *= lerped_multiplier( craft_volume, allowed_volume,
-                                     default_tile_volume );
+    multiplier *= lerped_multiplier( craft_volume, allowed_volume, default_tile_volume );
 
     return multiplier;
 }

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -327,7 +327,7 @@ float Character::workbench_crafting_speed_multiplier( const item &craft,
 
     multiplier *= lerped_multiplier( craft_mass, allowed_mass, 1000_kilogram );
     multiplier *= lerped_multiplier( craft_volume, allowed_volume,
-                                     units::from_liter( get_option<int>( "DEFAULT_TILE_VOLUME" ) ) );
+                                     default_tile_volume );
 
     return multiplier;
 }
@@ -603,12 +603,12 @@ std::vector<const item *> Character::get_eligible_containers_for_crafting() cons
     worn.get_eligible_containers_for_crafting( conts );
 
     map &here = get_map();
-    // get all potential containers within PICKUP_RANGE tiles including vehicles
+    // get all potential containers within pickup_range tiles including vehicles
     for( const tripoint_bub_ms &loc : closest_points_first( pos_bub(),
-            get_option<int>( "PICKUP_RANGE" ) ) ) {
+            pickup_range ) ) {
         // can not reach this -> can not access its contents
         if( pos_bub() != loc &&
-            !here.clear_path( pos_bub(), loc, get_option<int>( "PICKUP_RANGE" ), 1, 100 ) ) {
+            !here.clear_path( pos_bub(), loc, pickup_range, 1, 100 ) ) {
             continue;
         }
         if( here.accessible_items( loc ) ) {
@@ -663,7 +663,7 @@ bool Character::can_start_craft( const recipe *rec, recipe_filter_flags flags,
 
 const inventory &Character::crafting_inventory( bool clear_path ) const
 {
-    return crafting_inventory( tripoint_bub_ms::zero, get_option<int>( "PICKUP_RANGE" ), clear_path );
+    return crafting_inventory( tripoint_bub_ms::zero, pickup_range, clear_path );
 }
 
 const inventory &Character::crafting_inventory( const tripoint_bub_ms &src_pos, int radius,
@@ -805,7 +805,7 @@ static item_location set_item_inventory( Character &p, item &newit )
 {
     item_location ret_val = item_location::nowhere;
     if( newit.made_of( phase_id::LIQUID ) ) {
-        liquid_handler::handle_all_or_npc_liquid( p, newit, get_option<int>( "PICKUP_RANGE" ) );
+        liquid_handler::handle_all_or_npc_liquid( p, newit, pickup_range );
     } else {
         p.inv->assign_empty_invlet( newit, p );
         // We might not have space for the item
@@ -1242,7 +1242,7 @@ static step_source_context resolve_step_source( const item &craft, const item_lo
     map &m = get_map();
     step_source_context src;
     src.origin = m.get_bub( loc.pos_abs() );
-    src.radius = get_option<int>( "PICKUP_RANGE" );
+    src.radius = pickup_range;
     if( loc.where() == item_location::type::character ) {
         src.present_char = loc.carrier();
     } else {
@@ -2519,7 +2519,7 @@ static void spawn_items( Character &guy, std::vector<item> &results,
         prepare( newit );
 
         if( newit.made_of( phase_id::LIQUID ) ) {
-            liquid_handler::handle_all_or_npc_liquid( guy, newit, get_option<int>( "PICKUP_RANGE" ) );
+            liquid_handler::handle_all_or_npc_liquid( guy, newit, pickup_range );
             ++i;
             continue;
         }
@@ -2764,7 +2764,7 @@ bool Character::can_continue_craft( item &craft, const requirement_data &continu
         }
 
         inventory map_inv;
-        map_inv.form_from_map( pos_bub(), get_option<int>( "PICKUP_RANGE" ), this );
+        map_inv.form_from_map( pos_bub(), pickup_range, this );
 
         auto filter = [&]( const item & it ) {
             return std_filter( it ) &&
@@ -2844,7 +2844,7 @@ bool Character::can_continue_craft( item &craft, const requirement_data &continu
         }
 
         inventory map_inv;
-        map_inv.form_from_map( pos_bub(), get_option<int>( "PICKUP_RANGE" ), this );
+        map_inv.form_from_map( pos_bub(), pickup_range, this );
 
         if( rec.has_steps() ) {
             const std::vector<std::vector<step_tool_alloc>> &prior = craft.get_step_tool_allocs();
@@ -3290,7 +3290,7 @@ std::vector<item_location> preview_source_locations( Character &crafter,
     map &here = get_map();
     if( selection.use_from & usage_from::map ) {
         const std::vector<tripoint_bub_ms> reachable = here.reachable_item_points(
-                    crafter.pos_bub(), get_option<int>( "PICKUP_RANGE" ), 1, 100 );
+                    crafter.pos_bub(), pickup_range, 1, 100 );
         for( const tripoint_bub_ms &point : reachable ) {
             if( !here.accessible_items( point ) ) {
                 continue;
@@ -3315,7 +3315,7 @@ std::optional<item> preview_infinite_map_charge_source( Character &crafter, cons
 {
     map &here = get_map();
     const std::vector<tripoint_bub_ms> reachable = here.reachable_item_points(
-                crafter.pos_bub(), get_option<int>( "PICKUP_RANGE" ), 1, 100 );
+                crafter.pos_bub(), pickup_range, 1, 100 );
     for( const tripoint_bub_ms &point : reachable ) {
         item source = here.liquid_from( point );
         if( source.typeId() == type && source.charges == item::INFINITE_CHARGES ) {
@@ -3421,7 +3421,7 @@ std::optional<item_components> Character::preview_crafting_components(
                             *this, map_selection, filter, preferred );
                 map &here = get_map();
                 const std::vector<tripoint_bub_ms> reachable = here.reachable_item_points(
-                            pos_bub(), get_option<int>( "PICKUP_RANGE" ), 1, 100 );
+                            pos_bub(), pickup_range, 1, 100 );
                 const bool vehicle_first = !by_charges;
                 for( const tripoint_bub_ms &point : reachable ) {
                     for( item_location &location : map_candidates ) {
@@ -3479,7 +3479,7 @@ std::list<item> Character::consume_items( const comp_selection<item_comp> &is, i
     }
     // populate a grid of spots that can be reached
     const std::vector<tripoint_bub_ms> &reachable_pts = m.reachable_item_points( pos_bub(),
-            get_option<int>( "PICKUP_RANGE" ), 1, 100 );
+            pickup_range, 1, 100 );
     return consume_items( m, is, batch, filter, reachable_pts, select_ind, disable_preference );
 }
 
@@ -3595,7 +3595,7 @@ std::list<item> Character::consume_items( const std::vector<item_comp> &componen
         const bool can_cancel, const bool disable_preference )
 {
     inventory map_inv;
-    map_inv.form_from_map( pos_bub(), get_option<int>( "PICKUP_RANGE" ), this );
+    map_inv.form_from_map( pos_bub(), pickup_range, this );
     comp_selection<item_comp> sel = select_item_component( components, batch, map_inv, can_cancel,
                                     filter );
     return consume_items( sel, batch, filter, select_ind( sel.comp.type ), disable_preference );
@@ -3790,7 +3790,7 @@ bool Character::craft_consume_tools( item &craft, int multiplier, bool start_cra
     }
 
     inventory map_inv;
-    map_inv.form_from_map( pos_bub(), get_option<int>( "PICKUP_RANGE" ), this );
+    map_inv.form_from_map( pos_bub(), pickup_range, this );
 
     for( const comp_selection<tool_comp> &tool_sel : cached_tool_selections ) {
         itype_id type = tool_sel.comp.type;
@@ -4097,7 +4097,7 @@ bool Character::craft_consume_step_tools( item &craft, const crafting_cost_conte
         }
     }
     return consume_step_tool_targets( craft, targets,
-                                      pos_bub(), get_option<int>( "PICKUP_RANGE" ), /*pin_to_map=*/false );
+                                      pos_bub(), pickup_range, /*pin_to_map=*/false );
 }
 
 bool Character::craft_consume_passive_step_tools( item &craft, time_point now,
@@ -4146,7 +4146,7 @@ bool Character::craft_consume_passive_step_tools( item &craft, time_point now,
 
 void Character::consume_tools( const comp_selection<tool_comp> &tool, int batch )
 {
-    consume_tools( get_map(), tool, batch, pos_bub(), get_option<int>( "PICKUP_RANGE" ) );
+    consume_tools( get_map(), tool, batch, pos_bub(), pickup_range );
 }
 
 /* we use this if we selected the tool earlier */
@@ -4203,7 +4203,7 @@ to consume_tools */
 void Character::consume_tools( const std::vector<tool_comp> &tools, int batch )
 {
     inventory map_inv;
-    map_inv.form_from_map( pos_bub(), get_option<int>( "PICKUP_RANGE" ), this );
+    map_inv.form_from_map( pos_bub(), pickup_range, this );
     consume_tools( select_tool_component( tools, batch, map_inv ), batch );
 }
 
@@ -4678,7 +4678,7 @@ void Character::complete_disassemble( item_location &target, const recipe &dis )
             }
 
             if( act_item.made_of( phase_id::LIQUID ) ) {
-                liquid_handler::handle_all_or_npc_liquid( *this, act_item, get_option<int>( "PICKUP_RANGE" ) );
+                liquid_handler::handle_all_or_npc_liquid( *this, act_item, pickup_range );
             } else {
                 drop_items.push_back( act_item );
             }
@@ -4747,7 +4747,7 @@ void drop_or_handle( const item &newit, Character &p )
 {
     item tmp( newit );
     if( newit.made_of( phase_id::LIQUID ) ) {
-        liquid_handler::handle_all_or_npc_liquid( p, tmp, get_option<int>( "PICKUP_RANGE" ) );
+        liquid_handler::handle_all_or_npc_liquid( p, tmp, pickup_range );
     } else {
         p.i_add_or_drop( tmp );
     }
@@ -4795,15 +4795,15 @@ std::vector<Character *> Character::get_crafting_helpers() const
                && ( !is_mp_partner || cata_mp::is_partner_helping_us() )
                && !guy.in_sleep_state()
                && guy.is_obeying( *this )
-               && rl_dist( guy.pos_bub(), pos_bub() ) < get_option<int>( "PICKUP_RANGE" )
-               && get_map().clear_path( pos_bub(), guy.pos_bub(), get_option<int>( "PICKUP_RANGE" ), 1, 100 );
+               && rl_dist( guy.pos_bub(), pos_bub() ) < pickup_range
+               && get_map().clear_path( pos_bub(), guy.pos_bub(), pickup_range, 1, 100 );
 #else
         return getID() != guy.getID()
                && guy.is_npc()
                && !guy.in_sleep_state()
                && guy.is_obeying( *this )
-               && rl_dist( guy.pos_bub(), pos_bub() ) < get_option<int>( "PICKUP_RANGE" )
-               && get_map().clear_path( pos_bub(), guy.pos_bub(), get_option<int>( "PICKUP_RANGE" ), 1, 100 );
+               && rl_dist( guy.pos_bub(), pos_bub() ) < pickup_range
+               && get_map().clear_path( pos_bub(), guy.pos_bub(), pickup_range, 1, 100 );
 #endif
     } );
 }
@@ -4815,12 +4815,12 @@ std::vector<Character *> Character::get_crafting_group() const
         const bool is_mp_partner = cata_mp::is_partner_npc( guy.getID() );
         return guy.is_ally( *this )
                && ( !is_mp_partner || cata_mp::is_partner_helping_us() )
-               && rl_dist( guy.pos_bub(), pos_bub() ) < get_option<int>( "PICKUP_RANGE" )
-               && get_map().clear_path( pos_bub(), guy.pos_bub(), get_option<int>( "PICKUP_RANGE" ), 1, 100 );
+               && rl_dist( guy.pos_bub(), pos_bub() ) < pickup_range
+               && get_map().clear_path( pos_bub(), guy.pos_bub(), pickup_range, 1, 100 );
 #else
         return guy.is_ally( *this )
-               && rl_dist( guy.pos_bub(), pos_bub() ) < get_option<int>( "PICKUP_RANGE" )
-               && get_map().clear_path( pos_bub(), guy.pos_bub(), get_option<int>( "PICKUP_RANGE" ), 1, 100 );
+               && rl_dist( guy.pos_bub(), pos_bub() ) < pickup_range
+               && get_map().clear_path( pos_bub(), guy.pos_bub(), pickup_range, 1, 100 );
 #endif
     } );
 }

--- a/src/crafting_gui_helpers.cpp
+++ b/src/crafting_gui_helpers.cpp
@@ -198,7 +198,6 @@ bool availability::check_can_craft_nested( Character &_crafter, const recipe &r 
 craft_confirm_result can_start_craft(
     const recipe &rec,
     const availability &avail,
-    // Cleanwater: 撤销 PR #87043 — 移除 batch_size 参数及 4096 物品限制
     const Character &crafter )
 {
     if( !avail.can_craft || !avail.crafter_has_primary_skill ) {

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -1775,7 +1775,7 @@ void cata::lua_platform::detail::erase_platform_effect_migration(
 }
 
 std::vector<std::pair<std::string, std::string>>
-cata::lua_platform::detail::effect_migration_snapshot()
+        cata::lua_platform::detail::effect_migration_snapshot()
 {
     std::vector<std::pair<std::string, std::string>> result;
     result.reserve( effect_migrations.size() );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -5178,7 +5178,7 @@ drop_locations basecamp::give_equipment( Character *pc, const inventory_filter_p
                                    make_raw_stats, /*allow_select_contained =*/ true );
 
     inv_s.add_character_items( *pc );
-    inv_s.add_nearby_items( PICKUP_RANGE );
+    inv_s.add_nearby_items( get_option<int>( "PICKUP_RANGE" ) );
     inv_s.set_title( title );
     inv_s.set_hint( _( "To select items, type a number before selecting." ) );
 

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -22,6 +22,7 @@
 #include "avatar.h"
 #include "basecamp.h"
 #include "build_reqs.h"
+#include "cached_options.h"
 #include "calendar.h"
 #include "cata_assert.h"
 #include "cata_utility.h"
@@ -5178,7 +5179,7 @@ drop_locations basecamp::give_equipment( Character *pc, const inventory_filter_p
                                    make_raw_stats, /*allow_select_contained =*/ true );
 
     inv_s.add_character_items( *pc );
-    inv_s.add_nearby_items( get_option<int>( "PICKUP_RANGE" ) );
+    inv_s.add_nearby_items( pickup_range );
     inv_s.set_title( title );
     inv_s.set_hint( _( "To select items, type a number before selecting." ) );
 

--- a/src/fault.cpp
+++ b/src/fault.cpp
@@ -64,7 +64,7 @@ cata::lua_platform::detail::fault_registry_snapshot()
         result.emplace_back( std::move( entry ) );
     }
     std::sort( result.begin(), result.end(),
-    []( const fault_snapshot_entry &left, const fault_snapshot_entry &right ) {
+    []( const fault_snapshot_entry & left, const fault_snapshot_entry & right ) {
         return left.id < right.id;
     } );
     return result;

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -434,7 +434,7 @@ cata::lua_platform::detail::json_flag_snapshot()
         result.emplace_back( std::move( entry ) );
     }
     std::sort( result.begin(), result.end(),
-    []( const json_flag_snapshot_entry &left, const json_flag_snapshot_entry &right ) {
+    []( const json_flag_snapshot_entry & left, const json_flag_snapshot_entry & right ) {
         return left.id < right.id;
     } );
     return result;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7212,8 +7212,8 @@ void game::butcher( const std::optional<tripoint_bub_ms> &p )
 
     const tripoint_bub_ms pos = p.value_or( u.pos_bub() );
 
-    const int factor = u.max_quality( qual_BUTCHER, get_option<int>( "PICKUP_RANGE" ) );
-    const int factorD = u.max_quality( qual_CUT_FINE, get_option<int>( "PICKUP_RANGE" ) );
+    const int factor = u.max_quality( qual_BUTCHER, pickup_range );
+    const int factorD = u.max_quality( qual_CUT_FINE, pickup_range );
     const std::string no_knife_msg = _( "You don't have a butchering tool." );
     const std::string no_corpse_msg = _( "There are no corpses here to butcher." );
 
@@ -7312,7 +7312,7 @@ void game::butcher( const std::optional<tripoint_bub_ms> &p )
     }
 
     // Magic indices for special butcher options
-    const int MAX_ITEM = get_option<int>( "MAX_ITEM_IN_SQUARE" );
+    const int MAX_ITEM = max_item_in_square;
     const int MULTISALVAGE = MAX_ITEM + 1, MULTIBUTCHER = MAX_ITEM + 2,
               MULTIDISASSEMBLE_ONE = MAX_ITEM + 3,
               MULTIDISASSEMBLE_ALL = MAX_ITEM + 4, NUM_BUTCHER_ACTIONS = MAX_ITEM + 5;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7212,8 +7212,8 @@ void game::butcher( const std::optional<tripoint_bub_ms> &p )
 
     const tripoint_bub_ms pos = p.value_or( u.pos_bub() );
 
-    const int factor = u.max_quality( qual_BUTCHER, PICKUP_RANGE );
-    const int factorD = u.max_quality( qual_CUT_FINE, PICKUP_RANGE );
+    const int factor = u.max_quality( qual_BUTCHER, get_option<int>( "PICKUP_RANGE" ) );
+    const int factorD = u.max_quality( qual_CUT_FINE, get_option<int>( "PICKUP_RANGE" ) );
     const std::string no_knife_msg = _( "You don't have a butchering tool." );
     const std::string no_corpse_msg = _( "There are no corpses here to butcher." );
 
@@ -7312,13 +7312,10 @@ void game::butcher( const std::optional<tripoint_bub_ms> &p )
     }
 
     // Magic indices for special butcher options
-    enum : int {
-        MULTISALVAGE = MAX_ITEM_IN_SQUARE + 1,
-        MULTIBUTCHER,
-        MULTIDISASSEMBLE_ONE,
-        MULTIDISASSEMBLE_ALL,
-        NUM_BUTCHER_ACTIONS
-    };
+    const int MAX_ITEM = get_option<int>( "MAX_ITEM_IN_SQUARE" );
+    const int MULTISALVAGE = MAX_ITEM + 1, MULTIBUTCHER = MAX_ITEM + 2,
+              MULTIDISASSEMBLE_ONE = MAX_ITEM + 3,
+              MULTIDISASSEMBLE_ALL = MAX_ITEM + 4, NUM_BUTCHER_ACTIONS = MAX_ITEM + 5;
     // What are we butchering (i.e.. which vector to pick indices from)
     enum {
         BUTCHER_CORPSE,
@@ -7398,7 +7395,8 @@ void game::butcher( const std::optional<tripoint_bub_ms> &p )
         }
 
         ret = static_cast<size_t>( kmenu.ret );
-        if( ret >= MULTISALVAGE && ret < NUM_BUTCHER_ACTIONS ) {
+        if( ret >= static_cast<size_t>( MULTISALVAGE ) &&
+            ret < static_cast<size_t>( NUM_BUTCHER_ACTIONS ) ) {
             butcher_select = BUTCHER_OTHER;
             indexer_index = ret;
         } else if( ret < corpses.size() ) {
@@ -7432,31 +7430,25 @@ void game::butcher( const std::optional<tripoint_bub_ms> &p )
     }
     switch( butcher_select ) {
         case BUTCHER_OTHER:
-            switch( indexer_index ) {
-                case MULTISALVAGE:
-                    u.assign_activity( longsalvage_activity_actor( salvage_tool_index ) );
-                    break;
-                case MULTIBUTCHER: {
-                    const std::optional<butcher_type> bt = butcher_submenu( corpses );
-                    if( bt.has_value() ) {
-                        std::vector<butchery_data> bd;
-                        for( map_stack::iterator &it : corpses ) {
-                            item_location corpse_loc = item_location( map_cursor( pos ), &*it );
-                            bd.emplace_back( corpse_loc, bt.value() );
-                        }
-                        u.assign_activity( butchery_activity_actor( bd ) );
+            if( indexer_index == MULTISALVAGE ) {
+                u.assign_activity( longsalvage_activity_actor( salvage_tool_index ) );
+            } else if( indexer_index == MULTIBUTCHER ) {
+                const std::optional<butcher_type> bt = butcher_submenu( corpses );
+                if( bt.has_value() ) {
+                    std::vector<butchery_data> bd;
+                    for( map_stack::iterator &it : corpses ) {
+                        item_location corpse_loc = item_location( map_cursor( pos ), &*it );
+                        bd.emplace_back( corpse_loc, bt.value() );
                     }
-                    break;
+                    u.assign_activity( butchery_activity_actor( bd ) );
                 }
-                case MULTIDISASSEMBLE_ONE:
-                    u.disassemble_all( true );
-                    break;
-                case MULTIDISASSEMBLE_ALL:
-                    u.disassemble_all( false );
-                    break;
-                default:
-                    debugmsg( "Invalid butchery type: %d", indexer_index );
-                    return;
+            } else if( indexer_index == MULTIDISASSEMBLE_ONE ) {
+                u.disassemble_all( true );
+            } else if( indexer_index == MULTIDISASSEMBLE_ALL ) {
+                u.disassemble_all( false );
+            } else {
+                debugmsg( "Invalid butchery type: %d", indexer_index );
+                return;
             }
             break;
         case BUTCHER_CORPSE: {

--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -27,21 +27,9 @@ constexpr int EXPLOSION_MULTIPLIER = 7;
 
 constexpr int fov_3d_z_range = 10;
 
-// Really just a sanity check for functions not tested beyond this. in theory 4096 works (`InvletInvlet).
-constexpr int MAX_ITEM_IN_SQUARE = 4096;
-// no reason to differ.
-constexpr int MAX_ITEM_IN_VEHICLE_STORAGE = MAX_ITEM_IN_SQUARE;
-// Sanity checks for volume
-constexpr units::volume DEFAULT_TILE_VOLUME = units::from_liter( 1000 );
-constexpr units::volume MAX_ITEM_VOLUME = DEFAULT_TILE_VOLUME;
+
 // only can wear a maximum of two of any type of clothing.
 constexpr int MAX_WORN_PER_TYPE = 2;
-
-/**
- * Items on the map with at most this distance to the player are considered available for crafting,
- * see inventory::form_from_map
-*/
-constexpr int PICKUP_RANGE = 6;
 
 // Maximum move cost when handling an item.
 constexpr int MAX_HANDLING_COST = 400;

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -21,6 +21,7 @@
 #include "avatar.h"
 #include "bionics.h"
 #include "bodypart.h"
+#include "cached_options.h"
 #include "calendar.h"
 #include "cata_utility.h"
 #include "character.h"
@@ -695,7 +696,7 @@ class disassemble_inventory_preset : public inventory_selector_preset
 item_location game_menus::inv::disassemble( Character &you )
 {
     return inv_internal( you, disassemble_inventory_preset( you, you.crafting_inventory() ),
-                         _( "Disassemble item" ), get_option<int>( "PICKUP_RANGE" ),
+                         _( "Disassemble item" ), pickup_range,
                          _( "You don't have any items you could disassemble." ) );
 }
 
@@ -1716,7 +1717,7 @@ drop_locations game_menus::inv::ebooksave( Character &who, item_location &ereade
     inventory_multiselector inv_s( who, preset, _( "SELECT BOOKS TO SCAN" ),
                                    make_raw_stats, /*allow_select_contained=*/true );
     inv_s.add_character_items( who );
-    inv_s.add_nearby_items( get_option<int>( "PICKUP_RANGE" ) );
+    inv_s.add_nearby_items( pickup_range );
     inv_s.remove_duplicate_itypes( true );
     inv_s.set_title( _( "Scan which books?" ) );
     if( inv_s.empty() ) {
@@ -1778,7 +1779,7 @@ drop_locations game_menus::inv::edevice_select( Character &who, item_location &u
     if( action == EF_READ || efile_activity_actor::efile_action_is_from( action ) ) {
         inventory_pick_selector select_one_edevice( who, preset );
         select_one_edevice.add_character_items( who );
-        select_one_edevice.add_nearby_items( get_option<int>( "PICKUP_RANGE" ) );
+        select_one_edevice.add_nearby_items( pickup_range );
         select_one_edevice.set_title( inv_title );
         if( select_one_edevice.empty() ) {
             popup( string_format( _( "You have no eligible devices to %s." ), action_name ), PF_GET_KEY );
@@ -1794,7 +1795,7 @@ drop_locations game_menus::inv::edevice_select( Character &who, item_location &u
         inventory_multiselector inv_s( who, preset, string_format( _( "Select devices to %s" ),
                                        action_name ) );
         inv_s.add_character_items( who );
-        inv_s.add_nearby_items( get_option<int>( "PICKUP_RANGE" ) );
+        inv_s.add_nearby_items( pickup_range );
         inv_s.set_title( inv_title );
         if( inv_s.empty() ) {
             popup( string_format( _( "You have no eligible devices to %s." ), action_name ), PF_GET_KEY );
@@ -2612,7 +2613,7 @@ drop_locations game_menus::inv::smoke_food( Character &you, units::volume total_
 
     inventory_multiselector smoke_s( you, preset, _( "FOOD TO SMOKE" ), make_raw_stats );
 
-    smoke_s.add_nearby_items( get_option<int>( "PICKUP_RANGE" ) );
+    smoke_s.add_nearby_items( pickup_range );
     smoke_s.add_character_items( you );
 
     smoke_s.set_title( _( "Insert food into smoking rack" ) );

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -695,7 +695,7 @@ class disassemble_inventory_preset : public inventory_selector_preset
 item_location game_menus::inv::disassemble( Character &you )
 {
     return inv_internal( you, disassemble_inventory_preset( you, you.crafting_inventory() ),
-                         _( "Disassemble item" ), PICKUP_RANGE,
+                         _( "Disassemble item" ), get_option<int>( "PICKUP_RANGE" ),
                          _( "You don't have any items you could disassemble." ) );
 }
 
@@ -1716,7 +1716,7 @@ drop_locations game_menus::inv::ebooksave( Character &who, item_location &ereade
     inventory_multiselector inv_s( who, preset, _( "SELECT BOOKS TO SCAN" ),
                                    make_raw_stats, /*allow_select_contained=*/true );
     inv_s.add_character_items( who );
-    inv_s.add_nearby_items( PICKUP_RANGE );
+    inv_s.add_nearby_items( get_option<int>( "PICKUP_RANGE" ) );
     inv_s.remove_duplicate_itypes( true );
     inv_s.set_title( _( "Scan which books?" ) );
     if( inv_s.empty() ) {
@@ -1778,7 +1778,7 @@ drop_locations game_menus::inv::edevice_select( Character &who, item_location &u
     if( action == EF_READ || efile_activity_actor::efile_action_is_from( action ) ) {
         inventory_pick_selector select_one_edevice( who, preset );
         select_one_edevice.add_character_items( who );
-        select_one_edevice.add_nearby_items( PICKUP_RANGE );
+        select_one_edevice.add_nearby_items( get_option<int>( "PICKUP_RANGE" ) );
         select_one_edevice.set_title( inv_title );
         if( select_one_edevice.empty() ) {
             popup( string_format( _( "You have no eligible devices to %s." ), action_name ), PF_GET_KEY );
@@ -1794,7 +1794,7 @@ drop_locations game_menus::inv::edevice_select( Character &who, item_location &u
         inventory_multiselector inv_s( who, preset, string_format( _( "Select devices to %s" ),
                                        action_name ) );
         inv_s.add_character_items( who );
-        inv_s.add_nearby_items( PICKUP_RANGE );
+        inv_s.add_nearby_items( get_option<int>( "PICKUP_RANGE" ) );
         inv_s.set_title( inv_title );
         if( inv_s.empty() ) {
             popup( string_format( _( "You have no eligible devices to %s." ), action_name ), PF_GET_KEY );
@@ -2612,7 +2612,7 @@ drop_locations game_menus::inv::smoke_food( Character &you, units::volume total_
 
     inventory_multiselector smoke_s( you, preset, _( "FOOD TO SMOKE" ), make_raw_stats );
 
-    smoke_s.add_nearby_items( PICKUP_RANGE );
+    smoke_s.add_nearby_items( get_option<int>( "PICKUP_RANGE" ) );
     smoke_s.add_character_items( you );
 
     smoke_s.set_title( _( "Insert food into smoking rack" ) );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -20,6 +20,7 @@
 #include "basecamp.h"
 #include "bionics.h"
 #include "bodypart.h"
+#include "cached_options.h"
 #include "calendar.h"
 #include "cata_utility.h"
 #include "catalua_ui.h"
@@ -702,7 +703,7 @@ void iexamine::nanofab( Character &you, const tripoint_bub_ms &examp )
             [&e]( const itype_id itid ) {
                 return e.typeId() == itid;
             } );
-        }, _( "Introduce a compatible template." ), get_option<int>( "PICKUP_RANGE" ),
+        }, _( "Introduce a compatible template." ), pickup_range,
         _( "You don't have any usable templates.\n\nCompatible templates are: " ) + name_list );
 
         if( !nanofab_template ) {
@@ -4204,7 +4205,7 @@ void iexamine::fireplace( Character &you, const tripoint_bub_ms &examp )
     }
 
     for( const tripoint_bub_ms &pos : closest_points_first( you.pos_bub(),
-            get_option<int>( "PICKUP_RANGE" ) ) ) {
+            pickup_range ) ) {
         if( pos == examp ) {
             // stuff in the fireplace can't light or quench itself
             continue;
@@ -5132,7 +5133,7 @@ static item_location maple_tree_sap_container()
     const item maple_sap = item( itype_maple_sap, calendar::turn_zero );
     return g->inv_map_splice( [&]( const item & it ) {
         return it.get_remaining_capacity_for_liquid( maple_sap, true ) > 0;
-    }, _( "Use which container to collect sap?" ), get_option<int>( "PICKUP_RANGE" ),
+    }, _( "Use which container to collect sap?" ), pickup_range,
     _( "You don't have a container at hand." ) );
 }
 
@@ -5154,7 +5155,7 @@ void iexamine::tree_maple( Character &you, const tripoint_bub_ms &examp )
     item_location spile_loc = g->inv_map_splice( [&here]( const item_location & it ) {
         return it->get_quality_nonrecursive( qual_TREE_TAP ) > 0 &&
                !( here.ter( it.pos_bub( here ) ) == ter_t_tree_maple_tapped );
-    }, _( "Use which tapping tool?" ), get_option<int>( "PICKUP_RANGE" ),
+    }, _( "Use which tapping tool?" ), pickup_range,
     _( "You don't have a tapping tool at hand." ) );
 
     item *spile = spile_loc.get_item();
@@ -5273,7 +5274,7 @@ void iexamine::tree_maple_tapped( Character &you, const tripoint_bub_ms &examp )
 
         case HARVEST_SAP: {
             item_location loc( map_cursor( examp ), container );
-            liquid_handler::handle_all_liquids_from_container( loc, get_option<int>( "PICKUP_RANGE" ) );
+            liquid_handler::handle_all_liquids_from_container( loc, pickup_range );
             return;
         }
 
@@ -7537,7 +7538,7 @@ static void mill_load_food( Character &you, const tripoint_bub_ms &examp,
 
     Character &player_character = get_player_character();
     // select from where to get the items from and place them
-    inv.form_from_map( player_character.pos_bub(), get_option<int>( "PICKUP_RANGE" ),
+    inv.form_from_map( player_character.pos_bub(), pickup_range,
                        &player_character );
     inv.remove_items_with( []( const item & it ) {
         return it.rotten();

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -702,7 +702,7 @@ void iexamine::nanofab( Character &you, const tripoint_bub_ms &examp )
             [&e]( const itype_id itid ) {
                 return e.typeId() == itid;
             } );
-        }, _( "Introduce a compatible template." ), PICKUP_RANGE,
+        }, _( "Introduce a compatible template." ), get_option<int>( "PICKUP_RANGE" ),
         _( "You don't have any usable templates.\n\nCompatible templates are: " ) + name_list );
 
         if( !nanofab_template ) {
@@ -4203,7 +4203,8 @@ void iexamine::fireplace( Character &you, const tripoint_bub_ms &examp )
         add_firestarter( it, firestarters, you, examp );
     }
 
-    for( const tripoint_bub_ms &pos : closest_points_first( you.pos_bub(), PICKUP_RANGE ) ) {
+    for( const tripoint_bub_ms &pos : closest_points_first( you.pos_bub(),
+            get_option<int>( "PICKUP_RANGE" ) ) ) {
         if( pos == examp ) {
             // stuff in the fireplace can't light or quench itself
             continue;
@@ -5131,7 +5132,7 @@ static item_location maple_tree_sap_container()
     const item maple_sap = item( itype_maple_sap, calendar::turn_zero );
     return g->inv_map_splice( [&]( const item & it ) {
         return it.get_remaining_capacity_for_liquid( maple_sap, true ) > 0;
-    }, _( "Use which container to collect sap?" ), PICKUP_RANGE,
+    }, _( "Use which container to collect sap?" ), get_option<int>( "PICKUP_RANGE" ),
     _( "You don't have a container at hand." ) );
 }
 
@@ -5153,7 +5154,8 @@ void iexamine::tree_maple( Character &you, const tripoint_bub_ms &examp )
     item_location spile_loc = g->inv_map_splice( [&here]( const item_location & it ) {
         return it->get_quality_nonrecursive( qual_TREE_TAP ) > 0 &&
                !( here.ter( it.pos_bub( here ) ) == ter_t_tree_maple_tapped );
-    }, _( "Use which tapping tool?" ), PICKUP_RANGE, _( "You don't have a tapping tool at hand." ) );
+    }, _( "Use which tapping tool?" ), get_option<int>( "PICKUP_RANGE" ),
+    _( "You don't have a tapping tool at hand." ) );
 
     item *spile = spile_loc.get_item();
     if( !spile ) {
@@ -5271,7 +5273,7 @@ void iexamine::tree_maple_tapped( Character &you, const tripoint_bub_ms &examp )
 
         case HARVEST_SAP: {
             item_location loc( map_cursor( examp ), container );
-            liquid_handler::handle_all_liquids_from_container( loc, PICKUP_RANGE );
+            liquid_handler::handle_all_liquids_from_container( loc, get_option<int>( "PICKUP_RANGE" ) );
             return;
         }
 
@@ -7535,7 +7537,8 @@ static void mill_load_food( Character &you, const tripoint_bub_ms &examp,
 
     Character &player_character = get_player_character();
     // select from where to get the items from and place them
-    inv.form_from_map( player_character.pos_bub(), PICKUP_RANGE, &player_character );
+    inv.form_from_map( player_character.pos_bub(), get_option<int>( "PICKUP_RANGE" ),
+                       &player_character );
     inv.remove_items_with( []( const item & it ) {
         return it.rotten();
     } );

--- a/src/iexamine_actors.cpp
+++ b/src/iexamine_actors.cpp
@@ -8,6 +8,7 @@
 #include <set>
 
 #include "ammo_effect.h"
+#include "cached_options.h"
 #include "calendar.h"
 #include "character.h"
 #include "coordinates.h"
@@ -346,7 +347,7 @@ void mortar_examine_actor::call( Character &you, const tripoint_bub_ms &examp ) 
         return false;
     } );
     inventory_pick_selector inv_s( you, preset );
-    inv_s.add_nearby_items( get_option<int>( "PICKUP_RANGE" ) );
+    inv_s.add_nearby_items( pickup_range );
     inv_s.add_character_items( you );
     inv_s.set_title( _( "Pick a projectile to be used." ) );
 

--- a/src/iexamine_actors.cpp
+++ b/src/iexamine_actors.cpp
@@ -346,7 +346,7 @@ void mortar_examine_actor::call( Character &you, const tripoint_bub_ms &examp ) 
         return false;
     } );
     inventory_pick_selector inv_s( you, preset );
-    inv_s.add_nearby_items( PICKUP_RANGE );
+    inv_s.add_nearby_items( get_option<int>( "PICKUP_RANGE" ) );
     inv_s.add_character_items( you );
     inv_s.set_title( _( "Pick a projectile to be used." ) );
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -17,6 +17,7 @@
 #include "avatar.h"
 #include "bionics.h"
 #include "butchery.h"
+#include "cached_options.h"
 #include "calendar.h"
 #include "cata_assert.h"
 #include "cata_utility.h"
@@ -2243,10 +2244,9 @@ units::volume item::corpse_volume( const mtype *corpse ) const
     if( has_flag( flag_SKINNED ) ) {
         corpse_volume *= 0.85;
     }
-    units::volume MAX_VOLUME = units::from_liter( get_option<int>( "DEFAULT_TILE_VOLUME" ) );
-    if( corpse_volume > MAX_VOLUME ) {
-        // Silently set volume so the corpse can still spawn but a mtype can have a volume > DEFAULT_TILE_VOLUME
-        corpse_volume = MAX_VOLUME;
+    if( corpse_volume > default_tile_volume ) {
+        // Silently set volume so the corpse can still spawn but a mtype can have a volume > default_tile_volume
+        corpse_volume = default_tile_volume;
     }
     if( corpse_volume > 0_ml ) {
         return corpse_volume;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2243,9 +2243,10 @@ units::volume item::corpse_volume( const mtype *corpse ) const
     if( has_flag( flag_SKINNED ) ) {
         corpse_volume *= 0.85;
     }
-    if( corpse_volume > MAX_ITEM_VOLUME ) {
-        // Silently set volume so the corpse can still spawn but a mtype can have a volume > MAX_ITEM_VOLUME
-        corpse_volume = MAX_ITEM_VOLUME;
+    units::volume MAX_VOLUME = units::from_liter( get_option<int>( "DEFAULT_TILE_VOLUME" ) );
+    if( corpse_volume > MAX_VOLUME ) {
+        // Silently set volume so the corpse can still spawn but a mtype can have a volume > DEFAULT_TILE_VOLUME
+        corpse_volume = MAX_VOLUME;
     }
     if( corpse_volume > 0_ml ) {
         return corpse_volume;

--- a/src/item_action.cpp
+++ b/src/item_action.cpp
@@ -260,7 +260,7 @@ const item_action *cata::lua_platform::detail::item_action_registry_find(
 }
 
 std::vector<std::pair<item_action_id, item_action>>
-cata::lua_platform::detail::item_action_registry_snapshot()
+        cata::lua_platform::detail::item_action_registry_snapshot()
 {
     std::vector<std::pair<item_action_id, item_action>> result;
     result.reserve( item_action_generator::generator().item_actions.size() );

--- a/src/item_action.h
+++ b/src/item_action.h
@@ -43,7 +43,7 @@ class item_action_generator
         friend const item_action *cata::lua_platform::detail::item_action_registry_find(
             const item_action_id &id );
         friend std::vector<std::pair<item_action_id, item_action>>
-        cata::lua_platform::detail::item_action_registry_snapshot();
+                cata::lua_platform::detail::item_action_registry_snapshot();
         friend void cata::lua_platform::detail::item_action_registry_set(
             const item_action &value );
         friend void cata::lua_platform::detail::item_action_registry_erase(

--- a/src/item_category.cpp
+++ b/src/item_category.cpp
@@ -42,8 +42,8 @@ cata::lua_platform::detail::item_category_snapshot()
         result.emplace_back( std::move( entry ) );
     }
     std::sort( result.begin(), result.end(),
-    []( const item_category_snapshot_entry &left,
-        const item_category_snapshot_entry &right ) {
+               []( const item_category_snapshot_entry & left,
+    const item_category_snapshot_entry & right ) {
         return left.id < right.id;
     } );
     return result;

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2676,8 +2676,9 @@ void Item_factory::check_definitions() const
         if( type->volume < 0_ml ) {
             msg += "negative volume\n";
         }
-        if( type->volume > MAX_ITEM_VOLUME ) {
-            msg += string_format( "exceeds max volume(%s L)\n", units::to_liter( MAX_ITEM_VOLUME ) );
+        if( type->volume > units::from_liter( get_option<int>( "DEFAULT_TILE_VOLUME" ) ) ) {
+            msg += string_format( "exceeds max volume(%s L)\n",
+                                  units::to_liter( units::from_liter( get_option<int>( "DEFAULT_TILE_VOLUME" ) ) ) );
         }
         if( type->stack_size <= 0 ) {
             if( type->count_by_charges() ) {

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2676,9 +2676,9 @@ void Item_factory::check_definitions() const
         if( type->volume < 0_ml ) {
             msg += "negative volume\n";
         }
-        if( type->volume > units::from_liter( get_option<int>( "DEFAULT_TILE_VOLUME" ) ) ) {
+        if( type->volume > default_tile_volume ) {
             msg += string_format( "exceeds max volume(%s L)\n",
-                                  units::to_liter( units::from_liter( get_option<int>( "DEFAULT_TILE_VOLUME" ) ) ) );
+                                  units::to_liter( default_tile_volume ) );
         }
         if( type->stack_size <= 0 ) {
             if( type->count_by_charges() ) {

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -13,6 +13,7 @@
 #include <variant>
 #include <vector>
 
+#include "cached_options.h"
 #include "character.h"
 #include "character_id.h"
 #include "color.h"
@@ -1225,7 +1226,7 @@ ret_val<int> item_location::max_charges_by_parent_recursive( const item &it ) co
     float weight_multiplier = 1.0f;
     float volume_multiplier = 1.0f;
     units::mass max_weight = 1000_kilogram;
-    units::volume max_volume = units::from_liter( get_option<int>( "DEFAULT_TILE_VOLUME" ) );
+    units::volume max_volume = default_tile_volume;
     item_location current_location = *this;
     //item_location class cannot return current pocket so use first pocket for innermost container
     //Only used for weight and volume multipliers

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -1225,7 +1225,7 @@ ret_val<int> item_location::max_charges_by_parent_recursive( const item &it ) co
     float weight_multiplier = 1.0f;
     float volume_multiplier = 1.0f;
     units::mass max_weight = 1000_kilogram;
-    units::volume max_volume = MAX_ITEM_VOLUME;
+    units::volume max_volume = units::from_liter( get_option<int>( "DEFAULT_TILE_VOLUME" ) );
     item_location current_location = *this;
     //item_location class cannot return current pocket so use first pocket for innermost container
     //Only used for weight and volume multipliers

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2268,7 +2268,7 @@ class exosuit_interact
                 candidates.emplace_back( c, i );
             }
             for( const tripoint_bub_ms &p : here.points_in_radius( c.pos_bub(),
-                    get_option<int>( "PICKUP_RANGE" ) ) ) {
+                    pickup_range ) ) {
                 for( item &i : here.i_at( p ) ) {
                     if( filter( i ) ) {
                         candidates.emplace_back( map_cursor( p ), &i );
@@ -2381,7 +2381,7 @@ std::optional<int> iuse::pack_cbm( Character *p, item *it, const tripoint_bub_ms
 {
     item_location bionic = g->inv_map_splice( []( const item & e ) {
         return e.is_bionic() && e.has_flag( flag_NO_PACKED );
-    }, _( "Choose CBM to pack" ), get_option<int>( "PICKUP_RANGE" ), _( "You don't have any CBMs." ) );
+    }, _( "Choose CBM to pack" ), pickup_range, _( "You don't have any CBMs." ) );
 
     if( !bionic ) {
         return std::nullopt;
@@ -2503,7 +2503,7 @@ std::optional<int> iuse::purify_water( Character *p, item *purifier, item_locati
         p->add_msg_if_player( m_info, _( "Purifying %d water using %d %s" ), charges_of_water,
                               to_consume, purifier->tname( to_consume ) );
         // Pull from surrounding map first because it will update to_consume
-        get_map().use_amount( p->pos_bub(), get_option<int>( "PICKUP_RANGE" ), itype_pur_tablets,
+        get_map().use_amount( p->pos_bub(), pickup_range, itype_pur_tablets,
                               to_consume );
         // Then pull from inventory
         if( to_consume > 0 ) {
@@ -7682,7 +7682,7 @@ std::optional<int> iuse::multicooker( Character *p, item *it, const tripoint_bub
 
                 return 0;
             }
-            liquid_handler::handle_all_liquid( dish, get_option<int>( "PICKUP_RANGE" ) );
+            liquid_handler::handle_all_liquid( dish, pickup_range );
         } else {
             p->i_add( dish );
         }
@@ -8537,7 +8537,7 @@ static bool heat_items( Character *p, item *it, bool liquid_items, bool solid_it
         inventory_multiselector inv_s( *p, preset, _( "ITEMS TO HEAT" ),
                                        make_raw_stats, /*allow_select_contained=*/true );
         inv_s.add_character_items( *p );
-        inv_s.add_nearby_items( get_option<int>( "PICKUP_RANGE" ) );
+        inv_s.add_nearby_items( pickup_range );
         inv_s.set_title( _( "Heat menu" ) );
         inv_s.set_hint( _( "To heat x items, type a number before selecting." ) );
         if( inv_s.empty() ) {
@@ -8788,7 +8788,7 @@ std::optional<int> iuse::wash_items( Character *p, bool soft_items, bool hard_it
     inventory_multiselector inv_s( *p, preset, _( "ITEMS TO CLEAN" ),
                                    make_raw_stats, /*allow_select_contained=*/true );
     inv_s.add_character_items( *p );
-    inv_s.add_nearby_items( get_option<int>( "PICKUP_RANGE" ) );
+    inv_s.add_nearby_items( pickup_range );
     inv_s.set_title( _( "Multiclean" ) );
     inv_s.set_hint( _( "To clean x items, type a number before selecting." ) );
     if( inv_s.empty() ) {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2267,7 +2267,8 @@ class exosuit_interact
             for( item *i : c.items_with( filter ) ) {
                 candidates.emplace_back( c, i );
             }
-            for( const tripoint_bub_ms &p : here.points_in_radius( c.pos_bub(), PICKUP_RANGE ) ) {
+            for( const tripoint_bub_ms &p : here.points_in_radius( c.pos_bub(),
+                    get_option<int>( "PICKUP_RANGE" ) ) ) {
                 for( item &i : here.i_at( p ) ) {
                     if( filter( i ) ) {
                         candidates.emplace_back( map_cursor( p ), &i );
@@ -2380,7 +2381,7 @@ std::optional<int> iuse::pack_cbm( Character *p, item *it, const tripoint_bub_ms
 {
     item_location bionic = g->inv_map_splice( []( const item & e ) {
         return e.is_bionic() && e.has_flag( flag_NO_PACKED );
-    }, _( "Choose CBM to pack" ), PICKUP_RANGE, _( "You don't have any CBMs." ) );
+    }, _( "Choose CBM to pack" ), get_option<int>( "PICKUP_RANGE" ), _( "You don't have any CBMs." ) );
 
     if( !bionic ) {
         return std::nullopt;
@@ -2502,7 +2503,8 @@ std::optional<int> iuse::purify_water( Character *p, item *purifier, item_locati
         p->add_msg_if_player( m_info, _( "Purifying %d water using %d %s" ), charges_of_water,
                               to_consume, purifier->tname( to_consume ) );
         // Pull from surrounding map first because it will update to_consume
-        get_map().use_amount( p->pos_bub(), PICKUP_RANGE, itype_pur_tablets, to_consume );
+        get_map().use_amount( p->pos_bub(), get_option<int>( "PICKUP_RANGE" ), itype_pur_tablets,
+                              to_consume );
         // Then pull from inventory
         if( to_consume > 0 ) {
             p->use_amount( itype_pur_tablets, to_consume );
@@ -7680,7 +7682,7 @@ std::optional<int> iuse::multicooker( Character *p, item *it, const tripoint_bub
 
                 return 0;
             }
-            liquid_handler::handle_all_liquid( dish, PICKUP_RANGE );
+            liquid_handler::handle_all_liquid( dish, get_option<int>( "PICKUP_RANGE" ) );
         } else {
             p->i_add( dish );
         }
@@ -8535,7 +8537,7 @@ static bool heat_items( Character *p, item *it, bool liquid_items, bool solid_it
         inventory_multiselector inv_s( *p, preset, _( "ITEMS TO HEAT" ),
                                        make_raw_stats, /*allow_select_contained=*/true );
         inv_s.add_character_items( *p );
-        inv_s.add_nearby_items( PICKUP_RANGE );
+        inv_s.add_nearby_items( get_option<int>( "PICKUP_RANGE" ) );
         inv_s.set_title( _( "Heat menu" ) );
         inv_s.set_hint( _( "To heat x items, type a number before selecting." ) );
         if( inv_s.empty() ) {
@@ -8786,7 +8788,7 @@ std::optional<int> iuse::wash_items( Character *p, bool soft_items, bool hard_it
     inventory_multiselector inv_s( *p, preset, _( "ITEMS TO CLEAN" ),
                                    make_raw_stats, /*allow_select_contained=*/true );
     inv_s.add_character_items( *p );
-    inv_s.add_nearby_items( PICKUP_RANGE );
+    inv_s.add_nearby_items( get_option<int>( "PICKUP_RANGE" ) );
     inv_s.set_title( _( "Multiclean" ) );
     inv_s.set_hint( _( "To clean x items, type a number before selecting." ) );
     if( inv_s.empty() ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6599,7 +6599,7 @@ std::pair<item *, tripoint_bub_ms> map::_add_item_or_charges( const tripoint_bub
     auto how_many_copies_fit = [&]( const tripoint_bub_ms & e ) {
         return std::min( { copies_remaining,
                            obj.volume() == 0_ml ? INT_MAX : free_volume( e ) / obj.volume(),
-                           static_cast<int>( get_option<int>( "MAX_ITEM_IN_SQUARE" ) - i_at( e ).size() ) } );
+                           static_cast<int>( max_item_in_square- i_at( e ).size() ) } );
     };
 
     // Performs the actual insertion of the object onto the map
@@ -6650,7 +6650,7 @@ std::pair<item *, tripoint_bub_ms> map::_add_item_or_charges( const tripoint_bub
                     return true;
                 }
             }
-            return static_cast<int>( i_at( e ).size() ) < get_option<int>( "MAX_ITEM_IN_SQUARE" );
+            return static_cast<int>( i_at( e ).size() ) < max_item_in_square;
         };
 
         // Place up to qty charges of obj on tile e, merging into an existing

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6599,7 +6599,7 @@ std::pair<item *, tripoint_bub_ms> map::_add_item_or_charges( const tripoint_bub
     auto how_many_copies_fit = [&]( const tripoint_bub_ms & e ) {
         return std::min( { copies_remaining,
                            obj.volume() == 0_ml ? INT_MAX : free_volume( e ) / obj.volume(),
-                           static_cast<int>( MAX_ITEM_IN_SQUARE - i_at( e ).size() ) } );
+                           static_cast<int>( get_option<int>( "MAX_ITEM_IN_SQUARE" ) - i_at( e ).size() ) } );
     };
 
     // Performs the actual insertion of the object onto the map
@@ -6650,7 +6650,7 @@ std::pair<item *, tripoint_bub_ms> map::_add_item_or_charges( const tripoint_bub
                     return true;
                 }
             }
-            return static_cast<int>( i_at( e ).size() ) < MAX_ITEM_IN_SQUARE;
+            return static_cast<int>( i_at( e ).size() ) < get_option<int>( "MAX_ITEM_IN_SQUARE" );
         };
 
         // Place up to qty charges of obj on tile e, merging into an existing

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6599,7 +6599,7 @@ std::pair<item *, tripoint_bub_ms> map::_add_item_or_charges( const tripoint_bub
     auto how_many_copies_fit = [&]( const tripoint_bub_ms & e ) {
         return std::min( { copies_remaining,
                            obj.volume() == 0_ml ? INT_MAX : free_volume( e ) / obj.volume(),
-                           static_cast<int>( max_item_in_square- i_at( e ).size() ) } );
+                           static_cast<int>( max_item_in_square - i_at( e ).size() ) } );
     };
 
     // Performs the actual insertion of the object onto the map

--- a/src/map.h
+++ b/src/map.h
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "active_item_cache.h"
+#include "cached_options.h"
 #include "calendar.h"
 #include "cata_assert.h"
 #include "cata_small_literal_vector.h"
@@ -124,7 +125,7 @@ class map_stack : public item_stack
         void insert( const item &newitem );
         iterator erase( const_iterator it ) override;
         int count_limit() const override {
-            return get_option<int>( "MAX_ITEM_IN_SQUARE" );
+            return max_item_in_square;
         }
         units::volume max_volume() const override;
 };

--- a/src/map.h
+++ b/src/map.h
@@ -41,6 +41,7 @@
 #include "map_selector.h"
 #include "mapdata.h"
 #include "maptile_fwd.h"
+#include "options.h"
 #include "point.h"
 #include "rng.h"
 #include "type_id.h"
@@ -123,7 +124,7 @@ class map_stack : public item_stack
         void insert( const item &newitem );
         iterator erase( const_iterator it ) override;
         int count_limit() const override {
-            return MAX_ITEM_IN_SQUARE;
+            return get_option<int>( "MAX_ITEM_IN_SQUARE" );
         }
         units::volume max_volume() const override;
 };

--- a/src/map_extras.h
+++ b/src/map_extras.h
@@ -31,7 +31,8 @@ template<typename T> struct enum_traits;
 
 enum class om_vision_level : int8_t;
 
-enum class map_extra_method : int {    null = 0,
+enum class map_extra_method : int {
+    null = 0,
     map_extra_function,
     mapgen,
     update_mapgen,

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -698,7 +698,7 @@ furn_t null_furniture_t()
     new_furniture.transparent = true;
     new_furniture.set_flag( ter_furn_flag::TFLAG_TRANSPARENT );
     new_furniture.examine_func.emplace_back( iexamine_functions_from_string( "none" ) );
-    new_furniture.max_volume = DEFAULT_TILE_VOLUME;
+    new_furniture.max_volume = units::from_liter( get_option<int>( "DEFAULT_TILE_VOLUME" ) );
     return new_furniture;
 }
 
@@ -720,7 +720,7 @@ ter_t null_terrain_t()
     new_terrain.set_flag( ter_furn_flag::TFLAG_TRANSPARENT );
     new_terrain.set_flag( ter_furn_flag::TFLAG_DIGGABLE );
     new_terrain.examine_func.emplace_back( iexamine_functions_from_string( "none" ) );
-    new_terrain.max_volume = DEFAULT_TILE_VOLUME;
+    new_terrain.max_volume = units::from_liter( get_option<int>( "DEFAULT_TILE_VOLUME" ) );
     return new_terrain;
 }
 
@@ -1452,7 +1452,8 @@ void ter_t::load( const JsonObject &jo, const std::string &src )
 {
     map_data_common_t::load( jo, src );
     optional( jo, was_loaded, "move_cost", movecost );
-    optional( jo, was_loaded, "max_volume", max_volume, DEFAULT_TILE_VOLUME );
+    optional( jo, was_loaded, "max_volume", max_volume,
+              units::from_liter( get_option<int>( "DEFAULT_TILE_VOLUME" ) ) );
     optional( jo, was_loaded, "trap", trap_id_str );
     optional( jo, was_loaded, "heat_radiation", heat_radiation );
 
@@ -1740,7 +1741,8 @@ void furn_t::load( const JsonObject &jo, const std::string &src )
     optional( jo, was_loaded, "bonus_fire_warmth_feet", legacy_bonus_fire_warmth_feet, 300 );
     bonus_fire_warmth_feet = units::from_legacy_bodypart_temp_delta( legacy_bonus_fire_warmth_feet );
     optional( jo, was_loaded, "keg_capacity", keg_capacity, volume_reader(), 0_ml );
-    optional( jo, was_loaded, "max_volume", max_volume, volume_reader(), DEFAULT_TILE_VOLUME );
+    optional( jo, was_loaded, "max_volume", max_volume, volume_reader(),
+              units::from_liter( get_option<int>( "DEFAULT_TILE_VOLUME" ) ) );
     optional( jo, was_loaded, "crafting_pseudo_item", crafting_pseudo_item, itype_id() );
     optional( jo, was_loaded, "deployed_item", deployed_item );
     load_symbol_color( jo, "furniture " + id.str() );

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "avatar.h"
+#include "cached_options.h"
 #include "calendar.h"
 #include "character.h"
 #include "catalua_platform_content.h"
@@ -698,7 +699,7 @@ furn_t null_furniture_t()
     new_furniture.transparent = true;
     new_furniture.set_flag( ter_furn_flag::TFLAG_TRANSPARENT );
     new_furniture.examine_func.emplace_back( iexamine_functions_from_string( "none" ) );
-    new_furniture.max_volume = units::from_liter( get_option<int>( "DEFAULT_TILE_VOLUME" ) );
+    new_furniture.max_volume = default_tile_volume;
     return new_furniture;
 }
 
@@ -720,7 +721,7 @@ ter_t null_terrain_t()
     new_terrain.set_flag( ter_furn_flag::TFLAG_TRANSPARENT );
     new_terrain.set_flag( ter_furn_flag::TFLAG_DIGGABLE );
     new_terrain.examine_func.emplace_back( iexamine_functions_from_string( "none" ) );
-    new_terrain.max_volume = units::from_liter( get_option<int>( "DEFAULT_TILE_VOLUME" ) );
+    new_terrain.max_volume = default_tile_volume;
     return new_terrain;
 }
 
@@ -1453,7 +1454,7 @@ void ter_t::load( const JsonObject &jo, const std::string &src )
     map_data_common_t::load( jo, src );
     optional( jo, was_loaded, "move_cost", movecost );
     optional( jo, was_loaded, "max_volume", max_volume,
-              units::from_liter( get_option<int>( "DEFAULT_TILE_VOLUME" ) ) );
+              default_tile_volume );
     optional( jo, was_loaded, "trap", trap_id_str );
     optional( jo, was_loaded, "heat_radiation", heat_radiation );
 
@@ -1742,7 +1743,7 @@ void furn_t::load( const JsonObject &jo, const std::string &src )
     bonus_fire_warmth_feet = units::from_legacy_bodypart_temp_delta( legacy_bonus_fire_warmth_feet );
     optional( jo, was_loaded, "keg_capacity", keg_capacity, volume_reader(), 0_ml );
     optional( jo, was_loaded, "max_volume", max_volume, volume_reader(),
-              units::from_liter( get_option<int>( "DEFAULT_TILE_VOLUME" ) ) );
+              default_tile_volume );
     optional( jo, was_loaded, "crafting_pseudo_item", crafting_pseudo_item, itype_id() );
     optional( jo, was_loaded, "deployed_item", deployed_item );
     load_symbol_color( jo, "furniture " + id.str() );

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -608,8 +608,9 @@ struct map_data_common_t {
         int comfort = 0;
         //flat damage reduction (increase if negative) on fall (some logic may apply)
         int fall_damage_reduction = 0;
+
         // Maximal volume of items that can be stored in/on this furniture/terrain
-        units::volume max_volume = DEFAULT_TILE_VOLUME;
+        units::volume max_volume;
 
         itype_id liquid_source_item_id = itype_id::NULL_ID(); // id of a liquid this tile provides
         double liquid_source_min_temp = 4; // in centigrades, cold water as default value

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4429,7 +4429,8 @@ talk_effect_fun_t::func f_consume_item_sum( const JsonObject &jo, std::string_vi
         double amount_desired = 0.0f;
         int count_present = 0;
         Character *you = d.actor( is_npc )->get_character();
-        inventory inventory_and_around = you->crafting_inventory( you->pos_bub(), PICKUP_RANGE );
+        inventory inventory_and_around = you->crafting_inventory( you->pos_bub(),
+                                         get_option<int>( "PICKUP_RANGE" ) );
         std::vector<item_comp> items_to_remove_vector;
 
         for( const auto &pair : item_and_amount ) {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -28,6 +28,7 @@
 #include "avatar.h"
 #include "bionics.h"
 #include "bodypart.h"
+#include "cached_options.h"
 #include "calendar.h"
 #include "cata_lazy.h"
 #include "cata_path.h"
@@ -4430,7 +4431,7 @@ talk_effect_fun_t::func f_consume_item_sum( const JsonObject &jo, std::string_vi
         int count_present = 0;
         Character *you = d.actor( is_npc )->get_character();
         inventory inventory_and_around = you->crafting_inventory( you->pos_bub(),
-                                         get_option<int>( "PICKUP_RANGE" ) );
+                                         pickup_range );
         std::vector<item_comp> items_to_remove_vector;
 
         for( const auto &pair : item_and_amount ) {

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -24,6 +24,7 @@
 #include "basecamp.h"
 #include "bionics.h"
 #include "bodypart.h"
+#include "cached_options.h"
 #include "calendar.h"
 #include "cata_utility.h"
 #include "character.h"
@@ -1495,7 +1496,7 @@ void talk_function::lesser_give_all_aid( npc &p )
     Character &player_character = get_player_character();
     for( npc &guy : g->all_npcs() ) {
         if( guy.is_walking_with() &&
-            rl_dist( guy.pos_bub(), player_character.pos_bub() ) < get_option<int>( "PICKUP_RANGE" ) ) {
+            rl_dist( guy.pos_bub(), player_character.pos_bub() ) < pickup_range ) {
             for( const bodypart_id &bp :
                  guy.get_all_body_parts( get_body_part_flags::only_main ) ) {
                 guy.heal( bp, rng( 5, 15 ) );
@@ -1536,7 +1537,7 @@ void talk_function::give_all_aid( npc &p )
     Character &player_character = get_player_character();
     for( npc &guy : g->all_npcs() ) {
         if( guy.is_walking_with() &&
-            rl_dist( guy.pos_bub(), player_character.pos_bub() ) < get_option<int>( "PICKUP_RANGE" ) ) {
+            rl_dist( guy.pos_bub(), player_character.pos_bub() ) < pickup_range ) {
             for( const bodypart_id &bp :
                  guy.get_all_body_parts( get_body_part_flags::only_main ) ) {
                 guy.heal( bp, 5 * rng( 2, 5 ) );

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -1494,7 +1494,8 @@ void talk_function::lesser_give_all_aid( npc &p )
 
     Character &player_character = get_player_character();
     for( npc &guy : g->all_npcs() ) {
-        if( guy.is_walking_with() && rl_dist( guy.pos_bub(), player_character.pos_bub() ) < PICKUP_RANGE ) {
+        if( guy.is_walking_with() &&
+            rl_dist( guy.pos_bub(), player_character.pos_bub() ) < get_option<int>( "PICKUP_RANGE" ) ) {
             for( const bodypart_id &bp :
                  guy.get_all_body_parts( get_body_part_flags::only_main ) ) {
                 guy.heal( bp, rng( 5, 15 ) );
@@ -1534,7 +1535,8 @@ void talk_function::give_all_aid( npc &p )
 
     Character &player_character = get_player_character();
     for( npc &guy : g->all_npcs() ) {
-        if( guy.is_walking_with() && rl_dist( guy.pos_bub(), player_character.pos_bub() ) < PICKUP_RANGE ) {
+        if( guy.is_walking_with() &&
+            rl_dist( guy.pos_bub(), player_character.pos_bub() ) < get_option<int>( "PICKUP_RANGE" ) ) {
             for( const bodypart_id &bp :
                  guy.get_all_body_parts( get_body_part_flags::only_main ) ) {
                 guy.heal( bp, 5 * rng( 2, 5 ) );

--- a/src/npctrade_utils.cpp
+++ b/src/npctrade_utils.cpp
@@ -107,12 +107,12 @@ void add_fallback_zone( npc &guy )
     faction_id const &fac_id = guy.get_fac_id();
     map &here = get_map();
 
-    if( zmgr.has_near( zone_type_LOOT_UNSORTED, loc, PICKUP_RANGE, fac_id ) ) {
+    if( zmgr.has_near( zone_type_LOOT_UNSORTED, loc, get_option<int>( "PICKUP_RANGE" ), fac_id ) ) {
         return;
     }
 
     std::vector<tripoint_abs_ms> points;
-    for( tripoint_abs_ms const &t : closest_points_first( loc, PICKUP_RANGE ) ) {
+    for( tripoint_abs_ms const &t : closest_points_first( loc, get_option<int>( "PICKUP_RANGE" ) ) ) {
         tripoint_bub_ms const t_here = here.get_bub( t );
         const pathfinding_target pf_t = pathfinding_target::point( t_here );
         const furn_id &f = here.furn( t_here );
@@ -147,13 +147,14 @@ std::list<item> distribute_items_to_npc_zones( std::list<item> &items, npc &guy 
 
     std::list<item> leftovers;
     dest_t const fallback = _get_shuffled_point_set(
-                                zmgr.get_near( zone_type_LOOT_UNSORTED, loc_abs, PICKUP_RANGE, nullptr, fac_id ) );
+                                zmgr.get_near( zone_type_LOOT_UNSORTED, loc_abs, get_option<int>( "PICKUP_RANGE" ), nullptr,
+                                        fac_id ) );
     for( item const &it : items ) {
         zone_type_id const zid =
-            zmgr.get_near_zone_type_for_item( it, loc_abs, PICKUP_RANGE, fac_id );
+            zmgr.get_near_zone_type_for_item( it, loc_abs, get_option<int>( "PICKUP_RANGE" ), fac_id );
 
         dest_t dest = zid.is_valid() ? _get_shuffled_point_set( zmgr.get_near(
-                          zid, loc_abs, PICKUP_RANGE, &it, fac_id ) )
+                          zid, loc_abs, get_option<int>( "PICKUP_RANGE" ), &it, fac_id ) )
                       : dest_t();
         std::copy( fallback.begin(), fallback.end(), std::back_inserter( dest ) );
 
@@ -181,7 +182,7 @@ std::list<item> distribute_items_to_npc_zones( std::list<item> &items, npc &guy 
 void consume_items_in_zones( npc &guy, time_duration const &elapsed )
 {
     std::unordered_set<tripoint_bub_ms> const src = zone_manager::get_manager().get_point_set_loot(
-                guy.pos_abs(), PICKUP_RANGE, guy.get_fac_id() );
+                guy.pos_abs(), get_option<int>( "PICKUP_RANGE" ), guy.get_fac_id() );
 
     consume_cache cache;
     map &here = get_map();

--- a/src/npctrade_utils.cpp
+++ b/src/npctrade_utils.cpp
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "cached_options.h"
 #include "calendar.h"
 #include "clzones.h"
 #include "coordinates.h"
@@ -107,12 +108,12 @@ void add_fallback_zone( npc &guy )
     faction_id const &fac_id = guy.get_fac_id();
     map &here = get_map();
 
-    if( zmgr.has_near( zone_type_LOOT_UNSORTED, loc, get_option<int>( "PICKUP_RANGE" ), fac_id ) ) {
+    if( zmgr.has_near( zone_type_LOOT_UNSORTED, loc, pickup_range, fac_id ) ) {
         return;
     }
 
     std::vector<tripoint_abs_ms> points;
-    for( tripoint_abs_ms const &t : closest_points_first( loc, get_option<int>( "PICKUP_RANGE" ) ) ) {
+    for( tripoint_abs_ms const &t : closest_points_first( loc, pickup_range ) ) {
         tripoint_bub_ms const t_here = here.get_bub( t );
         const pathfinding_target pf_t = pathfinding_target::point( t_here );
         const furn_id &f = here.furn( t_here );
@@ -147,14 +148,14 @@ std::list<item> distribute_items_to_npc_zones( std::list<item> &items, npc &guy 
 
     std::list<item> leftovers;
     dest_t const fallback = _get_shuffled_point_set(
-                                zmgr.get_near( zone_type_LOOT_UNSORTED, loc_abs, get_option<int>( "PICKUP_RANGE" ), nullptr,
+                                zmgr.get_near( zone_type_LOOT_UNSORTED, loc_abs, pickup_range, nullptr,
                                         fac_id ) );
     for( item const &it : items ) {
         zone_type_id const zid =
-            zmgr.get_near_zone_type_for_item( it, loc_abs, get_option<int>( "PICKUP_RANGE" ), fac_id );
+            zmgr.get_near_zone_type_for_item( it, loc_abs, pickup_range, fac_id );
 
         dest_t dest = zid.is_valid() ? _get_shuffled_point_set( zmgr.get_near(
-                          zid, loc_abs, get_option<int>( "PICKUP_RANGE" ), &it, fac_id ) )
+                          zid, loc_abs, pickup_range, &it, fac_id ) )
                       : dest_t();
         std::copy( fallback.begin(), fallback.end(), std::back_inserter( dest ) );
 
@@ -182,7 +183,7 @@ std::list<item> distribute_items_to_npc_zones( std::list<item> &items, npc &guy 
 void consume_items_in_zones( npc &guy, time_duration const &elapsed )
 {
     std::unordered_set<tripoint_bub_ms> const src = zone_manager::get_manager().get_point_set_loot(
-                guy.pos_abs(), get_option<int>( "PICKUP_RANGE" ), guy.get_fac_id() );
+                guy.pos_abs(), pickup_range, guy.get_fac_id() );
 
     consume_cache cache;
     map &here = get_map();

--- a/src/omdata.h
+++ b/src/omdata.h
@@ -865,7 +865,7 @@ struct overmap_special_migration {
     public:
         friend class cata::lua_platform::content_transaction;
         friend std::vector<std::pair<std::string, std::string>>
-        cata::lua_platform::detail::overmap_special_migration_snapshot();
+                cata::lua_platform::detail::overmap_special_migration_snapshot();
         static void load_migrations( const JsonObject &jo, const std::string &src );
         static void finalize_all();
         static void reset();

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3584,7 +3584,7 @@ void options_manager::add_options_world_default()
 
         add( "CROP_OVERGROWN_ENABLED", page_id,
              to_translation( "Crops can wither from overgrowth" ),
-             to_translation( "If true, mature crops will eventually become overgrown and "
+             to_translation( "If true, mature cMAX_ITEM_IN_SQUARErops will eventually become overgrown and "
                              "wither if not harvested." ),
              true
            );
@@ -3595,6 +3595,23 @@ void options_manager::add_options_world_default()
     add_option_group( "world_default", Group( "misc_worlddef_opts", to_translation( "Misc options" ),
                       to_translation( "Miscellaneous options." ) ),
     [&]( const std::string & page_id ) {
+
+        add( "MAX_ITEM_IN_SQUARE", page_id,
+             to_translation( "Max item in square" ),
+             to_translation( "How many items could place in one tile." ),
+             4096, 99999, 8192
+           );
+        add( "DEFAULT_TILE_VOLUME", page_id,
+             to_translation( "Default tile volume (L)" ),
+             to_translation( "How many liters of item could place in one tile." ),
+             1000, 3000, 1000
+           );
+        add( "PICKUP_RANGE", page_id,
+             to_translation( "Pickup range" ),
+             to_translation( "Items on the map that are at most this distance from the player are considered available for crafting and other purposes." ),
+             1, 20, 6
+           );
+
         // TODO: find the code keypoint and implement this option.
         // add( "WANDER_SPAWNS", page_id, to_translation( "Wandering hordes" ),
         //      to_translation( "If true, emulates zombie hordes.  Zombies can group together into hordes, which can wander around cities and will sometimes move towards noise.  Note: the current implementation does not properly respect obstacles, so hordes can appear to walk through walls under some circumstances.  Must reset world directory after changing for it to take effect." ),

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3584,7 +3584,7 @@ void options_manager::add_options_world_default()
 
         add( "CROP_OVERGROWN_ENABLED", page_id,
              to_translation( "Crops can wither from overgrowth" ),
-             to_translation( "If true, mature cMAX_ITEM_IN_SQUARErops will eventually become overgrown and "
+             to_translation( "If true, mature crops will eventually become overgrown and "
                              "wither if not harvested." ),
              true
            );
@@ -5113,6 +5113,9 @@ void options_manager::update_options_cache()
     cata::options::mouse.enabled = ::get_option<bool>( "ENABLE_MOUSE" );
     cata::options::mouse.hidekb = ::get_option<std::string>( "HIDE_CURSOR" ) == "hidekb";
     use_pinyin_search = ::get_option<bool>( "USE_PINYIN_SEARCH" );
+    max_item_in_square = ::get_option<int>( "MAX_ITEM_IN_SQUARE" );
+    default_tile_volume = units::from_liter( ::get_option<int>( "DEFAULT_TILE_VOLUME" ) );
+    pickup_range = ::get_option<int>( "PICKUP_RANGE" );
 
     cata::options::damage_indicators.clear();
     for( int i = 0; i < 6; i++ ) {

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -1361,7 +1361,7 @@ void cata::lua_platform::detail::erase_platform_oter_migration(
 }
 
 std::vector<std::pair<std::string, std::string>>
-cata::lua_platform::detail::oter_migration_snapshot()
+        cata::lua_platform::detail::oter_migration_snapshot()
 {
     std::vector<std::pair<std::string, std::string>> result;
     result.reserve( oter_id_migrations.size() );

--- a/src/overmap_special.cpp
+++ b/src/overmap_special.cpp
@@ -48,7 +48,7 @@ cata::lua_platform::detail::overmap_special_migration_registry()
 }
 
 std::vector<std::pair<std::string, std::string>>
-cata::lua_platform::detail::overmap_special_migration_snapshot()
+        cata::lua_platform::detail::overmap_special_migration_snapshot()
 {
     std::vector<std::pair<std::string, std::string>> result;
     result.reserve( migrations.size() );

--- a/src/proficiency.cpp
+++ b/src/proficiency.cpp
@@ -705,7 +705,7 @@ void cata::lua_platform::detail::erase_platform_proficiency_migration(
 }
 
 std::vector<std::pair<std::string, std::string>>
-cata::lua_platform::detail::proficiency_migration_snapshot()
+        cata::lua_platform::detail::proficiency_migration_snapshot()
 {
     std::vector<std::pair<std::string, std::string>> result;
     result.reserve( prof_migrations.size() );

--- a/src/recipe_groups.cpp
+++ b/src/recipe_groups.cpp
@@ -109,8 +109,8 @@ cata::lua_platform::detail::recipe_group_snapshot()
         result.emplace_back( convert_recipe_group( value ) );
     }
     std::sort( result.begin(), result.end(),
-    []( const cata::lua_platform::detail::recipe_group_native_definition &left,
-        const cata::lua_platform::detail::recipe_group_native_definition &right ) {
+               []( const cata::lua_platform::detail::recipe_group_native_definition & left,
+    const cata::lua_platform::detail::recipe_group_native_definition & right ) {
         return left.id < right.id;
     } );
     return result;

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -1121,8 +1121,7 @@ bool requirement_data::check_enough_materials( const read_only_visitable &crafti
 
     // This will be the volume of the resulting in-progress craft item (see item::volume), so we don't want to exceed it.
     // TODO: Feedback? Some sort of indicator to the player that resulting volume is why it can't be crafted
-    if( restrict_volume &&
-        total_component_volume > default_tile_volume ) {
+    if( restrict_volume && total_component_volume > default_tile_volume ) {
         retval = false;
     }
 

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -1120,7 +1120,8 @@ bool requirement_data::check_enough_materials( const read_only_visitable &crafti
 
     // This will be the volume of the resulting in-progress craft item (see item::volume), so we don't want to exceed it.
     // TODO: Feedback? Some sort of indicator to the player that resulting volume is why it can't be crafted
-    if( restrict_volume && total_component_volume > MAX_ITEM_VOLUME ) {
+    if( restrict_volume &&
+        total_component_volume > units::from_liter( get_option<int>( "DEFAULT_TILE_VOLUME" ) ) ) {
         retval = false;
     }
 

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -14,6 +14,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include "cached_options.h"
 #include "cata_assert.h"
 #include "cata_utility.h"
 #include "catalua_platform_content.h"
@@ -1121,7 +1122,7 @@ bool requirement_data::check_enough_materials( const read_only_visitable &crafti
     // This will be the volume of the resulting in-progress craft item (see item::volume), so we don't want to exceed it.
     // TODO: Feedback? Some sort of indicator to the player that resulting volume is why it can't be crafted
     if( restrict_volume &&
-        total_component_volume > units::from_liter( get_option<int>( "DEFAULT_TILE_VOLUME" ) ) ) {
+        total_component_volume > default_tile_volume ) {
         retval = false;
     }
 

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -2003,7 +2003,7 @@ void cata::lua_platform::detail::erase_platform_var_migration(
 }
 
 std::vector<std::pair<std::string, std::string>>
-cata::lua_platform::detail::var_migration_snapshot()
+        cata::lua_platform::detail::var_migration_snapshot()
 {
     std::vector<std::pair<std::string, std::string>> result;
     const std::map<std::string, std::string> &migrations =

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -5367,7 +5367,7 @@ void cata::lua_platform::detail::erase_platform_savegame_migration(
 }
 
 std::vector<std::pair<std::string, std::string>>
-cata::lua_platform::detail::terrain_migration_snapshot()
+        cata::lua_platform::detail::terrain_migration_snapshot()
 {
     std::vector<std::pair<std::string, std::string>> result;
     result.reserve( ter_migrations.size() );
@@ -5379,7 +5379,7 @@ cata::lua_platform::detail::terrain_migration_snapshot()
 }
 
 std::vector<std::pair<std::string, std::string>>
-cata::lua_platform::detail::furniture_migration_snapshot()
+        cata::lua_platform::detail::furniture_migration_snapshot()
 {
     std::vector<std::pair<std::string, std::string>> result;
     result.reserve( furn_migrations.size() );
@@ -5391,7 +5391,7 @@ cata::lua_platform::detail::furniture_migration_snapshot()
 }
 
 std::vector<std::pair<std::string, std::string>>
-cata::lua_platform::detail::trap_migration_snapshot()
+        cata::lua_platform::detail::trap_migration_snapshot()
 {
     std::vector<std::pair<std::string, std::string>> result;
     result.reserve( tr_migrations.size() );

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -91,7 +91,7 @@ cata::lua_platform::detail::scenario_registry_snapshot()
         result.emplace_back( std::move( entry ) );
     }
     std::sort( result.begin(), result.end(),
-    []( const scenario_snapshot_entry &left, const scenario_snapshot_entry &right ) {
+    []( const scenario_snapshot_entry & left, const scenario_snapshot_entry & right ) {
         return left.id < right.id;
     } );
     return result;

--- a/src/skill.cpp
+++ b/src/skill.cpp
@@ -51,7 +51,7 @@ std::vector<cata::lua_platform::detail::skill_snapshot_entry>
 cata::lua_platform::detail::skill_registry_snapshot()
 {
     std::vector<skill_snapshot_entry> result;
-    const auto collect = [&result]( const Skill &sk ) {
+    const auto collect = [&result]( const Skill & sk ) {
         skill_snapshot_entry entry;
         entry.id = sk.ident().str();
         entry.name = sk.name();
@@ -77,7 +77,7 @@ cata::lua_platform::detail::skill_registry_snapshot()
         entry.survival_rank = sk.companion_survival_rank_factor();
         entry.industry_rank = sk.companion_industry_rank_factor();
         entry.requires_all.assign( sk._requires_all_traits.begin(),
-                                  sk._requires_all_traits.end() );
+                                   sk._requires_all_traits.end() );
         entry.requires_any.assign( sk._requires_any_traits.begin(),
                                    sk._requires_any_traits.end() );
         result.emplace_back( std::move( entry ) );
@@ -89,7 +89,7 @@ cata::lua_platform::detail::skill_registry_snapshot()
         collect( sk );
     }
     std::sort( result.begin(), result.end(),
-    []( const skill_snapshot_entry &left, const skill_snapshot_entry &right ) {
+    []( const skill_snapshot_entry & left, const skill_snapshot_entry & right ) {
         return left.id < right.id;
     } );
     return result;

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -95,8 +95,8 @@ cata::lua_platform::detail::start_location_snapshot()
         result.emplace_back( std::move( entry ) );
     }
     std::sort( result.begin(), result.end(),
-    []( const start_location_snapshot_entry &left,
-        const start_location_snapshot_entry &right ) {
+               []( const start_location_snapshot_entry & left,
+    const start_location_snapshot_entry & right ) {
         return left.id < right.id;
     } );
     return result;

--- a/src/trade_ui.cpp
+++ b/src/trade_ui.cpp
@@ -10,6 +10,7 @@
 #include <unordered_set>
 
 #include "avatar.h"
+#include "cached_options.h"
 #include "character.h"
 #include "clzones.h"
 #include "color.h"
@@ -81,7 +82,7 @@ void populate_trade_selectors( Character &you, npc &trader, trade_selector &you_
 
         zone_manager &zmgr = zone_manager::get_manager();
         const std::unordered_set<tripoint_bub_ms> src =
-            zmgr.get_point_set_loot( trader.pos_abs(), get_option<int>( "PICKUP_RANGE" ), trader.get_fac_id() );
+            zmgr.get_point_set_loot( trader.pos_abs(), pickup_range, trader.get_fac_id() );
 
         for( const tripoint_bub_ms &pt : src ) {
             trader_pane.add_map_items( pt );

--- a/src/trade_ui.cpp
+++ b/src/trade_ui.cpp
@@ -81,7 +81,7 @@ void populate_trade_selectors( Character &you, npc &trader, trade_selector &you_
 
         zone_manager &zmgr = zone_manager::get_manager();
         const std::unordered_set<tripoint_bub_ms> src =
-            zmgr.get_point_set_loot( trader.pos_abs(), PICKUP_RANGE, trader.get_fac_id() );
+            zmgr.get_point_set_loot( trader.pos_abs(), get_option<int>( "PICKUP_RANGE" ), trader.get_fac_id() );
 
         for( const tripoint_bub_ms &pt : src ) {
             trader_pane.add_map_items( pt );

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -17,6 +17,7 @@
 
 #include "activity_actor_definitions.h"
 #include "avatar.h"
+#include "cached_options.h"
 #include "calendar.h"
 #include "cata_scope_helpers.h"
 #include "cata_utility.h"
@@ -915,7 +916,7 @@ void veh_interact::cache_tool_availability()
         mech_jack = player_character.mounted_creature->mech_str_addition() + 10;
     }
     int max_quality = std::max( { player_character.max_quality( qual_JACK ), mech_jack,
-                                  map_selector( player_character.pos_bub(), get_option<int>( "PICKUP_RANGE" ) ).max_quality( qual_JACK ),
+                                  map_selector( player_character.pos_bub(), pickup_range ).max_quality( qual_JACK ),
                                   vehicle_selector( here, player_character.pos_bub(), 2, true, *veh ).max_quality( qual_JACK )
                                 } );
     max_jack = lifting_quality_to_mass( max_quality );

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -915,7 +915,7 @@ void veh_interact::cache_tool_availability()
         mech_jack = player_character.mounted_creature->mech_str_addition() + 10;
     }
     int max_quality = std::max( { player_character.max_quality( qual_JACK ), mech_jack,
-                                  map_selector( player_character.pos_bub(), PICKUP_RANGE ).max_quality( qual_JACK ),
+                                  map_selector( player_character.pos_bub(), get_option<int>( "PICKUP_RANGE" ) ).max_quality( qual_JACK ),
                                   vehicle_selector( here, player_character.pos_bub(), 2, true, *veh ).max_quality( qual_JACK )
                                 } );
     max_jack = lifting_quality_to_mass( max_quality );

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -1848,7 +1848,7 @@ void cata::lua_platform::detail::erase_platform_vpart_migration(
 }
 
 std::vector<std::pair<std::string, std::string>>
-cata::lua_platform::detail::vehicle_part_migration_snapshot()
+        cata::lua_platform::detail::vehicle_part_migration_snapshot()
 {
     std::vector<std::pair<std::string, std::string>> result;
     result.reserve( vpart_migrations.size() );

--- a/src/veh_utils.cpp
+++ b/src/veh_utils.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "avatar.h"
+#include "cached_options.h"
 #include "calendar.h"
 #include "cata_imgui.h"
 #include "character.h"
@@ -106,13 +107,13 @@ bool repair_part( map &here, vehicle &veh, vehicle_part &pt, Character &who )
                                   ? vp.install_requirements()
                                   : vp.repair_requirements() * pt.get_base().repairable_levels();
 
-    const inventory &inv = who.crafting_inventory( who.pos_bub(), get_option<int>( "PICKUP_RANGE" ),
+    const inventory &inv = who.crafting_inventory( who.pos_bub(), pickup_range,
                            !who.is_npc() );
     inventory map_inv;
     // allow NPCs to use welding rigs they can't see ( on the other side of a vehicle )
     // as they have the handicap of not being able to use the veh interaction menu
     // or able to drag a welding cart etc.
-    map_inv.form_from_map( who.pos_bub(), get_option<int>( "PICKUP_RANGE" ), &who, false,
+    map_inv.form_from_map( who.pos_bub(), pickup_range, &who, false,
                            !who.is_npc() );
     if( !reqs.can_make_with_inventory( inv, is_crafting_component ) ) {
         who.add_msg_if_player( m_info, _( "You don't meet the requirements to repair the %s." ),

--- a/src/veh_utils.cpp
+++ b/src/veh_utils.cpp
@@ -106,12 +106,14 @@ bool repair_part( map &here, vehicle &veh, vehicle_part &pt, Character &who )
                                   ? vp.install_requirements()
                                   : vp.repair_requirements() * pt.get_base().repairable_levels();
 
-    const inventory &inv = who.crafting_inventory( who.pos_bub(), PICKUP_RANGE, !who.is_npc() );
+    const inventory &inv = who.crafting_inventory( who.pos_bub(), get_option<int>( "PICKUP_RANGE" ),
+                           !who.is_npc() );
     inventory map_inv;
     // allow NPCs to use welding rigs they can't see ( on the other side of a vehicle )
     // as they have the handicap of not being able to use the veh interaction menu
     // or able to drag a welding cart etc.
-    map_inv.form_from_map( who.pos_bub(), PICKUP_RANGE, &who, false, !who.is_npc() );
+    map_inv.form_from_map( who.pos_bub(), get_option<int>( "PICKUP_RANGE" ), &who, false,
+                           !who.is_npc() );
     if( !reqs.can_make_with_inventory( inv, is_crafting_component ) ) {
         who.add_msg_if_player( m_info, _( "You don't meet the requirements to repair the %s." ),
                                pt.name() );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -24,6 +24,7 @@
 #include "avatar.h"
 #include "bionics.h"
 #include "bodypart.h"
+#include "cached_options.h"
 #include "cata_assert.h"
 #include "cata_bitset.h"
 #include "cata_utility.h"
@@ -216,7 +217,7 @@ void vehicle_stack::insert( map &here, const item &newitem )
 
 int vehicle_stack::count_limit() const
 {
-    return get_option<int>( "MAX_ITEM_IN_SQUARE" );
+    return max_item_in_square;
 }
 
 units::volume vehicle_stack::max_volume() const

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -216,7 +216,7 @@ void vehicle_stack::insert( map &here, const item &newitem )
 
 int vehicle_stack::count_limit() const
 {
-    return MAX_ITEM_IN_VEHICLE_STORAGE;
+    return get_option<int>( "MAX_ITEM_IN_SQUARE" );
 }
 
 units::volume vehicle_stack::max_volume() const

--- a/src/vehicle_group.cpp
+++ b/src/vehicle_group.cpp
@@ -43,7 +43,7 @@ void cata::lua_platform::detail::vehicle_group_registry_erase( const std::string
 }
 
 std::vector<std::pair<std::string, int>>
-cata::lua_platform::detail::vehicle_group_weighted_entries( const vgroup_id &id )
+                                      cata::lua_platform::detail::vehicle_group_weighted_entries( const vgroup_id &id )
 {
     std::vector<std::pair<std::string, int>> result;
     const auto found = vgroups.find( id );

--- a/src/vehicle_group.h
+++ b/src/vehicle_group.h
@@ -27,7 +27,7 @@ namespace cata::lua_platform
 namespace detail
 {
 std::vector<std::pair<std::string, int>> vehicle_group_weighted_entries(
-    const vgroup_id &id );
+        const vgroup_id &id );
 } // namespace detail
 } // namespace cata::lua_platform
 
@@ -59,8 +59,8 @@ class VehicleGroup
 
     private:
         friend std::vector<std::pair<std::string, int>>
-        cata::lua_platform::detail::vehicle_group_weighted_entries(
-            const vgroup_id &id );
+                cata::lua_platform::detail::vehicle_group_weighted_entries(
+                    const vgroup_id &id );
         weighted_int_list<vproto_id> vehicles;
 };
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -88,7 +88,7 @@ check-single: $(TEST_TARGET)
 	cd .. && tests/$(TEST_TARGET) --min-duration 0.2 --rng-seed time --order lex
 
 clean:
-	rm -rf *obj *objwin
+	rm -rf *obj *objwin *obj-lua
 	rm -f *cata_test
 
 #Unconditionally create object directory on invocation.

--- a/tests/act_build_test.cpp
+++ b/tests/act_build_test.cpp
@@ -13,6 +13,7 @@
 #include "activity_handlers.h"
 #include "avatar.h"
 #include "build_reqs.h"
+#include "cached_options.h"
 #include "calendar.h"
 #include "cata_catch.h"
 #include "character.h"
@@ -302,7 +303,7 @@ void run_test_case( Character &u )
         here.build_map_cache( u.posz() );
         tripoint_bub_ms const tri_door( tripoint::south );
         construction const build =
-            setup_testcase( u, "test_constr_door_peep", tri_door, { 0, get_option<int>( "PICKUP_RANGE" ) * 2 + 1, 0 } );
+            setup_testcase( u, "test_constr_door_peep", tri_door, { 0, pickup_range * 2 + 1, 0 } );
         run_activities( u, build.time * 100 );
         REQUIRE( here.ter( tri_door ) == ter_id( build.post_terrain ) );
     }

--- a/tests/act_build_test.cpp
+++ b/tests/act_build_test.cpp
@@ -302,7 +302,7 @@ void run_test_case( Character &u )
         here.build_map_cache( u.posz() );
         tripoint_bub_ms const tri_door( tripoint::south );
         construction const build =
-            setup_testcase( u, "test_constr_door_peep", tri_door, { 0, PICKUP_RANGE * 2 + 1, 0 } );
+            setup_testcase( u, "test_constr_door_peep", tri_door, { 0, get_option<int>( "PICKUP_RANGE" ) * 2 + 1, 0 } );
         run_activities( u, build.time * 100 );
         REQUIRE( here.ter( tri_door ) == ter_id( build.post_terrain ) );
     }

--- a/tests/clzones_test.cpp
+++ b/tests/clzones_test.cpp
@@ -442,7 +442,7 @@ TEST_CASE( "zone_sorting_skips_source_when_all_destinations_count_full",
 
     std::optional<vpart_reference> dest_vp;
 
-    SECTION( "vehicle cargo destination at MAX_ITEM_IN_VEHICLE_STORAGE" ) {
+    SECTION( "vehicle cargo destination at MAX_ITEM_IN_SQUARE" ) {
         vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
                                           dest_pos, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
         REQUIRE( cart != nullptr );
@@ -450,7 +450,7 @@ TEST_CASE( "zone_sorting_skips_source_when_all_destinations_count_full",
         dest_vp = here.veh_at( dest_pos ).cargo();
         REQUIRE( dest_vp );
 
-        const int cargo_fill_target = MAX_ITEM_IN_VEHICLE_STORAGE;
+        const int cargo_fill_target = get_option<int>( "MAX_ITEM_IN_SQUARE" );
         int inserted = 0;
         for( int i = 0; i < cargo_fill_target; ++i ) {
             item filler( itype_test_rod_14cm );
@@ -468,7 +468,7 @@ TEST_CASE( "zone_sorting_skips_source_when_all_destinations_count_full",
 
     SECTION( "ground destination at MAX_ITEM_IN_SQUARE" ) {
         int inserted = 0;
-        for( int i = 0; i < MAX_ITEM_IN_SQUARE; ++i ) {
+        for( int i = 0; i < get_option<int>( "MAX_ITEM_IN_SQUARE" ); ++i ) {
             item *added = here.add_item_or_charges_ret_loc( dest_pos, item( itype_test_rod_14cm ),
                           false ).get_item();
             if( added == nullptr ) {
@@ -476,7 +476,7 @@ TEST_CASE( "zone_sorting_skips_source_when_all_destinations_count_full",
             }
             ++inserted;
         }
-        REQUIRE( inserted >= MAX_ITEM_IN_SQUARE - 1 );
+        REQUIRE( inserted >= get_option<int>( "MAX_ITEM_IN_SQUARE" ) - 1 );
 
         create_tile_zone( "Food", zone_type_LOOT_FOOD, dest_abs );
     }
@@ -533,7 +533,7 @@ TEST_CASE( "zone_sorting_activity_terminates_with_count_full_vehicle_destination
     REQUIRE( vp );
 
     int inserted = 0;
-    for( int i = 0; i < MAX_ITEM_IN_VEHICLE_STORAGE; ++i ) {
+    for( int i = 0; i < get_option<int>( "MAX_ITEM_IN_SQUARE" ); ++i ) {
         item filler( itype_test_rod_14cm );
         if( vp->vehicle().add_item( here, vp->part(), filler ) ) {
             ++inserted;
@@ -541,7 +541,7 @@ TEST_CASE( "zone_sorting_activity_terminates_with_count_full_vehicle_destination
             break;
         }
     }
-    REQUIRE( inserted >= MAX_ITEM_IN_VEHICLE_STORAGE - 1 );
+    REQUIRE( inserted >= get_option<int>( "MAX_ITEM_IN_SQUARE" ) - 1 );
 
     create_tile_zone( "Food", zone_type_LOOT_FOOD, dest_abs, /*veh=*/true );
     create_tile_zone( "Unsorted", zone_type_LOOT_UNSORTED, src_abs );

--- a/tests/clzones_test.cpp
+++ b/tests/clzones_test.cpp
@@ -442,7 +442,7 @@ TEST_CASE( "zone_sorting_skips_source_when_all_destinations_count_full",
 
     std::optional<vpart_reference> dest_vp;
 
-    SECTION( "vehicle cargo destination at MAX_ITEM_IN_SQUARE" ) {
+    SECTION( "vehicle cargo destination at max_item_in_square" ) {
         vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
                                           dest_pos, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
         REQUIRE( cart != nullptr );
@@ -450,7 +450,7 @@ TEST_CASE( "zone_sorting_skips_source_when_all_destinations_count_full",
         dest_vp = here.veh_at( dest_pos ).cargo();
         REQUIRE( dest_vp );
 
-        const int cargo_fill_target = get_option<int>( "MAX_ITEM_IN_SQUARE" );
+        const int cargo_fill_target = max_item_in_square;
         int inserted = 0;
         for( int i = 0; i < cargo_fill_target; ++i ) {
             item filler( itype_test_rod_14cm );
@@ -466,9 +466,9 @@ TEST_CASE( "zone_sorting_skips_source_when_all_destinations_count_full",
         REQUIRE( zone_manager::get_manager().has_vehicle( zone_type_LOOT_FOOD, dest_abs ) );
     }
 
-    SECTION( "ground destination at MAX_ITEM_IN_SQUARE" ) {
+    SECTION( "ground destination at max_item_in_square" ) {
         int inserted = 0;
-        for( int i = 0; i < get_option<int>( "MAX_ITEM_IN_SQUARE" ); ++i ) {
+        for( int i = 0; i < max_item_in_square; ++i ) {
             item *added = here.add_item_or_charges_ret_loc( dest_pos, item( itype_test_rod_14cm ),
                           false ).get_item();
             if( added == nullptr ) {
@@ -476,7 +476,7 @@ TEST_CASE( "zone_sorting_skips_source_when_all_destinations_count_full",
             }
             ++inserted;
         }
-        REQUIRE( inserted >= get_option<int>( "MAX_ITEM_IN_SQUARE" ) - 1 );
+        REQUIRE( inserted >= max_item_in_square- 1 );
 
         create_tile_zone( "Food", zone_type_LOOT_FOOD, dest_abs );
     }
@@ -533,7 +533,7 @@ TEST_CASE( "zone_sorting_activity_terminates_with_count_full_vehicle_destination
     REQUIRE( vp );
 
     int inserted = 0;
-    for( int i = 0; i < get_option<int>( "MAX_ITEM_IN_SQUARE" ); ++i ) {
+    for( int i = 0; i < max_item_in_square; ++i ) {
         item filler( itype_test_rod_14cm );
         if( vp->vehicle().add_item( here, vp->part(), filler ) ) {
             ++inserted;
@@ -541,7 +541,7 @@ TEST_CASE( "zone_sorting_activity_terminates_with_count_full_vehicle_destination
             break;
         }
     }
-    REQUIRE( inserted >= get_option<int>( "MAX_ITEM_IN_SQUARE" ) - 1 );
+    REQUIRE( inserted >= max_item_in_square- 1 );
 
     create_tile_zone( "Food", zone_type_LOOT_FOOD, dest_abs, /*veh=*/true );
     create_tile_zone( "Unsorted", zone_type_LOOT_UNSORTED, src_abs );

--- a/tests/clzones_test.cpp
+++ b/tests/clzones_test.cpp
@@ -476,7 +476,7 @@ TEST_CASE( "zone_sorting_skips_source_when_all_destinations_count_full",
             }
             ++inserted;
         }
-        REQUIRE( inserted >= max_item_in_square- 1 );
+        REQUIRE( inserted >= max_item_in_square - 1 );
 
         create_tile_zone( "Food", zone_type_LOOT_FOOD, dest_abs );
     }
@@ -541,7 +541,7 @@ TEST_CASE( "zone_sorting_activity_terminates_with_count_full_vehicle_destination
             break;
         }
     }
-    REQUIRE( inserted >= max_item_in_square- 1 );
+    REQUIRE( inserted >= max_item_in_square - 1 );
 
     create_tile_zone( "Food", zone_type_LOOT_FOOD, dest_abs, /*veh=*/true );
     create_tile_zone( "Unsorted", zone_type_LOOT_UNSORTED, src_abs );

--- a/tests/craft_attention_test.cpp
+++ b/tests/craft_attention_test.cpp
@@ -997,7 +997,7 @@ TEST_CASE( "craft_unattended_charged_tool_offset_crafter_uses_map_source",
     avatar &u = get_avatar();
     map &here = get_map();
     const tripoint_bub_ms craft_pos( 75, 75, 0 );
-    // Crafter stands well outside PICKUP_RANGE of the workbench craft.
+    // Crafter stands well outside get_option<int>( "PICKUP_RANGE" ) of the workbench craft.
     u.setpos( here, tripoint_bub_ms( 60, 60, 0 ) );
 
     // The charged tool sits on the map at the craft, not in the crafter's pack.
@@ -1281,7 +1281,7 @@ TEST_CASE( "craft_unattended_noncharged_tool_offset_crafter_uses_map_source",
             on_map.set_tools_to_continue( true );
 
             THEN( "the verifier fails and clears tools_to_continue" ) {
-                CHECK_FALSE( u.verify_step_tools( on_map, 1, craft_pos, PICKUP_RANGE,
+                CHECK_FALSE( u.verify_step_tools( on_map, 1, craft_pos, get_option<int>( "PICKUP_RANGE" ),
                                                   /*pin_to_map=*/true ) );
                 CHECK_FALSE( on_map.has_tools_to_continue() );
             }

--- a/tests/craft_attention_test.cpp
+++ b/tests/craft_attention_test.cpp
@@ -7,6 +7,7 @@
 
 #include "activity_actor_definitions.h"
 #include "avatar.h"
+#include "cached_options.h"
 #include "calendar.h"
 #include "cata_catch.h"
 #include "character_id.h"
@@ -997,7 +998,7 @@ TEST_CASE( "craft_unattended_charged_tool_offset_crafter_uses_map_source",
     avatar &u = get_avatar();
     map &here = get_map();
     const tripoint_bub_ms craft_pos( 75, 75, 0 );
-    // Crafter stands well outside get_option<int>( "PICKUP_RANGE" ) of the workbench craft.
+    // Crafter stands well outside pickup_range of the workbench craft.
     u.setpos( here, tripoint_bub_ms( 60, 60, 0 ) );
 
     // The charged tool sits on the map at the craft, not in the crafter's pack.
@@ -1281,7 +1282,7 @@ TEST_CASE( "craft_unattended_noncharged_tool_offset_crafter_uses_map_source",
             on_map.set_tools_to_continue( true );
 
             THEN( "the verifier fails and clears tools_to_continue" ) {
-                CHECK_FALSE( u.verify_step_tools( on_map, 1, craft_pos, get_option<int>( "PICKUP_RANGE" ),
+                CHECK_FALSE( u.verify_step_tools( on_map, 1, craft_pos, pickup_range,
                                                   /*pin_to_map=*/true ) );
                 CHECK_FALSE( on_map.has_tools_to_continue() );
             }

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "avatar.h"
+#include "cached_options.h"
 #include "calendar.h"
 #include "cata_catch.h"
 #include "cata_utility.h"
@@ -1517,7 +1518,7 @@ TEST_CASE( "craft_step_consume_requires_selected_noncharged_tool",
         u.invalidate_crafting_inventory();
 
         THEN( "the verifier fails and clears tools_to_continue" ) {
-            CHECK_FALSE( u.verify_step_tools( craft, 0, u.pos_bub(), get_option<int>( "PICKUP_RANGE" ),
+            CHECK_FALSE( u.verify_step_tools( craft, 0, u.pos_bub(), pickup_range,
                                               /*pin_to_map=*/false ) );
             CHECK_FALSE( craft.has_tools_to_continue() );
         }

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -1517,7 +1517,7 @@ TEST_CASE( "craft_step_consume_requires_selected_noncharged_tool",
         u.invalidate_crafting_inventory();
 
         THEN( "the verifier fails and clears tools_to_continue" ) {
-            CHECK_FALSE( u.verify_step_tools( craft, 0, u.pos_bub(), PICKUP_RANGE,
+            CHECK_FALSE( u.verify_step_tools( craft, 0, u.pos_bub(), get_option<int>( "PICKUP_RANGE" ),
                                               /*pin_to_map=*/false ) );
             CHECK_FALSE( craft.has_tools_to_continue() );
         }


### PR DESCRIPTION
<!-- 使用说明：在下面每个「#### 标题」下填写与你的 PR 相关的信息。
请保留这些标题。像这样的注释可以安全删除。

如果你是在 GitHub 网页界面发起这个 PR，可以用「preview（预览）」按钮查看 PR 对他人显示的样子。

PR 提交准则：
- 让你的改动只聚焦于一个具体的问题或变更，外加为实现它所必需的最小相关改动。
- 一个经验法则：大多数 PR 的改动应少于 500 行。
- 你可以另开 PR 来拆分一次较大的预期改动；如果不确定怎么拆，尽管问。我们很乐意与你协作，并建议合并你 PR 的最佳方式。
-->

#### Summary
<!-- #### 概述 -->
Interface "Add options for unlock limits"
<!-- 这一节应当只有一行，请编辑上面那一行。
1. 把「分类」替换为下列具体分类之一：Features、Content、Interface、Mods、Balance、Bugfixes、Performance、Infrastructure、Build、I18N。
2. 把引号内的文字替换为对你改动的简要描述。
如果你不希望生成更新日志条目，把整行替换为单独一个词「None」（不带引号）。
示例：
1. None
2. Bugfixes "修复长矛无法锁定不同楼层敌人的问题"
3. Interface "在制作界面显示制作失败几率"
分类含义详见：
https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/blob/master/doc/CHANGELOG_GUIDELINES.md
合并后，你的概述会被加入项目更新日志：
https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/blob/master/data/changelog.txt -->

#### Responsible human
<!-- #### 责任人 -->

@Minecrafthyr 

<!-- 每个 PR 必须指定一名真实的人类责任人。AI 工具或模型无需披露，但责任人
必须理解修改、审查最终 diff、确认测试与许可证/外部来源，并回答审阅问题。 -->

#### Purpose of change
<!-- #### 变更目的 -->
The 4096 item count limit per tile is an outdated rule that now prevents players from placing items inappropriately.
Add more customisation options.
<!-- 用几句话描述你做这次改动的原因。
如果它与某个已有 issue 相关，可以用「#」加 GitHub issue 编号来关联，例如 #1234。

【重要】当你的 PR 能完全解决某个 issue 时，必须使用 [GitHub 的英文关闭关键字](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
才能在 PR 合并后自动关闭该 issue，例如：Fixes #1234。
只能用以下英文关键词（后面紧跟「#编号」）：
  close / closes / closed
  fix / fixes / fixed
  resolve / resolves / resolved
注意：中文「修复 #1234」不会触发自动关闭，GitHub 只识别上述英文关键词。

如果没有相关 issue，请在这里说明你要解决的问题、特性或其他关注点。如果这是一个 bug 修复，请附上复现原始 bug 的步骤，以便你的修复可以被验证。 -->

#### Describe the solution
<!-- #### 解决方案描述 -->
Add options: 
- Max item in square (max 99999, default 8192, previous 4096).
- Default tile volume (max 3000L, default 1000L).
- Pickup range (max 20, default 6).
<!-- 这个特性是如何工作的，或者这个 bug 是怎么被修复的？方案越易于理解，就越快能被合并。 -->

#### Describe alternatives you've considered
<!-- #### 你考虑过的替代方案 -->
Set a higher constant of Max item in square limit instead using option.

<!-- 说明你为解决同一问题考虑过的其他方案、不同思路或可能性。 -->

#### Testing
<!-- #### 测试 -->
Test in local builds, seems no problem.
<!-- 描述你采取了哪些步骤来测试这个 PR 是否修复了 bug 或添加了特性，以及你做了哪些测试以确保没有引入回归问题。也请为审阅者和维护者提供测试建议。参见 TESTING_YOUR_CHANGES.md -->

#### Documentation impact
<!-- None，或说明需要新增、更新、迁移、归档或标记 stale 的开发文档。
实际执行级别以 ai/docs-impact.yml 为准。required 映射不能填写 None/N/A/TBD。 -->

None

#### Related CCB-Docs PR
<!-- None，或填写 CrimsonCrossBunker/CCB-Docs 的 PR 链接。required 映射必须链接实际 PR。 -->

None

#### Affected documentation IDs
<!-- None，或填写 docs-catalog.yml 中稳定的文档 ID，多个 ID 用逗号分隔。
required 映射至少填写一个 ai/docs-impact.yml 列出的对应 ID。 -->

None

#### Generated reference impact
<!-- None，或说明 Schema、LuaLS、注册信息或生成清单是否需要刷新。 -->

None

#### Additional context
<!-- #### 补充说明 -->
Some changes are formating.
Makefile modifed for `make clean` works (somehow it reverts).

<!-- 在此添加关于这个特性或 bug 修复的其他背景信息（例如原型图、概念验证或截图）。 -->


<!--README: Cataclysm: Cleanwater Bomb (CCB) 以 Creative Commons Attribution ShareAlike 3.0 许可证发布。
游戏的代码与内容可自由用于任何目的的使用、修改和再分发。
通过为本项目做贡献，你即同意该许可证的条款，并同意你所做的任何贡献也将受同一许可证覆盖。
详见 http://creativecommons.org/licenses/by-sa/3.0/ 。 -->
