### PR TITLE
make backrooms available in skyisland

### DIFF
--- a/data/mods/Sky_Island/dialog_statue.json
+++ b/data/mods/Sky_Island/dialog_statue.json
@@ -53,7 +53,7 @@
   {
     "type": "talk_topic",
     "id": "SKYISLAND_EXPLAIN5",
-    "dynamic_line": "This statue offers a variety of services.  You can be instantly healed, check your current statistics and progress, and tweak your expedition difficulty settings.\n\nHealing is free until you have survived 10 expeditions.  After this point, healing costs 4 warp shards per treatment.\n\nExpedition difficulty is set to default when you start a new game, but here you can change many finer details to suit your own playstyle.",
+    "dynamic_line": "This statue offers a variety of services.  You can be instantly healed, dispel an ongoing portal storm, check your current statistics and progress, and tweak your expedition difficulty settings.\n\nHealing is free until you have survived 10 expeditions.  After this point, healing costs 4 warp shards per treatment.\n\nExpedition difficulty is set to default when you start a new game, but here you can change many finer details to suit your own playstyle.",
     "responses": [ { "text": "Interesting…", "topic": "SKYISLAND_QUESTIONS" } ]
   },
   {
@@ -98,6 +98,14 @@
         "text": "Heal me.  (Costs 4 Warp Shards)",
         "condition": { "math": [ "islandrank != 0" ] },
         "effect": [ { "run_eocs": [ "EOC_HEAL_NEWBIE" ] } ],
+        "topic": "SKYISLAND_SERVICES"
+      },
+      {
+        "text": "End an active portal storm.",
+        "effect": [
+          { "run_eocs": [ "EOC_CANCEL_PORTAL_STORM" ] },
+          { "u_message": "The air crackles with static electricity, then stabilizes.", "popup": true }
+        ],
         "topic": "SKYISLAND_SERVICES"
       },
       {
@@ -168,7 +176,11 @@
       {
         "text": "Unlock Start Location: Basements",
         "condition": {
-          "and": [ { "not": { "u_has_mission": "SKYISLAND_UPGRADE_basementsunlock" } }, { "math": [ "basementsunlocked == 0" ] } ]
+          "and": [
+            { "not": { "u_has_mission": "SKYISLAND_UPGRADE_basementsunlock" } },
+            { "math": [ "basementsunlocked == 0" ] },
+            { "not": { "mod_is_loaded": "backrooms" } }
+          ]
         },
         "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_basementsunlock" } ],
         "topic": "SKYISLAND_UPGRADES_RAIDS"
@@ -179,7 +191,8 @@
           "and": [
             { "not": { "u_has_mission": "SKYISLAND_UPGRADE_roofsunlock" } },
             { "math": [ "roofsunlocked == 0" ] },
-            { "math": [ "islandrank >= 2" ] }
+            { "math": [ "islandrank >= 2" ] },
+            { "not": { "mod_is_loaded": "backrooms" } }
           ]
         },
         "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_roofsunlock" } ],
@@ -191,7 +204,8 @@
           "and": [
             { "not": { "u_has_mission": "SKYISLAND_UPGRADE_labsunlock" } },
             { "math": [ "labsunlocked == 0" ] },
-            { "math": [ "islandrank >= 4" ] }
+            { "math": [ "islandrank >= 4" ] },
+            { "not": { "mod_is_loaded": "backrooms" } }
           ]
         },
         "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_labsunlock" } ],
@@ -260,7 +274,8 @@
             { "math": [ "bonusmissions >= 5" ] },
             { "math": [ "hardestmissions > 0" ] },
             { "math": [ "bonuspulses >= 6" ] },
-            { "math": [ "islandrank >= 4" ] }
+            { "math": [ "islandrank >= 4" ] },
+            { "not": { "mod_is_loaded": "backrooms" } }
           ]
         },
         "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_challenge_mode" } ],

--- a/data/mods/Sky_Island/effectoncondition/obelisk_selector.json
+++ b/data/mods/Sky_Island/effectoncondition/obelisk_selector.json
@@ -45,10 +45,21 @@
     "effect": [
       { "math": [ "lengthofthisraid = 0" ] },
       { "math": [ "currentpulselength = sicknessintervals" ] },
-      { "math": [ "missiondistancemax = 30" ] },
-      { "math": [ "missiondistancemin = 5" ] },
-      { "math": [ "exfildistancemax = 35" ] },
-      { "math": [ "exfildistancemin = 5" ] },
+      {
+        "if": { "mod_is_loaded": "backrooms" },
+        "then": [
+          { "math": [ "missiondistancemax = 10" ] },
+          { "math": [ "missiondistancemin = 5" ] },
+          { "math": [ "exfildistancemax = 12" ] },
+          { "math": [ "exfildistancemin = 5" ] }
+        ],
+        "else": [
+          { "math": [ "missiondistancemax = 30" ] },
+          { "math": [ "missiondistancemin = 5" ] },
+          { "math": [ "exfildistancemax = 35" ] },
+          { "math": [ "exfildistancemin = 5" ] }
+        ]
+      },
       { "run_eocs": [ "EOC_warp_choose_locale" ] }
     ]
   },
@@ -60,10 +71,21 @@
     "effect": [
       { "math": [ "lengthofthisraid = 1" ] },
       { "math": [ "currentpulselength = sicknessintervals * 2" ] },
-      { "math": [ "missiondistancemax = 60" ] },
-      { "math": [ "missiondistancemin = 20" ] },
-      { "math": [ "exfildistancemax = 90" ] },
-      { "math": [ "exfildistancemin = 30" ] },
+      {
+        "if": { "mod_is_loaded": "backrooms" },
+        "then": [
+          { "math": [ "missiondistancemax = 20" ] },
+          { "math": [ "missiondistancemin = 10" ] },
+          { "math": [ "exfildistancemax = 30" ] },
+          { "math": [ "exfildistancemin = 10" ] }
+        ],
+        "else": [
+          { "math": [ "missiondistancemax = 60" ] },
+          { "math": [ "missiondistancemin = 20" ] },
+          { "math": [ "exfildistancemax = 90" ] },
+          { "math": [ "exfildistancemin = 30" ] }
+        ]
+      },
       { "run_eocs": [ "EOC_warp_choose_locale" ] }
     ]
   },
@@ -75,10 +97,21 @@
     "effect": [
       { "math": [ "lengthofthisraid = 2" ] },
       { "math": [ "currentpulselength = sicknessintervals * 3" ] },
-      { "math": [ "missiondistancemax = 80" ] },
-      { "math": [ "missiondistancemin = 30" ] },
-      { "math": [ "exfildistancemax = 160" ] },
-      { "math": [ "exfildistancemin = 50" ] },
+      {
+        "if": { "mod_is_loaded": "backrooms" },
+        "then": [
+          { "math": [ "missiondistancemax = 30" ] },
+          { "math": [ "missiondistancemin = 15" ] },
+          { "math": [ "exfildistancemax = 50" ] },
+          { "math": [ "exfildistancemin = 20" ] }
+        ],
+        "else": [
+          { "math": [ "missiondistancemax = 80" ] },
+          { "math": [ "missiondistancemin = 30" ] },
+          { "math": [ "exfildistancemax = 160" ] },
+          { "math": [ "exfildistancemin = 50" ] }
+        ]
+      },
       { "run_eocs": [ "EOC_warp_choose_locale" ] }
     ]
   },

--- a/data/mods/Sky_Island/effectoncondition/raid_missions.json
+++ b/data/mods/Sky_Island/effectoncondition/raid_missions.json
@@ -3,29 +3,45 @@
     "type": "effect_on_condition",
     "id": "EOC_Random_Loc_Extract",
     "//": "Picks a random location to place the extract based on the player's unlocked difficulty.",
-    "effect": [
-      {
-        "weighted_list_eocs": [
-          [ "EOC_Location1e", { "global_val": "target_fields_weight", "default": 15 } ],
-          [ "EOC_Location2e", { "global_val": "target_forests_weight", "default": 0 } ],
-          [ "EOC_Location3e", { "global_val": "target_houses_weight", "default": 0 } ]
-        ]
-      }
-    ]
+    "effect": [ { "run_eocs": "EOC_set_target_terrain" }, { "run_eocs": "EOC_extract_location" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_Random_Loc_Mission",
     "//": "Picks a random location to place the missions based on the player's unlocked difficulty.",
+    "effect": [ { "run_eocs": "EOC_set_target_terrain" }, { "run_eocs": "EOC_mission_location" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_set_target_terrain",
     "effect": [
       {
-        "weighted_list_eocs": [
-          [ "EOC_Location1m", { "global_val": "target_fields_weight", "default": 15 } ],
-          [ "EOC_Location2m", { "global_val": "target_forests_weight", "default": 0 } ],
-          [ "EOC_Location3m", { "global_val": "target_houses_weight", "default": 0 } ]
-        ]
+        "if": { "mod_is_loaded": "backrooms" },
+        "then": { "set_string_var": "backfloorchamber", "target_var": { "global_val": "sky_island_target_terrain" } },
+        "else": {
+          "weighted_list_eocs": [
+            [ "EOC_set_target_terrain_field", { "global_val": "target_fields_weight", "default": 15 } ],
+            [ "EOC_set_target_terrain_forest", { "global_val": "target_forests_weight", "default": 0 } ],
+            [ "EOC_set_target_terrain_house", { "global_val": "target_houses_weight", "default": 0 } ]
+          ]
+        }
       }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_set_target_terrain_field",
+    "effect": [ { "set_string_var": "field", "target_var": { "global_val": "sky_island_target_terrain" } } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_set_target_terrain_forest",
+    "effect": [ { "set_string_var": "forest", "target_var": { "global_val": "sky_island_target_terrain" } } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_set_target_terrain_house",
+    "effect": [ { "set_string_var": "house", "target_var": { "global_val": "sky_island_target_terrain" } } ]
   },
   {
     "type": "effect_on_condition",
@@ -196,13 +212,13 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_Location1e",
-    "//": "Picks a random field.",
+    "id": "EOC_extract_location",
+    "//": "Picks a random location of terrain specified by global_val sky_island_target_terrain, for extract.",
     "effect": [
       {
         "u_location_variable": { "global_val": "OM_missionspot" },
         "target_params": {
-          "om_terrain": "field",
+          "om_terrain": { "global_val": "sky_island_target_terrain" },
           "om_terrain_match_type": "CONTAINS",
           "search_range": { "global_val": "exfildistancemax", "default": 30 },
           "min_distance": { "global_val": "exfildistancemin", "default": 5 },
@@ -215,51 +231,13 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_Location2e",
-    "//": "Picks a random forest.",
+    "id": "EOC_mission_location",
+    "//": "Picks a random location of terrain specified by global_val sky_island_target_terrain, for mission.",
     "effect": [
       {
         "u_location_variable": { "global_val": "OM_missionspot" },
         "target_params": {
-          "om_terrain": "forest",
-          "om_terrain_match_type": "CONTAINS",
-          "search_range": { "global_val": "exfildistancemax", "default": 30 },
-          "min_distance": { "global_val": "exfildistancemin", "default": 5 },
-          "reveal_radius": { "global_val": "scoutingdistancetargets", "default": 0 },
-          "z": 0,
-          "random": true
-        }
-      }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_Location3e",
-    "//": "Picks a random house.",
-    "effect": [
-      {
-        "u_location_variable": { "global_val": "OM_missionspot" },
-        "target_params": {
-          "om_terrain": "house",
-          "om_terrain_match_type": "CONTAINS",
-          "search_range": { "global_val": "exfildistancemax", "default": 30 },
-          "min_distance": { "global_val": "exfildistancemin", "default": 5 },
-          "reveal_radius": { "global_val": "scoutingdistancetargets", "default": 0 },
-          "z": 0,
-          "random": true
-        }
-      }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_Location1m",
-    "//": "Picks a random field.",
-    "effect": [
-      {
-        "u_location_variable": { "global_val": "OM_missionspot" },
-        "target_params": {
-          "om_terrain": "field",
+          "om_terrain": { "global_val": "sky_island_target_terrain" },
           "om_terrain_match_type": "CONTAINS",
           "search_range": { "global_val": "missiondistancemax", "default": 30 },
           "min_distance": { "global_val": "missiondistancemin", "default": 5 },
@@ -269,46 +247,6 @@
         }
       },
       { "math": [ "total_difficulty_bonus = lengthofthisraid" ] }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_Location2m",
-    "//": "Picks a random forest.",
-    "effect": [
-      {
-        "u_location_variable": { "global_val": "OM_missionspot" },
-        "target_params": {
-          "om_terrain": "forest",
-          "om_terrain_match_type": "CONTAINS",
-          "search_range": { "global_val": "missiondistancemax", "default": 30 },
-          "min_distance": { "global_val": "missiondistancemin", "default": 5 },
-          "reveal_radius": { "global_val": "scoutingdistancetargets", "default": 0 },
-          "z": 0,
-          "random": true
-        }
-      },
-      { "math": [ "total_difficulty_bonus = lengthofthisraid" ] }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_Location3m",
-    "//": "Picks a random house.",
-    "effect": [
-      {
-        "u_location_variable": { "global_val": "OM_missionspot" },
-        "target_params": {
-          "om_terrain": "house",
-          "om_terrain_match_type": "CONTAINS",
-          "search_range": { "global_val": "missiondistancemax", "default": 30 },
-          "min_distance": { "global_val": "missiondistancemin", "default": 5 },
-          "reveal_radius": { "global_val": "scoutingdistancetargets", "default": 0 },
-          "z": 0,
-          "random": true
-        }
-      },
-      { "math": [ "total_difficulty_bonus = lengthofthisraid + 1" ] }
     ]
   },
   {

--- a/data/mods/Sky_Island/effectoncondition/teleport.json
+++ b/data/mods/Sky_Island/effectoncondition/teleport.json
@@ -13,7 +13,10 @@
         "if": { "math": [ "skyisland_merchant_stall == 1" ] },
         "then": { "run_eocs": "EOC_SKY_ISLAND_RANDOM_MERCHANTS_LEAVE" }
       },
-      { "run_eocs": [ "EOC_raid_challenge_mode_pre_raid" ] },
+      {
+        "if": { "not": { "mod_is_loaded": "backrooms" } },
+        "then": { "run_eocs": [ "EOC_raid_challenge_mode_pre_raid" ] }
+      },
       { "u_location_variable": { "global_val": "OM_HQ_origin" } },
       { "u_location_variable": { "global_val": "OM_HQ_origin_npc" } },
       { "copy_var": { "global_val": "OM_HQ_origin" }, "target_var": { "global_val": "OM_temp" } },
@@ -42,7 +45,6 @@
       },
       { "run_eocs": [ "EOC_SKY_ISLAND_DIMENSION_SHIFT_CHARACTER_EFFECTS" ] },
       { "u_teleport": { "global_val": "OM_temp" }, "force_safe": true },
-      { "clear_dimension": { "global_val": "sky_island_target_region_settings" } },
       {
         "if": { "math": [ "si_npcs_will_join_raid == 1" ] },
         "then": { "u_travel_to_dimension": { "global_val": "sky_island_target_region_settings" }, "npc_travel_radius": 10 },

--- a/data/mods/Sky_Island/mod_interactions/backrooms/eocs/obelisk_selector.json
+++ b/data/mods/Sky_Island/mod_interactions/backrooms/eocs/obelisk_selector.json
@@ -1,0 +1,36 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_warp_choose_locale",
+    "effect": [
+      {
+        "run_eoc_selector": [ "EOC_Level0_Loc_Warp", "EOC_raidcancel" ],
+        "names": [ "Target: Level 0", "Cancel" ],
+        "keys": [ "1", "2" ],
+        "title": "Select a starting location",
+        "descriptions": [ "Arrive in the boundless monotone yellow space of level 0.", "Stay on the island for now." ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_Level0_Loc_Warp",
+    "//": "Picks a random location in level 0 and activates the actual teleport EOC.",
+    "effect": [
+      { "set_string_var": "backrooms_level_0", "target_var": { "global_val": "sky_island_target_region_settings" } },
+      { "run_eocs": "EOC_SKY_ISLAND_MISSION_DIMENSION_SHIFT" },
+      {
+        "u_location_variable": { "global_val": "OM_missionspot" },
+        "target_params": {
+          "om_terrain": "backfloorchamber",
+          "search_range": 200,
+          "min_distance": 0,
+          "reveal_radius": { "global_val": "scoutingdistancelanding", "default": 0 },
+          "z": 0,
+          "random": true
+        }
+      },
+      { "run_eocs": [ "EOC_initiate_randomport" ] }
+    ]
+  }
+]

--- a/data/mods/Sky_Island/mod_interactions/backrooms/external_options.json
+++ b/data/mods/Sky_Island/mod_interactions/backrooms/external_options.json
@@ -1,0 +1,9 @@
+[
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "DEFAULT_REGION",
+    "//": "Reapply to override backrooms setting",
+    "stype": "string_input",
+    "value": "default_skyisland"
+  }
+]

--- a/data/mods/Sky_Island/mod_interactions/backrooms/region_settings.json
+++ b/data/mods/Sky_Island/mod_interactions/backrooms/region_settings.json
@@ -1,0 +1,13 @@
+[
+  {
+    "type": "dimension",
+    "id": "backrooms_level_0",
+    "region_layout": "backrooms_level_0"
+  },
+  {
+    "type": "dimension_region_layout",
+    "id": "backrooms_level_0",
+    "generation_mode": "UNIFORM",
+    "uniform_region": "default_backrooms"
+  }
+]

--- a/data/mods/Sky_Island/modinfo.json
+++ b/data/mods/Sky_Island/modinfo.json
@@ -8,7 +8,7 @@
     "description": "An attempt at an entirely new way to play CDDA, inspired by games like Escape from Tarkov and Dark and Darker.  Begin on a floating island in the sky and warp down to random spots on the earth below to conduct expeditions for items you need.  Permadeath is gone - you will return to the island on death but lose any items you had on you.  Build up your stockpile, carry out missions for unique rewards, customize your home island, unlock upgrades, and be prudent about what you take on any given outing.  Be aware that 'PLAY NOW' will NOT work, you MUST make a custom character.",
     "category": "total_conversion",
     "dependencies": [ "dda" ],
-    "conflicts": [ "backrooms", "MA", "extra_mut_scens" ],
+    "conflicts": [ "MA", "extra_mut_scens" ],
     "version": "0.4.0",
     "loading_images": [ "skyisland1.png" ],
     "disable_other_loading_screens": true


### PR DESCRIPTION
<!-- 使用说明：在下面每个「#### 标题」下填写与你的 PR 相关的信息。
请保留这些标题。像这样的注释可以安全删除。

如果你是在 GitHub 网页界面发起这个 PR，可以用「preview（预览）」按钮查看 PR 对他人显示的样子。

PR 提交准则：
- 让你的改动只聚焦于一个具体的问题或变更，外加为实现它所必需的最小相关改动。
- 一个经验法则：大多数 PR 的改动应少于 500 行。
- 你可以另开 PR 来拆分一次较大的预期改动；如果不确定怎么拆，尽管问。我们很乐意与你协作，并建议合并你 PR 的最佳方式。
-->

#### Summary
Mods "Make Backrooms playable with Sky Island"

#### Responsible human
@martinrhan 

#### Purpose of change
Backrooms is a collection of fantastic imaginary dimensions and I think it should be a good settings for the raid-and-evac play style like the sky island mod. Since we only have the level 0 dimension so far, this PR is just a initial change.

#### Describe the solution
- Locator upgrades (basements, rooftop, lab) and challenge mode upgrades won't appear if backrooms mod is loaded.
- When launching a raid the user is asked to choose a Backrooms level as target.
- Significantly reduced the range of selection for mission and evac points when playing with backrooms, to compensate the terrain complexity of backrooms, while in vanila sky islands the world is mostly vast fields.
- Parameterized EOCs in raid_missions.json to reduce boilerplate codes.

#### Describe alternatives you've considered
Include the frontrooms. However the frontwrooms is too aboundant of resources comparing to the only level 0 we have now, that makes level 0 a useless option for scavenging.

#### Testing
I cloned the fork into my PC. After the text edit, I copied the mod folder into my game and renamed to mod to sky_island_test. Then I started a new game to make sure things work.

#### Documentation impact
None

#### Related CCB-Docs PR
None

#### Affected documentation IDs
None

#### Generated reference impact
None

#### Additional context
I additionally did some other minor edits to make it sync with newest version in cdda repo.
- In dialog_statue.json there should be an option to end portal storm.
- In teleport.json there is an redundant line of clear_dimention, I removed it.
