### PR TITLE
Hydroponics units should be able to work in places without sunlight.

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -312,6 +312,11 @@
     "info": "You could probably use this to get into a secure military facility."
   },
   {
+    "id": "INDOOR_GROWTH",
+    "type": "json_flag",
+    "info": "It allows planting indoors without sunlight."
+  },
+  {
     "id": "INDUSTRIAL_CARD",
     "type": "json_flag",
     "info": "You could probably use this to get into a secure industrial facility."

--- a/data/mods/FuturismCataclysmLegacy/furniture_and_terrain/hydroponics.json
+++ b/data/mods/FuturismCataclysmLegacy/furniture_and_terrain/hydroponics.json
@@ -10,7 +10,7 @@
     "light_emitted": 10,
     "required_str": 12,
     "looks_like": "f_planter",
-    "flags": [ "TRANSPARENT", "PLANTABLE", "SHALLOW_WATER", "FLAT", "MOUNTABLE", "NO_CROP_OVERGROWTH" ],
+    "flags": [ "TRANSPARENT", "PLANTABLE", "SHALLOW_WATER", "FLAT", "MOUNTABLE", "NO_CROP_OVERGROWTH", "INDOOR_GROWTH" ],
     "deconstruct": { "items": [ { "group": "fcl_hydrop_deconstruct_results" } ] },
     "bash": {
       "str_min": 6,

--- a/data/mods/FuturismCataclysmLegacy/furniture_and_terrain/hydroponics.json
+++ b/data/mods/FuturismCataclysmLegacy/furniture_and_terrain/hydroponics.json
@@ -10,7 +10,7 @@
     "light_emitted": 10,
     "required_str": 12,
     "looks_like": "f_planter",
-    "flags": [ "TRANSPARENT", "PLANTABLE", "SHALLOW_WATER", "FLAT", "MOUNTABLE", "NO_CROP_OVERGROWTH" ],
+    "flags": [ "TRANSPARENT", "PLANTABLE", "SHALLOW_WATER", "FLAT", "MOUNTABLE", "NO_CROP_OVERGROWTH", "INDOOR_GROWTH" ],
     "deconstruct": { "items": [ { "group": "fcl_hydrop_deconstruct_results" } ] },
     "bash": {
       "str_min": 6,
@@ -40,7 +40,8 @@
       "TINY",
       "DONT_REMOVE_ROTTEN",
       "GROWTH_SEED",
-      "NO_CROP_OVERGROWTH"
+      "NO_CROP_OVERGROWTH",
+      "INDOOR_GROWTH"
     ],
     "examine_action": "aggie_plant",
     "copy-from": "f_fcl_hydroponics",
@@ -64,7 +65,8 @@
       "TINY",
       "DONT_REMOVE_ROTTEN",
       "GROWTH_SEEDLING",
-      "NO_CROP_OVERGROWTH"
+      "NO_CROP_OVERGROWTH",
+      "INDOOR_GROWTH"
     ],
     "examine_action": "aggie_plant",
     "copy-from": "f_fcl_hydroponics_seed",
@@ -90,7 +92,8 @@
       "DONT_REMOVE_ROTTEN",
       "GROWTH_MATURE",
       "SMALL_HIDE",
-      "NO_CROP_OVERGROWTH"
+      "NO_CROP_OVERGROWTH",
+      "INDOOR_GROWTH"
     ],
     "examine_action": "aggie_plant",
     "copy-from": "f_fcl_hydroponics_seed",
@@ -115,7 +118,8 @@
       "DONT_REMOVE_ROTTEN",
       "GROWTH_HARVEST",
       "SMALL_HIDE",
-      "NO_CROP_OVERGROWTH"
+      "NO_CROP_OVERGROWTH",
+      "INDOOR_GROWTH"
     ],
     "examine_action": "harvest_plant_ex",
     "copy-from": "f_fcl_hydroponics_mature",

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -715,6 +715,7 @@ Can also be used as `pre_flags` for `construction`.
 - ```HARVESTED``` Marks the harvested version of a terrain type (e.g. harvesting an apple tree turns it into a harvested tree, which later becomes an apple tree again).
 - ```HIDE_PLACE``` Creatures on this tile can't be seen by creatures not standing on adjacent tiles.
 - ```INDOORS``` Has a roof over it; blocks rain, sunlight, etc.
+- ```INDOOR_GROWTH``` Allows planting without sunlight. Bypasses has_sunlight_access; does not bypass cold-temperature check.
 - ```LADDER``` This piece of furniture that makes climbing easy.
 - ```LIQUIDCONT``` Furniture that contains liquid, allows for contents to be accessed in some checks even if `SEALED`.
 - ```LIQUID``` Terrain is liquid (e.g. water, lava, etc.), blocking movement without being a wall.
@@ -725,6 +726,7 @@ Can also be used as `pre_flags` for `construction`.
 - ```NATURAL_UNDERGROUND``` This terrain occurs naturally underground and is not man made.
 - ```NOCOLLIDE``` Feature that simply doesn't collide with vehicles at all.
 - ```NOITEM``` Items cannot be added here but may overflow to adjacent tiles.  See also `DESTROY_ITEM`.
+- ```NO_CROP_OVERGROWTH``` Furniture with this flag prevents plants growing on it from becoming overgrown. Crops can still reach and remain at the harvest stage.
 - ```NO_FLOOR``` Things should fall when placed on this tile.
 - ```NO_FLOOR_WATER``` This tile has no floor, but there is water so it doesn't free fall.
 - ```NO_PICKUP_ON_EXAMINE``` Examining this tile (<kbd>e</kbd> by default) won't open Pick Up menu even if there are items here.
@@ -741,7 +743,6 @@ Can also be used as `pre_flags` for `construction`.
 - ```PLACE_ITEM``` Valid terrain for `place_item()` to put items on.
 - ```PLANTABLE``` This terrain or furniture can have seeds planted in it.
 - ```PLANT``` A 'furniture' that grows and fruits.
-- ```NO_CROP_OVERGROWTH``` Furniture with this flag prevents plants growing on it from becoming overgrown. Crops can still reach and remain at the harvest stage.
 - ```PLOWABLE``` Terrain can be plowed.
 - ```RAIL``` This is a railroad, railroad vehicles can use it to move.
 - ```RAMP_DOWN``` The end of a ramp that leads down, walking into this moves you one z-level down.  Overrides `WALL`, while still displaying the tile as Impassable.

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -350,6 +350,7 @@ std::string enum_to_string<ter_furn_flag>( ter_furn_flag data )
         case ter_furn_flag::TFLAG_ONE_DIMENSIONAL_Z: return "ONE_DIMENSIONAL_Z";
         case ter_furn_flag::TFLAG_CD_DELIGHT_PADDY: return "CD_DELIGHT_PADDY";
         case ter_furn_flag::TFLAG_CD_DELIGHT_TRELLIS: return "CD_DELIGHT_TRELLIS";
+        case ter_furn_flag::TFLAG_INDOOR_GROWTH: return "INDOOR_GROWTH";
 
         // *INDENT-ON*
         case ter_furn_flag::NUM_TFLAG_FLAGS:

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -418,6 +418,7 @@ enum class ter_furn_flag : int {
     TFLAG_ONE_DIMENSIONAL_Z,
     TFLAG_CD_DELIGHT_PADDY,
     TFLAG_CD_DELIGHT_TRELLIS,
+    TFLAG_INDOOR_GROWTH,
 
     NUM_TFLAG_FLAGS
 };

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -966,7 +966,8 @@ ret_val<void> warm_enough_to_plant( const tripoint_bub_ms &pos, const itype_id &
 {
     std::map<time_point, units::temperature> planting_times;
 
-    if( !has_sunlight_access( pos ) ) {
+    if( !has_sunlight_access( pos ) &&
+        !get_map().has_flag( ter_furn_flag::TFLAG_INDOOR_GROWTH, pos ) ) {
         return ret_val<void>::make_failure( _( "Plants need sunlight to grow!  You can't plant there." ) );
     }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The current farming system only allows planting when sunlight is available. Judging from the commented-out code, it seems that the original check was abandoned because of an implementation bug and replaced with a more awkward system...

However, this kind of blanket fix clearly does not work very well either. For example, the hydroponics units I added to Futurism Cataclysm: Legacy have LED strips as "grow lights" among their construction materials, yet when I perform hydroponics in my basement, I get the `Plants need sunlight.` message. This does not make sense. A high-tech hydroponics unit like this cannot even solve the simple problem of sunlight?

#### Describe the solution
Add the `INDOOR_GROWTH` flag. Allows planting without sunlight. Bypasses has_sunlight_access; does not bypass cold-temperature check.

Add this flag to all hydroponics units in FCL.