### PR TITLE
Balance tire repair kit glue cost and availability

### DIFF
--- a/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_goods.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_goods.json
@@ -21,6 +21,7 @@
       { "group": "FREE_MERCHANTS_Shop_Parts_Generic", "count": [ 40, 50 ] },
       { "group": "FREE_MERCHANTS_Shop_Parts_Tailoring", "count": [ 5, 8 ] },
       { "group": "FREE_MERCHANTS_Shop_Parts_Mechanics", "count": [ 5, 8 ] },
+      { "item": "tire_repair_kit", "prob": 60, "count": [ 1, 2 ] },
       { "group": "FREE_MERCHANTS_Shop_Weapons_Ammo", "count": [ 2, 4 ] },
       { "group": "FREE_MERCHANTS_Shop_Weapons_Guns", "prob": 75 },
       { "group": "FREE_MERCHANTS_Shop_Weapons_Melee" },

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -1209,7 +1209,7 @@
     "autolearn": true,
     "components": [
       [ [ "bag_plastic_small", 1 ], [ "bag_plastic", 1 ] ],
-      [ [ "glue_strong", 10 ] ],
+      [ [ "glue_strong", 5 ] ],
       [ [ "soapy_water", 1 ] ],
       [
         [ "shredded_rubber", 1 ],


### PR DESCRIPTION
#### Summary

Balance "Reduce tire repair kit glue cost and add refugee-center availability"

#### Responsible human

@LYHGLYTX

#### Purpose of change

Players reported that crafting a one-use tire repair kit consumed too much strong glue and that the refugee center did not reliably provide a practical repair option.

#### Describe the solution

- Reduce the tire repair kit recipe cost from 10 to 5 charges of strong glue.
- Add a 60% chance for the Free Merchant shop to stock 1–2 tire repair kits.
- Leave tire puncture probabilities and fault progression unchanged.

#### Alternatives considered

Increasing global strong-glue spawns would affect unrelated crafting recipes. Adding vehicle-specific repair kits keeps the change scoped to tire maintenance.

#### Testing

- `make -j2 json-check`
- `git diff --check`

#### Documentation impact

None

#### Related CCB-Docs PR

None

#### Affected documentation IDs

None

#### Generated reference impact

None

#### Additional context

This is a follow-up balance fix to PR #658.