### PR TITLE
Fix the broken mod_migration system

### DIFF
--- a/src/mod_manager.cpp
+++ b/src/mod_manager.cpp
@@ -911,37 +911,50 @@ bool mod_manager::check_mods_list( WORLD *world ) const
 #endif
     }
 
-    for( auto check_it = amo.begin(); check_it != amo.end(); check_it++ ) {
+    for( auto check_it = amo.begin(); check_it != amo.end(); ) {
         if( !check_it->is_valid() ) {
-            if( const auto replace_it = migrated_mods.find( *check_it ); replace_it != migrated_mods.end() &&
-                std::find( amo.begin(), amo.end(), replace_it->second ) == amo.end() ) {
-                amo.insert( check_it, replace_it->second );
-                amo.erase( check_it );
-                changed = true;
-            } else {
-                input_context dummy_ctxt( "YESNOQUIT" );
-                const std::string cancel_option_name = dummy_ctxt.get_action_name( "QUIT" );
-                query_ynq_result res;
-                if( const auto it = removed_mods.find( *check_it ); it != removed_mods.end() ) {
-                    res = query_ynq(
-                              _( "Mod %s has been removed with reason: %s\nRemove it from this world's active mods?  (%s aborts load)" ),
-                              check_it->c_str(), it->second.translated(), cancel_option_name );
+            if( const auto replace_it = migrated_mods.find( *check_it );
+                replace_it != migrated_mods.end() ) {
+                const mod_id &new_id = replace_it->second;
+                if( !new_id.is_valid() ) {
+                    debugmsg( "mod_migration from '%s' specifies invalid new_id '%s'", check_it->c_str(),
+                              new_id.c_str() );
+                } else if( std::find( amo.begin(), amo.end(), new_id ) != amo.end() ) {
+                    check_it = amo.erase( check_it );
+                    changed = true;
+                    continue;
                 } else {
-                    res = query_ynq(
-                              _( "Mod %s not found in mods folder, remove it from this world's active mods?  (%s aborts load)" ),
-                              check_it->c_str(), cancel_option_name );
-                }
-                switch( res ) {
-                    case query_ynq_result::quit:
-                        return false;
-                    case query_ynq_result::no:
-                        break;
-                    case query_ynq_result::yes:
-                        amo.erase( check_it-- );
-                        changed = true;
-                        break;
+                    *check_it = new_id;
+                    changed = true;
+                    ++check_it;
+                    continue;
                 }
             }
+            input_context dummy_ctxt( "YESNOQUIT" );
+            const std::string cancel_option_name = dummy_ctxt.get_action_name( "QUIT" );
+            query_ynq_result res;
+            if( const auto it = removed_mods.find( *check_it ); it != removed_mods.end() ) {
+                res = query_ynq(
+                          _( "Mod %s has been removed with reason: %s\nRemove it from this world's active mods?  (%s aborts load)" ),
+                          check_it->c_str(), it->second.translated(), cancel_option_name );
+            } else {
+                res = query_ynq(
+                          _( "Mod %s not found in mods folder, remove it from this world's active mods?  (%s aborts load)" ),
+                          check_it->c_str(), cancel_option_name );
+            }
+            switch( res ) {
+                case query_ynq_result::quit:
+                    return false;
+                case query_ynq_result::no:
+                    ++check_it;
+                    break;
+                case query_ynq_result::yes:
+                    check_it = amo.erase( check_it );
+                    changed = true;
+                    break;
+            }
+        } else {
+            ++check_it;
         }
     }
     // If we migrated or the player chose to remove a mod, overwrite the mod list.


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The upstream branch's mod_migration system has had serious problems for a long time. For example, when a mod changes its ID, even if `mod_migration` data is configured according to the standard procedure in the documentation, the migration still cannot work correctly: if no migration is performed, or only a deprecation is performed, loading a save will directly remove the mod; but explicitly configuring a migration with a new_id instead instead leads directly to being unable to enter the save and having the save corrupted. After inspecting the relevant logic, I found problems including invalidated iterators, repeated interception by the guard process, lack of validity checks, and potentially incorrect timing for clearing data.

Furthermore, the system has not received **any** maintenance for over **14 months**.

#### Describe the solution
Fix the `check_mods_list` function in `src/mod_manager.cpp`, including bugs such as `mods.json` corruption caused by dangling iterators and repeated guard processes. Change it to perform silent migration instead of incorrectly triggering the mod-missing check early during loading. Additionally, validate `new_id` so that a missing or invalid `new_id` no longer forcibly replaces the data with incorrect data, and reconnect it to the mod-missing process.