### PR TITLE
Bugfixes "清理上下楼梯后失效的车辆抓取状态"

### DIFF
--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -37,10 +37,15 @@ bool game::grabbed_veh_move_stairs( const tripoint_rel_ms &dp )
     const optional_vpart_position grabbed_vehicle_vp = here.veh_at( you.pos_bub(
                 here ) + you.grab_point );
     if( !grabbed_vehicle_vp ) {
+        // The vehicle may have been unloaded while changing z-levels.  Clear
+        // the grab state so the next movement does not use a stale grab point.
+        add_msg( m_info, _( "No vehicle at grabbed point." ) );
+        you.grab( object_type::NONE );
         return false;
     }
     vehicle *grabbed_vehicle = &grabbed_vehicle_vp->vehicle();
     if( !grabbed_vehicle ) {
+        you.grab( object_type::NONE );
         return false;
     }
 

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -1,5 +1,8 @@
 #include "game.h" // IWYU pragma: associated
 
+#include <calendar.h>
+#include <coordinates.h>
+#include <enums.h>
 #include <algorithm>
 #include <cstdlib>
 

--- a/tests/vehicle_ramp_test.cpp
+++ b/tests/vehicle_ramp_test.cpp
@@ -1,18 +1,23 @@
 #include <array>
+#include <cstdio>
+#include <fstream>
 #include <memory>
 #include <optional>
 #include <set>
 #include <string>
 #include <vector>
 
+#include "avatar.h"
 #include "calendar.h"
 #include "cata_catch.h"
+#include "cata_scope_helpers.h"
 #include "character.h"
 #include "coordinates.h"
 #include "creature.h"
 #include "creature_tracker.h"
 #include "enums.h"
 #include "game.h"
+#include "input_replay.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "map_helpers_tests.h"
@@ -85,6 +90,47 @@ static void clear_game_and_set_ramp( const int transit_x, bool use_ramp, bool up
     }
     here.invalidate_map_cache( 0 );
     here.build_map_cache( 0, true );
+}
+
+TEST_CASE( "vehicle_grab_releases_missing_vehicle_after_stairs", "[vehicle][stairs]" )
+{
+    clear_map_without_vision();
+    build_test_map( ter_id( "t_floor" ) );
+
+    map &here = get_map();
+    avatar &player_character = get_avatar();
+    const tripoint_bub_ms test_origin( 60, 60, 0 );
+    player_character.setpos( here, test_origin );
+    here.ter_set( test_origin, ter_id( "t_stairs_up" ) );
+    here.ter_set( test_origin + tripoint::above, ter_id( "t_stairs_down" ) );
+    here.invalidate_map_cache( 0 );
+    here.build_map_cache( 0, true );
+
+    // Simulate a vehicle that became unavailable while the map changed z-levels.
+    player_character.grab( object_type::VEHICLE, tripoint_rel_ms::east );
+    REQUIRE( player_character.get_grab_type() == object_type::VEHICLE );
+
+    const std::string replay_path = "vehicle_stairs_grab_replay.txt";
+    const on_out_of_scope cleanup( [&]() {
+        input_replay::finish();
+        const int rc = std::remove( replay_path.c_str() );
+        ( void )rc;
+    } );
+    {
+        std::ofstream replay( replay_path );
+        REQUIRE( replay.good() );
+        replay << "CATA_REPLAY 1\n"
+               << "SEED 0\n"
+               << "EV " << static_cast<int>( input_event_t::keyboard_char )
+               << " 0 1 " << static_cast<int>( 'l' ) << " 0 0 - -\n";
+    }
+    REQUIRE( input_replay::begin_replay( replay_path ) );
+
+    g->vertical_move( 1, false );
+
+    CHECK( input_replay::replay_remaining() == 0 );
+    CHECK( player_character.get_grab_type() == object_type::NONE );
+    CHECK( player_character.grab_point == tripoint_rel_ms::zero );
 }
 
 // Algorithm goes as follows:

--- a/tests/vehicle_ramp_test.cpp
+++ b/tests/vehicle_ramp_test.cpp
@@ -1,6 +1,8 @@
+#include <input_enums.h>
 #include <array>
 #include <cstdio>
 #include <fstream>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <set>


### PR DESCRIPTION
#### Summary
Bugfixes "清理上下楼梯后失效的车辆抓取状态"

#### Responsible human

@LYHGLYTX

#### Purpose of change

拖拽车辆手推车上下楼梯或坡道时，如果换层后抓取点暂时找不到车辆，楼梯专用拖拽函数会直接返回但保留旧的抓取状态。玩家下一次移动时，walk_move 会报告 “Can't find grabbed object.”。

复现方式：抓住一辆车辆手推车，沿楼梯/坡道上下移动，在出现“选择拖拽方向”后继续移动。该问题与上游 Cataclysm-DDA issue #86991 的现象一致：https://github.com/CleverRaven/Cataclysm-DDA/issues/86991。上游 issue 不属于本仓库，因此不使用自动关闭关键字。

#### Describe the solution

在 grabbed_veh_move_stairs 找不到车辆时提示并清除 avatar 的车辆抓取状态；对防御性空指针分支也同步清除状态。新增回归测试，使用输入回放走完整的楼梯方向选择路径，确认抓取类型和抓取点都会被重置。

#### Describe alternatives you've considered

考虑过在 walk_move 或 vertical_move 中兜底清理，但失效状态的来源是楼梯专用车辆拖拽函数。放在该函数的失败出口可以避免 stale grab 状态继续传播，也保持普通车辆拖拽路径的行为一致。

#### Testing

- git diff --check：通过。
- 使用仓库同等级警告参数对 src/grab.cpp 和 tests/vehicle_ramp_test.cpp 做 g++ -fsyntax-only：通过。
- make astyle-check：环境缺少 astyle，未执行格式检查。
- make -j2 tests：编译到第三方 imtui 时因环境缺少 ncurses.h 中止，未能运行完整测试套件。

#### Documentation impact

None

#### Related CCB-Docs PR

None

#### Affected documentation IDs

None

#### Generated reference impact

None

#### Additional context

本 PR 只修改车辆楼梯拖拽的失败状态清理和对应回归测试，不改变车辆能够通过楼梯的判定规则。