### PR TITLE
Allow vehicle tiles to block player passage based on cargo size in exchange for greater capacity

### DIFF
--- a/data/json/vehicleparts/seats.json
+++ b/data/json/vehicleparts/seats.json
@@ -49,6 +49,7 @@
       }
     },
     "size": "40 L",
+    "cargo_passable_size": "100 L",
     "type": "vehicle_part",
     "variants_bases": [ { "id": "windshield", "label": "Windshield" }, { "id": "swivel_chair", "label": "Swivel Chair" } ],
     "variants": [

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -2210,7 +2210,8 @@
     "categories": [ "cargo" ],
     "broken_color": "dark_gray",
     "durability": 250,
-    "size": "500 L",
+    "size": "1000 L",
+    "cargo_passable_size": "500 L",
     "//": "Based roughly on a quarter of a 2 m x 1.2 m pickup truck bed, assuming a reasonable amount of piling up (about 80 cm, ie. sticking up around 20 cm over the sides if really stacked).  Could definitely use more subtypes.",
     "//1": "240 cm weld to install, 60 cm per damage quadrant to repair",
     "item": "cargo_rack",
@@ -2228,7 +2229,7 @@
       },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "20 m", "using": [ [ "repair_welding_standard", 12 ] ] }
     },
-    "flags": [ "BOARDABLE", "CARGO", "COVERED", "HUGE_OK", "FURNITURE_TIEDOWN" ],
+    "flags": [ "BOARDABLE", "CARGO", "COVERED", "HUGE_OK", "FURNITURE_TIEDOWN", "CARGO_PASSABLE_BY_STORED" ],
     "breaks_into": [
       { "item": "mc_steel_lump", "count": [ 12, 19 ] },
       { "item": "mc_steel_chunk", "count": [ 7, 12 ] },

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -2519,6 +2519,7 @@
     "item": "frame_wood",
     "location": "center",
     "size": "40 L",
+    "cargo_passable_size": "100 L",
     "requirements": {
       "install": { "skills": [ [ "mechanics", 1 ] ], "time": "30 m", "using": [ [ "vehicle_nail_install", 1 ] ] },
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },

--- a/data/json/vehicleparts/vp_flags.json
+++ b/data/json/vehicleparts/vp_flags.json
@@ -730,6 +730,11 @@
     "info": "Items stored here won't get in the way of any passengers."
   },
   {
+    "id": "CARGO_PASSABLE_BY_STORED",
+    "type": "json_flag",
+    "info": "Items stored here can obstruct passage if there are too many of them."
+  },
+  {
     "id": "HUGE_OK",
     "type": "json_flag",
     "info": "Even when roofed, this part is roomy enough to comfortably admit very large creatures, like cows and horses."

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -1730,6 +1730,7 @@ Note: Vehicle parts requiring other parts is defined by setting a `requires_flag
 - ```CAPTURE_MONSTER_VEH``` Can be used to capture monsters when mounted on a vehicle.
 - ```CARGO_LOCKING``` This cargo area is inaccessible to NPCs.  Can only be installed on a part with `LOCKABLE_CARGO` flag.
 - ```CARGO_PASSABLE``` Items stored in vehicle part with this flag won't hinder passenger's ability to fit in comfortably into a given tile.
+- ```CARGO_PASSABLE_BY_STORED``` When present, the part becomes impassable when stored volume exceeds `cargo_passable_size` (requires `cargo_passable_size < size`; `cargo_passable_size > size` is a json error). Cramped check uses `cargo_passable_size` instead of `size`. Without this flag, `cargo_passable_size` if present only affects cramped check using `max(cargo_passable_size, size)`.
 - ```CARGO``` Cargo holding area.
 - ```CHIMES``` Generates continuous noise when used.
 - ```CIRCLE_LIGHT``` Projects a circular radius of light when turned on.

--- a/doc/JSON/JSON_INFO.md
+++ b/doc/JSON/JSON_INFO.md
@@ -2906,6 +2906,7 @@ Unless specified as optional, the following fields are mandatory for parts with 
 #### The following optional fields are specific to CARGO parts.
 ```jsonc
 "size": "400 L",              // for parts with "CARGO" flag the capacity in liters
+"cargo_passable_size": "200 L", // (Optional) When `CARGO_PASSABLE_BY_STORED` is present, part becomes impassable if stored volume exceeds this value (must be < `size`). Cramped check uses this value instead of `size`. Without the flag, cramped check uses `max(cargo_passable_size, size)`.
 "cargo_weight_modifier": 33,  // (Optional, default = 100) Multiplies cargo weight by this percentage.
 "cargo_spoil_multiplier": 50, // (Optional, default = 100) Multiplies the spoilage rate of items
                               // stored in this part by this percentage.  0 preserves indefinitely.

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -265,8 +265,18 @@ bool Creature::will_be_cramped_in_vehicle_tile( map &here, const tripoint_abs_ms
         if( !vp_there.part_with_feature( "CARGO_PASSABLE", false ) &&
             !vp_there.part_with_feature( "APPLIANCE", false ) &&
             !vp_there.part_with_feature( "OBSTACLE", false ) ) {
-            capacity += contents.max_volume();
-            free_cargo += contents.free_volume();
+            units::volume eff_max = contents.max_volume();
+            if( part->info().has_flag( VPFLAG_CARGO_PASSABLE_BY_STORED ) ) {
+                if( part->info().cargo_passable_size &&
+                    *part->info().cargo_passable_size < part->info().size ) {
+                    eff_max = *part->info().cargo_passable_size;
+                }
+            } else if( part->info().cargo_passable_size ) {
+                eff_max = std::max( *part->info().cargo_passable_size, eff_max );
+            }
+            capacity += eff_max;
+            const units::volume stored = contents.stored_volume();
+            free_cargo += eff_max > stored ? eff_max - stored : 0_ml;
         }
     }
     if( capacity > 0_ml ) {

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -945,6 +945,16 @@ void vpart_info::check() const
     if( has_flag( "CARGO" ) && has_flag( "FLUIDTANK" ) ) {
         debugmsg( "vehicle part %s can't have both CARGO and FLUIDTANK flags at the same time", id.str() );
     }
+    if( has_flag( VPFLAG_CARGO_PASSABLE_BY_STORED ) && !cargo_passable_size ) {
+        debugmsg( "vehicle part %s has CARGO_PASSABLE_BY_STORED flag but no cargo_passable_size", id.str() );
+    }
+    if( cargo_passable_size && *cargo_passable_size > size ) {
+        debugmsg( "vehicle part %s has cargo_passable_size %s greater than size %s", id.str(),
+                  cargo_passable_size->str(), size.str() );
+    }
+    if( cargo_passable_size && *cargo_passable_size < 0_ml ) {
+        debugmsg( "vehicle part %s has negative cargo_passable_size", id.str() );
+    }
     if( !item::type_is_defined( base_item ) ) {
         debugmsg( "vehicle part %s uses undefined item %s", id.str(), base_item.str() );
     }

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -1109,10 +1109,10 @@ int vpart_info::format_description( std::string &msg, const nc_color &format_col
         if( spoil_multiplier != 1.0f ) {
             if( spoil_multiplier != 0.0f ) {
                 const int percent = static_cast<int>( std::lround( spoil_multiplier * 100 ) );
-                append_desc( string_format( _( "Stored items spoil at %d%% their original rate." ),
+                append_desc( string_format( _( "Stored items spoil at <neutral>%d%%</neutral> their original rate." ),
                                             percent ) );
             } else {
-                append_desc( _( "Stored items won't spoil." ) );
+                append_desc( _( "Stored items <info>won't spoil</info>." ) );
             }
         }
     }

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -951,7 +951,7 @@ void vpart_info::check() const
     if( has_flag( VPFLAG_CARGO_PASSABLE_BY_STORED ) && cargo_passable_size &&
         *cargo_passable_size > size ) {
         debugmsg( "vehicle part %s has cargo_passable_size %s greater than size %s", id.str(),
-                  cargo_passable_size->str(), size.str() );
+                  format_volume( *cargo_passable_size ), format_volume( size ) );
     }
     if( cargo_passable_size && *cargo_passable_size < 0_ml ) {
         debugmsg( "vehicle part %s has negative cargo_passable_size", id.str() );

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -1118,7 +1118,7 @@ int vpart_info::format_description( std::string &msg, const nc_color &format_col
     }
     if( has_flag( VPFLAG_CARGO_PASSABLE_BY_STORED ) && cargo_passable_size &&
         *cargo_passable_size < size ) {
-        append_desc( string_format( _( "Becomes impassable when stored volume exceeds %s." ),
+        append_desc( string_format( _( "Becomes impassable when stored volume exceeds <info>%s</info>." ),
                                       format_volume( *cargo_passable_size ) ) );
     }
     if( has_flag( "TURRET" ) ) {

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -146,6 +146,7 @@ static const std::unordered_map<std::string, vpart_bitflags> vpart_bitflag_map =
     { "CURTAIN", VPFLAG_CURTAIN },
     { "CARGO", VPFLAG_CARGO },
     { "CARGO_PASSABLE", VPFLAG_CARGO_PASSABLE },
+    { "CARGO_PASSABLE_BY_STORED", VPFLAG_CARGO_PASSABLE_BY_STORED },
     { "INTERNAL", VPFLAG_INTERNAL },
     { "SOLAR_PANEL", VPFLAG_SOLAR_PANEL },
     { "WIND_TURBINE", VPFLAG_WIND_TURBINE },
@@ -279,6 +280,7 @@ void vpart_info::load( const JsonObject &jo, const std::string_view src )
     optional( jo, was_loaded, "default_ammo", default_ammo, itype_id::NULL_ID() );
     optional( jo, was_loaded, "folded_volume", folded_volume, std::nullopt );
     optional( jo, was_loaded, "size", size, 0_ml );
+    optional( jo, was_loaded, "cargo_passable_size", cargo_passable_size, std::nullopt );
     optional( jo, was_loaded, "bonus", bonus, 0 );
     if( jo.has_array( "light_color" ) ) {
         JsonArray jarr = jo.get_array( "light_color" );

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -1116,6 +1116,11 @@ int vpart_info::format_description( std::string &msg, const nc_color &format_col
             }
         }
     }
+    if( has_flag( VPFLAG_CARGO_PASSABLE_BY_STORED ) && cargo_passable_size &&
+        *cargo_passable_size < size ) {
+        append_desc( string_format( _( "Becomes impassable when stored volume exceeds %s." ),
+                                      format_volume( *cargo_passable_size ) ) );
+    }
     if( has_flag( "TURRET" ) ) {
         class::item base( base_item );
         if( base.ammo_required() && !base.ammo_remaining( ) ) {

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -948,7 +948,8 @@ void vpart_info::check() const
     if( has_flag( VPFLAG_CARGO_PASSABLE_BY_STORED ) && !cargo_passable_size ) {
         debugmsg( "vehicle part %s has CARGO_PASSABLE_BY_STORED flag but no cargo_passable_size", id.str() );
     }
-    if( cargo_passable_size && *cargo_passable_size > size ) {
+    if( has_flag( VPFLAG_CARGO_PASSABLE_BY_STORED ) && cargo_passable_size &&
+        *cargo_passable_size > size ) {
         debugmsg( "vehicle part %s has cargo_passable_size %s greater than size %s", id.str(),
                   cargo_passable_size->str(), size.str() );
     }

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -111,6 +111,7 @@ enum vpart_bitflags : int {
     VPFLAG_CURTAIN,
     VPFLAG_CARGO,
     VPFLAG_CARGO_PASSABLE,
+    VPFLAG_CARGO_PASSABLE_BY_STORED,
     VPFLAG_INTERNAL,
     VPFLAG_SOLAR_PANEL,
     VPFLAG_WATER_WHEEL,
@@ -483,6 +484,9 @@ class vpart_info
 
         /** Cargo location volume */
         units::volume size = 0_ml;
+
+        /** Volume threshold for CARGO_PASSABLE_BY_STORED */
+        std::optional<units::volume> cargo_passable_size = std::nullopt;
 
         /** hint to tilesets for what tile to use if this part doesn't have one */
         std::string looks_like;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2868,6 +2868,27 @@ std::vector<int> vehicle::parts_at_relative( const point_rel_ms &dp, const bool 
 
 std::optional<vpart_reference> vpart_position::obstacle_at_part() const
 {
+    for( const int idx : vehicle().parts_at_relative( mount_pos(), false ) ) {
+        const vehicle_part &vp = vehicle().part( idx );
+        if( vp.is_broken() ) {
+            continue;
+        }
+        if( !vp.info().has_flag( VPFLAG_CARGO_PASSABLE_BY_STORED ) ) {
+            continue;
+        }
+        if( !vp.info().cargo_passable_size ) {
+            continue;
+        }
+        const units::volume thr = *vp.info().cargo_passable_size;
+        if( thr >= vp.info().size ) {
+            continue;
+        }
+        const vpart_reference ref( vehicle(), idx );
+        if( ref.items().stored_volume() > thr ) {
+            return ref;
+        }
+    }
+
     std::optional<vpart_reference> part = part_with_feature( VPFLAG_OBSTACLE, true, true );
     if( !part ) {
         return std::nullopt; // No obstacle here


### PR DESCRIPTION
#### Summary
Features "Allow vehicle tiles to block player passage based on cargo size"

#### Purpose of change
According to the results of my research, in the New England region of the United States, the effective cargo capacity per square meter of floor area in professional vans or truck cargo compartments (although this is not a specific concept used in the real world, this wording actually refers to the volume capacity per unit floor area) is generally greater than the 500L of the largest cargo space currently available in the game.

Since the effective cargo capacity per square meter of a truck cargo compartment directly depends on the usable interior height of the cargo compartment, I looked up several types of trucks commonly found in the New England region:
 - 5-Axle Tractor Semi-Trailer: Freightliner Cascadia, Volvo VNL, Peterbilt 579, Kenworth T680, etc., 110" high (2.79 meters), approximately 2,790 liters of cargo capacity per square meter
 - 3-Axle Single-Unit Trucks: Hino 268, Isuzu NPR/NQR series, Ford F-650/F-750, etc., 96-108 inches high, approximately 2,440-2,740 liters of cargo capacity per square meter

The relevant data comes mainly from the 2023 Massachusetts Freight Plan and the Vermont Pilot Program Report (FHWA, 2012). Although some of the information may be relatively old, the changes should not have been enough to completely invalidate the data I found. From this perspective, even if we assume that only half of the space can actually be used because cargo cannot be stacked completely tightly throughout the entire compartment, the capacity of these common trucks would still exceed 1000L. In contrast, the data balance within the game seems somewhat unrealistic. However, considering that in some cases the same vehicle part is also used for the trunks of passenger cars, increasing the capacity to more than 2000L would not be very reasonable either.

However, considering that currently the cargo size does not prevent a player or other character from moving through a tile, while piling up a large amount of cargo would indeed make the corresponding position on the vehicle difficult to pass through, introducing this mechanic while increasing the capacity of vehicle parts seems to provide a suitable balance between balance, gameplay, and realism.

#### Describe the solution
Add the `CARGO_PASSABLE_BY_STORED` flag and the `cargo_passable_size` field:
 - When the `CARGO_PASSABLE_BY_STORED` flag is present:
   + If the vehicle part does not have the `cargo_passable_size` field configured, report a JSON error.
   + If the configured `cargo_passable_size` field is greater than `size`, report a JSON error.
   + If the configured `cargo_passable_size` field is less than `size`:
       - It becomes impassable when the total volume of stored items exceeds the configured `cargo_passable_size`.
       - The cramped-space check uses the `cargo_passable_size` field instead of the `size` field.
       - The corresponding data will be displayed in the vehicle component information and installation interface.
 - When only the `cargo_passable_size` field is present:
   + The part's passability check retains the original logic.
   + The cramped-space check uses the greater of the `cargo_passable_size` and `size` field values.

At the same time, the new functionality is applied to some vehicle parts:
 - The capacity (`size`) of cargo space is doubled, allowing it to store a total of 1m³ of items (1000L), with the original capacity as a passable limit. (The external cargo rack version has not been adjusted for now.)
 - All seat-type vehicle parts are now configured with a `cargo_passable_size` of 100L, without adding the corresponding flag, so it only takes effect when `will_be_cramped_in_vehicle_tile` determines whether the space is cramped.

Incidentally, during the process of displaying the data, I also fixed a missing tag in the data display text (which I had added in a previous PR, so I fixed it as well).