### PR TITLE
Adjust the maximum capacity of vehicle part containers

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -227,7 +227,7 @@ units::volume vehicle_stack::max_volume() const
         return 0_ml;
     }
     // Set max volume for vehicle cargo to prevent integer overflow
-    return std::min( vpi.size, 10000_liter );
+    return std::min( vpi.size, units::volume::max() );
 }
 
 units::volume vehicle_stack::stored_volume() const


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
There was an integer overflow issue in `vehicle_stack::max_volume()` for vehicle containers and in a series of related data modifications in the past, and C:DDA chose 10000 liters as a clamp... This seems to be a magic number, with no direct relationship to the scale of the integer limit and no comment explaining it. According to the git history, it appears to be a remnant of a compromise and temporary solution from the int32 era. Since the relevant intermediate data types have now been fully changed to int64, this appears to be a combination of a magic number and leftover dead code.

#### Describe the solution
Change the upper clamp from `10000_liter` to `units::volume::max()` as overflow protection.