### PR TITLE
Fix the bug where grab attacks can be repeated infinitely in a single turn and frequently damage player armor

### DIFF
--- a/src/character.h
+++ b/src/character.h
@@ -1333,12 +1333,17 @@ class Character : public Creature, public visitable
         /** Runs through all bionics and armor on a part and reduces damage through their armor_absorb */
         const weakpoint *absorb_hit( const weakpoint_attack &attack, const bodypart_id &bp,
                                      damage_instance &dam, const weakpoint &wp = weakpoint() ) override;
+        // Overload for pressure / non-durability cases: when damage_armor is false, mitigation still applies but durability is not damaged
+        const weakpoint *absorb_hit( const weakpoint_attack &attack, const bodypart_id &bp,
+                                     damage_instance &dam, const weakpoint &wp,
+                                     bool damage_armor );
         /** Runs through all bionics and armor on a specific sub-body part without damaging the character. */
         void absorb_hit( const sub_bodypart_id &sbp, damage_instance &dam,
-                         bool allow_torso_neck_fallback = false );
+                         bool allow_torso_neck_fallback = false, bool damage_armor = true );
     protected:
         void absorb_damage( const bodypart_id &bp, const std::optional<sub_bodypart_id> &sbp,
-                            damage_instance &dam, bool allow_torso_neck_fallback = false );
+                            damage_instance &dam, bool allow_torso_neck_fallback = false,
+                            bool damage_armor = true );
         float generic_weakpoint_skill( skill_id skill_1, skill_id skill_2,
                                        limb_score_id limb_score_1, limb_score_id limb_score_2 ) const;
     public:
@@ -1353,20 +1358,22 @@ class Character : public Creature, public visitable
          * Requires a roll out of 100
          * @return true if the armor was completely destroyed (and the item must be deleted).
          */
-        bool armor_absorb( damage_unit &du, item &armor, const bodypart_id &bp, int roll ) const;
+        bool armor_absorb( damage_unit &du, item &armor, const bodypart_id &bp, int roll,
+                           bool damage_armor = true ) const;
         /**
          * Reduces and mutates du, prints messages about armor taking damage.
          * Requires a roll out of 100
          * @return true if the armor was completely destroyed (and the item must be deleted).
          */
         bool armor_absorb( damage_unit &du, item &armor, const bodypart_id &bp, const sub_bodypart_id &sbp,
-                           int roll ) const;
+                           int roll, bool damage_armor = true ) const;
         /**
          * Reduces and mutates du, prints messages about armor taking damage.
          * If the armor is fully destroyed it is replaced
          * @return true if the armor was completely destroyed.
          */
-        bool ablative_armor_absorb( damage_unit &du, item &armor, const sub_bodypart_id &bp, int roll );
+        bool ablative_armor_absorb( damage_unit &du, item &armor, const sub_bodypart_id &bp, int roll,
+                                    bool damage_armor = true );
         // prints a message related to an item if an item is damaged
         void describe_damage( damage_unit &du, item &armor ) const;
         /**

--- a/src/character.h
+++ b/src/character.h
@@ -1333,7 +1333,7 @@ class Character : public Creature, public visitable
         /** Runs through all bionics and armor on a part and reduces damage through their armor_absorb */
         const weakpoint *absorb_hit( const weakpoint_attack &attack, const bodypart_id &bp,
                                      damage_instance &dam, const weakpoint &wp = weakpoint() ) override;
-        // Overload for pressure / non-durability cases: when damage_armor is false, mitigation still applies but durability is not damaged
+        // Overload for non-durability cases: when damage_armor is false, mitigation still applies but durability is not damaged
         const weakpoint *absorb_hit( const weakpoint_attack &attack, const bodypart_id &bp,
                                      damage_instance &dam, const weakpoint &wp,
                                      bool damage_armor );

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -273,7 +273,7 @@ bool Character::armor_absorb( damage_unit &du, item &armor, const bodypart_id &b
     // -1 is passed as roll so that each material is rolled individually
     armor.mitigate_damage( du, sbp, -1 );
 
-    // check if the armor was damaged - crowd pressure (damage_armor=false) still mitigates but does not degrade durability
+    // check if the armor was damaged - damage_armor=false still mitigates but does not degrade durability
     const double dmg_mult = damage_armor ? calculate_by_enchantment( 1,
                                         enchant_vals::mod::EQUIPMENT_DAMAGE_CHANCE ) : 0.0;
     item::armor_status damaged = armor.damage_armor_durability( du, pre_mitigation, bp, dmg_mult,
@@ -312,7 +312,7 @@ bool Character::armor_absorb( damage_unit &du, item &armor, const bodypart_id &b
     // -1 is passed as roll so that each material is rolled individually
     armor.mitigate_damage( du, bp, -1 );
 
-    // check if the armor was damaged - crowd pressure (damage_armor=false) still mitigates but does not degrade durability
+    // check if the armor was damaged - damage_armor=false still mitigates but does not degrade durability
     const double dmg_mult = damage_armor ? calculate_by_enchantment( 1,
                                         enchant_vals::mod::EQUIPMENT_DAMAGE_CHANCE ) : 0.0;
     item::armor_status damaged = armor.damage_armor_durability( du, pre_mitigation, bp, dmg_mult,
@@ -350,7 +350,7 @@ bool Character::ablative_armor_absorb( damage_unit &du, item &armor, const sub_b
                 // mitigate the actual damage instance
                 ablative_armor.mitigate_damage( du );
 
-                // check if the item will break - crowd pressure (damage_armor=false) still mitigates but does not degrade plates
+                // check if the item will break - damage_armor=false still mitigates but does not degrade plates
                 item::armor_status damaged = item::armor_status::UNDAMAGED;
                 if( ablative_armor.find_armor_data()->non_functional != itype_id() ) {
                     // if the item transforms on destruction damage it that way

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -147,14 +147,25 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
     return nullptr;
 }
 
-void Character::absorb_hit( const sub_bodypart_id &sbp, damage_instance &dam,
-                            bool allow_torso_neck_fallback )
+const weakpoint *Character::absorb_hit( const weakpoint_attack &attack, const bodypart_id &bp,
+                                        damage_instance &dam, const weakpoint &wp,
+                                        bool damage_armor )
 {
-    absorb_damage( sbp->parent.id(), sbp, dam, allow_torso_neck_fallback );
+    ( void )attack;
+    ( void )wp;
+    absorb_damage( bp, std::nullopt, dam, false, damage_armor );
+    return nullptr;
+}
+
+void Character::absorb_hit( const sub_bodypart_id &sbp, damage_instance &dam,
+                            bool allow_torso_neck_fallback, bool damage_armor )
+{
+    absorb_damage( sbp->parent.id(), sbp, dam, allow_torso_neck_fallback, damage_armor );
 }
 
 void Character::absorb_damage( const bodypart_id &bp, const std::optional<sub_bodypart_id> &sbp,
-                               damage_instance &dam, bool allow_torso_neck_fallback )
+                               damage_instance &dam, bool allow_torso_neck_fallback,
+                               bool damage_armor )
 {
     std::list<item> worn_remains;
     bool armor_destroyed = false;
@@ -208,7 +219,7 @@ void Character::absorb_damage( const bodypart_id &bp, const std::optional<sub_bo
         adjust_taken_damage_by_enchantments( elem );
 
         worn.absorb_damage( *this, elem, bp, worn_remains, armor_destroyed, sbp,
-                            allow_torso_neck_fallback );
+                            allow_torso_neck_fallback, damage_armor );
 
         passive_absorb_hit( bp, elem );
 
@@ -237,7 +248,7 @@ void Character::armor_use_power_when_hit( damage_unit &du, item &armor ) const
 }
 
 bool Character::armor_absorb( damage_unit &du, item &armor, const bodypart_id &bp,
-                              const sub_bodypart_id &sbp, int roll ) const
+                              const sub_bodypart_id &sbp, int roll, bool damage_armor ) const
 {
     item::cover_type ctype = item::get_cover_type( du.type );
 
@@ -262,10 +273,10 @@ bool Character::armor_absorb( damage_unit &du, item &armor, const bodypart_id &b
     // -1 is passed as roll so that each material is rolled individually
     armor.mitigate_damage( du, sbp, -1 );
 
-    // check if the armor was damaged
-    item::armor_status damaged = armor.damage_armor_durability( du, pre_mitigation, bp,
-                                 calculate_by_enchantment( 1,
-                                         enchant_vals::mod::EQUIPMENT_DAMAGE_CHANCE ),
+    // check if the armor was damaged - crowd pressure (damage_armor=false) still mitigates but does not degrade durability
+    const double dmg_mult = damage_armor ? calculate_by_enchantment( 1,
+                                        enchant_vals::mod::EQUIPMENT_DAMAGE_CHANCE ) : 0.0;
+    item::armor_status damaged = armor.damage_armor_durability( du, pre_mitigation, bp, dmg_mult,
                                  this );
 
     // describe what happened if the armor took damage
@@ -276,7 +287,8 @@ bool Character::armor_absorb( damage_unit &du, item &armor, const bodypart_id &b
     return damaged == item::armor_status::DESTROYED;
 }
 
-bool Character::armor_absorb( damage_unit &du, item &armor, const bodypart_id &bp, int roll ) const
+bool Character::armor_absorb( damage_unit &du, item &armor, const bodypart_id &bp, int roll,
+                           bool damage_armor ) const
 {
     item::cover_type ctype = item::get_cover_type( du.type );
 
@@ -300,10 +312,10 @@ bool Character::armor_absorb( damage_unit &du, item &armor, const bodypart_id &b
     // -1 is passed as roll so that each material is rolled individually
     armor.mitigate_damage( du, bp, -1 );
 
-    // check if the armor was damaged
-    item::armor_status damaged = armor.damage_armor_durability( du, pre_mitigation, bp,
-                                 calculate_by_enchantment( 1,
-                                         enchant_vals::mod::EQUIPMENT_DAMAGE_CHANCE ),
+    // check if the armor was damaged - crowd pressure (damage_armor=false) still mitigates but does not degrade durability
+    const double dmg_mult = damage_armor ? calculate_by_enchantment( 1,
+                                        enchant_vals::mod::EQUIPMENT_DAMAGE_CHANCE ) : 0.0;
+    item::armor_status damaged = armor.damage_armor_durability( du, pre_mitigation, bp, dmg_mult,
                                  this );
 
     // describe what happened if the armor took damage
@@ -315,11 +327,13 @@ bool Character::armor_absorb( damage_unit &du, item &armor, const bodypart_id &b
 }
 
 bool Character::ablative_armor_absorb( damage_unit &du, item &armor, const sub_bodypart_id &bp,
-                                       int roll )
+                                       int roll, bool damage_armor )
 {
     const map &here = get_map();
 
     item::cover_type ctype = item::get_cover_type( du.type );
+    const double dmg_mult = damage_armor ? calculate_by_enchantment( 1,
+                                        enchant_vals::mod::EQUIPMENT_DAMAGE_CHANCE ) : 0.0;
 
     for( item_pocket *const pocket : armor.get_ablative_pockets() ) {
         // if the pocket is ablative and not empty we should use its values
@@ -336,17 +350,15 @@ bool Character::ablative_armor_absorb( damage_unit &du, item &armor, const sub_b
                 // mitigate the actual damage instance
                 ablative_armor.mitigate_damage( du );
 
-                // check if the item will break
+                // check if the item will break - crowd pressure (damage_armor=false) still mitigates but does not degrade plates
                 item::armor_status damaged = item::armor_status::UNDAMAGED;
                 if( ablative_armor.find_armor_data()->non_functional != itype_id() ) {
                     // if the item transforms on destruction damage it that way
                     // ablative armor is concerned with incoming damage not mitigated damage
-                    damaged = ablative_armor.damage_armor_transforms( pre_mitigation, calculate_by_enchantment( 1,
-                              enchant_vals::mod::EQUIPMENT_DAMAGE_CHANCE ) );
+                    damaged = ablative_armor.damage_armor_transforms( pre_mitigation, dmg_mult );
                 } else {
                     damaged = ablative_armor.damage_armor_durability( du, pre_mitigation, bp->parent,
-                              calculate_by_enchantment( 1,
-                                                        enchant_vals::mod::EQUIPMENT_DAMAGE_CHANCE ),
+                              dmg_mult,
                               this );
                 }
 

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1868,7 +1868,7 @@ item &outfit::front()
 void outfit::absorb_damage( Character &guy, damage_unit &elem, bodypart_id bp,
                             std::list<item> &worn_remains, bool &armor_destroyed,
                             const std::optional<sub_bodypart_id> &forced_sbp,
-                            bool allow_torso_neck_fallback )
+                            bool allow_torso_neck_fallback, bool damage_armor )
 {
     const map &here = get_map();
 
@@ -1924,14 +1924,14 @@ void outfit::absorb_damage( Character &guy, damage_unit &elem, bodypart_id bp,
                                               sub_body_part_torso_upper.id() : sbp;
             // if the armor location has ablative armor apply that first
             if( armor.is_ablative() ) {
-                guy.ablative_armor_absorb( elem, armor, armor_sbp, roll );
+                guy.ablative_armor_absorb( elem, armor, armor_sbp, roll, damage_armor );
             }
 
             // if not already destroyed to an armor absorb
-            destroy = guy.armor_absorb( elem, armor, bp, armor_sbp, roll );
+            destroy = guy.armor_absorb( elem, armor, bp, armor_sbp, roll, damage_armor );
             // for the torso we also need to consider if it hits anything hanging off the character or their neck
             if( secondary_sbp != sub_bodypart_id() && !destroy ) {
-                destroy = guy.armor_absorb( elem, armor, bp, secondary_sbp, roll );
+                destroy = guy.armor_absorb( elem, armor, bp, secondary_sbp, roll, damage_armor );
             }
         }
 

--- a/src/character_attire.h
+++ b/src/character_attire.h
@@ -196,7 +196,7 @@ class outfit
         void absorb_damage( Character &guy, damage_unit &elem, bodypart_id bp,
                             std::list<item> &worn_remains, bool &armor_destroyed,
                             const std::optional<sub_bodypart_id> &forced_sbp = std::nullopt,
-                            bool allow_torso_neck_fallback = false );
+                            bool allow_torso_neck_fallback = false, bool damage_armor = true );
         /** Draws the UI and handles player input for the armor re-ordering window */
         void sort_armor( Character &guy );
         /*

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -888,7 +888,12 @@ bool melee_actor::call( monster &z ) const
         }
     }
 
-    z.mod_moves( -move_cost );
+    // Grab attacks minimum default move cost
+    int eff_cost = move_cost;
+    if( is_grab && eff_cost < 100 ) {
+        eff_cost = 100;
+    }
+    z.mod_moves( -eff_cost );
 
     const std::string mon_name = get_player_character().sees( here, z.pos_bub( here ) ) ?
                                  z.disp_name( false, true ) : _( "Something" );

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -424,7 +424,6 @@ void suffer::while_grabbed( Character &you )
     bool pressure_absorbed = true;
     const auto absorb_bodypart_pressure = [&]( const bodypart_id & bp, float pressure_amount ) {
         damage_instance pressure( damage_bash, pressure_amount );
-        // Crowd pressure is sustained crushing; it should be mitigated by armor but must not degrade durability (see A-fix)
         you.absorb_hit( weakpoint_attack(), bp, pressure, weakpoint(), false );
         if( pressure.total_damage() > 0.0f ) {
             pressure_absorbed = false;
@@ -433,7 +432,6 @@ void suffer::while_grabbed( Character &you )
     const auto absorb_sub_bodypart_pressure = [&]( const sub_bodypart_id & sbp, float pressure_amount,
     bool allow_torso_neck_fallback = false ) {
         damage_instance pressure( damage_bash, pressure_amount );
-        // Crowd pressure still mitigates through armor but does not damage durability
         you.absorb_hit( sbp, pressure, allow_torso_neck_fallback, false );
         if( pressure.total_damage() > 0.0f ) {
             pressure_absorbed = false;

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -424,7 +424,8 @@ void suffer::while_grabbed( Character &you )
     bool pressure_absorbed = true;
     const auto absorb_bodypart_pressure = [&]( const bodypart_id & bp, float pressure_amount ) {
         damage_instance pressure( damage_bash, pressure_amount );
-        you.absorb_hit( weakpoint_attack(), bp, pressure );
+        // Crowd pressure is sustained crushing; it should be mitigated by armor but must not degrade durability (see A-fix)
+        you.absorb_hit( weakpoint_attack(), bp, pressure, weakpoint(), false );
         if( pressure.total_damage() > 0.0f ) {
             pressure_absorbed = false;
         }
@@ -432,7 +433,8 @@ void suffer::while_grabbed( Character &you )
     const auto absorb_sub_bodypart_pressure = [&]( const sub_bodypart_id & sbp, float pressure_amount,
     bool allow_torso_neck_fallback = false ) {
         damage_instance pressure( damage_bash, pressure_amount );
-        you.absorb_hit( sbp, pressure, allow_torso_neck_fallback );
+        // Crowd pressure still mitigates through armor but does not damage durability
+        you.absorb_hit( sbp, pressure, allow_torso_neck_fallback, false );
         if( pressure.total_damage() > 0.0f ) {
             pressure_absorbed = false;
         }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Due to some settings inherited from the upstream branch, some widely used grab-type monster special attacks were configured with `"cooldown": 0`. In addition, because `monster::move()` does not break after a successful loop iteration, fast monsters can repeatedly perform multiple zero-cooldown special attacks in the same turn. Grab attacks originally had a soft cooldown design, but it was implemented through `self_effects_onhit`, which has multiple ways to bypass the restriction when the attack does not successfully hit or when the target is already grabbed and no new grab is actually produced. As a result, monsters may be able to repeatedly attempt high-frequency attacks multiple times within a single turn. Furthermore, since not all grabs explicitly declare `damage_max_instance` as 0, some grabs also carry the default bash damage of 9 and undergo normal armor durability calculations. In addition, in early August I modified the group crushing logic so that the pressure can be absorbed by armor covering the breathing-related body parts, but because `Character::absorb_damage` natively does not support absorbing virtual damage without reducing armor durability, the pressure still consumes armor durability even though it is not actual damage.

The combination of the above issues currently causes player armor to rapidly melt away when being grabbed by a group, followed by the exact same suffocation death process as in the old version.

#### Describe the solution
Add a bool parameter `damage_armor` to `Character::absorb_damage`, defaulting to true, and pass false when absorbing the virtual damage from pressure so that it no longer consumes armor durability.

Set a minimum default move cost for grab attacks. Each grab must consume at least 100 moves (equivalent to one full turn / 1 s of action for a creature with standard speed), preventing infinite repeated grab attacks caused by the default configuration of 0.

#### Describe alternatives you've considered
I considered whether to set a minimum cooldown and a per-turn activation limit for the entire special attack system, but considering that the designs of some monsters may already be based on the current behavior, I am not changing this for now.

Regarding the soft-limit bypass, I am not sure whether it is intentional to allow another attempt in the following turn when the grab was unsuccessful, so for now I have not changed `self_effects_onhit` in the JSON configuration to `self_effects_always`. If grab attacks continue to have significant problems, I will adjust this further.