### PR TITLE
Fix crowd crush suffocation to require head instead of eyes

### DIFF
--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -440,7 +440,7 @@ void suffer::while_grabbed( Character &you )
     absorb_sub_bodypart_pressure( sub_body_part_torso_upper.id(), pressure_per_part );
     absorb_sub_bodypart_pressure( sub_body_part_torso_neck.id(), pressure_per_part, true );
     absorb_bodypart_pressure( body_part_mouth.id(), pressure_per_part );
-    absorb_bodypart_pressure( body_part_eyes.id(), pressure_per_part );
+    absorb_bodypart_pressure( body_part_head.id(), pressure_per_part );
 
     if( pressure_absorbed ) {
         return;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Previously, the suffocation effect of while_grabbed required armor covering the entire head and upper torso to resist. Head armor is primarily used to determine whether the neck is within the defensive range and includes the entire face in damage absorption calculations, resulting in the exclusion of some full-body armor that only does not cover the eyes.

#### Describe the solution
In damage absorption assessment, head armor is used instead of eye armor to absorb damage.