### PR TITLE
suffer::while_grabbed use sub_body_part_head_throat

### DIFF
--- a/src/character.h
+++ b/src/character.h
@@ -1339,11 +1339,10 @@ class Character : public Creature, public visitable
                                      bool damage_armor );
         /** Runs through all bionics and armor on a specific sub-body part without damaging the character. */
         void absorb_hit( const sub_bodypart_id &sbp, damage_instance &dam,
-                         bool allow_torso_neck_fallback = false, bool damage_armor = true );
+                         bool damage_armor = true );
     protected:
         void absorb_damage( const bodypart_id &bp, const std::optional<sub_bodypart_id> &sbp,
-                            damage_instance &dam, bool allow_torso_neck_fallback = false,
-                            bool damage_armor = true );
+                            damage_instance &dam, bool damage_armor = true );
         float generic_weakpoint_skill( skill_id skill_1, skill_id skill_2,
                                        limb_score_id limb_score_1, limb_score_id limb_score_2 ) const;
     public:

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -153,19 +153,18 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &attack, const bo
 {
     ( void )attack;
     ( void )wp;
-    absorb_damage( bp, std::nullopt, dam, false, damage_armor );
+    absorb_damage( bp, std::nullopt, dam, damage_armor );
     return nullptr;
 }
 
 void Character::absorb_hit( const sub_bodypart_id &sbp, damage_instance &dam,
-                            bool allow_torso_neck_fallback, bool damage_armor )
+                            bool damage_armor )
 {
-    absorb_damage( sbp->parent.id(), sbp, dam, allow_torso_neck_fallback, damage_armor );
+    absorb_damage( sbp->parent.id(), sbp, dam, damage_armor );
 }
 
 void Character::absorb_damage( const bodypart_id &bp, const std::optional<sub_bodypart_id> &sbp,
-                               damage_instance &dam, bool allow_torso_neck_fallback,
-                               bool damage_armor )
+                               damage_instance &dam, bool damage_armor )
 {
     std::list<item> worn_remains;
     bool armor_destroyed = false;
@@ -219,7 +218,7 @@ void Character::absorb_damage( const bodypart_id &bp, const std::optional<sub_bo
         adjust_taken_damage_by_enchantments( elem );
 
         worn.absorb_damage( *this, elem, bp, worn_remains, armor_destroyed, sbp,
-                            allow_torso_neck_fallback, damage_armor );
+                            damage_armor );
 
         passive_absorb_hit( bp, elem );
 

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1868,7 +1868,7 @@ item &outfit::front()
 void outfit::absorb_damage( Character &guy, damage_unit &elem, bodypart_id bp,
                             std::list<item> &worn_remains, bool &armor_destroyed,
                             const std::optional<sub_bodypart_id> &forced_sbp,
-                            bool allow_torso_neck_fallback, bool damage_armor )
+                            bool damage_armor )
 {
     const map &here = get_map();
 
@@ -1916,12 +1916,7 @@ void outfit::absorb_damage( Character &guy, damage_unit &elem, bodypart_id bp,
         }
 
         if( !destroy ) {
-            const bool use_torso_upper = allow_torso_neck_fallback &&
-                                         sbp == sub_body_part_torso_neck.id() && !armor.covers( sbp ) &&
-                                         armor.covers( body_part_torso ) &&
-                                         ( armor.covers( body_part_head ) || armor.covers( body_part_mouth ) );
-            const sub_bodypart_id armor_sbp = use_torso_upper ?
-                                              sub_body_part_torso_upper.id() : sbp;
+            const sub_bodypart_id armor_sbp = sbp;
             // if the armor location has ablative armor apply that first
             if( armor.is_ablative() ) {
                 guy.ablative_armor_absorb( elem, armor, armor_sbp, roll, damage_armor );

--- a/src/character_attire.h
+++ b/src/character_attire.h
@@ -196,7 +196,7 @@ class outfit
         void absorb_damage( Character &guy, damage_unit &elem, bodypart_id bp,
                             std::list<item> &worn_remains, bool &armor_destroyed,
                             const std::optional<sub_bodypart_id> &forced_sbp = std::nullopt,
-                            bool allow_torso_neck_fallback = false, bool damage_armor = true );
+                            bool damage_armor = true );
         /** Draws the UI and handles player input for the armor re-ordering window */
         void sort_armor( Character &guy );
         /*

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -146,6 +146,7 @@ json_flag_SUNBURN_SUPERNATURAL_REDUCTION( "SUNBURN_SUPERNATURAL_REDUCTION" );
 static const damage_type_id damage_bash( "bash" );
 static const sub_bodypart_str_id sub_body_part_torso_upper( "torso_upper" );
 static const sub_bodypart_str_id sub_body_part_torso_neck( "torso_neck" );
+static const sub_bodypart_str_id sub_body_part_head_throat( "head_throat" );
 
 static const morale_type morale_feeling_bad( "morale_feeling_bad" );
 static const morale_type morale_feeling_good( "morale_feeling_good" );
@@ -420,7 +421,7 @@ void suffer::while_grabbed( Character &you )
                           crowd_pressure / ( crowd - impassable_ter ) );
     }
 
-    const float pressure_per_part = crowd_pressure / 4;
+    const float pressure_per_part = crowd_pressure / 3;
     bool pressure_absorbed = true;
     const auto absorb_bodypart_pressure = [&]( const bodypart_id & bp, float pressure_amount ) {
         damage_instance pressure( damage_bash, pressure_amount );
@@ -433,13 +434,19 @@ void suffer::while_grabbed( Character &you )
         damage_instance pressure( damage_bash, pressure_amount );
         you.absorb_hit( sbp, pressure, false );
         if( pressure.total_damage() > 0.0f ) {
-            pressure_absorbed = false;
+            if ( sbp == sub_body_part_head_throat.id() ) {
+                you.absorb_hit( sub_body_part_torso_neck.id(), pressure, false );
+                if( pressure.total_damage() > 0.0f ) {
+                    pressure_absorbed = false;
+                }
+            } else {
+                pressure_absorbed = false;
+            }
         }
     };
     absorb_sub_bodypart_pressure( sub_body_part_torso_upper.id(), pressure_per_part );
-    absorb_sub_bodypart_pressure( sub_body_part_torso_neck.id(), pressure_per_part );
+    absorb_sub_bodypart_pressure( sub_body_part_head_throat.id(), pressure_per_part );
     absorb_bodypart_pressure( body_part_mouth.id(), pressure_per_part );
-    absorb_bodypart_pressure( body_part_head.id(), pressure_per_part );
 
     if( pressure_absorbed ) {
         return;

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -429,16 +429,15 @@ void suffer::while_grabbed( Character &you )
             pressure_absorbed = false;
         }
     };
-    const auto absorb_sub_bodypart_pressure = [&]( const sub_bodypart_id & sbp, float pressure_amount,
-    bool allow_torso_neck_fallback = false ) {
+    const auto absorb_sub_bodypart_pressure = [&]( const sub_bodypart_id & sbp, float pressure_amount ) {
         damage_instance pressure( damage_bash, pressure_amount );
-        you.absorb_hit( sbp, pressure, allow_torso_neck_fallback, false );
+        you.absorb_hit( sbp, pressure, false );
         if( pressure.total_damage() > 0.0f ) {
             pressure_absorbed = false;
         }
     };
     absorb_sub_bodypart_pressure( sub_body_part_torso_upper.id(), pressure_per_part );
-    absorb_sub_bodypart_pressure( sub_body_part_torso_neck.id(), pressure_per_part, true );
+    absorb_sub_bodypart_pressure( sub_body_part_torso_neck.id(), pressure_per_part );
     absorb_bodypart_pressure( body_part_mouth.id(), pressure_per_part );
     absorb_bodypart_pressure( body_part_head.id(), pressure_per_part );
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
It was discovered that a body part with the ID `head_throat` in the game is actually the real neck and respiratory tract, while `torso_neck` is a mysterious part that is difficult to evaluate and is actually designed specifically for hanging necklaces.

Therefore, the assessment of suffocation during grabbing actually only involves three areas: the upper torso containing the chest cavity, the throat, and the mouth and nose. Everything else is superfluous.

#### Describe the solution
The ugly calls to the allow_torso_neck_fallback parameter and related logic have been removed.

The checks requiring the entire head to be protected and the checks requiring `torso_neck` armor have been removed. These two parts are now unified under `head_throat`. `torso_neck` is temporarily used as a fallback option when `head_throat` has no armor, to prevent some mod designers from making similar mistakes.

#### Additional context
One side effect of this change is that the total number of body parts that actually absorb virtual damage as pressure has decreased, resulting in more pressure being distributed among individual body parts, and thus increasing the amount of armor needed to prevent suffocation. However, if we only look at the initial PR design, it's still in line with expectations.