### PR TITLE
Fix Android menus disappearing after display refresh

### DIFF
--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -5468,11 +5468,14 @@ static void android_request_repaint()
 
 static void android_force_full_redraw()
 {
-    if( g != nullptr && android_has_active_world() ) {
-        g->invalidate_main_ui_adaptor();
-    } else {
-        ui_manager::invalidate_all_ui_adaptors();
-    }
+    // This path services lifecycle, visible-frame and input-context changes.
+    // The display buffer may have been cleared or replaced, so invalidating
+    // only the gameplay adaptor is insufficient while a menu is on top: a
+    // fully covering menu can suppress the lower invalidation and remain
+    // "clean", leaving the cleared frame visible until the next keypress.
+    // Rebuild the complete active stack so the current menu is present in the
+    // first frame after the transition as well.
+    ui_manager::invalidate_all_ui_adaptors();
     ui_manager::redraw_invalidated();
     needupdate = true;
 }


### PR DESCRIPTION
#### Summary
Bugfixes "Fix Android menus disappearing until the next input"

#### Responsible human

@LYHGLYTX

#### Purpose of change

On recent Android builds, opening a menu can make it flash once and then disappear. The menu still accepts input, and pressing an unrelated key or scrolling makes it visible again. Advanced Inventory can repeat the problem after transferring an item.

The Android display-refresh path is used for lifecycle, visible-frame, and input-context transitions. While a world was active, its "full redraw" helper invalidated only the gameplay adaptor. If the display buffer had been cleared or replaced while a menu covered that adaptor, the menu remained marked clean and was not reconstructed until a later input invalidated it.

Reproduction reported by players:

1. Enter an active world on Android.
2. Open Advanced Inventory or another menu.
3. Observe the menu flash or remain invisible while still accepting input.
4. Press an unrelated key or scroll to make it reappear.
5. In Advanced Inventory, transfer an item and observe the menu disappear again.

#### Describe the solution

Make `android_force_full_redraw()` invalidate the complete active UI adaptor stack before redrawing. This guarantees that the current top-level menu is rebuilt into a cleared or replaced display buffer together with the gameplay UI.

The code is inside the Android-specific rendering path, so desktop behavior is unchanged.

#### Describe alternatives you've considered

Forcing an additional present before each Android input wait would only present whatever is already in the display buffer. It would not reconstruct a menu that remained incorrectly marked clean after the buffer was cleared, and would add unnecessary presents. Correcting the invalidation scope addresses the lost state directly.

#### Testing

- `git diff --check`
- Android arm64 Stable configuration: directly compiled `sdltiles.cpp.o` successfully with the configured NDK/SDL3 toolchain.
- Full `:app:assembleStableRelease` was attempted, but the current default branch is independently blocked in `src/lua_platform_interaction.cpp:675`, `:686`, and `:955` by translation-cache namespace lookup errors before APK linking.
- `make astyle-check` was attempted; the repository baseline currently reports formatting regressions across hundreds of existing `src/` and `tests/` files.
- No Android device was connected for runtime verification.

Suggested manual check: repeatedly open ordinary menus and Advanced Inventory, transfer items, and background/foreground the app; the active menu should remain visible without requiring a second keypress.

#### Documentation impact

None

#### Related CCB-Docs PR

None

#### Affected documentation IDs

None

#### Generated reference impact

None

#### Additional context

The issue was independently reported by two Android players and affects menu presentation rather than menu input handling.
