### PR TITLE
Finalize PR artifact links after merge

### DIFF
--- a/.github/workflows/publish-pr-artifacts.yml
+++ b/.github/workflows/publish-pr-artifacts.yml
@@ -84,9 +84,19 @@ jobs:
             const workflowHeadRepository =
               workflowRun.head_repository && workflowRun.head_repository.full_name;
 
-            const matchesCurrentPullRequest = pullRequest =>
+            const hasPublishablePullRequestState = pullRequest =>
               pullRequest &&
-              pullRequest.state === 'open' &&
+              (
+                pullRequest.state === 'open' ||
+                (
+                  action === 'completed' &&
+                  pullRequest.state === 'closed' &&
+                  pullRequest.merged === true
+                )
+              );
+
+            const matchesCurrentPullRequest = pullRequest =>
+              hasPublishablePullRequestState(pullRequest) &&
               pullRequest.draft === false &&
               pullRequest.base &&
               pullRequest.base.ref === 'master' &&
@@ -135,7 +145,7 @@ jobs:
             }
 
             if (!pullRequest) {
-              core.info('No matching open, non-draft master pull request was found.');
+              core.info('No matching open or merged, non-draft master pull request was found.');
               return;
             }
 

--- a/tools/agent/test_publish_pr_artifacts.py
+++ b/tools/agent/test_publish_pr_artifacts.py
@@ -209,6 +209,7 @@ def make_pull_request(
     number: int = 42,
     *,
     state: str = "open",
+    merged: bool = False,
     draft: bool = False,
     base_ref: str = "master",
     base_repo: str = CURRENT_REPOSITORY,
@@ -218,6 +219,7 @@ def make_pull_request(
     return {
         "number": number,
         "state": state,
+        "merged": merged,
         "draft": draft,
         "base": {"ref": base_ref, "repo": {"full_name": base_repo}},
         "head": {"repo": {"full_name": head_repo}, "sha": head_sha},
@@ -437,6 +439,9 @@ class PublishPrArtifactsContractTest(unittest.TestCase):
         for fragment in (
             "workflowRun.event !== 'pull_request'",
             "pullRequest.state === 'open'",
+            "action === 'completed'",
+            "pullRequest.state === 'closed'",
+            "pullRequest.merged === true",
             "pullRequest.draft === false",
             "pullRequest.base.ref === 'master'",
             "pullRequest.base.repo.full_name === currentRepository",
@@ -497,6 +502,58 @@ class PublishPrArtifactsContractTest(unittest.TestCase):
         for label, url in expected.items():
             self.assertIn(f"| {label} | ✅ [download]({url}) |", body)
         self.assert_artifact_run_ids(result, {101, 102})
+
+    def test_completed_event_updates_artifacts_after_pr_merge(self) -> None:
+        pending = (
+            f"{BEGIN_MARKER}\n"
+            f"<!-- ccb-pr-artifacts-head: {HEAD_SHA} -->\n"
+            "pending\n"
+            f"{END_MARKER}"
+        )
+        result = self.run_publisher(
+            self.successful_scenario(
+                pull_requests={
+                    42: make_pull_request(
+                        state="closed",
+                        merged=True,
+                    )
+                },
+                comments=[marker_comment(4201, pending)],
+            )
+        )
+        self.assertEqual([], result["failures"], result)
+        self.assertEqual(
+            [4201],
+            [item["comment_id"] for item in result["updates"]],
+        )
+        self.assertEqual([], result["creates"], result)
+        body = result["updates"][0]["body"]
+        for artifact_id in (1001, 1002, 1003, 1004):
+            self.assertIn(f"/artifacts/{artifact_id}", body)
+        self.assertNotIn("⏳ pending", body)
+
+    def test_requested_event_does_not_publish_to_merged_pr(self) -> None:
+        workflow_run = make_workflow_run(
+            run_id=103,
+            status="requested",
+            conclusion=None,
+        )
+        result = self.run_publisher(
+            make_scenario(
+                workflow_run,
+                action="requested",
+                pull_requests={
+                    42: make_pull_request(
+                        state="closed",
+                        merged=True,
+                    )
+                },
+                workflow_runs=[workflow_run],
+            )
+        )
+        self.assertEqual([], result["failures"], result)
+        self.assert_no_writes(result)
+        self.assertEqual([], self.artifact_calls(result))
 
     def test_pending_runs_are_pending_without_artifact_lookup(self) -> None:
         general = make_workflow_run(


### PR DESCRIPTION
#### Summary

Infrastructure "Finalize PR artifact links after merge"

#### Responsible human

@LYHGLYTX

#### Purpose of change

PR artifact comments are initialized when source builds are requested, but a PR can merge before the General build matrix and Windows build finish. The publisher currently rejects every closed PR, so a successfully built and merged PR such as #698 keeps permanent pending rows even though all four artifacts exist.

#### Describe the solution

Keep requested events restricted to open, non-draft master PRs. For completed events, also accept a closed PR only when GitHub reports `merged: true` and its base repository, base branch, head repository, and full head SHA still match the source workflow. This allows the workflow-owned pending comment to be finalized after merge without publishing to abandoned or unrelated closed PRs.

#### Describe alternatives you've considered

Waiting to merge every PR until all artifact builds finish avoids the symptom but unnecessarily couples merges to optional downloadable packages. Accepting every closed PR would be too broad and could publish stale or abandoned builds.

#### Testing

- `python3 -m unittest discover -s tools/agent -p 'test_publish_pr_artifacts.py'` — 21 tests
- `python3 -m unittest discover -s tools/agent -p 'test_*.py'` — 99 tests
- `python3 tools/agent/check_project_metadata.py`
- `flake8 --jobs=1`
- `git diff --check`

#### Documentation impact

None

#### Related CCB-Docs PR

None

#### Affected documentation IDs

None

#### Generated reference impact

None

#### Additional context

The regression test reproduces the #698 sequence: an existing pending bot comment, a completed source workflow, and a closed PR with `merged: true`. It verifies all four final artifact links replace the pending rows, while requested events still ignore merged PRs.