### PR TITLE
Balance: Exempt zombie corpses from butchery empathy

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2284,10 +2284,8 @@ activity_reason_info multi_butchery_activity_actor::multi_activity_can_do( Chara
     if( !corpses.empty() ) {
         for( item &body : corpses ) {
             const mtype &corpse = *body.get_mtype();
-            for( species_id species : corpse.species ) {
-                if( you.empathizes_with_species( species ) ) {
-                    return activity_reason_info::fail( do_activity_reason::REFUSES_THIS_WORK );
-                }
+            if( character_has_butchery_empathy( you, corpse.id ) ) {
+                return activity_reason_info::fail( do_activity_reason::REFUSES_THIS_WORK );
             }
         }
         if( big_count > 0 && small_count == 0 ) {

--- a/src/butchery.cpp
+++ b/src/butchery.cpp
@@ -86,6 +86,7 @@ static const skill_id skill_firstaid( "firstaid" );
 static const skill_id skill_survival( "survival" );
 
 static const species_id species_HUMAN( "HUMAN" );
+static const species_id species_ZOMBIE( "ZOMBIE" );
 
 namespace io
 {
@@ -182,6 +183,12 @@ butcher_type get_butcher_type( player_activity *act )
     return action;
 }
 
+bool character_has_butchery_empathy( const Character &character, const mtype_id &corpse )
+{
+    return ( corpse == mtype_id::NULL_ID() || !corpse->in_species( species_ZOMBIE ) ) &&
+           character.empathizes_with_monster( corpse );
+}
+
 static bool check_anger_empathetic_npcs_with_cannibalism( const Character &you,
         const mtype_id &monster )
 {
@@ -191,11 +198,12 @@ static bool check_anger_empathetic_npcs_with_cannibalism( const Character &you,
         return true; // NPCs dont accidentally cause player hate
     }
 
-    bool you_empathize = you.empathizes_with_monster( monster );
+    bool you_empathize = character_has_butchery_empathy( you, monster );
     bool nearby_empathetic_npc = false;
 
     for( npc &guy : g->all_npcs() ) {
-        if( guy.is_active() && guy.sees( here, you ) && guy.empathizes_with_monster( monster ) ) {
+        if( guy.is_active() && guy.sees( here, you ) &&
+            character_has_butchery_empathy( guy, monster ) ) {
             nearby_empathetic_npc = true;
             break;
         }
@@ -220,7 +228,8 @@ static bool check_anger_empathetic_npcs_with_cannibalism( const Character &you,
     // !you_empathize && !nearby_empathetic_npc means no check.  Will likely happen for most combinations.
 
     for( npc &guy : g->all_npcs() ) {
-        if( guy.is_active() && guy.sees( here, you ) && guy.empathizes_with_monster( monster ) ) {
+        if( guy.is_active() && guy.sees( here, you ) &&
+            character_has_butchery_empathy( guy, monster ) ) {
             guy.say( _( "<swear!>?  Are you butchering them?  That's not okay, <name_b>." ) );
             // massive opinion penalty
             guy.op_of_u.trust -= 5;
@@ -346,14 +355,14 @@ bool set_up_butchery( player_activity &act, Character &you, butchery_data bd )
     // Dissections are slightly less angering than other butcher types
     if( action == butcher_type::DISSECT ) {
         if( you.has_proficiency( proficiency_prof_dissect_humans ) ) {
-            if( you.empathizes_with_monster( corpse.id ) ) {
+            if( character_has_butchery_empathy( you, corpse.id ) ) {
                 // this is a dissection, and we are trained for dissection, so no morale penalty, anger, and lighter flavor text.
                 you.add_msg_if_player( m_good, SNIPPET.random_from_category(
                                            "msg_human_dissection_with_prof" ).value_or( translation() ).translated() );
             }
         } else {
             if( check_anger_empathetic_npcs_with_cannibalism( you, corpse.id ) ) {
-                if( you.empathizes_with_monster( corpse.id ) ) {
+                if( character_has_butchery_empathy( you, corpse.id ) ) {
                     // give us a message indicating we are dissecting without the stomach for it, but not actually butchering. lower morale penalty.
                     you.add_msg_if_player( m_good, SNIPPET.random_from_category(
                                                "msg_human_dissection_no_prof" ).value_or( translation() ).translated() );
@@ -371,7 +380,7 @@ bool set_up_butchery( player_activity &act, Character &you, butchery_data bd )
         }
     } else if( action != butcher_type::DISMEMBER ) {
         if( check_anger_empathetic_npcs_with_cannibalism( you, corpse.id ) ) {
-            if( you.empathizes_with_monster( corpse.id ) ) {
+            if( character_has_butchery_empathy( you, corpse.id ) ) {
                 // give the player a random message showing their disgust and cause morale penalty.
                 you.add_msg_if_player( m_good, SNIPPET.random_from_category(
                                            "msg_human_butchery" ).value_or( translation() ).translated() );

--- a/src/butchery.h
+++ b/src/butchery.h
@@ -41,6 +41,10 @@ struct butchery_data {
 
 int butcher_time_to_cut( Character &you, const item &corpse_item, butcher_type action );
 
+// Whether this corpse should trigger species-empathy reactions during butchery.
+// CCB keeps the pre-CDDA#78796 rule: zombified corpses are exempt.
+bool character_has_butchery_empathy( const Character &character, const mtype_id &corpse );
+
 std::string butcher_progress_var( butcher_type action );
 
 std::string butcher_progress_time_var();

--- a/tests/harvest_test.cpp
+++ b/tests/harvest_test.cpp
@@ -32,9 +32,11 @@ static const itype_id itype_rope_30( "rope_30" );
 static const itype_id itype_scalpel( "scalpel" );
 
 static const mtype_id mon_chicken( "mon_chicken" );
+static const mtype_id mon_civilian_panic( "mon_civilian_panic" );
 static const mtype_id mon_deer( "mon_deer" );
 static const mtype_id mon_test_CBM( "mon_test_CBM" );
 static const mtype_id mon_test_bovine( "mon_test_bovine" );
+static const mtype_id mon_zombie( "mon_zombie" );
 
 static const skill_id skill_firstaid( "firstaid" );
 static const skill_id skill_survival( "survival" );
@@ -100,6 +102,22 @@ TEST_CASE( "Harvest_drops_from_dissecting_corpse", "[harvest]" )
         CHECK( cbm_count > 0 );
         CHECK( sample_count == 0 );
     }
+}
+
+TEST_CASE( "zombie_corpses_do_not_trigger_butchery_empathy", "[harvest][butchery]" )
+{
+    Character &u = get_player_character();
+    clear_character( u, true );
+
+    REQUIRE( u.empathizes_with_monster( mon_civilian_panic ) );
+    CHECK( character_has_butchery_empathy( u, mon_civilian_panic ) );
+
+    // Keep general species empathy intact; only butchery exempts zombified corpses.
+    REQUIRE( u.empathizes_with_monster( mon_zombie ) );
+    CHECK_FALSE( character_has_butchery_empathy( u, mon_zombie ) );
+
+    // NPC corpses use the null monster id and remain human for butchery purposes.
+    CHECK( character_has_butchery_empathy( u, mtype_id::NULL_ID() ) );
 }
 
 static void do_butchery_timing( int expected_turns, butcher_type butchery_type,


### PR DESCRIPTION
#### Summary

Balance "Zombified corpses no longer trigger butchery empathy reactions"

#### Responsible human

@LYHGLYTX

#### Purpose of change

CCB should retain the pre-[CDDA #78796](https://github.com/CleverRaven/Cataclysm-DDA/pull/78796) behavior for corpse processing: once a corpse is zombified, butchering or dissecting it should not be treated as desecrating a human corpse.

The upstream behavior currently affects player morale and confirmation prompts, nearby NPC opinion penalties, and automatic zone butchery.

#### Describe the solution

Add a shared butchery-specific empathy predicate that exempts corpses belonging to the `ZOMBIE` species while delegating all other decisions to the existing generalized species-empathy system.

Use the predicate for:

- player butchery and dissection reactions;
- nearby NPC reactions and opinion penalties;
- automatic multi-butchery refusal checks.

Add regression coverage proving that ordinary human and NPC corpses still trigger butchery empathy, general monster empathy remains unchanged, and human zombies are exempt only in the butchery context.

#### Describe alternatives you've considered

A direct revert of the old CDDA merge commit would target code that has since moved and been substantially refactored.

Changing `Character::empathizes_with_monster()` globally would also affect the later JSON-driven species-empathy behavior used by mods such as Xedra Evolved and Magiclysm, so the exemption is kept local to butchery.

#### Testing

- `git diff --check`
- Compiled `src/butchery.cpp` and `src/activity_item_handling.cpp` with the release configuration and `-Werror`.
- Compiled `tests/harvest_test.cpp` with the release configuration and `-Werror`.
- The focused test executable was not linked or run locally; the existing cache was from a different source ABI. CI should run the new `[butchery]` regression test and the normal test suite.

#### Documentation impact

None

#### Related CCB-Docs PR

None

#### Affected documentation IDs

None

#### Generated reference impact

None

#### Additional context

This removes the gameplay behavior introduced by CDDA #78796 without reverting the later generalized species-empathy architecture.