### PR TITLE
Fix Clang build failure from unused lambda capture

### DIFF
--- a/src/lua_platform_content_creatures.cpp
+++ b/src/lua_platform_content_creatures.cpp
@@ -3340,7 +3340,7 @@ bool creatures_content_transaction::validate( const runtime &owner_runtime,
                 return entry.definition->id == id;
             } ) || ( check_engine_state && native_exists( std::string( id ) ) );
         };
-        const auto item_exists = [&index, &staged, check_engine_state]( const std::string & id ) {
+        const auto item_exists = [&index, check_engine_state]( const std::string & id ) {
             return ( index.defines_item && index.defines_item( id ) ) ||
                    ( check_engine_state && itype_id( id ).is_valid() );
         };


### PR DESCRIPTION
#### Summary

Build "Fix Clang builds failing on an unused lambda capture"

#### Responsible human

@LYHGLYTX

#### Purpose of change

The Linux Clang build triggered by #702 failed because `item_exists` captured `staged` without using it. With `-Werror`, Clang promoted `-Wunused-lambda-capture` to a compilation error.

Failing job: https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/actions/runs/33650843436/job/100318781476

#### Describe the solution

Remove the unused `&staged` entry from the `item_exists` lambda capture list. The shared `staged` helper remains in use by the subsequent catalog-validation lambdas.

#### Describe alternatives you've considered

Suppressing the warning or marking the capture unused would preserve dead code. Removing the accidental capture is smaller and leaves runtime behavior unchanged.

#### Testing

- `git diff --check`
- Successfully compiled the affected Lua-enabled translation unit with Clang 22, release flags, and `-Werror`:

  `make -j10 BUILD_PREFIX=ci-fix- RELEASE=1 CLANG=1 CATA_ENABLE_LUA_PLATFORM=1 TESTS=0 ASTYLE=0 LINTJSON=0 PCH=0 LOCALIZE=0 ci-fix-obj-lua/lua_platform_content_creatures.o`

- Output: `ci-fix-obj-lua/lua_platform_content_creatures.o`
- Full test suite was not run because this is a compile-only warning fix.

#### Documentation impact

None

#### Related CCB-Docs PR

None

#### Affected documentation IDs

None

#### Generated reference impact

None

#### Additional context

This failure was already present in the base branch and was unrelated to the butchery changes in #702.