### PR TITLE
Fix C++17 structured-binding captures in Lua requirements

### DIFF
--- a/src/lua_platform_content_items.cpp
+++ b/src/lua_platform_content_items.cpp
@@ -4299,7 +4299,9 @@ bool items_content_transaction::validate_scaled_requirement_set(
         scaled_requirement_groups scaled_component_groups;
         scaled_requirement_groups scaled_tool_groups;
         std::set<std::string> ids;
-        for( const auto &[id, count] : requirements ) {
+        for( const std::pair<std::string, std::int64_t> &requirement : requirements ) {
+            const std::string &id = requirement.first;
+            const std::int64_t count = requirement.second;
             if( id.empty() || id.size() > 256 || id.find( '\0' ) != std::string::npos ||
                 count <= 0 || count > std::numeric_limits<int>::max() ||
                 !ids.insert( id ).second ) {


### PR DESCRIPTION
#### Summary

Build "Keep Lua requirement scaling compatible with C++17 compilers"

#### Responsible human

@LYHGLYTX

#### Purpose of change

After #703 fixed the first Clang build blocker, the Linux and macOS matrix jobs progressed to `lua_platform_content_items.cpp` and failed because nested lambdas captured structured bindings. Capturing structured bindings is a C++20 feature, while CCB builds this code as C++17.

Failing run: https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/actions/runs/33653820250

#### Describe the solution

Iterate over each scaled requirement as an explicit `std::pair<std::string, std::int64_t>`, then bind `id` and `count` as ordinary local variables. The existing validation and scaling lambdas can capture those locals legally in C++17, with no runtime behavior change.

#### Describe alternatives you've considered

Suppressing `-Wc++20-extensions` would not help the oldest supported Clang, which rejects the capture names outright. Raising the project language level to C++20 would be a project-wide contract change and is unnecessary for this code.

#### Testing

- `git diff --check`
- Successfully compiled the affected Lua-enabled translation unit with Clang 22, Release, C++17, `-Werror`, and an explicit `-Werror=c++20-extensions` gate:

  `make -j10 BUILD_PREFIX=ci-cxx17- RELEASE=1 CLANG=1 CATA_ENABLE_LUA_PLATFORM=1 TESTS=0 ASTYLE=0 LINTJSON=0 PCH=0 LOCALIZE=0 OTHERS=-Werror=c++20-extensions ci-cxx17-obj-lua/lua_platform_content_items.o`

- Output: `ci-cxx17-obj-lua/lua_platform_content_items.o`
- Full tests were not run because this is a compile-only C++17 compatibility change.

#### Documentation impact

No documentation changes are required. This is a compiler-compatibility fix; Lua Platform behavior, authoring syntax, and public contracts are unchanged.

#### Related CCB-Docs PR

No CCB-Docs PR is required because no documented behavior or contract changes.

#### Affected documentation IDs

Reviewed `cpp.lua-bridge`, `architecture.lua-first-glossary`, and `architecture.lua-first-eoc-workflow`; none require updates for this compile-only fix.

#### Generated reference impact

No generated references are affected. Schema, LuaLS declarations, registrations, and generated inventories remain unchanged.

#### Additional context

The Clang-tidy, IWYU, and repository-wide AStyle findings exposed when directly changing these split Lua source files are existing file/repository debt and are outside this focused compiler fix.