### PR TITLE
fix(android): stop touch-only edge scrolling toward upper left

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2590,6 +2590,9 @@ std::pair<tripoint_rel_ms, tripoint_rel_ms> game::mouse_edge_scrolling( input_co
     ( void ) speed;
     ( void ) iso;
 #if !defined(TUI)
+    if( !is_mouse_active_for_edge_scrolling() ) {
+        return std::make_pair( tripoint_rel_ms::zero, tripoint_rel_ms::zero );
+    }
     std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
     if( now < last_mouse_edge_scroll + std::chrono::milliseconds( rate ) ) {
         return ret;

--- a/src/hover_mouse_input.h
+++ b/src/hover_mouse_input.h
@@ -1,0 +1,24 @@
+#pragma once
+#ifndef CATA_SRC_HOVER_MOUSE_INPUT_H
+#define CATA_SRC_HOVER_MOUSE_INPUT_H
+
+class hover_mouse_input_state
+{
+    public:
+        void activate() {
+            active_ = true;
+        }
+
+        void deactivate() {
+            active_ = false;
+        }
+
+        bool active() const {
+            return active_;
+        }
+
+    private:
+        bool active_ = false;
+};
+
+#endif // CATA_SRC_HOVER_MOUSE_INPUT_H

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -62,6 +62,7 @@
 #include "game_ui.h"
 #include "hash_utils.h"
 #include "horde_entity.h"
+#include "hover_mouse_input.h"
 #include "input.h"
 #include "input_context.h"
 #include "input_replay.h"
@@ -147,6 +148,9 @@ static bool needupdate = false;
 // Synthetic Android touch clicks carry their own coordinates.  Preserve them
 // instead of replacing them with the (usually stale) hardware mouse position.
 static bool last_input_has_explicit_mouse_pos = false;
+#if defined(__ANDROID__)
+static hover_mouse_input_state android_hover_mouse_input;
+#endif
 static bool need_invalidate_framebuffers = false;
 palette_array windowsPalette;
 
@@ -636,6 +640,9 @@ static Uint32 renderer_watch_window_id = 0;
 //Registers, creates, and shows the Window!!
 static void WinCreate()
 {
+#if defined(__ANDROID__)
+    android_hover_mouse_input.deactivate();
+#endif
     // Common flags used for windowed mode (fullscreen applied after creation)
     Uint32 window_flags = CATA_WINDOW_RESIZABLE | CATA_WINDOW_HIGH_DPI;
     WindowWidth = TERMINAL_WIDTH * fontwidth * scaling_factor;
@@ -876,6 +883,7 @@ static void WinDestroy()
     SDL_DelEventWatch( renderer_event_watch, &renderer_coordinator );
 #endif
 #if defined(__ANDROID__)
+    android_hover_mouse_input.deactivate();
     touch_joystick.reset();
 #endif
     imclient.reset();
@@ -1581,6 +1589,15 @@ void get_display_buffer_dims( int *w, int *h )
     if( h ) {
         *h = buf_h;
     }
+}
+
+bool is_mouse_active_for_edge_scrolling()
+{
+#if defined(__ANDROID__)
+    return android_hover_mouse_input.active();
+#else
+    return true;
+#endif
 }
 
 SDL_Point window_to_display_buffer_coords( SDL_Point window_pt )
@@ -6447,6 +6464,43 @@ static void CheckMessages()
     int imgui_buf_h = 0;
     get_display_buffer_dims( &imgui_buf_w, &imgui_buf_h );
     while( SDL_PollEvent( &ev ) ) {
+#if defined(__ANDROID__)
+        // Touchscreens do not provide a persistent hover position.  SDL's
+        // hardware mouse state remains at its default (usually 0, 0) on a
+        // touch-only device, so only real mouse input may enable timeout-based
+        // edge scrolling.  Switching back to touch also retires a stale
+        // external-mouse position until that mouse is used again.
+        if( IsWindowEvent( ev ) &&
+            GetWindowEventID( ev ) == CATA_WINDOWEVENT_FOCUS_LOST ) {
+            android_hover_mouse_input.deactivate();
+        } else if( ev.type == CATA_FINGERMOTION || ev.type == CATA_FINGERDOWN ||
+                   ev.type == CATA_FINGERUP ) {
+            android_hover_mouse_input.deactivate();
+        } else if( ev.type == CATA_MOUSEMOTION ) {
+            if( ev.motion.which == SDL_TOUCH_MOUSEID ) {
+                android_hover_mouse_input.deactivate();
+            } else {
+                android_hover_mouse_input.activate();
+            }
+        } else if( ev.type == CATA_MOUSEBUTTONDOWN || ev.type == CATA_MOUSEBUTTONUP ) {
+            if( ev.button.which == SDL_TOUCH_MOUSEID ) {
+                android_hover_mouse_input.deactivate();
+            } else {
+                android_hover_mouse_input.activate();
+            }
+        } else if( ev.type == CATA_MOUSEWHEEL ) {
+            if( ev.wheel.which == SDL_TOUCH_MOUSEID ) {
+                android_hover_mouse_input.deactivate();
+            } else {
+                android_hover_mouse_input.activate();
+            }
+        }
+#if SDL_MAJOR_VERSION >= 3
+        else if( ev.type == SDL_EVENT_MOUSE_REMOVED ) {
+            android_hover_mouse_input.deactivate();
+        }
+#endif
+#endif
         // Build a display_buffer-coord copy for ImGui and gameplay
         // consumers. The raw `ev` stays in window coordinates so android
         // shortcut and joystick hit-tests see the same domain SDL emitted.

--- a/src/sdltiles.h
+++ b/src/sdltiles.h
@@ -80,6 +80,11 @@ SDL_Window *get_sdl_window();
 // or android letterboxing. Zero before the buffer exists.
 void get_display_buffer_dims( int *w, int *h );
 
+// Whether a hover-capable mouse is the active Android pointer source.  Desktop
+// platforms always return true.  Touch input must not make an idle timeout look
+// like a mouse parked at SDL's default (0, 0) position.
+bool is_mouse_active_for_edge_scrolling();
+
 // Map window coordinates to display_buffer (terminal) pixel coordinates.
 // Returns the input unchanged when either dimension source is unavailable.
 SDL_Point window_to_display_buffer_coords( SDL_Point window_pt );

--- a/tests/hover_mouse_input_test.cpp
+++ b/tests/hover_mouse_input_test.cpp
@@ -1,0 +1,24 @@
+#include "catch/catch.hpp"
+
+#include "hover_mouse_input.h"
+
+TEST_CASE( "hover mouse input follows the active pointer source", "[input][mouse]" )
+{
+    hover_mouse_input_state state;
+
+    CHECK_FALSE( state.active() );
+
+    state.activate();
+    CHECK( state.active() );
+
+    SECTION( "touch input retires the last mouse position" ) {
+        state.deactivate();
+        CHECK_FALSE( state.active() );
+    }
+
+    SECTION( "a real mouse can become active again" ) {
+        state.deactivate();
+        state.activate();
+        CHECK( state.active() );
+    }
+}


### PR DESCRIPTION
#### Summary
Bugfixes "修复 Android 纯触摸设备进入大地图或观察界面后自动向左上角滚动"

#### Responsible human

@LYHGLYTX

#### Purpose of change

Android deliberately separates touch and mouse input. On a touch-only device, the SDL hardware mouse position can therefore remain at its default `(0, 0)`.

After timeout events began re-evaluating the sampled mouse position for desktop ImGui edge scrolling, entering the overmap or the `x` look-around UI with edge scrolling enabled repeatedly interpreted `(0, 0)` as the top-left edge and moved the view northwest.

Reproduction:

1. Run the Android build on a touch-only device with edge scrolling enabled.
2. Enter the overmap or press `x` to look around.
3. Leave the screen idle.
4. The cursor/view scrolls toward the upper-left corner.

#### Describe the solution

Track whether a hover-capable mouse is the active Android pointer source.

- Real SDL mouse motion, button, or wheel events activate hover edge scrolling.
- Touch events, focus loss, and mouse removal deactivate it.
- When no hover mouse is active, edge scrolling returns a zero vector and clears the previous direction.
- Desktop behavior remains unchanged, preserving timeout-driven scrolling while ImGui captures mouse motion.
- Android USB/Bluetooth mice remain supported and become active again on their next real mouse event.

A focused state regression test covers initial inactivity, touch deactivation, and mouse reactivation.

#### Describe alternatives you've considered

- Re-centering SDL's default mouse coordinates would hide the invalid-pointer state and prevent legitimate edge scrolling.
- Reverting timeout position checks globally would reintroduce the desktop ImGui-sidebar regression.
- Disabling Android edge scrolling entirely would unnecessarily break external mouse support.

#### Testing

- `git diff --check`
- Focused Catch test: `[input][mouse]` — 1 test case, 6 assertions passed.
- Android arm64 Stable Release build:
  `./gradlew --no-daemon --console=plain -Pj=8 -Pabi_arm_32=false -Pabi_arm_64=true -Pabi_x86_32=false -Pabi_x86_64=false :app:assembleStableRelease`
  — BUILD SUCCESSFUL in 20m 11s.
- Verified the APK contains `lib/arm64-v8a/libmain.so` and no other `libmain.so` ABI.

Not run: installation/manual touch-device smoke test. The generated APK is unsigned.

#### Documentation impact

None

#### Related CCB-Docs PR

None

#### Affected documentation IDs

None

#### Generated reference impact

None

#### Additional context

The fix intentionally treats the most recently used Android pointer source as authoritative: switching from an external mouse back to touch retires the stale hardware mouse position until the mouse is used again.
