### PR TITLE
Allow the `extract_effect` mods module of effects to affect focus

### DIFF
--- a/doc/JSON/EFFECTS_JSON.md
+++ b/doc/JSON/EFFECTS_JSON.md
@@ -542,6 +542,15 @@ Valid arguments:
 "stim_chance_bot"
 "stim_tick"         // Defaults to every tick
 
+"focus_amount"      // Amount of focus it can give/take. Affects the focus stat, which is used in crafting and studying.
+"focus_min"         // Minimal amount of focus, certain effect will give/take
+"focus_max"         // if 0 or missing value will be exactly "focus_min"
+"focus_min_val"     // Defaults to 0, which means uncapped
+"focus_max_val"     // Defaults to 0, which means uncapped
+"focus_chance"      // Chance to change focus
+"focus_chance_bot"
+"focus_tick"        // Defaults to every tick
+
 "health_amount"     // Negatives decrease health and positives increase it. It's semi-hidden stat, which affects healing.
 "health_min"        // Minimal amount of health, certain effect will give/take.
 "health_max"        // if 0 or missing value will be exactly "health_min"

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7005,6 +7005,16 @@ void Character::process_one_effect( effect &it, bool is_new )
         }
     }
 
+    // Handle focus
+    val = get_effect( "FOCUS", reduced );
+    if( val != 0 ) {
+        mod = 1;
+        if( is_new || it.activated( calendar::turn, "FOCUS", val, reduced, mod ) ) {
+            mod_focus( bound_mod_to_vals( get_focus(), val, it.get_max_val( "FOCUS", reduced ),
+                                          it.get_min_val( "FOCUS", reduced ) ) );
+        }
+    }
+
     // Handle Radiation
     val = get_effect( "RAD", reduced );
     if( val != 0 ) {

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -426,6 +426,18 @@ void effect_type::load_mod_data( const JsonObject &j )
         {"stim_tick",        mod_action::TICK},
     } );
 
+    // Then focus
+    extract_effect( to_extract, "FOCUS", {
+        {"focus_amount",      mod_action::AMOUNT},
+        {"focus_min",         mod_action::MIN},
+        {"focus_max",         mod_action::MAX},
+        {"focus_min_val",     mod_action::MIN_VAL},
+        {"focus_max_val",     mod_action::MAX_VAL},
+        {"focus_chance",      mod_action::CHANCE_TOP},
+        {"focus_chance_bot",  mod_action::CHANCE_BOT},
+        {"focus_tick",        mod_action::TICK},
+    } );
+
     // Then health
     extract_effect( to_extract, "HEALTH", {
         {"health_amount",      mod_action::AMOUNT},

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -976,6 +976,9 @@ std::string effect::disp_desc( bool reduced ) const
     val = get_avg_mod( "SLEEPINESS", reduced );
     values.emplace_back( get_percentage( "SLEEPINESS", val, reduced ), val, _( "sleepiness" ),
                          _( "rest" ) );
+    val = get_avg_mod( "FOCUS", reduced );
+    values.emplace_back( get_percentage( "FOCUS", val, reduced ), val, _( "focus" ),
+                         _( "distraction" ) );
     val = get_avg_mod( "COUGH", reduced );
     values.emplace_back( get_percentage( "COUGH", val, reduced ), val, _( "coughing" ),
                          _( "coughing" ) );


### PR DESCRIPTION
#### Summary
Features "Allow the `extract_effect` mods module of effects to affect focus"

#### Purpose of change
Some basic infrastructure work for mod extensibility (as described in issue #44).

It is also one of the preparatory changes for migrating the effects of alcohol, caffeine, and nicotine from the `sitm` module to vitamins, which I mentioned in PR #688.

#### Describe the solution
Add the relevant implementation to `load_mod_data` in `src/effect.cpp` and `process_one_effect` in `src/character.cpp`.