### PR TITLE
fix(ci): target repository for Candidate dispatch

### DIFF
--- a/.github/workflows/bootstrap-ccb-candidate.yml
+++ b/.github/workflows/bootstrap-ccb-candidate.yml
@@ -19,6 +19,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh workflow run release.yml --ref master \
+          gh workflow run release.yml \
+            --repo CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb \
+            --ref master \
             -f channel=candidate \
             -f version=0.Ag


### PR DESCRIPTION
The one-time Candidate bootstrap has the correct `actions: write` permission, but its first run had no checkout and therefore `gh` could not infer a repository. Pass the repository explicitly so it can dispatch `release.yml` with `channel=candidate` and `version=0.Ag`.

This path only triggers the bootstrap workflow, not another Experimental release.