### PR TITLE
fix(ci): isolate release channel concurrency

### DIFF
--- a/.github/workflows/bootstrap-ccb-candidate.yml
+++ b/.github/workflows/bootstrap-ccb-candidate.yml
@@ -1,0 +1,26 @@
+name: Bootstrap 0.Ag Candidate
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/bootstrap-ccb-candidate.yml'
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch the first 0.Ag Candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run release.yml \
+            --repo CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb \
+            --ref master \
+            -f channel=candidate \
+            -f version=0.Ag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
 name: "Experimental Release"
-concurrency: release
+concurrency:
+  group: release-${{ github.event_name == 'workflow_dispatch' && inputs.channel || 'experimental' }}
+  cancel-in-progress: false
 on:
   push:
     branches:


### PR DESCRIPTION
## Problem

GitHub keeps at most one pending run per concurrency group. A routine Experimental push arrived while the first Candidate was pending and cancelled it.

## Fix

- use one concurrency group per requested release channel
- keep `cancel-in-progress: false`
- re-add the corrected one-time `0.Ag Candidate` dispatcher

Candidate and Stable releases can no longer be displaced by a later Experimental push. The one-time dispatcher will be removed as soon as the Candidate run starts.