### PR TITLE
fix(ui): 修复车辆预览缩放后的居中偏移

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -4532,7 +4532,13 @@ bool cata_tiles::draw_vehicle_preview( const catacurses::window &w_disp, const v
     // This temporarily rescales the shared tile context. cata_tiles::draw() does not reset
     // the scale every frame, so we must restore it before returning or the map would stay
     // at the preview scale.
+    restore_on_out_of_scope restore_origin( o );
+    restore_on_out_of_scope restore_pixel_origin( op );
+    restore_on_out_of_scope restore_entity_offset( m_entity_draw_offset );
     const int saved_zoom = g->get_zoom();
+    on_out_of_scope restore_scale( [this, saved_zoom]() {
+        set_draw_scale( saved_zoom );
+    } );
     // Fixed preview scale (16 == native tile size). Lower it to fit more of large vehicles.
     constexpr int preview_scale = 16;
     set_draw_scale( preview_scale );
@@ -4540,8 +4546,10 @@ bool cata_tiles::draw_vehicle_preview( const catacurses::window &w_disp, const v
     // Target window rectangle, in screen pixels.
     const window_dimensions dim = get_window_dimensions( w_disp );
     const point win_px_beg = dim.window_pos_pixel;
-    const point win_px_size = dim.window_size_pixel;
-    const point center_px = win_px_beg + win_px_size / 2;
+    // This panel is drawn into the logical display buffer. Generic window
+    // dimensions include UI scaling in their size, but not their position.
+    const point win_px_size = dim.window_size_pixel / get_scaling_factor();
+    const point center_px = win_px_beg + ( win_px_size - point( tile_width, tile_height ) ) / 2;
 
     // Repurpose the draw origin so a synthetic tile coordinate maps straight to a screen
     // pixel: player_to_screen( pos ) == op + ( pos - o ) * { tile_width, tile_height } in the
@@ -4549,8 +4557,15 @@ bool cata_tiles::draw_vehicle_preview( const catacurses::window &w_disp, const v
     // lands at the centre, where the cursor part is drawn.
     o = point::zero;
     op = center_px;
+    m_entity_draw_offset = point::zero;
 
     // Clip to the panel so an oversized vehicle does not bleed into neighbouring windows.
+    const bool had_clip = RenderIsClipEnabled( renderer );
+    SDL_Rect saved_clip;
+    RenderGetClipRect( renderer, &saved_clip );
+    on_out_of_scope restore_clip( [this, had_clip, saved_clip]() {
+        RenderSetClipRect( renderer, had_clip ? &saved_clip : nullptr );
+    } );
     const SDL_Rect clip{ win_px_beg.x, win_px_beg.y, win_px_size.x, win_px_size.y };
     RenderSetClipRect( renderer, &clip );
 
@@ -4595,9 +4610,6 @@ bool cata_tiles::draw_vehicle_preview( const catacurses::window &w_disp, const v
     draw_from_id_string( "cursor", tripoint_bub_ms( tripoint::zero ), 0, 0, lit_level::LIT,
                          false );
 
-    // Restore the clip rectangle and the map draw scale.
-    RenderSetClipRect( renderer, nullptr );
-    set_draw_scale( saved_zoom );
     return true;
 }
 


### PR DESCRIPTION
#### Summary
Bugfixes "修复车辆预览缩放后的居中偏移"

#### Responsible human
@LYHGLYTX

#### Purpose of change
车辆页面的预览在较大 UI 缩放下偏向右侧，预览绘制还会复用地图绘制状态。

#### Describe the solution
将预览窗口大小换算回逻辑显示坐标，以中心格的中心对齐窗口中心；通过作用域恢复原点、实体偏移、缩放与裁剪状态。

#### Describe alternatives you've considered
None

#### Testing
Linux SDL2 的 cata_tiles.cpp 和 Android arm64 SDL3 的同一文件目标编译通过。改动行格式检查与 git diff --check 通过。未完成界面视觉验收；建议在不同 UI 缩放和地图缩放下打开车辆页面检查居中与返回地图后的显示。

各独立分支的 CI 状态以当前 PR 检查为准。

#### Documentation impact
None — 修复现有行为，不改变公共 API、数据格式或构建契约。

#### Related CCB-Docs PR
None

#### Affected documentation IDs
None

#### Generated reference impact
None

#### Additional context
从最新 `origin/master` 独立建立，仅包含本修复及对应测试，可独立合并。
