### PR TITLE
fix(monster): 正常拒绝不可见目标攻击并消除跨层误报

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2243,7 +2243,9 @@ bool monster::melee_attack( Creature &target, float accuracy )
         return false;
     }
     if( !sees( here, target ) && !target.is_hallucination() ) {
-        debugmsg( "Z-Level view violation: %s tried to attack %s.", disp_name(), target.disp_name() );
+        // Adjacency does not guarantee visibility: stairs can connect tiles
+        // without line of sight, and a target can be invisible. A rejected
+        // attack is an ordinary AI outcome, with its move cost paid above.
         return false;
     }
     // Prevent monsters from attacking THROUGH terrain if they are submerged under it & target isn't.

--- a/tests/monster_melee_visibility_test.cpp
+++ b/tests/monster_melee_visibility_test.cpp
@@ -1,0 +1,30 @@
+#include "calendar.h"
+#include "cata_catch.h"
+#include "coordinates.h"
+#include "debug.h"
+#include "game.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "map_helpers_tests.h"
+#include "monster.h"
+#include "mtype.h"
+#include "point.h"
+#include "type_id.h"
+
+TEST_CASE( "rejected_monster_melee_is_not_a_debug_error", "[monster][regression]" )
+{
+    clear_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    monster &attacker = spawn_test_monster( "mon_zombie", origin );
+    monster &target = spawn_test_monster( "mon_zombie", origin + tripoint::east );
+    target.add_effect( efftype_id( "invisibility" ), 1_hours );
+    REQUIRE( attacker.is_adjacent( &target, true ) );
+    REQUIRE_FALSE( attacker.sees( get_map(), target ) );
+    const int hp = target.get_hp();
+    const int moves = attacker.get_moves();
+    CHECK( capture_debugmsg_during( [&]() {
+        CHECK_FALSE( attacker.melee_attack( target ) );
+    } ).empty() );
+    CHECK( target.get_hp() == hp );
+    CHECK( attacker.get_moves() == moves - attacker.type->attack_cost );
+}


### PR DESCRIPTION
#### Summary
Bugfixes "正常拒绝不可见目标攻击并消除跨层误报"

#### Responsible human
@LYHGLYTX

#### Purpose of change
怪物与目标相邻但不可见时，普通攻击拒绝被报告为 Z-Level view violation；跨层楼梯和隐身目标都可能遇到。

#### Describe the solution
保留相邻、视线和穿透地形限制，视线不足时正常拒绝并消耗原有行动点；移除这一正常结果的调试弹窗。

#### Describe alternatives you've considered
None

#### Testing
新增 rejected_monster_melee_is_not_a_debug_error 回归通过，检查不造成伤害、保留行动点消耗且不弹调试错误。既有 monster_attack 测试通过，覆盖楼梯、楼板、天花板和悬崖。Linux 核心代码及 Android arm64 目标编译通过。

本地回归在本轮修复合集的 Linux 无 Lua 配置上运行，随机种子为 `1788590000`。拆分后的四个测试文件独立编译通过，并重跑五项新增回归，共 41 个断言通过。各独立分支的 CI 状态以当前 PR 检查为准。

#### Documentation impact
None — 修复现有行为，不改变公共 API、数据格式或构建契约。

#### Related CCB-Docs PR
None

#### Affected documentation IDs
None

#### Generated reference impact
None

#### Additional context
从最新 `origin/master` 独立建立，仅包含本修复及对应测试，可独立合并。
