### PR TITLE
fix(vehicle): 修复飞艇登乘状态、地板支撑及电网越界

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1954,6 +1954,10 @@ void map::board_vehicle( const tripoint_bub_ms &pos, Character *p )
     }
     if( vp->part().has_flag( vp_flag::passenger_flag ) ) {
         Character *psg = vp->vehicle().get_passenger( vp->part_index() );
+        if( psg == p && p->pos_abs() == get_abs( pos ) ) {
+            p->in_vehicle = true;
+            return;
+        }
         debugmsg( "map::board_vehicle: %s failed to board passenger (%s) is already there",
                   p ? p->get_name() : "<null_boarder>",
                   psg ? psg->get_name() : "<null_passenger>" );
@@ -1963,8 +1967,8 @@ void map::board_vehicle( const tripoint_bub_ms &pos, Character *p )
     vp->part().passenger_id = p->getID();
     vp->vehicle().invalidate_mass();
 
-    p->setpos( *this, pos );
     p->in_vehicle = true;
+    p->setpos( *this, pos );
     if( p->is_avatar() ) {
         g->update_map( *p->as_avatar() );
     }
@@ -7452,10 +7456,19 @@ void map::process_items_in_submap( submap &current_submap, const tripoint_rel_sm
 std::vector<item_reference> map::item_network_connections( vehicle *power_grid )
 {
     std::vector<item_reference> result;
+    update_submaps_with_active_items();
     for( const auto &iter : submaps_with_active_items ) {
         tripoint_abs_sm const abs_pos = iter;
+        // Shifting the bubble leaves old entries until process_items prunes
+        // them. Appliance merging can run before that next processing pass.
+        if( !inbounds( project_to<coords::ms>( abs_pos ) ) ) {
+            continue;
+        }
         const tripoint_rel_sm local_pos = abs_pos - abs_sub.xy();
         submap *const current_submap = get_submap_at_grid( local_pos );
+        if( current_submap == nullptr ) {
+            continue;
+        }
         std::vector<item_reference> active_items = current_submap->active_items.get_for_processing();
         for( item_reference &active_item_ref : active_items ) {
             if( !active_item_ref.item_ref ) {
@@ -12339,6 +12352,12 @@ void map::maybe_trigger_prox_trap( const tripoint_bub_ms &pos, Creature &c,
 bool map::try_fall( const tripoint_bub_ms &p, Creature *c )
 {
     if( c == nullptr ) {
+        return false;
+    }
+    // A character moving between seats is temporarily unboarded. Vehicle
+    // support still prevents falling, including the zero-height case which
+    // would otherwise push a monster below aside and drop through the deck.
+    if( has_vehicle_floor( p ) ) {
         return false;
     }
 

--- a/tests/airship_state_regression_test.cpp
+++ b/tests/airship_state_regression_test.cpp
@@ -1,0 +1,73 @@
+#include "avatar.h"
+#include "cata_catch.h"
+#include "cata_scope_helpers.h"
+#include "coordinates.h"
+#include "debug.h"
+#include "game.h"
+#include "item.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "map_helpers_tests.h"
+#include "player_helpers.h"
+#include "point.h"
+#include "type_id.h"
+#include "units.h"
+#include "vehicle.h"
+#include "vpart_position.h"
+#include "vpart_range.h"
+
+TEST_CASE( "airborne_vehicle_supports_unboarded_character_above_monster", "[vehicle][regression]" )
+{
+    clear_map( -2, 1 );
+    clear_avatar();
+    map &here = get_map();
+    avatar &you = get_avatar();
+    const tripoint_bub_ms seat( 60, 60, 1 );
+    here.vertical_shift( seat.z() );
+    on_out_of_scope restore_level( [&]() {
+        here.vertical_shift( 0 );
+        clear_map( -2, 1 );
+    } );
+    here.ter_set( seat, ter_id( "t_open_air" ) );
+    vehicle *veh = here.add_vehicle( vproto_id( "bicycle" ), seat, 0_degrees, 0,
+                                     veh_spawn_status::UNDAMAGED );
+    REQUIRE( veh != nullptr );
+    REQUIRE( here.has_vehicle_floor( seat ) );
+    // Moving between vehicle parts temporarily clears in_vehicle.
+    you.setpos( here, seat, false );
+    spawn_test_monster( "mon_zombie", seat + tripoint::below );
+    REQUIRE_FALSE( you.in_vehicle );
+    const tripoint_abs_ms original = you.pos_abs();
+    CHECK_FALSE( here.try_fall( seat, &you ) );
+    CHECK( you.pos_abs() == original );
+    here.board_vehicle( seat, &you );
+    you.controlling_vehicle = true;
+    CHECK( capture_debugmsg_during( [&]() {
+        here.board_vehicle( seat, &you );
+    } ).empty() );
+    CHECK( you.controlling_vehicle );
+    CHECK( veh->is_passenger( you ) );
+    here.unboard_vehicle( you.pos_bub() );
+    you.setpos( here, tripoint_bub_ms( 61, 60, 0 ) );
+}
+
+TEST_CASE( "appliance_connections_skip_submaps_left_behind_by_shift", "[map][vehicle][regression]" )
+{
+    clear_map();
+    map &here = get_map();
+    const tripoint_bub_ms edge( 6, 0, 0 );
+    here.add_item( edge, item( itype_id( "disinfectant" ) ) );
+    here.update_submaps_with_active_items();
+    const tripoint_abs_sm old_submap = project_to<coords::sm>( here.get_abs( edge ) );
+    REQUIRE( here.get_submaps_with_active_items().count( old_submap ) == 1 );
+    here.shift( point_rel_sm( 0, 1 ) );
+    on_out_of_scope restore_map( [&]() {
+        here.shift( point_rel_sm( 0, -1 ) );
+        clear_map();
+    } );
+    REQUIRE_FALSE( here.inbounds( project_to<coords::ms>( old_submap ) ) );
+    vehicle grid( vproto_id( "none" ) );
+    CHECK( capture_debugmsg_during( [&]() {
+        CHECK( here.item_network_connections( &grid ).empty() );
+    } ).empty() );
+}


### PR DESCRIPTION
#### Summary
Bugfixes "修复飞艇登乘状态、地板支撑及电网越界"

#### Responsible human
@LYHGLYTX

#### Purpose of change
飞艇日志包含同一乘客重复登乘、乘客状态丢失，以及合并电网时访问已移出现实气泡的子地图。载具地板下方有怪物时，临时离座还可能错误触发零高度坠落逻辑。

#### Describe the solution
在设置角色位置前完成登乘标记；重复登乘同一座位保持驾驶状态。载具地板阻止错误坠落。电网连接扫描刷新活跃物品缓存，并跳过气泡外或未加载的子地图。

#### Describe alternatives you've considered
None

#### Testing
新增 airborne_vehicle_supports_unboarded_character_above_monster 和 appliance_connections_skip_submaps_left_behind_by_shift 回归通过。既有飞艇梯子拉拽保护、拆除载具解除乘客状态测试通过。Linux map.cpp 与 Android arm64 目标编译通过。未使用报告者的实际飞艇存档做整局复测。

本地回归在本轮修复合集的 Linux 无 Lua 配置上运行，随机种子为 `1788590000`。拆分后的四个测试文件独立编译通过，并重跑五项新增回归，共 41 个断言通过。各独立分支的 CI 状态以当前 PR 检查为准。

#### Documentation impact
None — 修复现有行为，不改变公共 API、数据格式或构建契约。

#### Related CCB-Docs PR
None

#### Affected documentation IDs
None

#### Generated reference impact
None

#### Additional context
从最新 `origin/master` 独立建立，仅包含本修复及对应测试，可独立合并。
