### PR TITLE
fix(save): 防止安卓后台快速保存写入未加载会话或重复进入

### DIFF
--- a/src/game_io.cpp
+++ b/src/game_io.cpp
@@ -811,8 +811,17 @@ bool game::save_external_options_record()
     return saved_externals;
 }
 
+// Saving can pump UI events. These guards cover nested callbacks even if a
+// callback tries to enter through a different save entry point.
+static bool save_in_progress = false;
+
 bool game::save()
 {
+    if( save_in_progress ) {
+        return false;
+    }
+    restore_on_out_of_scope restore_saving( save_in_progress );
+    save_in_progress = true;
     // total_time_played accumulates real wall-clock seconds, which is inherently
     // non-deterministic. Under input replay we freeze the delta at 0 so the
     // persisted playtime (written to both .pt and the character .sav) is
@@ -997,6 +1006,16 @@ void game::init_autosave()
 
 void game::quicksave()
 {
+    static bool quicksave_in_progress = false;
+    // Android can pump focus events from loading screens and save popups.
+    // Only save a running session, never a half-loaded avatar/map or a save
+    // already in progress. Check this here so every quicksave caller is safe.
+    if( !world_generator || !world_generator->active_world || new_game ||
+        !should_draw || uquit != QUIT_NO || save_in_progress || quicksave_in_progress ) {
+        return;
+    }
+    restore_on_out_of_scope restore_quicksaving( quicksave_in_progress );
+    quicksave_in_progress = true;
     //Don't autosave if the player hasn't done anything since the last autosave/quicksave,
     if( !moves_since_last_save && !world_generator->active_world->world_saves.empty() ) {
         return;
@@ -1012,7 +1031,9 @@ void game::quicksave()
     time_t now = std::time( nullptr ); //timestamp for start of saving procedure
 
     //perform save
-    save();
+    if( !save() ) {
+        return;
+    }
     //Now reset counters for autosaving, so we don't immediately autosave after a quicksave or autosave.
     moves_since_last_save = 0;
     last_save_timestamp = now;

--- a/tests/quicksave_session_test.cpp
+++ b/tests/quicksave_session_test.cpp
@@ -1,0 +1,42 @@
+#include "cata_catch.h"
+#include "cata_scope_helpers.h"
+#include "debug.h"
+#include "event.h"
+#include "event_bus.h"
+#include "event_subscriber.h"
+#include "game.h"
+#include "worldfactory.h"
+
+namespace
+{
+struct save_observer : event_subscriber {
+    using event_subscriber::notify;
+    void notify( const cata::event &e ) override {
+        if( e.type() == event_type::game_save ) {
+            ++saves;
+        }
+    }
+    int saves = 0;
+};
+} // namespace
+
+TEST_CASE( "quicksave_ignores_a_session_still_loading", "[save][regression]" )
+{
+    REQUIRE( world_generator != nullptr );
+    REQUIRE( world_generator->active_world != nullptr );
+    restore_on_out_of_scope restore_saves( world_generator->active_world->world_saves );
+    world_generator->active_world->world_saves.clear();
+    restore_on_out_of_scope restore_should_draw( g->should_draw );
+    restore_on_out_of_scope restore_quit( g->uquit );
+    restore_on_out_of_scope restore_new_game( g->new_game );
+    g->should_draw = true;
+    g->uquit = QUIT_NO;
+    g->new_game = true;
+    save_observer observer;
+    get_event_bus().subscribe( &observer );
+    CHECK( capture_debugmsg_during( []() {
+        g->quicksave();
+    } ).empty() );
+    CHECK( observer.saves == 0 );
+    CHECK( world_generator->active_world->world_saves.empty() );
+}


### PR DESCRIPTION
#### Summary
Bugfixes "防止安卓后台快速保存写入未加载会话或重复进入"

#### Responsible human
@LYHGLYTX

#### Purpose of change
Android 切换到其他应用时会触发快速保存；加载界面及保存弹窗也会处理窗口事件，可能在角色尚未加载完整时保存，或嵌套进入保存。

#### Describe the solution
快速保存只接受可运行的会话，排除加载、重载、退出和保存中的状态；为保存及快速保存设置作用域重入保护。保存失败时保留脏状态与原保存时间。

#### Describe alternatives you've considered
None

#### Testing
新增 quicksave_ignores_a_session_still_loading 回归通过，检查加载阶段不发出保存事件，也不登记新存档。Linux game_io.cpp 与 Android arm64 目标编译通过。未进行 Android 真机后台切换复测；本 PR 修复不安全保存路径，尚不能据此确认所有返回主菜单情形均已消失。

本地回归在本轮修复合集的 Linux 无 Lua 配置上运行，随机种子为 `1788590000`。拆分后的四个测试文件独立编译通过，并重跑五项新增回归，共 41 个断言通过。各独立分支的 CI 状态以当前 PR 检查为准。

#### Documentation impact
None — 修复现有行为，不改变公共 API、数据格式或构建契约。

#### Related CCB-Docs PR
None

#### Affected documentation IDs
None

#### Generated reference impact
None

#### Additional context
从最新 `origin/master` 独立建立，仅包含本修复及对应测试，可独立合并。
