### PR TITLE
fix(npc): 延迟读档时的人格特质更新以避免访问未加载地图

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -873,6 +873,8 @@ void npc::generate_personality_traits()
                 ( required->min_collector <= ur.collector && ur.collector <= required->max_collector ) &&
                 ( required->min_altruism <= ur.altruism && ur.altruism <= required->max_altruism ) ) {
                 set_mutation( mdata.id );
+            } else if( has_trait( mdata.id ) ) {
+                unset_mutation( mdata.id );
             }
         }
     }
@@ -3593,6 +3595,10 @@ void npc::npc_update_body()
 
 void npc::on_load( map *here )
 {
+    // Reconcile only changed traits; an unchanged personality must not
+    // repeatedly activate passive enchantments when re-entering the bubble.
+    generate_personality_traits();
+
     const auto advance_effects = [&]( const time_duration & elapsed_dur ) {
         for( auto &elem : *effects ) {
             for( auto &_effect_it : elem.second ) {

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2403,8 +2403,9 @@ void npc::load( const JsonObject &data )
         platform_identity_generation_ = loaded_platform_identity_generation;
         reserve_platform_npc_identity_generation( platform_identity_generation_ );
     }
-    clear_personality_traits();
-    generate_personality_traits();
+    // Personality reconciliation uses live mutation changes, which can emit
+    // fields or cast passive spells. Defer it to on_load(), after placement
+    // in the fully loaded reality bubble; overmap deserialization is too early.
     data.read( "may_activity_occupancy_after_end_items_loc",
                may_activity_occupancy_after_end_items_loc );
 }

--- a/tests/npc_load_enchantment_test.cpp
+++ b/tests/npc_load_enchantment_test.cpp
@@ -1,0 +1,42 @@
+#include <sstream>
+#include <string>
+
+#include "cata_catch.h"
+#include "coordinates.h"
+#include "current_map.h"
+#include "debug.h"
+#include "game.h"
+#include "json.h"
+#include "json_loader.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "map_helpers_tests.h"
+#include "npc.h"
+#include "point.h"
+#include "type_id.h"
+
+TEST_CASE( "npc_deserialization_does_not_require_loaded_terrain", "[npc][regression]" )
+{
+    clear_map( -4, 0 );
+    npc original;
+    original.randomize();
+    original.setpos( get_map(), tripoint_bub_ms( 59, 106, -4 ), false );
+    // This mutation supplies a passive field emitter, like Magiclysm auras.
+    // Rebuilding personality traits must not activate it during deserialization.
+    original.personality.aggression = 10;
+    original.set_mutation( trait_id( "TEST_ENCH_MUTATION" ) );
+    map unloaded;
+    original.set_pos_abs_only( unloaded.get_abs( tripoint_bub_ms( 59, 106, -4 ) ) );
+    std::ostringstream saved;
+    JsonOut out( saved );
+    original.serialize( out );
+    npc restored;
+    swap_map use_unloaded_map( unloaded );
+    REQUIRE( unloaded.inbounds( original.pos_abs() ) );
+    const std::string errors = capture_debugmsg_during( [&]() {
+        restored.deserialize( json_loader::from_string( saved.str() ).get_object() );
+    } );
+    INFO( errors );
+    CHECK( errors.empty() );
+    CHECK( restored.pos_abs() == original.pos_abs() );
+}


### PR DESCRIPTION
#### Summary
Bugfixes "延迟读档时的人格特质更新以避免访问未加载地图"

#### Responsible human
@LYHGLYTX

#### Purpose of change
带被动附魔的 NPC 在反序列化阶段重新生成特质，会激活场效果并访问尚未加载的地图，对应 NPC 密集区域读档时的 submap is not loaded 报错。

#### Describe the solution
将人格特质协调移到 NPC 放置到已加载地图后的 on_load，并仅增删实际变化的特质，避免反复触发未变化特质的被动效果。

#### Describe alternatives you've considered
None

#### Testing
新增 npc_deserialization_does_not_require_loaded_terrain 回归通过。使用修复前的 savegame_json.cpp 构建隔离对照，复现 Tried to process terrain at (11,10) but the submap is not loaded；修复后同一测试通过。既有 mutation_enchantments 与 on_load_migrates_legacy_camp_npcs 通过。Linux 和 Android arm64 相关文件编译通过。尚未载入报告者原始 mod 存档复测。

本地回归在本轮修复合集的 Linux 无 Lua 配置上运行，随机种子为 `1788590000`。拆分后的四个测试文件独立编译通过，并重跑五项新增回归，共 41 个断言通过。各独立分支的 CI 状态以当前 PR 检查为准。

#### Documentation impact
None — 修复现有行为，不改变公共 API、数据格式或构建契约。

#### Related CCB-Docs PR
None

#### Affected documentation IDs
None

#### Generated reference impact
None

#### Additional context
从最新 `origin/master` 独立建立，仅包含本修复及对应测试，可独立合并。
