### PR TITLE
fix(magic): 修复反重力跳跃误触发悬崖菜单并遁入地下

### DIFF
--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1937,8 +1937,13 @@ void spell_effect::bash( const spell &sp, Creature &caster, const tripoint_bub_m
 void spell_effect::dash( const spell &sp, Creature &caster, const tripoint_bub_ms &target )
 {
     const tripoint_bub_ms source = caster.pos_bub();
+    if( source == target ) {
+        return;
+    }
     const std::vector<tripoint_bub_ms> trajectory_local = line_to( source, target );
     ::map &here = get_map();
+    const tripoint_abs_ms source_abs = caster.pos_abs();
+    const units::angle direction = coord_to_angle( source, target );
     // uses abs() coordinates
     std::vector<tripoint_abs_ms> trajectory;
     trajectory.reserve( trajectory_local.size() );
@@ -1946,43 +1951,43 @@ void spell_effect::dash( const spell &sp, Creature &caster, const tripoint_bub_m
         trajectory.push_back( here.get_abs( local_point ) );
     }
     avatar *caster_you = caster.as_avatar();
-    auto walk_point = trajectory.begin();
-    if( here.get_bub( *walk_point ) == source ) {
-        ++walk_point;
-    }
+    tripoint_abs_ms last_reached = source_abs;
     // save the amount of moves the caster has so we can restore them after the dash
     const int cur_moves = caster.get_moves();
     creature_tracker &creatures = get_creature_tracker();
-    while( walk_point != trajectory.end() ) {
+    for( const tripoint_abs_ms &step : trajectory ) {
         if( caster_you != nullptr ) {
-            if( creatures.creature_at( here.get_bub( *walk_point ) ) ||
-                !g->walk_move( here.get_bub( *walk_point ), false ) ) {
-                if( walk_point != trajectory.begin() ) {
-                    --walk_point;
-                }
+            const tripoint_bub_ms next = here.get_bub( step );
+            if( !here.inbounds( next ) ||
+                !here.valid_move( here.get_bub( last_reached ), next, false, true ) ||
+                creatures.creature_at( next ) ) {
                 break;
-            } else if( walk_point != trajectory.begin() ) {
-                sp.create_field( here.get_bub( *( walk_point - 1 ) ), caster );
-                g->draw_ter();
+            } else if( last_reached != source_abs ) {
+                sp.create_field( here.get_bub( last_reached ), caster );
             }
         }
-        ++walk_point;
+        last_reached = step;
     }
-    if( walk_point == trajectory.end() ) {
-        // we want the last tripoint in the actually reached trajectory
-        --walk_point;
+    if( caster_you != nullptr && last_reached != source_abs ) {
+        // A leap crosses unsupported tiles in flight. Walking each tile opens
+        // the ledge menu, whose climb action can move the caster off the path
+        // before the remaining steps run. Apply gravity and landing effects
+        // only at the reachable endpoint, using the normal placement routine.
+        g->place_player( here.get_bub( last_reached ), true );
+        g->draw_ter();
     }
     caster.set_moves( cur_moves );
 
     tripoint_bub_ms far_target;
-    calc_ray_end( coord_to_angle( source, target ), sp.aoe( caster ),
-                  here.get_bub( *walk_point ),
+    calc_ray_end( direction, sp.aoe( caster ),
+                  caster_you != nullptr ? caster.pos_bub() : here.get_bub( last_reached ),
                   far_target );
 
     spell_effect::override_parameters params( sp, caster );
     params.range = sp.aoe( caster );
-    const std::set<tripoint_bub_ms> hit_area = spell_effect_cone_range_override( params, source,
-            far_target );
+    const std::set<tripoint_bub_ms> hit_area = spell_effect_cone_range_override( params,
+        here.get_bub( source_abs ),
+        far_target );
     damage_targets( sp, caster, hit_area );
 }
 

--- a/tests/spell_dash_movement_test.cpp
+++ b/tests/spell_dash_movement_test.cpp
@@ -1,0 +1,104 @@
+#include <string>
+
+#include "avatar.h"
+#include "cata_catch.h"
+#include "cata_scope_helpers.h"
+#include "coordinates.h"
+#include "debug.h"
+#include "game.h"
+#include "magic.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "player_helpers.h"
+#include "point.h"
+#include "type_id.h"
+
+TEST_CASE( "spell_dash_respects_movement_and_floor_boundaries", "[magic][movement][regression]" )
+{
+    clear_map( -1, 1 );
+    clear_avatar();
+    map &here = get_map();
+    avatar &you = get_avatar();
+    const tripoint_bub_ms source( 60, 60, 0 );
+    for( int z = -1; z <= 1; ++z ) {
+        for( int x = 58; x <= 66; ++x ) {
+            for( int y = 58; y <= 62; ++y ) {
+                here.ter_set( tripoint_bub_ms( x, y, z ), ter_id( "t_floor" ) );
+            }
+        }
+    }
+    you.setpos( here, source );
+    on_out_of_scope restore_level( [&]() {
+        here.vertical_shift( 0 );
+        you.setpos( here, source, false );
+        clear_map( -1, 1 );
+    } );
+    const spell leap( spell_id( "bio_nl_antigravity_jump_spell" ) );
+    tripoint_bub_ms target = source + tripoint::east * 5;
+    tripoint_bub_ms expected = target;
+
+    SECTION( "unobstructed_horizontal_leap" ) {
+    }
+    SECTION( "cannot_cross_a_solid_floor_into_a_basement" ) {
+        target = source + tripoint( 1, 0, -1 );
+        REQUIRE_FALSE( here.valid_move( source, target, false, true ) );
+        expected = source;
+    }
+    SECTION( "cannot_cross_a_solid_ceiling" ) {
+        target = source + tripoint( 1, 0, 1 );
+        REQUIRE_FALSE( here.valid_move( source, target, false, true ) );
+        expected = source;
+    }
+    SECTION( "leap_over_open_air_onto_a_roof" ) {
+        for( int x = 58; x <= 63; ++x ) {
+            here.ter_set( tripoint_bub_ms( x, 60, 1 ), ter_id( "t_open_air" ) );
+        }
+        here.ter_set( tripoint_bub_ms( 64, 60, 0 ), ter_id( "t_wall" ) );
+        target = source + tripoint( 5, 0, 1 );
+        expected = target;
+    }
+    SECTION( "a_wall_stops_the_leap" ) {
+        here.ter_set( source + tripoint::east * 2, ter_id( "t_wall" ) );
+        expected = source + tripoint::east;
+    }
+    SECTION( "leap_down_from_a_roof_without_a_ledge_menu" ) {
+        for( int x = 61; x <= 66; ++x ) {
+            here.ter_set( tripoint_bub_ms( x, 60, 1 ), ter_id( "t_open_air" ) );
+        }
+        here.vertical_shift( 1 );
+        you.setpos( here, source + tripoint::above );
+    }
+    SECTION( "leap_across_a_gap_without_falling_mid_flight" ) {
+        here.ter_set( source + tripoint::east * 2, ter_id( "t_open_air" ) );
+    }
+    SECTION( "an_unsupported_endpoint_still_causes_a_fall" ) {
+        for( int x = 61; x <= 66; ++x ) {
+            here.ter_set( tripoint_bub_ms( x, 60, 1 ), ter_id( "t_open_air" ) );
+        }
+        here.vertical_shift( 1 );
+        you.setpos( here, source + tripoint::above );
+        target += tripoint::above;
+    }
+    SECTION( "stairs_still_allow_a_connected_vertical_step" ) {
+        target = source + tripoint::below;
+        here.ter_set( source, ter_id( "t_stairs_down" ) );
+        here.ter_set( target, ter_id( "t_stairs_up" ) );
+        REQUIRE( here.valid_move( source, target, false, true ) );
+        expected = target;
+    }
+    SECTION( "targeting_the_current_tile_is_a_no_op" ) {
+        target = source;
+        expected = source;
+    }
+
+    const int moves = you.get_moves();
+    const tripoint_abs_ms expected_abs = here.get_abs( expected );
+    const std::string errors = capture_debugmsg_during( [&]() {
+        spell_effect::dash( leap, you, target );
+    } );
+    INFO( errors );
+    CHECK( errors.empty() );
+    CHECK( you.pos_abs() == expected_abs );
+    CHECK( here.get_abs_sub().z() == you.posz() );
+    CHECK( you.get_moves() == moves );
+}


### PR DESCRIPTION
#### Summary

Bugfixes "修复反重力跳跃误触发悬崖菜单并遁入地下"

#### Responsible human

@LYHGLYTX

#### Purpose of change

反重力跳跃及其他使用 dash 效果的法术在跳上房顶、向下跳跃或跨越悬空地形时，逐格调用普通步行逻辑，意外弹出“这里是悬空的，你想做什么？”菜单。选择爬下后，角色已改变楼层，但旧跳跃路径仍继续执行，可能反复进入悬崖交互并落入地下。

#### Describe the solution

沿跳跃路径逐段检查地图范围、地形连接和生物占位，确定能够抵达的落点，再通过正常角色放置流程处理落地、楼层更新及重力。飞行过程中不再执行普通步行的悬崖菜单或提前坠落。保留跳上房顶、向下跳跃和跨越缺口的能力，同时阻止穿过墙壁、实心楼板或天花板；落点悬空时仍正常坠落。

保留移动点数和沿途法术场，并使用绝对坐标保存起点，避免落地刷新地图后影响后续法术范围计算。

#### Describe alternatives you've considered

None

#### Testing

- 修复前，房顶跳跃回归场景触发 `uilist::init` 的 `!test_mode` 断言，证实跳跃错误进入交互菜单。
- 修复后，新增回归测试通过：10 个场景、43 个断言，覆盖上下跳跃、缺口、墙壁、楼板、天花板、楼梯、悬空落点和原地目标。
- 现有 `line_attack,spell_damage,spell_area_of_effect` 测试通过：3 个测试、27 个断言。
- Linux 禁用 Lua 的测试构建通过；Android arm64 使用项目缓存编译配置编译受影响的 C++ 翻译单元通过。
- 变更行格式检查及 `git diff --check` 通过。
- 未进行 Android 真机验证或完整 APK 构建；远程 CI 以 PR 检查结果为准。

#### Documentation impact

None — 修复现有跳跃行为，不改变公开 API 或配置格式。

#### Related CCB-Docs PR

None

#### Affected documentation IDs

None

#### Generated reference impact

None

#### Additional context

根据用户提供的正常跳跃和异常悬崖菜单视频定位。此 PR 仅包含 dash 跳跃修复及其回归测试，与其他已报告问题分开提交。
