### PR TITLE
修复专长调试菜单滚动位置来回跳动

### DIFF
--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -1456,7 +1456,6 @@ void debug_menu::wishproficiency( Character *you )
 
     uilist prmenu;
     prmenu.text = _( "Select proficiency to toggle" );
-    prmenu.allow_anykey = true;
     prmenu.addentry( 0, true, '1', _( "Toggle all proficiencies" ) );
 
     const std::vector<proficiency_id> &known_profs = you->known_proficiencies();
@@ -1496,6 +1495,8 @@ void debug_menu::wishproficiency( Character *you )
         }
     }
 
+    // Keep the same ImGui window (and its scroll position) across toggles.
+    shared_ptr_fast<uilist_impl> prmenu_ui = prmenu.create_or_get_ui();
     do {
         prmenu.query();
         const int prsel = prmenu.ret;


### PR DESCRIPTION
#### Summary
Bugfixes "修复专长调试菜单滚动位置来回跳动"

#### Responsible human
@LYHGLYTX

#### Purpose of change
打开调试菜单的“选择要切换的专长”，向下滚动后将鼠标移到菜单外，列表可能跳回顶部或切回旧位置；连续切换专长也会重建窗口。

`allow_anykey = true` 使未处理输入（包括菜单外的鼠标移动）结束本轮查询。调用方没有保存窗口强引用，而 `uilist` 内部只持有弱引用，导致窗口在查询返回后销毁。ImGui 窗口 ID 包含对象地址，重建会丢失或复用其他滚动状态。

#### Describe the solution
移除不必要的 `allow_anykey`，并像同文件的技能编辑菜单一样，在整个专长编辑循环中保留 `uilist_impl` 强引用，使后续切换复用同一个窗口及滚动状态。

#### Describe alternatives you've considered
仅移除 `allow_anykey` 不能解决切换专长后窗口重建的问题；没有修改通用 `uilist` 的生命周期约定。

#### Testing
- 已通过 Linux SDL2 / Lua 启用 / C++17 的受影响翻译单元编译（`-Werror`）：
  `CCACHE_DIR=/tmp/cataclysm-ccache make -j10 RELEASE=1 TILES=1 SOUND=0 SDL3=0 CATA_ENABLE_LUA_PLATFORM=1 LOCALIZE=0 ASTYLE=0 LINTJSON=0 TESTS=0 PCH=0 CCACHE=1 ODIR=validation-obj validation-obj/wish.o`
- `git diff --check` 通过。
- `make astyle-check ASTYLE_SOURCES=src/wish.cpp ODIR=validation-obj` 报告基线已有格式问题；分别格式化基线和修复副本并比较，5 处差异完全相同，本次未新增。
- 未运行完整游戏构建、Catch2 套件或 Windows 实机 UI 测试；此交互问题尚未获得自动化回归测试覆盖。
- 待实机复测：滚到列表中部，反复移入/移出菜单；连续启用/移除专长；检查键盘选择、筛选和取消仍正常。

#### Documentation impact
None — 修复现有菜单行为，无新增用户选项或公开契约。

#### Related CCB-Docs PR
None

#### Affected documentation IDs
None

#### Generated reference impact
None

#### Additional context
从最新 `origin/master`（3053bf16057）建立独立分支，只有一个文件、一个修复提交。关闭窗口崩溃另行提交 PR。