### PR TITLE
修复点击窗口关闭按钮时 Lua 清理触发 SIGSEGV

### DIFF
--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -7329,6 +7329,11 @@ static void CheckMessages()
         // report_unvisited() -> DebugLog() after the debug subsystem is gone,
         // crashing. Disable the report globally before exiting.
         Json::globally_report_unvisited_members( false );
+        input_replay::finish();
+        // Match normal exit: destroy the game while its Lua session registries
+        // and renderer dependencies are still alive. Leaving g to static
+        // destruction makes game::~game() revisit already-destroyed registries.
+        g.reset();
         catacurses::endwin();
         exit( 0 );
     }


### PR DESCRIPTION
#### Summary
Bugfixes "修复点击窗口关闭按钮退出游戏时的段错误"

#### Responsible human
@LYHGLYTX

#### Purpose of change
用户在游戏中点击窗口关闭按钮会收到 SIGSEGV 崩溃报告，而通过正常菜单退出不会。提供的调用栈为：
```
CheckMessages → exit → dynamic atexit destructor for g
→ game::~game → lua_platform::shutdown → clear_active_runtimes
→ retire_all_sessions → dialogue_lifetime::retire
```

窗口关闭路径直接调用 `endwin()` 和 `exit(0)`，将全局游戏对象 `g` 留到静态析构阶段。运行期间创建的函数内静态对话注册表此时已先行销毁，游戏析构再次清理 Lua 会话时访问了失效对象。

#### Describe the solution
在 SDL 关闭事件路径中，关闭输入记录/回放流，并在图形资源释放与 `exit(0)` 前执行 `g.reset()`。游戏析构负责现有 Lua 清理，执行时其注册表和渲染依赖仍存活；随后全局 `g` 已为空，不会再次析构游戏。

清理顺序与正常退出保持一致；保留原有关闭窗口直接退出、不自动保存的行为，以及禁止退出阶段 JSON 未访问成员报告的保护。

#### Describe alternatives you've considered
只给 `dialogue_lifetime::retire` 加空指针检查无法保护已经析构的注册表。将单个注册表改成永久存活也不能解决其他清理依赖的顺序问题，因此在退出入口修正游戏对象生命周期。

#### Testing
- 用户 crash.log 的符号栈与源码路径吻合。
- 已通过 Linux SDL2 / Lua 启用 / C++17 的受影响翻译单元编译（`-Werror`）：
  `CCACHE_DIR=/tmp/cataclysm-ccache make -j10 RELEASE=1 TILES=1 SOUND=0 SDL3=0 CATA_ENABLE_LUA_PLATFORM=1 LOCALIZE=0 ASTYLE=0 LINTJSON=0 TESTS=0 PCH=0 CCACHE=1 ODIR=validation-obj validation-obj/sdltiles.o`
- `git diff --check` 通过。
- `make astyle-check ASTYLE_SOURCES=src/sdltiles.cpp ODIR=validation-obj` 报告基线已有格式问题；分别格式化基线和修复副本并比较，53 处差异完全相同，本次未新增。
- 未运行完整游戏构建、Catch2 套件或 Windows 实机关闭窗口测试；真实进程退出尚未获得自动化回归测试覆盖。
- 待实机复测：主菜单、载入后的游戏、使用过对话/调试菜单后的游戏分别点击叉号；确认无崩溃报告，并验证正常菜单退出仍正常。

#### Documentation impact
None — 修复现有退出生命周期，无新增配置或公开 API。

#### Related CCB-Docs PR
None

#### Affected documentation IDs
None

#### Generated reference impact
None

#### Additional context
从最新 `origin/master`（3053bf16057）建立独立分支，只有一个文件、一个修复提交。专长菜单跳动另行提交 PR。