### PR TITLE
fix(monster): 修复跨层拖拽重复坠落并陷入地下

### DIFF
--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -673,32 +673,19 @@ int melee_actor::do_grab( monster &z, Creature *target, bodypart_id bp_id ) cons
         while( pull_range > 0 ) {
             // Recalculate the ray each step
             // We can't depend on either the target position being constant (obviously),
-            // but neither on z pos staying constant, because we may want to shift the map mid-pull
+            // nor on the attacker's position staying constant.
             const units::angle dir = coord_to_angle( target_pos, monster_pos );
             tileray tdir( dir );
             tdir.advance();
             pt.x() = target_pos.x() + tdir.dx();
             pt.y() = target_pos.y() + tdir.dy();
             //Cancel the grab if the space is occupied by something
-            if( !g->is_empty( pt ) ) {
+            if( !here.inbounds( pt ) || !g->is_empty( pt ) ) {
                 break;
             }
 
-            if( foe != nullptr ) {
-                if( foe->in_vehicle ) {
-                    here.unboard_vehicle( target_pos );
-                }
-
-                if( foe->is_avatar() && ( pt.x() < HALF_MAPSIZE_X || pt.y() < HALF_MAPSIZE_Y ||
-                                          pt.x() >= HALF_MAPSIZE_X + SEEX || pt.y() >= HALF_MAPSIZE_Y + SEEY ) ) {
-                    const tripoint_abs_ms pt_abs = here.get_abs(
-                                                       pt ); // Could have used the result from update_map to shift the value instead.
-                    g->update_map( pt.x(), pt.y() );
-                    // update_map invalidates bubble positions on a shift. Refetch invalidated positions.
-                    pt = here.get_bub( pt_abs );
-                    monster_pos = z.pos_bub( here );
-                    target_pos = target->pos_bub( here );
-                }
+            if( foe != nullptr && foe->in_vehicle ) {
+                here.unboard_vehicle( target_pos );
             }
 
             // Don't try to fall mid pull
@@ -721,6 +708,13 @@ int melee_actor::do_grab( monster &z, Creature *target, bodypart_id bp_id ) cons
         // The monster might drag a target that's not on it's z level
         // So if they leave them on open air, make them fall
         target->gravity_check();
+        // update_map sets the avatar's position and checks gravity. Doing that
+        // mid-pull can cause a fall, then restore the old height while the map
+        // remains on the landing level. Finish the pull and fall first.
+        if( target->is_avatar() ) {
+            g->update_map( *foe );
+        }
+        monster_pos = z.pos_bub( here );
         target_pos = target->pos_bub( here );
         here.creature_on_trap( *target );
 

--- a/tests/ranged_pull_fall_test.cpp
+++ b/tests/ranged_pull_fall_test.cpp
@@ -1,0 +1,54 @@
+#include "bodypart.h"
+#include "cata_catch.h"
+#include "cata_scope_helpers.h"
+#include "character.h"
+#include "coordinates.h"
+#include "game.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "map_helpers_tests.h"
+#include "mattack_actors.h"
+#include "monster.h"
+#include "mtype.h"
+#include "player_helpers.h"
+#include "point.h"
+#include "type_id.h"
+
+TEST_CASE( "ranged_pull_from_above_lands_on_ground_at_map_boundary", "[mattack][grab][zlevel]" )
+{
+    clear_map( -2, 1 );
+    clear_avatar();
+    map &here = get_map();
+    Character &you = get_player_character();
+    const int x = GENERATE( 60, 65, 71 );
+    const tripoint_bub_ms start( x, 65, 1 );
+    for( int tx = 50; tx <= 80; ++tx ) {
+        for( int ty = 60; ty <= 70; ++ty ) {
+            here.ter_set( tripoint_bub_ms( tx, ty, 0 ), ter_id( "t_dirt" ) );
+            here.ter_set( tripoint_bub_ms( tx, ty, 1 ), ter_id( "t_open_air" ) );
+        }
+    }
+    here.ter_set( start, ter_id( "t_floor" ) );
+    here.vertical_shift( 1 );
+    you.setpos( here, start );
+    on_out_of_scope cleanup( [&]() {
+        here.vertical_shift( 0 );
+        you.setpos( here, tripoint_bub_ms( 60, 60, 0 ), false );
+        clear_map( -2, 1 );
+    } );
+    const int direction = GENERATE( -1, 1 );
+    CAPTURE( x, direction );
+    monster &puller = spawn_test_monster( "mon_debug_puller_strong",
+                                          start + tripoint( direction * 2, 0, -1 ) );
+    melee_actor attack = dynamic_cast<const melee_actor &>(
+                             *puller.type->special_attacks.at( "ranged_pull" ) );
+    attack.range = 6;
+    attack.grab_data.pull_chance = 100;
+    attack.grab_data.pull_weight_ratio = 100;
+    const tripoint_abs_ms before = you.pos_abs();
+    attack.do_grab( puller, &you, bodypart_id( "torso" ) );
+    CHECK( you.pos_abs().xy() != before.xy() );
+    CHECK( you.posz() == 0 );
+    CHECK( here.get_abs_sub().z() == you.posz() );
+    CHECK( here.ter( you.pos_bub( here ) ) == ter_id( "t_dirt" ) );
+}


### PR DESCRIPTION
#### Summary

Bugfixes "修复长臂丧尸等跨层拖拽时将角色拉入地下的问题"

#### Responsible human

@LYHGLYTX

#### Purpose of change

角色在树上等高处被远程拖拽时，如果途中越过地图刷新边界，update_map 会设置角色位置并提前触发重力。拖拽随后恢复旧高度，但地图已位于落地楼层；结束时再次坠落便将角色送入地下岩石。

新增回归在修复前稳定复现地下第 1 层、落点 t_rock，而预期应落在地面 t_dirt。

#### Describe the solution

将地图刷新推迟到拖拽和最终坠落结束后，再重新获取怪物及目标的地图坐标。保留拖拽期间不坠落的既有语义，避免中途刷新产生重复坠落和过期高度。逐步移动增加地图范围检查，防止延后刷新时越出已加载区域。

#### Describe alternatives you've considered

None

#### Testing

- Linux 禁用 Lua 的测试构建通过。
- 新增回归覆盖地图刷新边界两侧及中央、向左右拖拽，共 6 种组合。与现有空中车辆梯子拖拽测试一起通过：2 个测试、72 个断言，随机种子 1788590000。
- 同时检查 Ranged_pull_tests 和 Grab_drag_tests：修复后有 3 处失败。用修复前代码执行完全相同的 4 项测试和种子，确认这 3 处失败同样存在（monster_attack_test.cpp:375、413、503）；本次新增回归的另外 4 处失败被修复。扩展测试集因此不能标记为全绿。
- Android arm64 使用项目现有编译配置编译 mattack_actors.cpp 通过。
- 变更行格式及 git diff --check 通过。
- 未构建完整 APK，未进行安卓真机验证；本地测试使用当前工作区，PR 仅含本项独立修复，远程 CI 结果另行显示。

#### Documentation impact

None — 修复现有移动时序，不改变公开 API、数据格式或配置。

#### Related CCB-Docs PR

None

#### Affected documentation IDs

None

#### Generated reference impact

None

#### Additional context

用户报告在树上被长臂丧尸拉下时直接进入地下。本 PR 单独处理远程拖拽，与法术跳跃修复 #720 分开提交。
