### PR TITLE
fix(android): 保留筛选输入焦点并支持重新唤起键盘

### DIFF
--- a/android/app/src/main/java/org/libsdl/app/CleanwaterDummyEdit.java
+++ b/android/app/src/main/java/org/libsdl/app/CleanwaterDummyEdit.java
@@ -2,6 +2,7 @@ package org.libsdl.app;
 
 import android.content.Context;
 import android.view.KeyEvent;
+import android.view.View;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 
@@ -18,6 +19,19 @@ import android.view.inputmethod.InputConnection;
 public final class CleanwaterDummyEdit extends SDLDummyEdit {
     public CleanwaterDummyEdit(Context context) {
         super(context);
+    }
+
+    @Override
+    public boolean onKeyPreIme(int keyCode, KeyEvent event) {
+        if (keyCode == KeyEvent.KEYCODE_BACK && getVisibility() == View.VISIBLE) {
+            if (event.getAction() == KeyEvent.ACTION_UP && !event.isCanceled()) {
+                SDLActivity.onNativeKeyboardFocusLost();
+            }
+            // Hide the IME without forwarding Back to the game's editor.
+            // Its text and cursor must remain available when the IME reopens.
+            return true;
+        }
+        return super.onKeyPreIme(keyCode, event);
     }
 
     @Override

--- a/src/input_popup.cpp
+++ b/src/input_popup.cpp
@@ -14,6 +14,11 @@
 #include "ui_manager.h"
 #include "uistate.h"
 
+#if defined(__ANDROID__)
+    #include "sdl_wrappers.h"
+    #include "sdltiles.h"
+#endif
+
 input_popup::input_popup( int width, const std::string &title, const point &pos,
                           ImGuiWindowFlags flags ) :
     cataimgui::window( title, ImGuiWindowFlags_NoNavInputs | flags | ( title.empty() ?
@@ -221,6 +226,15 @@ void string_input_popup_imgui::draw_input_control()
 
     std::string input_label = "##string_input_" + label;
     ImGui::InputText( input_label.c_str(), &text, flags, input_callback, this );
+#if defined(__ANDROID__)
+    // An IME may have been dismissed, or its first show request may have
+    // failed. Clicking an already-active widget does not make ImGui request
+    // text input again, so explicitly retry on an input-field tap.
+    if( ImGui::IsItemClicked() && !SDL_ScreenKeyboardShown( get_sdl_window() ) ) {
+        StopTextInput( get_sdl_window() );
+        StartTextInput( get_sdl_window() );
+    }
+#endif
 }
 
 void string_input_popup_imgui::set_identifier( const std::string &ident )

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -6512,7 +6512,7 @@ static void CheckMessages()
                                      ( ev.type == CATA_KEYDOWN || ev.type == CATA_KEYUP ||
                                        ev.type == CATA_TEXTINPUT || ev.type == CATA_TEXTEDITING );
 #if defined(__ANDROID__)
-        // Android's system Back key dismisses the focused text widget below;
+        // Android's system Back key toggles the soft keyboard below;
         // it is not text editing input and must keep following that path.
         if( imgui_owns_text_event &&
             ( ev.type == CATA_KEYDOWN || ev.type == CATA_KEYUP ) &&
@@ -6704,12 +6704,7 @@ static void CheckMessages()
                         if( ( !android_ui_mode::is_new_ui_build() || ac_back_down_time > 0 ) &&
                             ticks - ac_back_down_time <= static_cast<uint32_t>
                             ( get_option<int>( "ANDROID_INITIAL_DELAY" ) ) ) {
-                            if( cataimgui::client::want_text_input() ) {
-                                // ImGui owns the keyboard while a text widget is
-                                // focused. Defocus it so ImGui releases text input
-                                // and the keyboard dismisses.
-                                cataimgui::client::clear_text_focus();
-                            } else if( IsTextInputActive( ::window.get() ) ) {
+                            if( IsTextInputActive( ::window.get() ) ) {
                                 focus_aware_stop_text_input();
                             } else {
                                 focus_aware_start_text_input();

--- a/tests/imgui_text_edit_test.cpp
+++ b/tests/imgui_text_edit_test.cpp
@@ -1,0 +1,51 @@
+#include <string>
+
+#include "cata_catch.h"
+#include "cata_scope_helpers.h"
+#include "imgui/imgui.h"
+#include "imgui/imgui_stdlib.h"
+
+TEST_CASE( "imgui_filter_backspace_removes_one_unicode_character", "[imgui][input]" )
+{
+    ImGuiContext *previous = ImGui::GetCurrentContext();
+    ImGuiContext *context = ImGui::CreateContext();
+    on_out_of_scope cleanup( [&]() {
+        ImGui::DestroyContext( context );
+        ImGui::SetCurrentContext( previous );
+    } );
+    ImGuiIO &io = ImGui::GetIO();
+    io.IniFilename = nullptr;
+    io.DisplaySize = ImVec2( 800, 600 );
+    io.DeltaTime = 1.0F / 60.0F;
+    unsigned char *pixels = nullptr;
+    int width = 0;
+    int height = 0;
+    io.Fonts->GetTexDataAsRGBA32( &pixels, &width, &height );
+    std::string text = "背包";
+    auto frame = [&]( bool focus ) {
+        ImGui::NewFrame();
+        ImGui::Begin( "filter" );
+        if( focus ) {
+            ImGui::SetKeyboardFocusHere();
+        }
+        ImGui::InputText( "text", &text );
+        ImGui::End();
+        ImGui::Render();
+    };
+    frame( true );
+    frame( false );
+    // Place the cursor at the end without a selection, just as when editing
+    // a previously saved filter.
+    io.AddKeyEvent( ImGuiKey_End, true );
+    frame( false );
+    io.AddKeyEvent( ImGuiKey_End, false );
+    frame( false );
+    io.AddKeyEvent( ImGuiKey_Backspace, true );
+    frame( false );
+    io.AddKeyEvent( ImGuiKey_Backspace, false );
+    frame( false );
+    CHECK( text == "背" );
+    io.AddInputCharactersUTF8( "包" );
+    frame( false );
+    CHECK( text == "背包" );
+}


### PR DESCRIPTION
#### Summary

Bugfixes "修复安卓筛选输入时返回键丢失编辑焦点及键盘无法重新唤起"

#### Responsible human

@LYHGLYTX

#### Purpose of change

V → f 输入筛选条件时，Android 返回键处理会清除 ImGui 输入焦点。收起输入法后，或首次软键盘唤起失败时，点击已激活的输入框也不会触发新的文本输入请求，用户只能退出后重进。

用户同时报告中文退格。当前代码已有 Android 删除事件兼容逻辑，本 PR 补充已有中文文本的一次退格和继续输入测试，不将已有退格修复归为本次新增实现。

#### Describe the solution

- CleanwaterDummyEdit 消费输入法阶段的 Back 按下、抬起事件，抬起时通过 SDL 原有回调收起键盘，避免 Back 继续传给游戏编辑器；取消事件不触发收起。
- 原生 Back 键键盘切换保留 ImGui 编辑焦点，不再 ClearActiveID。
- 点击字符串输入框且软键盘未显示时，重新启动文本输入，以恢复键盘；键盘已显示时不重启，避免干扰正在组合的文字。
- 生产行为变更仅作用于 Android。

#### Describe alternatives you've considered

None

#### Testing

- 新增真实 ImGui 输入控件测试通过：已有“背包”一次 Backspace 后为“背”，继续输入“包”恢复为“背包”（2 个断言）。
- Linux 禁用 Lua 的测试构建通过。
- Android arm64 编译 input_popup.cpp 和 sdltiles.cpp 通过。
- CleanwaterDummyEdit.java 使用 Android 35 SDK 和项目 SDL 3.4.10 classes.jar 编译通过。
- 临时 JVM 测试使用 Android/SDL 边界替身执行实际 CleanwaterDummyEdit 和 CleanwaterInputConnection：16 个断言通过，涵盖 Back 按下、抬起、取消、非 Back/不可见状态转发，以及退格按键和 code point 删除。该检查不等同于真实 IME 集成测试。
- 变更行格式及 git diff --check 通过。
- 未构建完整 APK、未做安卓真机或多输入法验证。远程 CI 以 PR 检查为准。

#### Documentation impact

None — 修复现有输入交互，不改变公开 API 或配置格式。

#### Related CCB-Docs PR

None

#### Affected documentation IDs

None

#### Generated reference impact

None

#### Additional context

核对了项目使用的 SDL 3.4.10 官方 SDLDummyEdit、SDLInputConnection 及 onNativeKeyboardFocusLost 实现；未修改第三方代码。本 PR 与其他 bug 修复独立提交。
