### PR TITLE
fix(android): 修复切回前台后捏人预览消失或花屏

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2027,6 +2027,16 @@ void cata_tiles::reset_minimap()
     minimap->reset();
 }
 
+void cata_tiles::reset_character_preview()
+{
+    char_preview_work_tex.reset();
+    char_preview_tex.reset();
+    char_preview_work_w = 0;
+    char_preview_work_h = 0;
+    char_preview_w = 0;
+    char_preview_h = 0;
+}
+
 void cata_tiles::reset_tint_mask()
 {
     tint_mask_tex.reset();

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -600,6 +600,7 @@ using color_block_overlay_container = std::pair<SDL_BlendMode, std::multimap<poi
 class cata_tiles
 {
         friend class cata_tiles_test_helper;
+        friend struct renderer_recovery_test_support;
 
     public:
         cata_tiles( const SDL_Renderer_Ptr &render, const GeometryRenderer_Ptr &geometry,
@@ -1487,6 +1488,7 @@ class cata_tiles
         // Drop the pixel minimap's renderer-owned resources and cache so
         // they rebuild against the live renderer on the next draw.
         void reset_minimap();
+        void reset_character_preview();
 
         // Drop the scratch silhouette mask target so the next tinted ortho
         // draw reallocates it against the live renderer.

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -3169,6 +3169,14 @@ static SDL_Texture *character_preview_texture( const avatar &u, int &out_w, int 
     static SDL_Texture *cached_tex = nullptr;
     static int cached_w = 0;
     static int cached_h = 0;
+    static uint64_t last_renderer_generation = 0;
+    const uint64_t renderer_generation = renderer_resource_generation();
+    if( last_renderer_generation != renderer_generation ) {
+        last_sig.clear();
+        cached_tex = nullptr;
+        cached_w = 0;
+        cached_h = 0;
+    }
 
     // This function is called more than once per frame (to size the preview column, then to draw
     // it) and the creator redraws continuously. Building the signature string -- an allocation plus
@@ -3179,7 +3187,8 @@ static SDL_Texture *character_preview_texture( const avatar &u, int &out_w, int 
     static const avatar *last_u = nullptr;
     static int last_scale = 0;
     const int frame = ImGui::GetFrameCount();
-    if( frame == last_frame && last_u == &u && last_scale == preview_scale ) {
+    if( frame == last_frame && last_u == &u && last_scale == preview_scale &&
+        last_renderer_generation == renderer_generation ) {
         out_w = cached_w;
         out_h = cached_h;
         return cached_tex;
@@ -3187,6 +3196,7 @@ static SDL_Texture *character_preview_texture( const avatar &u, int &out_w, int 
     last_frame = frame;
     last_u = &u;
     last_scale = preview_scale;
+    last_renderer_generation = renderer_generation;
 
     std::string sig = std::string( u.male ? "m|" : "f|" ) + ( outfit ? "o1|" : "o0|" ) +
                       std::to_string( preview_scale ) + "|" +

--- a/src/sdl_renderer_recovery.h
+++ b/src/sdl_renderer_recovery.h
@@ -400,6 +400,9 @@ struct renderer_recovery_test_support {
     // and geometry on the file-static globals, then seed and bootstrap the
     // coordinator. False (globals clean) if the dummy backend fails or a window is up.
     static bool setup_software_renderer();
+    static bool install_character_preview_targets();
+    static bool has_character_preview_targets();
+    static void remove_character_preview_context();
     // Reverse setup: drain the quarantine and release atlases on the live
     // renderer, destroy variant_pass before the renderer, reset globals and the
     // coordinator, and quit video only if this fixture acquired it.

--- a/src/sdl_wrappers.cpp
+++ b/src/sdl_wrappers.cpp
@@ -1196,20 +1196,16 @@ bool RenderReadPixels( const SDL_Renderer_Ptr &renderer, const SDL_Rect *rect,
         return false;
     }
 #if SDL_MAJOR_VERSION >= 3
-    ( void )format;
     SDL_Surface *surf = SDL_RenderReadPixels( renderer.get(), rect );
     if( !surf ) {
         return false;
     }
-    const int copy_h = surf->h;
-    const int copy_pitch = std::min( pitch, surf->pitch );
-    for( int row = 0; row < copy_h; row++ ) {
-        std::memcpy( static_cast<Uint8 *>( pixels ) + row * pitch,
-                     static_cast<const Uint8 *>( surf->pixels ) + row * surf->pitch,
-                     copy_pitch );
-    }
+    // SDL3 chooses the surface format. Honor the caller's requested format
+    // and pitch instead of copying bytes from a potentially different layout.
+    const bool converted = SDL_ConvertPixels( surf->w, surf->h, surf->format,
+                           surf->pixels, surf->pitch, static_cast<SDL_PixelFormat>( format ), pixels, pitch );
     SDL_DestroySurface( surf );
-    return true;
+    return converted;
 #else
     return SDL_RenderReadPixels( renderer.get(), rect, format, pixels, pitch ) == 0;
 #endif

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1980,6 +1980,7 @@ static void reset_context_minimaps()
 {
     for_each_unique_tile_context( []( cata_tiles & c ) {
         c.reset_minimap();
+        c.reset_character_preview();
     } );
 }
 
@@ -2770,6 +2771,29 @@ bool renderer_recovery_test_support::setup_software_renderer()
     renderer_coordinator.seed_renderer_policy( {} );
     renderer_coordinator.finish_bootstrap();
     return true;
+}
+
+bool renderer_recovery_test_support::install_character_preview_targets()
+{
+    if( tilecontext ) {
+        return false;
+    }
+    tilecontext = std::make_unique<cata_tiles>( renderer, geometry, ts_cache );
+    tilecontext->char_preview_work_tex = CreateTexture( renderer, SDL_PIXELFORMAT_ARGB8888,
+                                         SDL_TEXTUREACCESS_TARGET, 8, 8 );
+    tilecontext->char_preview_tex = CreateTexture( renderer, SDL_PIXELFORMAT_ARGB8888,
+                                    SDL_TEXTUREACCESS_TARGET, 4, 4 );
+    return tilecontext->char_preview_work_tex && tilecontext->char_preview_tex;
+}
+
+bool renderer_recovery_test_support::has_character_preview_targets()
+{
+    return tilecontext && ( tilecontext->char_preview_work_tex || tilecontext->char_preview_tex );
+}
+
+void renderer_recovery_test_support::remove_character_preview_context()
+{
+    tilecontext.reset();
 }
 
 void renderer_recovery_test_support::teardown_software_renderer()

--- a/tests/character_preview_recovery_test.cpp
+++ b/tests/character_preview_recovery_test.cpp
@@ -1,0 +1,42 @@
+#if defined(TILES)
+#include "cata_catch.h"
+#include "cata_scope_helpers.h"
+#include "sdl_renderer_recovery.h"
+#include "sdltiles.h"
+#include "sdl_wrappers.h"
+#include <array>
+#include <cstdint>
+
+TEST_CASE( "character_preview_targets_are_released_during_renderer_recovery",
+           "[tiles][renderer_recovery][character_preview]" )
+{
+    software_render_fixture fixture;
+    REQUIRE( fixture.available() );
+    REQUIRE( renderer_recovery_test_support::install_character_preview_targets() );
+    on_out_of_scope cleanup( []() {
+        renderer_recovery_test_support::remove_character_preview_context();
+    } );
+    const auto generation = renderer_coordinator.resource_generation();
+    const auto severity = GENERATE( renderer_recovery_severity::targets_reset,
+                                    renderer_recovery_severity::device_reset,
+                                    renderer_recovery_severity::device_lost );
+    renderer_coordinator.request_recovery( severity );
+    renderer_coordinator.drain_pending();
+    CHECK_FALSE( renderer_recovery_test_support::has_character_preview_targets() );
+    CHECK( renderer_coordinator.resource_generation() > generation );
+}
+TEST_CASE( "preview_pixel_readback_honors_requested_format", "[tiles][character_preview]" )
+{
+    software_render_fixture fixture;
+    REQUIRE( fixture.available() );
+    const auto &renderer = get_sdl_renderer();
+    SetRenderDrawColor( renderer, 255, 0, 0, 255 );
+    RenderClear( renderer );
+    std::array<uint16_t, 4> pixels{};
+    const SDL_Rect rect{ 0, 0, 2, 2 };
+    REQUIRE( RenderReadPixels( renderer, &rect, SDL_PIXELFORMAT_RGB565, pixels.data(), 4 ) );
+    for( const uint16_t pixel : pixels ) {
+        CHECK( pixel == 0xf800 );
+    }
+}
+#endif


### PR DESCRIPTION
#### Summary

Bugfixes "修复切回前台后捏人预览消失或花屏"

#### Responsible human

@LYHGLYTX

#### Purpose of change

安卓在捏人界面切换到其他应用，再返回后，角色预览可能消失或出现竖条花屏。

#### Describe the solution

渲染器恢复时释放角色预览的工作纹理和裁剪纹理；预览缓存随资源代数失效，下一次绘制重新生成。SDL3 像素读取包装按调用方要求转换格式和行距，避免直接复制不匹配的表面数据。

#### Describe alternatives you've considered

仅使窗口重绘仍会复用失效纹理，因此在资源恢复与预览缓存两处处理生命周期。

#### Testing

Linux SDL2、禁用 Lua Platform 的联合工作区完成游戏库及聚焦测试程序编译。相关渲染恢复、电网、烟熏和区域拆配件测试共 63 个用例、626 条断言全部通过（RNG seed 20260905）。每份补丁另经检查可独立应用到 master；未运行完整测试套件。 Android arm64/SDL3 的 sdl_wrappers.cpp、cata_tiles.cpp、newcharacter.cpp、sdltiles.cpp 四个编译单元通过。未进行真机验证。

覆盖 targets reset、device reset、device lost 三类恢复以及 RGB565 读回格式。

#### Documentation impact

None — 内部缺陷修复，未改变公开 Lua/JSON 作者接口。

#### Related CCB-Docs PR

None

#### Affected documentation IDs

None

#### Generated reference impact

None

#### Additional context

仍需安卓真机在捏人界面反复切后台验证；没有打包或安装 APK。
