### PR TITLE
fix(zones): 拆卸地面和车载枪械配件后继续整理并恢复视角

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -11825,10 +11825,14 @@ void unload_loot_activity_actor::stage_do( player_activity &, Character &you )
 
         const std::unordered_set<tripoint_abs_ms> dest_set;
 
-        zone_sorting::unload_item( you, src,
-                                   zone_unload_options,
-                                   it->second ? zone_sorting::cargo_part_from_index( src_bub, *it->second ) : std::nullopt,
-                                   it->first, dest_set, num_processed );
+        if( !zone_sorting::unload_item( you, src,
+                                        zone_unload_options,
+                                        it->second ? zone_sorting::cargo_part_from_index( src_bub, *it->second ) : std::nullopt,
+                                        it->first, dest_set, num_processed ) ) {
+            // Starting gunmod removal replaces this actor.  Resume from the
+            // saved zone activity instead of continuing through destroyed state.
+            return;
+        }
 
         if( you.get_moves() <= 0 ) {
             return;

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1414,9 +1414,17 @@ std::optional<bool> unload_item( Character &you, const tripoint_abs_ms &src,
                     if( mod->is_irremovable() ) {
                         continue;
                     }
-                    you.gunmod_remove( *it, *mod );
-                    // need to return so the remove gunmod activity starts
-                    return std::nullopt;
+                    const item_location gun_loc = vpr_src ?
+                                                  item_location( vehicle_cursor( vpr_src->vehicle(), vpr_src->part_index() ), it ) :
+                                                  item_location( map_cursor( src_bub ), it );
+                    // Keep the zone activity in the backlog while the removable
+                    // mod is processed, including its viewport and tile progress.
+                    const bool was_auto_resume = you.activity.auto_resume;
+                    you.activity.auto_resume = true;
+                    if( you.gunmod_remove( gun_loc, *mod ) ) {
+                        return std::nullopt;
+                    }
+                    you.activity.auto_resume = was_auto_resume;
                 }
             }
 

--- a/src/character.h
+++ b/src/character.h
@@ -1953,6 +1953,7 @@ class Character : public Creature, public visitable
          * Returns true on success (activity has been started)
          */
         bool gunmod_remove( item &gun, item &mod );
+        bool gunmod_remove( item_location gun_loc, item &mod );
 
         /** Starts activity to install gunmod having warned user about any risk of failure or irremovable mods s*/
         void gunmod_add( item &gun, item &mod );

--- a/src/character_guns.cpp
+++ b/src/character_guns.cpp
@@ -295,6 +295,15 @@ void Character::gunmod_add( item &gun, item &mod )
 
 bool Character::gunmod_remove( item &gun, item &mod )
 {
+    return gunmod_remove( item_location( *this, &gun ), mod );
+}
+
+bool Character::gunmod_remove( item_location gun_loc, item &mod )
+{
+    if( !gun_loc ) {
+        return false;
+    }
+    item &gun = *gun_loc.get_item();
     std::vector<item *> mods = gun.gunmods();
     size_t gunmod_idx = mods.size();
     for( size_t i = 0; i < mods.size(); i++ ) {
@@ -315,7 +324,6 @@ bool Character::gunmod_remove( item &gun, item &mod )
     // Removing gunmod takes only half as much time as installing it
     const int moves = has_trait( trait_DEBUG_HS ) ? 0 : to_moves<int>
                       ( mod.type->gunmod->install_time ) / 2;
-    item_location gun_loc = item_location( *this, &gun );
     assign_activity( gunmod_remove_activity_actor( moves, gun_loc, static_cast<int>( gunmod_idx ) ) );
     return true;
 }

--- a/tests/zone_gunmod_removal_test.cpp
+++ b/tests/zone_gunmod_removal_test.cpp
@@ -1,0 +1,85 @@
+#include <optional>
+#include <unordered_set>
+
+#include "activity_actor_definitions.h"
+#include "activity_item_handling.h"
+#include "avatar.h"
+#include "calendar.h"
+#include "cata_catch.h"
+#include "cata_scope_helpers.h"
+#include "clone_ptr.h"
+#include "clzones.h"
+#include "item.h"
+#include "item_location.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "player_helpers.h"
+#include "pocket_type.h"
+#include "ret_val.h"
+#include "type_id.h"
+#include "units.h"
+#include "veh_type.h"
+#include "vehicle.h"
+#include "vpart_position.h"
+#include "vpart_range.h"
+
+static const activity_id ACT_GUNMOD_REMOVE( "ACT_GUNMOD_REMOVE" );
+static const activity_id ACT_MOVE_LOOT( "ACT_MOVE_LOOT" );
+
+TEST_CASE( "zone_gunmod_removal_preserves_location_and_resumes_sorting",
+           "[zones][activities][gunmod]" )
+{
+    clear_avatar();
+    clear_map_without_vision();
+    avatar &you = get_avatar();
+    map &here = get_map();
+    zone_manager &zones = zone_manager::get_manager();
+    zones.clear();
+    on_out_of_scope cleanup( [&]() {
+        you.cancel_activity();
+        you.backlog.clear();
+        zones.clear();
+    } );
+    const tripoint_bub_ms pos( 60, 60, 0 );
+    you.setpos( here, pos );
+    const tripoint_abs_ms abs = here.get_abs( pos );
+    zones.add( "Unload", zone_type_id( "UNLOAD_ALL" ), faction_id( "your_followers" ),
+               false, true, abs, abs );
+    zones.cache_data();
+    item gun( itype_id( "win70" ) );
+    REQUIRE( gun.put_in( item( itype_id( "shoulder_strap" ) ), pocket_type::MOD ).success() );
+    item *stored = nullptr;
+    std::optional<vpart_reference> cargo;
+    if( GENERATE( false, true ) ) {
+        vehicle *cart = here.add_vehicle( vproto_id( "test_shopping_cart" ), pos,
+                                          0_degrees, 0, veh_spawn_status::UNDAMAGED );
+        REQUIRE( cart );
+        cargo = here.veh_at( pos ).cargo();
+        REQUIRE( cargo );
+        const auto added = cart->add_item( here, cargo->part(), gun );
+        REQUIRE( added );
+        stored = & **added;
+    } else {
+        stored = &here.add_item_or_charges( pos, gun );
+    }
+    REQUIRE( stored );
+    you.assign_activity( zone_sort_activity_actor() );
+    you.set_moves( 1000 );
+    zone_sorting::unload_sort_options options;
+    options.unload_mods = true;
+    int processed = 0;
+    CHECK_FALSE( zone_sorting::unload_item( you, abs, options, cargo, stored, {}, processed ) );
+    REQUIRE( you.activity.id() == ACT_GUNMOD_REMOVE );
+    REQUIRE_FALSE( you.backlog.empty() );
+    CHECK( you.backlog.front().id() == ACT_MOVE_LOOT );
+    CHECK( you.backlog.front().auto_resume );
+    you.activity.actor->finish( you.activity, you );
+    CHECK( stored->gunmods().empty() );
+    you.resume_backlog_activity();
+    REQUIRE( you.activity.id() == ACT_MOVE_LOOT );
+    // With no remaining sortable items, the resumed parent restores the view.
+    you.zone_sort_viewport.active = true;
+    process_activity( you );
+    CHECK_FALSE( you.activity );
+    CHECK_FALSE( you.zone_sort_viewport.active );
+}


### PR DESCRIPTION
#### Summary

Bugfixes "拆卸地面和车载枪械配件后继续整理并恢复视角"

#### Responsible human

@LYHGLYTX

#### Purpose of change

区域整理在拆卸地面或车载枪械配件时，子活动拿到错误的角色持有位置，且父活动未自动恢复，导致整理停止、视角留在远处。

#### Describe the solution

保留枪械的实际 item_location，拆卸前将区域父活动设为自动恢复；卸载活动启动子活动后立即返回，避免继续访问已替换的 actor。完成后由恢复的父活动正常清理视角。

#### Describe alternatives you've considered

单独恢复父活动无法修正枪械的错误位置；两者必须一起维护。

#### Testing

Linux SDL2、禁用 Lua Platform 的联合工作区完成游戏库及聚焦测试程序编译。相关渲染恢复、电网、烟熏和区域拆配件测试共 63 个用例、626 条断言全部通过（RNG seed 20260905）。每份补丁另经检查可独立应用到 master；未运行完整测试套件。

覆盖地面和车载枪械：配件拆卸完成、ACT_MOVE_LOOT 恢复、整理结束后视角状态清理。

#### Documentation impact

None — 内部缺陷修复，未改变公开 Lua/JSON 作者接口。

#### Related CCB-Docs PR

None

#### Affected documentation IDs

None

#### Generated reference impact

None

#### Additional context

验证使用测试枪械和独立区域，不依赖玩家存档。
