### PR TITLE
fix(smoking): 恢复丢失燃烧计时器的烟熏架状态

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -7809,9 +7809,37 @@ void iexamine::quern_examine( Character &you, const tripoint_bub_ms &examp )
     }
 }
 
+void iexamine::smoker_reconcile( map &here, const tripoint_bub_ms &examp )
+{
+    const furn_id rack = here.furn( examp );
+    if( rack != furn_f_smoking_rack_active && rack != furn_f_metal_smoking_rack_active ) {
+        return;
+    }
+    map_stack items = here.i_at( examp );
+    if( std::any_of( items.begin(), items.end(), []( const item & it ) {
+    return it.typeId() == itype_fake_smoke_plume && it.active;
+    } ) ) {
+        return;
+    }
+    // No live embers means there is no timer capable of completing this batch.
+    // Preserve the food, but let the player relight the rack. Never invent a
+    // completion time for a save that has lost its timer.
+    for( auto it = items.begin(); it != items.end(); ) {
+        if( it->typeId() == itype_fake_smoke_plume ) {
+            it = items.erase( it );
+        } else {
+            it->unset_flag( flag_PROCESSING );
+            ++it;
+        }
+    }
+    here.furn_set( examp, rack == furn_f_metal_smoking_rack_active ?
+                   furn_f_metal_smoking_rack : furn_f_smoking_rack );
+}
+
 void iexamine::smoker_options( Character &you, const tripoint_bub_ms &examp )
 {
     map &here = get_map();
+    smoker_reconcile( here, examp );
     const furn_id &f = here.furn( examp );
     const bool active = f == furn_f_smoking_rack_active ||
                         f == furn_f_metal_smoking_rack_active;

--- a/src/iexamine.h
+++ b/src/iexamine.h
@@ -161,6 +161,7 @@ void quern_examine( Character &you, const tripoint_bub_ms &examp );
 void smoker_options( Character &you, const tripoint_bub_ms &examp );
 bool smoker_prep( Character &you, const tripoint_bub_ms &examp );
 bool smoker_fire( Character &you, const tripoint_bub_ms &examp );
+void smoker_reconcile( map &here, const tripoint_bub_ms &examp );
 void open_safe( Character &you, const tripoint_bub_ms &examp );
 void workbench( Character &you, const tripoint_bub_ms &examp );
 void workbench_internal( Character &you, const tripoint_bub_ms &examp,

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -10934,6 +10934,7 @@ void map::actualize( const tripoint_rel_sm &grid )
         for( int y = 0; y < SEEY; y++ ) {
             const tripoint_bub_ms pnt =  rebase_bub( coords::project_to<coords::ms>( grid ) + point( x, y ) );
             const point_sm_ms p( x, y );
+            iexamine::smoker_reconcile( *this, pnt );
             const furn_t &furn = *this->furn( pnt );
             const ter_t &terr = *this->ter( pnt );
             if( !furn.emissions.empty() ) {

--- a/tests/smoking_rack_reload_test.cpp
+++ b/tests/smoking_rack_reload_test.cpp
@@ -1,0 +1,74 @@
+#include <sstream>
+
+#include "calendar.h"
+#include "cata_catch.h"
+#include "flag.h"
+#include "flexbuffer_json.h"
+#include "iexamine.h"
+#include "item.h"
+#include "itype.h"
+#include "json.h"
+#include "json_loader.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "mapdata.h"
+#include "type_id.h"
+
+TEST_CASE( "smoking_rack_finishes_after_absence_and_item_reload", "[item][smoking][save]" )
+{
+    clear_map_without_vision();
+    map &here = get_map();
+    const tripoint_bub_ms pos( 60, 60, 0 );
+    const bool metal = GENERATE( false, true );
+    here.furn_set( pos, furn_str_id( metal ? "f_metal_smoking_rack_active" :
+                                     "f_smoking_rack_active" ) );
+    calendar::turn = calendar::turn_zero + 12_hours;
+    item meat( itype_id( "meat" ), calendar::turn );
+    meat.set_flag( flag_PROCESSING );
+    const itype_id result = meat.get_comestible()->smoking_result;
+    REQUIRE_FALSE( result.is_null() );
+    here.add_item( pos, meat );
+    item embers( itype_id( "fake_smoke_plume" ), calendar::turn );
+    embers.item_counter = to_turns<int>( 6_hours );
+    embers.activate();
+    std::ostringstream saved;
+    JsonOut out( saved );
+    embers.serialize( out );
+    item loaded;
+    loaded.deserialize( json_loader::from_string( saved.str() ).get_object() );
+    here.add_item( pos, loaded );
+    calendar::turn += 3_days;
+    here.process_items();
+    CHECK( here.furn( pos ) == furn_str_id( metal ? "f_metal_smoking_rack" : "f_smoking_rack" ) );
+    REQUIRE( here.i_at( pos ).size() == 1 );
+    CHECK( here.i_at( pos ).only_item().typeId() == result );
+}
+
+TEST_CASE( "smoking_rack_without_embers_can_be_relit", "[item][smoking][save]" )
+{
+    clear_map_without_vision();
+    map &here = get_map();
+    const tripoint_bub_ms pos( 60, 60, 0 );
+    const bool metal = GENERATE( false, true );
+    const furn_str_id active( metal ? "f_metal_smoking_rack_active" : "f_smoking_rack_active" );
+    here.furn_set( pos, active );
+    item meat( itype_id( "meat" ), calendar::turn );
+    meat.set_flag( flag_PROCESSING );
+    here.add_item( pos, meat );
+    // Missing, inactive and live embers are distinct saved states.
+    const int timer_state = GENERATE( -1, 0, 1 );
+    const bool has_timer = timer_state == 1;
+    if( timer_state >= 0 ) {
+        item embers( itype_id( "fake_smoke_plume" ), calendar::turn );
+        if( has_timer ) {
+            embers.activate();
+        }
+        embers.item_counter = to_turns<int>( 6_hours );
+        here.add_item( pos, embers );
+    }
+    iexamine::smoker_reconcile( here, pos );
+    CHECK( ( here.furn( pos ) == active ) == has_timer );
+    CHECK( here.i_at( pos ).begin()->typeId() == itype_id( "meat" ) );
+    CHECK( here.i_at( pos ).begin()->has_flag( flag_PROCESSING ) == has_timer );
+    CHECK( here.i_at( pos ).size() == ( has_timer ? 2 : 1 ) );
+}


### PR DESCRIPTION
#### Summary

Bugfixes "恢复丢失燃烧计时器的烟熏架状态"

#### Responsible human

@LYHGLYTX

#### Purpose of change

烟熏架在存档中可能保留燃烧家具状态，却已没有活跃的烟熏计时物品，表现为持续冒烟且没有剩余时间。此时无法完成或重新点燃。

#### Describe the solution

在地图实际化和查看烟熏架时对齐家具与计时物品的状态：缺少活跃余烬时恢复闲置家具、清理无效余烬和食物 PROCESSING 标志，保留原食物以便重新点燃。存在有效计时器时保留正常加工流程。

#### Describe alternatives you've considered

缺少计时器时无法可靠推算结束时间，因此保留食物并允许重新点燃。

#### Testing

Linux SDL2、禁用 Lua Platform 的联合工作区完成游戏库及聚焦测试程序编译。相关渲染恢复、电网、烟熏和区域拆配件测试共 63 个用例、626 条断言全部通过（RNG seed 20260905）。每份补丁另经检查可独立应用到 master；未运行完整测试套件。

覆盖木制及金属烟熏架、缺失/停用/有效计时器，并检查序列化余烬在离开三天后完成加工。

#### Documentation impact

None — 内部缺陷修复，未改变公开 Lua/JSON 作者接口。

#### Related CCB-Docs PR

None

#### Affected documentation IDs

None

#### Generated reference impact

None

#### Additional context

尚未复现玩家正常探索过程中计时器丢失的起点；本 PR 修复可确认的无计时器卡死状态，不把未知食物状态直接改成加工完成。
