### PR TITLE
fix(power): 修正气泡外车辆坐标与电缆端点查找

### DIFF
--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -17,6 +17,7 @@
 
 #include "cata_path.h"
 #include "cata_utility.h"
+#include "coordinates.h"
 #include "debug.h"
 #include "filesystem.h"
 #include "flexbuffer_json.h"
@@ -38,6 +39,7 @@
 #include "translations.h"
 #include "type_id.h"
 #include "ui_manager.h"
+#include "vehicle.h"
 #include "worldfactory.h"
 #include "zzip.h"
 
@@ -92,6 +94,12 @@ bool mapbuffer::add_submap( const tripoint_abs_sm &p, std::unique_ptr<submap> &s
         return false;
     }
 
+    // Vehicles store their mount origin within the submap, not its absolute
+    // coordinates. Cable lookup can load this submap without map::loadn(), so
+    // establish the absolute origin here before any off-bubble processing.
+    for( const std::unique_ptr<vehicle> &veh : sm->vehicles ) {
+        veh->sm_pos = p;
+    }
     submaps[p] = std::move( sm );
 
     return true;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6105,9 +6105,7 @@ vehicle *vehicle::find_vehicle_using_parts( const map &here,  const tripoint_abs
         return &vp->vehicle();
     }
     // Nope. Load up its submap...
-    point_sm_ms_ib veh_in_sm;
-    tripoint_abs_sm veh_sm;
-    std::tie( veh_sm, veh_in_sm ) = project_remain<coords::sm>( where );
+    const tripoint_abs_sm veh_sm = project_to<coords::sm>( where );
     const submap *sm = MAPBUFFER.lookup_submap( veh_sm );
     if( sm == nullptr ) {
         return nullptr;
@@ -6116,10 +6114,7 @@ vehicle *vehicle::find_vehicle_using_parts( const map &here,  const tripoint_abs
     for( const auto &elem : sm->vehicles ) {
         vehicle *found_veh = elem.get();
         for( const vpart_reference &vp : found_veh->get_all_parts() ) {
-            point_sm_ms_ib vp_in_sm;
-            tripoint_bub_sm vp_sm;
-            std::tie( vp_sm, vp_in_sm ) = project_remain<coords::sm>( vp.pos_bub( here ) );
-            if( vp_in_sm == veh_in_sm ) {
+            if( vp.pos_abs() == where ) {
                 return found_veh;
             }
         }

--- a/tests/offbubble_vehicle_origin_test.cpp
+++ b/tests/offbubble_vehicle_origin_test.cpp
@@ -1,0 +1,47 @@
+#include <functional>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "cata_catch.h"
+#include "cata_scope_helpers.h"
+#include "coordinates.h"
+#include "flexbuffer_json.h"
+#include "json.h"
+#include "json_loader.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "mapbuffer.h"
+#include "point.h"
+#include "submap.h"
+#include "type_id.h"
+#include "vehicle.h"
+
+TEST_CASE( "offbubble_vehicle_origin_restored_before_grid_lookup", "[vehicle][grid][save]" )
+{
+    clear_map_without_vision();
+    const tripoint_abs_sm origin( 2400, 1800, GENERATE( -2, 0, 2 ) );
+    vehicle original( vproto_id( "test_shopping_cart" ) );
+    original.sm_pos = origin;
+    original.pos = point_sm_ms( 2, 3 );
+    std::ostringstream saved;
+    JsonOut out( saved );
+    original.serialize( out );
+    auto loaded = std::make_unique<vehicle>( vproto_id() );
+    loaded->deserialize( json_loader::from_string( saved.str() ).get_object() );
+    auto sm = std::make_unique<submap>();
+    sm->vehicles.push_back( std::move( loaded ) );
+    REQUIRE( MAPBUFFER.add_submap( origin, sm ) );
+    on_out_of_scope cleanup( []() {
+        MAPBUFFER.clear_outside_reality_bubble();
+    } );
+    const submap *stored = MAPBUFFER.lookup_submap( origin );
+    REQUIRE( stored );
+    REQUIRE( stored->vehicles.size() == 1 );
+    CHECK( stored->vehicles.front()->sm_pos == origin );
+    CHECK( stored->vehicles.front()->pos_abs() == original.pos_abs() );
+    CHECK( vehicle::find_vehicle_using_parts( get_map(), original.pos_abs() ) ==
+           stored->vehicles.front().get() );
+}


### PR DESCRIPTION
#### Summary

Bugfixes "修正气泡外车辆坐标与电缆端点查找"

#### Responsible human

@LYHGLYTX

#### Purpose of change

电缆查找可以直接从 mapbuffer 载入气泡外车辆，而车辆绝对子地图坐标原先只在 map::loadn 设置。未进入现实气泡的端点因此可能使用错误坐标。

#### Describe the solution

将车辆 sm_pos 的初始化提前到 mapbuffer::add_submap，使所有加载入口得到正确绝对位置；电缆部件查找比较完整绝对坐标，避免仅比较子地图内余数而误匹配。

#### Describe alternatives you've considered

只在 map::loadn 设置坐标覆盖不到电缆直接加载气泡外子地图的入口。

#### Testing

Linux SDL2、禁用 Lua Platform 的联合工作区完成游戏库及聚焦测试程序编译。相关渲染恢复、电网、烟熏和区域拆配件测试共 63 个用例、626 条断言全部通过（RNG seed 20260905）。每份补丁另经检查可独立应用到 master；未运行完整测试套件。

覆盖地下、地面和楼上车辆的序列化加载、绝对位置恢复和气泡外部件查找，并运行相关电网回归。

#### Documentation impact

None — 内部缺陷修复，未改变公开 Lua/JSON 作者接口。

#### Related CCB-Docs PR

None

#### Affected documentation IDs

None

#### Generated reference impact

None

#### Additional context

跨层电缆实际脱落与仍连接但失电的玩家报告都需要真机存档复测；本 PR 针对已确认的气泡外坐标错误。
