### PR TITLE
perf(chargen): 避免预览同步像素回读和空闲加载提示

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -4620,11 +4620,8 @@ SDL_Texture *cata_tiles::render_character_preview( const Character &ch, const in
     const int saved_zoom = g->get_zoom();
     set_draw_scale( scale );
 
-    // Character sprites are not tile-sized: they carry per-sprite offsets and overlays (hair,
-    // hats, mutations) that extend above and around the base tile by an amount that varies per
-    // tileset. Rather than guess a headroom that fits every case, draw into a generous work
-    // canvas, then read the rendered pixels back to find the tight non-transparent bounding box
-    // and crop to exactly that. This removes the dead space above the sprite for any tileset.
+    // Use the opaque sprite bounds cached when the tileset was loaded. Reading
+    // pixels back from the GPU here stalls every appearance change on mobile.
     const int work_w = tile_width * 3;
     const int work_h = tile_height * 3;
     if( work_w <= 0 || work_h <= 0 ) {
@@ -4650,8 +4647,12 @@ SDL_Texture *cata_tiles::render_character_preview( const Character &ch, const in
     o = point::zero;
     m_entity_draw_offset = point::zero;
 
-    // Pixel buffer for readback: ARGB8888, 4 bytes per pixel.
-    std::vector<uint32_t> pixels( static_cast<size_t>( work_w ) * work_h, 0 );
+    sprite_screen_bounds bounds;
+    sprite_screen_bounds *const previous_bounds = m_cur_bounds;
+    m_cur_bounds = &bounds;
+    on_out_of_scope restore_bounds( [&]() {
+        m_cur_bounds = previous_bounds;
+    } );
     bool drawn = false;
     {
         scoped_render_target preview_scope( renderer, char_preview_work_tex.get()
@@ -4670,9 +4671,7 @@ SDL_Texture *cata_tiles::render_character_preview( const Character &ch, const in
             draw_entity_with_overlays( ch, tripoint_bub_ms( tripoint::zero ), lit_level::BRIGHT,
                                        height_3d, FacingDirection::RIGHT );
 
-            const SDL_Rect full{ 0, 0, work_w, work_h };
-            drawn = RenderReadPixels( renderer, &full, SDL_PIXELFORMAT_ARGB8888, pixels.data(),
-                                      work_w * 4 );
+            drawn = bounds.valid;
             RenderSetClipRect( renderer, nullptr );
         }
     }
@@ -4682,22 +4681,9 @@ SDL_Texture *cata_tiles::render_character_preview( const Character &ch, const in
         return nullptr;
     }
 
-    // Scan for the bounding box of any non-zero (non-transparent) pixel. The canvas was cleared
-    // to all-zero bytes, so a pixel is "drawn" iff it is non-zero -- no need to assume which byte
-    // is alpha, sidestepping format/endianness concerns.
-    point min( work_w, work_h );
-    point max = point::north_west;
-    for( int y = 0; y < work_h; y++ ) {
-        const uint32_t *row = pixels.data() + static_cast<size_t>( y ) * work_w;
-        for( int x = 0; x < work_w; x++ ) {
-            if( row[x] != 0 ) {
-                min.x = std::min( min.x, x );
-                max.x = std::max( max.x, x );
-                min.y = std::min( min.y, y );
-                max.y = std::max( max.y, y );
-            }
-        }
-    }
+    const point min( std::max( 0, bounds.x ), std::max( 0, bounds.y ) );
+    const point max( std::min( work_w, bounds.x + bounds.w ) - 1,
+                     std::min( work_h, bounds.y + bounds.h ) - 1 );
 
     if( max.x < min.x || max.y < min.y ) {
         // Nothing was drawn (e.g. a tileset with no player sprite); show nothing.

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -600,6 +600,7 @@ using color_block_overlay_container = std::pair<SDL_BlendMode, std::multimap<poi
 class cata_tiles
 {
         friend class cata_tiles_test_helper;
+        friend struct renderer_recovery_test_support;
 
     public:
         cata_tiles( const SDL_Renderer_Ptr &render, const GeometryRenderer_Ptr &geometry,

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -3584,7 +3584,7 @@ bool character_creator_ui::display( pool_type &pool )
                 }
             }
             const std::string input_action = current_tab_input.handle_input( 33 );
-            if( !input_action.empty() ) {
+            if( !input_action.empty() && input_action != "TIMEOUT" && input_action != "MOUSE_MOVE" ) {
                 adaptive_ccui->show_loading();
                 handle_action( input_action );
             }

--- a/src/sdl_renderer_recovery.h
+++ b/src/sdl_renderer_recovery.h
@@ -396,6 +396,7 @@ class atlas_upload_scope
 // coordinator, tileset cache, and tileset so a Catch2 suite can stand up a
 // headless renderer and synthetic bundle without those members going public.
 struct renderer_recovery_test_support {
+    static point character_preview_size( const Character &ch, int scale );
     // Stand up a hidden-window software renderer, display_buffer, variant_pass,
     // and geometry on the file-static globals, then seed and bootstrap the
     // coordinator. False (globals clean) if the dummy backend fails or a window is up.

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -2840,6 +2840,24 @@ std::shared_ptr<const tileset> renderer_recovery_test_support::install_synthetic
     return ts;
 }
 
+point renderer_recovery_test_support::character_preview_size( const Character &ch, int scale )
+{
+    auto ts = std::const_pointer_cast<tileset>( install_synthetic_bundle(
+                  "character_preview_test", "color_pixel_sepia_light",
+                  renderer_coordinator.instance_generation(), renderer_coordinator.textures_generation() ) );
+    ts->tile_width = 1;
+    ts->tile_height = 1;
+    tile_type player_tile;
+    player_tile.fg.add( std::vector<int> { 0 }, 1 );
+    ts->create_tile_type( "player_male", tile_type( player_tile ) );
+    ts->create_tile_type( "player_female", tile_type( player_tile ) );
+    cata_tiles preview( renderer, geometry, ts_cache );
+    preview.tileset_ptr = ts;
+    point size;
+    preview.render_character_preview( ch, scale, size.x, size.y );
+    return size;
+}
+
 atlas_replay_quarantine::gate renderer_recovery_test_support::populate_mode2_quarantine(
     atlas_replay_quarantine &quarantine )
 {

--- a/tests/character_preview_bounds_test.cpp
+++ b/tests/character_preview_bounds_test.cpp
@@ -1,0 +1,17 @@
+#if defined(TILES)
+#include "avatar.h"
+#include "cata_catch.h"
+#include "player_helpers.h"
+#include "sdl_renderer_recovery.h"
+
+TEST_CASE( "character_preview_uses_scaled_opaque_sprite_bounds", "[tiles][character_preview]" )
+{
+    clear_avatar();
+    software_render_fixture fixture;
+    REQUIRE( fixture.available() );
+    const int scale = GENERATE( 16, 32, 48 );
+    get_avatar().male = GENERATE( false, true );
+    CHECK( renderer_recovery_test_support::character_preview_size( get_avatar(), scale ) ==
+           point( scale / 16, scale / 16 ) );
+}
+#endif


### PR DESCRIPTION
#### Summary

Performance "避免预览同步像素回读和空闲加载提示"

#### Responsible human

@LYHGLYTX

#### Purpose of change

捏人界面每次改变性别或外观都同步读取 GPU 像素以计算预览边界，移动设备会为此等待；空闲 TIMEOUT 和鼠标移动也可能触发自适应加载提示。

#### Describe the solution

复用贴图加载时计算的非透明区域，在绘制过程中汇总并裁剪预览，取消同步 GPU 像素回读。空闲和纯鼠标移动不再触发加载提示。

#### Describe alternatives you've considered

降低预览刷新频率会降低操作反馈；复用已缓存的透明边界可直接省去读回。

#### Testing

Linux SDL2、禁用 Lua Platform 的联合工作区完成游戏库及聚焦测试程序编译。相关渲染恢复、电网、烟熏和区域拆配件测试共 63 个用例、626 条断言全部通过（RNG seed 20260905）。每份补丁另经检查可独立应用到 master；未运行完整测试套件。 Android arm64/SDL3 的 sdl_wrappers.cpp、cata_tiles.cpp、newcharacter.cpp、sdltiles.cpp 四个编译单元通过。未进行真机验证。

覆盖男女角色在三档缩放下的预览尺寸，并运行渲染恢复相关回归。

#### Documentation impact

None — 内部缺陷修复，未改变公开 Lua/JSON 作者接口。

#### Related CCB-Docs PR

None

#### Affected documentation IDs

None

#### Generated reference impact

None

#### Additional context

未做安卓真机耗时测量，不能把用户报告的一秒停顿全部归因于该等待；需要继续在设备上检查输入法和捏人响应。
