### PR TITLE
修复锁定季节时创建角色无法正确选择开局季节

### DIFF
--- a/src/calendar.cpp
+++ b/src/calendar.cpp
@@ -811,27 +811,17 @@ constexpr const std::array<std::pair<std::string_view, time_duration>, 15> time_
     }
 };
 
-season_type season_of_year( const time_point &p )
+season_type season_of_year( const time_point &p, bool ignore_eternal_season )
 {
-    static time_point prev_turn = calendar::before_time_starts;
-    static season_type prev_season = calendar::initial_season;
-
-    if( p != prev_turn ) {
-        prev_turn = p;
-        if( calendar::eternal_season() ) {
-            // If we use calendar::start to determine the initial season, and the user shortens the season length
-            // mid-game, the result could be the wrong season!
-            return prev_season = calendar::initial_season;
-        }
-        return prev_season = static_cast<season_type>(
-                                 to_turn<int>( p ) / to_turns<int>( calendar::season_length() ) % 4
-                             );
+    if( calendar::eternal_season() && !ignore_eternal_season ) {
+        // Keep the opening season even if the season length changes during play.
+        return calendar::initial_season;
     }
-
-    return prev_season;
+    return static_cast<season_type>(
+               to_turn<int>( p ) / to_turns<int>( calendar::season_length() ) % 4 );
 }
 
-std::string to_string( const time_point &p )
+std::string to_string( const time_point &p, bool ignore_eternal_season )
 {
     const int year = calendar::years_since_cataclysm( p ) + 1;
     const std::string time = to_string_time_of_day( p );
@@ -841,7 +831,7 @@ std::string to_string( const time_point &p )
         //~ 1 is the year, 2 is the month, 3 is the day, 4 is the time of the day in its usual format
         return string_format( _( "Year %1$d, %2$s %3$d %4$s" ), year, to_string( month_day.first ),
                               month_day.second, time );
-    } else if( calendar::eternal_season() ) {
+    } else if( calendar::eternal_season() && !ignore_eternal_season ) {
         const int day = to_days<int>( time_past_new_year( p ) );
         //~ 1 is the year, 2 is the day (of the *year*), 3 is the time of the day in its usual format
         return string_format( _( "Year %1$d, day %2$d %3$s" ), year, day, time );
@@ -849,7 +839,7 @@ std::string to_string( const time_point &p )
     const int day = day_of_season<int>( p ) + 1;
     //~ 1 is the year, 2 is the season name, 3 is the day (of the season), 4 is the time of the day in its usual format
     return string_format( _( "Year %1$d, %2$s, day %3$d %4$s" ), year,
-                          calendar::name_season( season_of_year( p ) ), day, time );
+                          calendar::name_season( season_of_year( p, ignore_eternal_season ) ), day, time );
 
 }
 

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -605,9 +605,11 @@ inline T day_of_season( const time_point &p )
 
 /// @returns The season of the of the given time point. Returns the same season for
 /// any input if the calendar::eternal_season yields true.
-season_type season_of_year( const time_point &p );
+/// With ignore_eternal_season, use the date itself (e.g. when choosing an opening date).
+season_type season_of_year( const time_point &p, bool ignore_eternal_season = false );
 /// @returns The time point formatted to be shown to the player. Contains year, season, day and time of day.
-std::string to_string( const time_point &p );
+/// With ignore_eternal_season, show the date's season even before the game starts.
+std::string to_string( const time_point &p, bool ignore_eternal_season = false );
 /// @returns The time point formatted to be shown to the player. Contains only the time of day, not the year, day or season.
 std::string to_string_time_of_day( const time_point &p );
 /** Time approximation based on the player's timekeeping capability, formatted for diary pages **/

--- a/src/calendar_ui.cpp
+++ b/src/calendar_ui.cpp
@@ -15,7 +15,7 @@
 #include "uilist.h"
 
 time_point calendar_ui::select_time_point( time_point initial_value, std::string_view title,
-        calendar_ui::granularity granularity_level )
+        calendar_ui::granularity granularity_level, bool ignore_eternal_season )
 {
     time_point return_value = initial_value;
     auto set_turn = [&]( const int initial, const time_duration & factor, const char *const msg,
@@ -45,8 +45,8 @@ time_point calendar_ui::select_time_point( time_point initial_value, std::string
         smenu.reset();
         smenu.title = title;
         smenu.text += string_format( _( "Old date: %1$s\nNew date: %2$s" ),
-                                     colorize( to_string( initial_value ), c_light_red ),
-                                     colorize( to_string( return_value ), c_light_cyan ) );
+                                     colorize( to_string( initial_value, ignore_eternal_season ), c_light_red ),
+                                     colorize( to_string( return_value, ignore_eternal_season ), c_light_cyan ) );
         smenu.desc_enabled = true;
         smenu.allow_additional = true;
         smenu.input_category = "CALENDAR_UI";
@@ -68,7 +68,8 @@ time_point calendar_ui::select_time_point( time_point initial_value, std::string
         smenu.addentry( static_cast<int>( calendar_ui::granularity::year ), true,
                         'y', "%s: %d", _( "year" ), years( return_value ) + 1 );
         smenu.addentry( static_cast<int>( calendar_ui::granularity::season ), true,
-                        's', "%s: %s", _( "season" ), calendar::name_season( season_of_year( return_value ) ) );
+                        's', "%s: %s", _( "season" ), calendar::name_season( season_of_year( return_value,
+                                ignore_eternal_season ) ) );
         smenu.addentry( static_cast<int>( calendar_ui::granularity::day ), true,
                         'd', "%s: %d", _( "day" ), day_of_season<int>( return_value ) + 1 );
         smenu.addentry( static_cast<int>( calendar_ui::granularity::hour ), true,
@@ -92,7 +93,8 @@ time_point calendar_ui::select_time_point( time_point initial_value, std::string
                 set_turn( years( return_value ) + 1, calendar::year_length(), _( "Set year to?" ) );
                 break;
             case static_cast<int>( calendar_ui::granularity::season ):
-                set_turn( static_cast<int>( season_of_year( return_value ) ), calendar::season_length(),
+                set_turn( static_cast<int>( season_of_year( return_value, ignore_eternal_season ) ),
+                          calendar::season_length(),
                           _( "Set season to?  (0 = spring)" ) );
                 break;
             case static_cast<int>( calendar_ui::granularity::day ):
@@ -123,7 +125,8 @@ time_point calendar_ui::select_time_point( time_point initial_value, std::string
                             set_turn( years( return_value ) + 1, calendar::year_length(), "", auto_value );
                             break;
                         case static_cast<int>( calendar_ui::granularity::season ):
-                            set_turn( static_cast<int>( season_of_year( return_value ) ), calendar::season_length(), "",
+                            set_turn( static_cast<int>( season_of_year( return_value, ignore_eternal_season ) ),
+                                      calendar::season_length(), "",
                                       auto_value );
                             break;
                         case static_cast<int>( calendar_ui::granularity::day ):

--- a/src/calendar_ui.h
+++ b/src/calendar_ui.h
@@ -21,10 +21,12 @@ enum class granularity : int {
 
 /**
  * Displays ui element that allows to select and return time point.
+ * ignore_eternal_season edits absolute dates before the opening season is established.
  */
 time_point select_time_point( time_point initial_value,
                               std::string_view title,
-                              calendar_ui::granularity granularity_level = calendar_ui::granularity::turn );
+                              calendar_ui::granularity granularity_level = calendar_ui::granularity::turn,
+                              bool ignore_eternal_season = false );
 } // namespace calendar_ui
 
 #endif // CATA_SRC_CALENDAR_UI_H

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -2303,14 +2303,15 @@ void draw_time_cataclysm_start()
 {
     draw_action_button( _( "Start of cataclysm:" ), "CHANGE_START_OF_CATACLYSM" );
     ImGui::SameLine();
-    cataimgui::draw_colored_text( to_string( get_scenario()->start_of_cataclysm() ), c_light_gray );
+    cataimgui::draw_colored_text( to_string( get_scenario()->start_of_cataclysm(), true ),
+                                  c_light_gray );
 }
 
 void draw_time_game_start()
 {
     draw_action_button( _( "Start of game:" ), "CHANGE_START_OF_GAME" );
     ImGui::SameLine();
-    cataimgui::draw_colored_text( to_string( get_scenario()->start_of_game() ), c_light_gray );
+    cataimgui::draw_colored_text( to_string( get_scenario()->start_of_game(), true ), c_light_gray );
 }
 
 void draw_location( const avatar &you )
@@ -4348,11 +4349,11 @@ bool character_creator_ui::handle_action( const std::string &action )
     } else if( action == "CHANGE_START_OF_CATACLYSM" ) {
         const scenario *scen = get_scenario();
         scen->change_start_of_cataclysm( calendar_ui::select_time_point( scen->start_of_cataclysm(),
-                                         _( "Select cataclysm start date" ), calendar_ui::granularity::hour ) );
+                                         _( "Select cataclysm start date" ), calendar_ui::granularity::hour, true ) );
     } else if( action == "CHANGE_START_OF_GAME" ) {
         const scenario *scen = get_scenario();
         scen->change_start_of_game( calendar_ui::select_time_point( scen->start_of_game(),
-                                    _( "Select game start date" ), calendar_ui::granularity::hour ) );
+                                    _( "Select game start date" ), calendar_ui::granularity::hour, true ) );
     } else if( action == "RESET_CALENDAR" ) {
         get_scenario()->reset_calendar();
     } else if( action == "CHOOSE_CITY" ) {

--- a/tests/calendar_test.cpp
+++ b/tests/calendar_test.cpp
@@ -9,6 +9,7 @@
 #include "cata_catch.h"
 #include "cata_scope_helpers.h"
 #include "options.h"
+#include "options_helpers.h"
 #include "string_formatter.h"
 
 TEST_CASE( "time_duration_to_string", "[calendar][nogame]" )
@@ -49,6 +50,48 @@ TEST_CASE( "time_duration_to_string_eternal_season", "[calendar][nogame]" )
     CHECK( to_string( 3650_days ) == "521 weeks and 3 days" );
     calendar::set_eternal_season( false );
     REQUIRE( calendar::season_from_default_ratio() == Approx( 1.0f ) );
+}
+
+TEST_CASE( "opening_dates_ignore_eternal_season", "[calendar][nogame]" )
+{
+    const bool was_eternal = calendar::eternal_season();
+    const int old_length = to_days<int>( calendar::season_length() );
+    on_out_of_scope restore_calendar( [was_eternal, old_length]() {
+        calendar::set_eternal_season( was_eternal );
+        calendar::set_season_length( old_length );
+    } );
+    restore_on_out_of_scope restore_initial_season( calendar::initial_season );
+    const int length = GENERATE( 91, 73 );
+    const season_type initial = GENERATE( SPRING, SUMMER, AUTUMN, WINTER );
+    const bool show_months = GENERATE( false, true );
+    override_option months( "SHOW_MONTHS", show_months ? "true" : "false" );
+    calendar::set_season_length( length );
+    calendar::initial_season = initial;
+
+    const std::array<season_type, 4> seasons = {{ SPRING, SUMMER, AUTUMN, WINTER }};
+    for( const season_type selected : seasons ) {
+        CAPTURE( length, initial, show_months, selected );
+        const time_point date = calendar::turn_zero + calendar::season_length() * selected +
+                                10_days + 8_hours;
+        calendar::set_eternal_season( false );
+        const std::string expected_preview = to_string( date );
+        calendar::set_eternal_season( true );
+
+        CHECK( season_of_year( date ) == initial );
+        CHECK( season_of_year( date, true ) == selected );
+        CHECK( to_string( date, true ) == expected_preview );
+        // A date preview must not change the world's lock or its opening season.
+        CHECK( calendar::eternal_season() );
+        CHECK( calendar::initial_season == initial );
+        CHECK( season_of_year( date ) == initial );
+
+        // At game start the chosen date establishes the lock, even if the UI
+        // has just queried this exact timestamp with the previous initial season.
+        calendar::initial_season = selected;
+        CHECK( season_of_year( date ) == selected );
+        CHECK( season_of_year( date + calendar::season_length() ) == selected );
+        calendar::initial_season = initial;
+    }
 }
 
 TEST_CASE( "months_and_days_over_time", "[calendar]" )


### PR DESCRIPTION
#### Summary
Bugfixes "修复锁定季节时创建角色无法正确选择和预览开局季节"

#### Responsible human

@LYHGLYTX

#### Purpose of change

开启世界选项“锁定季节”后，在创建角色界面修改开局季节，日期选择器会提前使用尚未初始化的新角色初始季节。春季开局时选择夏季，底层日期已推进一季，界面却仍显示春季；重复选择夏季还会继续推进日期，最终可能以错误季节开局。

复现：新建开启“锁定季节”的世界，进入创建角色界面的开局日期选择器，将季节设为夏季，再次选择夏季，观察季节预览与日期。

#### Describe the solution

- 为季节查询、日期格式化和日期选择器增加显式忽略季节锁定的参数，默认保留游戏内锁定行为。
- 创建角色时的大灾变日期、游戏开始日期及两处日期预览使用实际日期计算季节。
- 移除只按时间点缓存季节的逻辑，确保正式开局更新初始季节后，同一时间点也能立即得到正确结果。
- 增加回归测试，覆盖四种初始季节、四种目标季节、91/73 天季节长度和月份显示开关，并检查预览不改变世界锁定状态、正式开局后锁定到所选季节。

#### Describe alternatives you've considered

不采用临时修改全局锁定开关来驱动日期预览；日期编辑通过显式参数选择计算方式。

#### Testing

- `git diff --check` 通过。
- C++17、警告视为错误：`calendar.cpp`、`calendar_ui.cpp`、`newcharacter.cpp` 和 `calendar_test.cpp` 均完成聚焦对象编译；平台为 Linux SDL2，`CATA_ENABLE_LUA_PLATFORM=0`（测试对象单独编译）。独立 PR 工作树另行编译了剔除无关修改后的 `newcharacter.cpp`。
- 临时原生 C++ 检查程序直接链接本次 `calendar.cpp` 和 `string_id.cpp`，224 项断言通过，覆盖日期选择、重复选择不继续推进、初始季节更新和锁定/解锁；旧实现可复现断言失败。
- 新增 Catch2 回归用例已编译，尚未链接并执行完整测试程序；未重建完整游戏，也未进行界面实测。
- 对上述 6 个文件运行聚焦 `make astyle-check` 未通过：本机为 AStyle 3.6.18，仓库要求 3.1；与修改前比较没有新增格式差异。

建议界面验收：开启锁定季节，创建角色时依次切换四季，并重复选择同一季节；确认预览和日期一致、重复选择不推进日期，正式开局后保持所选季节。

#### Documentation impact

None。恢复开局日期选择的预期行为，不改变“保持初始季节”的世界选项语义。

#### Related CCB-Docs PR

None

#### Affected documentation IDs

None

#### Generated reference impact

None。未修改 JSON、Lua 公共契约或生成文件。

#### Additional context

基于最新 `origin/master` 的独立分支，仅包含本次季节修复。游戏开始日期不能早于大灾变日期的既有限制保持不变。
