### PR TITLE
fix(power): 保存电器缺电关闭状态以支持读档后恢复供电

### DIFF
--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3836,6 +3836,7 @@ void vehicle_part::deserialize( const JsonObject &data )
     direction = units::from_degrees( direction_int );
     data.read( "blood", blood );
     data.read( "enabled", enabled );
+    power_disabled = data.get_bool( "power_disabled", false );
     data.read( "flags", flags );
     data.read( "passenger_id", passenger_id );
     if( data.has_int( "z_offset" ) ) {
@@ -3894,6 +3895,7 @@ void vehicle_part::serialize( JsonOut &json ) const
     json.member( "direction", std::lround( to_degrees( direction ) ) );
     json.member( "blood", blood );
     json.member( "enabled", enabled );
+    json.member( "power_disabled", power_disabled );
     json.member( "flags", flags );
     if( !carried_stack.empty() ) {
         std::stack<vehicle_part::carried_part_data> carried_copy = carried_stack;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -548,7 +548,7 @@ struct vehicle_part {
         bool removed = false; // NOLINT(cata-serialize)
         bool enabled = true;
         // set by power_parts() on deficit, cleared by grid resolution on recovery
-        bool power_disabled = false; // NOLINT(cata-serialize)
+        bool power_disabled = false;
 
         /** ID of player passenger */
         character_id passenger_id;

--- a/tests/appliance_power_restore_test.cpp
+++ b/tests/appliance_power_restore_test.cpp
@@ -1,0 +1,61 @@
+#include <optional>
+#include <sstream>
+
+#include "calendar.h"
+#include "cata_catch.h"
+#include "flexbuffer_json.h"
+#include "item.h"
+#include "json.h"
+#include "json_loader.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "player_helpers.h"
+#include "type_id.h"
+#include "veh_appliance.h"
+#include "vehicle.h"
+#include "vpart_position.h"
+#include "vpart_range.h"
+
+TEST_CASE( "appliance_power_failure_recovers_after_save_load", "[vehicle][power][save]" )
+{
+    clear_avatar();
+    clear_map_without_vision();
+    map &here = get_map();
+    const tripoint_bub_ms battery_pos( 60, 60, 0 );
+    const tripoint_bub_ms lamp_pos( 62, 60, 0 );
+    std::optional<item> battery( itype_id( "test_storage_battery" ) );
+    std::optional<item> lamp( itype_id( "test_standing_lamp" ) );
+    place_appliance( here, battery_pos, vpart_id( "ap_test_storage_battery" ),
+                     get_player_character(), battery );
+    place_appliance( here, lamp_pos, vpart_id( "ap_test_standing_lamp" ),
+                     get_player_character(), lamp );
+    item cord( itype_id( "test_power_cord" ) );
+    REQUIRE( cord.link_to( here.veh_at( battery_pos ), here.veh_at( lamp_pos ),
+                           link_state::vehicle_port ).success() );
+    vehicle &consumer = here.veh_at( lamp_pos )->vehicle();
+    vehicle &supply = here.veh_at( battery_pos )->vehicle();
+    bool tested_consumer = false;
+    for( const vpart_reference &vp : consumer.get_all_parts() ) {
+        if( !vp.info().has_flag( "ENABLED_DRAINS_EPOWER" ) ) {
+            continue;
+        }
+        tested_consumer = true;
+        const bool deficit = GENERATE( false, true );
+        vp.part().enabled = false;
+        vp.part().power_disabled = deficit;
+        std::ostringstream saved;
+        JsonOut out( saved );
+        vp.part().serialize( out );
+        vehicle_part restored;
+        restored.deserialize( json_loader::from_string( saved.str() ).get_object() );
+        CHECK( restored.power_disabled == deficit );
+        vp.part().power_disabled = restored.power_disabled;
+        supply.discharge_battery( here, 100000000 );
+        REQUIRE( supply.charge_battery( here, 1000 ) == 0 );
+        calendar::turn += 1_turns;
+        here.vehmove();
+        CHECK( vp.part().enabled == deficit );
+        CHECK_FALSE( vp.part().power_disabled );
+    }
+    REQUIRE( tested_consumer );
+}


### PR DESCRIPTION
#### Summary

Bugfixes "保存电器缺电关闭状态以支持读档后恢复供电"

#### Responsible human

@LYHGLYTX

#### Purpose of change

电器因电网缺电自动关闭后，power_disabled 标志没有写入存档；读档时它与玩家主动关机无法区分，供电恢复后仍保持关闭。

#### Describe the solution

序列化和反序列化 power_disabled，旧存档缺省为 false，保持手动关闭语义。现有电网恢复逻辑据此重新启动因缺电关闭的设备。

#### Describe alternatives you've considered

把所有关闭设备重新开启会覆盖玩家的手动选择，因此持久化已有的缺电原因标志。

#### Testing

Linux SDL2、禁用 Lua Platform 的联合工作区完成游戏库及聚焦测试程序编译。本批修复及相关渲染、电网回归共 68 个用例、673 条断言全部通过（RNG seed 20260905）。每份补丁另经检查可独立应用到 master；未运行完整测试套件，未使用玩家原始存档或安卓真机复测。

覆盖缺电关闭状态的保存恢复和充电后重新开启，同时验证玩家主动关闭的设备不会被自动开启。

#### Documentation impact

None — 内部缺陷修复，未改变公开 Lua/JSON 作者接口。

#### Related CCB-Docs PR

None

#### Affected documentation IDs

None

#### Generated reference impact

None

#### Additional context

没有本地电池的跨层供电设备可保留恢复资格；本 PR 不改变电缆连接拓扑。
