### PR TITLE
fix(zones): 清理中断区域行动遗留的工具使用标记

### DIFF
--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -206,6 +206,8 @@ int move_cost_cart( const item &it, const tripoint_bub_ms &src, const tripoint_b
                     const units::volume &capacity );
 int move_cost_inv( const item &it, const tripoint_bub_ms &src, const tripoint_bub_ms &dest );
 
+// Reserve the final location so cancellation can release ground, cargo and inventory items.
+void reserve_activity_item( Character &you, item_location loc );
 void clean_may_activity_occupancy_items_var( Character &you );
 void clean_may_activity_occupancy_items_var_if_is_avatar_and_no_activity_now( Character &you );
 // defined in activity_handlers.cpp

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -762,7 +762,13 @@ static void move_item( Character &you, item &it, const int quantity, const tripo
         if( activity_to_restore == ACT_FETCH_REQUIRED ) {
             it.set_var( "activity_var", you.name );
         }
-        put_into_vehicle_or_drop( you, item_drop_reason::deliberate, { it }, &here, dest );
+        const std::vector<item_location> moved = put_into_vehicle_or_drop_ret_locs(
+                you, item_drop_reason::deliberate, { it }, &here, dest );
+        if( activity_to_restore == ACT_FETCH_REQUIRED ) {
+            for( const item_location &loc : moved ) {
+                activity_handlers::reserve_activity_item( you, loc );
+            }
+        }
         // Remove from map or vehicle.
         if( vpr_src ) {
             vpr_src->vehicle().remove_item( vpr_src->part(), &it );
@@ -2339,7 +2345,7 @@ activity_reason_info multi_study_activity_actor::multi_activity_can_do( Characte
 
     item_location book = find_study_book( abspos, you );
     if( book ) {
-        book->set_var( "activity_var", you.name );
+        activity_handlers::reserve_activity_item( you, book );
         return activity_reason_info::ok( do_activity_reason::NEEDS_BOOK_TO_LEARN );
     }
 
@@ -2588,7 +2594,7 @@ activity_reason_info multi_disassemble_activity_actor::multi_activity_can_do( Ch
                 continue;
             }
             // check passed, mark the item
-            i.set_var( "activity_var", you.name );
+            activity_handlers::reserve_activity_item( you, item_location( map_cursor( src_loc ), &i ) );
             return activity_reason_info::ok( do_activity_reason::NEEDS_DISASSEMBLE );
         }
     }
@@ -3355,7 +3361,7 @@ bool fetch_required_activity_actor::fetch_activity(
                         leftovers.charges = 0;
                     }
                     it.set_var( "activity_var", you.name );
-                    you.i_add( it );
+                    activity_handlers::reserve_activity_item( you, you.i_add( it ) );
                     if( you.is_npc() ) {
                         if( pickup_count == 1 ) {
                             const std::string item_name = it.tname();
@@ -3396,8 +3402,8 @@ static bool butcher_corpse_activity( Character &you, const tripoint_bub_ms &src_
             if( corpse.size > creature_size::medium && reason != do_activity_reason::NEEDS_BIG_BUTCHERING ) {
                 continue;
             }
-            elem.set_var( "activity_var", you.name );
             item_location corpse_loc = item_location( map_cursor( src_loc ), &elem );
+            activity_handlers::reserve_activity_item( you, corpse_loc );
             bd.emplace_back( corpse_loc, butcher_type::FULL );
         }
     }
@@ -3906,8 +3912,7 @@ bool multi_study_activity_actor::multi_activity_do( Character &you,
     if( reason == do_activity_reason::NEEDS_BOOK_TO_LEARN ) {
         item_location book_loc = find_study_book( src, you );
         if( book_loc ) {
-            book_loc->set_var( "activity_var", you.name );
-            you.may_activity_occupancy_after_end_items_loc.push_back( book_loc );
+            activity_handlers::reserve_activity_item( you, book_loc );
             const time_duration time_taken = you.time_to_read( *book_loc, you );
             item_location ereader;
             you.assign_activity( read_activity_actor( time_taken, book_loc, ereader, true ) );
@@ -4590,6 +4595,18 @@ bool try_fuel_fire( Character &you, std::optional<tripoint_bub_ms> fire_target )
         }
     }
     return true;
+}
+
+void activity_handlers::reserve_activity_item( Character &you, item_location loc )
+{
+    if( !loc ) {
+        return;
+    }
+    loc.get_item()->set_var( "activity_var", you.name );
+    auto &reserved = you.may_activity_occupancy_after_end_items_loc;
+    if( std::find( reserved.begin(), reserved.end(), loc ) == reserved.end() ) {
+        reserved.push_back( loc );
+    }
 }
 
 void activity_handlers::clean_may_activity_occupancy_items_var_if_is_avatar_and_no_activity_now(

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -218,11 +218,10 @@ static bool pick_one_up( item_location &loc, int quantity, bool &got_water, bool
     //new item (copy)
     item newit = it;
 
-    // Clear activity_var if it differs from the picker's name
-    if( it.has_var( "activity_var" ) && it.get_var( "activity_var", "" ) != player_character.name ) {
-        it.erase_var( "activity_var" );
-        newit.erase_var( "activity_var" );
-    }
+    // The picked-up copy no longer belongs to the reservation at this location.
+    // Also release orphaned marks from older activities, including our own.
+    // Leave the source unchanged if pickup is cancelled or only takes a portion.
+    newit.erase_var( "activity_var" );
     if( !newit.is_owned_by( player_character, true ) ) {
         const std::string thief_mode = player_character.get_value( "THIEF_MODE" ).str();
         if( thief_mode == "THIEF_HONEST" ) {

--- a/tests/zone_reservation_cleanup_test.cpp
+++ b/tests/zone_reservation_cleanup_test.cpp
@@ -1,0 +1,57 @@
+#include <vector>
+
+#include "activity_actor_definitions.h"
+#include "activity_handlers.h"
+#include "avatar.h"
+#include "cata_catch.h"
+#include "character_attire.h"
+#include "item.h"
+#include "item_location.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "pickup.h"
+#include "player_helpers.h"
+#include "type_id.h"
+
+TEST_CASE( "zone_disassembly_releases_reservation_on_cancel", "[activities][zones][reservation]" )
+{
+    clear_avatar();
+    clear_map_without_vision();
+    avatar &you = get_avatar();
+    you.name = "Reservation test";
+    map &here = get_map();
+    const tripoint_bub_ms pos = you.pos_bub( here );
+    item &target = here.add_item_or_charges( pos, item( itype_id( "sheet" ) ) );
+    REQUIRE( target.is_disassemblable() );
+    you.i_add( item( itype_id( "scissors" ) ) );
+    multi_disassemble_activity_actor actor;
+    you.assign_activity( actor );
+    actor.multi_activity_can_do( you, pos );
+    REQUIRE( target.get_var( "activity_var" ) == you.name );
+    you.cancel_activity();
+    CHECK_FALSE( target.has_var( "activity_var" ) );
+    CHECK( you.may_activity_occupancy_after_end_items_loc.empty() );
+    you.backlog.clear();
+}
+
+TEST_CASE( "pickup_releases_legacy_own_reservation", "[activities][zones][reservation]" )
+{
+    clear_avatar();
+    clear_map_without_vision();
+    avatar &you = get_avatar();
+    you.name = "Reservation test";
+    you.wear_item( item( itype_id( "backpack" ) ), false );
+    map &here = get_map();
+    const tripoint_bub_ms pos = you.pos_bub( here );
+    item &target = here.add_item_or_charges( pos, item( itype_id( "hammer" ) ) );
+    target.set_var( "activity_var", you.name );
+    std::vector<item_location> targets{ item_location( map_cursor( pos ), &target ) };
+    std::vector<int> quantities{ 0 };
+    bool stashed = true;
+    Pickup::pick_info info;
+    you.set_moves( 1000 );
+    REQUIRE( Pickup::do_pickup( targets, quantities, true, stashed, info ) );
+    const auto hammers = you.cache_get_items_with( itype_id( "hammer" ) );
+    REQUIRE( hammers.size() == 1 );
+    CHECK_FALSE( hammers.front()->has_var( "activity_var" ) );
+}


### PR DESCRIPTION
#### Summary

Bugfixes "清理中断区域行动遗留的工具使用标记"

#### Responsible human

@LYHGLYTX

#### Purpose of change

区域行动会给地面、车载和取回工具设置“使用中”，但部分路径没有记录最终 item_location，活动中断时无法清理。玩家自己遗留的旧标记又不会在拾取时解除。

#### Describe the solution

统一记录被占用物品的最终位置，覆盖取回、移动、拆解、阅读和屠宰路径，复用已有的取消/结束清理与存档机制。拾取副本清除包括本人在内的旧标记，取消拾取时保留源物品状态。

#### Describe alternatives you've considered

使用现有的物品位置列表定点清理，避免每次结束活动都扫描整个地图。

#### Testing

Linux SDL2、禁用 Lua Platform 的联合工作区完成游戏库及聚焦测试程序编译。本批修复及相关渲染、电网回归共 68 个用例、673 条断言全部通过（RNG seed 20260905）。每份补丁另经检查可独立应用到 master；未运行完整测试套件，未使用玩家原始存档或安卓真机复测。

覆盖区域拆解中断后释放标记，以及拾取本人遗留使用标记的工具。

#### Documentation impact

None — 内部缺陷修复，未改变公开 Lua/JSON 作者接口。

#### Related CCB-Docs PR

None

#### Affected documentation IDs

None

#### Generated reference impact

None

#### Additional context

新记录使用现有序列化列表，兼容原有存档。旧的孤立标记可通过拾取解除。
