### PR TITLE
fix(save): 避免维度切换后读档重复生成怪物

### DIFF
--- a/src/horde_entity.cpp
+++ b/src/horde_entity.cpp
@@ -16,7 +16,7 @@ horde_entity::horde_entity( const monster &original )
     }
     moves = original.get_moves();
     type_id = original.type->id.id();
-    monster_data = std::make_unique<monster>( original );
+    monster_data = std::make_unique<monster>( original.copy_for_persistence() );
 }
 
 horde_entity::horde_entity( const mtype_id &original )

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -363,6 +363,13 @@ monster::~monster() = default;
 monster &monster::operator=( const monster & ) = default;
 monster &monster::operator=( monster && ) noexcept( string_is_noexcept ) = default;
 
+monster monster::copy_for_persistence() const
+{
+    monster result( *this );
+    result.uid_.deserialize( uid_.get_value() );
+    return result;
+}
+
 void monster::ensure_uid()
 {
     if( !uid_.is_valid() ) {

--- a/src/monster.h
+++ b/src/monster.h
@@ -106,6 +106,8 @@ class monster : public Creature
             return uid_;
         }
         void ensure_uid();
+        // Transfer between active and overmap storage without creating a new entity.
+        monster copy_for_persistence() const;
 
         mfaction_id get_monster_faction() const override {
             return faction.id();

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -25,6 +25,7 @@
 #include "city.h"
 #include "color.h"
 #include "coordinates.h"
+#include "creature_tracker.h"
 #include "cuboid_rectangle.h"
 #include "debug.h"
 #include "filesystem.h"
@@ -2403,9 +2404,16 @@ void overmapbuffer::spawn_monster( const tripoint_abs_sm &p, bool spawn_nonlocal
         }
         monster *placed = nullptr;
         if( entry.node.mapped().monster_data ) {
-            placed = g->place_critter_around( make_shared_fast<monster>(
-                                                  *entry.node.mapped().monster_data ),
-                                              local, 1, true );
+            const monster &stored = *entry.node.mapped().monster_data;
+            // A dimension departure saves these monsters to the overmap even
+            // when the player later reloads an older character save. If that
+            // save already restored this entity, consume the stale map copy.
+            if( get_creature_tracker().find_by_uid( stored.uid().get_value() ) ) {
+                continue;
+            }
+            const shared_ptr_fast<monster> restored(
+                std::make_unique<monster>( stored.copy_for_persistence() ) );
+            placed = g->place_critter_around( restored, local, 1, true );
             // TODO: make sure entity data such as destination is synched
         } else {
             placed = g->place_critter_around( entry.node.mapped().type_id->id, local, 1 );

--- a/tests/dimension_monster_persistence_test.cpp
+++ b/tests/dimension_monster_persistence_test.cpp
@@ -1,0 +1,54 @@
+#include "avatar.h"
+#include "cata_catch.h"
+#include "coordinates.h"
+#include "creature_tracker.h"
+#include "game.h"
+#include "horde_entity.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "map_helpers_tests.h"
+#include "monster.h"
+#include "monster_helpers.h"
+#include "overmapbuffer.h"
+#include "player_helpers.h"
+#include "type_id.h"
+
+TEST_CASE( "dimension_monster_storage_preserves_identity", "[monster][dimension][save]" )
+{
+    clear_avatar();
+    clear_map_without_vision();
+    monster &original = spawn_test_monster( "mon_zombie", get_avatar().pos_bub() + point( 3, 0 ) );
+    const int64_t uid = original.uid().get_value();
+    horde_entity stored( original );
+    REQUIRE( stored.monster_data );
+    CHECK( stored.monster_data->uid().get_value() == uid );
+    monster restored = stored.monster_data->copy_for_persistence();
+    CHECK( restored.uid().get_value() == uid );
+    // Deliberately cloning a monster still gives the new creature a new identity.
+    monster clone( original );
+    CHECK( clone.uid().get_value() != uid );
+}
+
+TEST_CASE( "reloading_before_dimension_departure_does_not_duplicate_monsters",
+           "[monster][dimension][save]" )
+{
+    clear_avatar();
+    clear_map_without_vision();
+    const tripoint_bub_ms pos = get_avatar().pos_bub() + point( 3, 0 );
+    monster &original = spawn_test_monster( "mon_zombie", pos );
+    const int64_t uid = original.uid().get_value();
+    const tripoint_abs_ms abs = original.pos_abs();
+    // Dimension departure writes a copy into the source overmap. Reloading
+    // the earlier character save restores the same original active monster.
+    overmap_buffer.despawn_monster( original );
+    REQUIRE( overmap_buffer.entity_at( abs ) );
+    if( GENERATE( false, true ) ) {
+        // A normal dimension return has no earlier active copy to deduplicate.
+        g->remove_zombie( original );
+        REQUIRE( get_creature_tracker().size() == 0 );
+    }
+    overmap_buffer.spawn_monster( project_to<coords::sm>( abs ) );
+    CHECK( get_creature_tracker().size() == 1 );
+    CHECK( get_creature_tracker().find_by_uid( uid ) );
+    CHECK( overmap_buffer.entity_at( abs ) == nullptr );
+}


### PR DESCRIPTION
#### Summary

Bugfixes "避免维度切换后读档重复生成怪物"

#### Responsible human

@LYHGLYTX

#### Purpose of change

空岛等维度玩法中，在撤离点附近有怪物时存档，返回岛屿后重新读原存档，会同时恢复角色存档和源维度大地图中的怪物。原先存储复制还会分配新 UID，使两份记录无法识别为同一只怪物。

#### Describe the solution

为持久化复制保留 monster UID，用于大地图归档和恢复。恢复大地图节点时若相同 UID 已在活动怪物集合中，消费重复归档记录。正常的游戏内克隆继续生成新身份。

#### Describe alternatives you've considered

按怪物种类和位置去重可能删除合法的同类怪物，因此使用持久化身份。

#### Testing

Linux SDL2、禁用 Lua Platform 的联合工作区完成游戏库及聚焦测试程序编译。本批修复及相关渲染、电网回归共 68 个用例、673 条断言全部通过（RNG seed 20260905）。每份补丁另经检查可独立应用到 master；未运行完整测试套件，未使用玩家原始存档或安卓真机复测。

覆盖归档/恢复身份保持、正常克隆身份独立、正常维度返回以及已有活动副本时的去重。

#### Documentation impact

None — 内部缺陷修复，未改变公开 Lua/JSON 作者接口。

#### Related CCB-Docs PR

None

#### Affected documentation IDs

None

#### Generated reference impact

None

#### Additional context

保持 UID 的修复对之后的维度切换生效；不会按类型和位置强行删除旧存档里已经拥有不同 UID 的怪物。
