### PR TITLE
Partial fix for issue #225

### DIFF
--- a/src/advanced_inv_pane.cpp
+++ b/src/advanced_inv_pane.cpp
@@ -1,4 +1,4 @@
-#include "advanced_inv_pane.h"
+﻿#include "advanced_inv_pane.h"
 
 #include <cstddef>
 #include <iterator>
@@ -110,7 +110,7 @@ static std::vector<std::vector<item_location>> item_list_to_stack(
     for( auto iter_outer = item_list.begin(); iter_outer != item_list.end(); ++iter_outer ) {
         std::vector<item_location> item_stack( { item_location( parent, *iter_outer ) } );
         for( auto iter_inner = std::next( iter_outer ); iter_inner != item_list.end(); ) {
-            if( ( *iter_outer )->display_stacked_with( **iter_inner ) ) {
+            if( ( *iter_outer )->stacks_with( **iter_inner ) ) {
                 item_stack.emplace_back( parent, *iter_inner );
                 iter_inner = item_list.erase( iter_inner );
             } else {

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -1,4 +1,4 @@
-#include "inventory.h"
+﻿#include "inventory.h"
 
 #include <item.h>
 #include <visitable.h>
@@ -502,7 +502,7 @@ void inventory::restack( Character &p )
         for( invstack::iterator other = iter; other != items.end(); ++other ) {
             if( iter != other && iter->front().stacks_with( other->front() ) ) {
                 if( other->front().count_by_charges() ) {
-                    iter->front().charges += other->front().charges;
+                    iter->front().merge_charges( other->front() );
                 } else {
                     iter->splice( iter->begin(), *other );
                 }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1,4 +1,4 @@
-#include "item.h"
+﻿#include "item.h"
 
 #include <cata_lazy.h>
 #include <crafting_enums.h>
@@ -3447,6 +3447,11 @@ bool item::is_same_relic( item const &rhs ) const
 
 bool item::is_same_temperature( item const &rhs ) const
 {
+    // Stackable items are treated as the same temperature regardless of
+    // individual temperature flags, so they can stack and merge together.
+    if( is_stackable() && rhs.is_stackable() ) {
+        return true;
+    }
     return ( !has_temperature() && !rhs.has_temperature() ) ||
            ( has_temperature() && rhs.has_temperature() &&
              has_flag( flag_HOT ) == rhs.has_flag( flag_HOT ) &&

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1,4 +1,4 @@
-// Associated headers here are the ones for which their only non-inline
+﻿// Associated headers here are the ones for which their only non-inline
 // functions are serialization functions.  This allows IWYU to check the
 // includes in such headers.
 
@@ -1423,6 +1423,10 @@ void Character::load( const JsonObject &data )
         queued_effect_on_conditions.push( temp );
     }
     data.read( "inactive_eocs", inactive_effect_on_condition_vector );
+
+    // Merge stackable items that older saves stored as separate entries, so a
+    // stackable field change takes effect after loading the character.
+    inv->restack( *this );
 }
 
 /**
@@ -6865,6 +6869,23 @@ void submap::load( const JsonValue &jv, const std::string &member_name, int vers
                     const int stored = legacy_charges > 0 ? legacy_charges :
                                        terrain.liquid_source_count.second;
                     set_finite_liquid( p, std::min( stored, terrain.liquid_source_count.second ) );
+                }
+            }
+            // Merge stackable items that older saves stored as separate
+            // entries, so a stackable field change is reflected after load.
+            auto &items_here = m->itm[p.x()][p.y()];
+            for( auto outer = items_here.begin(); outer != items_here.end(); ++outer ) {
+                if( !outer->is_stackable() ) {
+                    continue;
+                }
+                auto inner = outer;
+                ++inner;
+                while( inner != items_here.end() ) {
+                    if( outer->merge_charges( *inner ) ) {
+                        inner = items_here.erase( inner );
+                    } else {
+                        ++inner;
+                    }
                 }
             }
             // some portion could've been read even if error occurred


### PR DESCRIPTION
<!-- 使用说明：在下面每个「#### 标题」下填写与你的 PR 相关的信息。
请保留这些标题。像这样的注释可以安全删除。

如果你是在 GitHub 网页界面发起这个 PR，可以用「preview（预览）」按钮查看 PR 对他人显示的样子。

PR 提交准则：
- 让你的改动只聚焦于一个具体的问题或变更，外加为实现它所必需的最小相关改动。
- 一个经验法则：大多数 PR 的改动应少于 500 行。
- 你可以另开 PR 来拆分一次较大的预期改动；如果不确定怎么拆，尽管问。我们很乐意与你协作，并建议合并你 PR 的最佳方式。
-->

#### Summary
<!-- #### 概述 -->
Bugfixes Partial fix for issue #225

<!-- 这一节应当只有一行，请编辑上面那一行。
1. 把「分类」替换为下列具体分类之一：Features、Content、Interface、Mods、Balance、Bugfixes、Performance、Infrastructure、Build、I18N。
2. 把引号内的文字替换为对你改动的简要描述。
如果你不希望生成更新日志条目，把整行替换为单独一个词「None」（不带引号）。
示例：
1. None
2. Bugfixes "修复长矛无法锁定不同楼层敌人的问题"
3. Interface "在制作界面显示制作失败几率"
分类含义详见：
https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/blob/master/doc/CHANGELOG_GUIDELINES.md
合并后，你的概述会被加入项目更新日志：
https://github.com/CrimsonCrossBunker/Cataclysm-Cleanwater-Bomb/blob/master/data/changelog.txt -->

#### Responsible human
<!-- #### 责任人 -->

@nameless-feng

<!-- 每个 PR 必须指定一名真实的人类责任人。AI 工具或模型无需披露，但责任人
必须理解修改、审查最终 diff、确认测试与许可证/外部来源，并回答审阅问题。 -->

#### Purpose of change
<!-- #### 变更目的 -->
#225
在高级物品管理显示数量；拆解堆叠物品、拾取物品显示计量和数量。

查看周围界面显示计量和数量。

能正确被搬运菜单分离。

在加载存档时重新计算堆叠。
<!-- 用几句话描述你做这次改动的原因。
如果它与某个已有 issue 相关，可以用「#」加 GitHub issue 编号来关联，例如 #1234。

【重要】当你的 PR 能完全解决某个 issue 时，必须使用 [GitHub 的英文关闭关键字](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
才能在 PR 合并后自动关闭该 issue，例如：Fixes #1234。
只能用以下英文关键词（后面紧跟「#编号」）：
  close / closes / closed
  fix / fixes / fixed
  resolve / resolves / resolved
注意：中文「修复 #1234」不会触发自动关闭，GitHub 只识别上述英文关键词。

如果没有相关 issue，请在这里说明你要解决的问题、特性或其他关注点。如果这是一个 bug 修复，请附上复现原始 bug 的步骤，以便你的修复可以被验证。 -->


#### Describe the solution
<!-- #### 解决方案描述 -->
item.cpp: show quantity for stackable items in display_name

advanced_inv.cpp: fix split handling in hauling menu

inventory.cpp etc.: make restack compatible with stackable merge

savegame_json.cpp: trigger restack after load

Freezing‑related issues are not addressed; I haven’t found a good solution so far.
<!-- 这个特性是如何工作的，或者这个 bug 是怎么被修复的？方案越易于理解，就越快能被合并。 -->

#### Describe alternatives you've considered
<!-- #### 你考虑过的替代方案 -->

<!-- 说明你为解决同一问题考虑过的其他方案、不同思路或可能性。 -->

#### Testing
<!-- #### 测试 -->
Reproduced according to the original issue's reproduction steps; the corresponding bug has been resolved.
<!-- 描述你采取了哪些步骤来测试这个 PR 是否修复了 bug 或添加了特性，以及你做了哪些测试以确保没有引入回归问题。也请为审阅者和维护者提供测试建议。参见 TESTING_YOUR_CHANGES.md -->

#### Documentation impact
<!-- None，或说明需要新增、更新、迁移、归档或标记 stale 的开发文档。
实际执行级别以 ai/docs-impact.yml 为准。required 映射不能填写 None/N/A/TBD。 -->

None

#### Related CCB-Docs PR
<!-- None，或填写 CrimsonCrossBunker/CCB-Docs 的 PR 链接。required 映射必须链接实际 PR。 -->

None

#### Affected documentation IDs
<!-- None，或填写 docs-catalog.yml 中稳定的文档 ID，多个 ID 用逗号分隔。
required 映射至少填写一个 ai/docs-impact.yml 列出的对应 ID。 -->

None

#### Generated reference impact
<!-- None，或说明 Schema、LuaLS、注册信息或生成清单是否需要刷新。 -->

None

#### Additional context
<!-- #### 补充说明 -->
Freezing‑related content is not fixed yet, as I have not found a good solution. A preliminary idea is to use material specific heat capacity and volume to compute the freezing effect comprehensively, but this appears to introduce significant performance overhead, so it has not been pursued further.
<!-- 在此添加关于这个特性或 bug 修复的其他背景信息（例如原型图、概念验证或截图）。 -->


<!--README: Cataclysm: Cleanwater Bomb (CCB) 以 Creative Commons Attribution ShareAlike 3.0 许可证发布。
游戏的代码与内容可自由用于任何目的的使用、修改和再分发。
通过为本项目做贡献，你即同意该许可证的条款，并同意你所做的任何贡献也将受同一许可证覆盖。
详见 http://creativecommons.org/licenses/by-sa/3.0/ 。 -->
