### PR TITLE
fix(input): 修复菜单退出后鼠标失灵及点击穿透

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -781,6 +781,9 @@ bool cataimgui::client::auto_size_frame_active()
 
 bool cataimgui::client::any_window_shown()
 {
+    if( !ui_adaptor::has_imgui() ) {
+        return false;
+    }
     bool any_window_shown = false;
     for( const ImGuiWindow *window : GImGui->Windows ) {
         if( window->Active && !window->Hidden ) {
@@ -794,7 +797,7 @@ bool cataimgui::client::any_window_shown()
 bool cataimgui::client::want_capture_mouse()
 {
     ImGuiContext *ctx = ImGui::GetCurrentContext();
-    if( !ctx ) {
+    if( !ctx || !ui_adaptor::has_imgui() ) {
         return false;
     }
 
@@ -1194,7 +1197,12 @@ cataimgui::window::~window()
     if( GImGui ) {
         ImGui::ClearWindowSettings( id.c_str() );
         if( !ui_adaptor::has_imgui() ) {
+            // ClearInputKeys deliberately excludes mouse state.  A queued
+            // release can be discarded with the window, leaving ImGui holding
+            // a button and capturing subsequent map clicks indefinitely.
+            ImGui::ClearActiveID();
             ImGui::GetIO().ClearInputKeys();
+            ImGui::GetIO().ClearInputMouse();
             GImGui->InputEventsQueue.resize( 0 );
 #ifdef TILES
             // Removes leftover ImGui artifacts

--- a/src/mouse_button_capture.h
+++ b/src/mouse_button_capture.h
@@ -1,0 +1,33 @@
+#pragma once
+#ifndef CATA_SRC_MOUSE_BUTTON_CAPTURE_H
+#define CATA_SRC_MOUSE_BUTTON_CAPTURE_H
+
+#include <bitset>
+
+// A UI owns the release of a button it consumed, even if the UI closes
+// between the press and release.  Otherwise that release clicks the map.
+class mouse_button_capture
+{
+    public:
+        bool process( unsigned int button, bool pressed, bool captured ) {
+            if( button >= owned.size() ) {
+                return captured;
+            }
+            if( pressed ) {
+                owned.set( button, captured );
+                return captured;
+            }
+            const bool consume = captured || owned.test( button );
+            owned.reset( button );
+            return consume;
+        }
+
+        void clear() {
+            owned.reset();
+        }
+
+    private:
+        std::bitset<32> owned;
+};
+
+#endif // CATA_SRC_MOUSE_BUTTON_CAPTURE_H

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -73,6 +73,7 @@
 #include "map_extras.h"
 #include "mapbuffer.h"
 #include "mission.h"
+#include "mouse_button_capture.h"
 #include "npc.h"
 #include "options.h"
 #include "output.h"
@@ -6142,6 +6143,7 @@ static bool pop_extra_button_input( input_event &event )
 //Check for any window messages (keypress, paint, mousemove, etc)
 static void CheckMessages()
 {
+    static mouse_button_capture imgui_mouse_buttons;
     SDL_Event ev;
     bool quit = false;
     bool text_refresh = false;
@@ -6561,6 +6563,14 @@ static void CheckMessages()
         convert_event_to_display_buffer_coords( &ev_display );
         imclient->process_input( &ev_display, imgui_buf_w, imgui_buf_h, scaling_factor );
 
+        if( IsWindowEvent( ev ) && GetWindowEventID( ev ) == CATA_WINDOWEVENT_FOCUS_LOST ) {
+            imgui_mouse_buttons.clear();
+        }
+        const bool imgui_owns_mouse_button =
+            ( ev.type == CATA_MOUSEBUTTONDOWN || ev.type == CATA_MOUSEBUTTONUP ) &&
+            imgui_mouse_buttons.process( ev.button.button, ev.type == CATA_MOUSEBUTTONDOWN,
+                                         cataimgui::client::want_capture_mouse() );
+
         bool imgui_owns_text_event = cataimgui::client::want_text_input() &&
                                      ( ev.type == CATA_KEYDOWN || ev.type == CATA_KEYUP ||
                                        ev.type == CATA_TEXTINPUT || ev.type == CATA_TEXTEDITING );
@@ -6886,7 +6896,7 @@ static void CheckMessages()
                     if( ! mouse.enabled ) {
                         break;
                     }
-                    if( cataimgui::client::want_capture_mouse() ) {
+                    if( imgui_owns_mouse_button ) {
                         break;
                     }
                     switch( ev.button.button ) {
@@ -6909,7 +6919,7 @@ static void CheckMessages()
                     if( ! mouse.enabled ) {
                         break;
                     }
-                    if( cataimgui::client::want_capture_mouse() ) {
+                    if( imgui_owns_mouse_button ) {
                         break;
                     }
                     switch( ev.button.button ) {

--- a/tests/imgui_mouse_lifetime_test.cpp
+++ b/tests/imgui_mouse_lifetime_test.cpp
@@ -1,0 +1,59 @@
+#include "cata_catch.h"
+#include "cata_imgui.h"
+#include "cata_scope_helpers.h"
+#include "imgui/imgui.h"
+#include "imgui/imgui_internal.h"
+#include "ui_manager.h"
+
+namespace
+{
+class mouse_test_window : public cataimgui::window
+{
+    public:
+        mouse_test_window() : window( "mouse_lifetime_test" ) {}
+
+    protected:
+        void draw_controls() override {}
+};
+} // namespace
+
+TEST_CASE( "closing_last_imgui_window_releases_mouse", "[imgui][input][mouse_capture]" )
+{
+    ImGuiContext *previous = ImGui::GetCurrentContext();
+    ImGuiContext *context = ImGui::CreateContext();
+    on_out_of_scope cleanup( [&]() {
+        ImGui::DestroyContext( context );
+        ImGui::SetCurrentContext( previous );
+    } );
+    ImGuiIO &io = ImGui::GetIO();
+    io.IniFilename = nullptr;
+    io.DisplaySize = ImVec2( 800, 600 );
+    io.DeltaTime = 1.0F / 60.0F;
+    unsigned char *pixels = nullptr;
+    int width = 0;
+    int height = 0;
+    io.Fonts->GetTexDataAsRGBA32( &pixels, &width, &height );
+    REQUIRE_FALSE( ui_adaptor::has_imgui() );
+    {
+        mouse_test_window menu;
+        ImGui::NewFrame();
+        ImGui::Begin( "held_mouse" );
+        ImGui::SetActiveID( ImGui::GetID( "held_button" ), ImGui::GetCurrentWindow() );
+        ImGui::End();
+        ImGui::Render();
+        // Model a menu destroyed before its queued mouse-up is processed.
+        io.MouseDown[0] = true;
+        io.WantCaptureMouse = true;
+        io.AddMouseButtonEvent( 0, false );
+        REQUIRE( cataimgui::client::want_capture_mouse() );
+    }
+    CHECK_FALSE( io.MouseDown[0] );
+    CHECK( context->ActiveId == 0 );
+    CHECK( context->InputEventsQueue.empty() );
+    CHECK_FALSE( cataimgui::client::want_capture_mouse() );
+
+    // ImGui's previous-frame capture flag can stay set until NewFrame.
+    // It must not suppress input while no live GUI adaptor remains.
+    io.WantCaptureMouse = true;
+    CHECK_FALSE( cataimgui::client::want_capture_mouse() );
+}

--- a/tests/mouse_button_capture_test.cpp
+++ b/tests/mouse_button_capture_test.cpp
@@ -1,0 +1,28 @@
+#include "cata_catch.h"
+#include "mouse_button_capture.h"
+
+TEST_CASE( "menu_click_release_does_not_reach_map", "[input][mouse_capture]" )
+{
+    mouse_button_capture capture;
+    REQUIRE( capture.process( 1, true, true ) );
+    // The menu closed while the button was held.  Its release is still owned.
+    CHECK( capture.process( 1, false, false ) );
+    // A fresh click must immediately work on the map, without Escape.
+    CHECK_FALSE( capture.process( 1, true, false ) );
+    CHECK_FALSE( capture.process( 1, false, false ) );
+}
+
+TEST_CASE( "mouse_capture_is_per_button_and_cleared_on_focus_loss", "[input][mouse_capture]" )
+{
+    mouse_button_capture capture;
+    REQUIRE( capture.process( 1, true, true ) );
+    CHECK_FALSE( capture.process( 3, true, false ) );
+    CHECK_FALSE( capture.process( 3, false, false ) );
+    CHECK( capture.process( 1, false, false ) );
+    REQUIRE( capture.process( 1, true, true ) );
+    capture.clear();
+    CHECK_FALSE( capture.process( 1, false, false ) );
+    // A release over a newly opened menu is consumed even if the press was outside it.
+    CHECK_FALSE( capture.process( 1, true, false ) );
+    CHECK( capture.process( 1, false, true ) );
+}


### PR DESCRIPTION
#### Summary
Bugfixes "修复退出菜单后鼠标失灵及点击穿透到地图"

#### Responsible human
@LYHGLYTX

#### Purpose of change
PC 玩家反馈退出 t、i 等菜单后鼠标可能失灵，按 Esc 后恢复；在菜单中点击物品后可能额外选中地图移动位置。菜单销毁时只调用 ClearInputKeys，但 ImGui 的该接口明确不清理鼠标状态；已关闭窗口的上一帧捕获状态仍可阻挡地图输入，按下与松开分别判定捕获也会让同一次点击跨越窗口边界。

#### Describe the solution
最后一个 GUI 窗口销毁时清除鼠标状态及活动控件；没有存活的 GUI adaptor 时不再报告窗口可见或捕获鼠标。SDL 事件按鼠标按钮记录按下事件的归属，菜单消失后的对应松开事件仍由菜单消费，下一次全新点击正常交给地图；失去窗口焦点时清理归属记录。保留 QUERY_POPUP 的现有输入路由。

#### Describe alternatives you've considered
不依赖额外 Esc 或屏蔽菜单关闭后的所有点击；仅消费属于上一菜单的松开事件。

#### Testing
- Linux SDL2、Lua Platform 关闭配置下，相关 C++ 源码和测试编译、链接通过。
- `[mouse_capture]`：3 个测试、19 条断言通过，随机种子 20260905。
- 将窗口生命周期实现换回 master 原版后，同一生命周期测试有 4 条断言失败；修复版通过。
- 新增文件的聚焦 astyle 检查及 git diff --check 通过。
- 未在 Windows 实机验证具体 t/i 操作，也未进行 Android 设备测试；建议复核退出菜单后的首次地图点击及按住鼠标关闭菜单后松开的行为。CI 状态以 GitHub 当前检查为准。

#### Documentation impact
None — 修复输入事件生命周期，不改变公共作者接口或数据格式。

#### Related CCB-Docs PR
None

#### Affected documentation IDs
None

#### Generated reference impact
None

#### Additional context
独立基于 master 的 1a8ce59e04bc8ed83dcaee8a01e9423714bcbc25，仅包含本项修复和回归测试。