### PR TITLE
fix(vehicle): 防止飞艇内部动物随车移动时坠落

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2186,7 +2186,10 @@ bool map::displace_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const bool 
                 z_change = psgp.z() - part_pos.z();
             }
 
-            psg->setpos( *this, psgp );
+            // Riders and their supporting vehicle move together.  The vehicle
+            // cache still describes the old position here, so checking gravity
+            // now would drop monsters through the not-yet-moved deck.
+            psg->setpos( *this, psgp, false );
             r.moved = true;
         }
     }

--- a/tests/airship_state_regression_test.cpp
+++ b/tests/airship_state_regression_test.cpp
@@ -1,4 +1,5 @@
 #include "avatar.h"
+#include "calendar.h"
 #include "cata_catch.h"
 #include "cata_scope_helpers.h"
 #include "coordinates.h"
@@ -8,6 +9,7 @@
 #include "map.h"
 #include "map_helpers.h"
 #include "map_helpers_tests.h"
+#include "monster.h"
 #include "player_helpers.h"
 #include "point.h"
 #include "type_id.h"
@@ -15,6 +17,50 @@
 #include "vehicle.h"
 #include "vpart_position.h"
 #include "vpart_range.h"
+
+TEST_CASE( "airborne_vehicle_carries_tied_animal", "[vehicle][regression][airship_rider]" )
+{
+    clear_map( -2, 2 );
+    clear_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms seat( 60, 60, 1 );
+    here.vertical_shift( seat.z() );
+    on_out_of_scope restore_level( [&]() {
+        here.vertical_shift( 0 );
+        clear_map( -2, 2 );
+    } );
+    for( int z = 1; z <= 2; ++z ) {
+        for( int x = 58; x <= 65; ++x ) {
+            for( int y = 58; y <= 62; ++y ) {
+                here.ter_set( tripoint_bub_ms( x, y, z ), ter_id( "t_open_air" ) );
+            }
+        }
+    }
+    vehicle *veh = here.add_vehicle( vproto_id( "bicycle" ), seat, 0_degrees, 0,
+                                     veh_spawn_status::UNDAMAGED );
+    REQUIRE( veh != nullptr );
+    monster &cow = spawn_test_monster( "mon_cow", seat );
+    cow.add_effect( efftype_id( "tied" ), 1_turns, true );
+    REQUIRE( veh->get_riders().size() == 1 );
+    const int seat_part = veh->get_riders().front().prt;
+    tripoint_rel_ms movement = tripoint_rel_ms::above;
+    SECTION( "takeoff" ) {}
+    SECTION( "horizontal_flight" ) {
+        movement = tripoint_rel_ms::east;
+    }
+    SECTION( "descent" ) {
+        movement = tripoint_rel_ms::below;
+    }
+    REQUIRE( here.displace_vehicle( *veh, movement ) );
+    CHECK( cow.pos_bub( here ) == veh->bub_part_pos( here, seat_part ) );
+    CHECK( cow.pos_bub( here ).z() == seat.z() + movement.z() );
+    CHECK( cow.has_effect( efftype_id( "tied" ) ) );
+    // Normal gravity checks after the displacement must see the moved deck.
+    cow.gravity_check( &here );
+    CHECK( cow.pos_bub( here ) == veh->bub_part_pos( here, seat_part ) );
+    REQUIRE( here.displace_vehicle( *veh, tripoint_rel_ms::east ) );
+    CHECK( cow.pos_bub( here ) == veh->bub_part_pos( here, seat_part ) );
+}
 
 TEST_CASE( "airborne_vehicle_supports_unboarded_character_above_monster", "[vehicle][regression]" )
 {


### PR DESCRIPTION
#### Summary
Bugfixes "防止飞艇移动时内部动物提前执行重力检查而掉落"

#### Responsible human
@LYHGLYTX

#### Purpose of change
将牛拴在飞艇内部后，起飞或飞行几步，牛会掉到地面。此前的车辆地板支撑修复只能识别车体缓存中的地板；displace_vehicle 先移动乘客，再更新车体和缓存。怪物 setpos 默认立即检查重力，导致牛在新地板尚未出现的瞬间坠落。

#### Describe the solution
随车移动乘客时使用 setpos 的现有参数关闭此次中间状态下的重力检查，使动物与车体完成同一次位移。正常重力检查仍保留，并能在车体更新完成后读取正确的地板位置。

#### Describe alternatives you've considered
不赋予动物飞行或悬浮效果，也不永久关闭动物重力；只跳过车辆位移尚未完成时的检查。

#### Testing
- Linux SDL2、Lua Platform 关闭配置编译和测试链接通过。
- 新增 airborne_vehicle_carries_tied_animal，覆盖起飞、水平飞行、下降、位移后的主动重力检查以及继续平移。
- 修复版：1 个测试中的 3 种场景，42 条断言全部通过，随机种子 20260905。
- 换回 master 原版 map.cpp 的编译对象后，同一测试出现 8 条预期断言失败，并实际记录 “the cow falls down a level!”。
- 聚焦测试文件的 astyle 检查和 git diff --check 通过。
- 未在实际玩家飞艇存档或 Windows/Android 设备上验证；CI 以 GitHub 检查为准。

#### Documentation impact
None — 修复车辆乘客位移时序，不改变数据格式或公共作者接口。

#### Related CCB-Docs PR
None

#### Affected documentation IDs
None

#### Generated reference impact
None

#### Additional context
基于 master 1a8ce59e04bc8ed83dcaee8a01e9423714bcbc25 独立提交，补齐 #716 未覆盖的动物随车移动时序问题。