### PR TITLE
Fix Android native character selection dialog contrast

### DIFF
--- a/android/app/src/main/java/com/crimsoncrossbunker/cataclysmcb/NativeUI.java
+++ b/android/app/src/main/java/com/crimsoncrossbunker/cataclysmcb/NativeUI.java
@@ -8,6 +8,7 @@ import android.content.DialogInterface;
 import android.text.InputFilter;
 import android.text.InputType;
 import android.view.WindowManager;
+import android.view.ContextThemeWrapper;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import android.widget.LinearLayout;
@@ -162,7 +163,9 @@ public class NativeUI {
             activity.runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
-                    final EditText input = new EditText(activity);
+                    final Context dialogContext = new ContextThemeWrapper(
+                            activity, R.style.AlertDialogTheme);
+                    final EditText input = new EditText(dialogContext);
                     input.setSingleLine(true);
                     input.setInputType(InputType.TYPE_CLASS_TEXT
                         | InputType.TYPE_TEXT_FLAG_CAP_WORDS);
@@ -175,7 +178,7 @@ public class NativeUI {
 
                     int padding = Math.round(20f
                         * activity.getResources().getDisplayMetrics().density);
-                    LinearLayout container = new LinearLayout(activity);
+                    LinearLayout container = new LinearLayout(dialogContext);
                     container.setPadding(padding, 0, padding, 0);
                     container.addView(input, new LinearLayout.LayoutParams(
                         LinearLayout.LayoutParams.MATCH_PARENT,

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -16,7 +16,13 @@
         <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
     </style>
 
-    <style name="AlertDialogTheme" parent="@android:style/Theme.Material.Dialog.Alert" >
-        <item name="android:colorAccent">#F2F2F2</item>
+    <style name="AlertDialogTheme" parent="@android:style/Theme.Material.Light.Dialog.Alert" >
+        <item name="android:colorBackground">#F2F2F2</item>
+        <item name="android:colorBackgroundFloating">#F2F2F2</item>
+        <item name="android:textColorPrimary">#202020</item>
+        <item name="android:textColorSecondary">#505050</item>
+        <item name="android:textColorHint">#606060</item>
+        <item name="android:colorAccent">#1565C0</item>
+        <item name="android:forceDarkAllowed">false</item>
     </style>
 </resources>


### PR DESCRIPTION
#### Summary
Bugfixes "修复安卓原生读档人物菜单浅色背景配白字的问题"

#### Responsible human
@LYHGLYTX

#### Purpose of change
安卓启用原生菜单后，在主菜单选择读档、选择人物，部分设备稳定出现浅色底配白色文字，难以辨认选项。

#### Describe the solution
为原生弹窗指定统一的浅色背景、深色文字和蓝色按钮，禁用系统自动深色转换。自定义文本输入框使用相同弹窗主题，避免继承游戏的深色主题。仅影响安卓原生弹窗。

#### Describe alternatives you've considered
仅修改强调色不能保证列表文字与背景一致。

#### Testing
- Android SDK 35 / AAPT2 34.0.0：全部 main 资源编译、链接通过。
- NativeUI.java javac 编译通过，使用真实 android.jar、生成的 R.java 和最小 Activity 类型替身；不是完整应用编译。
- git diff --check 通过。
- Gradle 离线检查未能运行：缺少 com.android.tools.build:gradle:8.7.3 缓存。
- 尚未在报告设备上复测，需验证人物选择列表及输入弹窗在系统浅色/深色模式下的可读性。

#### Documentation impact
None — bug fix; no documented workflow change.

#### Related CCB-Docs PR
None

#### Affected documentation IDs
None

#### Generated reference impact
None

#### Additional context
根据用户截图及稳定复现入口定位。