### PR TITLE
Fix redundant crafting category refreshes on keyboard tab navigation

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -812,7 +812,8 @@ void crafting_ui_impl::draw_category_tabs()
             bool should_select = force_select_tab &&
                                  ( tab.cur_index() == static_cast<int>( i ) );
             if( cataimgui::BeginTabItem( label.c_str(), should_select ) ) {
-                if( tab.cur_index() != static_cast<int>( i ) ) {
+                if( crafting_tab_selection_changed( tab.cur_index(), static_cast<int>( i ),
+                                                    force_select_tab ) ) {
                     pending_tab_index = static_cast<int>( i );
                 }
                 ImGui::EndTabItem();
@@ -853,7 +854,8 @@ void crafting_ui_impl::draw_subcategory_tabs()
             bool should_select = force_select_subtab &&
                                  ( subtab.cur_index() == static_cast<int>( i ) );
             if( cataimgui::BeginTabItem( label.c_str(), should_select ) ) {
-                if( subtab.cur_index() != static_cast<int>( i ) ) {
+                if( crafting_tab_selection_changed( subtab.cur_index(), static_cast<int>( i ),
+                                                    force_select_subtab ) ) {
                     pending_subtab_index = static_cast<int>( i );
                 }
                 ImGui::EndTabItem();

--- a/src/crafting_gui.h
+++ b/src/crafting_gui.h
@@ -15,6 +15,13 @@ class inventory;
 class recipe;
 class recipe_subset;
 
+// ImGui still exposes the previous tab during the frame that queues SetSelected.
+// Do not interpret that stale visible tab as a mouse selection.
+inline bool crafting_tab_selection_changed( int selected, int visible, bool synchronizing )
+{
+    return !synchronizing && selected != visible;
+}
+
 /**
  * Open crafting menu where user selects who will craft what (the crafter & the recipe).
  *

--- a/tests/crafting_tab_selection_test.cpp
+++ b/tests/crafting_tab_selection_test.cpp
@@ -1,0 +1,92 @@
+#include <array>
+
+#include "cata_catch.h"
+#include "cata_scope_helpers.h"
+#include "crafting_gui.h"
+#include "imgui/imgui.h"
+
+TEST_CASE( "crafting_keyboard_tabs_do_not_restore_stale_selection", "[crafting][imgui]" )
+{
+    ImGuiContext *previous = ImGui::GetCurrentContext();
+    ImGuiContext *context = ImGui::CreateContext();
+    on_out_of_scope cleanup( [&]() {
+        ImGui::DestroyContext( context );
+        ImGui::SetCurrentContext( previous );
+    } );
+    ImGuiIO &io = ImGui::GetIO();
+    io.IniFilename = nullptr;
+    io.DisplaySize = ImVec2( 800, 600 );
+    io.DeltaTime = 1.0F / 60.0F;
+    unsigned char *pixels = nullptr;
+    int width = 0;
+    int height = 0;
+    io.Fonts->GetTexDataAsRGBA32( &pixels, &width, &height );
+
+    const std::array<const char *, 3> labels = { "Food", "Weapons", "Armor" };
+    std::array<ImVec2, 3> centers;
+    int selected = 0;
+    int visible = -1;
+    bool synchronizing = true;
+    int changes = 0;
+    const auto frame = [&]() {
+        ImGui::NewFrame();
+        ImGui::SetNextWindowSize( ImVec2( 600, 400 ) );
+        ImGui::Begin( "crafting_tabs_test" );
+        int pending = -1;
+        if( ImGui::BeginTabBar( "categories" ) ) {
+            for( int i = 0; i < 3; ++i ) {
+                const ImGuiTabItemFlags flags = synchronizing && selected == i ?
+                                                ImGuiTabItemFlags_SetSelected : ImGuiTabItemFlags_None;
+                if( ImGui::BeginTabItem( labels[i], nullptr, flags ) ) {
+                    visible = i;
+                    if( crafting_tab_selection_changed( selected, i, synchronizing ) ) {
+                        pending = i;
+                    }
+                    ImGui::EndTabItem();
+                }
+                const ImVec2 min = ImGui::GetItemRectMin();
+                const ImVec2 max = ImGui::GetItemRectMax();
+                centers[i] = ImVec2( ( min.x + max.x ) / 2, ( min.y + max.y ) / 2 );
+            }
+            ImGui::EndTabBar();
+        }
+        synchronizing = false;
+        if( pending >= 0 ) {
+            selected = pending;
+            ++changes;
+        }
+        ImGui::End();
+        ImGui::Render();
+    };
+    frame();
+    frame();
+    frame();
+    REQUIRE( visible == 0 );
+
+    // Next/previous category and subcategory use this same synchronization path.
+    for( int target : {
+             1, 0, 2
+         } ) {
+        const int old = selected;
+        selected = target;
+        synchronizing = true;
+        frame();
+        CHECK( visible == old );
+        CHECK( selected == target );
+        frame();
+        CHECK( visible == target );
+        CHECK( selected == target );
+        CHECK( changes == 0 );
+    }
+
+    // A real mouse click must still be accepted once synchronization finishes.
+    io.AddMousePosEvent( centers[0].x, centers[0].y );
+    frame();
+    io.AddMouseButtonEvent( 0, true );
+    frame();
+    io.AddMouseButtonEvent( 0, false );
+    frame();
+    frame();
+    CHECK( selected == 0 );
+    CHECK( changes == 1 );
+}


### PR DESCRIPTION
#### Summary
Bugfixes "修复制作界面键盘切页被旧标签覆盖并重复刷新的问题"

#### Responsible human
@LYHGLYTX

#### Purpose of change
用户报告制作界面鼠标点击分类流畅，Tab 切页会停顿几秒。键盘路径先更新分类，再通过 ImGuiTabItemFlags_SetSelected 同步标签；ImGui 当帧仍返回旧标签可见，代码误认为用户重新选择旧标签，随后又切回新标签。

#### Describe the solution
主分类和子分类都在程序同步帧忽略旧可见标签的回写。非同步帧继续正常接受鼠标选择。避免由状态往返引起的重复配方刷新，不改变配方筛选或制造规则。

#### Describe alternatives you've considered
不改第三方 ImGui，也不取消鼠标导航；在游戏与 ImGui 状态同步边界处理。

#### Testing
- 新增 Catch2 回归测试，使用真实 ImGui 帧循环及鼠标按下/释放事件，覆盖向前、向后切换和鼠标选择。
- 独立编译该测试、Catch2 和仓库 ImGui 源码：18 个断言全部通过。
- 对照实验恢复旧选择判断：同一测试有 7 个断言失败，并记录每次键盘切页多出两次选择变化。
- 新测试和头文件 AStyle 检查通过；git diff --check 通过。crafting_gui.cpp 保留原有无关格式，仅修改两个选择判断。
- 未重新构建完整游戏，也未测量报告设备的实际卡顿时长；需要在实际配方数据量下复测。

#### Documentation impact
None — bug fix; existing controls unchanged.

#### Related CCB-Docs PR
None

#### Affected documentation IDs
None

#### Generated reference impact
None

#### Additional context
与安卓原生菜单配色修复 #740 分开提交。