### PR TITLE
feat(lua): 精简开发验收并提供 Mod 编辑器 SDK 与诊断

### DIFF
--- a/.github/workflows/lua-contract.yml
+++ b/.github/workflows/lua-contract.yml
@@ -17,6 +17,8 @@ on:
       - 'src/lua_platform*.h'
       - 'src/event.h'
       - 'tools/lua_api/**'
+      - 'tools/create_lua_mod.py'
+      - 'tools/test_create_lua_mod.py'
   push:
     branches: [ master ]
     paths:
@@ -34,6 +36,8 @@ on:
       - 'src/lua_platform*.h'
       - 'src/event.h'
       - 'tools/lua_api/**'
+      - 'tools/create_lua_mod.py'
+      - 'tools/test_create_lua_mod.py'
   workflow_dispatch:
 
 permissions:
@@ -56,15 +60,22 @@ jobs:
 
       - name: Install pinned validation dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install --no-install-recommends lua5.4
           python3 -m pip install --disable-pip-version-check -r tools/lua_api/requirements.txt
 
       - name: Validate Lua-first Platform declarations and contracts
+        # Includes live repository checks for all five contracts and negative cases.
         run: |
-          python3 tools/lua_api/check_luals_declarations.py
-          python3 tools/lua_api/check_platform_native_inventory.py
-          python3 tools/lua_api/check_platform_contract.py
-          python3 tools/lua_api/check_platform_coverage.py
-          python3 tools/lua_api/check_cmake_contract.py
           python3 -m unittest discover -s tools/lua_api -p 'test_*.py'
+
+      - name: Validate Mod scaffolds and editor diagnostics
+        env:
+          CCB_LUALS: ${{ runner.temp }}/ccb-luals/bin/lua-language-server
+        run: |
+          curl --fail --location --retry 3 --silent --show-error \
+            https://github.com/LuaLS/lua-language-server/releases/download/3.19.1/lua-language-server-3.19.1-linux-x64.tar.gz \
+            -o "${RUNNER_TEMP}/ccb-luals.tar.gz"
+          echo "e9235d2d72ef55bc41cf8c99cda2ed64777682024b4bb81f5dea425060c5cbb8  ${RUNNER_TEMP}/ccb-luals.tar.gz" | sha256sum --check
+          mkdir -p "${RUNNER_TEMP}/ccb-luals"
+          tar -xzf "${RUNNER_TEMP}/ccb-luals.tar.gz" -C "${RUNNER_TEMP}/ccb-luals"
+          python3 tools/test_create_lua_mod.py
+          python3 -m unittest discover -s tools/lua_api -p 'test_mod_sdk.py' -k LuaLanguageServerIntegrationTest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,28 +49,18 @@ Lua runtime and public authoring contract; the former API v5 runtime,
 capability sandbox, manifest, and `game.*` compatibility surface are removed
 rather than maintained as a second system.
 
-Lua-first EOC capability work follows
-`data/lua/LUA_FIRST_EOC_WORKFLOW.md`.  Its active objective is to finish a
-composable, domain-shaped Lua alternative for every EOC capability before
-migrating shipped JSON/EOC content.  Group implementation by complete domain
-batches, write tests with the code, and defer builds and test execution to the
-batch acceptance gate instead of validating every selector or small edit.
-`ai/test-matrix.yml` selects commands for that gate; it does not require them
-to be rerun during the high-throughput implementation loop.
+Lua-first EOC capability work follows `data/lua/LUA_FIRST_EOC_WORKFLOW.md`.
+Finish one domain batch with its implementation, declarations, and test source.
+Run the affected acceptance gate once; reuse passing evidence while its inputs
+and build configuration are unchanged. Focused tool tests are allowed during
+implementation. Defer C++ builds, broad suites and generated refreshes to batch
+acceptance; full corpus audits are for migration, parity claims, or EOC removal.
+`ai/test-matrix.yml` lists available checks, not a mandate to run them all.
 
-Until the current source batches are closed, the same loop also defers Python
-checkers, generators, public-contract refreshes, ledger/registry refreshes,
-and full JSON/EOC audits. The final gate runs these once after implementation
-is complete.
-
-Lua-first 的 EOC 能力开发遵循 `data/lua/LUA_FIRST_EOC_WORKFLOW.md`。当前目标是先让
-Lua 以领域化、可组合的 API 覆盖 EOC 的全部能力，再迁移现有 JSON/EOC 语料。实现时按
-完整领域批量推进，测试随代码编写但集中到批次验收执行；不得为每个 selector 或小改动
-重复编译、加载游戏数据和运行测试。`ai/test-matrix.yml` 负责选择验收命令，不代表开发
-循环中必须反复执行这些命令。
-
-当前源码批次完成前也不得运行 Python checker、generator、完整契约刷新、ledger/registry
-刷新或全量 JSON/EOC 审计；这些检查统一留到实现完成后的总门禁。
+Lua-first 的 EOC 能力开发遵循 `data/lua/LUA_FIRST_EOC_WORKFLOW.md`：按完整领域批次同步
+实现、声明与测试，集中验收受影响的范围；输入和构建配置不变时复用已通过证据。开发中可执行
+聚焦工具测试，C++ 构建、宽测试与生成刷新留到批次验收；全量语料审计用于迁移、完整替代声明
+或删除 EOC。`ai/test-matrix.yml` 是可选检查的路由表，不是每轮全跑的清单。
 
 ## Modification boundaries / 修改边界
 

--- a/ai/agent-benchmark-baseline.json
+++ b/ai/agent-benchmark-baseline.json
@@ -3,7 +3,7 @@
   "cases": [
     {
       "errors": [],
-      "estimated_tokens": 3219,
+      "estimated_tokens": 3122,
       "id": "repository-navigation",
       "passed": true,
       "selected_routes": [
@@ -12,7 +12,7 @@
     },
     {
       "errors": [],
-      "estimated_tokens": 3024,
+      "estimated_tokens": 2927,
       "id": "cpp-bug",
       "passed": true,
       "selected_routes": [
@@ -21,7 +21,7 @@
     },
     {
       "errors": [],
-      "estimated_tokens": 2707,
+      "estimated_tokens": 2610,
       "id": "json-content",
       "passed": true,
       "selected_routes": [
@@ -30,7 +30,7 @@
     },
     {
       "errors": [],
-      "estimated_tokens": 2788,
+      "estimated_tokens": 2782,
       "id": "eoc",
       "passed": true,
       "selected_routes": [
@@ -39,7 +39,7 @@
     },
     {
       "errors": [],
-      "estimated_tokens": 3940,
+      "estimated_tokens": 3798,
       "id": "lua-api",
       "passed": true,
       "selected_routes": [
@@ -48,7 +48,7 @@
     },
     {
       "errors": [],
-      "estimated_tokens": 3765,
+      "estimated_tokens": 3668,
       "id": "upstream-port",
       "passed": true,
       "selected_routes": [
@@ -57,7 +57,7 @@
     },
     {
       "errors": [],
-      "estimated_tokens": 3044,
+      "estimated_tokens": 2947,
       "id": "save-compatibility",
       "passed": true,
       "selected_routes": [
@@ -66,7 +66,7 @@
     },
     {
       "errors": [],
-      "estimated_tokens": 2816,
+      "estimated_tokens": 2719,
       "id": "generated-file-detection",
       "passed": true,
       "selected_routes": [
@@ -75,7 +75,7 @@
     },
     {
       "errors": [],
-      "estimated_tokens": 3488,
+      "estimated_tokens": 3391,
       "id": "documentation-impact",
       "passed": true,
       "selected_routes": [

--- a/ai/lua-first-replacement-ledger.yml
+++ b/ai/lua-first-replacement-ledger.yml
@@ -31,17 +31,17 @@ sources:
 - id: json-object-types
   path: data/reference/json/ccb_json_object_types.json
   selector: type
-  source_fingerprint: sha256:7a312ca0a6a04c9f73736e9f792bf33e05eefadac952bde972142d94cdcb5222
+  source_fingerprint: sha256:0e28bff9b70ded8d69250da89baf121992dd37ec181fd59c69c8bd1d63aa927b
   entry_count: 190
 - id: eoc-conditions
   path: data/reference/json/ccb_eoc_conditions.json
   selector: key
-  source_fingerprint: sha256:7a312ca0a6a04c9f73736e9f792bf33e05eefadac952bde972142d94cdcb5222
+  source_fingerprint: sha256:0e28bff9b70ded8d69250da89baf121992dd37ec181fd59c69c8bd1d63aa927b
   entry_count: 275
 - id: eoc-effects
   path: data/reference/json/ccb_eoc_effects.json
   selector: key
-  source_fingerprint: sha256:7a312ca0a6a04c9f73736e9f792bf33e05eefadac952bde972142d94cdcb5222
+  source_fingerprint: sha256:0e28bff9b70ded8d69250da89baf121992dd37ec181fd59c69c8bd1d63aa927b
   entry_count: 311
 summary:
   total: 776

--- a/ai/lua-first-roadmap.schema.json
+++ b/ai/lua-first-roadmap.schema.json
@@ -42,8 +42,8 @@
         "complete_means"
       ],
       "properties": {
-        "implementation_loop": { "enum": ["source_and_test_writes_only"] },
-        "acceptance_gate": { "enum": ["one_final_gate_after_all_source_batches"] },
+        "implementation_loop": { "enum": ["domain_batch_with_focused_checks"] },
+        "acceptance_gate": { "enum": ["scoped_gate_after_each_domain_batch"] },
         "forbidden_before_gate": {
           "type": "array",
           "items": {

--- a/ai/lua-first-roadmap.yml
+++ b/ai/lua-first-roadmap.yml
@@ -9,12 +9,10 @@ target: Lua is the sole executable authoring language for CCB core content and M
 current_phase: core_platform_complete
 
 verification_policy:
-  implementation_loop: source_and_test_writes_only
-  acceptance_gate: one_final_gate_after_all_source_batches
+  implementation_loop: domain_batch_with_focused_checks
+  acceptance_gate: scoped_gate_after_each_domain_batch
   forbidden_before_gate:
     - cxx_build
-    - catch2
-    - python_suite
     - contract_generation
     - ledger_refresh
     - full_corpus_audit
@@ -645,12 +643,15 @@ capabilities:
     next_actions: []
   - id: platform-hardening
     phase: hardening
-    status: in_progress
-    target_surface: "High-priority follow-on runtime hardening. Existing standard-library whitelist changes are useful incremental hardening; per-state memory budgets, callback instruction budgets or equivalent interruptible boundaries, process isolation, and any wider limits remain separately planned and are not core Platform closure conditions."
+    status: planned
+    target_surface: "Accepted trusted-code policy: complete Lua standard libraries, ordinary external Lua and platform-supported native module loading, per-Mod state ownership, no security-sandbox promise and no mandatory global instruction/memory quotas by default. Preserve supported ccb API correctness/lifetime checks; provide reliability and opt-in diagnostics. Current loader whitelist and package restrictions do not yet implement this policy."
     legacy_dependency: none
     evidence: [src/lua_platform_runtime.cpp, src/lua_platform_loader.cpp, tests/lua_platform_test.cpp, data/lua/LUA_FIRST_PLATFORM.md]
     verification: not_run
-    next_actions: [Track the existing whitelist changes as incremental hardening without claiming the broader batch is complete; design and verify resource, callback, and isolation limits in an independent follow-on gate; do not add this capability as a platform-capability-closure or final-acceptance dependency.]
+    next_actions:
+      - Replace library/package restrictions while preserving the reserved ccb entrypoint and local module resolution; verify full standard libraries and ordinary external/native loading on supported platforms.
+      - Document executable metadata discovery and provide execution-risk notice before downloaded Mod code first runs; do not claim existing catalog or launcher integration supplies this notice.
+      - Validate handle safety, reload and error cleanup; add profiling or optional diagnostic limits only when useful. Supersede sandbox/process-isolation and mandatory-budget plans rather than introducing another runtime or permission manifest.
   - id: shared-ccb-std
     phase: standard-library
     status: planned
@@ -669,9 +670,11 @@ capabilities:
     next_actions: [Design and implement internationalization in an independent follow-on batch with its own extraction, declaration, example, test, and acceptance evidence; do not make it a platform-capability-closure or final-acceptance dependency.]
   - id: author-experience
     phase: tooling
-    status: planned
+    status: in_progress
     target_surface: "Recommended future cookbook/console/author-experience work: actionable diagnostics, editor declarations, scaffolding, runnable examples, cookbook guidance, console support, and migration reports that make typed Lua workflows discoverable and debuggable."
     legacy_dependency: none
-    evidence: [tools/create_lua_mod.py, tools/test_create_lua_mod.py, data/lua/templates/minimal/main.lua, data/lua/templates/complete/main.lua, data/mods/Lua_First_Example/main.lua, data/lua/LUA_FIRST_EOC_WORKFLOW.md]
+    evidence: [tools/create_lua_mod.py, tools/test_create_lua_mod.py, tools/lua_api/mod_sdk.py, tools/lua_api/test_mod_sdk.py, data/lua/templates/minimal/main.lua, data/lua/templates/complete/main.lua, data/mods/Lua_First_Example/main.lua, data/lua/LUA_FIRST_EOC_WORKFLOW.md]
     verification: not_run
-    next_actions: [Plan cookbook, console, diagnostics, editor, scaffolding, examples, and migration-report improvements as an independent follow-on batch; evaluate author workflows rather than selector or TODO counts; do not make this capability a platform-capability-closure or final-acceptance dependency.]
+    next_actions:
+      - The initial declaration-snapshot, scaffold/editor and static-diagnostic slice passed local tool tests and the real LuaLS gate; it does not implement an in-game debugger, state/task inspector or native compatibility negotiation.
+      - Continue runtime debugging, cookbook and author-workflow improvements as independent batches with their own evidence; do not make the whole author-experience capability a core Platform closure dependency.

--- a/ai/project-map.yml
+++ b/ai/project-map.yml
@@ -18,10 +18,10 @@ entries:
     boundaries:
       - Preserve stable IDs or provide explicit migration data.
   - id: lua-api
-    paths: [data/lua/types/ccb_platform_v1.d.lua, 'data/lua/reference/ccb_platform_*', tools/lua_api/, src/main.cpp, src/game_io.cpp, src/lua_platform_loader.cpp, src/lua_platform_runtime.cpp, 'src/lua_platform*.cpp', 'src/lua_platform*.h']
+    paths: [data/lua/types/ccb_platform_v1.d.lua, 'data/lua/reference/ccb_platform_*', tools/lua_api/, tools/create_lua_mod.py, tools/test_create_lua_mod.py, data/lua/templates/, src/main.cpp, src/game_io.cpp, src/lua_platform_loader.cpp, src/lua_platform_runtime.cpp, 'src/lua_platform*.cpp', 'src/lua_platform*.h']
     purpose: Lua-first Platform v1 declarations, native inventory, public contract, synchronization coverage, and contract checks.
     instructions: data/lua/AGENTS.md
-    validation_ids: [lua-contract]
+    validation_ids: [lua-contract, lua-authoring]
     boundaries:
       - Platform v1 declarations, registrations, generated inventory, and contract checks are authoritative.
       - This is a contract-validation route within the sole Platform runtime, not a second Lua system.

--- a/ai/test-matrix.yml
+++ b/ai/test-matrix.yml
@@ -68,7 +68,12 @@ entries:
     cost: medium
   - id: lua-contract
     paths: [src/CMakeLists.txt, src/lua/CMakeLists.txt, src/main.cpp, 'src/lua_platform*.cpp', 'src/lua_platform*.h', src/event.h, data/lua/, tools/lua_api/]
-    command: python3 tools/lua_api/check_luals_declarations.py && python3 tools/lua_api/check_platform_native_inventory.py && python3 tools/lua_api/check_platform_contract.py && python3 tools/lua_api/check_platform_coverage.py && python3 tools/lua_api/check_cmake_contract.py && python3 -m unittest discover -s tools/lua_api -p 'test_*.py'
+    command: python3 -m unittest discover -s tools/lua_api -p 'test_*.py'
+    workdir: .
+    cost: fast
+  - id: lua-authoring
+    paths: [tools/create_lua_mod.py, tools/test_create_lua_mod.py, tools/lua_api/mod_sdk.py, tools/lua_api/test_mod_sdk.py, data/lua/templates/, data/lua/types/]
+    command: python3 tools/test_create_lua_mod.py
     workdir: .
     cost: fast
   - id: lua-playable-mvp

--- a/data/lua/AGENTS.md
+++ b/data/lua/AGENTS.md
@@ -9,18 +9,25 @@ tracked in `ai/lua-first-roadmap.yml`.
   Platform inventories are authoritative for the current Lua runtime contract.
 - `LUA_FIRST_PLATFORM.md` is authoritative for CCB Lua 0.1 platform design decisions.
 - `LUA_FIRST_EOC_WORKFLOW.md` defines the active EOC-capability objective,
-  domain-batch development cadence, and deferred acceptance gate.  Follow it
+  domain-batch development cadence, and scoped acceptance gates.  Follow it
   for Lua-first EOC parity work.
+- The accepted trust policy in `LUA_FIRST_PLATFORM.md` permits full standard
+  libraries and external/native modules at the player's risk. Do not reintroduce
+  sandbox tiers or mandatory global runtime quotas; preserve supported `ccb`
+  correctness and lifetime checks. The current loader restrictions still need
+  implementation changes, so do not describe the accepted policy as shipped.
 - Never hand-edit generated reference inventories; run their named generator.
 - Do not add a second Lua runtime, `game.*` surface, capability sandbox,
   authored manifest, JSON loader, EOC runner, or EOC-key-shaped API. Useful
   native operations belong under the Platform contract; compatibility-only
   operations are deleted.
 - Keep examples runnable and synchronized with declarations.
-- `templates/minimal/` and `templates/complete/` contain no JSON/EOC and are
+- `templates/minimal/` and `templates/complete/` contain no runtime JSON/EOC and are
   copied by `tools/create_lua_mod.py`; never make their suggested directories
   loader requirements.  The complete template's Mod-id token is replaced only
   in the scaffold staging directory before atomic installation.
+  The scaffolder may add optional `.luarc.json` and a frozen `.ccb-sdk/` for
+  editor use; neither is a runtime manifest, and `--no-editor` omits them.
 - `ai/lua-first-replacement-ledger.yml` is generated. Change its generator,
   never the ledger by hand. A bounded or primitive disposition is not
   completeness; only the final semantic gate may produce a verified status.
@@ -36,30 +43,11 @@ tracked in `ai/lua-first-roadmap.yml`.
 - Platform Mods must not require a `lua/` subdirectory or author-maintained
   JSON manifest.  Templates may recommend structure but may not require it.
 
-Development and validation cadence:
-
-- Implement a coherent domain closure rather than one legacy selector at a
-  time.  Add declarations, migration support, and test code in the same batch.
-- During implementation, do not compile C++, start Catch2, run Python
-  checkers, run generators, refresh the public contract/ledger/registry, or
-  audit the full corpus after each edit. Defer all of them to the final batch
-  gate unless a check is needed to unblock an otherwise unresolved native
-  signature or safety boundary.
-- At acceptance, compile once and run one broad matching Catch2 process.
-  Focused filters are diagnostic follow-ups after a failure, not prerequisites
-  for a broad suite that will exercise the same code.
-- Do not rerun a passing gate unless a later change touched its evidence.
-
-Final acceptance commands are selected from `ai/test-matrix.yml`; common Lua
-contract commands include:
+Follow `LUA_FIRST_EOC_WORKFLOW.md` for validation selection and cadence.
+The single Lua contract gate includes live repository checks and tool regressions:
 
 ```sh
-python3 tools/lua_api/check_luals_declarations.py
-python3 tools/lua_api/check_platform_native_inventory.py
-python3 tools/lua_api/check_platform_contract.py
-python3 tools/lua_api/check_platform_coverage.py
 python3 -m unittest discover -s tools/lua_api -p 'test_*.py'
-python3 tools/agent/check_project_metadata.py
 ```
 
 CCB-Docs 只能解释这些契约；与本目录声明或注册冲突时，应更新并标记文档，

--- a/data/lua/LUA_FIRST_EOC_WORKFLOW.md
+++ b/data/lua/LUA_FIRST_EOC_WORKFLOW.md
@@ -1,228 +1,123 @@
 # Lua-first EOC capability workflow / Lua-first EOC 能力流程
 
-Status: active implementation workflow for the sole Lua-first Platform.
-
-状态：唯一 Lua-first Platform 的当前开发流程。
+Status: active workflow for the sole `require("ccb")` / Platform v1 system.
+状态：唯一 `require("ccb")` / Platform v1 系统的当前开发流程。
 
 ## Objective / 当前目标
 
-Close the Platform runtime, native domain services, and migration boundaries
-for the PR scope. Lua is the only executable authoring language and the sole
-behaviour system; this is capability replacement, not syntax replacement. Lua
-uses ordinary functions, modules, control flow, typed handles, snapshots,
-named tasks, synchronous hooks, and domain services. Passive,
-schema-validatable JSON may remain and is loaded into the same typed C++
-content model as Lua definitions.
+Work on one complete author workflow at a time, in this order:
 
-先闭合本 PR 范围内的 Platform 运行时、原生领域服务和迁移边界。Lua 是唯一可执行作者语言
-和唯一行为系统；这里追求能力替代而不是语法复刻。静态、被动且可由 Schema 校验的 JSON
-可以保留，并与 Lua 定义进入同一个类型化 C++ 内容模型。
+1. Fix runtime blockers that prevent loading, playing, saving, or reloading.
+2. Close and verify composable native domain capabilities needed to replace EOC.
+3. Migrate shipped behaviour after capability acceptance; remove the EOC runner
+   only when an exact reference audit proves its references are zero.
 
-Never add a new public JSON loader, EOC runner, legacy key tree, raw legacy
-object, or hidden compatibility call. The existing C++ JSON parser and EOC
-runner remain private compatibility infrastructure for the C++ core and old
-Mods during the transition; new Platform code does not depend on them. Delete
-the EOC runner only after an exact reference audit proves that EOC references
-are zero. If a shape is not proven safe and bounded, the migrator emits an
-explicitly classified TODO and the ledger keeps it unverified or planned.
+Lua is the sole executable authoring language. Passive schema-validatable JSON
+may remain. Do not add public JSON loaders, EOC runners, legacy key trees, or
+hidden compatibility calls; the transitional EOC path stays private.
 
-不得新增公开 JSON loader、EOC runner、旧键树、旧对象或隐藏兼容调用。过渡期间，现有 C++
-JSON parser 和 EOC runner 作为本体及旧 Mod 的私有兼容基础设施保留，Platform 新代码不得
-依赖它们；只有精确引用审计证明 EOC 引用归零后才可删除 runner。无法证明安全且有界的形状
-必须由迁移器输出明确分类的 TODO，账本保持 unverified 或 planned。
+每次只推进一个完整作者工作流：先修复加载、游玩、存档与重载阻塞，再补齐并验证替代 EOC
+所需的领域能力，通过能力验收后迁移现有行为。精确引用审计证明 EOC 引用归零后才删除 runner。
+静态 JSON 可以保留；Lua 是唯一可执行作者语言。不得新增公开 JSON loader、EOC runner、
+旧键树或隐藏兼容调用。过渡期的旧 EOC 执行路径仍是私有兼容基础设施。
 
-## Domain batch unit / 领域批次单位
+`ai/lua-first-roadmap.yml` retains milestone evidence; it is not a checklist to
+repeat on every change. PR 664's foundation gate is historical scope. Optional
+helpers, internationalization, and author tooling enter a batch when an actual
+workflow needs them; they are not prerequisites for every Lua change.
 
-The unit of work is one coherent author workflow, not one selector or the whole
-inventory. A capability-closure batch contains, as applicable:
+roadmap 保留历史里程碑证据，不作为每次修改的待办清单。PR 664 的基础设施总验收属于历史范围。
+可选 helper、国际化与作者工具按实际需求进入批次，不再成为每轮 Lua 开发的前置目标。
 
-- native `src/lua_platform_*` implementation and lifecycle boundary;
-- LuaLS declarations in `data/lua/types/ccb_platform_v1.d.lua`;
-- bounded migration output in `tools/migrate_lua_first.py`;
-- regression-test source in `tests/lua_platform_test.cpp` or the matching
-  Platform test;
-- status-specific ledger evidence and a short architecture note.
+The accepted trust/library/resource policy is defined in
+`LUA_FIRST_PLATFORM.md`. Reliability work means correct errors, lifecycle and
+native API semantics; it does not restore a security sandbox or mandatory
+runtime quotas. Track full-library/module-loader implementation separately from
+accepting that policy.
 
-实现单位是一个完整的作者工作流，而不是单个 selector 或整个语料。能力闭合批次应同步包含原生
-`src/lua_platform_*` 实现、LuaLS 声明、`tools/migrate_lua_first.py` 的有界迁移输出、
-Platform 测试源码、状态对应的账本证据和必要的架构说明。
+信任、标准库和资源策略统一见架构契约；可靠性工作围绕错误、生命周期与原生接口正确性展开，
+不恢复安全沙盒或默认强制运行配额。契约采纳与完整标准库/模块加载的实现验收分别记录。
 
-Recommended domains are character identity/health, inventory and item use,
-map and world, NPC/creature, vehicle, mission/faction, weather/time,
-dialogue/presentation, and persistent tasks. Group related conditions and
-effects in one domain so the author workflow is composable.
+## One domain batch / 单个领域批次
 
-## Implementation sprint / 开发冲刺规则
+A batch records its author-visible result, affected files, unresolved boundary,
+and acceptance evidence in one compact checkpoint. Include native implementation,
+LuaLS declarations, relevant regression tests, and migration output when affected.
+Use ordinary Lua functions and typed domain services, not selector-shaped APIs.
+Do not create another progress tracker or update generated counts after each edit.
 
-Until every source batch required for the core Platform closure milestone in the
-current roadmap is closed, the loop is limited to:
+批次只记录作者可用结果、涉及文件、未解决边界和验收证据；同步修改受影响的实现、LuaLS 声明、
+回归测试与迁移输出。用普通 Lua 和类型化领域服务组合行为，不按 selector 逐个复刻 API。
+不另建进度系统，不在每次编辑后刷新生成统计。
 
-- exact `rg` search and small-window source/document reads;
-- `apply_patch` edits to implementation, declarations, test source, and
-  checkpoint files;
-- compact diff/path inspection;
-- recording unresolved capability boundaries.
+## Validation / 验证流程
 
-The loop must not run a C++ build, Catch2, Python suite, checker, generator,
-full public-contract refresh, ledger refresh, documentation-registry refresh,
-or full JSON/EOC corpus audit. Do not use a passing old output as evidence for
-the renamed or newly edited source.
+`ai/test-matrix.yml` lists available checks. Select them for the changed inputs;
+it does not require every listed command for every Lua task.
 
-在当前 roadmap 中核心 Platform 闭合所需的源码批次闭合前，只能做精确 `rg`、小窗口读取、
-`apply_patch`、路径/diff 检查和 checkpoint 记录。不得运行 C++ 编译、Catch2、Python 套件、
-checker、generator、完整 public contract 刷新、ledger 刷新、documentation registry 刷新或
-全量 JSON/EOC 语料审计。旧输出的通过结果不能作为重命名或新修改源码的证据。
+| Change / 修改 | Batch acceptance / 批次验收 |
+| --- | --- |
+| Lua contract or its Python tools / Lua 契约及其 Python 工具 | Run the single contract suite below; it includes live repository checks and negative cases / 运行下方统一套件，包含真实仓库校验与反例 |
+| Native Lua behaviour / 原生 Lua 行为 | Build once and run one matching Catch2 process; include lifecycle, saves and handles when affected / 一次构建、一个匹配的 Catch2 进程，按影响覆盖生命周期、存档和句柄 |
+| Disabled-build integration / 禁用构建集成 | Add the disabled-build route when build inputs or disabled paths change / 构建输入或禁用路径变化时增加禁用构建验收 |
+| Migration or real content / 迁移器或真实内容 | Check changed migration shapes and load affected content / 检查受影响的迁移形状并加载对应内容 |
+| Workflow or prose only / 仅流程或说明 | Check affected metadata, links and workflow syntax / 检查相关元数据、链接与工作流语法 |
 
-## Honest status vocabulary / 诚实状态口径
+```sh
+python3 -m unittest discover -s tools/lua_api -p 'test_*.py'
+```
 
-- `primitive_available_unverified`: native building blocks exist; no
-  selector-level replacement claim is made.
-- `bounded_implemented_unverified`: named real shapes have source,
-  declaration, migration, test source, and documentation evidence; other
-  legal shapes remain outside the claim.
-- `implemented_unverified`: the Platform source path exists but the final
-  semantic gate has not proved the relevant real inventory.
-- `*_verified`: allowed only after the final semantic gate records native
-  behavior and real JSON/EOC evidence for that exact disposition.
-- `planned`: no bounded implementation claim exists yet.
+The suite calls the LuaLS, native-inventory, public-contract, synchronization,
+and CMake checks. Their individual CLI commands remain available for diagnosis;
+do not run all five again before or after the suite.
 
-- `primitive_available_unverified`：只有原生积木存在，不代表 selector 替代完成。
-- `bounded_implemented_unverified`：明确的真实形状有源码、声明、迁移、测试源码和文档证据，
-  其他合法形状不在声明内。
-- `implemented_unverified`：Platform 源码路径存在，但相关真实语料尚未经过最终语义门禁。
-- `*_verified`：只有最终语义门禁记录了该 disposition 的原生行为和真实 JSON/EOC 证据后才可用。
-- `planned`：尚无 bounded 实现声明。
+统一套件已执行 LuaLS、原生清单、公开契约、同步覆盖和 CMake 校验。各 CLI 保留用于定位问题，
+不要在统一套件前后再重复运行五个检查器。
 
-Ledger totals, public-symbol counts, generated synchronization counts, or a
-small converted example never mean complete EOC capability.
+During implementation, write tests with the code. Use focused Python tests or
+syntax checks when useful; defer C++ builds, broad suites and generated refreshes
+to batch acceptance. A broad `[lua][platform]` run already includes
+`[playable_mvp]`; do not run that subset again on the same binary and inputs.
+Tool-only or documentation-only changes do not need a game build.
 
-账本总数、公开符号数量、生成同步数量或少量转换样例都不能代表 EOC 能力完整。
+开发时测试随代码编写，按需执行聚焦 Python 测试或语法检查；C++ 构建、宽测试与生成刷新留到
+批次验收。`[lua][platform]` 已包含 `[playable_mvp]`，相同程序和输入不重复运行子集。
+只改工具或文档无需编译游戏。
 
-## Migration TODO taxonomy / 迁移 TODO 分类
+Refresh generated outputs only when their declared inputs change, in dependency
+order (native inventory, public contract, synchronization coverage). Ledger,
+registry and migration reports follow the inputs of their generators listed in
+`ai/generated-files.yml`.
+Full corpus audits belong to corpus migration, parity claims, or EOC removal,
+not every domain fix. Never hand-edit generated files.
 
-Every TODO has one primary category and a source location:
+只在声明的输入变化时刷新生成输出，按原生清单、公开契约、同步覆盖的依赖顺序执行。
+ledger、registry 与迁移报告按 `ai/generated-files.yml` 指定生成器的输入决定是否刷新。全量语料
+审计用于语料迁移、完整替代声明或删除 EOC，不是每个领域修复的固定步骤。禁止手改生成文件。
 
-- `auto_fix`: the required Platform API already exists, but the migrator does
-  not generate the correct Lua shape yet; fix the migrator/output rather than
-  adding a new core capability;
-- `manual_rewrite`: an author or maintainer must express the workflow in
-  ordinary Lua;
-- `platform_gap`: a typed native service, registrar, or lifecycle boundary is
-  missing. Only this category drives Platform core development;
-- `semantic_choice`: the legacy shape has multiple intentional native
-  interpretations and needs a human decision.
+Reuse passing evidence while its inputs and build configuration remain unchanged.
+After a failure, diagnose narrowly and rerun the affected gate after the fix.
+Report exactly what ran and what remains unverified.
 
-The category is part of the migration record, not a priority shortcut. TODOs
-are boundary records, not completion records, and their counts are never a
-completion metric. A capability closes when its stated source, declaration,
-migration shape, test source, documentation, and safety boundary are closed.
-Remaining TODOs may be preserved for later batches.
+相关输入和构建配置不变时复用已通过证据；失败后聚焦定位，修复后重跑受影响门禁。
+明确报告实际执行内容和仍未验证的部分。
 
-每个 TODO 都带一个主分类和源位置：`auto_fix` 表示所需 Platform API 已存在，但迁移器尚未生成
-正确的 Lua 形状，应修复迁移器/输出而不是增加核心能力；`manual_rewrite` 是作者或维护者必须用普通 Lua 表达的 workflow；`platform_gap` 表示缺少类型化
-native service、registrar 或生命周期边界，只有这一类会驱动 Platform 核心开发；
-`semantic_choice` 表示旧形状存在多种有意的原生解释，需要人做选择。
+## Completion and migration boundaries / 完成度与迁移边界
 
-分类是迁移记录的一部分，不是绕过优先级的捷径。TODO 是边界记录，不是完成记录，数量永远不是
-完成指标。能力只有在其声明的源码、声明、迁移形状、测试源码、文档和安全边界闭合后才算完成；
-剩余 TODO 可以留给后续批次。
+- `planned`: no bounded implementation claim / 尚无有界实现声明。
+- `primitive_available_unverified`: native building blocks only / 只有原生积木，不代表 selector 替代完成。
+- `bounded_implemented_unverified`: named shapes have implementation, declarations,
+  migration and test source; other legal shapes remain outside the claim / 仅明确形状有实现、声明、迁移与测试源码。
+- `implemented_unverified`: source exists, semantic acceptance is pending / 已有源码，语义验收未完成。
+- `*_verified`: requires native behaviour and real JSON/EOC evidence for the exact
+  claimed scope / 必须有对应范围的原生行为与真实语料证据。
 
-## Final acceptance gate / 最终验收门禁
+Keep migration TODOs classified with a source location: `auto_fix` (existing API,
+fix the migrator), `manual_rewrite` (ordinary Lua rewrite), `platform_gap` (missing
+native capability), or `semantic_choice` (human intent needed). Only
+`platform_gap` drives new Platform core capabilities.
 
-After all core source batches required by PR 664 are complete, run one gate in
-this order:
-
-1. Generate the Platform native inventory, Platform v1 public contract, and
-   Platform synchronization coverage.
-2. Run the Platform LuaLS, native-inventory, public-contract, coverage, CMake,
-   and tool-source checks selected by `ai/test-matrix.yml`.
-3. Run one low-memory C++ build when native source changed.
-4. Run one broad `[lua][platform]` Catch2 process, including relevant disabled
-   and Mod-manager checks when routed.
-5. Classify the real JSON/EOC inventory entries once, preserving the four TODO
-   categories and recording any remaining references to the legacy runner.
-6. Refresh the generated replacement ledger, documentation registry, and
-   migration reports only after their source inputs are final; inspect the
-   final diff.
-
-The three Platform references and generated reports are absent or stale during
-the implementation sprint by design. A failure gets one focused diagnostic;
-after repair return to the same gate instead of declaring a partial pass. This
-gate accepts the core Platform foundation and generic capability scope named by
-the roadmap; it does not require all core JSON/EOC content to migrate, passive
-JSON to disappear, TODOs to reach zero, the EOC runner to be removed early, or
-any independent follow-on capability batch to close. Follow-on batches have
-their own scoped evidence and acceptance records.
-
-PR 664 所需的核心源码批次完成后只执行一次总门禁：先生成 Platform native inventory、
-Platform v1 public contract 和同步 coverage；再运行 LuaLS/native/contract/coverage/CMake/工具
-检查；源码变化时做一次低内存构建；运行一次 broad `[lua][platform]` Catch2；分类一次真实
-JSON/EOC 语料并记录旧 runner 引用；最后刷新 ledger、documentation registry、迁移报告并检查
-diff。开发冲刺期间三个 Platform reference 和生成报告缺失或陈旧是有意状态。该门禁只验收
-roadmap 指定的核心 Platform 基础设施和通用能力，不要求迁移全部本体 JSON/EOC、删除被动
-JSON、TODO 归零、提前删除 EOC runner 或闭合任何独立后续能力批次。后续批次各自维护有界的
-证据和验收记录。失败只能做一次聚焦诊断，修复后回到同一总门禁。
-
-Cached gate results may be reused while the inputs relevant to that gate remain
-unchanged. Once a change touches a relevant input, return to the final gate;
-this workflow records the gate to run and claims no current gate result.
-
-相关输入未变化时可以复用缓存的门禁结果；一旦修改触及相关输入，就必须回到最终门禁。本流程
-只记录待执行的门禁，不声称本次文档批次有当前门禁结果。
-
-## PR 664 closure and follow-on batches / PR 664 闭合与后续批次
-
-PR 664 closes at the core Platform infrastructure and generic capability
-boundary: one Platform v1 runtime and public `ccb` contract, a typed content
-model and registrars, lifecycle and handle/identity safety, reusable generic
-domain services, and an honest migration boundary. Passive schema-validatable
-JSON may remain in the shared typed C++ model, and selected content migrations
-remain later consumers. The EOC runner is removed only after an exact audit
-proves that EOC references are zero.
-
-PR 664 在核心 Platform 基础设施和通用能力边界闭合：唯一 Platform v1 runtime 与公开
-`ccb` 契约、类型化内容模型和 registrar、生命周期与句柄/身份安全、可复用的通用领域服务，
-以及诚实的迁移边界。静态且可由 Schema 校验的 JSON 可以保留在共享的类型化 C++ 模型中，
-选定的内容迁移是后续消费者。只有精确审计证明 EOC 引用归零后，才删除 EOC runner。
-
-High-priority follow-on work remains independently tracked and is not a
-prerequisite for the PR 664 closure gate: the current standard-library
-whitelist slice as incremental hardening, broader runtime hardening, shared
-standard helpers, author-facing internationalization, and cookbook/console/
-author experience. The whitelist changes are useful in this PR, but they do
-not claim that resource budgets, callback instruction limits, process isolation,
-or the wider hardening batch is complete; the broader items remain planned or
-recommended. Each follow-on batch gets its own scope, evidence, and acceptance
-record.
-
-高优先级后续工作继续独立跟踪，不是 PR 664 闭合门禁的前置条件：当前标准库白名单切片作为
-增量 hardening、更广泛的 runtime hardening、共享标准库 helper、面向作者的国际化，以及
-cookbook/console/作者体验。白名单修改对本 PR 有价值，但不代表资源预算、callback 指令限制、
-进程隔离或更广泛的 hardening 批次已经完成；其余项目仍是 planned 或 recommended。每个后续
-批次都有自己的范围、证据和验收记录。
-
-The names `ccb.std.collections`, `ccb.std.ui`, `ccb.std.inspect`, and
-`ccb.std.text` are recommended candidates only for a future shared-helper
-design. No `ccb.std` namespace, sub-namespace, or helper name is a frozen
-Platform v1 contract. If implemented, such helpers continue to use the sole
-`require("ccb")` entrypoint and typed model, but they are not dependencies of
-`platform-capability-closure` or `final-acceptance-gate`.
-
-`ccb.std.collections`、`ccb.std.ui`、`ccb.std.inspect`、`ccb.std.text` 只是未来共享 helper
-设计的推荐候选。没有任何 `ccb.std` 命名空间、子命名空间或 helper 名称是冻结的 Platform v1
-契约。若未来实现，这些 helper 仍沿用唯一 `require("ccb")` 入口和类型化模型，但不是
-`platform-capability-closure` 或 `final-acceptance-gate` 的依赖。
-
-## Evidence routing / 证据路径
-
-Current implementation evidence must point to:
-
-- `src/lua_platform_*.cpp` and `.h`;
-- `data/lua/types/ccb_platform_v1.d.lua`;
-- Platform schemas and Platform-only tool sources;
-- `tools/migrate_lua_first.py` and its tests;
-- `tests/lua_platform_test.cpp` or the matching Platform test;
-- the real JSON/EOC inventory entry being classified.
-
-The architecture specification and roadmap explain intent. They cannot promote
-a status or replace a source/test/gate result.
+迁移 TODO 保留源位置及四类分类：`auto_fix` 修迁移器、`manual_rewrite` 用普通 Lua 重写、
+`platform_gap` 补原生能力、`semantic_choice` 明确人的意图。只有 `platform_gap` 驱动新增核心能力。
+里程碑、符号、同步覆盖、TODO 数量和少量示例都不能换算为 EOC 完成率；源码已写、实际验证和
+语料迁移必须分别报告。架构说明与 roadmap 不能替代源码、测试和验收证据。

--- a/data/lua/LUA_FIRST_PLATFORM.md
+++ b/data/lua/LUA_FIRST_PLATFORM.md
@@ -24,8 +24,8 @@ Platform Lua 是 CCB 核心内容和 Mod 的原生创作模型。作者使用普
 For author-facing content, Lua is the only executable content language. All
 new behaviour, policies, conditions, effects, and workflows enter through the
 Platform contract; EOC is not a second behaviour system. One isolated Lua
-state per Mod is an ownership and failure boundary, not a second runtime or a
-second public API.
+state per Mod separates ownership and ordinary Lua globals; it is not process
+isolation, crash containment, a second runtime, or a second public API.
 
 Static JSON may remain when it is passive, schema-validatable data. Such JSON
 and Lua builders enter the same typed C++ content model; the distinction is
@@ -38,8 +38,8 @@ proves that EOC references have reached zero; retaining the parser for passive
 or engine-owned JSON is not a failure of the Lua-first direction.
 
 面向作者的内容只有 Lua 一种可执行语言。新的行为、策略、条件、效果和 workflow 都必须
-进入 Platform 契约；EOC 不是第二套行为系统。每个 Mod 一个隔离 Lua state 只是 owner 和
-故障边界，不是第二个 runtime 或第二套公开 API。
+进入 Platform 契约；EOC 不是第二套行为系统。每个 Mod 一个独立 Lua state 用于区分 owner 和普通全局变量，
+不代表进程隔离或崩溃隔离，也不是第二个 runtime 或第二套公开 API。
 
 只要 JSON 是静态、被动且可由 Schema 校验，就可以长期保留。这样的 JSON 与 Lua builder
 进入同一个类型化 C++ 内容模型；边界在于内容是否携带可执行行为，而不在于文件扩展名。
@@ -57,14 +57,18 @@ local ccb = require("ccb")
 ```
 
 The loader installs that table in `package.loaded["ccb"]` and provides a
-root-local module resolver. It does not create a global `game` table, a second
+Mod-local module resolver. Under the accepted trusted-code policy, ordinary
+Lua/package and native module loading also remain available; these are module
+mechanisms, not alternative game-authoring APIs. It does not create a global
+`game` table, a second
 authoring entry, or a compatibility namespace. The Platform may own one Lua
 state per loaded Mod for isolation; those states are all instances of this
 same Platform runtime and share no alternate public contract.
 
 Platform v1 是唯一受支持的 Lua 运行时、加载器、状态模型和作者契约。Mod 通过
 `require("ccb")` 获得包内 `ccb` 表。加载器只注册 `package.loaded["ccb"]` 并提供根目录内
-模块解析，不创建全局 `game` 表、第二个作者入口或兼容命名空间。为隔离 Mod，Platform
+模块解析；按已采纳的可信代码契约，也允许普通 Lua/package 与原生模块加载。这些是模块
+加载机制，不是另一套游戏创作 API。不创建全局 `game` 表、第二个作者入口或兼容命名空间。为隔离 Mod，Platform
 可以为每个已加载 Mod 持有一个 Lua state；这些 state 都属于同一个 Platform 运行时，
 不存在另一套公开契约。
 
@@ -75,6 +79,7 @@ stable groups:
 - `ccb.content` — transactional native definitions and content builders;
 - `ccb.runtime` — named handlers, lifecycle hooks, synchronous callbacks, and
   persistent task policies;
+- `ccb.dialogue` — typed dialogue topics, responses, and extensions;
 - `ccb.services` — generation-checked world, character, item, creature, NPC,
   vehicle, map, weather, mission, faction, time, and presentation services;
 - `ccb.state`, `ccb.tasks`, and `ccb.presentation` — bounded persistent and
@@ -82,7 +87,7 @@ stable groups:
 
 公开 LuaLS 声明是 `data/lua/types/ccb_platform_v1.d.lua`。公共根表稳定地分为
 `ccb.content`（事务化原生定义）、`ccb.runtime`（命名 handler、生命周期 hook、同步回调和
-持久任务）、`ccb.services`（代际安全的世界、角色、物品、地图、天气、任务等领域服务），
+持久任务）、`ccb.dialogue`（类型化对话与扩展）、`ccb.services`（代际安全的世界、角色、物品、地图、天气、任务等领域服务），
 以及 `ccb.state`、`ccb.tasks`、`ccb.presentation` 等运行时支持。
 
 ## Mod discovery / Mod 发现
@@ -106,10 +111,58 @@ JSON/EOC author files.
 `content/`、`runtime/`、`lib/`、`tests/` 只是作者的组织选择，模板可以推荐但加载器不
 强制。Platform Mod 不需要 `lua/`、`manifest.json`、`modinfo.json` 或 JSON/EOC 作者文件。
 
-The local `require` helper resolves only safe module names inside the Mod root
-(`?.lua` and `?/init.lua`). It rejects traversal and path escape. This is a
-module boundary, not a sandbox promise: bundled Platform Lua is trusted code
-and its native operations remain bounded by C++ validation.
+## Trust, libraries, and resource policy / 信任、库与资源契约
+
+Accepted on 2026-09-06: Platform Mods are trusted executable code chosen by the
+player, regardless of author or source. CCB does not promise to protect the
+player's system from them. This is one Platform contract, not separate
+restricted and unrestricted runtime tiers.
+
+- Expose the complete bundled Lua standard library, including `io`, `os`,
+  `debug`, and ordinary `load`, `loadfile`, `dofile`, and `package` facilities.
+  Preserve `require("ccb")` as the stable game API and prefer local modules
+  without making the Mod root a security boundary for other loading paths.
+- Permit external Lua modules and native dynamic libraries where the host
+  platform supports them. Native extensions are executable code with the game
+  process's privileges; authors own OS, architecture, Lua ABI, and dependency
+  compatibility. This does not create a stable ABI for internal C++ objects.
+- Keep per-Mod Lua states for namespacing and ownership. A state is not a
+  thread, a process sandbox, or protection against a native crash.
+- Do not impose mandatory global Lua instruction or memory budgets by default.
+  Profiling, diagnostics and explicitly enabled developer limits may assist
+  debugging. Bounded queries, persistent data formats, valid parameters and
+  handle/lifecycle checks in supported `ccb` services remain API correctness
+  requirements, not a security boundary against trusted code.
+- Present a clear execution-risk notice before first executing downloaded Mod
+  code, including executable `mod.lua` metadata discovery. Selection to trust
+  code is not a per-API permission dialog, and catalog inclusion is not a
+  security guarantee. Record this as an integration requirement, not a claim
+  that a launcher or game notice already exists.
+- Report ordinary Lua errors with context and perform supported cleanup, but
+  do not promise safe interruption of arbitrary loops/native calls, crash
+  containment, or rollback of external filesystem/process side effects.
+
+2026-09-06 已采纳：所有来源的 Mod 均按玩家选择运行的可信代码处理；CCB 不承诺保护玩家系统，
+不划分两套受限/无限制运行时。开放完整 Lua 标准库、文件/系统/调试能力、外部 Lua 模块和
+平台支持的原生动态库；`require("ccb")` 仍是稳定游戏接口，本地模块优先不是安全边界。
+原生扩展作者负责系统、架构、Lua ABI 与依赖适配，引擎内部 C++ ABI 不因此成为稳定公开契约。
+每 Mod 独立 state 只用于命名与 owner 隔离，不能隔离崩溃。默认不设全局执行指令或内存配额；
+可提供自愿启用的诊断限制。`ccb` 的分页、有界数据格式、参数、句柄和生命周期校验继续保留。
+首次执行下载的 Mod 代码前应明确告知风险，包含会执行代码的 `mod.lua` 发现阶段，不对每次
+API 调用弹权限窗口。此告知是待落实的集成要求，不代表现有启动器已实现。普通 Lua 错误应可
+定位与清理，但不承诺无限循环/原生调用可安全中断，也不承诺崩溃隔离或外部副作用回滚。
+
+Implementation checkpoint (2026-09-06): `initialize_state` still uses a
+standard-library whitelist, removes `io`/`os`/`debug` and native package loaders,
+and restricts module resolution to the Mod root. Full-library and external/native
+loading support is **accepted, pending implementation and runtime acceptance**.
+The roadmap's `platform-hardening` entry now tracks this trust-policy transition
+and reliability/diagnostics work; old sandbox and mandatory-budget plans are
+superseded. This documentation update changes no running permissions.
+
+实现断点：当前加载器仍使用白名单并移除系统库与原生加载入口，因此完整标准库与外部/原生模块
+加载是**已采纳、待实现和运行验证**。roadmap 的 `platform-hardening` 改为跟踪此策略切换及
+可靠性/诊断；旧沙盒和默认强制配额计划作废。本次文档修改不改变运行中的权限。
 
 ## Loading and lifecycle / 加载与生命周期
 
@@ -250,6 +303,27 @@ to use the exact-Item `quote/get/commit` API.
 任务和 presentation。每个服务都应说明读写阶段、边界、返回 envelope、生命周期保护和
 失败行为；回调接收类型化 payload 与句柄，不接收任意引擎对象。
 
+## Persistence, tasks, and failure semantics / 持久化、任务与失败语义
+
+- Persist explicit serializable state and stable entity identities, not live
+  handles, functions, C++ pointers, or arbitrary Lua globals. Exact scopes,
+  accepted value types and payload bounds are defined in LuaLS and native code.
+- Persistent tasks refer to named handlers and versioned payloads. On reload,
+  resolve identities into fresh handles; unavailable entities, missing handlers
+  and payload migrations follow the documented retry/failure policy.
+- Native service results, optional values, errors, snapshots and cursors follow
+  each declared signature. A detached snapshot is not a writable engine object;
+  tokens/cursors can expire and must not be reused after their stated lifetime.
+- Content registration rollback is not a universal gameplay transaction.
+  Multi-step world operations are atomic only where the API explicitly promises
+  it. Files, processes and native extension side effects remain author-owned.
+
+持久化只保存明确可序列化的数据与稳定身份，不保存活句柄、函数、指针或任意全局变量；作用域、
+类型与边界以 LuaLS/源码为准。持久任务绑定命名 handler 与版本化 payload，重载后重新解析
+句柄，缺失实体/handler 与 payload 迁移遵循各自失败或重试约定。结果、快照和游标按具体签名
+使用；快照不是可写引擎对象，失效 token 不可复用。内容注册回滚不等于任意世界操作有事务，
+只有接口明确声明的操作才保证原子性；外部文件、进程和原生扩展副作用不在回滚承诺内。
+
 ## Behaviour instead of EOC / 用 Lua 行为表达能力
 
 Lua expresses conditions, effects, branching, loops, composition, and policy
@@ -325,97 +399,23 @@ The source of current Platform references is deliberately small:
 - `tools/migrate_lua_first.py` and `tests/lua_platform_test.cpp` — migration
   and semantic evidence sources.
 
-The generated Platform references, ledger, documentation registry, and
-migration reports are outputs. They are not hand-edited evidence and are
-refreshed together at the final acceptance gate.
+Generated references, ledger, documentation registry, and migration reports are
+outputs, never hand-edited evidence. Refresh them only when their declared
+inputs change. Validation cadence, current priorities, and completion reporting
+are defined once in [the EOC capability workflow](LUA_FIRST_EOC_WORKFLOW.md).
 
-当前 Platform 参考资料只来自 LuaLS 声明、`lua_platform_*` 原生注册、Platform schema、
-Platform 工具、迁移器和测试源码。Platform reference、账本、文档 registry 与迁移报告都
-是生成输出，不手工编辑，统一留到最终门禁刷新。
+Platform reference、账本、文档 registry 与迁移报告是生成输出，禁止手改；只在声明的输入
+变化时刷新。当前优先级、验证流程与完成度口径统一见 [EOC 能力流程](LUA_FIRST_EOC_WORKFLOW.md)。
 
-Cached gate results may be reused while the inputs relevant to that gate remain
-unchanged. Once a change touches a relevant input, the final gate must be run
-again; this documentation batch claims no current gate result.
+PR 664's foundation scope and later capabilities retain their evidence in
+`ai/lua-first-roadmap.yml`. They are not recurring prerequisites for every
+change. Optional standard helpers, internationalization and author tools remain
+separate needs. Proposed `ccb.std` helper names are not frozen public contracts;
+any future implementation uses the sole `require("ccb")` entrypoint.
 
-相关输入未变化时可以复用缓存的门禁结果；一旦修改触及相关输入，就必须重新回到最终门禁。
-本次文档批次不声称任何当前门禁结果。
-
-## Development sprint and acceptance / 开发冲刺与验收
-
-Before all core source batches required by PR 664 are closed, the implementation
-loop permits focused read-only search, narrow source reads, test-source edits,
-and compact checkpoints. It does not run a C++ build, Catch2, Python suite,
-checker, generator, full contract refresh, ledger refresh, or full JSON/EOC
-audit.
-
-The final gate runs once, in dependency order: generate the Platform native
-inventory, public contract, and synchronization coverage; run applicable
-Platform checkers and tool tests; perform one low-memory build; run one broad
-Platform Catch2 process; classify the real JSON/EOC inventories once; then
-inspect the final diff. This gate accepts the core Platform infrastructure and
-generic capability scope named by the roadmap. It does not require migrating
-all core JSON/EOC content, deleting passive JSON, reducing TODOs to zero, or
-closing any independent follow-on capability batch. A failure receives one
-focused diagnostic and returns to the same gate after repair.
-
-在 PR 664 所需的核心源码批次闭合前，只允许精确搜索、小窗口读取、测试源码修改和
-checkpoint；不运行编译、Catch2、Python 套件、checker、generator、完整契约刷新、账本刷新或
-全量 JSON/EOC 审计。最终门禁只运行一次，按生成 reference、运行 Platform 检查和工具测试、
-一次低内存构建、一次 broad Platform Catch2、一次真实语料分类、最终 diff 的顺序执行。
-该门禁只验收 roadmap 指定的核心 Platform 基础设施和通用能力，不要求迁移全部本体 JSON/EOC、
-删除静态 JSON、把 TODO 降到零或闭合任何独立的后续能力批次。失败只做一次聚焦诊断，修复后
-回到同一总门禁。
-
-## PR 664 boundary / PR 664 边界
-
-The reasonable endpoint for PR 664 is the core Platform foundation and generic
-capability closure: one Platform v1 runtime and `ccb` contract, a typed content
-model and registrars, lifecycle and handle/identity safety, reusable generic
-domain services, and an honest migration boundary. Passive schema-validatable
-JSON may remain in the shared typed C++ model, and the EOC runner remains a
-private legacy path until an exact audit proves that its references are zero.
-Core and bundled content migration remains a later consumer of the Platform.
-Runtime hardening, optional standard helpers, author-facing internationalization,
-and cookbook/console/author-experience work are high-priority follow-on batches;
-none is a prerequisite for closing or merging PR 664.
-
-PR 664 的合理终点是核心 Platform 基础设施和通用能力闭合：唯一 Platform v1 runtime 与
-`ccb` 契约、类型化内容模型和 registrar、生命周期与句柄/身份安全、可复用的通用领域服务，
-以及诚实的迁移边界。静态且可由 Schema 校验的 JSON 可以保留在共享的类型化 C++ 模型中；
-EOC runner 作为私有旧路径保留，直到精确审计证明 EOC 引用归零。核心与捆绑内容迁移是
-Platform 的后续消费者。runtime hardening、可选标准库 helper、面向作者的国际化以及
-cookbook/console/作者体验是高优先级后续批次，都不是 PR 664 闭合或合并的前置条件。
-
-## Follow-on capability batches / 后续能力批次
-
-The roadmap keeps the following high-priority work independently trackable
-rather than treating it as a frozen Platform v1 contract: the current
-standard-library whitelist slice as incremental hardening, broader runtime
-hardening, shared standard helpers, author-facing internationalization, and
-cookbook/console/author experience. The whitelist changes are useful in this
-PR, but they do not claim that memory budgets, callback instruction limits,
-process isolation, or the wider hardening batch is complete; the broader items
-remain planned or recommended follow-ons.
-
-The names `ccb.std.collections`, `ccb.std.ui`, `ccb.std.inspect`, and
-`ccb.std.text` are recommended candidates for a future shared-helper design
-only. No `ccb.std` namespace, sub-namespace, or helper name is a frozen public
-contract; any such design gets its own declarations, tests, documentation, and
-acceptance record. The follow-on batches continue to use the sole
-`require("ccb")` entrypoint and typed model if implemented, but none is a
-dependency of `platform-capability-closure` or `final-acceptance-gate`.
-
-roadmap 会把以下高优先级工作独立跟踪，而不是把它们冻结为 Platform v1 契约：当前标准库
-白名单切片作为增量 hardening、更广泛的 runtime hardening、共享标准库 helper、面向作者的
-国际化，以及 cookbook/console/作者体验。白名单修改对本 PR 有价值，但不能据此声称内存预算、
-callback 指令限制、进程隔离或更广泛的 hardening 批次已经完成；其余项目仍是 planned 或
-recommended 后续批次。
-
-`ccb.std.collections`、`ccb.std.ui`、`ccb.std.inspect`、`ccb.std.text` 只是未来共享 helper
-设计的推荐候选；没有任何 `ccb.std` 命名空间、子命名空间或 helper 名称是冻结的公开契约。
-后续如实现，应各自补充声明、测试、文档和验收记录。后续批次如实现，继续使用唯一
-`require("ccb")` 入口和类型化模型，但都不是 `platform-capability-closure` 或
-`final-acceptance-gate` 的依赖。
+PR 664 的基础设施范围和后续能力证据保留在 roadmap，不作为每轮修改的重复前置条件。
+可选标准 helper、国际化与作者工具按需求独立推进；候选 `ccb.std` 名称不是冻结公开契约，
+未来实现仍使用唯一 `require("ccb")` 入口。
 
 ## Templates, examples, and maintenance / 模板、样例与维护
 

--- a/data/lua/reference/ccb_platform_api_v1.json
+++ b/data/lua/reference/ccb_platform_api_v1.json
@@ -29216,7 +29216,6 @@
       "src/lua_platform_bionics.h",
       "src/lua_platform_camps.cpp",
       "src/lua_platform_camps.h",
-      "src/lua_platform_canvas.h",
       "src/lua_platform_content.h",
       "src/lua_platform_content_character.cpp",
       "src/lua_platform_content_character.h",

--- a/data/lua/reference/ccb_platform_api_v1_coverage.json
+++ b/data/lua/reference/ccb_platform_api_v1_coverage.json
@@ -1078,7 +1078,7 @@
     "native_export_root_count": 178,
     "native_export_roots_declared": 178,
     "native_export_roots_in_public_contract": 178,
-    "native_registration_file_count": 120,
+    "native_registration_file_count": 119,
     "public_contract_export_root_count": 178,
     "synchronized": true,
     "unmatched_native_export_roots": []

--- a/data/lua/templates/complete/README.md
+++ b/data/lua/templates/complete/README.md
@@ -39,3 +39,13 @@ For existing JSON/EOC content, start with
 `python3 tools/migrate_lua_first.py INPUT --output TARGET`.  Its output is a
 reviewable skeleton: every unsupported semantic field remains an explicit
 TODO in `MIGRATION_REPORT.md`, never a hidden legacy runner.
+
+
+The scaffolder normally also creates optional `.luarc.json` and `.ccb-sdk/`
+editor files. Open this directory in a LuaLS-enabled editor for completion and
+parameter diagnostics. The SDK is a frozen declaration snapshot, not runtime
+code; `require("ccb")` is supplied by the game. `--no-editor` creates only the
+runtime template. Keep the SDK matched to the game you target and review API
+changes explicitly; copying an SDK does not upgrade the game or prove save
+compatibility. See the source repository's `tools/lua_api/README.md` for the
+`mod_sdk.py check` and `compare` commands.

--- a/data/lua/templates/complete/main.lua
+++ b/data/lua/templates/complete/main.lua
@@ -1,4 +1,6 @@
 local ccb = require("ccb")
+assert(ccb.platform_version == 1,
+    "This Mod requires CCB Lua Platform v1; got " .. tostring(ccb.platform_version))
 local behaviour = require("runtime.behaviour")
 local token_content = require("content.token")
 

--- a/data/lua/templates/minimal/main.lua
+++ b/data/lua/templates/minimal/main.lua
@@ -1,4 +1,6 @@
 local ccb = require("ccb")
+assert(ccb.platform_version == 1,
+    "This Mod requires CCB Lua Platform v1; got " .. tostring(ccb.platform_version))
 
 ccb.runtime.handler("welcome", function()
     ccb.services.message("Lua-first Mod is running.")

--- a/tools/create_lua_mod.py
+++ b/tools/create_lua_mod.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Create an author-owned, zero-JSON Lua-first Platform Mod."""
+"""Create a manifest-free Lua-first Mod with optional editor metadata."""
 
 from __future__ import annotations
 
@@ -7,6 +7,8 @@ import argparse
 import shutil
 import tempfile
 from pathlib import Path
+
+from lua_api.mod_sdk import DEFAULT_DECLARATIONS, write_editor_files
 
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
@@ -55,7 +57,10 @@ def _install_staged_directory(staging: Path, target: Path) -> None:
     staging.replace(target)
 
 
-def create_mod(target: Path, template: str) -> None:
+def create_mod(
+    target: Path, template: str, *, editor: bool = True,
+    declarations: Path = DEFAULT_DECLARATIONS,
+) -> None:
     source = TEMPLATE_ROOT / template
     if not source.is_dir():
         raise ValueError(f"unknown Lua-first template: {template}")
@@ -87,6 +92,8 @@ def create_mod(target: Path, template: str) -> None:
                 render_template_file(entry, destination, mod_id)
             else:
                 raise ValueError(f"unsupported template entry: {entry}")
+        if editor:
+            write_editor_files(staging, declarations)
         removed_empty_target = False
         if target.exists() or target.is_symlink():
             if target.is_symlink() or not had_empty_target:
@@ -131,9 +138,18 @@ def main() -> int:
     parser.add_argument(
         "--template", choices=("minimal", "complete"), default="minimal"
     )
+    parser.add_argument(
+        "--no-editor", action="store_true",
+        help="create runtime files only, without the optional LuaLS SDK",
+    )
+    parser.add_argument(
+        "--declarations", type=Path, default=DEFAULT_DECLARATIONS,
+        help="LuaLS declaration file from the target CCB checkout or release",
+    )
     args = parser.parse_args()
     try:
-        create_mod(args.target, args.template)
+        create_mod(args.target, args.template, editor=not args.no_editor,
+                   declarations=args.declarations)
     except (FileExistsError, OSError, ValueError) as error:
         parser.error(str(error))
     return 0

--- a/tools/lua_api/README.md
+++ b/tools/lua_api/README.md
@@ -26,17 +26,93 @@ classes, native registration roots, and the public contract, also using its
 explicit schema. Its result is not JSON/EOC migration parity or a historical
 API coverage score.
 
-The acceptance commands are intentionally documented here but are deferred to
-the final batch gate:
+The single repository contract gate includes the five live contract checks
+and their tool regressions (individual checker CLIs remain diagnostic tools):
 
 ```sh
-python3 tools/lua_api/check_luals_declarations.py
-python3 tools/lua_api/check_platform_native_inventory.py
-python3 tools/lua_api/check_platform_contract.py
-python3 tools/lua_api/check_platform_coverage.py
-python3 tools/lua_api/check_cmake_contract.py
 python3 -m unittest discover -s tools/lua_api -p 'test_*.py'
 ```
 
 No historical API v5/CBN contract, authored manifest, capability sandbox, or
 global `game.*` surface is part of the Platform workflow.
+
+## Mod author quick start
+
+```sh
+python3 tools/create_lua_mod.py /path/MyMod --template complete
+```
+
+Open the generated directory as a workspace in a LuaLS-enabled editor. The
+scaffolder adds `.luarc.json` and `.ccb-sdk/ccb.lua` automatically. The SDK file
+is a byte-for-byte snapshot of the selected release/checkout's LuaLS declaration;
+`version.json` records Platform v1, Lua 5.4 and its SHA-256. Game packages already
+include `data/lua/types/ccb_platform_v1.d.lua`; select the file from the actual
+target game with `--declarations /path/game/data/lua/types/ccb_platform_v1.d.lua`.
+This identifies editor declarations, not the executable currently running or a
+promise of native/save compatibility. SDK files never auto-update.
+
+The editor configuration provides completion and API diagnostics, resolves
+`require("ccb")` to the SDK, and loads local author modules. The game continues
+to provide its real `ccb` module. `.luarc.json` and `.ccb-sdk/` are optional
+editor metadata, not a runtime manifest or executable content; omit them with
+`--no-editor` or exclude them when packaging. Both templates check the Platform
+major version before registering content. An exact declaration revision check
+is an author upgrade aid, not a new mandatory runtime version system.
+
+## Diagnose a Mod
+
+With LuaLS installed (the CI/editor gate is tested with 3.19.1):
+
+```sh
+python3 tools/lua_api/mod_sdk.py check /path/MyMod
+```
+
+`--language-server /absolute/path/to/lua-language-server` selects an existing
+server without installing one. Diagnostics include clickable absolute file,
+line and column, a diagnostic code, and LuaLS's actual/expected type explanation.
+Exit 0 means no warnings/errors in this static check; 1 means diagnostics;
+2 means invalid SDK/setup or a failed checker. A crashed or silent checker is
+never reported as a pass. This checks author files using the frozen declarations;
+it does not audit the declaration library itself, execute callbacks, validate
+native content IDs, or prove gameplay/save correctness. The library has existing
+annotation gaps, so dynamically typed/undeclared portions need runtime validation.
+
+Lua runtime failures still use the engine's existing Mod/handler context and
+Lua error text in `debug.log`. This tooling does not add an in-game debugger or
+state/task inspector. Use the game's existing `--check-mods` path for actual
+loading, and exercise the affected behavior for runtime acceptance.
+
+## Review an API upgrade
+
+Create a separate scaffold with the target version's declarations, then compare:
+
+```sh
+python3 tools/lua_api/mod_sdk.py compare /path/OldMod /path/NewVersionScaffold
+```
+
+The JSON report shows the two SDK identities and added, removed, or changed
+class/field/function declarations, including parameter and return annotations.
+It never overwrites either project. Review changed declarations, read the game's
+release/migration notes, then intentionally update the editor SDK and rerun static
+and affected runtime checks. Unchanged signatures do not prove behavior parity;
+the tool does not invent replacement APIs for removed symbols.
+
+For an interface change, maintainers should explain its concrete before/after
+behavior, replacement API if one exists, and save/data implications in release
+notes. Preserve supported calls where practical or mark deprecation in LuaLS;
+a signature report supplements that explanation, not a compatibility runtime.
+
+## Editor acceptance
+
+CI downloads a SHA-256-pinned LuaLS binary and runs the two real editor tests
+once, separately from the fast tool tests. Locally, set `CCB_LUALS` to run them
+inside the normal contract suite (otherwise they are explicitly skipped):
+
+```sh
+CCB_LUALS=/path/lua-language-server python3 -m unittest discover -s tools/lua_api -p 'test_*.py'
+python3 tools/test_create_lua_mod.py
+```
+
+The editor gate checks both real templates and deliberately invalid author code
+for unknown APIs, missing arguments and wrong argument types. It is a static
+acceptance gate and does not trigger a C++ build or a full content audit.

--- a/tools/lua_api/mod_sdk.py
+++ b/tools/lua_api/mod_sdk.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Snapshot CCB declarations, compare upgrades, and report LuaLS errors."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from urllib.parse import urlparse
+from urllib.request import url2pathname
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_DECLARATIONS = ROOT / "data/lua/types/ccb_platform_v1.d.lua"
+SDK_DIRECTORY = ".ccb-sdk"
+
+
+def digest(contents: bytes) -> str:
+    return hashlib.sha256(contents).hexdigest()
+
+
+def write_editor_files(target: Path, declarations: Path) -> None:
+    """Write only inside create_lua_mod's unpublished staging directory."""
+    contents = declarations.read_bytes()
+    text = contents.decode("utf-8")
+    if "---@class CcbPlatformV1" not in text or "return ccb" not in text:
+        raise ValueError("expected CCB Platform v1 LuaLS declarations")
+    sdk = target / SDK_DIRECTORY
+    sdk.mkdir()
+    # The editor resolves require("ccb") from this library file. The game
+    # resolves its own reserved module and never loads this metadata file.
+    (sdk / "ccb.lua").write_bytes(contents)
+    metadata = {
+        "schema_version": 1,
+        "platform_version": 1,
+        "lua_version": "5.4",
+        "declarations_sha256": digest(contents),
+    }
+    (sdk / "version.json").write_text(
+        json.dumps(metadata, indent=2) + "\n", encoding="utf-8"
+    )
+    settings = {
+        "$schema": ("https://raw.githubusercontent.com/LuaLS/"
+                    "vscode-lua/master/setting/schema.json"),
+        "runtime.version": "Lua 5.4",
+        "runtime.path": ["?.lua", "?/init.lua"],
+        "workspace.library": [SDK_DIRECTORY],
+        "workspace.ignoreDir": [SDK_DIRECTORY],
+        "workspace.checkThirdParty": False,
+        "diagnostics.libraryFiles": "Disable",
+    }
+    (target / ".luarc.json").write_text(
+        json.dumps(settings, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def read_sdk(mod: Path) -> tuple[dict, str]:
+    sdk = mod / SDK_DIRECTORY
+    metadata = json.loads((sdk / "version.json").read_text(encoding="utf-8"))
+    if not isinstance(metadata, dict) or metadata.get("schema_version") != 1:
+        raise ValueError(f"{sdk}: unsupported SDK metadata format")
+    contents = (sdk / "ccb.lua").read_bytes()
+    if metadata.get("declarations_sha256") != digest(contents):
+        raise ValueError(f"{sdk}: declaration checksum mismatch")
+    return metadata, contents.decode("utf-8")
+
+
+def declaration_surface(text: str) -> dict[str, list[str]]:
+    """Compare annotations as declarations, not as a proof of compatibility."""
+    result: dict[str, list[str]] = {}
+    owner = ""
+    annotations: list[str] = []
+    for line in text.splitlines():
+        line = line.strip()
+        match = re.match(r"---@class\s+(\w+)", line)
+        if match:
+            owner = match[1]
+            result.setdefault(f"class {owner}", []).append(line)
+            annotations = []
+            continue
+        match = re.match(r"---@alias\s+(\w+)", line)
+        if match:
+            result[f"alias {match[1]}"] = [line]
+            annotations = []
+            continue
+        if line.startswith("---@operator") and owner:
+            result.setdefault(f"class {owner}", []).append(line)
+            continue
+        match = re.match(r"---@field\s+(\w+)\??\s+", line)
+        if match and owner:
+            result.setdefault(f"{owner}.{match[1]}", []).append(line)
+            continue
+        if line.startswith(("---@param", "---@return", "---@overload",
+                            "---@deprecated", "---@generic")):
+            annotations.append(line)
+            continue
+        match = re.match(r"function\s+(\w+[.:]\w+)\s*\(", line)
+        if match:
+            result.setdefault(match[1], []).extend(annotations + [line])
+            annotations = []
+        elif line and not line.startswith("--"):
+            annotations = []
+    return result
+
+
+def compare_sdks(old: Path, new: Path) -> dict:
+    old_metadata, old_text = read_sdk(old)
+    new_metadata, new_text = read_sdk(new)
+    before = declaration_surface(old_text)
+    after = declaration_surface(new_text)
+    return {
+        "old": old_metadata,
+        "new": new_metadata,
+        "added": sorted(after.keys() - before.keys()),
+        "removed": sorted(before.keys() - after.keys()),
+        "changed": {
+            name: {"before": before[name], "after": after[name]}
+            for name in sorted(before.keys() & after.keys())
+            if before[name] != after[name]
+        },
+        "note": "Declaration changes require review; unchanged signatures do "
+                "not prove runtime or save compatibility.",
+    }
+
+
+def check_mod(mod: Path, language_server: str) -> list[str]:
+    """Use the author's pinned SDK/config; never run the game or Mod entry."""
+    mod = mod.resolve()
+    read_sdk(mod)
+    if not (mod / ".luarc.json").is_file():
+        raise ValueError(f"{mod}: missing .luarc.json editor configuration")
+    with tempfile.TemporaryDirectory(prefix="ccb-luals-") as directory:
+        result = subprocess.run(
+            [language_server, "--check=" + str(mod), "--checklevel=Warning",
+             "--check_format=json",
+             "--configpath=" + str(mod / ".luarc.json"),
+             "--logpath=" + directory],
+            cwd=mod, capture_output=True, text=True, timeout=120,
+        )
+        report = Path(directory) / "check.json"
+        if not report.is_file():
+            raise RuntimeError(
+                "LuaLS produced no diagnostic report "
+                f"(exit {result.returncode}): " +
+                (result.stderr or result.stdout)[-2000:]
+            )
+        data = json.loads(report.read_text(encoding="utf-8"))
+        if data == []:
+            data = {}  # LuaLS serializes an empty Lua table as a JSON array.
+        if not isinstance(data, dict):
+            raise ValueError("LuaLS report must map file URIs to diagnostics")
+        diagnostics = []
+        for uri, entries in sorted(data.items()):
+            path = uri
+            if uri.startswith("file:"):
+                parsed = urlparse(uri)
+                host = parsed.netloc if parsed.netloc != "localhost" else ""
+                path = url2pathname(
+                    ("//" + host if host else "") + parsed.path
+                )
+            for entry in sorted(entries, key=lambda e: (
+                e["range"]["start"]["line"],
+                e["range"]["start"]["character"], str(e.get("code", "")),
+            )):
+                start = entry["range"]["start"]
+                diagnostics.append(
+                    f"{path}:{start['line'] + 1}:{start['character'] + 1}: "
+                    f"{entry.get('code', 'diagnostic')}: {entry['message']}"
+                )
+        if result.returncode != 0 and not diagnostics:
+            raise RuntimeError(
+                f"LuaLS exited {result.returncode} without diagnostics: " +
+                (result.stderr or result.stdout)[-2000:]
+            )
+        return diagnostics
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    compare = commands.add_parser(
+        "compare", help="compare two Mod SDK snapshots"
+    )
+    compare.add_argument("old", type=Path)
+    compare.add_argument("new", type=Path)
+    check = commands.add_parser(
+        "check", help="report LuaLS warnings and errors"
+    )
+    check.add_argument("mod", type=Path)
+    check.add_argument("--language-server", default="lua-language-server")
+    args = parser.parse_args()
+    try:
+        if args.command == "compare":
+            print(json.dumps(compare_sdks(args.old, args.new),
+                             ensure_ascii=False, indent=2))
+            return 0
+        diagnostics = check_mod(args.mod, args.language_server)
+        for diagnostic in diagnostics:
+            print(diagnostic)
+        print(f"LuaLS: {len(diagnostics)} diagnostic(s)")
+        return 1 if diagnostics else 0
+    except (OSError, ValueError, RuntimeError,
+            subprocess.TimeoutExpired) as error:
+        parser.exit(2, f"Mod SDK: {error}\n")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lua_api/test_check_platform_contract.py
+++ b/tools/lua_api/test_check_platform_contract.py
@@ -33,6 +33,10 @@ except ImportError:
 
 
 class PlatformContractCheckTest(unittest.TestCase):
+    def test_checked_in_contract_matches_sources(self) -> None:
+        summary = check()
+        self.assertGreater(summary["export_roots"], 0)
+
     def test_matching_contract_is_accepted(self) -> None:
         contract = build_contract(
             declarations=parse_luals_declarations(DECLARATIONS),

--- a/tools/lua_api/test_check_platform_coverage.py
+++ b/tools/lua_api/test_check_platform_coverage.py
@@ -33,6 +33,10 @@ except ImportError:
 
 
 class PlatformCoverageCheckTest(unittest.TestCase):
+    def test_checked_in_coverage_is_current_and_synchronized(self) -> None:
+        summary = check()
+        self.assertGreater(summary["native_roots"], 0)
+
     def test_matching_synchronization_is_accepted(self) -> None:
         contract = build_contract(
             declarations=parse_luals_declarations(DECLARATIONS),

--- a/tools/lua_api/test_check_platform_native_inventory.py
+++ b/tools/lua_api/test_check_platform_native_inventory.py
@@ -8,22 +8,34 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 try:
     from .check_platform_native_inventory import check
     from .generate_platform_native_inventory import (
         DEFAULT_OUTPUT,
-        build_native_inventory,
     )
 except ImportError:
     from check_platform_native_inventory import check
     from generate_platform_native_inventory import (
         DEFAULT_OUTPUT,
-        build_native_inventory,
     )
 
 
 class PlatformNativeInventoryCheckTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.inventory = json.loads(DEFAULT_OUTPUT.read_text(encoding="utf-8"))
+
+    def check_fixture(self, path: Path) -> dict[str, int]:
+        # Negative cases exercise validation against a fixed source snapshot.
+        # The repository test below keeps the real source scan end to end.
+        with patch(
+            f"{check.__module__}.build_native_inventory",
+            return_value=self.inventory,
+        ):
+            return check(path)
+
     def test_checked_in_inventory_matches_sources(self) -> None:
         summary = check(DEFAULT_OUTPUT)
         for key in (
@@ -47,7 +59,7 @@ class PlatformNativeInventoryCheckTest(unittest.TestCase):
         return path
 
     def test_missing_platform_shared_root_is_rejected(self) -> None:
-        stale = copy.deepcopy(build_native_inventory())
+        stale = copy.deepcopy(self.inventory)
         graph = stale["export_installation_graph"]
         graph["edges"] = [
             edge
@@ -64,10 +76,10 @@ class PlatformNativeInventoryCheckTest(unittest.TestCase):
                 RuntimeError,
                 r"platform_v1 installation root parity.*GameHandle",
             ):
-                check(self.write_inventory(directory, stale))
+                self.check_fixture(self.write_inventory(directory, stale))
 
     def test_root_without_member_disposition_is_rejected(self) -> None:
-        stale = copy.deepcopy(build_native_inventory())
+        stale = copy.deepcopy(self.inventory)
         root = next(
             entry
             for entry in stale["export_roots"]
@@ -79,10 +91,10 @@ class PlatformNativeInventoryCheckTest(unittest.TestCase):
                 RuntimeError,
                 r"GameHandle lacks member disposition structure",
             ):
-                check(self.write_inventory(directory, stale))
+                self.check_fixture(self.write_inventory(directory, stale))
 
     def test_member_without_disposition_is_rejected(self) -> None:
-        stale = copy.deepcopy(build_native_inventory())
+        stale = copy.deepcopy(self.inventory)
         root = next(
             entry
             for entry in stale["export_roots"]
@@ -99,10 +111,10 @@ class PlatformNativeInventoryCheckTest(unittest.TestCase):
                 RuntimeError,
                 r"GameHandle.status lacks a valid disposition",
             ):
-                check(self.write_inventory(directory, stale))
+                self.check_fixture(self.write_inventory(directory, stale))
 
     def test_unbound_member_without_reason_is_rejected(self) -> None:
-        stale = copy.deepcopy(build_native_inventory())
+        stale = copy.deepcopy(self.inventory)
         root = next(
             entry
             for entry in stale["export_roots"]
@@ -119,10 +131,10 @@ class PlatformNativeInventoryCheckTest(unittest.TestCase):
                 RuntimeError,
                 r"UnitValue.native.canonical_wide unbound.*reason",
             ):
-                check(self.write_inventory(directory, stale))
+                self.check_fixture(self.write_inventory(directory, stale))
 
     def test_registered_root_missing_from_inventory_is_rejected(self) -> None:
-        stale = copy.deepcopy(build_native_inventory())
+        stale = copy.deepcopy(self.inventory)
         stale["export_roots"] = [
             entry
             for entry in stale["export_roots"]
@@ -133,10 +145,10 @@ class PlatformNativeInventoryCheckTest(unittest.TestCase):
                 RuntimeError,
                 r"registered export roots missing from inventory.*GameHandle",
             ):
-                check(self.write_inventory(directory, stale))
+                self.check_fixture(self.write_inventory(directory, stale))
 
     def test_adapted_member_without_lua_access_is_rejected(self) -> None:
-        stale = copy.deepcopy(build_native_inventory())
+        stale = copy.deepcopy(self.inventory)
         root = next(
             entry
             for entry in stale["export_roots"]
@@ -153,21 +165,21 @@ class PlatformNativeInventoryCheckTest(unittest.TestCase):
                 RuntimeError,
                 r"PointCoord.native.line_to adapted.*Lua access",
             ):
-                check(self.write_inventory(directory, stale))
+                self.check_fixture(self.write_inventory(directory, stale))
 
     def test_source_drift_is_rejected(self) -> None:
-        stale = build_native_inventory()
+        stale = copy.deepcopy(self.inventory)
         stale["id_kinds"] = stale["id_kinds"][:-1]
         with tempfile.TemporaryDirectory() as directory:
             with self.assertRaisesRegex(RuntimeError, "stale"):
-                check(self.write_inventory(directory, stale))
+                self.check_fixture(self.write_inventory(directory, stale))
 
     def test_non_object_inventory_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "inventory.json"
             path.write_text("[]\n", encoding="utf-8")
             with self.assertRaisesRegex(RuntimeError, "JSON object"):
-                check(path)
+                self.check_fixture(path)
 
 
 if __name__ == "__main__":

--- a/tools/lua_api/test_generate_platform_native_inventory.py
+++ b/tools/lua_api/test_generate_platform_native_inventory.py
@@ -211,8 +211,14 @@ class PlatformNativeInventoryGeneratorTest(unittest.TestCase):
             )
         )
 
+
+class RepositoryNativeInventoryGeneratorTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.inventory = build_native_inventory()
+
     def test_repository_inventory_has_expected_native_baselines(self) -> None:
-        inventory = build_native_inventory()
+        inventory = self.inventory
         self.assertEqual(inventory["schema_version"], 2)
         self.assertEqual(len(inventory["id_kinds"]), 132)
         self.assertEqual(len(inventory["json_types"]), 190)
@@ -237,7 +243,7 @@ class PlatformNativeInventoryGeneratorTest(unittest.TestCase):
         )
 
     def test_repository_inventory_records_alias_and_dispositions(self) -> None:
-        inventory = build_native_inventory()
+        inventory = self.inventory
         roots = {
             entry["lua_name"]: entry
             for entry in inventory["export_roots"]
@@ -337,12 +343,12 @@ class PlatformNativeInventoryGeneratorTest(unittest.TestCase):
             )
 
     def test_repository_inventory_uses_generator_format(self) -> None:
-        serialized = serialize_native_inventory(build_native_inventory())
+        serialized = serialize_native_inventory(self.inventory)
         self.assertEqual(
             serialized,
             DEFAULT_OUTPUT.read_text(encoding="utf-8"),
         )
-        self.assertEqual(json.loads(serialized), build_native_inventory())
+        self.assertEqual(json.loads(serialized), self.inventory)
 
 
 if __name__ == "__main__":

--- a/tools/lua_api/test_mod_sdk.py
+++ b/tools/lua_api/test_mod_sdk.py
@@ -1,0 +1,163 @@
+"""SDK snapshots and author diagnostics with an optional real LuaLS gate."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+try:
+    from . import mod_sdk
+except ImportError:
+    import mod_sdk
+
+ROOT = Path(__file__).resolve().parents[2]
+DECLARATIONS = '''---@meta
+---@class CcbPlatformV1
+---@field runtime Runtime
+---@class Runtime
+local Runtime = {}
+---@param name string
+function Runtime.hello(name) end
+---@type CcbPlatformV1
+local ccb = {}
+return ccb
+'''
+
+
+class ModSdkTest(unittest.TestCase):
+    def make_sdk(
+        self, root: Path, name: str, text: str = DECLARATIONS,
+    ) -> Path:
+        source = root / (name + ".d.lua")
+        source.write_text(text, encoding="utf-8")
+        mod = root / name
+        mod.mkdir()
+        mod_sdk.write_editor_files(mod, source)
+        return mod
+
+    def test_snapshot_survives_source_changes_and_project_move(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            mod = self.make_sdk(root, "before")
+            (root / "before.d.lua").write_text("changed", encoding="utf-8")
+            moved = root / "moved"
+            shutil.move(mod, moved)
+            metadata, text = mod_sdk.read_sdk(moved)
+            self.assertEqual(text, DECLARATIONS)
+            self.assertEqual(metadata["platform_version"], 1)
+            settings = json.loads((moved / ".luarc.json").read_text())
+            library = moved / settings["workspace.library"][0]
+            self.assertTrue(library.is_dir())
+
+    def test_tampered_declarations_are_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            mod = self.make_sdk(Path(directory), "example")
+            (mod / ".ccb-sdk/ccb.lua").write_text(
+                "tampered", encoding="utf-8"
+            )
+            with self.assertRaisesRegex(ValueError, "checksum"):
+                mod_sdk.read_sdk(mod)
+
+    def test_compare_reports_types_removals_and_additions_without_writes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            before = self.make_sdk(root, "before")
+            after = self.make_sdk(root, "after", DECLARATIONS.replace(
+                "---@param name string", "---@param name integer"
+            ).replace(
+                "---@field runtime Runtime", "---@field service Runtime"
+            ))
+            saved = (before / ".ccb-sdk/ccb.lua").read_bytes()
+            report = mod_sdk.compare_sdks(before, after)
+            self.assertIn("Runtime.hello", report["changed"])
+            self.assertEqual(
+                report["removed"], ["CcbPlatformV1.runtime"]
+            )
+            self.assertEqual(report["added"], ["CcbPlatformV1.service"])
+            self.assertEqual((before / ".ccb-sdk/ccb.lua").read_bytes(), saved)
+
+    def test_source_line_movement_does_not_change_signatures(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            before = self.make_sdk(root, "before")
+            after = self.make_sdk(root, "after", "-- comment\n" + DECLARATIONS)
+            report = mod_sdk.compare_sdks(before, after)
+            self.assertEqual(report["changed"], {})
+            self.assertNotEqual(report["old"]["declarations_sha256"],
+                                report["new"]["declarations_sha256"])
+
+    def test_checker_crash_is_not_a_clean_report(self):
+        with tempfile.TemporaryDirectory() as directory:
+            mod = self.make_sdk(Path(directory), "example")
+
+            def crash(command, **kwargs):
+                log = next(x.split("=", 1)[1] for x in command
+                           if x.startswith("--logpath="))
+                (Path(log) / "check.json").write_text("[]", encoding="utf-8")
+                return subprocess.CompletedProcess(command, -11, "", "crash")
+
+            with patch.object(mod_sdk.subprocess, "run", side_effect=crash):
+                with self.assertRaisesRegex(RuntimeError, "exited -11"):
+                    mod_sdk.check_mod(mod, "luals")
+
+
+@unittest.skipUnless(
+    os.environ.get("CCB_LUALS"), "set CCB_LUALS for editor gate"
+)
+class LuaLanguageServerIntegrationTest(unittest.TestCase):
+    def scaffold(self, root: Path, template: str) -> Path:
+        mod = root / template
+        subprocess.run(
+            [sys.executable, str(ROOT / "tools/create_lua_mod.py"),
+             str(mod), "--template", template], check=True,
+            capture_output=True, text=True,
+        )
+        return mod
+
+    def test_both_templates_are_clean_in_real_language_server(self):
+        with tempfile.TemporaryDirectory() as directory:
+            for template in ("minimal", "complete"):
+                with self.subTest(template=template):
+                    mod = self.scaffold(Path(directory), template)
+                    self.assertEqual(
+                        mod_sdk.check_mod(mod, os.environ["CCB_LUALS"]), []
+                    )
+
+    def test_real_errors_have_file_line_expected_type_and_api_name(self):
+        with tempfile.TemporaryDirectory() as directory:
+            mod = self.scaffold(Path(directory), "minimal")
+            invalid = mod / "invalid.lua"
+            invalid.write_text('''local ccb = require("ccb")
+ccb.runtime.handler("bad", "not a function")
+ccb.runtime.nonexistent_api()
+ccb.presentation.confirm(123)
+ccb.runtime.handler()
+''', encoding="utf-8")
+            report = "\n".join(
+                mod_sdk.check_mod(mod, os.environ["CCB_LUALS"])
+            )
+            self.assertIn(str(invalid) + ":2:", report)
+            self.assertIn("param-type-mismatch", report)
+            self.assertIn("fun(payload: any):any", report)
+            self.assertIn(str(invalid) + ":3:", report)
+            self.assertIn("nonexistent_api", report)
+            self.assertIn(str(invalid) + ":5:", report)
+            self.assertIn("missing-parameter", report)
+            result = subprocess.run(
+                [sys.executable, str(ROOT / "tools/lua_api/mod_sdk.py"),
+                 "check", str(mod), "--language-server",
+                 os.environ["CCB_LUALS"]],
+                capture_output=True, text=True,
+            )
+            self.assertEqual(result.returncode, 1, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_create_lua_mod.py
+++ b/tools/test_create_lua_mod.py
@@ -1,4 +1,5 @@
 import tempfile
+import json
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -20,7 +21,7 @@ class CreateLuaModTest(unittest.TestCase):
     def test_complete_template_is_zero_json_and_has_vertical_slice(self):
         with tempfile.TemporaryDirectory() as directory:
             target = Path(directory) / "complete"
-            create_mod(target, "complete")
+            create_mod(target, "complete", editor=False)
             files = [path for path in target.rglob("*") if path.is_file()]
             self.assertTrue((target / "runtime" / "behaviour.lua").is_file())
             self.assertTrue((target / "content" / "token.lua").is_file())
@@ -49,6 +50,28 @@ class CreateLuaModTest(unittest.TestCase):
             self.assertEqual(
                 sentinel.read_text(encoding="utf-8"), "author owned\n"
             )
+
+    def test_default_editor_library_is_portable_and_not_runtime_content(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory) / "editor_mod"
+            create_mod(target, "minimal")
+            settings = json.loads((target / ".luarc.json").read_text())
+            self.assertEqual(settings["runtime.version"], "Lua 5.4")
+            self.assertEqual(settings["workspace.library"], [".ccb-sdk"])
+            self.assertEqual(
+                (target / ".ccb-sdk/ccb.lua").read_bytes(),
+                create_lua_mod.DEFAULT_DECLARATIONS.read_bytes(),
+            )
+            self.assertNotIn(".ccb-sdk", (target / "main.lua").read_text())
+
+    def test_missing_sdk_input_preserves_empty_target(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory) / "editor_mod"
+            target.mkdir()
+            with self.assertRaises(FileNotFoundError):
+                create_mod(target, "minimal", declarations=target / "missing")
+            self.assertEqual(list(target.iterdir()), [])
+            self.assertEqual(list(target.parent.iterdir()), [target])
 
     def test_file_target_is_never_replaced(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
#### Summary

Mods "为 Lua Mod 提供固定声明 SDK、编辑器诊断与精简验证流程"

#### Responsible human

@LYHGLYTX

#### Purpose of change

Mod 作者需要自行配置编辑器，升级时缺少声明差异报告；Lua 验证流程还会重复运行同一组检查和重建测试夹具。本 PR 让脚手架生成可移动的编辑器配置与固定声明快照，提供能定位文件和行列的静态诊断，并将开发验收集中到受影响的领域批次。

#### Describe the solution

- `create_lua_mod.py` 默认生成可选的 `.luarc.json` 和 `.ccb-sdk/`；`--declarations` 选择目标游戏包/源码的声明，`--no-editor` 保留纯运行时文件。保留原有原子安装和作者文件保护。
- 新增 `mod_sdk.py check/compare`：验证声明 SHA-256、输出真实 LuaLS 错误、只读比较声明增删及签名变化。两种模板在注册前检查 Platform 主版本。
- 单一 Lua unittest 入口覆盖五种真实契约及负例，复用类级测试夹具；CI 固定 LuaLS 3.19.1 及下载 SHA-256，真实编辑器集成测试只执行一次。
- 精简 Lua 目标、工作流和验收路由；保留单一 `require("ccb")` Platform 与静态 JSON 边界。记录已采纳的可信 Mod/完整标准库策略，并明确标记为待实现，未改变 loader 权限。
- 同步主分支后由原有生成器修复派生元数据：移除注册文件清单中的旧 canvas 头文件，更新覆盖率指纹及 replacement ledger 的三个来源指纹。未改变 selector 状态或数量。

#### Describe alternatives you've considered

保留独立 checker CLI 用于失败诊断，正常验收只调用统一套件。SDK 使用显式声明快照，作者自行选择升级；不引入第二套运行时、自动修改 Mod 或二进制/存档兼容保证。

#### Testing

- 同步到主分支 `4b9fa3b0313` 后，`CCB_LUALS=/tmp/ccb-luals-3.19.1/bin/lua-language-server python3 -m unittest discover -s tools/lua_api -p 'test_*.py'`：44 项通过，8.041 s，包含真实 LuaLS 检查两种模板及错误用例。
- `python3 tools/test_create_lua_mod.py`：11 项通过。
- `check_project_metadata.py`、replacement ledger 生成器 `--check`、9/9 context benchmark 及 `--check` 通过；context-pack 4 项测试通过。
- 修改的 Python 文件 flake8、工作流 YAML/全部 shell 步骤 bash -n、git diff --check 通过。
- 精简夹具的同机 profile：原 35 项 70.73 s；保留原测试并加两个真实契约检查后 37 项 12.19 s。该比较来自添加编辑器测试前的同一基线，不代表远端 CI 用时。
- 无 C++/游戏运行时实现改动，未编译游戏、运行 Catch2 或进行 Mod 加载/试玩；远端 Actions 结果待返回。现有声明注解缺口仍在，静态检查不审计 SDK 库，也不证明游戏行为/存档兼容。

#### Documentation impact

更新仓库 Lua 架构/信任策略、批次验收说明、路线图、脚手架 README 和工具用法；同步双语 native Lua bridge 文档，明确 SDK、静态诊断与运行时能力的边界。

#### Related CCB-Docs PR

https://github.com/CrimsonCrossBunker/CCB-Docs/pull/45

文档 PR 保持 draft；本 PR 合并后刷新最终源码提交，再恢复 active/索引并合并。

#### Affected documentation IDs

cpp.lua-bridge, architecture.project-map, validation.quickstart

#### Generated reference impact

原生 API 和 LuaLS 声明未改变。通过已登记生成器同步 Platform 公共契约、派生 coverage 和 replacement ledger 的过期元数据；context benchmark 基线仅更新 token 估计。SDK 声明副本在创建 Mod 时生成，不作为第二套 API 清单。

#### Additional context

游戏内调试器、状态/任务检查器、原生兼容版本协商、完整标准库/外部模块开放及执行风险告知仍待独立实现；本 PR 不声称这些运行时功能已经交付。
