### PR TITLE
fix(lua): 补齐画布头文件并修复字符版编译

### DIFF
--- a/data/lua/reference/ccb_platform_api_v1.json
+++ b/data/lua/reference/ccb_platform_api_v1.json
@@ -29216,6 +29216,7 @@
       "src/lua_platform_bionics.h",
       "src/lua_platform_camps.cpp",
       "src/lua_platform_camps.h",
+      "src/lua_platform_canvas.h",
       "src/lua_platform_content.h",
       "src/lua_platform_content_character.cpp",
       "src/lua_platform_content_character.h",

--- a/data/lua/reference/ccb_platform_api_v1_coverage.json
+++ b/data/lua/reference/ccb_platform_api_v1_coverage.json
@@ -1078,7 +1078,7 @@
     "native_export_root_count": 178,
     "native_export_roots_declared": 178,
     "native_export_roots_in_public_contract": 178,
-    "native_registration_file_count": 119,
+    "native_registration_file_count": 120,
     "public_contract_export_root_count": 178,
     "synchronized": true,
     "unmatched_native_export_roots": []

--- a/src/lua_platform_canvas.h
+++ b/src/lua_platform_canvas.h
@@ -1,0 +1,54 @@
+#pragma once
+#ifndef CATA_SRC_LUA_PLATFORM_CANVAS_H
+#define CATA_SRC_LUA_PLATFORM_CANVAS_H
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace cata::lua_platform
+{
+
+/** A single canvas frame, invalidated when its Lua callback returns. */
+class platform_canvas_context
+{
+    public:
+        platform_canvas_context( int width, int height, std::int64_t elapsed_ms,
+                                 std::int64_t delta_ms, float origin_x = 0.0F,
+                                 float origin_y = 0.0F, float scale = 1.0F );
+
+        void invalidate();
+        int width() const;
+        int height() const;
+        std::int64_t elapsed_ms() const;
+        std::int64_t delta_ms() const;
+        bool is_open() const;
+        void close();
+
+        void rect( float x, float y, float w, float h,
+                   float r, float g, float b, float a );
+        void text( float x, float y, const std::string &value,
+                   float r, float g, float b, float a );
+        bool sprite( const std::string &id, float x, float y, float w, float h );
+        bool button( const std::string &id, const std::string &label,
+                     float x, float y, float w, float h, bool request_focus );
+
+    private:
+        void require_active() const;
+        void operation( float x, float y, float w, float h );
+
+        int width_;
+        int height_;
+        std::int64_t elapsed_ms_;
+        std::int64_t delta_ms_;
+        float origin_x_;
+        float origin_y_;
+        float scale_;
+        std::size_t operations_ = 0;
+        bool active_ = true;
+        bool open_ = true;
+};
+
+} // namespace cata::lua_platform
+
+#endif // CATA_SRC_LUA_PLATFORM_CANVAS_H

--- a/src/lua_platform_runtime_dialogue.cpp
+++ b/src/lua_platform_runtime_dialogue.cpp
@@ -60,8 +60,8 @@ platform_canvas_context::platform_canvas_context( const int width, const int hei
 {
     if( width < 1 || width > 2048 || height < 1 || height > 2048 ||
         elapsed_ms < 0 || delta_ms < 0 || delta_ms > 250 ||
-        !std::isfinite( origin_x ) || !std::isfinite( origin_y ) ||
-        !std::isfinite( scale ) || scale <= 0 || scale > 1 ) {
+        !std::isfinite( origin_x_ ) || !std::isfinite( origin_y_ ) ||
+        !std::isfinite( scale_ ) || scale_ <= 0 || scale_ > 1 ) {
         throw std::invalid_argument( "invalid Platform canvas frame" );
     }
 }


### PR DESCRIPTION
#### Summary

Bugfixes "补齐 Lua 画布头文件，修复启用 Platform 的编译失败"

#### Responsible human

@LYHGLYTX

#### Purpose of change

#742 的运行时代码和测试引用 `lua_platform_canvas.h`，但该文件没有随提交加入仓库。启用 Lua Platform 后无法编译这两个翻译单元。

#### Describe the solution

- 根据现有实现、Lua 绑定和回归测试恢复 `platform_canvas_context` 声明，包含帧状态初值、绘图方法及构造默认参数；头文件无需图形后端头文件。
- 构造函数校验已存入的坐标/缩放成员，保持原有校验语义，消除 Clang 字符版构建的 unused-private-field 错误，无告警抑制。
- 用登记的生成器同步公共契约头文件列表及 coverage 文件数量。Lua API/LuaLS 签名不变。

#### Describe alternatives you've considered

复用现有实现与测试，不引入第二套画布 API，也不删除调用来掩盖缺失声明。

#### Testing

- Clang C++17、O2、-Werror、PCH=0、Lua enabled：完整 `lua_platform_runtime_dialogue.cpp` 目标文件分别在 curses 与 SDL2 Tiles+Sound 配置下编译通过。
- 现有完整 `tests/lua_platform_cuisine_test.cpp` 目标文件编译通过；独立头文件 C++17 -Wall -Wextra -Werror 检查通过。
- Lua 契约套件：44 项发现，42 项通过，2 项可选 LuaLS 集成测试因未设置 CCB_LUALS 跳过。
- 仓库元数据、git diff --check 通过。新头文件 astyle 无差异；运行时 cpp 的已有格式差异在基线和补丁上完全一致。
- 未完成整游戏链接、Catch2 执行、图形试玩或 Android/Windows 构建。尝试单独链接帧测试受运行时翻译单元的引擎静态初始化依赖阻断，不作为测试通过证据。本 PR 不宣称 #742 所有功能均已验收。

#### Documentation impact

恢复已有画布接口缺失的 C++ 声明，不改变作者用法、权限、LuaLS 或运行时契约；已合并的双语 bridge 说明仍适用，无需新的正文文档改动。

#### Related CCB-Docs PR

https://github.com/CrimsonCrossBunker/CCB-Docs/pull/45

该 PR 已合并；本修复沿用其中现行 Platform 契约，不是新文档交付依赖。

#### Affected documentation IDs

cpp.lua-bridge

#### Generated reference impact

用 `generate_platform_contract.py` 和 `generate_platform_coverage.py` 添加恢复的头文件记录，将注册文件数量从 119 同步为 120。原生 Lua 注册和公开签名均未改变。

#### Additional context

已同步最新 master `f2821e0bf31ba12879672cc06f111a2e6fc5bc13`；这是缺失头文件的窄范围修复，EOC 语义验收单独核对。
