### PR TITLE
Fix Some Remaining Issues After Migrating Nicotine to the Vitamin System

### DIFF
--- a/src/addiction.cpp
+++ b/src/addiction.cpp
@@ -202,7 +202,9 @@ static bool nicotine_effect( Character &u, addiction &add )
         if( one_in( 800 - 50 * in ) ) {
             u.mod_sleepiness( 1 );
         }
-        if( current_stim > -5 * in && one_in( 400 - 20 * in ) ) {
+        //Withdrawal only erodes a mild, non-overdose stimulant effect: it must
+        //never fabricate depressant symptoms or ease an ongoing overdose.
+        if( current_stim > 0 && current_stim <= 30 && one_in( 400 - 20 * in ) ) {
             u.mod_stim( -1 );
         }
         return true;

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -125,6 +125,7 @@ static const trait_id trait_SLIMY( "SLIMY" );
 static const trait_id trait_URSINE_FUR( "URSINE_FUR" );
 
 static const vitamin_id vitamin_blood( "blood" );
+static const vitamin_id vitamin_nicotine( "nicotine" );
 
 void Character::update_body_wetness( const w_point &weather )
 {
@@ -1467,10 +1468,11 @@ void Character::update_heartrate_index()
         hr_stim_mod = 2 - 2 / ( 1 + 0.001 * stim_level * stim_level );
     }
     float hr_nicotine_mod = 0.0f;
-    if( get_effect_dur( effect_cig ) > 0_turns ) {
-        //Nicotine-induced tachycardia
-        if( get_effect_dur( effect_cig ) >
-            10_minutes * ( addiction_level( addiction_nicotine ) + 1 ) ) {
+    if( has_effect( effect_cig ) ) {
+        //Nicotine-induced tachycardia.  The excess effect is permanent, so compare
+        //nicotine load to tolerance: 1 unit decays per vitamin rate, 10 min = 2 units.
+        if( vitamin_get( vitamin_nicotine ) >
+            2 * ( addiction_level( addiction_nicotine ) + 1 ) ) {
             hr_nicotine_mod = 0.2f;
         } else {
             hr_nicotine_mod = 0.1f;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
In PR #738, I migrated the `stim` fields of caffeine, nicotine, and alcohol to the vitamin system for differential implementation, but there are still some omissions in the nicotine migration:
 - Nicotine tachycardia is partially ineffective. The only post-migration addition path for `effect_cig` is the per-turn processing of `update_vitamins`, causing its duration to currently always be 1_turns, while the original code used duration checks to actually adjust the intensity.
 - The stim semantics of nicotine withdrawal have drifted. The nicotine truncation hard-coding at `addiction.cpp:206` was not modified, and after the withdrawal condition is met it still applies `mod_stim(-1)` without clamping.

#### Describe the solution
Change the nicotine tachycardia tier determination logic. Nicotine has a default rate of 5m, with a load decay duration of ≈ 5min × addiction_level. The old threshold of 10min × (addiction_level + 1) is migrated to the new version as approximately addiction_level > 2 × (smoking addiction + 1).

Change the original `mod_stim` for nicotine withdrawal so that it is only applied when the stimulant level is non-zero and there is no tendency toward overdose. The semantics therefore become that, when experiencing nicotine withdrawal without smoking, stimulants from other sources will have a less pronounced effect as long as they are not used excessively.