### PR TITLE
fix: 恢复声音侧边栏的失聪提示

### DIFF
--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -1103,6 +1103,10 @@ bool widget::has_flag( const std::string &flag ) const
 std::string widget::show( const avatar &ava, const unsigned int max_width )
 {
     set_default_var_range( ava );
+    // Hearing loss takes precedence over emitted volume in every sound widget.
+    if( _var == widget_var::sound && ava.is_deaf() ) {
+        return colorize( _( "Deaf!" ), c_red );
+    }
     if( uses_text_function() ) {
         // Text functions are a carry-over from before widgets, with existing functions generating
         // descriptive colorized text for avatar attributes.  The "value" for these is immaterial;

--- a/tests/widget_test.cpp
+++ b/tests/widget_test.cpp
@@ -22,6 +22,7 @@
 #include "cata_scope_helpers.h"
 #include "cata_utility.h"
 #include "character_attire.h"
+#include "color.h"
 #include "coordinates.h"
 #include "display.h"
 #include "effect.h"
@@ -3072,4 +3073,32 @@ TEST_CASE( "widgets_using_custom_vars", "[widget]" )
             CHECK( dynamic_range_w.layout( ava ) == "STR: <color_c_green>11</color>" );
         }
     }
+}
+
+TEST_CASE( "sound_widget_reports_deafness_and_recovers", "[widget][sound]" )
+{
+    clear_avatar();
+    avatar &ava = get_avatar();
+    widget sound = widget_id( "sound_num" ).obj();
+    ava.volume = 6;
+    REQUIRE_FALSE( ava.is_deaf() );
+    const std::string hearing = sound.show( ava, 20 );
+    CHECK( remove_color_tags( hearing ) == "6" );
+
+    SECTION( "earplugs" ) {
+        ava.wear_item( item( itype_ear_plugs ), false );
+    }
+    SECTION( "temporary_deafness" ) {
+        ava.add_effect( efftype_id( "deaf" ), 1_minutes, false, 3 );
+    }
+
+    REQUIRE( ava.is_deaf() );
+    CHECK( sound.show( ava, 20 ) == colorize( _( "Deaf!" ), c_red ) );
+    // The volume remains available to game logic while its display is overridden.
+    CHECK( sound.get_var_value( ava ) == 6 );
+
+    clear_avatar();
+    ava.volume = 6;
+    REQUIRE_FALSE( ava.is_deaf() );
+    CHECK( sound.show( ava, 20 ) == hearing );
 }


### PR DESCRIPTION
#### Summary
Bugfixes "恢复声音侧边栏在耳塞或震聋状态下的失聪提示"

#### Responsible human
@LYHGLYTX

#### Purpose of change
新版声音部件只显示角色发出的音量；戴耳塞或被震聋后仍显示数字，缺少旧版的失聪提示。

#### Describe the solution
在所有 sound 变量部件的共用显示入口使用 Character::is_deaf() 判定，失聪时显示可翻译的红色 Deaf!，恢复听力后恢复原有数字或图形显示。保留音量数值和游戏逻辑。

#### Describe alternatives you've considered
不在单个侧边栏 JSON 中重复定义判断，以覆盖使用 sound 变量的不同布局。

#### Testing
- src/widget.cpp 与 tests/widget_test.cpp 使用项目 Linux SDL2、C++17、-O2、警告视为错误的参数分别编译通过。
- 新增耳塞、临时失聪、恢复听力及原始音量保留的 Catch2 回归测试；尚未链接运行完整测试程序，也未进行设备实测。
- git diff --check 通过。
- AStyle 基线对比：src/widget.cpp 原有 40 行格式差异、tests/widget_test.cpp 原有 14 行格式差异，本次没有新增格式差异。

#### Documentation impact
None

#### Related CCB-Docs PR
None

#### Affected documentation IDs
None

#### Generated reference impact
None

#### Additional context
独立修复声音侧边栏失聪显示。