### PR TITLE
ui: 默认开启拼音搜索并跳过无效转换

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2400,7 +2400,7 @@ void options_manager::add_options_interface()
         add( "USE_PINYIN_SEARCH", page_id, to_translation( "Use pinyin in search" ),
              to_translation( "If true, pinyin (pronunciation of Chinese characters) can be used in searching/filtering "
                              "(may cause major slowdown when searching through too many entries.)" ),
-             false
+             true
            );
 
         add( "FORCE_CAPITAL_YN", page_id,

--- a/src/pinyin.cpp
+++ b/src/pinyin.cpp
@@ -13,6 +13,14 @@ namespace pinyin
 {
 bool pinyin_match( const std::u32string_view str, const std::u32string_view qry )
 {
+    // ASCII has no entries in the pronunciation table.  Avoid initializing the
+    // index or allocating conversion buffers for ordinary English names.
+    if( std::all_of( str.begin(), str.end(), []( char32_t ch ) {
+    return ch <= 0x7f;
+} ) ) {
+        return str.find( qry ) != std::u32string_view::npos;
+    }
+
     // we convert the data to an unordered map to lower the cost of looking up entries.
     // O(1) instead of O(n)
     static std::unordered_map<char32_t, std::vector<std::u32string>> indexed_pinyin_map;
@@ -37,6 +45,14 @@ bool pinyin_match( const std::u32string_view str, const std::u32string_view qry 
                 }
             }
         }
+    }
+
+    // Other scripts can also have no convertible characters.  Preserve literal
+    // matching without constructing an identical string for them.
+    if( std::none_of( str.begin(), str.end(), []( char32_t ch ) {
+    return indexed_pinyin_map.find( ch ) != indexed_pinyin_map.end();
+    } ) ) {
+        return str.find( qry ) != std::u32string_view::npos;
     }
 
     int combination_index = 0;                  //how many combinations have we tried

--- a/tests/pinyin_test.cpp
+++ b/tests/pinyin_test.cpp
@@ -1,0 +1,33 @@
+#include <map>
+#include <string>
+#include <utility>
+
+#include "cata_catch.h"
+#include "pinyin.h"
+#include "third-party/pinyin/pinyin_data.hpp"
+
+TEST_CASE( "pinyin_search_preserves_literal_and_chinese_matching", "[pinyin]" )
+{
+    CHECK( pinyin::pinyin_match( U"steel hammer", U"hammer" ) );
+    CHECK_FALSE( pinyin::pinyin_match( U"steel hammer", U"nail" ) );
+    CHECK( pinyin::pinyin_match( U"steel hammer", U"" ) );
+    CHECK( pinyin::pinyin_match( U"", U"" ) );
+    CHECK_FALSE( pinyin::pinyin_match( U"", U"hammer" ) );
+    CHECK( pinyin::pinyin_match( U"молоток", U"молот" ) );
+    CHECK_FALSE( pinyin::pinyin_match( U"молоток", U"hammer" ) );
+    CHECK( pinyin::pinyin_match( U"钢锤", U"gangchui" ) );
+    CHECK( pinyin::pinyin_match( U"steel 钢锤", U"steel gangchui" ) );
+    CHECK( pinyin::pinyin_match( U"重", U"zhong" ) );
+    CHECK( pinyin::pinyin_match( U"重", U"chong" ) );
+    CHECK_FALSE( pinyin::pinyin_match( U"钢锤", U"nail" ) );
+}
+
+TEST_CASE( "pinyin_table_has_no_ascii_characters", "[pinyin]" )
+{
+    // This invariant makes it safe to bypass even index initialization for ASCII.
+    for( const auto &entry : pinyin_data ) {
+        for( const char32_t ch : entry.second ) {
+            REQUIRE( ch > 0x7f );
+        }
+    }
+}


### PR DESCRIPTION
#### Summary
Interface "默认开启拼音搜索，并跳过纯英文名称的不必要转换"

#### Responsible human
@LYHGLYTX

#### Purpose of change
默认提供拼音搜索，同时避免英文名称在普通匹配失败后初始化拼音索引、逐字符查表和分配转换字符串。

#### Describe the solution
USE_PINYIN_SEARCH 默认改为 true，保留已有配置选择。拼音匹配对纯 ASCII 文本直接进行字面匹配，不初始化索引。其他文本在索引中没有任何可转换字符时也直接字面匹配。中文、混合名称和多音字沿用原转换逻辑，按实际文本判断，不依赖界面语言。

#### Describe alternatives you've considered
按界面语言禁用会导致英文界面下的中文名称无法拼音搜索，因此采用文本快速路径。

#### Testing
- 使用真实 src/pinyin.cpp 和新增 tests/pinyin_test.cpp 构建独立 Catch2 程序，C++17 / -O2 / -Wall -Wextra -Werror：2 个测试、12446 个断言全部通过。覆盖英文、空字符串、俄文、中文、混合名称、多音字及拼音表无 ASCII 字符的快速路径前提。
- 相同编译参数、相同英文未匹配输入，百万次拼音函数调用：修改前 132.063 ms，修改后 20.634 ms；首次调用分别为 1984.54 us 与 1.397 us。仅为局部函数微基准，不代表完整游戏搜索界面的加速比。
- AStyle 对修改的 C++ 文件检查无变化；git diff --check 通过。
- 未构建完整游戏或进行 Android 实测。

#### Documentation impact
None

#### Related CCB-Docs PR
None

#### Affected documentation IDs
None

#### Generated reference impact
None