### PR TITLE
fix: 修复 Lua 职业引用同批新变异时的加载失败

### DIFF
--- a/src/lua_platform_content_character.cpp
+++ b/src/lua_platform_content_character.cpp
@@ -3464,9 +3464,10 @@ bool character_content_transaction::validate( const runtime &owner_runtime,
             for( const profession_trait_definition_data &value : definition.traits ) {
                 require_valid_id( value.trait, "profession trait" );
                 const trait_id trait( value.trait );
+                const bool staged = index_defines( index.defines_trait, value.trait );
                 if( !unique.insert( value.trait ).second ||
-                    ( check_engine_state && !trait.is_valid() ) ||
-                    ( check_engine_state && !value.variant.empty() && trait.is_valid() &&
+                    ( check_engine_state && !staged && !trait.is_valid() ) ||
+                    ( check_engine_state && !staged && !value.variant.empty() && trait.is_valid() &&
                       trait->variant( value.variant ) == nullptr ) ) {
                     throw std::runtime_error( "profession '" + definition.id +
                                               "' has an unknown, duplicate, or invalid trait '" +
@@ -3476,7 +3477,8 @@ bool character_content_transaction::validate( const runtime &owner_runtime,
             for( const std::string &trait : definition.forbidden_traits ) {
                 require_valid_id( trait, "profession forbidden trait" );
                 if( !unique.insert( trait ).second ||
-                    ( check_engine_state && !trait_id( trait ).is_valid() ) ) {
+                    ( check_engine_state && !index_defines( index.defines_trait, trait ) &&
+                      !trait_id( trait ).is_valid() ) ) {
                     throw std::runtime_error( "profession '" + definition.id +
                                               "' has an unknown, duplicate, or contradictory trait '" +
                                               trait + "'" );
@@ -5066,6 +5068,24 @@ bool character_content_transaction::validate_finalized( std::string &error ) con
         if( !require_valid( profession_id( entry.definition->id ).is_valid(),
                             "profession", entry.definition->id ) ) {
             return false;
+        }
+        // Staged mutations (including replacements of existing ids) are installed
+        // after professions. Resolve their variants against the final definitions.
+        for( const profession_trait_definition_data &value : entry.definition->traits ) {
+            const trait_id trait( value.trait );
+            if( !trait.is_valid() ||
+                ( !value.variant.empty() && trait->variant( value.variant ) == nullptr ) ) {
+                error = "profession '" + entry.definition->id +
+                        "' has an unknown or invalid finalized trait '" + value.trait + "'";
+                return false;
+            }
+        }
+        for( const std::string &value : entry.definition->forbidden_traits ) {
+            if( !trait_id( value ).is_valid() ) {
+                error = "profession '" + entry.definition->id +
+                        "' has an unknown finalized forbidden trait '" + value + "'";
+                return false;
+            }
         }
     }
     for( const profession_group_registration &entry : pimpl_->profession_groups ) {

--- a/tests/lua_platform_profession_test.cpp
+++ b/tests/lua_platform_profession_test.cpp
@@ -1,0 +1,110 @@
+#if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
+#include "lua_platform_test_support.h"
+#include "profession.h"
+
+namespace
+{
+struct profession_test_mod : platform_lua_test_directory {
+    ~profession_test_mod() {
+        cata::lua_platform::shutdown();
+    }
+    cata::lua_platform::mod_source source( const std::string &id ) const {
+        return { id, root, root / "main.lua" };
+    }
+};
+} // namespace
+
+TEST_CASE( "lua_platform_profession_resolves_staged_traits",
+           "[lua][platform][content][profession]" )
+{
+    cata::lua_platform::shutdown();
+    profession_test_mod files;
+    const bool invalid_variant = GENERATE( false, true );
+    files.write( "main.lua", std::string( R"lua(
+local ccb = require("ccb")
+local profession = ccb.content.Profession {
+    id = "platform_staged_trait_profession", name = "Staged trait profession",
+    description = "Exercises same-transaction trait references.", points = 0,
+}
+profession:trait("platform_staged_trait", ")lua" ) +
+                 ( invalid_variant ? "missing" : "golden" ) + R"lua(")
+profession:forbid_trait("platform_staged_forbidden")
+ccb.content.add(profession)
+-- Deliberately declare the referenced mutations after the profession.
+local mutation = ccb.content.Mutation {
+    id = "platform_staged_trait", name = "Staged trait",
+    description = "A mutation declared in the same transaction.",
+}
+mutation:variant { id = "golden", name = "Golden", description = "Golden fur.", weight = 1 }
+ccb.content.add(mutation)
+ccb.content.add(ccb.content.Mutation {
+    id = "platform_staged_forbidden", name = "Forbidden staged trait",
+    description = "A forbidden mutation declared in the same transaction.",
+})
+)lua" );
+    std::string error;
+    REQUIRE( cata::lua_platform::prepare_mods( { files.source( "profession_staged_traits" ) },
+            error ) );
+    CAPTURE( error );
+    REQUIRE( cata::lua_platform::apply_prepared_content( error ) );
+    const profession_id id( "platform_staged_trait_profession" );
+    REQUIRE( id.is_valid() );
+    if( invalid_variant ) {
+        CHECK_FALSE( cata::lua_platform::validate_finalized_prepared_content( error ) );
+        CHECK( error.find( "invalid finalized trait" ) != std::string::npos );
+    } else {
+        REQUIRE( cata::lua_platform::validate_finalized_prepared_content( error ) );
+        const auto traits = id->get_locked_traits();
+        REQUIRE( traits.size() == 1 );
+        CHECK( traits.front().trait == trait_id( "platform_staged_trait" ) );
+        CHECK( traits.front().variant == "golden" );
+        CHECK( id->get_forbidden_traits().count( trait_id( "platform_staged_forbidden" ) ) == 1 );
+    }
+    cata::lua_platform::discard_prepared_mods();
+    CHECK_FALSE( id.is_valid() );
+    CHECK_FALSE( trait_id( "platform_staged_trait" ).is_valid() );
+    CHECK_FALSE( trait_id( "platform_staged_forbidden" ).is_valid() );
+}
+
+TEST_CASE( "lua_platform_profession_rejects_invalid_trait_references",
+           "[lua][platform][content][profession]" )
+{
+    cata::lua_platform::shutdown();
+    profession_test_mod files;
+    std::string references;
+    SECTION( "unknown starting trait" ) {
+        references = "profession:trait('platform_missing_trait', '')";
+    }
+    SECTION( "unknown forbidden trait" ) {
+        references = "profession:forbid_trait('platform_missing_trait')";
+    }
+    SECTION( "duplicate staged trait" ) {
+        references = "profession:trait('platform_staged_trait', '')\n"
+                     "profession:trait('platform_staged_trait', '')";
+    }
+    SECTION( "contradictory staged trait" ) {
+        references = "profession:trait('platform_staged_trait', '')\n"
+                     "profession:forbid_trait('platform_staged_trait')";
+    }
+    files.write( "main.lua", std::string( R"lua(
+local ccb = require("ccb")
+ccb.content.add(ccb.content.Mutation {
+    id = "platform_staged_trait", name = "Staged trait", description = "Test trait.",
+})
+local profession = ccb.content.Profession {
+    id = "platform_invalid_trait_profession", name = "Invalid trait profession",
+    description = "Must be rejected without publishing content.", points = 0,
+}
+)lua" ) + references + "\nccb.content.add(profession)\n" );
+    std::string error;
+    const bool prepared = cata::lua_platform::prepare_mods(
+    { files.source( "profession_invalid_traits" ) }, error );
+    const bool applied = prepared && cata::lua_platform::apply_prepared_content( error );
+    CHECK_FALSE( applied );
+    CHECK( error.find( "trait" ) != std::string::npos );
+    cata::lua_platform::discard_prepared_mods();
+    CHECK_FALSE( profession_id( "platform_invalid_trait_profession" ).is_valid() );
+    CHECK_FALSE( trait_id( "platform_staged_trait" ).is_valid() );
+}
+
+#endif


### PR DESCRIPTION
#### Summary

Bugfixes "修复 Lua 职业无法引用同批注册变异的问题"

#### Responsible human

@LYHGLYTX

#### Purpose of change

当一个 Lua Mod 同时注册变异和自带该变异的职业时，职业校验只查询已安装的原生变异，导致有效引用被拒绝。例如猴王 Mod 的职业引用 MONKEY_KING_MIGHT 时，创建角色报 unknown, duplicate, or invalid trait。调整 Lua 文件内的声明顺序无法解决，因为校验发生在整批内容应用之前。

#### Describe the solution

职业的初始特质和禁止特质校验复用现有 defines_trait 暂存索引，同时保留重复、矛盾和缺失引用检查。同批变异的外观分支在内容完成注册后，使用最终原生定义校验；无效分支仍会阻止提交。

新增独立职业回归测试，覆盖后声明的变异、禁止特质、有效/无效外观分支、缺失/重复/矛盾引用，以及撤销后职业和变异的清理。仅修改引擎和测试，不包含猴王 Mod 内容或其他工作区改动。

#### Describe alternatives you've considered

把职业拆为依赖基础 Mod 的扩展，或使用静态 JSON 职业，可以兼容旧引擎，但无法修复同批原生 Lua 内容引用缺陷。

#### Testing

- 修改后的引擎源文件和新增测试文件分别通过 C++17 编译：Lua Platform enabled、PCH=0、-O0、-g0、warnings-as-errors。
- `python3 -m unittest discover -s tools/lua_api -p 'test_*.py'`：44 项，42 项通过、2 项跳过。
- 新测试文件的 astyle 检查通过；引擎文件保留既有格式差异，仅检查修改范围；`git diff --check` 通过。
- PR 文件与上述已编译文件 SHA-256 一致，已基于最新 master 整理。
- 未链接或运行原生回归测试，也未完成游戏内创建角色/存档实测。此前尝试编译原有 cuisine 测试文件时发现其引用缺失的 lua_platform_canvas.h，因此本次测试放在独立文件中，不修改该无关问题。

#### Documentation impact

恢复现有 Lua 内容事务契约下的有效引用；没有新增或变更公开 API、签名或配置字段。本 PR 不修改文档页面。

#### Related CCB-Docs PR

既有 Lua 契约背景：https://github.com/CrimsonCrossBunker/CCB-Docs/pull/38 。未为本修复新建配套文档 PR。

#### Affected documentation IDs

cpp.lua-bridge（相关实现修复；公开用法不变）。

#### Generated reference impact

无生成接口变更，无需刷新公开 API 清单。

#### Additional context

本修复需要编译进入游戏程序；仅更新 Mod 无法修复旧二进制的校验行为。