### PR TITLE
test(lua): fix trait migration Flake8 failures

### DIFF
--- a/tools/test_lua_mutation_migration.py
+++ b/tools/test_lua_mutation_migration.py
@@ -36,8 +36,8 @@ class MutationMigrationTest(unittest.TestCase):
                     ),
                     (
                         {
-                            prefix + "has_any_trait": ["QUICK"] * 64
-                            + [{"context_val": "trait"}]
+                            prefix + "has_any_trait": ["QUICK"] * 64 +
+                            [{"context_val": "trait"}]
                         },
                         "true",
                         target,
@@ -99,15 +99,12 @@ services.variables.resolve = function(data, owner, scope, key)
 end
 """
                 raw = next(iter(condition.values()))
-                script += (
-                    "local match_quick = "
-                    + (
-                        "false"
-                        if isinstance(raw, list) and len(raw) > 64
-                        else "true"
-                    )
-                    + "\n"
+                match_quick = (
+                    "false"
+                    if isinstance(raw, list) and len(raw) > 64
+                    else "true"
                 )
+                script += f"local match_quick = {match_quick}\n"
                 if target is not None:
                     script += f"""
 services.mutations.has = function(owner, id)
@@ -135,7 +132,8 @@ end
         cases = [
             ("data/json/npcs/holdouts/Mr_Lapin.json", "u_has_any_trait"),
             (
-                "data/json/npcs/refugee_center/surface_visitors/NPC_arsonist.json",
+                "data/json/npcs/refugee_center/surface_visitors/"
+                "NPC_arsonist.json",
                 "npc_has_visible_trait",
             ),
             (


### PR DESCRIPTION
#### Summary
Fix four Flake8 violations in the trait migration tests that appeared on master after #752 merged. Preserve list and generated Lua behavior while simplifying string assembly and wrapping a fixture path.

#### Responsible human
@LYHGLYTX

#### Testing
Flake8 passes for the changed file. All 9 test_lua_mutation_migration tests pass. git diff --check passes. No native build is needed for this Python test formatting change.

#### Documentation impact
None: test formatting only.

#### Related CCB-Docs PR
Not required; #46 documents the already merged Lua behavior independently.

#### Affected documentation IDs
None.

#### Generated reference impact
None.

#### Additional context
20 changed lines in one cohesive commit.