### PR TITLE
feat(lua): implement trusted library and module loading (unverified)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1108,6 +1108,16 @@ CXXFLAGS += $(CXX_STD) $(CXX_WARNINGS) -fvisibility=hidden
 ifeq ($(CATA_ENABLE_LUA_PLATFORM),1)
   DEFINES += -DCATA_ENABLE_LUA_PLATFORM=1
   CXXFLAGS += -I$(SRC_DIR)/lua
+  # Native Lua modules resolve the public Lua C API from the host process.
+  # Override hidden visibility only for bundled Lua C objects, not game C++.
+  LUA_NATIVE_CFLAGS := -fvisibility=default
+  ifeq ($(NATIVE),osx)
+    LUA_NATIVE_CFLAGS += -DLUA_USE_DLOPEN
+    LDFLAGS += -Wl,-export_dynamic
+  else ifeq ($(TARGETSYSTEM),LINUX)
+    LUA_NATIVE_CFLAGS += -DLUA_USE_DLOPEN
+    LDFLAGS += -ldl -Wl,--export-dynamic
+  endif
 else
   DEFINES += -DCATA_ENABLE_LUA_PLATFORM=0
   # The disabled stub still exposes sol::table in linkable declarations.
@@ -1401,7 +1411,7 @@ $(ODIR)/third-party/%.o: $(SRC_DIR)/third-party/%.c
 	$(COMPILE.c) $(OUTPUT_OPTION) -x c $(CFLAGS) -w -MMD -MP $<
 
 $(ODIR)/lua/%.o: $(SRC_DIR)/lua/%.c
-	$(COMPILE.c) $(OUTPUT_OPTION) -x c $(CFLAGS) -w -MMD -MP $<
+	$(COMPILE.c) $(OUTPUT_OPTION) -x c $(CFLAGS) $(LUA_NATIVE_CFLAGS) -w -MMD -MP $<
 
 $(ODIR)/%.o: $(SRC_DIR)/%.cpp $(PCH_P)
 	$(COMPILE.cc) $(OUTPUT_OPTION) $(PCHFLAGS) -MMD -MP $<

--- a/Makefile
+++ b/Makefile
@@ -1117,6 +1117,10 @@ ifeq ($(CATA_ENABLE_LUA_PLATFORM),1)
   else ifeq ($(TARGETSYSTEM),LINUX)
     LUA_NATIVE_CFLAGS += -DLUA_USE_DLOPEN
     LDFLAGS += -ldl -Wl,--export-dynamic
+  else ifeq ($(TARGETSYSTEM),WINDOWS)
+    # Lua's own LUA_CORE/LUA_LIB headers mark public functions dllexport.
+    # Do not apply LUA_BUILD_AS_DLL to game C++ callers of the static library.
+    LUA_NATIVE_CFLAGS += -DLUA_BUILD_AS_DLL
   endif
 else
   DEFINES += -DCATA_ENABLE_LUA_PLATFORM=0

--- a/ai/lua-first-roadmap.yml
+++ b/ai/lua-first-roadmap.yml
@@ -644,13 +644,13 @@ capabilities:
   - id: platform-hardening
     phase: hardening
     status: planned
-    target_surface: "Accepted trusted-code policy: complete Lua standard libraries, ordinary external Lua and platform-supported native module loading, per-Mod state ownership, no security-sandbox promise and no mandatory global instruction/memory quotas by default. Preserve supported ccb API correctness/lifetime checks; provide reliability and opt-in diagnostics. Loader source now opens standard libraries and preserves normal external/native package searchers; native build/runtime acceptance and first-run notice integration remain pending."
+    target_surface: "Accepted trusted-code policy: complete Lua standard libraries, ordinary external Lua and platform-supported native module loading, per-Mod state ownership, no security-sandbox promise and no mandatory global instruction/memory quotas by default. Preserve supported ccb API correctness/lifetime checks; provide reliability and opt-in diagnostics. Loader source now opens standard libraries and preserves normal external/native package searchers; native build/runtime acceptance and startup notice UI acceptance remain pending."
     legacy_dependency: none
     evidence: [src/lua_platform_runtime.cpp, src/lua_platform_loader.cpp, tests/lua_platform_test.cpp, data/lua/LUA_FIRST_PLATFORM.md]
     verification: not_run
     next_actions:
       - Loader policy implementation and regression source are present but deliberately uncompiled. Run the loader tests and real external/native-module acceptance on supported platforms before claiming this slice verified.
-      - Document executable metadata discovery and provide execution-risk notice before downloaded Mod code first runs; do not claim existing catalog or launcher integration supplies this notice.
+      - Mod-manager source now notifies once per manager before Lua metadata discovery; validate normal and headless startup, refresh behavior and direct-loader host documentation. The notice is not a sandbox or per-API permission gate.
       - Validate handle safety, reload and error cleanup; add profiling or optional diagnostic limits only when useful. Supersede sandbox/process-isolation and mandatory-budget plans rather than introducing another runtime or permission manifest.
   - id: shared-ccb-std
     phase: standard-library

--- a/ai/lua-first-roadmap.yml
+++ b/ai/lua-first-roadmap.yml
@@ -643,7 +643,7 @@ capabilities:
     next_actions: []
   - id: platform-hardening
     phase: hardening
-    status: planned
+    status: in_progress
     target_surface: "Accepted trusted-code policy: complete Lua standard libraries, ordinary external Lua and platform-supported native module loading, per-Mod state ownership, no security-sandbox promise and no mandatory global instruction/memory quotas by default. Preserve supported ccb API correctness/lifetime checks; provide reliability and opt-in diagnostics. Loader source now opens standard libraries and preserves normal external/native package searchers; native build/runtime acceptance and startup notice UI acceptance remain pending."
     legacy_dependency: none
     evidence: [src/lua_platform_runtime.cpp, src/lua_platform_loader.cpp, tests/lua_platform_test.cpp, data/lua/LUA_FIRST_PLATFORM.md]

--- a/ai/lua-first-roadmap.yml
+++ b/ai/lua-first-roadmap.yml
@@ -644,12 +644,12 @@ capabilities:
   - id: platform-hardening
     phase: hardening
     status: planned
-    target_surface: "Accepted trusted-code policy: complete Lua standard libraries, ordinary external Lua and platform-supported native module loading, per-Mod state ownership, no security-sandbox promise and no mandatory global instruction/memory quotas by default. Preserve supported ccb API correctness/lifetime checks; provide reliability and opt-in diagnostics. Current loader whitelist and package restrictions do not yet implement this policy."
+    target_surface: "Accepted trusted-code policy: complete Lua standard libraries, ordinary external Lua and platform-supported native module loading, per-Mod state ownership, no security-sandbox promise and no mandatory global instruction/memory quotas by default. Preserve supported ccb API correctness/lifetime checks; provide reliability and opt-in diagnostics. Loader source now opens standard libraries and preserves normal external/native package searchers; native build/runtime acceptance and first-run notice integration remain pending."
     legacy_dependency: none
     evidence: [src/lua_platform_runtime.cpp, src/lua_platform_loader.cpp, tests/lua_platform_test.cpp, data/lua/LUA_FIRST_PLATFORM.md]
     verification: not_run
     next_actions:
-      - Replace library/package restrictions while preserving the reserved ccb entrypoint and local module resolution; verify full standard libraries and ordinary external/native loading on supported platforms.
+      - Loader policy implementation and regression source are present but deliberately uncompiled. Run the loader tests and real external/native-module acceptance on supported platforms before claiming this slice verified.
       - Document executable metadata discovery and provide execution-risk notice before downloaded Mod code first runs; do not claim existing catalog or launcher integration supplies this notice.
       - Validate handle safety, reload and error cleanup; add profiling or optional diagnostic limits only when useful. Supersede sandbox/process-isolation and mandatory-budget plans rather than introducing another runtime or permission manifest.
   - id: shared-ccb-std

--- a/data/lua/AGENTS.md
+++ b/data/lua/AGENTS.md
@@ -14,8 +14,9 @@ tracked in `ai/lua-first-roadmap.yml`.
 - The accepted trust policy in `LUA_FIRST_PLATFORM.md` permits full standard
   libraries and external/native modules at the player's risk. Do not reintroduce
   sandbox tiers or mandatory global runtime quotas; preserve supported `ccb`
-  correctness and lifetime checks. The current loader restrictions still need
-  implementation changes, so do not describe the accepted policy as shipped.
+  correctness and lifetime checks. Trusted loading and discovery notices are
+  implemented in source but still require native and startup acceptance; do not
+  describe the accepted policy as shipped merely because source exists.
 - Never hand-edit generated reference inventories; run their named generator.
 - Do not add a second Lua runtime, `game.*` surface, capability sandbox,
   authored manifest, JSON loader, EOC runner, or EOC-key-shaped API. Useful

--- a/data/lua/LUA_FIRST_PLATFORM.md
+++ b/data/lua/LUA_FIRST_PLATFORM.md
@@ -167,6 +167,16 @@ interactive acceptance. Direct loader embedders must provide their own notice.
 构建与 ABI。Mod 管理器已在元数据发现前加入每会话风险告知（无界面宿主输出到 stderr），
 启动 UI 顺序仍待交互验收；直接调用加载器的宿主应自行提供告知。不得将源码完成描述为已发布或已通过验收。
 
+Ordinary Lua 5.4 `require` returns the module and loader data on its first load.
+If `mod.lua` forwards a module that returns a `ccb.ModDefinition`, use
+`return (require("metadata"))` or assign its first return to a local variable;
+metadata still requires exactly one typed return value. This does not change
+`require("ccb")`, which always returns the reserved Platform root alone.
+
+普通 Lua 5.4 的 `require` 首次加载会返回模块及加载来源两个值。`mod.lua` 若转发返回
+`ccb.ModDefinition` 的模块，应写 `return (require("metadata"))`，或先用局部变量接收第一个
+结果再返回；元数据仍要求恰好一个类型化返回值。`require("ccb")` 只返回固定的 Platform 根表。
+
 ## Loading and lifecycle / 加载与生命周期
 
 The Platform lifecycle is a single transaction around the native engine:

--- a/data/lua/LUA_FIRST_PLATFORM.md
+++ b/data/lua/LUA_FIRST_PLATFORM.md
@@ -165,8 +165,9 @@ Lua metadata (stderr for headless hosts); its startup UI ordering still requires
 interactive acceptance. Direct loader embedders must provide their own notice.
 
 实现断点（2026-09-08）：加载器源码已开放 bundled 标准库，保留普通 package 查找器与原生
-加载入口，并优先查找 Mod 本地模块；`require("ccb")` 仍固定返回所属 state 的 Platform
-根表。实现与回归测试源码已提交，但**尚未编译、尚未运行验收**。原生模块仍取决于宿主 Lua
+加载入口，并优先查找 Mod 本地模块。原生库搜索路径增加 Mod 根目录的 `?.so`（Windows
+为 `?.dll`），同时保留原有路径；根目录含 `;` 或 `?` 时可使用明确的 `package.loadlib`
+路径，避免 cpath 语法歧义。`require("ccb")` 仍固定返回所属 state 的 Platform 根表。实现与回归测试源码已提交，但**尚未编译、尚未运行验收**。原生模块仍取决于宿主 Lua
 构建与 ABI。Mod 管理器已在元数据发现前加入每会话风险告知（无界面宿主输出到 stderr），
 启动 UI 顺序仍待交互验收；直接调用加载器的宿主应自行提供告知。不得将源码完成描述为已发布或已通过验收。
 

--- a/data/lua/LUA_FIRST_PLATFORM.md
+++ b/data/lua/LUA_FIRST_PLATFORM.md
@@ -157,13 +157,15 @@ standard libraries, retains normal package searchers and native loading, and
 inserts a Mod-local searcher before the ordinary searchers. The reserved `ccb`
 entry remains bound to the state-owned Platform table. These changes and their
 regression test source are **source-complete, not compiled or runtime-accepted**.
-Native loading still depends on the host Lua build and module ABI. The first-run
-execution-risk notice remains a separate pending integration requirement.
+Native loading still depends on the host Lua build and module ABI. The Mod manager now presents a session execution-risk notice before discovering
+Lua metadata (stderr for headless hosts); its startup UI ordering still requires
+interactive acceptance. Direct loader embedders must provide their own notice.
 
 实现断点（2026-09-08）：加载器源码已开放 bundled 标准库，保留普通 package 查找器与原生
 加载入口，并优先查找 Mod 本地模块；`require("ccb")` 仍固定返回所属 state 的 Platform
 根表。实现与回归测试源码已提交，但**尚未编译、尚未运行验收**。原生模块仍取决于宿主 Lua
-构建与 ABI；首次执行风险告知仍待单独集成。不得将源码完成描述为已发布或已通过验收。
+构建与 ABI。Mod 管理器已在元数据发现前加入每会话风险告知（无界面宿主输出到 stderr），
+启动 UI 顺序仍待交互验收；直接调用加载器的宿主应自行提供告知。不得将源码完成描述为已发布或已通过验收。
 
 ## Loading and lifecycle / 加载与生命周期
 

--- a/data/lua/LUA_FIRST_PLATFORM.md
+++ b/data/lua/LUA_FIRST_PLATFORM.md
@@ -154,7 +154,10 @@ API 调用弹权限窗口。此告知是待落实的集成要求，不代表现�
 
 Implementation checkpoint (2026-09-08): the loader source now opens the bundled
 standard libraries, retains normal package searchers and native loading, and
-inserts a Mod-local searcher before the ordinary searchers. The reserved `ccb`
+inserts a Mod-local searcher before the ordinary searchers. Native search paths
+also start with the Mod root's `?.so` (`?.dll` on Windows), preserving the original
+cpath. Roots containing cpath metacharacters `;` or `?` use explicit
+`package.loadlib` paths instead of an ambiguous automatic prefix. The reserved `ccb`
 entry remains bound to the state-owned Platform table. These changes and their
 regression test source are **source-complete, not compiled or runtime-accepted**.
 Native loading still depends on the host Lua build and module ABI. The Mod manager now presents a session execution-risk notice before discovering

--- a/data/lua/LUA_FIRST_PLATFORM.md
+++ b/data/lua/LUA_FIRST_PLATFORM.md
@@ -152,17 +152,18 @@ restricted and unrestricted runtime tiers.
 API 调用弹权限窗口。此告知是待落实的集成要求，不代表现有启动器已实现。普通 Lua 错误应可
 定位与清理，但不承诺无限循环/原生调用可安全中断，也不承诺崩溃隔离或外部副作用回滚。
 
-Implementation checkpoint (2026-09-06): `initialize_state` still uses a
-standard-library whitelist, removes `io`/`os`/`debug` and native package loaders,
-and restricts module resolution to the Mod root. Full-library and external/native
-loading support is **accepted, pending implementation and runtime acceptance**.
-The roadmap's `platform-hardening` entry now tracks this trust-policy transition
-and reliability/diagnostics work; old sandbox and mandatory-budget plans are
-superseded. This documentation update changes no running permissions.
+Implementation checkpoint (2026-09-08): the loader source now opens the bundled
+standard libraries, retains normal package searchers and native loading, and
+inserts a Mod-local searcher before the ordinary searchers. The reserved `ccb`
+entry remains bound to the state-owned Platform table. These changes and their
+regression test source are **source-complete, not compiled or runtime-accepted**.
+Native loading still depends on the host Lua build and module ABI. The first-run
+execution-risk notice remains a separate pending integration requirement.
 
-实现断点：当前加载器仍使用白名单并移除系统库与原生加载入口，因此完整标准库与外部/原生模块
-加载是**已采纳、待实现和运行验证**。roadmap 的 `platform-hardening` 改为跟踪此策略切换及
-可靠性/诊断；旧沙盒和默认强制配额计划作废。本次文档修改不改变运行中的权限。
+实现断点（2026-09-08）：加载器源码已开放 bundled 标准库，保留普通 package 查找器与原生
+加载入口，并优先查找 Mod 本地模块；`require("ccb")` 仍固定返回所属 state 的 Platform
+根表。实现与回归测试源码已提交，但**尚未编译、尚未运行验收**。原生模块仍取决于宿主 Lua
+构建与 ABI；首次执行风险告知仍待单独集成。不得将源码完成描述为已发布或已通过验收。
 
 ## Loading and lifecycle / 加载与生命周期
 

--- a/data/lua/types/ccb_platform_v1.d.lua
+++ b/data/lua/types/ccb_platform_v1.d.lua
@@ -6196,6 +6196,10 @@ function CcbPlatformDialogueApi.limits() end
 ---@field from_version integer
 ---@field to_version integer
 
+---Supply migrations before tasks with different payload versions are processed.
+---Missing handlers or failed
+---payload migrations discard the affected persistent tasks, including on script reload.
+---Detailed reasons go to debug.log; the message log summarizes discarded task counts.
 ---@param handler_id string
 ---@param from_version integer
 ---@param to_version integer

--- a/src/lua/CMakeLists.txt
+++ b/src/lua/CMakeLists.txt
@@ -48,6 +48,20 @@ file(GLOB LUA_HEADERS CONFIGURE_DEPENDS
 add_library(liblua ${LUA_SOURCES} ${LUA_HEADERS})
 target_include_directories(liblua SYSTEM PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
+# Native modules need both dlopen and visible Lua C API symbols. Keep this
+# scoped to bundled Lua; the game's internal C++ ABI stays hidden/unsupported.
+if(UNIX)
+    target_compile_definitions(liblua PRIVATE LUA_USE_DLOPEN)
+    set_target_properties(liblua PROPERTIES C_VISIBILITY_PRESET default)
+    target_link_libraries(liblua PUBLIC ${CMAKE_DL_LIBS})
+    if(APPLE)
+        target_link_options(liblua INTERFACE "LINKER:-export_dynamic")
+    else()
+        target_link_options(liblua INTERFACE "LINKER:--export-dynamic")
+    endif()
+endif()
+
+
 # Lua is third-party code.  Keep its diagnostics isolated from the game's
 # warning-as-error policy while preserving its standard C ABI.
 if(MSVC)

--- a/src/lua/CMakeLists.txt
+++ b/src/lua/CMakeLists.txt
@@ -50,7 +50,11 @@ target_include_directories(liblua SYSTEM PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Native modules need both dlopen and visible Lua C API symbols. Keep this
 # scoped to bundled Lua; the game's internal C++ ABI stays hidden/unsupported.
-if(UNIX)
+if(WIN32)
+    # Lua C sources define LUA_CORE/LUA_LIB, selecting dllexport rather than
+    # dllimport. Keep this private: game C++ statically calls the embedded Lua.
+    target_compile_definitions(liblua PRIVATE LUA_BUILD_AS_DLL)
+elseif(UNIX)
     target_compile_definitions(liblua PRIVATE LUA_USE_DLOPEN)
     set_target_properties(liblua PROPERTIES C_VISIBILITY_PRESET default)
     target_link_libraries(liblua PUBLIC ${CMAKE_DL_LIBS})

--- a/src/lua_platform_loader.cpp
+++ b/src/lua_platform_loader.cpp
@@ -115,7 +115,7 @@ std::optional<fs::path> resolve_local_module( const fs::path &root,
     for( const fs::path &candidate : candidates ) {
         std::error_code filesystem_error;
         const fs::path canonical_candidate = fs::canonical( candidate, filesystem_error );
-        if( !filesystem_error && path_is_within( canonical_candidate, root ) &&
+        if( !filesystem_error &&
             fs::is_regular_file( canonical_candidate, filesystem_error ) && !filesystem_error ) {
             return canonical_candidate;
         }
@@ -348,58 +348,11 @@ file_execution_result execute_file( sol::state &lua, const fs::path &path )
     return snapshot;
 }
 
-sol::object require_local_module( sol::state &lua, const fs::path &root,
-                                  const int platform_root_registry_index,
-                                  const std::string &module_name )
-{
-    if( !is_safe_module_name( module_name ) ) {
-        throw std::runtime_error( "invalid local module name '" + module_name + "'" );
-    }
-    if( module_name == "ccb" ) {
-        return sol::object( lua.lua_state(),
-                            sol::ref_index( platform_root_registry_index ) );
-    }
-    sol::table package = lua["package"];
-    sol::table loaded_modules = package["loaded"];
-    const sol::object cached = loaded_modules.raw_get<sol::object>( module_name );
-    if( cached.valid() && cached.get_type() != sol::type::nil &&
-        ( !cached.is<bool>() || cached.as<bool>() ) ) {
-        return cached;
-    }
-    const std::optional<fs::path> path = resolve_local_module( root, module_name );
-    if( !path ) {
-        throw std::runtime_error( "module '" + module_name +
-                                  "' was not found inside the Mod root" );
-    }
-
-    // Match Lua require's recursive-load behavior while keeping resolution
-    // independent from author-mutated package.path/searchers.
-    loaded_modules[module_name] = true;
-    try {
-        const file_execution_result execution = execute_file( lua, *path );
-        sol::object exported = loaded_modules.raw_get<sol::object>( module_name );
-        if( execution.first && execution.first->get_type() != sol::type::nil ) {
-            exported = *execution.first;
-        } else if( !exported.valid() || exported.get_type() == sol::type::nil ) {
-            exported = sol::make_object( lua, true );
-        }
-        loaded_modules[module_name] = exported;
-        return exported;
-    } catch( ... ) {
-        loaded_modules[module_name] = sol::make_object( lua, sol::lua_nil );
-        throw;
-    }
-}
-
 void initialize_state( sol::state &lua, const fs::path &requested_root,
                        const std::shared_ptr<runtime> &platform = nullptr )
 {
-    // Platform Mods use one restricted in-process Lua contract.  This is a
-    // capability boundary for the Platform API, not a process-level sandbox
-    // for untrusted code.
-    lua.open_libraries( sol::lib::base, sol::lib::math, sol::lib::string,
-                        sol::lib::table, sol::lib::utf8, sol::lib::coroutine,
-                        sol::lib::package );
+    // Mods are trusted executable code. State ownership is not a sandbox.
+    lua.open_libraries();
 
     std::error_code filesystem_error;
     const fs::path root = fs::canonical( requested_root, filesystem_error );
@@ -419,50 +372,66 @@ void initialize_state( sol::state &lua, const fs::path &requested_root,
     sol::table loaded = package["loaded"];
     loaded["ccb"] = ccb;
 
-    // Keep one raw registry reference in the state so require("ccb") remains
-    // anchored to this Platform root even if Lua code changes package.loaded.
-    // The integer is owned by the Lua registry and is reclaimed with the state;
-    // no sol::reference is captured by the long-lived C++ closure.
-    ccb.push( lua.lua_state() );
-    const int platform_root_registry_index =
-        luaL_ref( lua.lua_state(), LUA_REGISTRYINDEX );
-
-    // The Platform resolver below is the only supported module loader.  Keep
-    // package.loaded for its cache, but remove every package field that could
-    // expose an alternate filesystem or native-code loading path.
-    const std::array<const char *, 7> package_fields = {
-        "config", "cpath", "loadlib", "path", "preload", "searchers", "searchpath"
-    };
-    for( const char *field : package_fields ) {
-        package[field] = sol::lua_nil;
+    // Keep Lua's normal loaders, cache and loader-data return semantics. Insert
+    // the Mod-local searcher first, without restricting the remaining searchers.
+    sol::table searchers = package["searchers"];
+    for( std::size_t index = searchers.size(); index > 0; --index ) {
+        searchers[index + 1] = searchers.get<sol::object>( index );
     }
-
-    // These libraries are deliberately not part of the Platform whitelist.
-    // Assign nil explicitly so this remains true if the selected Lua build
-    // initializes any of them as part of its base setup.
-    const std::array<const char *, 3> forbidden_libraries = { "io", "os", "debug" };
-    for( const char *library : forbidden_libraries ) {
-        lua[library] = sol::lua_nil;
-    }
-    const std::array<const char *, 5> forbidden_globals = {
-        "dofile", "loadfile", "load", "loadstring", "collectgarbage"
-    };
-    for( const char *global : forbidden_globals ) {
-        lua[global] = sol::lua_nil;
-    }
-
-    lua.set_function( "require", [&lua, root, platform_root_registry_index](
-    const std::string & module_name ) {
-        return require_local_module( lua, root, platform_root_registry_index, module_name );
+    searchers.set_function( 1, [&lua, root]( const std::string & module_name ) {
+        sol::variadic_results result;
+        const std::optional<fs::path> path = resolve_local_module( root, module_name );
+        if( !path ) {
+            result.push_back( sol::make_object( lua, "\n\tno Mod-local module '" + module_name + "'" ) );
+            return result;
+        }
+        sol::load_result loaded_file = lua.load_file( path->string() );
+        if( !loaded_file.valid() ) {
+            const sol::error error = loaded_file;
+            throw std::runtime_error( path->string() + ": " + error.what() );
+        }
+        result.push_back( loaded_file.get<sol::function>() );
+        result.push_back( sol::make_object( lua, path->generic_u8string() ) );
+        return result;
     } );
+
+    // Lua-owned upvalues keep the original require and Platform table alive
+    // without retaining a C++ sol::reference inside a state-owned closure.
+    sol::load_result wrapper = lua.load( R"lua(
+return function(original_require, platform)
+    return function(name)
+        if name == "ccb" then
+            return platform
+        end
+        return original_require(name)
+    end
+end
+)lua" );
+    if( !wrapper.valid() ) {
+        const sol::error error = wrapper;
+        throw std::runtime_error( error.what() );
+    }
+    sol::protected_function factory = wrapper;
+    sol::protected_function_result factory_result = factory();
+    if( !factory_result.valid() ) {
+        const sol::error error = factory_result;
+        throw std::runtime_error( error.what() );
+    }
+    sol::protected_function bind = factory_result.get<sol::protected_function>();
+    sol::protected_function_result bound = bind( lua["require"], ccb );
+    if( !bound.valid() ) {
+        const sol::error error = bound;
+        throw std::runtime_error( error.what() );
+    }
+    lua["require"] = bound.get<sol::function>();
 }
 
 runtime_state load_source( const mod_source &source )
 {
     const mod_source resolved = resolve_source( source );
     DebugLog( D_WARNING, D_MAIN )
-            << "Executing Lua-first Platform Mod entry in the restricted in-process environment "
-            << "(not a process-level sandbox): "
+            << "Executing Lua-first Platform Mod entry as trusted executable code "
+            << "(with access to the player system): "
             << resolved.entry.generic_u8string();
     runtime_state result;
     result.id = resolved.id;
@@ -494,8 +463,8 @@ bool read_mod_definition( const fs::path &root, mod_definition &result, std::str
             throw std::runtime_error( "Lua-first mod.lua escapes its Mod root or is not a regular file" );
         }
         DebugLog( D_WARNING, D_MAIN )
-                << "Executing Lua-first Platform Mod metadata in the restricted in-process environment "
-                << "(not a process-level sandbox): "
+                << "Executing Lua-first Platform Mod metadata as trusted executable code "
+                << "(with access to the player system): "
                 << path.generic_u8string();
         sol::state lua;
         initialize_state( lua, canonical_root );

--- a/src/lua_platform_loader.cpp
+++ b/src/lua_platform_loader.cpp
@@ -365,6 +365,19 @@ void initialize_state( sol::state &lua, const fs::path &requested_root,
     }
 
     sol::table package = lua["package"];
+    // Let Lua's native searchers resolve a library shipped beside main.lua,
+    // preserving their entry-symbol rules and all original external paths.
+    // cpath has no escaping for its separators/placeholders. Such roots can
+    // still load native libraries through an explicit package.loadlib path.
+    if( root.generic_u8string().find_first_of( ";?" ) == std::string::npos ) {
+#if defined(_WIN32)
+        const fs::path native_pattern = root / "?.dll";
+#else
+        const fs::path native_pattern = root / "?.so";
+#endif
+        package["cpath"] = native_pattern.generic_u8string() + ";" +
+                           package.get<std::string>( "cpath" );
+    }
     sol::table loaded = package["loaded"];
     loaded["ccb"] = ccb;
 

--- a/src/lua_platform_loader.cpp
+++ b/src/lua_platform_loader.cpp
@@ -467,7 +467,8 @@ bool read_mod_definition( const fs::path &root, mod_definition &result, std::str
         const file_execution_result execution = execute_file( lua, path, "Lua-first Mod metadata" );
         if( execution.return_count != 1 ) {
             error = "Lua-first Mod metadata [" + path.generic_u8string() +
-                    "]: expected exactly one ccb.ModDefinition return value";
+                    "]: expected exactly one ccb.ModDefinition return value; "
+                    "use return (require(...)) when forwarding a metadata module";
             return false;
         }
         const sol::object &value = *execution.first;

--- a/src/lua_platform_loader.cpp
+++ b/src/lua_platform_loader.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <array>
-#include <cctype>
 #include <cstddef>
 #include <cstdint>
 #include <exception>
@@ -88,29 +87,25 @@ bool path_is_within( const fs::path &path, const fs::path &directory )
     return true;
 }
 
-bool is_safe_module_name( const std::string_view name )
-{
-    if( name.empty() || name.size() > 256 || name.front() == '.' ||
-        name.back() == '.' || name.find( ".." ) != std::string_view::npos ) {
-        return false;
-    }
-    return std::all_of( name.begin(), name.end(), []( const unsigned char value ) {
-        return std::isalnum( value ) != 0 || value == '_' || value == '-' || value == '.';
-    } );
-}
-
 std::optional<fs::path> resolve_local_module( const fs::path &root,
         const std::string &module_name )
 {
-    if( !is_safe_module_name( module_name ) ) {
+    // This is a preferred search path, not a module-name permission filter.
+    // Keep ordinary Lua names, including UTF-8 and repeated dot separators.
+    if( module_name.empty() || module_name.find( '\0' ) != std::string::npos ) {
         return std::nullopt;
     }
     std::string relative = module_name;
     std::replace( relative.begin(), relative.end(), '.',
                   static_cast<char>( fs::path::preferred_separator ) );
+    const fs::path relative_path = fs::u8path( relative );
+    if( relative_path.is_absolute() || relative_path.has_root_name() ) {
+        // Absolute names belong to the caller's ordinary package searchers.
+        return std::nullopt;
+    }
     const std::array<fs::path, 2> candidates = {
-        root / ( relative + ".lua" ),
-        root / relative / "init.lua"
+        root / fs::u8path( relative + ".lua" ),
+        root / relative_path / "init.lua"
     };
     for( const fs::path &candidate : candidates ) {
         std::error_code filesystem_error;
@@ -328,7 +323,7 @@ struct file_execution_result {
 file_execution_result execute_file( sol::state &lua, const fs::path &path,
                                     const std::string &context )
 {
-    sol::load_result loaded = lua.load_file( path.string() );
+    sol::load_result loaded = lua.load_file( path.generic_u8string() );
     if( !loaded.valid() ) {
         const sol::error error = loaded;
         throw std::runtime_error( context + " [" + path.generic_u8string() + "]: " + error.what() );
@@ -386,10 +381,10 @@ void initialize_state( sol::state &lua, const fs::path &requested_root,
             result.push_back( sol::make_object( lua, "\n\tno Mod-local module '" + module_name + "'" ) );
             return result;
         }
-        sol::load_result loaded_file = lua.load_file( path->string() );
+        sol::load_result loaded_file = lua.load_file( path->generic_u8string() );
         if( !loaded_file.valid() ) {
             const sol::error error = loaded_file;
-            throw std::runtime_error( path->string() + ": " + error.what() );
+            throw std::runtime_error( path->generic_u8string() + ": " + error.what() );
         }
         result.push_back( loaded_file.get<sol::function>() );
         result.push_back( sol::make_object( lua, path->generic_u8string() ) );

--- a/src/lua_platform_loader.cpp
+++ b/src/lua_platform_loader.cpp
@@ -325,18 +325,19 @@ struct file_execution_result {
     std::optional<sol::object> first;
 };
 
-file_execution_result execute_file( sol::state &lua, const fs::path &path )
+file_execution_result execute_file( sol::state &lua, const fs::path &path,
+                                    const std::string &context )
 {
     sol::load_result loaded = lua.load_file( path.string() );
     if( !loaded.valid() ) {
         const sol::error error = loaded;
-        throw std::runtime_error( path.string() + ": " + error.what() );
+        throw std::runtime_error( context + " [" + path.generic_u8string() + "]: " + error.what() );
     }
     sol::protected_function script = loaded;
     sol::protected_function_result result = script();
     if( !result.valid() ) {
         const sol::error error = result;
-        throw std::runtime_error( path.string() + ": " + error.what() );
+        throw std::runtime_error( context + " [" + path.generic_u8string() + "]: " + error.what() );
     }
     file_execution_result snapshot;
     snapshot.return_count = result.return_count();
@@ -441,7 +442,7 @@ runtime_state load_source( const mod_source &source )
     result.platform = make_runtime( resolved.id, generation_counter + 1,
                                     *result.lua, resolved.root );
     initialize_state( *result.lua, resolved.root, result.platform );
-    execute_file( *result.lua, resolved.entry );
+    execute_file( *result.lua, resolved.entry, "Lua-first Mod '" + resolved.id + "' entry" );
     return result;
 }
 
@@ -468,16 +469,16 @@ bool read_mod_definition( const fs::path &root, mod_definition &result, std::str
                 << path.generic_u8string();
         sol::state lua;
         initialize_state( lua, canonical_root );
-        const file_execution_result execution = execute_file( lua, path );
+        const file_execution_result execution = execute_file( lua, path, "Lua-first Mod metadata" );
         if( execution.return_count != 1 ) {
-            error = path.generic_u8string() +
-                    ": expected exactly one ccb.ModDefinition return value";
+            error = "Lua-first Mod metadata [" + path.generic_u8string() +
+                    "]: expected exactly one ccb.ModDefinition return value";
             return false;
         }
         const sol::object &value = *execution.first;
         if( !value.is<mod_definition>() ) {
-            error = path.generic_u8string() +
-                    ": expected a native ccb.ModDefinition return value";
+            error = "Lua-first Mod metadata [" + path.generic_u8string() +
+                    "]: expected a native ccb.ModDefinition return value";
             return false;
         }
         result = value.as<mod_definition>();

--- a/src/lua_platform_loader.h
+++ b/src/lua_platform_loader.h
@@ -51,7 +51,11 @@ struct mod_source {
     std::filesystem::path entry;
 };
 
-/** Execute root/mod.lua and require exactly one native ccb.ModDefinition result. */
+/** Execute root/mod.lua and require exactly one native ccb.ModDefinition result.
+ * This executes trusted code, including external/native modules. User-facing
+ * callers must present the execution-risk notice before invoking discovery;
+ * the low-level loader cannot assume an initialized UI or prompt safely.
+ */
 bool read_mod_definition( const std::filesystem::path &root, mod_definition &result,
                           std::string &error );
 

--- a/src/lua_platform_runtime_hooks.cpp
+++ b/src/lua_platform_runtime_hooks.cpp
@@ -311,7 +311,7 @@ static void dispatch_event_handler( runtime &owner, const std::string &name,
     callback_scope scope( owner );
     const sol::protected_function_result result = callback( payload );
     if( !result.valid() ) {
-        report_callback_error( owner, handler_id, result );
+        report_callback_error( owner, handler_id, result, "event " + name );
     }
 }
 
@@ -1622,7 +1622,8 @@ cata::lua_platform::native_hook_result dispatch_runtime_hook(
             callback_scope scope( *owner );
             const sol::protected_function_result result = callback( payload );
             if( !result.valid() ) {
-                report_callback_error( *owner, handler_id, result );
+                report_callback_error( *owner, handler_id, result,
+                                       "hook " + std::string( name ) );
                 continue;
             }
 

--- a/src/lua_platform_runtime_hooks.cpp
+++ b/src/lua_platform_runtime_hooks.cpp
@@ -93,11 +93,17 @@ bool runtime_callback_is_active( const std::weak_ptr<runtime> &weak )
 }
 
 void report_callback_error( const runtime &owner, std::string_view handler,
-                            const sol::protected_function_result &result )
+                            const sol::protected_function_result &result,
+                            const std::string_view context )
 {
     const sol::error error = result;
-    const std::string message = "Lua-first handler '" + owner.mod_id + ":" +
-                                std::string( handler ) + "' failed: " + error.what();
+    std::string message = "Lua-first handler '" + owner.mod_id + ":" +
+                          std::string( handler ) + "'";
+    if( !context.empty() ) {
+        message += " [" + std::string( context ) + "]";
+    }
+    message += " failed: ";
+    message += error.what();
     DebugLog( D_ERROR, D_MAIN ) << message;
     ::add_msg( m_bad, message );
 }

--- a/src/lua_platform_runtime_internal.h
+++ b/src/lua_platform_runtime_internal.h
@@ -253,7 +253,8 @@ void require_live_runtime( const std::weak_ptr<runtime> &weak,
                            std::string_view operation );
 bool runtime_callback_is_active( const std::weak_ptr<runtime> &weak );
 void report_callback_error( const runtime &owner, std::string_view handler,
-                            const sol::protected_function_result &result );
+                            const sol::protected_function_result &result,
+                            std::string_view context = {} );
 void dispatch_lifecycle( runtime &owner, const std::string &name,
                          const sol::optional<sol::table> &payload = sol::nullopt );
 bool migrate_task_payload( runtime &owner, persistent_task &task,

--- a/src/lua_platform_runtime_internal.h
+++ b/src/lua_platform_runtime_internal.h
@@ -188,7 +188,6 @@ class runtime : public std::enable_shared_from_this<runtime>
         script_persistent_state character_state;
         script_persistent_state world_state;
         std::vector<persistent_task> tasks;
-        std::set<std::uint64_t> reported_task_migration_failures;
         std::uint64_t next_task_id = 1;
         bool task_migration_active = false;
         std::mt19937_64 random_engine;

--- a/src/lua_platform_runtime_lifecycle.cpp
+++ b/src/lua_platform_runtime_lifecycle.cpp
@@ -313,6 +313,7 @@ void load_scope( const cata_path &path, const std::string &scope,
         error.clear();
         return;
     }
+    std::string context = "scope=" + scope;
     try {
         std::error_code size_error;
         const std::uintmax_t file_size = std::filesystem::file_size(
@@ -333,6 +334,8 @@ void load_scope( const cata_path &path, const std::string &scope,
         }
         const JsonObject mods = root.get_object( "mods" );
         for( const JsonMember member : mods ) {
+            const std::string record_context = "scope=" + scope + ", Mod='" + member.name() + "'";
+            context = record_context;
             const std::shared_ptr<runtime> owner = detail::find_active_runtime( member.name() );
             const JsonObject stored = member.get_object();
             persistent_scope_record record;
@@ -343,9 +346,12 @@ void load_scope( const cata_path &path, const std::string &scope,
                 if( stored_tasks.size() > maximum_tasks_per_mod ) {
                     throw std::runtime_error( "Platform state exceeds 1024 persistent tasks per Mod" );
                 }
+                std::size_t task_index = 0;
                 for( const JsonObject task_json : stored_tasks ) {
+                    context = record_context + ", task[" + std::to_string( task_index++ ) + "]";
                     persistent_task task;
                     const std::int64_t stored_id = task_json.get_int64( "id" );
+                    context += ", id=" + std::to_string( stored_id );
                     if( stored_id <= 0 ) {
                         throw std::runtime_error( "Platform task id must be positive" );
                     }
@@ -580,6 +586,7 @@ void load_scope( const cata_path &path, const std::string &scope,
                     task_json.allow_omitted_members();
                 }
             }
+            context = record_context;
             if( owner ) {
                 if( owner->tasks.size() + record.tasks.size() > maximum_tasks_per_mod ) {
                     throw std::runtime_error( "Platform state exceeds 1024 persistent tasks per Mod" );
@@ -610,7 +617,8 @@ void load_scope( const cata_path &path, const std::string &scope,
         error.clear();
     } catch( const std::exception &exception ) {
         clear_scope( scope );
-        error = path.get_unrelative_path().string() + ": " + exception.what();
+        error = path.get_unrelative_path().generic_u8string() + " [" + context + "]: " +
+                exception.what();
     }
 }
 

--- a/src/lua_platform_runtime_lifecycle.cpp
+++ b/src/lua_platform_runtime_lifecycle.cpp
@@ -1674,8 +1674,6 @@ void runtime_process_tasks()
             }
             return false;
         } ), owner->tasks.end() );
-        for( const persistent_task &task : due ) {
-        }
         std::sort( due.begin(), due.end(), []( const persistent_task & lhs,
         const persistent_task & rhs ) {
             return std::tie( lhs.due_turn, lhs.id ) < std::tie( rhs.due_turn, rhs.id );

--- a/src/lua_platform_runtime_lifecycle.cpp
+++ b/src/lua_platform_runtime_lifecycle.cpp
@@ -1291,7 +1291,6 @@ void detail::install_runtime_state_task_api(
         [task_id]( const persistent_task & task ) {
             return task.id == task_id;
         } ), owner->tasks.end() );
-        owner->reported_task_migration_failures.erase( task_id );
         return owner->tasks.size() != old_size;
     } );
     tasks.set_function( "get", [weak, task_snapshot](
@@ -1646,7 +1645,6 @@ void runtime_process_tasks()
                 continue;
             }
             if( handler->second.payload_version == task.payload_version ) {
-                owner->reported_task_migration_failures.erase( task.id );
                 continue;
             }
             std::string migration_error;
@@ -1656,8 +1654,6 @@ void runtime_process_tasks()
                                               << owner->mod_id << ':' << task.handler_id
                                               << "': " << migration_error;
                 retired_task_ids.insert( task.id );
-            } else {
-                owner->reported_task_migration_failures.erase( task.id );
             }
         }
         if( !retired_task_ids.empty() ) {
@@ -1666,9 +1662,6 @@ void runtime_process_tasks()
             [&retired_task_ids]( const persistent_task & task ) {
                 return retired_task_ids.count( task.id ) != 0;
             } ), owner->tasks.end() );
-            for( const std::uint64_t task_id : retired_task_ids ) {
-                owner->reported_task_migration_failures.erase( task_id );
-            }
         }
         std::vector<persistent_task> due;
         owner->tasks.erase( std::remove_if( owner->tasks.begin(), owner->tasks.end(),
@@ -1682,7 +1675,6 @@ void runtime_process_tasks()
             return false;
         } ), owner->tasks.end() );
         for( const persistent_task &task : due ) {
-            owner->reported_task_migration_failures.erase( task.id );
         }
         std::sort( due.begin(), due.end(), []( const persistent_task & lhs,
         const persistent_task & rhs ) {

--- a/src/lua_platform_runtime_lifecycle.cpp
+++ b/src/lua_platform_runtime_lifecycle.cpp
@@ -1933,7 +1933,10 @@ void runtime_process_tasks()
             callback_scope scope( *owner );
             const sol::protected_function_result result = callback( payload );
             if( !result.valid() ) {
-                report_callback_error( *owner, task.handler_id, result );
+                report_callback_error( *owner, task.handler_id, result,
+                                       "task " + std::to_string( task.id ) +
+                                       ", scope=" + task.owner +
+                                       ", due_turn=" + std::to_string( task.due_turn ) );
             } else if( next_due_turn && result.return_count() > 0 &&
                        result.get_type() == sol::type::boolean &&
                        !result.get<bool>() ) {

--- a/src/lua_platform_runtime_lifecycle.cpp
+++ b/src/lua_platform_runtime_lifecycle.cpp
@@ -41,6 +41,7 @@
 #include "messages.h"
 #include "monster.h"
 #include "path_info.h"
+#include "translations.h"
 #include "vehicle.h"
 #include "worldfactory.h"
 
@@ -1662,6 +1663,10 @@ void runtime_process_tasks()
             [&retired_task_ids]( const persistent_task & task ) {
                 return retired_task_ids.count( task.id ) != 0;
             } ), owner->tasks.end() );
+            ::add_msg( m_warning, n_gettext(
+                           "Lua Mod '%s' discarded %zu persistent task. See debug.log for details.",
+                           "Lua Mod '%s' discarded %zu persistent tasks. See debug.log for details.",
+                           retired_task_ids.size() ), owner->mod_id, retired_task_ids.size() );
         }
         std::vector<persistent_task> due;
         owner->tasks.erase( std::remove_if( owner->tasks.begin(), owner->tasks.end(),

--- a/src/lua_platform_runtime_services.cpp
+++ b/src/lua_platform_runtime_services.cpp
@@ -4833,8 +4833,6 @@ void hot_swap_active_runtimes(
         owner->character_state = std::move( old.character_state );
         owner->world_state = std::move( old.world_state );
         owner->tasks = std::move( old.tasks );
-        owner->reported_task_migration_failures =
-            std::move( old.reported_task_migration_failures );
         owner->next_task_id = old.next_task_id;
         owner->random_engine = std::move( old.random_engine );
         owner->world_is_ready = previously_ready.count( owner->mod_id ) != 0;

--- a/src/mod_manager.cpp
+++ b/src/mod_manager.cpp
@@ -255,13 +255,13 @@ void mod_migrations::check()
 static void show_lua_execution_notice()
 {
     const std::string message = _(
-                                   "Lua Mods are executable programs with access to your files and system. "
-                                   "CCB does not sandbox them or protect your system from their actions.\n\n"
-                                   "Reading the Mod list can already execute mod.lua metadata, before a Mod "
-                                   "is selected for a world. Only install Mods you choose to trust. "
-                                   "Native libraries can also crash the game.\n\n"
-                                   "Continuing will scan the installed Lua Mods. This notice appears once "
-                                   "per game session." );
+                                    "Lua Mods are executable programs with access to your files and system. "
+                                    "CCB does not sandbox them or protect your system from their actions.\n\n"
+                                    "Reading the Mod list can already execute mod.lua metadata, before a Mod "
+                                    "is selected for a world. Only install Mods you choose to trust. "
+                                    "Native libraries can also crash the game.\n\n"
+                                    "Continuing will scan the installed Lua Mods. This notice appears once "
+                                    "per game session." );
 #if !defined(HEADLESS)
     if( !test_mode ) {
         // The manager is constructed before load_static_data initializes

--- a/src/mod_manager.cpp
+++ b/src/mod_manager.cpp
@@ -10,6 +10,7 @@
 #include <filesystem>
 #include <functional>
 #include <iterator>
+#include <iostream>
 #include <memory>
 #include <ostream>
 #include <queue>
@@ -251,7 +252,30 @@ void mod_migrations::check()
     }
 }
 
-mod_manager::mod_manager()
+static void show_lua_execution_notice()
+{
+    if( test_mode ) {
+        return;
+    }
+    const std::string message = _(
+                                   "Lua Mods are executable programs with access to your files and system. "
+                                   "CCB does not sandbox them or protect your system from their actions.\n\n"
+                                   "Reading the Mod list can already execute mod.lua metadata, before a Mod "
+                                   "is selected for a world. Only install Mods you choose to trust. "
+                                   "Native libraries can also crash the game.\n\n"
+                                   "Continuing will scan the installed Lua Mods. This notice appears once "
+                                   "per game session." );
+#if defined(HEADLESS)
+    // Headless launchers must still receive the notice before metadata runs.
+    std::cerr << message << std::endl;
+#else
+    popup( message );
+#endif
+}
+
+mod_manager::mod_manager( std::function<void()> execution_notice ) :
+    lua_execution_notice( execution_notice ? std::move( execution_notice ) :
+                          show_lua_execution_notice )
 {
     refresh_mod_list();
     set_usable_mods();
@@ -408,6 +432,14 @@ void mod_manager::load_lua_platform_mod( const cata_path &root )
         // only its optional Platform entry.
         record_rejection( "Lua-first Platform is not enabled in this build" );
         return;
+    }
+
+    // Discovery itself executes metadata, so a world-load notice is too late.
+    // Keep this before read_mod_definition and before accepting main.lua-only
+    // candidates. Refreshing the catalog does not repeat the session notice.
+    if( !lua_execution_notice_shown ) {
+        lua_execution_notice();
+        lua_execution_notice_shown = true;
     }
 
     if( has_metadata ) {

--- a/src/mod_manager.cpp
+++ b/src/mod_manager.cpp
@@ -254,9 +254,6 @@ void mod_migrations::check()
 
 static void show_lua_execution_notice()
 {
-    if( test_mode ) {
-        return;
-    }
     const std::string message = _(
                                    "Lua Mods are executable programs with access to your files and system. "
                                    "CCB does not sandbox them or protect your system from their actions.\n\n"
@@ -265,12 +262,15 @@ static void show_lua_execution_notice()
                                    "Native libraries can also crash the game.\n\n"
                                    "Continuing will scan the installed Lua Mods. This notice appears once "
                                    "per game session." );
-#if defined(HEADLESS)
-    // Headless launchers must still receive the notice before metadata runs.
-    std::cerr << message << std::endl;
-#else
-    popup( message );
+#if !defined(HEADLESS)
+    if( !test_mode ) {
+        popup( message );
+        return;
+    }
 #endif
+    // --check-mods sets test_mode without initializing the UI. It must still
+    // receive the execution notice, just like a headless launcher.
+    std::cerr << message << std::endl;
 }
 
 mod_manager::mod_manager( std::function<void()> execution_notice ) :

--- a/src/mod_manager.cpp
+++ b/src/mod_manager.cpp
@@ -261,10 +261,12 @@ static void show_lua_execution_notice()
                                    "is selected for a world. Only install Mods you choose to trust. "
                                    "Native libraries can also crash the game.\n\n"
                                    "Continuing will scan the installed Lua Mods. This notice appears once "
-                                   "per game session." );
+                                   "per game session. Press any key to continue." );
 #if !defined(HEADLESS)
     if( !test_mode ) {
-        popup( message );
+        // The manager is constructed before load_static_data initializes
+        // keybindings. Accept a raw key instead of requiring CONFIRM/QUIT.
+        popup( message, PF_GET_KEY );
         return;
     }
 #endif

--- a/src/mod_manager.cpp
+++ b/src/mod_manager.cpp
@@ -261,12 +261,12 @@ static void show_lua_execution_notice()
                                    "is selected for a world. Only install Mods you choose to trust. "
                                    "Native libraries can also crash the game.\n\n"
                                    "Continuing will scan the installed Lua Mods. This notice appears once "
-                                   "per game session. Press any key to continue." );
+                                   "per game session." );
 #if !defined(HEADLESS)
     if( !test_mode ) {
         // The manager is constructed before load_static_data initializes
         // keybindings. Accept a raw key instead of requiring CONFIRM/QUIT.
-        popup( message, PF_GET_KEY );
+        popup( message + "\n\n" + _( "Press any key to continue." ), PF_GET_KEY );
         return;
     }
 #endif

--- a/src/mod_manager.h
+++ b/src/mod_manager.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_MOD_MANAGER_H
 
 #include <cstddef>
+#include <functional>
 #include <map>
 #include <optional>
 #include <set>
@@ -130,7 +131,11 @@ class mod_manager
     public:
         using t_mod_list = std::vector<mod_id>;
 
-        mod_manager();
+        /** Notify once before discovery executes any Lua metadata.
+         * The default displays an execution-risk notice. Embedders may supply
+         * their own user-facing notification before creating this manager.
+         */
+        explicit mod_manager( std::function<void()> lua_execution_notice = {} );
         ~mod_manager();
         /**
          * Reload the map of available mods (@ref mod_map).
@@ -214,6 +219,9 @@ class mod_manager
         void load_modfile( const JsonObject &jo, const cata_path &path );
 
         bool set_default_mods( const mod_id &ident );
+
+        std::function<void()> lua_execution_notice;
+        bool lua_execution_notice_shown = false;
 
         pimpl<dependency_tree> tree;
 

--- a/tests/lua_platform_callback_diagnostic_test.cpp
+++ b/tests/lua_platform_callback_diagnostic_test.cpp
@@ -24,7 +24,9 @@ TEST_CASE( "lua_platform_callback_errors_name_the_trigger_and_continue_dispatch"
     lua.set_function( "later_callback", [&later_calls]() {
         ++later_calls;
     } );
-    for( const char *handler : { "failing_callback", "later_callback" } ) {
+    for( const char *handler : {
+             "failing_callback", "later_callback"
+         } ) {
         const sol::protected_function_result registered =
             ccb["runtime"]["handler"]( handler, lua[handler] );
         REQUIRE( registered.valid() );
@@ -40,9 +42,11 @@ TEST_CASE( "lua_platform_callback_errors_name_the_trigger_and_continue_dispatch"
     cata::lua_platform::dispatch_runtime_hook( "on_craft_result" );
     CHECK( later_calls == 2 );
     const auto messages = Messages::recent_messages( 10 );
-    for( const char *context : { "event world_ready", "hook on_craft_result" } ) {
+    for( const char *context : {
+             "event world_ready", "hook on_craft_result"
+         } ) {
         const auto error = std::find_if( messages.begin(), messages.end(),
-        [context]( const auto &entry ) {
+        [context]( const auto & entry ) {
             return entry.second.find( context ) != std::string::npos;
         } );
         REQUIRE( error != messages.end() );

--- a/tests/lua_platform_callback_diagnostic_test.cpp
+++ b/tests/lua_platform_callback_diagnostic_test.cpp
@@ -1,0 +1,54 @@
+#if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
+#include "lua_platform_test_support.h"
+#include "messages.h"
+
+TEST_CASE( "lua_platform_callback_errors_name_the_trigger_and_continue_dispatch",
+           "[lua][platform][runtime][callbacks]" )
+{
+    cata::lua_platform::clear_active_runtimes();
+    Messages::clear_messages();
+    sol::state lua;
+    sol::table ccb = lua.create_table();
+    const std::shared_ptr<cata::lua_platform::runtime> runtime =
+        cata::lua_platform::make_runtime( "callback-diagnostic-owner", 1902, lua );
+    on_out_of_scope cleanup( []() {
+        cata::lua_platform::clear_active_runtimes();
+        Messages::clear_messages();
+    } );
+    cata::lua_platform::install_runtime_api( runtime, lua, ccb );
+    cata::lua_platform::set_active_runtimes( { runtime } );
+    lua.set_function( "failing_callback", []() {
+        throw std::runtime_error( "callback diagnostic sentinel" );
+    } );
+    int later_calls = 0;
+    lua.set_function( "later_callback", [&later_calls]() {
+        ++later_calls;
+    } );
+    for( const char *handler : { "failing_callback", "later_callback" } ) {
+        const sol::protected_function_result registered =
+            ccb["runtime"]["handler"]( handler, lua[handler] );
+        REQUIRE( registered.valid() );
+        const sol::protected_function_result event_subscription =
+            ccb["runtime"]["on"]( "world_ready", handler );
+        REQUIRE( event_subscription.valid() );
+        const sol::protected_function_result hook_subscription =
+            ccb["runtime"]["hook"]( "on_craft_result", handler );
+        REQUIRE( hook_subscription.valid() );
+    }
+    cata::lua_platform::runtime_world_ready( true );
+    CHECK( later_calls == 1 );
+    cata::lua_platform::dispatch_runtime_hook( "on_craft_result" );
+    CHECK( later_calls == 2 );
+    const auto messages = Messages::recent_messages( 10 );
+    for( const char *context : { "event world_ready", "hook on_craft_result" } ) {
+        const auto error = std::find_if( messages.begin(), messages.end(),
+        [context]( const auto &entry ) {
+            return entry.second.find( context ) != std::string::npos;
+        } );
+        REQUIRE( error != messages.end() );
+        CHECK( error->second.find( "callback-diagnostic-owner:failing_callback" ) !=
+               std::string::npos );
+        CHECK( error->second.find( "callback diagnostic sentinel" ) != std::string::npos );
+    }
+}
+#endif

--- a/tests/lua_platform_saved_state_diagnostic_test.cpp
+++ b/tests/lua_platform_saved_state_diagnostic_test.cpp
@@ -1,0 +1,60 @@
+#if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
+#include "lua_platform_test_support.h"
+#include "cata_path.h"
+#include "lua_platform_runtime_internal.h"
+#include "messages.h"
+#include "path_info.h"
+#include "worldfactory.h"
+
+TEST_CASE( "lua_platform_bad_saved_task_error_identifies_its_record",
+           "[lua][platform][runtime][persistence]" )
+{
+    namespace platform = cata::lua_platform;
+    platform::clear_active_runtimes();
+    Messages::clear_messages();
+    REQUIRE( world_generator != nullptr );
+    const platform_lua_test_directory temporary;
+    const std::string old_savedir = PATH_INFO::savedir();
+    WORLD *old_world = world_generator->active_world;
+    WORLD isolated_world( "saved_task_diagnostic" );
+    sol::state lua;
+    sol::table ccb = lua.create_table();
+    const std::shared_ptr<platform::runtime> runtime =
+        platform::make_runtime( "broken-owner", 1904, lua );
+    const on_out_of_scope cleanup( [&]() {
+        platform::clear_active_runtimes();
+        world_generator->active_world = old_world;
+        PATH_INFO::set_savedir( old_savedir );
+        Messages::clear_messages();
+    } );
+    PATH_INFO::set_savedir( temporary.root.string() + "/" );
+    world_generator->active_world = &isolated_world;
+    const std::filesystem::path directory = isolated_world.folder_path().get_unrelative_path();
+    REQUIRE( std::filesystem::create_directory( directory ) );
+    const std::filesystem::path state_path = directory / "lua_platform_world.json";
+    {
+        std::ofstream stream( state_path );
+        REQUIRE( stream.good() );
+        stream << R"({"version":1,"scope":"world","mods":{"broken-owner":{
+            "values":{},"tasks":[{"id":42,"handler":"","due_turn":0,
+            "payload_version":1,"payload":{}}]}}})";
+        stream.close();
+        REQUIRE( stream.good() );
+    }
+    platform::install_runtime_api( runtime, lua, ccb );
+    platform::set_active_runtimes( { runtime } );
+    platform::runtime_world_ready( false );
+    CHECK( runtime->world_state.empty() );
+    CHECK( runtime->tasks.empty() );
+    const auto messages = Messages::recent_messages( 10 );
+    const auto error = std::find_if( messages.begin(), messages.end(),
+    []( const auto &entry ) {
+        return entry.second.find( "handler id cannot be empty" ) != std::string::npos;
+    } );
+    REQUIRE( error != messages.end() );
+    CHECK( error->second.find( state_path.generic_u8string() ) != std::string::npos );
+    CHECK( error->second.find( "scope=world" ) != std::string::npos );
+    CHECK( error->second.find( "Mod='broken-owner'" ) != std::string::npos );
+    CHECK( error->second.find( "task[0], id=42" ) != std::string::npos );
+}
+#endif

--- a/tests/lua_platform_saved_state_diagnostic_test.cpp
+++ b/tests/lua_platform_saved_state_diagnostic_test.cpp
@@ -57,4 +57,51 @@ TEST_CASE( "lua_platform_bad_saved_task_error_identifies_its_record",
     CHECK( error->second.find( "Mod='broken-owner'" ) != std::string::npos );
     CHECK( error->second.find( "task[0], id=42" ) != std::string::npos );
 }
+
+TEST_CASE( "lua_platform_reload_reports_retired_tasks_and_keeps_valid_tasks",
+           "[lua][platform][runtime][persistence][reload]" )
+{
+    namespace platform = cata::lua_platform;
+    platform::clear_active_runtimes();
+    Messages::clear_messages();
+    sol::state old_lua;
+    sol::state new_lua;
+    sol::table old_ccb = old_lua.create_table();
+    sol::table new_ccb = new_lua.create_table();
+    const std::shared_ptr<platform::runtime> old_runtime =
+        platform::make_runtime( "retirement-owner", 1905, old_lua );
+    const std::shared_ptr<platform::runtime> new_runtime =
+        platform::make_runtime( "retirement-owner", 1906, new_lua );
+    const on_out_of_scope cleanup( []() {
+        platform::clear_active_runtimes();
+        Messages::clear_messages();
+    } );
+    platform::install_runtime_api( old_runtime, old_lua, old_ccb );
+    platform::install_runtime_api( new_runtime, new_lua, new_ccb );
+    old_lua.set_function( "noop", []() {} );
+    new_lua.set_function( "noop", []() {} );
+    for( const char *handler : { "kept", "removed" } ) {
+        const sol::protected_function_result registered =
+            old_ccb["runtime"]["handler"]( handler, old_lua["noop"] );
+        REQUIRE( registered.valid() );
+    }
+    const sol::protected_function_result registered =
+        new_ccb["runtime"]["handler"]( "kept", new_lua["noop"] );
+    REQUIRE( registered.valid() );
+    platform::set_active_runtimes( { old_runtime } );
+    platform::runtime_world_ready( true );
+    for( const char *handler : { "kept", "removed" } ) {
+        const sol::protected_function_result scheduled = old_ccb["tasks"]["after"](
+                    100, handler, old_lua.create_table(), 1, "world" );
+        REQUIRE( scheduled.valid() );
+    }
+    platform::hot_swap_active_runtimes( { new_runtime } );
+    REQUIRE( new_runtime->tasks.size() == 1 );
+    CHECK( new_runtime->tasks.front().handler_id == "kept" );
+    const auto messages = Messages::recent_messages( 10 );
+    CHECK( std::any_of( messages.begin(), messages.end(), []( const auto &entry ) {
+        return entry.second.find( "retirement-owner" ) != std::string::npos &&
+               entry.second.find( "discarded 1 persistent task" ) != std::string::npos;
+    } ) );
+}
 #endif

--- a/tests/lua_platform_saved_state_diagnostic_test.cpp
+++ b/tests/lua_platform_saved_state_diagnostic_test.cpp
@@ -48,7 +48,7 @@ TEST_CASE( "lua_platform_bad_saved_task_error_identifies_its_record",
     CHECK( runtime->tasks.empty() );
     const auto messages = Messages::recent_messages( 10 );
     const auto error = std::find_if( messages.begin(), messages.end(),
-    []( const auto &entry ) {
+    []( const auto & entry ) {
         return entry.second.find( "handler id cannot be empty" ) != std::string::npos;
     } );
     REQUIRE( error != messages.end() );
@@ -80,7 +80,9 @@ TEST_CASE( "lua_platform_reload_reports_retired_tasks_and_keeps_valid_tasks",
     platform::install_runtime_api( new_runtime, new_lua, new_ccb );
     old_lua.set_function( "noop", []() {} );
     new_lua.set_function( "noop", []() {} );
-    for( const char *handler : { "kept", "removed" } ) {
+    for( const char *handler : {
+             "kept", "removed"
+         } ) {
         const sol::protected_function_result registered =
             old_ccb["runtime"]["handler"]( handler, old_lua["noop"] );
         REQUIRE( registered.valid() );
@@ -90,16 +92,18 @@ TEST_CASE( "lua_platform_reload_reports_retired_tasks_and_keeps_valid_tasks",
     REQUIRE( registered.valid() );
     platform::set_active_runtimes( { old_runtime } );
     platform::runtime_world_ready( true );
-    for( const char *handler : { "kept", "removed" } ) {
+    for( const char *handler : {
+             "kept", "removed"
+         } ) {
         const sol::protected_function_result scheduled = old_ccb["tasks"]["after"](
-                    100, handler, old_lua.create_table(), 1, "world" );
+                100, handler, old_lua.create_table(), 1, "world" );
         REQUIRE( scheduled.valid() );
     }
     platform::hot_swap_active_runtimes( { new_runtime } );
     REQUIRE( new_runtime->tasks.size() == 1 );
     CHECK( new_runtime->tasks.front().handler_id == "kept" );
     const auto messages = Messages::recent_messages( 10 );
-    CHECK( std::any_of( messages.begin(), messages.end(), []( const auto &entry ) {
+    CHECK( std::any_of( messages.begin(), messages.end(), []( const auto & entry ) {
         return entry.second.find( "retirement-owner" ) != std::string::npos &&
                entry.second.find( "discarded 1 persistent task" ) != std::string::npos;
     } ) );

--- a/tests/lua_platform_test_02_loader.cpp
+++ b/tests/lua_platform_test_02_loader.cpp
@@ -4,7 +4,7 @@
 namespace
 {
 
-TEST_CASE( "lua_platform_loader_uses_restricted_environment_for_metadata_and_runtime",
+TEST_CASE( "lua_platform_loader_uses_trusted_environment_for_metadata_and_runtime",
            "[lua][platform][loader]" )
 {
     platform_lua_test_directory files;
@@ -21,6 +21,57 @@ TEST_CASE( "lua_platform_loader_uses_restricted_environment_for_metadata_and_run
     CHECK( error.empty() );
     CHECK( metadata.id == "platform-loader-policy-test" );
 
+    const cata::lua_platform::mod_source source = {
+        metadata.id, files.root, files.root / "main.lua"
+    };
+    REQUIRE( cata::lua_platform::validate_mods( { source }, error ) );
+    CHECK( error.empty() );
+}
+
+TEST_CASE( "lua_platform_loader_supports_external_paths_and_loader_data",
+           "[lua][platform][loader]" )
+{
+    platform_lua_test_directory files;
+    platform_lua_test_directory external;
+    external.write( "dofile_probe.lua", "return 42\n" );
+    external.write( "external_probe.lua", R"lua(
+local name, path = ...
+assert(name == "external_probe")
+assert(type(path) == "string")
+return { value = 42, path = path }
+)lua" );
+    // Long Lua brackets preserve Windows path separators without escaping.
+    const std::string external_root = external.root.generic_u8string();
+    const std::string probe = "local external_root = [=[" + external_root + "]=]\n" + R"lua(
+local ccb = require("ccb")
+package.path = external_root .. "/?.lua;" .. package.path
+local value, loader_data = require("external_probe")
+assert(value.value == 42)
+assert(loader_data == value.path)
+assert(require("external_probe") == value)
+assert(dofile(external_root .. "/dofile_probe.lua") == 42)
+local chunk = assert(loadfile(external_root .. "/external_probe.lua"))
+assert(chunk("external_probe", "loadfile").path == "loadfile")
+local marker = external_root .. "/io-probe.txt"
+local file = assert(io.open(marker, "w"))
+assert(file:write("trusted"))
+assert(file:close())
+file = assert(io.open(marker, "r"))
+assert(file:read("*a") == "trusted")
+assert(file:close())
+assert(os.remove(marker))
+-- A missing native library must return the standard error tuple, not a
+-- removed/disabled entry point. A real shared-library smoke test is separate.
+local native, message = package.loadlib(external_root .. "/missing-native-module", "luaopen_probe")
+assert(native == nil and type(message) == "string")
+)lua";
+    files.write( "mod.lua", probe +
+                 "\nreturn ccb.ModDefinition { id = \"external-loader-test\" }\n" );
+    files.write( "main.lua", probe );
+    cata::lua_platform::mod_definition metadata;
+    std::string error;
+    REQUIRE( cata::lua_platform::read_mod_definition( files.root, metadata, error ) );
+    CHECK( error.empty() );
     const cata::lua_platform::mod_source source = {
         metadata.id, files.root, files.root / "main.lua"
     };

--- a/tests/lua_platform_test_02_loader.cpp
+++ b/tests/lua_platform_test_02_loader.cpp
@@ -41,6 +41,36 @@ empty_export_loads = (empty_export_loads or 0) + 1
     CHECK( error.empty() );
 }
 
+TEST_CASE( "lua_platform_loader_finds_native_modules_beside_the_mod_entry",
+           "[lua][platform][loader]" )
+{
+    platform_lua_test_directory files;
+#if defined(_WIN32)
+    const std::string library_name = "ccb_native_path_probe.dll";
+#else
+    const std::string library_name = "ccb_native_path_probe.so";
+#endif
+    // This checks path resolution only, never loads the placeholder as a DLL/SO.
+    files.write( library_name, "native search path placeholder" );
+    const std::string expected =
+        std::filesystem::canonical( files.root / library_name ).generic_u8string();
+    const std::string probe = "local expected = [=[" + expected + "]=]\n" + R"lua(
+local ccb = require("ccb")
+local path = assert(package.searchpath("ccb_native_path_probe", package.cpath))
+assert(path == expected)
+)lua";
+    files.write( "mod.lua", probe +
+                 "\nreturn ccb.ModDefinition { id = \"native-path-test\" }\n" );
+    files.write( "main.lua", probe );
+    cata::lua_platform::mod_definition metadata;
+    std::string error;
+    REQUIRE( cata::lua_platform::read_mod_definition( files.root, metadata, error ) );
+    const cata::lua_platform::mod_source source = {
+        metadata.id, files.root, files.root / "main.lua"
+    };
+    REQUIRE( cata::lua_platform::validate_mods( { source }, error ) );
+}
+
 TEST_CASE( "lua_platform_loader_supports_external_paths_and_loader_data",
            "[lua][platform][loader]" )
 {

--- a/tests/lua_platform_test_02_loader.cpp
+++ b/tests/lua_platform_test_02_loader.cpp
@@ -79,6 +79,41 @@ assert(native == nil and type(message) == "string")
     CHECK( error.empty() );
 }
 
+TEST_CASE( "lua_platform_loader_errors_identify_stage_owner_and_script",
+           "[lua][platform][loader]" )
+{
+    platform_lua_test_directory files;
+    std::string error;
+    SECTION( "metadata syntax failure identifies its source before an id exists" ) {
+        files.write( "mod.lua", "return function(\n" );
+        cata::lua_platform::mod_definition metadata;
+        REQUIRE_FALSE( cata::lua_platform::read_mod_definition( files.root, metadata, error ) );
+        CHECK( error.find( "Lua-first Mod metadata" ) != std::string::npos );
+        CHECK( error.find( "mod.lua" ) != std::string::npos );
+    }
+    SECTION( "entry runtime failure identifies the declared owner" ) {
+        files.write( "main.lua", "error('entry diagnostic sentinel')\n" );
+        const cata::lua_platform::mod_source source = {
+            "diagnostic-owner", files.root, files.root / "main.lua"
+        };
+        REQUIRE_FALSE( cata::lua_platform::validate_mods( { source }, error ) );
+        CHECK( error.find( "Lua-first Mod 'diagnostic-owner' entry" ) != std::string::npos );
+        CHECK( error.find( "main.lua" ) != std::string::npos );
+        CHECK( error.find( "entry diagnostic sentinel" ) != std::string::npos );
+    }
+    SECTION( "required module keeps its own source in the entry error" ) {
+        files.write( "main.lua", "require('nested_failure')\n" );
+        files.write( "nested_failure.lua", "error('nested diagnostic sentinel')\n" );
+        const cata::lua_platform::mod_source source = {
+            "diagnostic-owner", files.root, files.root / "main.lua"
+        };
+        REQUIRE_FALSE( cata::lua_platform::validate_mods( { source }, error ) );
+        CHECK( error.find( "Lua-first Mod 'diagnostic-owner' entry" ) != std::string::npos );
+        CHECK( error.find( "nested_failure.lua" ) != std::string::npos );
+        CHECK( error.find( "nested diagnostic sentinel" ) != std::string::npos );
+    }
+}
+
 } // namespace
 
 #endif // CATA_ENABLE_LUA_PLATFORM

--- a/tests/lua_platform_test_02_loader.cpp
+++ b/tests/lua_platform_test_02_loader.cpp
@@ -127,6 +127,27 @@ TEST_CASE( "lua_platform_loader_errors_identify_stage_owner_and_script",
     }
 }
 
+TEST_CASE( "lua_platform_metadata_forwarding_uses_one_explicit_module_result",
+           "[lua][platform][loader]" )
+{
+    platform_lua_test_directory files;
+    files.write( "metadata.lua", R"lua(
+local ccb = require("ccb")
+return ccb.ModDefinition { id = "forwarded-metadata" }
+)lua" );
+    files.write( "mod.lua", "return require('metadata')\n" );
+    cata::lua_platform::mod_definition metadata;
+    std::string error;
+    // Lua 5.4 require forwards loader data on the first load. The metadata
+    // contract still requires precisely one typed result.
+    REQUIRE_FALSE( cata::lua_platform::read_mod_definition( files.root, metadata, error ) );
+    CHECK( error.find( "return (require(...))" ) != std::string::npos );
+    files.write( "mod.lua", "return (require('metadata'))\n" );
+    REQUIRE( cata::lua_platform::read_mod_definition( files.root, metadata, error ) );
+    CHECK( metadata.id == "forwarded-metadata" );
+    CHECK( error.empty() );
+}
+
 } // namespace
 
 #endif // CATA_ENABLE_LUA_PLATFORM

--- a/tests/lua_platform_test_02_loader.cpp
+++ b/tests/lua_platform_test_02_loader.cpp
@@ -8,7 +8,18 @@ TEST_CASE( "lua_platform_loader_uses_trusted_environment_for_metadata_and_runtim
            "[lua][platform][loader]" )
 {
     platform_lua_test_directory files;
-    files.write( "foo.lua", "return { value = \"foo\" }\n" );
+    files.write( "foo.lua", R"lua(
+local name, path = ...
+assert(name == "foo" and path:match("foo%.lua$"))
+return { value = "foo" }
+)lua" );
+    files.write( "false_export.lua", R"lua(
+false_export_loads = (false_export_loads or 0) + 1
+return false
+)lua" );
+    files.write( "empty_export.lua", R"lua(
+empty_export_loads = (empty_export_loads or 0) + 1
+)lua" );
     files.write( "nested/init.lua", "return { value = \"nested\" }\n" );
     files.write( "broken.lua", "error(\"broken module\")\n" );
     files.write( "mod.lua", std::string( platform_loader_policy_probe ) +

--- a/tests/lua_platform_test_02_loader.cpp
+++ b/tests/lua_platform_test_02_loader.cpp
@@ -21,6 +21,8 @@ return false
 empty_export_loads = (empty_export_loads or 0) + 1
 )lua" );
     files.write( "nested/init.lua", "return { value = \"nested\" }\n" );
+    files.write( std::filesystem::u8path( "模块.lua" ), "return 23\n" );
+    files.write( "nested/value.lua", "return 29\n" );
     files.write( "broken.lua", "error(\"broken module\")\n" );
     files.write( "mod.lua", std::string( platform_loader_policy_probe ) +
                  "\nreturn ccb.ModDefinition { id = \"platform-loader-policy-test\" }\n" );

--- a/tests/lua_platform_test_05_tasks.cpp
+++ b/tests/lua_platform_test_05_tasks.cpp
@@ -1,5 +1,6 @@
 #if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
 #include "lua_platform_test_support.h"
+#include "messages.h"
 
 TEST_CASE( "lua_platform_persistent_task_actor_payload_uses_live_handle_only_at_dispatch",
            "[lua][platform][runtime][tasks][handles]" )
@@ -574,6 +575,46 @@ TEST_CASE( "lua_platform_persistent_task_vehicle_actor_reacquires_persistent_ide
     REQUIRE( static_cast<bool>( resolved ) );
     CHECK( resolved.value == actor_vehicle );
     CHECK( resolved.value->uid().get_value() == vehicle_uid );
+}
+
+
+TEST_CASE( "lua_platform_task_failure_message_identifies_the_scheduled_instance",
+           "[lua][platform][runtime][tasks]" )
+{
+    cata::lua_platform::clear_active_runtimes();
+    Messages::clear_messages();
+    sol::state lua;
+    sol::table ccb = lua.create_table();
+    const std::shared_ptr<cata::lua_platform::runtime> runtime =
+        cata::lua_platform::make_runtime( "task-diagnostic-owner", 905, lua );
+    on_out_of_scope cleanup( []() {
+        cata::lua_platform::clear_active_runtimes();
+        Messages::clear_messages();
+    } );
+    cata::lua_platform::install_runtime_api( runtime, lua, ccb );
+    cata::lua_platform::set_active_runtimes( { runtime } );
+    lua.set_function( "failing_task", []() {
+        throw std::runtime_error( "task diagnostic sentinel" );
+    } );
+    const sol::protected_function_result registered =
+        ccb["runtime"]["handler"]( "failing_task", lua["failing_task"] );
+    REQUIRE( registered.valid() );
+    cata::lua_platform::runtime_world_ready( true );
+    const sol::protected_function_result scheduled = ccb["tasks"]["after"](
+                0, "failing_task", lua.create_table(), 1, "world" );
+    REQUIRE( scheduled.valid() );
+    const std::int64_t task_id = scheduled.get<std::int64_t>();
+    cata::lua_platform::runtime_process_tasks();
+    const auto messages = Messages::recent_messages( 10 );
+    const auto error = std::find_if( messages.begin(), messages.end(),
+    []( const auto & entry ) {
+        return entry.second.find( "task diagnostic sentinel" ) != std::string::npos;
+    } );
+    REQUIRE( error != messages.end() );
+    CHECK( error->second.find( "task-diagnostic-owner:failing_task" ) != std::string::npos );
+    CHECK( error->second.find( "task " + std::to_string( task_id ) ) != std::string::npos );
+    CHECK( error->second.find( "scope=world" ) != std::string::npos );
+    CHECK( error->second.find( "due_turn=" ) != std::string::npos );
 }
 
 #endif // CATA_ENABLE_LUA_PLATFORM

--- a/tests/lua_platform_test_05_tasks.cpp
+++ b/tests/lua_platform_test_05_tasks.cpp
@@ -605,7 +605,7 @@ TEST_CASE( "lua_platform_task_failure_message_identifies_the_scheduled_instance"
     REQUIRE( registered.valid() );
     cata::lua_platform::runtime_world_ready( true );
     const sol::protected_function_result scheduled = ccb["tasks"]["after"](
-                0, "failing_task", lua.create_table(), 1, "world" );
+            0, "failing_task", lua.create_table(), 1, "world" );
     REQUIRE( scheduled.valid() );
     const std::int64_t task_id = scheduled.get<std::int64_t>();
     cata::lua_platform::runtime_process_tasks();

--- a/tests/lua_platform_test_05_tasks.cpp
+++ b/tests/lua_platform_test_05_tasks.cpp
@@ -1,6 +1,10 @@
 #if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
 #include "lua_platform_test_support.h"
 #include "messages.h"
+#include <algorithm>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
 
 TEST_CASE( "lua_platform_persistent_task_actor_payload_uses_live_handle_only_at_dispatch",
            "[lua][platform][runtime][tasks][handles]" )

--- a/tests/lua_platform_test_support.h
+++ b/tests/lua_platform_test_support.h
@@ -274,6 +274,8 @@ local custom, custom_data = require("custom:probe")
 assert(custom.value == 19 and custom_data == "custom-loader-data")
 package.searchers[searcher_count + 1] = nil
 
+assert(require("模块") == 23)
+assert(require("nested..value") == 29)
 local nested = require("nested")
 if nested.value ~= "nested" then
     error("root-local nested/init.lua require failed")

--- a/tests/lua_platform_test_support.h
+++ b/tests/lua_platform_test_support.h
@@ -218,39 +218,36 @@ for _, name in ipairs({ "math", "string", "table", "utf8", "coroutine" }) do
         error("missing allowed library " .. name)
     end
 end
-for _, name in ipairs({ "io", "os", "debug", "dofile", "loadfile", "load", "loadstring", "collectgarbage" }) do
-    if _G[name] ~= nil then
-        error("forbidden global is exposed: " .. name)
-    end
+for _, name in ipairs({ "io", "os", "debug" }) do
+    assert(type(_G[name]) == "table", "missing standard library " .. name)
 end
-
-if type(package) ~= "table" or type(package.loaded) ~= "table" then
-    error("controlled package.loaded state is missing")
+for _, name in ipairs({ "dofile", "loadfile", "load", "collectgarbage" }) do
+    assert(type(_G[name]) == "function", "missing standard function " .. name)
 end
-if package.loaded["ccb"] ~= ccb then
-    error("package.loaded[ccb] does not contain the Platform root")
-end
-package.loaded["../outside"] = { value = "spoofed" }
-local unsafe_ok = pcall(require, "../outside")
-if unsafe_ok then
-    error("unsafe module name bypassed validation through package.loaded")
-end
-package.loaded["../outside"] = nil
+assert(load("return 6 * 7")() == 42)
+assert(type(debug.traceback("probe")) == "string")
+assert(type(os.date("!%Y")) == "string")
+assert(type(package.path) == "string" and type(package.cpath) == "string")
+assert(type(package.loadlib) == "function")
+assert(type(package.searchpath) == "function")
+assert(type(package.searchers) == "table")
+assert(type(package.preload) == "table")
+assert(package.loaded["ccb"] == ccb)
 package.loaded["ccb"] = { value = "spoofed" }
-if require("ccb") ~= ccb then
-    error("require[ccb] did not return the original Platform root")
-end
+assert(require("ccb") == ccb, "Platform root must remain stable")
 package.loaded["ccb"] = ccb
-for _, name in ipairs({ "config", "cpath", "loadlib", "path", "preload", "searchers", "searchpath" }) do
-    if package[name] ~= nil then
-        error("forbidden package field is exposed: " .. name)
-    end
+
+package.preload["preloaded_probe"] = function(name, loader_data)
+    assert(name == "preloaded_probe")
+    return { value = 42 }
 end
-for name in pairs(package) do
-    if name ~= "loaded" then
-        error("unexpected package field is exposed: " .. name)
-    end
-end
+assert(require("preloaded_probe").value == 42)
+package.loaded["../external-cache"] = { value = 7 }
+assert(require("../external-cache").value == 7)
+package.loaded["../external-cache"] = nil
+
+-- Local modules take priority over ordinary preload and path searchers.
+package.preload["foo"] = function() error("preload shadowed local module") end
 
 local foo = require("foo")
 if foo.value ~= "foo" or require("foo") ~= foo then

--- a/tests/lua_platform_test_support.h
+++ b/tests/lua_platform_test_support.h
@@ -253,6 +253,27 @@ local foo = require("foo")
 if foo.value ~= "foo" or require("foo") ~= foo then
     error("root-local foo.lua require was not cached")
 end
+-- Ordinary Lua semantics: false exports are reloaded; nil exports become true.
+assert(require("false_export") == false)
+assert(require("false_export") == false)
+assert(false_export_loads == 2)
+assert(require("empty_export") == true)
+assert(require("empty_export") == true)
+assert(empty_export_loads == 1)
+
+local searcher_count = #package.searchers
+package.searchers[searcher_count + 1] = function(name)
+    if name == "custom:probe" then
+        return function(requested, loader_data)
+            assert(requested == name and loader_data == "custom-loader-data")
+            return { value = 19 }
+        end, "custom-loader-data"
+    end
+end
+local custom, custom_data = require("custom:probe")
+assert(custom.value == 19 and custom_data == "custom-loader-data")
+package.searchers[searcher_count + 1] = nil
+
 local nested = require("nested")
 if nested.value ~= "nested" then
     error("root-local nested/init.lua require failed")

--- a/tests/mod_manager_test.cpp
+++ b/tests/mod_manager_test.cpp
@@ -16,6 +16,7 @@
 #include "worldfactory.h"
 
 static const mod_id MOD_INFORMATION_dda( "dda" );
+static const mod_id MOD_INFORMATION_Lua_First_Example( "Lua_First_Example" );
 static const mod_id MOD_INFORMATION_test_third_party_mod( "test_third_party_mod" );
 static const mod_id MOD_INFORMATION_test_third_party_mod_dda( "test_third_party_mod#dda" );
 static const mod_id MOD_INFORMATION_test_user_mod( "test_user_mod" );
@@ -155,7 +156,7 @@ TEST_CASE( "lua_mod_discovery_notifies_once_across_catalog_refreshes",
     } );
     const std::vector<mod_id> discovered = manager.all_mods();
     REQUIRE( std::find( discovered.begin(), discovered.end(),
-                        mod_id( "Lua_First_Example" ) ) != discovered.end() );
+                        MOD_INFORMATION_Lua_First_Example ) != discovered.end() );
     CHECK( notices == 1 );
     manager.refresh_mod_list();
     CHECK( notices == 1 );

--- a/tests/mod_manager_test.cpp
+++ b/tests/mod_manager_test.cpp
@@ -1,5 +1,6 @@
 #include <cata_path.h>
 #include <type_id.h>
+#include <algorithm>
 #include <filesystem>
 #include <functional>
 #include <memory>
@@ -139,5 +140,24 @@ TEST_CASE( "lua_first_platform_playable_mvp_is_discovered_and_activated",
 
     cata::lua_platform::shutdown();
     CHECK( cata::lua_platform::loaded_mod_ids().empty() );
+}
+#endif
+
+#if defined(CATA_ENABLE_LUA_PLATFORM) && CATA_ENABLE_LUA_PLATFORM
+TEST_CASE( "lua_mod_discovery_notifies_once_across_catalog_refreshes",
+           "[mod_manager][lua][platform][loader]" )
+{
+    // The bundled Platform example ensures that the real discovery path has
+    // Lua candidates. Supplying a notice callback keeps this test noninteractive.
+    int notices = 0;
+    mod_manager manager( [&notices]() {
+        ++notices;
+    } );
+    const std::vector<mod_id> discovered = manager.all_mods();
+    REQUIRE( std::find( discovered.begin(), discovered.end(),
+                        mod_id( "Lua_First_Example" ) ) != discovered.end() );
+    CHECK( notices == 1 );
+    manager.refresh_mod_list();
+    CHECK( notices == 1 );
 }
 #endif

--- a/tools/lua_api/check_cmake_contract.py
+++ b/tools/lua_api/check_cmake_contract.py
@@ -58,6 +58,7 @@ def validate_cmake_contract(
             "src/lua/CMakeLists.txt: bundled Lua sources must use LANGUAGE C"
         )
     native_loading_requirements = (
+        "target_compile_definitions(liblua PRIVATE LUA_BUILD_AS_DLL)",
         "target_compile_definitions(liblua PRIVATE LUA_USE_DLOPEN)",
         "set_target_properties(liblua PROPERTIES C_VISIBILITY_PRESET default)",
         "target_link_libraries(liblua PUBLIC ${CMAKE_DL_LIBS})",

--- a/tools/lua_api/check_cmake_contract.py
+++ b/tools/lua_api/check_cmake_contract.py
@@ -68,8 +68,8 @@ def validate_cmake_contract(
     for requirement in native_loading_requirements:
         if requirement not in normalized_lua:
             errors.append(
-                "src/lua/CMakeLists.txt: native Lua loading requires "
-                + requirement
+                "src/lua/CMakeLists.txt: native Lua loading requires " +
+                requirement
             )
     if "#define SOL_USE_CXX_LUA" in sol_config_source:
         errors.append(

--- a/tools/lua_api/check_cmake_contract.py
+++ b/tools/lua_api/check_cmake_contract.py
@@ -57,6 +57,19 @@ def validate_cmake_contract(
         errors.append(
             "src/lua/CMakeLists.txt: bundled Lua sources must use LANGUAGE C"
         )
+    native_loading_requirements = (
+        "target_compile_definitions(liblua PRIVATE LUA_USE_DLOPEN)",
+        "set_target_properties(liblua PROPERTIES C_VISIBILITY_PRESET default)",
+        "target_link_libraries(liblua PUBLIC ${CMAKE_DL_LIBS})",
+        'target_link_options(liblua INTERFACE "LINKER:--export-dynamic")',
+        'target_link_options(liblua INTERFACE "LINKER:-export_dynamic")',
+    )
+    for requirement in native_loading_requirements:
+        if requirement not in normalized_lua:
+            errors.append(
+                "src/lua/CMakeLists.txt: native Lua loading requires "
+                + requirement
+            )
     if "#define SOL_USE_CXX_LUA" in sol_config_source:
         errors.append(
             "src/sol/config.hpp: sol must use the bundled Lua C ABI"

--- a/tools/lua_api/fixtures/native_probe/README.md
+++ b/tools/lua_api/fixtures/native_probe/README.md
@@ -1,0 +1,36 @@
+# Optional native-module acceptance probe
+
+This fixture is source only. It is not a bundled gameplay Mod, a shared-library
+binary, or part of the normal Python tool test run. It has not been compiled or
+run as part of the overnight implementation work.
+
+After native builds are permitted, use it to check the actual game executable's
+exported Lua C ABI, rather than testing against the system `lua` executable.
+The game must have been built with the trusted loader changes. Run the probe
+with a disposable Mod/world and repeat through the supported Make and CMake
+builds as appropriate.
+
+Example preparation for Linux (commands are instructions, not recorded results):
+
+```sh
+mkdir -p /tmp/ccb-native-probe
+cc -shared -fPIC -Isrc/lua \
+  tools/lua_api/fixtures/native_probe/ccb_native_probe.c \
+  -o /tmp/ccb-native-probe/ccb_native_probe.so
+```
+
+Copy this directory's `main.lua` to an otherwise empty optional Lua Mod root.
+Set `CCB_NATIVE_PROBE_DIR=/tmp/ccb-native-probe` when launching the actual game,
+then select/load that Mod. The script changes only its state's package search
+path and checks native module loading/cache, integer round trips, native
+argument-error handling and stable `require("ccb")` identity. It should produce
+no gameplay effects and no error; absence of errors must be checked against the
+actual Mod load result, not assumed from a successful compiler invocation.
+
+On macOS, the equivalent fixture link needs `-undefined dynamic_lookup`; verify
+the real game binary exports the Lua API. Android needs an ABI-matched shared
+object and an OS-permitted library location. Windows import-library/runtime
+packaging needs separate acceptance; the `.so` recipe above is not a Windows
+recipe. Do not link a second Lua runtime into this fixture: it must exercise the
+host's Lua state and C API. This does not expose or stabilize CCB's internal C++
+objects.

--- a/tools/lua_api/fixtures/native_probe/README.md
+++ b/tools/lua_api/fixtures/native_probe/README.md
@@ -19,9 +19,11 @@ cc -shared -fPIC -Isrc/lua \
   -o /tmp/ccb-native-probe/ccb_native_probe.so
 ```
 
-Copy this directory's `main.lua` to an otherwise empty optional Lua Mod root.
-Set `CCB_NATIVE_PROBE_DIR=/tmp/ccb-native-probe` when launching the actual game,
-then select/load that Mod. The script changes only its state's package search
+Copy this directory's `main.lua` and the compiled probe to an otherwise empty
+optional Lua Mod root. The loader prepends that root's `?.so` (`?.dll` on Windows)
+to the ordinary native search path. Alternatively, keep the probe externally and
+set `CCB_NATIVE_PROBE_DIR=/tmp/ccb-native-probe` when launching the actual game.
+Select/load that Mod. The script changes only its state's package search
 path and checks native module loading/cache, integer round trips, native
 argument-error handling and stable `require("ccb")` identity. It should produce
 no gameplay effects and no error; absence of errors must be checked against the
@@ -34,3 +36,8 @@ Import-library/runtime packaging still needs separate acceptance; the `.so` reci
 recipe. Do not link a second Lua runtime into this fixture: it must exercise the
 host's Lua state and C API. This does not expose or stabilize CCB's internal C++
 objects.
+
+Lua's cpath grammar cannot escape literal `;` or `?` in directory names. The
+automatic local prefix is omitted for such roots; explicit `package.loadlib`
+paths and the original external searchers remain available. A path-resolution
+regression uses a placeholder library, which is not native loading evidence.

--- a/tools/lua_api/fixtures/native_probe/README.md
+++ b/tools/lua_api/fixtures/native_probe/README.md
@@ -29,8 +29,8 @@ actual Mod load result, not assumed from a successful compiler invocation.
 
 On macOS, the equivalent fixture link needs `-undefined dynamic_lookup`; verify
 the real game binary exports the Lua API. Android needs an ABI-matched shared
-object and an OS-permitted library location. Windows import-library/runtime
-packaging needs separate acceptance; the `.so` recipe above is not a Windows
+object and an OS-permitted library location. Windows public Lua functions are marked for export by the build configuration.
+Import-library/runtime packaging still needs separate acceptance; the `.so` recipe above is not a Windows
 recipe. Do not link a second Lua runtime into this fixture: it must exercise the
 host's Lua state and C API. This does not expose or stabilize CCB's internal C++
 objects.

--- a/tools/lua_api/fixtures/native_probe/ccb_native_probe.c
+++ b/tools/lua_api/fixtures/native_probe/ccb_native_probe.c
@@ -1,0 +1,27 @@
+/* Optional acceptance fixture. Never compiled by the ordinary tool tests. */
+#include <lua.h>
+#include <lauxlib.h>
+
+static int round_trip( lua_State *state )
+{
+    /* Exercise the host's auxiliary library and primitive stack API. */
+    const lua_Integer value = luaL_checkinteger( state, 1 );
+    lua_pushinteger( state, value );
+    return 1;
+}
+
+#if defined(_WIN32)
+__declspec(dllexport)
+#elif defined(__GNUC__)
+__attribute__((visibility("default")))
+#endif
+int luaopen_ccb_native_probe( lua_State *state )
+{
+    luaL_checkversion( state );
+    lua_newtable( state );
+    lua_pushcfunction( state, round_trip );
+    lua_setfield( state, -2, "round_trip" );
+    lua_pushliteral( state, "CCB native Lua acceptance probe" );
+    lua_setfield( state, -2, "description" );
+    return 1;
+}

--- a/tools/lua_api/fixtures/native_probe/main.lua
+++ b/tools/lua_api/fixtures/native_probe/main.lua
@@ -1,7 +1,10 @@
 local ccb = require("ccb")
-local directory = assert(os.getenv("CCB_NATIVE_PROBE_DIR"),
-    "set CCB_NATIVE_PROBE_DIR to the absolute directory containing the native probe")
-package.cpath = directory .. "/?.so;" .. package.cpath
+-- Without an override, require uses the native library beside this main.lua.
+local directory = os.getenv("CCB_NATIVE_PROBE_DIR")
+if directory then
+    local extension = package.config:sub(1, 1) == "\\" and ".dll" or ".so"
+    package.cpath = directory .. "/?" .. extension .. ";" .. package.cpath
+end
 local probe = require("ccb_native_probe")
 assert(probe.description == "CCB native Lua acceptance probe")
 assert(probe.round_trip(42) == 42)

--- a/tools/lua_api/fixtures/native_probe/main.lua
+++ b/tools/lua_api/fixtures/native_probe/main.lua
@@ -1,0 +1,11 @@
+local ccb = require("ccb")
+local directory = assert(os.getenv("CCB_NATIVE_PROBE_DIR"),
+    "set CCB_NATIVE_PROBE_DIR to the absolute directory containing the native probe")
+package.cpath = directory .. "/?.so;" .. package.cpath
+local probe = require("ccb_native_probe")
+assert(probe.description == "CCB native Lua acceptance probe")
+assert(probe.round_trip(42) == 42)
+assert(probe.round_trip(-7) == -7)
+assert(not pcall(probe.round_trip, "not an integer"))
+assert(require("ccb_native_probe") == probe)
+assert(require("ccb") == ccb)

--- a/tools/lua_api/test_check_cmake_contract.py
+++ b/tools/lua_api/test_check_cmake_contract.py
@@ -53,6 +53,27 @@ class CMakeContractTests(unittest.TestCase):
         self.assertTrue(
             any("LANGUAGE C" in error for error in errors), errors)
 
+    def test_native_loading_prerequisites_cannot_be_removed(self) -> None:
+        requirements = (
+            "target_compile_definitions(liblua PRIVATE LUA_USE_DLOPEN)",
+            "C_VISIBILITY_PRESET default",
+            "target_link_libraries(liblua PUBLIC ${CMAKE_DL_LIBS})",
+            '"LINKER:--export-dynamic"',
+            '"LINKER:-export_dynamic"',
+        )
+        for requirement in requirements:
+            with self.subTest(requirement=requirement):
+                changed = self.lua_source.replace(requirement, "")
+                self.assertNotEqual(changed, self.lua_source)
+                errors = validate_cmake_contract(
+                    self.engine_source, changed,
+                    self.sol_config_source, self.main_source,
+                )
+                self.assertTrue(
+                    any("native Lua loading requires" in e for e in errors),
+                    errors,
+                )
+
     def test_sol_cpp_lua_abi_is_rejected(self) -> None:
         sol_config_source = (
             self.sol_config_source + "\n#define SOL_USE_CXX_LUA 1\n"

--- a/tools/lua_api/test_check_cmake_contract.py
+++ b/tools/lua_api/test_check_cmake_contract.py
@@ -55,6 +55,7 @@ class CMakeContractTests(unittest.TestCase):
 
     def test_native_loading_prerequisites_cannot_be_removed(self) -> None:
         requirements = (
+            "target_compile_definitions(liblua PRIVATE LUA_BUILD_AS_DLL)",
             "target_compile_definitions(liblua PRIVATE LUA_USE_DLOPEN)",
             "C_VISIBILITY_PRESET default",
             "target_link_libraries(liblua PUBLIC ${CMAKE_DL_LIBS})",


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Implements the accepted trusted-Mod loading policy: full Lua standard libraries and ordinary package/native searchers, with preferred Mod-local resolution and a reserved require("ccb") entry. Preserves require caching and loader-data semantics through Lua-owned closures. Adds Mod-local native search paths where representable and the platform build flags needed for native loading; includes an optional native module probe fixture.

Warns before executable Mod discovery and adds actionable owner/stage/file diagnostics for loading, callbacks and saved task restoration. Missing or failed-migration task discards are summarized per Mod in the message log, with details retained in debug.log.

Validation: 6 focused CMake-contract Python tests passed; git diff --check passed. Native fixture, loader/callback/save regression source exists but was NOT compiled or executed. No game, UI, native library compatibility or broad acceptance ran. Supported-platform native loading and early UI notice remain pending morning acceptance. Trusted execution does not remove ccb lifetime/type correctness checks.

#### Responsible human

@LYHGLYTX

#### Documentation impact

Updates the Lua-first contract or author tooling guidance for the behavior described above.

#### Related CCB-Docs PR

https://github.com/CrimsonCrossBunker/CCB-Docs/pull/47 (draft; publish only after source acceptance).

#### Affected documentation IDs

cpp.lua-bridge

#### Generated reference impact

Generated native references are deferred to batch acceptance; no generated inventories were hand-edited.


#### Additional context

Keep draft; do not merge before morning review.